### PR TITLE
Rust emitter: #[inline] on every wire function + read_message_into

### DIFF
--- a/generated/rust/src/messages.rs
+++ b/generated/rust/src/messages.rs
@@ -35,11 +35,13 @@ impl Default for Heartbeat {
 pub const HEARTBEAT_MAX_BITS: u64 = 0;
 pub const HEARTBEAT_MAX_BYTES: usize = 0;
 
+#[inline]
 pub fn write_heartbeat(stream: &mut WriteStream<'_>, value: &Heartbeat) -> Result {
     let _ = (stream, value); // empty body — presence is the payload (SPEC §4.6)
     Ok(())
 }
 
+#[inline]
 pub fn read_heartbeat(stream: &mut ReadStream<'_>, value: &mut Heartbeat) -> Result {
     let _ = (stream, value);
     Ok(())
@@ -71,6 +73,7 @@ impl Default for Test {
 pub const TEST_MAX_BITS: u64 = 46;
 pub const TEST_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
     {
         let mut raw_value = value.test_a as u32;
@@ -100,6 +103,7 @@ pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_test(stream: &mut ReadStream<'_>, value: &mut Test) -> Result {
     {
         let mut raw_value: u32 = 0;
@@ -146,6 +150,7 @@ impl Default for Block {
 pub const BLOCK_MAX_BITS: u64 = 16018;
 pub const BLOCK_MAX_BYTES: usize = 2008;
 
+#[inline]
 pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
     if value.data_length < 0 || value.data_length > 2000 { // refused, not wrapped or panicked: guards the slice too
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -162,6 +167,7 @@ pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_block(stream: &mut ReadStream<'_>, value: &mut Block) -> Result {
     stream.serialize_int(&mut value.data_length, 0, MAX_BLOCK_SIZE as i32)?; // the length guards the slice (§6.3)
     stream.serialize_bytes(&mut value.data[..value.data_length as usize])?;
@@ -190,6 +196,7 @@ impl Default for Chat {
 pub const CHAT_MAX_BITS: u64 = 2064;
 pub const CHAT_MAX_BYTES: usize = 264;
 
+#[inline]
 pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
     if value.text_length < 0 || value.text_length > 256 { // refused, not wrapped or panicked: guards the slice too
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -206,6 +213,7 @@ pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_chat(stream: &mut ReadStream<'_>, value: &mut Chat) -> Result {
     stream.serialize_int(&mut value.text_length, 0, MAX_CHAT_LENGTH as i32)?; // the length guards the slice (§6.3)
     stream.serialize_bytes(&mut value.text[..value.text_length as usize])?;
@@ -239,6 +247,7 @@ impl Default for Synchronize {
 pub const SYNCHRONIZE_MAX_BITS: u64 = 80;
 pub const SYNCHRONIZE_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_synchronize(stream: &mut WriteStream<'_>, value: &Synchronize) -> Result {
     {
         let mut raw_value = value.sync_frame;
@@ -251,6 +260,7 @@ pub fn write_synchronize(stream: &mut WriteStream<'_>, value: &Synchronize) -> R
     Ok(())
 }
 
+#[inline]
 pub fn read_synchronize(stream: &mut ReadStream<'_>, value: &mut Synchronize) -> Result {
     stream.serialize_bits64(&mut value.sync_frame, 64)?;
     {
@@ -285,6 +295,7 @@ impl Default for Timescale {
 pub const TIMESCALE_MAX_BITS: u64 = 128;
 pub const TIMESCALE_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_timescale(stream: &mut WriteStream<'_>, value: &Timescale) -> Result {
     {
         let mut float_value = value.scale;
@@ -301,6 +312,7 @@ pub fn write_timescale(stream: &mut WriteStream<'_>, value: &Timescale) -> Resul
     Ok(())
 }
 
+#[inline]
 pub fn read_timescale(stream: &mut ReadStream<'_>, value: &mut Timescale) -> Result {
     stream.serialize_f64(&mut value.scale)?;
     stream.serialize_bits(&mut value.frame_a, 32)?;
@@ -310,12 +322,14 @@ pub fn read_timescale(stream: &mut ReadStream<'_>, value: &mut Timescale) -> Res
 
 // The message tag wire: MessageType in [0, 6], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
+#[inline]
 pub fn write_message_type(stream: &mut WriteStream<'_>, value: MessageType) -> Result {
     let mut tag_value = value.0 as i32;
     stream.serialize_int(&mut tag_value, 0, 6)?;
     Ok(())
 }
 
+#[inline]
 pub fn read_message_type(stream: &mut ReadStream<'_>, value: &mut MessageType) -> Result {
     let mut tag_value: i32 = 0;
     stream.serialize_int(&mut tag_value, 0, 6)?;
@@ -344,6 +358,7 @@ pub enum Message {
     Timescale(Timescale),
 }
 
+#[inline]
 pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result {
     match message {
         Message::None => write_message_type(stream, MessageType::NONE), // the stream terminator (SPEC §4.8)
@@ -374,6 +389,68 @@ pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result 
     }
 }
 
+// read_message_into decodes the next message into caller-owned storage: the
+// variant is reset to its zero form (SPEC §5), then its fields decode in
+// place — no per-message copy of the union out of the call. On error the
+// storage holds the partially decoded zero form: discard it.
+#[inline]
+pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {
+    let mut tag_value = MessageType::NONE;
+    read_message_type(stream, &mut tag_value)?;
+    match tag_value {
+        MessageType::NONE => {
+            *message = Message::None; // the stream terminator (SPEC §4.8)
+            Ok(())
+        }
+        MessageType::BLOCK => {
+            *message = Message::Block(Block::default()); // reused storage starts from the zero form, as the union does
+            let Message::Block(value) = message else {
+                unreachable!()
+            };
+            read_block(stream, value)
+        }
+        MessageType::CHAT => {
+            *message = Message::Chat(Chat::default()); // reused storage starts from the zero form, as the union does
+            let Message::Chat(value) = message else {
+                unreachable!()
+            };
+            read_chat(stream, value)
+        }
+        MessageType::HEARTBEAT => {
+            *message = Message::Heartbeat(Heartbeat::default()); // reused storage starts from the zero form, as the union does
+            let Message::Heartbeat(value) = message else {
+                unreachable!()
+            };
+            read_heartbeat(stream, value)
+        }
+        MessageType::SYNCHRONIZE => {
+            *message = Message::Synchronize(Synchronize::default()); // reused storage starts from the zero form, as the union does
+            let Message::Synchronize(value) = message else {
+                unreachable!()
+            };
+            read_synchronize(stream, value)
+        }
+        MessageType::TEST => {
+            *message = Message::Test(Test::default()); // reused storage starts from the zero form, as the union does
+            let Message::Test(value) = message else {
+                unreachable!()
+            };
+            read_test(stream, value)
+        }
+        MessageType::TIMESCALE => {
+            *message = Message::Timescale(Timescale::default()); // reused storage starts from the zero form, as the union does
+            let Message::Timescale(value) = message else {
+                unreachable!()
+            };
+            read_timescale(stream, value)
+        }
+        // read_message_type already rejected tags past the set; the match
+        // still needs the arm because tag constants are never exhaustive
+        _ => Err(Error::Validation),
+    }
+}
+
+#[inline]
 pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {
     let mut tag_value = MessageType::NONE;
     read_message_type(stream, &mut tag_value)?;

--- a/generated/rust/src/objects.rs
+++ b/generated/rust/src/objects.rs
@@ -313,6 +313,7 @@ impl Default for ShipData_Interpolate {
 pub const SHIP_DATA_DEEP_MAX_BITS: u64 = 1703;
 pub const SHIP_DATA_DEEP_MAX_BYTES: usize = 216; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_ship_data_deep(stream: &mut WriteStream<'_>, value: &ShipData_Deep) -> Result {
     if value.ship_type.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -412,6 +413,7 @@ pub fn write_ship_data_deep(stream: &mut WriteStream<'_>, value: &ShipData_Deep)
     Ok(())
 }
 
+#[inline]
 pub fn read_ship_data_deep(stream: &mut ReadStream<'_>, value: &mut ShipData_Deep) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -464,6 +466,7 @@ pub fn read_ship_data_deep(stream: &mut ReadStream<'_>, value: &mut ShipData_Dee
 pub const SHIP_DATA_SHALLOW_MAX_BITS: u64 = 218;
 pub const SHIP_DATA_SHALLOW_MAX_BYTES: usize = 32; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_ship_data_shallow(stream: &mut WriteStream<'_>, value: &ShipData_Shallow) -> Result {
     if value.ship_type.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -538,6 +541,7 @@ pub fn write_ship_data_shallow(stream: &mut WriteStream<'_>, value: &ShipData_Sh
     Ok(())
 }
 
+#[inline]
 pub fn read_ship_data_shallow(stream: &mut ReadStream<'_>, value: &mut ShipData_Shallow) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -895,6 +899,7 @@ impl Default for MissileData_Interpolate {
 pub const MISSILE_DATA_DEEP_MAX_BITS: u64 = 708;
 pub const MISSILE_DATA_DEEP_MAX_BYTES: usize = 96; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_missile_data_deep(stream: &mut WriteStream<'_>, value: &MissileData_Deep) -> Result {
     if value.missile_type.0 > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -920,6 +925,7 @@ pub fn write_missile_data_deep(stream: &mut WriteStream<'_>, value: &MissileData
     Ok(())
 }
 
+#[inline]
 pub fn read_missile_data_deep(stream: &mut ReadStream<'_>, value: &mut MissileData_Deep) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -941,6 +947,7 @@ pub fn read_missile_data_deep(stream: &mut ReadStream<'_>, value: &mut MissileDa
 pub const MISSILE_DATA_SHALLOW_MAX_BITS: u64 = 260;
 pub const MISSILE_DATA_SHALLOW_MAX_BYTES: usize = 40; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_missile_data_shallow(stream: &mut WriteStream<'_>, value: &MissileData_Shallow) -> Result {
     if value.missile_type.0 > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -1003,6 +1010,7 @@ pub fn write_missile_data_shallow(stream: &mut WriteStream<'_>, value: &MissileD
     Ok(())
 }
 
+#[inline]
 pub fn read_missile_data_shallow(stream: &mut ReadStream<'_>, value: &mut MissileData_Shallow) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -1307,6 +1315,7 @@ impl Default for DynamicPropData_Interpolate {
 pub const DYNAMIC_PROP_DATA_DEEP_MAX_BITS: u64 = 709;
 pub const DYNAMIC_PROP_DATA_DEEP_MAX_BYTES: usize = 96; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_dynamic_prop_data_deep(stream: &mut WriteStream<'_>, value: &DynamicPropData_Deep) -> Result {
     if value.prop_type.0 > 6 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -1332,6 +1341,7 @@ pub fn write_dynamic_prop_data_deep(stream: &mut WriteStream<'_>, value: &Dynami
     Ok(())
 }
 
+#[inline]
 pub fn read_dynamic_prop_data_deep(stream: &mut ReadStream<'_>, value: &mut DynamicPropData_Deep) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -1353,6 +1363,7 @@ pub fn read_dynamic_prop_data_deep(stream: &mut ReadStream<'_>, value: &mut Dyna
 pub const DYNAMIC_PROP_DATA_SHALLOW_MAX_BITS: u64 = 261;
 pub const DYNAMIC_PROP_DATA_SHALLOW_MAX_BYTES: usize = 40; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_dynamic_prop_data_shallow(stream: &mut WriteStream<'_>, value: &DynamicPropData_Shallow) -> Result {
     if value.prop_type.0 > 6 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -1415,6 +1426,7 @@ pub fn write_dynamic_prop_data_shallow(stream: &mut WriteStream<'_>, value: &Dyn
     Ok(())
 }
 
+#[inline]
 pub fn read_dynamic_prop_data_shallow(stream: &mut ReadStream<'_>, value: &mut DynamicPropData_Shallow) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -1693,6 +1705,7 @@ impl Default for TurretData_Interpolate {
 pub const TURRET_DATA_DEEP_MAX_BITS: u64 = 350;
 pub const TURRET_DATA_DEEP_MAX_BYTES: usize = 48; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_turret_data_deep(stream: &mut WriteStream<'_>, value: &TurretData_Deep) -> Result {
     write_handle(stream, &value.parent)?;
     if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
@@ -1710,6 +1723,7 @@ pub fn write_turret_data_deep(stream: &mut WriteStream<'_>, value: &TurretData_D
     Ok(())
 }
 
+#[inline]
 pub fn read_turret_data_deep(stream: &mut ReadStream<'_>, value: &mut TurretData_Deep) -> Result {
     read_handle(stream, &mut value.parent)?;
     stream.serialize_int(&mut value.turret_index, 0, (MAX_TURRETS_PER_SHIP - 1) as i32)?;
@@ -1721,6 +1735,7 @@ pub fn read_turret_data_deep(stream: &mut ReadStream<'_>, value: &mut TurretData
 pub const TURRET_DATA_SHALLOW_MAX_BITS: u64 = 142;
 pub const TURRET_DATA_SHALLOW_MAX_BYTES: usize = 24; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_turret_data_shallow(stream: &mut WriteStream<'_>, value: &TurretData_Shallow) -> Result {
     write_handle(stream, &value.parent)?;
     if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
@@ -1753,6 +1768,7 @@ pub fn write_turret_data_shallow(stream: &mut WriteStream<'_>, value: &TurretDat
     Ok(())
 }
 
+#[inline]
 pub fn read_turret_data_shallow(stream: &mut ReadStream<'_>, value: &mut TurretData_Shallow) -> Result {
     read_handle(stream, &mut value.parent)?;
     stream.serialize_int(&mut value.turret_index, 0, (MAX_TURRETS_PER_SHIP - 1) as i32)?;
@@ -1842,12 +1858,14 @@ pub fn unquantize_turret(input: &TurretData_Shallow, output: &mut TurretData_Int
 
 // The object tag wire: ObjectType in [0, 4], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
+#[inline]
 pub fn write_object_type(stream: &mut WriteStream<'_>, value: ObjectType) -> Result {
     let mut tag_value = value.0 as i32;
     stream.serialize_int(&mut tag_value, 0, 4)?;
     Ok(())
 }
 
+#[inline]
 pub fn read_object_type(stream: &mut ReadStream<'_>, value: &mut ObjectType) -> Result {
     let mut tag_value: i32 = 0;
     stream.serialize_int(&mut tag_value, 0, 4)?;

--- a/generated/rust/src/types.rs
+++ b/generated/rust/src/types.rs
@@ -29,6 +29,7 @@ impl Default for Vec3 {
 pub const VEC3_MAX_BITS: u64 = 192;
 pub const VEC3_MAX_BYTES: usize = 24;
 
+#[inline]
 pub fn write_vec3(stream: &mut WriteStream<'_>, value: &Vec3) -> Result {
     {
         let mut float_value = value.x;
@@ -45,6 +46,7 @@ pub fn write_vec3(stream: &mut WriteStream<'_>, value: &Vec3) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_vec3(stream: &mut ReadStream<'_>, value: &mut Vec3) -> Result {
     stream.serialize_f64(&mut value.x)?;
     stream.serialize_f64(&mut value.y)?;
@@ -79,6 +81,7 @@ impl Default for Quat {
 pub const QUAT_MAX_BITS: u64 = 256;
 pub const QUAT_MAX_BYTES: usize = 32;
 
+#[inline]
 pub fn write_quat(stream: &mut WriteStream<'_>, value: &Quat) -> Result {
     {
         let mut float_value = value.x;
@@ -99,6 +102,7 @@ pub fn write_quat(stream: &mut WriteStream<'_>, value: &Quat) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_quat(stream: &mut ReadStream<'_>, value: &mut Quat) -> Result {
     stream.serialize_f64(&mut value.x)?;
     stream.serialize_f64(&mut value.y)?;
@@ -129,6 +133,7 @@ impl Default for Handle {
 pub const HANDLE_MAX_BITS: u64 = 22;
 pub const HANDLE_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
     if value.object_id < 0 || value.object_id > 9999 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -144,6 +149,7 @@ pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_handle(stream: &mut ReadStream<'_>, value: &mut Handle) -> Result {
     stream.serialize_int(&mut value.object_id, 0, (MAX_OBJECTS - 1) as i32)?;
     {
@@ -178,6 +184,7 @@ impl Default for QuantizedPosition {
 pub const QUANTIZED_POSITION_MAX_BITS: u64 = 75;
 pub const QUANTIZED_POSITION_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedPosition) -> Result {
     if value.x < -8388608 || value.x > 8388608 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -203,6 +210,7 @@ pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedP
     Ok(())
 }
 
+#[inline]
 pub fn read_quantized_position(stream: &mut ReadStream<'_>, value: &mut QuantizedPosition) -> Result {
     stream.serialize_int(&mut value.x, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
     stream.serialize_int(&mut value.y, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
@@ -234,6 +242,7 @@ impl Default for QuantizedVelocity {
 pub const QUANTIZED_VELOCITY_MAX_BITS: u64 = 69;
 pub const QUANTIZED_VELOCITY_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedVelocity) -> Result {
     if value.x < -2097152 || value.x > 2097152 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -259,6 +268,7 @@ pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedV
     Ok(())
 }
 
+#[inline]
 pub fn read_quantized_velocity(stream: &mut ReadStream<'_>, value: &mut QuantizedVelocity) -> Result {
     stream.serialize_int(&mut value.x, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
     stream.serialize_int(&mut value.y, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
@@ -292,6 +302,7 @@ impl Default for QuantizedRotation {
 pub const QUANTIZED_ROTATION_MAX_BITS: u64 = 48;
 pub const QUANTIZED_ROTATION_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedRotation) -> Result {
     if value.x < -1024 || value.x > 1024 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -324,6 +335,7 @@ pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedR
     Ok(())
 }
 
+#[inline]
 pub fn read_quantized_rotation(stream: &mut ReadStream<'_>, value: &mut QuantizedRotation) -> Result {
     {
         let mut range_value: i32 = 0;
@@ -379,6 +391,7 @@ impl Default for RigidBody {
 pub const RIGID_BODY_MAX_BITS: u64 = 833;
 pub const RIGID_BODY_MAX_BYTES: usize = 112;
 
+#[inline]
 pub fn write_rigid_body(stream: &mut WriteStream<'_>, value: &RigidBody) -> Result {
     write_vec3(stream, &value.position)?;
     write_quat(stream, &value.orientation)?;
@@ -393,6 +406,7 @@ pub fn write_rigid_body(stream: &mut WriteStream<'_>, value: &RigidBody) -> Resu
     Ok(())
 }
 
+#[inline]
 pub fn read_rigid_body(stream: &mut ReadStream<'_>, value: &mut RigidBody) -> Result {
     read_vec3(stream, &mut value.position)?;
     read_quat(stream, &mut value.orientation)?;
@@ -451,6 +465,7 @@ impl Default for Input {
 pub const INPUT_MAX_BITS: u64 = 168;
 pub const INPUT_MAX_BYTES: usize = 24;
 
+#[inline]
 pub fn write_input(stream: &mut WriteStream<'_>, value: &Input) -> Result {
     {
         let mut float_value = value.stick_x;
@@ -507,6 +522,7 @@ pub fn write_input(stream: &mut WriteStream<'_>, value: &Input) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_input(stream: &mut ReadStream<'_>, value: &mut Input) -> Result {
     stream.serialize_f32(&mut value.stick_x)?;
     stream.serialize_f32(&mut value.stick_y)?;
@@ -552,6 +568,7 @@ impl Default for InputPacket {
 pub const INPUT_PACKET_MAX_BITS: u64 = 2837;
 pub const INPUT_PACKET_MAX_BYTES: usize = 360;
 
+#[inline]
 pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> Result {
     {
         let mut raw_value = value.synchronize_sequence as u32;
@@ -578,6 +595,7 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_input_packet(stream: &mut ReadStream<'_>, value: &mut InputPacket) -> Result {
     {
         let mut raw_value: u32 = 0;
@@ -633,6 +651,7 @@ impl Default for ShipCreate {
 pub const SHIP_CREATE_MAX_BITS: u64 = 219;
 pub const SHIP_CREATE_MAX_BYTES: usize = 32;
 
+#[inline]
 pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Result {
     if value.ship_type.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -682,6 +701,7 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
     Ok(())
 }
 
+#[inline]
 pub fn read_ship_create(stream: &mut ReadStream<'_>, value: &mut ShipCreate) -> Result {
     {
         let mut enum_value: i32 = 0;

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -53,6 +53,7 @@ impl Default for ProbeHeader {
 pub const PROBE_HEADER_MAX_BITS: u64 = 87;
 pub const PROBE_HEADER_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> Result {
     {
         let mut const_value: u32 = 171;
@@ -77,6 +78,7 @@ pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_header(stream: &mut ReadStream<'_>, value: &mut ProbeHeader) -> Result {
     {
         let mut const_value: u32 = 0;
@@ -128,6 +130,7 @@ impl Default for ProbeBits {
 pub const PROBE_BITS_MAX_BITS: u64 = 202;
 pub const PROBE_BITS_MAX_BYTES: usize = 32;
 
+#[inline]
 pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Result {
     if value.small >= 1 << 9 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -158,6 +161,7 @@ pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Resu
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_bits(stream: &mut ReadStream<'_>, value: &mut ProbeBits) -> Result {
     stream.serialize_bits(&mut value.small, 9)?;
     stream.serialize_bits64(&mut value.boundary, 33)?;
@@ -234,6 +238,7 @@ impl ProbeSample {
 pub const PROBE_SAMPLE_MAX_BITS: u64 = 276;
 pub const PROBE_SAMPLE_MAX_BYTES: usize = 40;
 
+#[inline]
 pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> Result {
     {
         let mut bool_value = value.active;
@@ -291,6 +296,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_sample(stream: &mut ReadStream<'_>, value: &mut ProbeSample) -> Result {
     stream.serialize_bool(&mut value.active)?;
     stream.serialize_compressed_float(&mut value.orientation, -180.0_f32, 180.0_f32, 0.01_f32)?;
@@ -372,6 +378,7 @@ impl ProbeConfig {
 pub const PROBE_CONFIG_MAX_BITS: u64 = 36;
 pub const PROBE_CONFIG_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> Result {
     {
         let mut raw_value = value.retries as u32;
@@ -387,6 +394,7 @@ pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_config(stream: &mut ReadStream<'_>, value: &mut ProbeConfig) -> Result {
     {
         let mut raw_value: u32 = 0;
@@ -437,6 +445,7 @@ impl ProbeArray {
 pub const PROBE_ARRAY_MAX_BITS: u64 = 588;
 pub const PROBE_ARRAY_MAX_BYTES: usize = 80;
 
+#[inline]
 pub fn write_probe_array(stream: &mut WriteStream<'_>, value: &ProbeArray) -> Result {
     for i in 0..2 {
         write_probe_sample(stream, &value.samples[i])?;
@@ -445,6 +454,7 @@ pub fn write_probe_array(stream: &mut WriteStream<'_>, value: &ProbeArray) -> Re
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_array(stream: &mut ReadStream<'_>, value: &mut ProbeArray) -> Result {
     for i in 0..2 {
         read_probe_sample(stream, &mut value.samples[i])?;
@@ -477,6 +487,7 @@ impl Default for ProbeReport {
 pub const PROBE_REPORT_MAX_BITS: u64 = 141;
 pub const PROBE_REPORT_MAX_BYTES: usize = 24;
 
+#[inline]
 pub fn write_probe_report(stream: &mut WriteStream<'_>, value: &ProbeReport) -> Result {
     write_probe_header(stream, &value.header)?;
     if value.flags >= 1 << 8 {
@@ -491,6 +502,7 @@ pub fn write_probe_report(stream: &mut WriteStream<'_>, value: &ProbeReport) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_report(stream: &mut ReadStream<'_>, value: &mut ProbeReport) -> Result {
     read_probe_header(stream, &mut value.header)?;
     {
@@ -566,6 +578,7 @@ impl Default for TestData {
 pub const TEST_DATA_MAX_BITS: u64 = 2735;
 pub const TEST_DATA_MAX_BYTES: usize = 344;
 
+#[inline]
 pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result {
     if value.a < -100 || value.a > 100 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -698,6 +711,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     Ok(())
 }
 
+#[inline]
 pub fn read_test_data(stream: &mut ReadStream<'_>, value: &mut TestData) -> Result {
     stream.serialize_int(&mut value.a, -100, 100)?;
     stream.serialize_int(&mut value.b, -100, 100)?;

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -27,6 +27,11 @@ func (g *gen) emitStructFunctions(st *ir.Struct) {
 	g.pf("pub const %s: u64 = %d;\n", ir.RustConstName(st.Name+"MaxBits"), maxBits)
 	g.pf("pub const %s: usize = %d;\n\n", ir.RustConstName(st.Name+"MaxBytes"), ir.MaxBytes(maxBits))
 
+	// #[inline] on every wire function: the generated crate is a separate
+	// compilation unit from the caller, and without the hint a 6-10 byte
+	// message pays a full call (and loses constant folding of its bit widths)
+	// per serialize — measured 2-6x on tiny messages (bench 2026-08-06)
+	g.pf("#[inline]\n")
 	g.pf("pub fn write_%s(stream: &mut WriteStream<'_>, value: &%s) -> Result {\n", snake, st.Name)
 	if len(st.Items) == 0 {
 		g.pf("    let _ = (stream, value); // empty body — presence is the payload (SPEC §4.6)\n")
@@ -35,6 +40,7 @@ func (g *gen) emitStructFunctions(st *ir.Struct) {
 	}
 	g.pf("    Ok(())\n}\n\n")
 
+	g.pf("#[inline]\n")
 	g.pf("pub fn read_%s(stream: &mut ReadStream<'_>, value: &mut %s) -> Result {\n", snake, st.Name)
 	if len(st.Items) == 0 {
 		g.pf("    let _ = (stream, value);\n")
@@ -588,10 +594,12 @@ func (g *gen) emitMessageTagFunctions() {
 	count := int64(len(g.unit.Messages))
 	g.pf("// The message tag wire: MessageType in [0, %d], minimal bits; None = 0 is a\n", count)
 	g.pf("// valid wire value meaning *no message* — the stream terminator (SPEC §4.8).\n")
+	g.pf("#[inline]\n")
 	g.pf("pub fn write_message_type(stream: &mut WriteStream<'_>, value: MessageType) -> Result {\n")
 	g.pf("    let mut tag_value = value.0 as i32;\n")
 	g.pf("    stream.serialize_int(&mut tag_value, 0, %d)?;\n", count)
 	g.pf("    Ok(())\n}\n\n")
+	g.pf("#[inline]\n")
 	g.pf("pub fn read_message_type(stream: &mut ReadStream<'_>, value: &mut MessageType) -> Result {\n")
 	g.pf("    let mut tag_value: i32 = 0;\n")
 	g.pf("    stream.serialize_int(&mut tag_value, 0, %d)?;\n", count)
@@ -630,6 +638,7 @@ func (g *gen) emitMessageTagFunctions() {
 	// the tag rides through the tag pair (one source), inside each arm BEFORE
 	// its payload; the out-of-set refusal the other targets carry has no Rust
 	// twin — the enum is closed, so no such value exists to refuse
+	g.pf("#[inline]\n")
 	g.pf("pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result {\n")
 	g.pf("    match message {\n")
 	g.pf("        Message::None => write_message_type(stream, MessageType::NONE), // the stream terminator (SPEC §4.8)\n")
@@ -641,6 +650,46 @@ func (g *gen) emitMessageTagFunctions() {
 	}
 	g.pf("    }\n}\n\n")
 
+	// the read-into surface: decodes into caller-owned storage, so steady
+	// loops re-read into one Message with no per-message copy-out of the
+	// ~largest-message-sized union — the Go/C# MessageStorage discipline in
+	// Rust shape. The tagged variant starts from the zero form before its
+	// fields decode (§5), exactly as the C# ReadMessage zeroes its storage;
+	// on error the message holds that zero form plus whatever fields decoded
+	// before the failure — discard it, as with any failed read.
+	g.pf("// read_message_into decodes the next message into caller-owned storage: the\n")
+	g.pf("// variant is reset to its zero form (SPEC §5), then its fields decode in\n")
+	g.pf("// place — no per-message copy of the union out of the call. On error the\n")
+	g.pf("// storage holds the partially decoded zero form: discard it.\n")
+	g.pf("#[inline]\n")
+	g.pf("pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {\n")
+	g.pf("    let mut tag_value = MessageType::NONE;\n")
+	g.pf("    read_message_type(stream, &mut tag_value)?;\n")
+	g.pf("    match tag_value {\n")
+	g.pf("        MessageType::NONE => {\n")
+	g.pf("            *message = Message::None; // the stream terminator (SPEC §4.8)\n")
+	g.pf("            Ok(())\n")
+	g.pf("        }\n")
+	for _, m := range msgs {
+		g.pf("        MessageType::%s => {\n", ir.RustConstName(m))
+		g.pf("            *message = Message::%s(%s::default()); // reused storage starts from the zero form, as the union does\n", m, m)
+		g.pf("            let Message::%s(value) = message else {\n", m)
+		g.pf("                unreachable!()\n")
+		g.pf("            };\n")
+		g.pf("            read_%s(stream, value)\n", ir.RustSnake(m))
+		g.pf("        }\n")
+	}
+	g.pf("        // read_message_type already rejected tags past the set; the match\n")
+	g.pf("        // still needs the arm because tag constants are never exhaustive\n")
+	g.pf("        _ => Err(Error::Validation),\n")
+	g.pf("    }\n}\n\n")
+
+	// read_message keeps its original by-value body rather than delegating to
+	// read_message_into: routing the return through a &mut out-param defeated
+	// LLVM's in-place construction of the returned union and cost the batch
+	// read 23% (measured M2, 2026-08-06) — each arm constructing directly
+	// into the return slot is what keeps the by-value surface cheap
+	g.pf("#[inline]\n")
 	g.pf("pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {\n")
 	g.pf("    let mut tag_value = MessageType::NONE;\n")
 	g.pf("    read_message_type(stream, &mut tag_value)?;\n")

--- a/internal/codegen/rust/objects.go
+++ b/internal/codegen/rust/objects.go
@@ -22,11 +22,13 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	g.pf("pub const %s: u64 = %d;\n", ir.RustConstName(deepName+"MaxBits"), deepBits)
 	g.pf("pub const %s: usize = %d; // rounded up to the 8-byte write-buffer granularity\n\n", ir.RustConstName(deepName+"MaxBytes"), ir.MaxBytes(deepBits))
 
+	g.pf("#[inline]\n")
 	g.pf("pub fn write_%s(stream: &mut WriteStream<'_>, value: &%s) -> Result {\n", deepSnake, deepName)
 	for _, f := range deep {
 		g.emitViewWriteField(f, ir.ViewDeep, "    ")
 	}
 	g.pf("    Ok(())\n}\n\n")
+	g.pf("#[inline]\n")
 	g.pf("pub fn read_%s(stream: &mut ReadStream<'_>, value: &mut %s) -> Result {\n", deepSnake, deepName)
 	for _, f := range deep {
 		g.emitViewReadField(f, ir.ViewDeep, "    ")
@@ -39,11 +41,13 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	g.pf("pub const %s: u64 = %d;\n", ir.RustConstName(shName+"MaxBits"), shBits)
 	g.pf("pub const %s: usize = %d; // rounded up to the 8-byte write-buffer granularity\n\n", ir.RustConstName(shName+"MaxBytes"), ir.MaxBytes(shBits))
 
+	g.pf("#[inline]\n")
 	g.pf("pub fn write_%s(stream: &mut WriteStream<'_>, value: &%s) -> Result {\n", shSnake, shName)
 	for _, f := range interp {
 		g.emitViewWriteField(f, ir.ViewShallow, "    ")
 	}
 	g.pf("    Ok(())\n}\n\n")
+	g.pf("#[inline]\n")
 	g.pf("pub fn read_%s(stream: &mut ReadStream<'_>, value: &mut %s) -> Result {\n", shSnake, shName)
 	for _, f := range interp {
 		g.emitViewReadField(f, ir.ViewShallow, "    ")
@@ -213,10 +217,12 @@ func (g *gen) emitObjectTagFunctions() {
 	count := int64(len(g.unit.ObjNames))
 	g.pf("// The object tag wire: ObjectType in [0, %d], minimal bits; None = 0 is the\n", count)
 	g.pf("// null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).\n")
+	g.pf("#[inline]\n")
 	g.pf("pub fn write_object_type(stream: &mut WriteStream<'_>, value: ObjectType) -> Result {\n")
 	g.pf("    let mut tag_value = value.0 as i32;\n")
 	g.pf("    stream.serialize_int(&mut tag_value, 0, %d)?;\n", count)
 	g.pf("    Ok(())\n}\n\n")
+	g.pf("#[inline]\n")
 	g.pf("pub fn read_object_type(stream: &mut ReadStream<'_>, value: &mut ObjectType) -> Result {\n")
 	g.pf("    let mut tag_value: i32 = 0;\n")
 	g.pf("    stream.serialize_int(&mut tag_value, 0, %d)?;\n", count)

--- a/testdata/golden/rust/messages.rs
+++ b/testdata/golden/rust/messages.rs
@@ -35,11 +35,13 @@ impl Default for Heartbeat {
 pub const HEARTBEAT_MAX_BITS: u64 = 0;
 pub const HEARTBEAT_MAX_BYTES: usize = 0;
 
+#[inline]
 pub fn write_heartbeat(stream: &mut WriteStream<'_>, value: &Heartbeat) -> Result {
     let _ = (stream, value); // empty body — presence is the payload (SPEC §4.6)
     Ok(())
 }
 
+#[inline]
 pub fn read_heartbeat(stream: &mut ReadStream<'_>, value: &mut Heartbeat) -> Result {
     let _ = (stream, value);
     Ok(())
@@ -71,6 +73,7 @@ impl Default for Test {
 pub const TEST_MAX_BITS: u64 = 46;
 pub const TEST_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
     {
         let mut raw_value = value.test_a as u32;
@@ -100,6 +103,7 @@ pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_test(stream: &mut ReadStream<'_>, value: &mut Test) -> Result {
     {
         let mut raw_value: u32 = 0;
@@ -146,6 +150,7 @@ impl Default for Block {
 pub const BLOCK_MAX_BITS: u64 = 16018;
 pub const BLOCK_MAX_BYTES: usize = 2008;
 
+#[inline]
 pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
     if value.data_length < 0 || value.data_length > 2000 { // refused, not wrapped or panicked: guards the slice too
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -162,6 +167,7 @@ pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_block(stream: &mut ReadStream<'_>, value: &mut Block) -> Result {
     stream.serialize_int(&mut value.data_length, 0, MAX_BLOCK_SIZE as i32)?; // the length guards the slice (§6.3)
     stream.serialize_bytes(&mut value.data[..value.data_length as usize])?;
@@ -190,6 +196,7 @@ impl Default for Chat {
 pub const CHAT_MAX_BITS: u64 = 2064;
 pub const CHAT_MAX_BYTES: usize = 264;
 
+#[inline]
 pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
     if value.text_length < 0 || value.text_length > 256 { // refused, not wrapped or panicked: guards the slice too
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -206,6 +213,7 @@ pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_chat(stream: &mut ReadStream<'_>, value: &mut Chat) -> Result {
     stream.serialize_int(&mut value.text_length, 0, MAX_CHAT_LENGTH as i32)?; // the length guards the slice (§6.3)
     stream.serialize_bytes(&mut value.text[..value.text_length as usize])?;
@@ -239,6 +247,7 @@ impl Default for Synchronize {
 pub const SYNCHRONIZE_MAX_BITS: u64 = 80;
 pub const SYNCHRONIZE_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_synchronize(stream: &mut WriteStream<'_>, value: &Synchronize) -> Result {
     {
         let mut raw_value = value.sync_frame;
@@ -251,6 +260,7 @@ pub fn write_synchronize(stream: &mut WriteStream<'_>, value: &Synchronize) -> R
     Ok(())
 }
 
+#[inline]
 pub fn read_synchronize(stream: &mut ReadStream<'_>, value: &mut Synchronize) -> Result {
     stream.serialize_bits64(&mut value.sync_frame, 64)?;
     {
@@ -285,6 +295,7 @@ impl Default for Timescale {
 pub const TIMESCALE_MAX_BITS: u64 = 128;
 pub const TIMESCALE_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_timescale(stream: &mut WriteStream<'_>, value: &Timescale) -> Result {
     {
         let mut float_value = value.scale;
@@ -301,6 +312,7 @@ pub fn write_timescale(stream: &mut WriteStream<'_>, value: &Timescale) -> Resul
     Ok(())
 }
 
+#[inline]
 pub fn read_timescale(stream: &mut ReadStream<'_>, value: &mut Timescale) -> Result {
     stream.serialize_f64(&mut value.scale)?;
     stream.serialize_bits(&mut value.frame_a, 32)?;
@@ -310,12 +322,14 @@ pub fn read_timescale(stream: &mut ReadStream<'_>, value: &mut Timescale) -> Res
 
 // The message tag wire: MessageType in [0, 6], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
+#[inline]
 pub fn write_message_type(stream: &mut WriteStream<'_>, value: MessageType) -> Result {
     let mut tag_value = value.0 as i32;
     stream.serialize_int(&mut tag_value, 0, 6)?;
     Ok(())
 }
 
+#[inline]
 pub fn read_message_type(stream: &mut ReadStream<'_>, value: &mut MessageType) -> Result {
     let mut tag_value: i32 = 0;
     stream.serialize_int(&mut tag_value, 0, 6)?;
@@ -344,6 +358,7 @@ pub enum Message {
     Timescale(Timescale),
 }
 
+#[inline]
 pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result {
     match message {
         Message::None => write_message_type(stream, MessageType::NONE), // the stream terminator (SPEC §4.8)
@@ -374,6 +389,68 @@ pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result 
     }
 }
 
+// read_message_into decodes the next message into caller-owned storage: the
+// variant is reset to its zero form (SPEC §5), then its fields decode in
+// place — no per-message copy of the union out of the call. On error the
+// storage holds the partially decoded zero form: discard it.
+#[inline]
+pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {
+    let mut tag_value = MessageType::NONE;
+    read_message_type(stream, &mut tag_value)?;
+    match tag_value {
+        MessageType::NONE => {
+            *message = Message::None; // the stream terminator (SPEC §4.8)
+            Ok(())
+        }
+        MessageType::BLOCK => {
+            *message = Message::Block(Block::default()); // reused storage starts from the zero form, as the union does
+            let Message::Block(value) = message else {
+                unreachable!()
+            };
+            read_block(stream, value)
+        }
+        MessageType::CHAT => {
+            *message = Message::Chat(Chat::default()); // reused storage starts from the zero form, as the union does
+            let Message::Chat(value) = message else {
+                unreachable!()
+            };
+            read_chat(stream, value)
+        }
+        MessageType::HEARTBEAT => {
+            *message = Message::Heartbeat(Heartbeat::default()); // reused storage starts from the zero form, as the union does
+            let Message::Heartbeat(value) = message else {
+                unreachable!()
+            };
+            read_heartbeat(stream, value)
+        }
+        MessageType::SYNCHRONIZE => {
+            *message = Message::Synchronize(Synchronize::default()); // reused storage starts from the zero form, as the union does
+            let Message::Synchronize(value) = message else {
+                unreachable!()
+            };
+            read_synchronize(stream, value)
+        }
+        MessageType::TEST => {
+            *message = Message::Test(Test::default()); // reused storage starts from the zero form, as the union does
+            let Message::Test(value) = message else {
+                unreachable!()
+            };
+            read_test(stream, value)
+        }
+        MessageType::TIMESCALE => {
+            *message = Message::Timescale(Timescale::default()); // reused storage starts from the zero form, as the union does
+            let Message::Timescale(value) = message else {
+                unreachable!()
+            };
+            read_timescale(stream, value)
+        }
+        // read_message_type already rejected tags past the set; the match
+        // still needs the arm because tag constants are never exhaustive
+        _ => Err(Error::Validation),
+    }
+}
+
+#[inline]
 pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {
     let mut tag_value = MessageType::NONE;
     read_message_type(stream, &mut tag_value)?;

--- a/testdata/golden/rust/objects.rs
+++ b/testdata/golden/rust/objects.rs
@@ -313,6 +313,7 @@ impl Default for ShipData_Interpolate {
 pub const SHIP_DATA_DEEP_MAX_BITS: u64 = 1703;
 pub const SHIP_DATA_DEEP_MAX_BYTES: usize = 216; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_ship_data_deep(stream: &mut WriteStream<'_>, value: &ShipData_Deep) -> Result {
     if value.ship_type.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -412,6 +413,7 @@ pub fn write_ship_data_deep(stream: &mut WriteStream<'_>, value: &ShipData_Deep)
     Ok(())
 }
 
+#[inline]
 pub fn read_ship_data_deep(stream: &mut ReadStream<'_>, value: &mut ShipData_Deep) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -464,6 +466,7 @@ pub fn read_ship_data_deep(stream: &mut ReadStream<'_>, value: &mut ShipData_Dee
 pub const SHIP_DATA_SHALLOW_MAX_BITS: u64 = 218;
 pub const SHIP_DATA_SHALLOW_MAX_BYTES: usize = 32; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_ship_data_shallow(stream: &mut WriteStream<'_>, value: &ShipData_Shallow) -> Result {
     if value.ship_type.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -538,6 +541,7 @@ pub fn write_ship_data_shallow(stream: &mut WriteStream<'_>, value: &ShipData_Sh
     Ok(())
 }
 
+#[inline]
 pub fn read_ship_data_shallow(stream: &mut ReadStream<'_>, value: &mut ShipData_Shallow) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -895,6 +899,7 @@ impl Default for MissileData_Interpolate {
 pub const MISSILE_DATA_DEEP_MAX_BITS: u64 = 708;
 pub const MISSILE_DATA_DEEP_MAX_BYTES: usize = 96; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_missile_data_deep(stream: &mut WriteStream<'_>, value: &MissileData_Deep) -> Result {
     if value.missile_type.0 > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -920,6 +925,7 @@ pub fn write_missile_data_deep(stream: &mut WriteStream<'_>, value: &MissileData
     Ok(())
 }
 
+#[inline]
 pub fn read_missile_data_deep(stream: &mut ReadStream<'_>, value: &mut MissileData_Deep) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -941,6 +947,7 @@ pub fn read_missile_data_deep(stream: &mut ReadStream<'_>, value: &mut MissileDa
 pub const MISSILE_DATA_SHALLOW_MAX_BITS: u64 = 260;
 pub const MISSILE_DATA_SHALLOW_MAX_BYTES: usize = 40; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_missile_data_shallow(stream: &mut WriteStream<'_>, value: &MissileData_Shallow) -> Result {
     if value.missile_type.0 > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -1003,6 +1010,7 @@ pub fn write_missile_data_shallow(stream: &mut WriteStream<'_>, value: &MissileD
     Ok(())
 }
 
+#[inline]
 pub fn read_missile_data_shallow(stream: &mut ReadStream<'_>, value: &mut MissileData_Shallow) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -1307,6 +1315,7 @@ impl Default for DynamicPropData_Interpolate {
 pub const DYNAMIC_PROP_DATA_DEEP_MAX_BITS: u64 = 709;
 pub const DYNAMIC_PROP_DATA_DEEP_MAX_BYTES: usize = 96; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_dynamic_prop_data_deep(stream: &mut WriteStream<'_>, value: &DynamicPropData_Deep) -> Result {
     if value.prop_type.0 > 6 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -1332,6 +1341,7 @@ pub fn write_dynamic_prop_data_deep(stream: &mut WriteStream<'_>, value: &Dynami
     Ok(())
 }
 
+#[inline]
 pub fn read_dynamic_prop_data_deep(stream: &mut ReadStream<'_>, value: &mut DynamicPropData_Deep) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -1353,6 +1363,7 @@ pub fn read_dynamic_prop_data_deep(stream: &mut ReadStream<'_>, value: &mut Dyna
 pub const DYNAMIC_PROP_DATA_SHALLOW_MAX_BITS: u64 = 261;
 pub const DYNAMIC_PROP_DATA_SHALLOW_MAX_BYTES: usize = 40; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_dynamic_prop_data_shallow(stream: &mut WriteStream<'_>, value: &DynamicPropData_Shallow) -> Result {
     if value.prop_type.0 > 6 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -1415,6 +1426,7 @@ pub fn write_dynamic_prop_data_shallow(stream: &mut WriteStream<'_>, value: &Dyn
     Ok(())
 }
 
+#[inline]
 pub fn read_dynamic_prop_data_shallow(stream: &mut ReadStream<'_>, value: &mut DynamicPropData_Shallow) -> Result {
     {
         let mut enum_value: i32 = 0;
@@ -1693,6 +1705,7 @@ impl Default for TurretData_Interpolate {
 pub const TURRET_DATA_DEEP_MAX_BITS: u64 = 350;
 pub const TURRET_DATA_DEEP_MAX_BYTES: usize = 48; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_turret_data_deep(stream: &mut WriteStream<'_>, value: &TurretData_Deep) -> Result {
     write_handle(stream, &value.parent)?;
     if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
@@ -1710,6 +1723,7 @@ pub fn write_turret_data_deep(stream: &mut WriteStream<'_>, value: &TurretData_D
     Ok(())
 }
 
+#[inline]
 pub fn read_turret_data_deep(stream: &mut ReadStream<'_>, value: &mut TurretData_Deep) -> Result {
     read_handle(stream, &mut value.parent)?;
     stream.serialize_int(&mut value.turret_index, 0, (MAX_TURRETS_PER_SHIP - 1) as i32)?;
@@ -1721,6 +1735,7 @@ pub fn read_turret_data_deep(stream: &mut ReadStream<'_>, value: &mut TurretData
 pub const TURRET_DATA_SHALLOW_MAX_BITS: u64 = 142;
 pub const TURRET_DATA_SHALLOW_MAX_BYTES: usize = 24; // rounded up to the 8-byte write-buffer granularity
 
+#[inline]
 pub fn write_turret_data_shallow(stream: &mut WriteStream<'_>, value: &TurretData_Shallow) -> Result {
     write_handle(stream, &value.parent)?;
     if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
@@ -1753,6 +1768,7 @@ pub fn write_turret_data_shallow(stream: &mut WriteStream<'_>, value: &TurretDat
     Ok(())
 }
 
+#[inline]
 pub fn read_turret_data_shallow(stream: &mut ReadStream<'_>, value: &mut TurretData_Shallow) -> Result {
     read_handle(stream, &mut value.parent)?;
     stream.serialize_int(&mut value.turret_index, 0, (MAX_TURRETS_PER_SHIP - 1) as i32)?;
@@ -1842,12 +1858,14 @@ pub fn unquantize_turret(input: &TurretData_Shallow, output: &mut TurretData_Int
 
 // The object tag wire: ObjectType in [0, 4], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
+#[inline]
 pub fn write_object_type(stream: &mut WriteStream<'_>, value: ObjectType) -> Result {
     let mut tag_value = value.0 as i32;
     stream.serialize_int(&mut tag_value, 0, 4)?;
     Ok(())
 }
 
+#[inline]
 pub fn read_object_type(stream: &mut ReadStream<'_>, value: &mut ObjectType) -> Result {
     let mut tag_value: i32 = 0;
     stream.serialize_int(&mut tag_value, 0, 4)?;

--- a/testdata/golden/rust/types.rs
+++ b/testdata/golden/rust/types.rs
@@ -29,6 +29,7 @@ impl Default for Vec3 {
 pub const VEC3_MAX_BITS: u64 = 192;
 pub const VEC3_MAX_BYTES: usize = 24;
 
+#[inline]
 pub fn write_vec3(stream: &mut WriteStream<'_>, value: &Vec3) -> Result {
     {
         let mut float_value = value.x;
@@ -45,6 +46,7 @@ pub fn write_vec3(stream: &mut WriteStream<'_>, value: &Vec3) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_vec3(stream: &mut ReadStream<'_>, value: &mut Vec3) -> Result {
     stream.serialize_f64(&mut value.x)?;
     stream.serialize_f64(&mut value.y)?;
@@ -79,6 +81,7 @@ impl Default for Quat {
 pub const QUAT_MAX_BITS: u64 = 256;
 pub const QUAT_MAX_BYTES: usize = 32;
 
+#[inline]
 pub fn write_quat(stream: &mut WriteStream<'_>, value: &Quat) -> Result {
     {
         let mut float_value = value.x;
@@ -99,6 +102,7 @@ pub fn write_quat(stream: &mut WriteStream<'_>, value: &Quat) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_quat(stream: &mut ReadStream<'_>, value: &mut Quat) -> Result {
     stream.serialize_f64(&mut value.x)?;
     stream.serialize_f64(&mut value.y)?;
@@ -129,6 +133,7 @@ impl Default for Handle {
 pub const HANDLE_MAX_BITS: u64 = 22;
 pub const HANDLE_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
     if value.object_id < 0 || value.object_id > 9999 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -144,6 +149,7 @@ pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_handle(stream: &mut ReadStream<'_>, value: &mut Handle) -> Result {
     stream.serialize_int(&mut value.object_id, 0, (MAX_OBJECTS - 1) as i32)?;
     {
@@ -178,6 +184,7 @@ impl Default for QuantizedPosition {
 pub const QUANTIZED_POSITION_MAX_BITS: u64 = 75;
 pub const QUANTIZED_POSITION_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedPosition) -> Result {
     if value.x < -8388608 || value.x > 8388608 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -203,6 +210,7 @@ pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedP
     Ok(())
 }
 
+#[inline]
 pub fn read_quantized_position(stream: &mut ReadStream<'_>, value: &mut QuantizedPosition) -> Result {
     stream.serialize_int(&mut value.x, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
     stream.serialize_int(&mut value.y, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
@@ -234,6 +242,7 @@ impl Default for QuantizedVelocity {
 pub const QUANTIZED_VELOCITY_MAX_BITS: u64 = 69;
 pub const QUANTIZED_VELOCITY_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedVelocity) -> Result {
     if value.x < -2097152 || value.x > 2097152 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -259,6 +268,7 @@ pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedV
     Ok(())
 }
 
+#[inline]
 pub fn read_quantized_velocity(stream: &mut ReadStream<'_>, value: &mut QuantizedVelocity) -> Result {
     stream.serialize_int(&mut value.x, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
     stream.serialize_int(&mut value.y, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
@@ -292,6 +302,7 @@ impl Default for QuantizedRotation {
 pub const QUANTIZED_ROTATION_MAX_BITS: u64 = 48;
 pub const QUANTIZED_ROTATION_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedRotation) -> Result {
     if value.x < -1024 || value.x > 1024 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -324,6 +335,7 @@ pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedR
     Ok(())
 }
 
+#[inline]
 pub fn read_quantized_rotation(stream: &mut ReadStream<'_>, value: &mut QuantizedRotation) -> Result {
     {
         let mut range_value: i32 = 0;
@@ -379,6 +391,7 @@ impl Default for RigidBody {
 pub const RIGID_BODY_MAX_BITS: u64 = 833;
 pub const RIGID_BODY_MAX_BYTES: usize = 112;
 
+#[inline]
 pub fn write_rigid_body(stream: &mut WriteStream<'_>, value: &RigidBody) -> Result {
     write_vec3(stream, &value.position)?;
     write_quat(stream, &value.orientation)?;
@@ -393,6 +406,7 @@ pub fn write_rigid_body(stream: &mut WriteStream<'_>, value: &RigidBody) -> Resu
     Ok(())
 }
 
+#[inline]
 pub fn read_rigid_body(stream: &mut ReadStream<'_>, value: &mut RigidBody) -> Result {
     read_vec3(stream, &mut value.position)?;
     read_quat(stream, &mut value.orientation)?;
@@ -451,6 +465,7 @@ impl Default for Input {
 pub const INPUT_MAX_BITS: u64 = 168;
 pub const INPUT_MAX_BYTES: usize = 24;
 
+#[inline]
 pub fn write_input(stream: &mut WriteStream<'_>, value: &Input) -> Result {
     {
         let mut float_value = value.stick_x;
@@ -507,6 +522,7 @@ pub fn write_input(stream: &mut WriteStream<'_>, value: &Input) -> Result {
     Ok(())
 }
 
+#[inline]
 pub fn read_input(stream: &mut ReadStream<'_>, value: &mut Input) -> Result {
     stream.serialize_f32(&mut value.stick_x)?;
     stream.serialize_f32(&mut value.stick_y)?;
@@ -552,6 +568,7 @@ impl Default for InputPacket {
 pub const INPUT_PACKET_MAX_BITS: u64 = 2837;
 pub const INPUT_PACKET_MAX_BYTES: usize = 360;
 
+#[inline]
 pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> Result {
     {
         let mut raw_value = value.synchronize_sequence as u32;
@@ -578,6 +595,7 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_input_packet(stream: &mut ReadStream<'_>, value: &mut InputPacket) -> Result {
     {
         let mut raw_value: u32 = 0;
@@ -633,6 +651,7 @@ impl Default for ShipCreate {
 pub const SHIP_CREATE_MAX_BITS: u64 = 219;
 pub const SHIP_CREATE_MAX_BYTES: usize = 32;
 
+#[inline]
 pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Result {
     if value.ship_type.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -682,6 +701,7 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
     Ok(())
 }
 
+#[inline]
 pub fn read_ship_create(stream: &mut ReadStream<'_>, value: &mut ShipCreate) -> Result {
     {
         let mut enum_value: i32 = 0;

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -53,6 +53,7 @@ impl Default for ProbeHeader {
 pub const PROBE_HEADER_MAX_BITS: u64 = 87;
 pub const PROBE_HEADER_MAX_BYTES: usize = 16;
 
+#[inline]
 pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> Result {
     {
         let mut const_value: u32 = 171;
@@ -77,6 +78,7 @@ pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_header(stream: &mut ReadStream<'_>, value: &mut ProbeHeader) -> Result {
     {
         let mut const_value: u32 = 0;
@@ -128,6 +130,7 @@ impl Default for ProbeBits {
 pub const PROBE_BITS_MAX_BITS: u64 = 202;
 pub const PROBE_BITS_MAX_BYTES: usize = 32;
 
+#[inline]
 pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Result {
     if value.small >= 1 << 9 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -158,6 +161,7 @@ pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Resu
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_bits(stream: &mut ReadStream<'_>, value: &mut ProbeBits) -> Result {
     stream.serialize_bits(&mut value.small, 9)?;
     stream.serialize_bits64(&mut value.boundary, 33)?;
@@ -234,6 +238,7 @@ impl ProbeSample {
 pub const PROBE_SAMPLE_MAX_BITS: u64 = 276;
 pub const PROBE_SAMPLE_MAX_BYTES: usize = 40;
 
+#[inline]
 pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> Result {
     {
         let mut bool_value = value.active;
@@ -291,6 +296,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_sample(stream: &mut ReadStream<'_>, value: &mut ProbeSample) -> Result {
     stream.serialize_bool(&mut value.active)?;
     stream.serialize_compressed_float(&mut value.orientation, -180.0_f32, 180.0_f32, 0.01_f32)?;
@@ -372,6 +378,7 @@ impl ProbeConfig {
 pub const PROBE_CONFIG_MAX_BITS: u64 = 36;
 pub const PROBE_CONFIG_MAX_BYTES: usize = 8;
 
+#[inline]
 pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> Result {
     {
         let mut raw_value = value.retries as u32;
@@ -387,6 +394,7 @@ pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_config(stream: &mut ReadStream<'_>, value: &mut ProbeConfig) -> Result {
     {
         let mut raw_value: u32 = 0;
@@ -437,6 +445,7 @@ impl ProbeArray {
 pub const PROBE_ARRAY_MAX_BITS: u64 = 588;
 pub const PROBE_ARRAY_MAX_BYTES: usize = 80;
 
+#[inline]
 pub fn write_probe_array(stream: &mut WriteStream<'_>, value: &ProbeArray) -> Result {
     for i in 0..2 {
         write_probe_sample(stream, &value.samples[i])?;
@@ -445,6 +454,7 @@ pub fn write_probe_array(stream: &mut WriteStream<'_>, value: &ProbeArray) -> Re
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_array(stream: &mut ReadStream<'_>, value: &mut ProbeArray) -> Result {
     for i in 0..2 {
         read_probe_sample(stream, &mut value.samples[i])?;
@@ -477,6 +487,7 @@ impl Default for ProbeReport {
 pub const PROBE_REPORT_MAX_BITS: u64 = 141;
 pub const PROBE_REPORT_MAX_BYTES: usize = 24;
 
+#[inline]
 pub fn write_probe_report(stream: &mut WriteStream<'_>, value: &ProbeReport) -> Result {
     write_probe_header(stream, &value.header)?;
     if value.flags >= 1 << 8 {
@@ -491,6 +502,7 @@ pub fn write_probe_report(stream: &mut WriteStream<'_>, value: &ProbeReport) -> 
     Ok(())
 }
 
+#[inline]
 pub fn read_probe_report(stream: &mut ReadStream<'_>, value: &mut ProbeReport) -> Result {
     read_probe_header(stream, &mut value.header)?;
     {
@@ -566,6 +578,7 @@ impl Default for TestData {
 pub const TEST_DATA_MAX_BITS: u64 = 2735;
 pub const TEST_DATA_MAX_BYTES: usize = 344;
 
+#[inline]
 pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result {
     if value.a < -100 || value.a > 100 { // out-of-contract writes are refused, not wrapped
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -698,6 +711,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     Ok(())
 }
 
+#[inline]
 pub fn read_test_data(stream: &mut ReadStream<'_>, value: &mut TestData) -> Result {
     stream.serialize_int(&mut value.a, -100, 100)?;
     stream.serialize_int(&mut value.b, -100, 100)?;


### PR DESCRIPTION
# Rust emitter: `#[inline]` on every wire function + `read_message_into`

## The conviction

Today's four-language bench (`bench-harness` @ 2568056,
`bench/results/2026-08-06-four-language.md`, finding 1) measured fixed
per-message overhead dominating 6-10 byte messages in the Rust target
(M2 probe_header write 0.16x C++). `perf` on the EPYC (taskset -c 0, rust
runner with debug symbols):

- the generated wire functions are **standalone symbols** — `read_test`
  5.5%, `read_probe_header` 3.7%, `write_test` 1.8%, `write_probe_header`
  1.3% self time — cross-crate calls the caller cannot inline (no hint, no
  LTO), which also forfeits constant folding of the bit widths;
- a visible `__memmove` (3.7% of all samples, inside the batch read loop)
  from `read_message` returning the ~2 KB `Message` union by value — the
  bench doc's finding 3, confirmed at the instruction level.

## The change (rust emitter only; wire bytes untouched)

1. **`#[inline]` on every generated wire function** — write_*/read_* for
   types, messages, object views, the tag pair, and the dispatch pair. The
   generated crate is a separate compilation unit from the game's; the hint
   is what lets a small message serialize inline into the caller and fold
   its constant bit widths.
2. **`read_message_into(stream, &mut Message) -> Result` — additive** — the
   read-into dispatch surface: resets the tagged variant to its zero form
   (SPEC §5), then decodes the fields in place; no per-message copy-out of
   the union. The Go/C# `MessageStorage` discipline in Rust shape (C#'s
   ReadMessage zeroes its storage member the same way).
   `read_message` keeps its **original by-value body unchanged** — a first
   cut had it delegate to the into-surface, which defeated LLVM's in-place
   construction of the returned union and cost the batch read 23% on the M2;
   refused, and recorded here so nobody re-tries it casually.

Source goldens re-pinned (deliberate emitter change; the source-golden step
of `make update-goldens` only). **Wire goldens untouched**:
`testdata/wire/*.bin` unchanged on this branch, and every gate byte-compares
against them.

## Measured (schema bench harness, paired same-sitting runs, median-of-7)

Apple M2 (quiet), rust rows, M msg/s: A = serialize.rs/main + main emitter,
B = serialize.rs#19 alone, C = serialize.rs#19 + this branch:

| bench | path | A | B | C | C/A | C vs B |
|---|---|---:|---:|---:|---:|---:|
| chat | write | 34.97 | 37.84 | 57.91 | **1.66x** | 1.53x |
| shipcreate | write | 38.42 | 47.46 | 65.77 | **1.71x** | 1.39x |
| shipcreate | read | 41.82 | 43.64 | 55.07 | **1.32x** | 1.26x |
| inputpacket | write | 18.98 | 35.85 | 40.08 | **2.11x** | 1.12x |
| probearray | read | 31.57 | 38.32 | 68.10 | **2.16x** | 1.78x |
| probe_header (10 B) | write | 165.80 | 184.06 | 195.82 | 1.18x | 1.06x |
| message_batch | read | 20.22 | 20.63 | 22.28 | 1.10x | 1.08x |

Nothing regressed (full tables in the bench results CSVs,
`2026-08-06-tiny-{A-before,B-runtime,C2-emit}-m2.csv` on the harness host).

**The read-into surface, measured directly** (the committed harness still
reads through `read_message`; this is a local, uncommitted one-line loop
swap to `read_message_into` into one reused `Message`, run beside state C):

- M2: message_batch read 22.28 → **58.57 M msg/s (2.6x)** — faster than
  every language's batch read in this morning's table (best was C# 39.37)
- EPYC: 18.44 → **39.34 M msg/s (2.1x)**, 0.8% spread

Refutation recorded plainly: the banked prediction had the *6-10 B* rows
recovering most of the C++ gap on the M2 — they did not (probe_header write
lands at 0.19x the same-run C++; apple-clang's whole-program folding of the
C++ header remains unmatched, and serialize.rs's bounds-checked,
`unsafe_code = "forbid"` write path is a deliberate boundary this pass does
not cross). The wins landed on the 13-105 B rows (1.3-2.2x) and the
dispatch read surface (2.1-2.6x). On the EPYC the game server made core 0
incomparably noisier across runs tonight (a control language with zero
changes moved 2-3x between runs), so the EPYC contribution here is the
profile conviction and the same-run side experiment, not cross-run pairing.

## Verification (all run locally — GitHub Actions is in a major outage today)

- `make test` — full chain green, twice: schema_test + variant + random
  (C++ wire goldens byte-compared), `test/go`, `test/rust`, `test/cs`
  corpus gates OK, `go test ./...` ok — run with the sibling runtimes on
  **main** and again on the **optimize-tiny** branches (both combinations)
- `gofmt` clean on the emitter changes

## Relations

- Measured together with, but independent of (no stacking):
  mas-bandwidth/serialize.rs#19 (Stream trait `#[inline]`) and
  mas-bandwidth/serialize.cs#2 (the C# twin).
- Branched from `main` (960bdd0). The measuring harness is the open
  `bench-harness` branch, unchanged. The open `optimize-read-zeroing` and
  `fixed-uint128` branches touch the same emitter — whichever lands second
  rebases (this diff is `#[inline]` lines + one added function in the
  message-tag emitter; conflicts will be trivial).
