### PR TITLE
cpp union dispatch: construction is the None message; an arm zeroes at selection — batch read 1.8-2.1x

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1104,7 +1104,15 @@ generates, per target:
   *"let's leave this up to the caller. I'd like for there to be an option to generate a
   regular union, and an option to use variant"*): `schema generate --cpp-message
   union|variant`, and the DEFAULT IS UNION** — a tagged struct over an anonymous union,
-  the classic game idiom, zero-initialized on construction, plain-switch dispatch,
+  the classic game idiom, constructed as the None message (the tag initializes to
+  `None`; an arm's storage is established ZEROED when the arm is selected — by
+  `ReadMessage` before it decodes, per §5's zero-baseline read rule, or by a writer
+  assigning the arm) *(was "zero-initialized on construction": the constructor's
+  whole-union memset zeroed the Block-sized union — ~2 KB per ~25 B message, measured
+  at 60.6% of batch-read self-cycles on Zen 4 by the 2026-08-06 bench pass — while
+  this same section pins representation as non-contract and the variant surface's
+  monostate never zeroed payload storage; zeroing moved to arm selection, the exact
+  work §5 requires and no more; repaired 2026-08-06)*, plain-switch dispatch,
   `GetMessageType` reads the tag field. The default was going to be variant until the
   measurement: isolating pure header cost (one identical representation-agnostic TU
   against each mode, arm64 clang), **union 0.09 s vs variant 0.13 s — the variant

--- a/generated/cpp/Messages.h
+++ b/generated/cpp/Messages.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 
 #include "serialize.h"
 
@@ -221,7 +220,11 @@ inline constexpr int64_t MessageMaxBits = 16021;
 inline constexpr int64_t MessageMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity
 
 // The message value: a tagged union — the payload member matching `type` is
-// the active one. Zero-initialized on construction; no heap, no templates.
+// the active one. Construction is the None message: the tag alone is
+// initialized (sentinel-zero — a zero tag is None); an arm's storage is
+// established ZEROED when the arm is selected — by ReadMessage before it
+// decodes (SPEC §5), or by assigning it: message.chat = Chat{}. Bytes of
+// unselected arms are indeterminate. No heap, no templates.
 // (--cpp-message variant generates a std::variant surface instead.)
 struct Message
 {
@@ -237,7 +240,7 @@ struct Message
         Timescale timescale;
     };
 
-    Message() { memset( static_cast<void*>( this ), 0, sizeof( *this ) ); }
+    Message() : type( MessageType::None ) {} // the tag only — arms are zero-established at selection
 };
 
 inline MessageType GetMessageType( const Message & message )

--- a/generated/cpp/ludicrous/Ludicrous.h
+++ b/generated/cpp/ludicrous/Ludicrous.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 
 #include "serialize.h"
 
@@ -208,7 +207,11 @@ inline constexpr int64_t MessageMaxBits = 1206;
 inline constexpr int64_t MessageMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity
 
 // The message value: a tagged union — the payload member matching `type` is
-// the active one. Zero-initialized on construction; no heap, no templates.
+// the active one. Construction is the None message: the tag alone is
+// initialized (sentinel-zero — a zero tag is None); an arm's storage is
+// established ZEROED when the arm is selected — by ReadMessage before it
+// decodes (SPEC §5), or by assigning it: message.chat = Chat{}. Bytes of
+// unselected arms are indeterminate. No heap, no templates.
 // (--cpp-message variant generates a std::variant surface instead.)
 struct Message
 {
@@ -219,7 +222,7 @@ struct Message
         LudicrousState ludicrous_state;
     };
 
-    Message() { memset( static_cast<void*>( this ), 0, sizeof( *this ) ); }
+    Message() : type( MessageType::None ) {} // the tag only — arms are zero-established at selection
 };
 
 inline MessageType GetMessageType( const Message & message )

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -469,15 +469,27 @@ func (g *gen) emitMessageTagFunctions() {
 
 // emitMessageDispatchUnion is the DEFAULT C++ dispatch surface: a tagged
 // struct over an anonymous union — the classic game idiom, zero template
-// machinery, zero extra includes beyond <cstring>. Zero-initialized on
-// construction (the house rule); the payload member matching `type` is the
-// active one, the caller's discipline exactly as in hand-written code.
+// machinery, zero extra includes. Construction initializes the tag only
+// (None); an arm's storage is zero-established when the arm is SELECTED —
+// by ReadMessage before it decodes (SPEC §5's read rule is relative to a
+// zero-initialized output object, and the arm re-init below provides that
+// baseline for exactly the arm the wire tag selects), or by the writer
+// assigning the arm (message.chat = Chat{} — the generated structs'
+// default member initializers make that a zero value). The constructor
+// used to memset the whole Block-sized union; the 2026-08-06 bench pass
+// measured that memset at 60.6% of batch-read self-cycles (Zen 4, ~2 KB
+// zeroed per ~25 B message), and the zeroing moved to arm selection —
+// the exact shape the variant surface always had: default construction
+// is monostate, emplace<T>() value-initializes only the selected arm.
 func (g *gen) emitMessageDispatchUnion() {
-	g.needsCstring = true
 	msgs := g.unit.Messages
 
 	g.pf("// The message value: a tagged union — the payload member matching `type` is\n")
-	g.pf("// the active one. Zero-initialized on construction; no heap, no templates.\n")
+	g.pf("// the active one. Construction is the None message: the tag alone is\n")
+	g.pf("// initialized (sentinel-zero — a zero tag is None); an arm's storage is\n")
+	g.pf("// established ZEROED when the arm is selected — by ReadMessage before it\n")
+	g.pf("// decodes (SPEC §5), or by assigning it: message.chat = Chat{}. Bytes of\n")
+	g.pf("// unselected arms are indeterminate. No heap, no templates.\n")
 	g.pf("// (--cpp-message variant generates a std::variant surface instead.)\n")
 	g.pf("struct Message\n{\n")
 	g.pf("    MessageType type;\n\n    union\n    {\n")
@@ -485,7 +497,7 @@ func (g *gen) emitMessageDispatchUnion() {
 		g.pf("        %s %s;\n", m, camelToSnake(m))
 	}
 	g.pf("    };\n\n")
-	g.pf("    Message() { memset( static_cast<void*>( this ), 0, sizeof( *this ) ); }\n")
+	g.pf("    Message() : type( MessageType::None ) {} // the tag only — arms are zero-established at selection\n")
 	g.pf("};\n\n")
 
 	g.pf("inline MessageType GetMessageType( const Message & message )\n{\n")

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -384,12 +384,17 @@ int main()
         static_assert(std::is_trivially_copyable<Message>::value,
                       "the tagged union is trivially copyable — no heap anywhere");
 
-        Message stream_out[3]; // zero-initialized by construction: type == None
+        Message stream_out[3]; // constructed as the None message: type == None
         check( stream_out[2].type == MessageType::None );
+        // a writer SELECTS an arm by assigning it — the assignment establishes
+        // the arm's storage as its zero value (default member initializers);
+        // construction alone initializes only the tag
         stream_out[0].type = MessageType::Chat;
+        stream_out[0].chat = Chat{};
         std::memcpy( stream_out[0].chat.text, "dispatch", 8 );
         stream_out[0].chat.text_length = 8;
         stream_out[1].type = MessageType::Test;
+        stream_out[1].test = Test{};
         stream_out[1].test.test_b = 42;
 
         serialize::WriteStream ws( buffer, sizeof( buffer ) );
@@ -410,6 +415,45 @@ int main()
         check( in.test.test_b == 42 );
         check( ReadMessage( rs, in ) );
         check( GetMessageType( in ) == MessageType::None ); // the terminator
+    }
+
+    // ---- union arm re-init: a re-read must not leak a previous arm's bytes ----
+    // SPEC §5: read success fully initializes relative to a ZERO-INITIALIZED
+    // output object — ReadMessage provides that baseline for exactly the arm
+    // the wire tag selects, so a Block full of nonzero bytes decoded into a
+    // Message must not remain readable through the chat arm after a smaller
+    // Chat is decoded into the SAME value. This pins the arm re-init: remove
+    // `message.chat = Chat{};` from ReadMessage and this fails.
+    {
+        serialize::WriteStream ws( buffer, sizeof( buffer ) );
+        Message big;
+        big.type = MessageType::Block;
+        big.block = Block{};
+        big.block.data_length = MaxBlockSize;
+        std::memset( big.block.data, 0xFF, MaxBlockSize ); // stand-in attacker bytes
+        check( WriteMessage( ws, big ) );
+        Message small;
+        small.type = MessageType::Chat;
+        small.chat = Chat{};
+        std::memcpy( small.chat.text, "hi", 2 );
+        small.chat.text_length = 2;
+        check( WriteMessage( ws, small ) );
+        ws.Flush();
+
+        Message reused; // ONE value, reused across reads — the arm-swap case
+        serialize::ReadStream rs( buffer, ws.GetBytesProcessed() );
+        check( ReadMessage( rs, reused ) );
+        check( GetMessageType( reused ) == MessageType::Block );
+        check( reused.block.data_length == MaxBlockSize );
+        check( reused.block.data[0] == 0xFF && reused.block.data[MaxBlockSize - 1] == 0xFF );
+        check( ReadMessage( rs, reused ) ); // the same value, now a Chat
+        check( GetMessageType( reused ) == MessageType::Chat );
+        check( reused.chat.text_length == 2 );
+        check( std::strcmp( reused.chat.text, "hi" ) == 0 );
+        for ( int i = 3; i < MaxChatLength + 1; i++ )
+        {
+            check( reused.chat.text[i] == 0 ); // no Block byte survives in the arm
+        }
     }
 
     // ---- the wire constants: const(0xAB, 8) leads, reserved holds zero,

--- a/testdata/golden/ludicrous/union/Ludicrous.h
+++ b/testdata/golden/ludicrous/union/Ludicrous.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 
 #include "serialize.h"
 
@@ -208,7 +207,11 @@ inline constexpr int64_t MessageMaxBits = 1206;
 inline constexpr int64_t MessageMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity
 
 // The message value: a tagged union — the payload member matching `type` is
-// the active one. Zero-initialized on construction; no heap, no templates.
+// the active one. Construction is the None message: the tag alone is
+// initialized (sentinel-zero — a zero tag is None); an arm's storage is
+// established ZEROED when the arm is selected — by ReadMessage before it
+// decodes (SPEC §5), or by assigning it: message.chat = Chat{}. Bytes of
+// unselected arms are indeterminate. No heap, no templates.
 // (--cpp-message variant generates a std::variant surface instead.)
 struct Message
 {
@@ -219,7 +222,7 @@ struct Message
         LudicrousState ludicrous_state;
     };
 
-    Message() { memset( static_cast<void*>( this ), 0, sizeof( *this ) ); }
+    Message() : type( MessageType::None ) {} // the tag only — arms are zero-established at selection
 };
 
 inline MessageType GetMessageType( const Message & message )

--- a/testdata/golden/union/Messages.h
+++ b/testdata/golden/union/Messages.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
 
 #include "serialize.h"
 
@@ -221,7 +220,11 @@ inline constexpr int64_t MessageMaxBits = 16021;
 inline constexpr int64_t MessageMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity
 
 // The message value: a tagged union — the payload member matching `type` is
-// the active one. Zero-initialized on construction; no heap, no templates.
+// the active one. Construction is the None message: the tag alone is
+// initialized (sentinel-zero — a zero tag is None); an arm's storage is
+// established ZEROED when the arm is selected — by ReadMessage before it
+// decodes (SPEC §5), or by assigning it: message.chat = Chat{}. Bytes of
+// unselected arms are indeterminate. No heap, no templates.
 // (--cpp-message variant generates a std::variant surface instead.)
 struct Message
 {
@@ -237,7 +240,7 @@ struct Message
         Timescale timescale;
     };
 
-    Message() { memset( static_cast<void*>( this ), 0, sizeof( *this ) ); }
+    Message() : type( MessageType::None ) {} // the tag only — arms are zero-established at selection
 };
 
 inline MessageType GetMessageType( const Message & message )


### PR DESCRIPTION
## What

The #1 measured hotspot in generated C++ read code, from today's bench pass (`bench-harness` @ d164c77): **decoding a ~25 B message zeroed the Block-sized union (~2 KB)**. On the EPYC box `perf annotate` attributed **60.6% of batch-read self-cycles to three `rep stos` (memset) sites**; on the M2, `_platform_memset` was #2 overall (callers: the batch read loop + `ReadMessage`). It is why `message_batch` read ran 2.4-3.2x behind write on every platform/compiler.

The cost was the union `Message()` constructor — `memset(this, 0, sizeof(*this))`, 2016 B — paid on every fresh `Message` (the natural per-message read pattern), on top of the per-arm `message.chat = Chat{};` re-init inside `ReadMessage`.

## The semantic rule, derived from SPEC

**Construction initializes the tag only (`None`); an arm's storage is zero-established when the arm is *selected* — by `ReadMessage` before it decodes, or by a writer assigning the arm. Zeroing is exactly `sizeof(arm)`, once, at selection — never the whole union.**

Where SPEC states it:

- **§5 (read rule):** "Read success fully initializes [the output] … *fully initializes* is relative to a **zero-initialized output object**." The union aliases arms, so the previously active arm's bytes are not a zero baseline — `ReadMessage` must establish that baseline for **exactly the arm the wire tag selects**. That is the existing `message.chat = Chat{};` before `ReadChat`: the semantics-bearing zeroing. It is **kept**, and now pinned by a new stale-leak test (below).
- **§5:** "Read failure leaves the output object in an unspecified state; callers use it only on success." Failure paths owe nothing — and because the arm is zeroed *before* decoding, even a failed read never exposes a previous message's bytes through the selected arm.
- **§4.8 (representation):** "Representation is per-language and explicitly **NOT part of the contract** … What binds every target is behavioral only: identical bytes, reading None is a valid none-result, reading an out-of-range tag is a validation failure." The whole-union construction memset was representation over-implementation: the **opt-in variant surface never had it** (default construction is `monostate`; its `ReadMessage` does `message.emplace<T>()` — value-initializing only the selected arm), and Go's surface is a nil interface. Both already pass the same corpus gates.
- **Sentinel-zero (§4.2, and the 2026-08-06 SPEC commit):** zero-init = None is the *interpretation* direction — zero storage reads as None. Preserved: the tag still initializes to `None`, and every generated message struct keeps its default member initializers (`Chat{}` is all-zero).

**The one judgment call, flagged for Glenn:** the union surface no longer underwrites *poking fields of an arm that was never selected* on a fresh stack `Message` (`m.type = Test; m.test.test_b = 42;`, with the arm's other fields expected to be wire-zero). That idiom now requires selecting the arm first — `m.test = Test{};`, an 8-byte assignment — the same shape the variant surface always required via `emplace`. Two in-repo call sites used the old idiom: the pinned dispatch test in `test/main.cpp`, and the bench harness's `message_stream` golden self-check on the unmerged `bench-harness` branch. Both are updated to the selection idiom; the wire they produce is byte-identical. SPEC §4.8's descriptive phrase "zero-initialized on construction" is repaired in place with a dated parenthetical (the SPEC's own repair style). If the poke-a-fresh-arm idiom must stay underwritten, the only implementation is the whole-union memset, and the batch-read cost returns with it — that trade is exactly what this PR prices.

## Semantics proof

- **Full suite green** (`make clean && make SERIALIZE=../serialize update-goldens` then `make SERIALIZE=../serialize test`): cpp union + cpp variant + random (2000 iterations) + go + rust + cs corpus gates + `go test ./...` incl. goldens.
- **Wire goldens byte-identical**: `git diff testdata/wire` empty after the deliberate `update-goldens` re-pin. Source golden re-pinned: `testdata/golden/union/Messages.h` only; the variant golden did not change.
- **New pinned stale-leak test** (`test/main.cpp`, "union arm re-init"): writes a Block with `data_length = MaxBlockSize` filled with `0xFF`, then a 2-byte Chat; reads both into the **same reused** `Message` and asserts every `chat.text` byte past the terminator is zero — a previous arm's bytes must not survive into the selected arm. Written first and verified green against origin/main's generated code, then against this branch. Removing the arm re-init (the *less-safety* "fix") makes it fail.
- Existing pins stay green: `message_stream` wire golden, the `stream_out[2].type == None` construction check, the trivially-copyable assert.

## Numbers

Methodology: identical to the baseline pass — `bench/run.sh`, median of 7 after one warmup, wire-golden self-check before benching (a mismatch refuses to bench), flags exactly as the baseline CSV preambles (g++ adds `-Wno-class-memaccess -Wno-type-limits`, as before), same `serialize` runtime @ 19d332e via `../serialize-cs-port/serialize`. "Before" = origin/main 960bdd0 + harness (= `bench-harness` @ d164c77); "after" = fd5f534 + harness. Each host ran before/after **back-to-back** so the paired ratio absorbs host drift. EPYC numbers are NOISY as in the baseline (bench shares core 0 with irqs/ssh/game-server aux threads; server running). Notably the EPYC *clang* pair ran under a much heavier core-0 load than this morning's baseline (~2x lower absolute throughput across all benchmarks, e.g. chat write 32.6 vs the baseline's 65.3) — the paired before/after ratio is the meaningful number there, not the absolutes.

**Prediction, recorded before measuring** (scratchpad note, quoted verbatim in the branch discussion): batch read ~1.6-2.2x on M2 clang (48-67 M msg/s), ~1.8-2.6x on EPYC g++ (36-53), ~1.5-2.2x on EPYC clang (44-65); batch write and all other benchmarks unchanged within noise; the read/write inversion closes but may not flip on g++.

### message_batch — the hotspot (M msg/s, median of 7, paired back-to-back runs)

| host / compiler | write before | write after | read before | read after | read change |
|---|---:|---:|---:|---:|---:|
| M2 / Apple clang 21 (quiet) | 89.59 | 83.25 | 32.03 | 67.55 | **2.11x** |
| EPYC 9124 / g++ 13.3 (core 0, NOISY) | 64.34 | 65.90 | 21.81 | 40.86 | **1.87x** |
| EPYC 9124 / clang 18.1 (core 0, NOISY) | 28.70 | 28.69 | 14.47 | 26.03 | **1.80x** |

**Prediction vs outcome:** M2 2.11x — in band, at the top (67.55 lands on the band edge). EPYC g++ 1.87x — in band, low end (40.86 M msg/s; the band's rate range assumed a quieter core). EPYC clang 1.80x — ratio in band; the absolute rate (26.03) fell far below the predicted 44-65 because the box was ~2x more loaded than the baseline the prediction extrapolated from. **One refutation to report plainly:** the read/write inversion did NOT flip anywhere — batch read now sits at 0.8-0.9x of batch write on all three pairs (was 0.35-0.5x). The remaining gap is consistent with hotspot 2 (per-field call overhead) plus the arm re-init that semantics require.

**Batch write:** unchanged within noise everywhere (M2 -7% with 3.2%/14.8% spreads; EPYC g++ +2.4% with 5.6%/19.0%; EPYC clang ±0.0%) — as predicted: the measured write loop constructs no `Message`.

**All other benchmarks:** unchanged within noise on all three pairs — read deltas -7.4%..+11.4% with overlapping spreads on the noisy box, |delta| <= 3.3% on the quiet M2; no systematic direction. (One artifact: EPYC g++ `testdata` write shows -33% on a 70% spread — a descheduled run, not a signal; its read side is +/-0.5%.) Full per-benchmark before/after tables with spreads are in the run CSVs; none of these benchmarks construct a `Message` in a measured loop.

**Perf confirmation (EPYC, whole-run, g++ binaries):** libc `__memset_avx512_unaligned_erms` drops from **6.86%** of total cycles (before) to **1.69%** (after); the baseline's three batch-read `rep stos` sites are gone from the profile.

## Notes

- **GitHub Actions is in a major outage today — no CI ran on this PR.** Everything above was run locally (M2) and over ssh (EPYC `space` box).
- The bench harness lives on the unmerged `bench-harness` branch; **this PR's diff carries no bench files**. Measurements used a local merge of `origin/bench-harness` into the fix branch. The harness's `message_stream` self-check needs the same two-line selection-idiom fix when that branch rebases onto this (the wire-golden self-check catches it loudly — that is how it was found).
- Go/Rust/C# read paths were not touched; their surfaces never had the whole-union zeroing (nil interface / real enum / base-type reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
