### PR TITLE
Rust emitter: the write path borrows fixed arrays in place - no whole-array copy

### DIFF
--- a/generated/rust/src/messages.rs
+++ b/generated/rust/src/messages.rs
@@ -159,11 +159,7 @@ pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
         let mut length_value = value.data_length;
         stream.serialize_int(&mut length_value, 0, MAX_BLOCK_SIZE as i32)?; // the length guards the slice (§6.3)
     }
-    {
-        // arrays are Copy: a mutable local because serialize_bytes takes &mut even on write
-        let mut bytes_value = value.data;
-        stream.serialize_bytes(&mut bytes_value[..value.data_length as usize])?;
-    }
+    stream.write_bytes(&value.data[..value.data_length as usize])?; // borrowed in place: the write side never mutates
     Ok(())
 }
 
@@ -205,11 +201,7 @@ pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
         let mut length_value = value.text_length;
         stream.serialize_int(&mut length_value, 0, MAX_CHAT_LENGTH as i32)?; // the length guards the slice (§6.3)
     }
-    {
-        // arrays are Copy: a mutable local because serialize_bytes takes &mut even on write
-        let mut bytes_value = value.text;
-        stream.serialize_bytes(&mut bytes_value[..value.text_length as usize])?;
-    }
+    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
     Ok(())
 }
 

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -703,11 +703,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut length_value = value.text_length;
         stream.serialize_int(&mut length_value, 0, 255)?; // the length guards the slice (§6.3)
     }
-    {
-        // arrays are Copy: a mutable local because serialize_bytes takes &mut even on write
-        let mut bytes_value = value.text;
-        stream.serialize_bytes(&mut bytes_value[..value.text_length as usize])?;
-    }
+    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
     Ok(())
 }
 

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -372,9 +372,11 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		g.pf("%s    stream.serialize_int(&mut length_value, 0, %s)?; // the length guards the slice (§6.3)\n",
 			ind, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "i32"))
 		g.pf("%s}\n", ind)
-		g.pf("%s{\n%s    // arrays are Copy: a mutable local because serialize_bytes takes &mut even on write\n", ind, ind)
-		g.pf("%s    let mut bytes_value = %s;\n", ind, name)
-		g.pf("%s    stream.serialize_bytes(&mut bytes_value[..%s_length as usize])?;\n%s}\n", ind, name, ind)
+		// the write side borrows the used bytes in place: WriteStream::write_bytes
+		// takes &[u8] (same wire as serialize_bytes — align, then the block copy),
+		// where the unified &mut signature forced a whole-array copy into a mutable
+		// local first — 256 B per chat, 2 KB per block, visible in perf (2026-08-06)
+		g.pf("%sstream.write_bytes(&%s[..%s_length as usize])?; // borrowed in place: the write side never mutates\n", ind, name, name)
 	case ir.TNamed:
 		switch ref := f.Type.Ref.(type) {
 		case *ir.Enum:

--- a/testdata/golden/rust/messages.rs
+++ b/testdata/golden/rust/messages.rs
@@ -159,11 +159,7 @@ pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
         let mut length_value = value.data_length;
         stream.serialize_int(&mut length_value, 0, MAX_BLOCK_SIZE as i32)?; // the length guards the slice (§6.3)
     }
-    {
-        // arrays are Copy: a mutable local because serialize_bytes takes &mut even on write
-        let mut bytes_value = value.data;
-        stream.serialize_bytes(&mut bytes_value[..value.data_length as usize])?;
-    }
+    stream.write_bytes(&value.data[..value.data_length as usize])?; // borrowed in place: the write side never mutates
     Ok(())
 }
 
@@ -205,11 +201,7 @@ pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
         let mut length_value = value.text_length;
         stream.serialize_int(&mut length_value, 0, MAX_CHAT_LENGTH as i32)?; // the length guards the slice (§6.3)
     }
-    {
-        // arrays are Copy: a mutable local because serialize_bytes takes &mut even on write
-        let mut bytes_value = value.text;
-        stream.serialize_bytes(&mut bytes_value[..value.text_length as usize])?;
-    }
+    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
     Ok(())
 }
 

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -703,11 +703,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut length_value = value.text_length;
         stream.serialize_int(&mut length_value, 0, 255)?; // the length guards the slice (§6.3)
     }
-    {
-        // arrays are Copy: a mutable local because serialize_bytes takes &mut even on write
-        let mut bytes_value = value.text;
-        stream.serialize_bytes(&mut bytes_value[..value.text_length as usize])?;
-    }
+    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
     Ok(())
 }
 


### PR DESCRIPTION
## The conviction

Today's tiny-message profiling flagged the generated Rust write path copying whole fixed arrays before slicing — 256 B per chat message, 2 KB per block, visible in perf. Reproduced here at the instruction level: in the bench binary built from main, `write_block` opens with `sub sp, sp, #0x7d0` (a 2000-byte stack frame) and calls `_memcpy` before ever reaching `BitWriter::write_bytes`. The generated shape was

```rust
// arrays are Copy: a mutable local because serialize_bytes takes &mut even on write
let mut bytes_value = value.data;
stream.serialize_bytes(&mut bytes_value[..value.data_length as usize])?;
```

— forced because the unified `Stream::serialize_bytes` signature takes `&mut [u8]` (the read side fills the slice in) while the write functions hold the message behind `&T`. Safe Rust cannot produce `&mut` from `&T` without the copy, and `unsafe_code = "forbid"` stands on both sides of the crate boundary.

## The fix

Two halves, one wire:

- **serialize.rs** ([mas-bandwidth/serialize.rs#20](https://github.com/mas-bandwidth/serialize.rs/pull/20), branch `optimize-write-bytes`): additive inherent `WriteStream::write_bytes(&mut self, &[u8]) -> Result` — the exact `serialize_bytes` write body (align, then block copy) minus the `&mut` demand. `cargo semver-checks --baseline-rev main`: 223 checks pass, no semver update required. **This PR path-depends on that branch.**
- **Emitter** (this PR): the `TString`/`TBytes` write case now emits
  ```rust
  stream.write_bytes(&value.data[..value.data_length as usize])?; // borrowed in place: the write side never mutates
  ```
  Three generated functions change: `write_block` (2000 B copy gone), `write_chat` (256 B), `write_test_data` (255 B). Read path untouched. After: `write_block`'s frame is 16 bytes and there is no memcpy call.

## Before/after, M2 (median-of-7 per run; three interleaved paired runs; golden gate green on every run)

| bench (write) | before (3 runs) | after (3 runs) | delta |
|---|---|---|---|
| chat | 39.67 / 38.93 / 37.80 M msg/s | 69.03 / 69.00 / 67.43 | **+74…+78%** |
| message_batch | 56.70 / 54.31 / 55.77 | 83.06 / 71.90 / 82.94 | **+32…+49%** (one noisy after-run, spread 13.9%) |
| testdata | 9.97 / 9.94 / 9.73 | 10.16 / 10.14 / 10.17 | +2…+4.5% |
| every other write row | — | — | within noise (±1.2% on run 2) |
| read rows | — | — | untouched code; within noise, except chat read below |

Predictions banked before any run, and their verdicts:

- chat write predicted +15–40% → **refuted upward**: +76% median. The copy cost more than the memcpy alone — it also carried the stack frame and its traffic.
- message_batch write predicted +10–30% → **refuted upward**: ~+47% (two of three runs; the third +32%).
- testdata write predicted +5–15% → **refuted downward**: ~+2%. The 255 B copy is amortized over a much larger many-field message than I credited.
- "everything else unchanged" held: run-1 dips of 3–4% on non-target rows vanished in run 2 (noise).

One honest wrinkle: **chat read** shows a consistent −3…−6% across pairs. `read_chat`'s instruction encodings are byte-identical between the two binaries (verified: every differing word is a `bl` relocation) — this is code-layout movement from the shrunken write functions, not a semantic change. Reads elsewhere (message_batch read ~−1%, testdata read ±0%) are within noise.

## Suite results (all local — GitHub Actions major outage today, no CI runs)

- `make SERIALIZE=../serialize test`: full chain green — C++ tests (both message representations + randomized round-trip), Go, Rust, C# wire tests, each byte-comparing the eleven C++-pinned wire goldens, plus `go test ./...`.
- Wire goldens **byte-identical**: `git diff -- testdata/wire/` is empty. Source goldens re-pinned deliberately (`go test ./internal/goldens -update`) — an emitter change, so the pins move with it.
- Bench harness self-checks (wire-golden gate + round-trip) passed on every bench run, before and after.

## Rebase relation to optimize-tiny-emit (#5)

Sibling branches, both cut from `main` @ 960bdd0 — neither contains the other. Overlap is real but shallow: both touch `internal/codegen/rust/functions.go` (different hunks: #5 adds `#[inline]` at function headers; this PR rewrites the `TString`/`TBytes` write case) and both re-pin `generated/rust/src/*` and `testdata/golden/rust/*`. Whichever lands second should rebase, **regenerate, and re-pin the source goldens rather than trust the textual merge** — the golden files are emitter output, not hand-merged text. Semantically independent: #[inline] hints and the borrow-in-place shape compose; no ordering preference.

Adjacent, untouched: the `[17]uint8` fixed-array element loop in `write_test_data`/`read_test_data` still serializes byte-at-a-time — that's `optimize-bulk-bytes` territory, and the new runtime `write_bytes` surface is reusable for its write half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
