### PR TITLE
C++ emitter: bulk-bytes path for statically byte-aligned [N]uint8 arrays

### DIFF
--- a/generated/cpp/Wire.h
+++ b/generated/cpp/Wire.h
@@ -390,10 +390,7 @@ inline bool WriteTestData( serialize::WriteStream & stream, const TestData & val
     write_bits( stream, value.int64_full, 64 );
     write_int64( stream, value.int64_range, -1000000000000, 1000000000000 );
     write_align( stream );
-    for ( int32_t i = 0; i < 17; i++ )
-    {
-        write_bits( stream, value.fixed_bytes[i], 8 );
-    }
+    write_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     for ( int32_t i = 0; i < value.text_length; i++ )
     {
         serialize_assert( value.text[i] != 0 );
@@ -449,14 +446,7 @@ inline bool ReadTestData( serialize::ReadStream & stream, TestData & value )
     }
     read_int64( stream, value.int64_range, -1000000000000, 1000000000000 );
     read_align( stream ); // rejects nonzero padding (SPEC §4.3)
-    for ( int32_t i = 0; i < 17; i++ )
-    {
-        {
-            uint32_t raw_value = 0;
-            read_bits( stream, raw_value, 8 );
-            value.fixed_bytes[i] = uint8_t( raw_value );
-        }
-    }
+    read_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     read_int( stream, value.text_length, 0, 255 );
     read_bytes( stream, value.text, value.text_length );
     for ( int32_t i = 0; i < value.text_length; i++ )

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -171,11 +171,12 @@ type gen struct {
 
 	body           strings.Builder
 	includes       map[string]bool
-	emitted        map[string]bool // consts of this file emitted so far (symbolic-reference safety)
-	needsSerialize bool            // the file emits wire functions -> include "serialize.h"
-	needsCstring   bool            // the file emits memset -> include <cstring>
-	needsCmath     bool            // the file emits floor() -> include <cmath>
-	needsVariant   bool            // the file emits the Message dispatch -> include <variant>
+	emitted        map[string]bool    // consts of this file emitted so far (symbolic-reference safety)
+	bulkBytes      map[*ir.Field]bool // fixed [N]uint8 arrays at statically byte-aligned positions (ir.AlignedFixedByteArrays)
+	needsSerialize bool               // the file emits wire functions -> include "serialize.h"
+	needsCstring   bool               // the file emits memset -> include <cstring>
+	needsCmath     bool               // the file emits floor() -> include <cmath>
+	needsVariant   bool               // the file emits the Message dispatch -> include <variant>
 }
 
 func (g *gen) pf(format string, args ...any) {

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -25,6 +25,11 @@ func (g *gen) maxBitsStruct(st *ir.Struct) int64 { return ir.MaxBitsStruct(st) }
 // for a type or message, in the topo order the struct itself was emitted.
 func (g *gen) emitStructFunctions(st *ir.Struct) {
 	g.needsSerialize = true
+	// fixed [N]uint8 arrays at statically byte-aligned positions take the
+	// runtime's bulk-bytes path instead of a per-byte loop — byte-identical
+	// wire (the internal align is zero bits when already aligned), measured
+	// ~2x on byte-array-heavy types
+	g.bulkBytes = ir.AlignedFixedByteArrays(st)
 	maxBits := g.maxBitsStruct(st)
 	g.pf("inline constexpr int64_t %sMaxBits = %d; // longest wire path; align pads at worst case (SPEC §6.1)\n", st.Name, maxBits)
 	g.pf("inline constexpr int64_t %sMaxBytes = %d; // rounded up to the 8-byte write-buffer granularity\n\n", st.Name, ir.MaxBytes(maxBits))
@@ -193,6 +198,13 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 	name := "value." + f.Name
 	if f.Array != ir.ArrayNone {
 		bound := g.renderInt(f.ArrayExpr, big.NewInt(f.ArrayBound))
+		if g.bulkBytes[f] {
+			// statically byte-aligned [N]uint8: the bulk path is
+			// byte-identical to the per-byte loop (its internal align is
+			// zero bits here) and memcpys instead of 8-bit packing
+			g.pf("%swrite_bytes( stream, %s, %s ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop\n", ind, name, bound)
+			return
+		}
 		if f.Array == ir.ArrayCounted {
 			g.pf("%swrite_int( stream, %s_count, %d, %s );\n", ind, name, f.ArrayMin, bound)
 			g.pf("%sfor ( int32_t i = 0; i < %s_count; i++ )\n%s{\n", ind, name, ind)
@@ -319,6 +331,10 @@ func (g *gen) emitReadField(f *ir.Field, ind string) {
 	name := "value." + f.Name
 	if f.Array != ir.ArrayNone {
 		bound := g.renderInt(f.ArrayExpr, big.NewInt(f.ArrayBound))
+		if g.bulkBytes[f] {
+			g.pf("%sread_bytes( stream, %s, %s ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop\n", ind, name, bound)
+			return
+		}
 		if f.Array == ir.ArrayCounted {
 			g.pf("%sread_int( stream, %s_count, %d, %s );\n", ind, name, f.ArrayMin, bound)
 			g.pf("%sfor ( int32_t i = 0; i < %s_count; i++ )\n%s{\n", ind, name, ind)

--- a/internal/ir/align_test.go
+++ b/internal/ir/align_test.go
@@ -1,0 +1,224 @@
+// Tests for the static byte-alignment analysis behind the bulk-bytes
+// emission path: a fixed [N]uint8 array is marked ONLY when its element
+// bytes provably begin on a byte boundary — anything else must keep the
+// per-byte loop, because the bulk path's internal align would put padding
+// bits on the wire that the pinned encoding does not have.
+package ir_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/internal/check"
+	"github.com/mas-bandwidth/schema/internal/ir"
+	"github.com/mas-bandwidth/schema/internal/parser"
+)
+
+// Each type carries one fixed byte array named data; the table below says
+// whether the analysis may mark it. Positions worked by hand from the SPEC
+// §4.3/§4.7 wire widths.
+const alignCorpus = `package aligntest
+
+type MarkedAfterAlign {
+    lead bits(3)
+    align
+    data [17]uint8
+}
+
+type UnmarkedAtEntry {
+    data [17]uint8
+}
+
+type MarkedAfterString {
+    s    string(31)
+    data [3]uint8
+}
+
+type MarkedAfterBytes {
+    b    bytes(64)
+    data [3]uint8
+}
+
+type UnmarkedOffBoundary {
+    align
+    flag bool
+    data [4]uint8
+}
+
+type MarkedWholeBytesBetween {
+    align
+    a    uint16
+    b    bits(24)
+    data [2]uint8
+}
+
+type UnmarkedRanged {
+    align
+    data [4]uint8 [min = 0, max = 255]
+}
+
+type UnmarkedCounted {
+    align
+    data [<= 8]uint8
+}
+
+type MarkedBranchAgree {
+    cond bool
+    align
+    if cond {
+        x bits(8)
+    } else {
+        y bits(8)
+    }
+    data [2]uint8
+}
+
+type UnmarkedBranchDisagree {
+    cond bool
+    align
+    if cond {
+        x bits(3)
+    }
+    data [2]uint8
+}
+
+type EndsAligned {
+    s string(15)
+}
+
+type EndsOffBoundary {
+    align
+    x bits(3)
+}
+
+type EndsUnknown {
+    x bits(3)
+}
+
+type MarkedAfterNestedAligned {
+    inner EndsAligned
+    data  [2]uint8
+}
+
+type UnmarkedAfterNestedOffBoundary {
+    inner EndsOffBoundary
+    data  [2]uint8
+}
+
+type UnmarkedAfterNestedUnknown {
+    align
+    inner EndsUnknown
+    data  [2]uint8
+}
+
+type UnmarkedAfterCountedPrefix {
+    align
+    counted [<= 3]uint16
+    data    [2]uint8
+}
+
+type MarkedAfterCountedBytePrefix {
+    align
+    counted [<= 255]uint16
+    data    [2]uint8
+}
+`
+
+// want: type name -> may the data field take the bulk path?
+var want = map[string]bool{
+	"MarkedAfterAlign":    true,  // align puts the elements on a boundary
+	"UnmarkedAtEntry":     false, // entry offset is unknown — a type may embed at any bit position
+	"MarkedAfterString":   true,  // string wire ends on a byte boundary (§4.7)
+	"MarkedAfterBytes":    true,  // same shape as string
+	"UnmarkedOffBoundary": false, // align + 1 bool bit = position 1 (mod 8)
+	// align + 16 + 24 bits keeps the boundary
+	"MarkedWholeBytesBetween": true,
+	// ranged elements go through the ranged wire path, not the raw byte path
+	"UnmarkedRanged": false,
+	// counted arrays are position-tracked but not on the bulk path (yet)
+	"UnmarkedCounted": false,
+	// both branch sides add exactly 8 bits from a boundary
+	"MarkedBranchAgree": true,
+	// then-side adds 3 bits, the empty else adds 0 — position unknown after
+	"UnmarkedBranchDisagree": false,
+	// the nested struct ends aligned regardless of its entry offset
+	"MarkedAfterNestedAligned": true,
+	// the nested struct exits 3 bits past a boundary
+	"UnmarkedAfterNestedOffBoundary": false,
+	// the nested struct's exit depends on its (unknown) entry
+	"UnmarkedAfterNestedUnknown": false,
+	// count prefix [0, 3] is 2 bits — elements whole bytes, data at 2 (mod 8)
+	"UnmarkedAfterCountedPrefix": false,
+	// count prefix [0, 255] is 8 bits — data back on a boundary
+	"MarkedAfterCountedBytePrefix": true,
+	// the exit-shape helper types have no data field at all
+	"EndsAligned":     false,
+	"EndsOffBoundary": false,
+	"EndsUnknown":     false,
+}
+
+func loadAlignCorpus(t *testing.T) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse("Align.schema", []byte(alignCorpus))
+	if len(perrs) > 0 {
+		t.Fatalf("test corpus does not parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path:  "Align.schema",
+		Name:  "Align.schema",
+		Base:  "Align",
+		Bytes: []byte(alignCorpus),
+		AST:   f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("test corpus does not check: %v", cerrs[0])
+	}
+	return u
+}
+
+func TestAlignedFixedByteArrays(t *testing.T) {
+	u := loadAlignCorpus(t)
+	seen := 0
+	for name, st := range u.Structs {
+		expect, ok := want[name]
+		if !ok {
+			t.Errorf("type %s missing from the expectation table", name)
+			continue
+		}
+		seen++
+		marked := ir.AlignedFixedByteArrays(st)
+		var dataField *ir.Field
+		for _, f := range st.Fields {
+			if f.Name == "data" {
+				dataField = f
+			}
+		}
+		if dataField == nil {
+			if expect {
+				t.Errorf("%s: no data field found", name)
+			}
+			if len(marked) != 0 {
+				t.Errorf("%s: no data field, yet %d fields marked", name, len(marked))
+			}
+			continue
+		}
+		if got := marked[dataField]; got != expect {
+			t.Errorf("%s.data: marked = %v, want %v", name, got, expect)
+		}
+		// nothing but the data field may ever be marked
+		for f := range marked {
+			if f != dataField {
+				t.Errorf("%s: unexpected marked field %s", name, f.Name)
+			}
+		}
+	}
+	if seen != len(want) {
+		var missing []string
+		for name := range want {
+			if _, ok := u.Structs[name]; !ok {
+				missing = append(missing, name)
+			}
+		}
+		t.Fatalf("expected %d types, saw %d (missing: %s)", len(want), seen, strings.Join(missing, ", "))
+	}
+}

--- a/internal/ir/wire.go
+++ b/internal/ir/wire.go
@@ -125,6 +125,137 @@ func MaxBitsStruct(st *Struct) int64 {
 	return walk(st.Items)
 }
 
+// ---- static byte-alignment analysis ----
+//
+// wirePos tracks the wire bit position modulo 8 through a struct's items.
+// known=false means the position cannot be determined statically; the
+// analysis is conservative — unknown never enables an optimization, so a
+// wrong "unknown" costs speed, never wire bytes.
+type wirePos struct {
+	mod   int64
+	known bool
+}
+
+func (p wirePos) add(bits int64) wirePos {
+	if !p.known {
+		return p
+	}
+	return wirePos{mod: ((p.mod+bits)%8 + 8) % 8, known: true}
+}
+
+var wireUnknown = wirePos{known: false}
+var wireAligned = wirePos{mod: 0, known: true}
+
+// AlignedFixedByteArrays returns the fixed [N]uint8 array fields of st whose
+// element bytes are statically guaranteed to begin on a byte boundary —
+// after an `align` item, after a string/bytes field (whose wire ends on a
+// byte boundary by §4.7), or any position provably ≡ 0 (mod 8) from there.
+//
+// At such a site, N consecutive unranged 8-bit writes produce exactly the N
+// array bytes in stream order (§4.3: bit i of the stream lives in byte i/8),
+// which is byte-identical to serialize's align-then-memcpy bulk path — the
+// align contributes zero bits when already aligned. A backend may therefore
+// serialize these fields with SerializeBytes instead of a per-byte loop
+// WITHOUT changing the wire. Fields not in the map must keep the per-byte
+// loop: bulk-copying them would insert padding the wire does not have.
+//
+// Entry position is unknown (a struct may be embedded at any bit offset),
+// so nothing before the first alignment-forcing item is ever marked.
+// Counted arrays ([<= N]uint8) are tracked for position but not marked —
+// extending the bulk path to them is future work.
+func AlignedFixedByteArrays(st *Struct) map[*Field]bool {
+	out := map[*Field]bool{}
+	walkAligned(st.Items, wireUnknown, out)
+	return out
+}
+
+// walkAligned advances the position across items, marking qualifying fields
+// into out (nil out = position tracking only, used for nested structs).
+func walkAligned(items []Item, pos wirePos, out map[*Field]bool) wirePos {
+	for _, item := range items {
+		switch item := item.(type) {
+		case *AlignItem:
+			pos = wireAligned
+		case *ConstItem:
+			pos = pos.add(item.Bits)
+		case *ReservedItem:
+			pos = pos.add(item.Bits)
+		case *Branch:
+			then := walkAligned(item.Then, pos, out)
+			els := pos
+			if item.Else != nil {
+				els = walkAligned(item.Else, pos, out)
+			}
+			// the untaken side writes nothing, so the position after the
+			// branch is known only when both sides agree
+			if then.known && els.known && then.mod == els.mod {
+				pos = then
+			} else {
+				pos = wireUnknown
+			}
+		case *FieldItem:
+			f := item.F
+			if out != nil && isFixedByteArray(f) && pos.known && pos.mod == 0 {
+				out[f] = true
+			}
+			pos = afterField(f, pos)
+		}
+	}
+	return pos
+}
+
+// isFixedByteArray: a fixed [N]uint8 array with the full 8-bit wire — the
+// shape whose per-element wire is exactly one byte with no transformation.
+// (int8 and bits(8) would also be byte-exact on the wire, but their C++
+// storage or wire casts differ; they can join when a profile convicts them.)
+func isFixedByteArray(f *Field) bool {
+	return f.Array == ArrayFixed && f.Type.Kind == TInt &&
+		f.Type.Width == 8 && !f.Type.Signed && !f.HasIntRange
+}
+
+// afterField advances the position across one field's wire.
+func afterField(f *Field, pos wirePos) wirePos {
+	isStruct := false
+	if f.Type.Kind == TNamed {
+		_, isStruct = f.Type.Ref.(*Struct)
+	}
+	switch f.Array {
+	case ArrayFixed:
+		switch {
+		case f.Type.Kind == TString || f.Type.Kind == TBytes:
+			// each element ends aligned (§4.7); bounds are ≥ 1 (§4.4)
+			return wireAligned
+		case isStruct:
+			// exit-from-unknown is entry-independent: if it is known, every
+			// element exits there (bounds are ≥ 1); otherwise give up
+			if e := walkAligned(f.Type.Ref.(*Struct).Items, wireUnknown, nil); e.known {
+				return e
+			}
+			return wireUnknown
+		}
+		return pos.add(f.ArrayBound * maxBitsScalar(f))
+	case ArrayCounted:
+		// count prefix, then count elements: the exit is static only when
+		// each element is a whole number of bytes
+		if f.Type.Kind == TString || f.Type.Kind == TBytes || isStruct || maxBitsScalar(f)%8 != 0 {
+			return wireUnknown
+		}
+		return pos.add(BitsRequired(big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound)))
+	}
+	switch {
+	case f.Type.Kind == TString || f.Type.Kind == TBytes:
+		// length prefix, align, then whole bytes — ends aligned (§4.7)
+		return wireAligned
+	case isStruct:
+		// nested structs are analyzed on their own; here only the exit
+		// position matters
+		return walkAligned(f.Type.Ref.(*Struct).Items, pos, nil)
+	}
+	// every remaining scalar kind is fixed-width, and maxBitsScalar is exact
+	// for it (TInt/TBits/TBool/TFloat32±compressed/TFloat64/Enum/Flags)
+	return pos.add(maxBitsScalar(f))
+}
+
 // View selects an object view's wire (SPEC §4.8).
 type View int
 

--- a/testdata/golden/union/Wire.h
+++ b/testdata/golden/union/Wire.h
@@ -390,10 +390,7 @@ inline bool WriteTestData( serialize::WriteStream & stream, const TestData & val
     write_bits( stream, value.int64_full, 64 );
     write_int64( stream, value.int64_range, -1000000000000, 1000000000000 );
     write_align( stream );
-    for ( int32_t i = 0; i < 17; i++ )
-    {
-        write_bits( stream, value.fixed_bytes[i], 8 );
-    }
+    write_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     for ( int32_t i = 0; i < value.text_length; i++ )
     {
         serialize_assert( value.text[i] != 0 );
@@ -449,14 +446,7 @@ inline bool ReadTestData( serialize::ReadStream & stream, TestData & value )
     }
     read_int64( stream, value.int64_range, -1000000000000, 1000000000000 );
     read_align( stream ); // rejects nonzero padding (SPEC §4.3)
-    for ( int32_t i = 0; i < 17; i++ )
-    {
-        {
-            uint32_t raw_value = 0;
-            read_bits( stream, raw_value, 8 );
-            value.fixed_bytes[i] = uint8_t( raw_value );
-        }
-    }
+    read_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     read_int( stream, value.text_length, 0, 255 );
     read_bytes( stream, value.text, value.text_length );
     for ( int32_t i = 0; i < value.text_length; i++ )

--- a/testdata/golden/variant/Wire.h
+++ b/testdata/golden/variant/Wire.h
@@ -390,10 +390,7 @@ inline bool WriteTestData( serialize::WriteStream & stream, const TestData & val
     write_bits( stream, value.int64_full, 64 );
     write_int64( stream, value.int64_range, -1000000000000, 1000000000000 );
     write_align( stream );
-    for ( int32_t i = 0; i < 17; i++ )
-    {
-        write_bits( stream, value.fixed_bytes[i], 8 );
-    }
+    write_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     for ( int32_t i = 0; i < value.text_length; i++ )
     {
         serialize_assert( value.text[i] != 0 );
@@ -449,14 +446,7 @@ inline bool ReadTestData( serialize::ReadStream & stream, TestData & value )
     }
     read_int64( stream, value.int64_range, -1000000000000, 1000000000000 );
     read_align( stream ); // rejects nonzero padding (SPEC §4.3)
-    for ( int32_t i = 0; i < 17; i++ )
-    {
-        {
-            uint32_t raw_value = 0;
-            read_bits( stream, raw_value, 8 );
-            value.fixed_bytes[i] = uint8_t( raw_value );
-        }
-    }
+    read_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     read_int( stream, value.text_length, 0, 255 );
     read_bytes( stream, value.text, value.text_length );
     for ( int32_t i = 0; i < value.text_length; i++ )


### PR DESCRIPTION
The C++ emitter now takes serialize's bulk-bytes path (align + memcpy) for fixed `[N]uint8` arrays wherever byte alignment is statically provable, instead of emitting a per-byte `write_bits(...,8)` / `read_bits(8)` loop. Glenn's approach, verbatim: *"Trick I have used in the past is to align so I can just memcpy in when writing bytes and strings."*

## The conviction

Serialize PR #27's EPYC profiling put ~58% of `WriteTestData` and ~57% of `ReadTestData` self-cycles in the generated 17x per-byte loop over `TestData.fixed_bytes`. The runtime already had the right primitive — `SerializeBytes` aligns then memcpys — but the emitter never used it for fixed byte arrays. (Strings and `bytes(N)` already rode `write_bytes`/`read_bytes`; the fixed array was the one construct still going byte-at-a-time.)

## The alignment finding, and the wire decision

`SerializeBytes` aligns to a byte boundary before the bulk copy, so emitting it blindly would CHANGE THE WIRE at any unaligned site. The decision here is wire-identity restricted to where it is provable:

- SPEC §4.3 pins bit `i` of the stream to byte `i/8`, LSB-first — so at a byte boundary, N consecutive unranged 8-bit writes produce exactly the N array bytes in order.
- `SerializeBytes`' internal align is ZERO bits when the stream is already aligned (write: zero pad bits emitted; read: zero pad bits consumed, nothing to reject).
- Therefore, at a **statically byte-aligned** position, the bulk path is byte-identical to the per-byte loop. Everywhere else the per-byte loop stays. No wire byte moves, anywhere, by construction — and no SPEC change is needed.

The proof is `ir.AlignedFixedByteArrays`: a conservative bit-position-mod-8 walk over a struct's items. Entry is unknown (a type may embed at any bit offset); `align` and the string/`bytes(N)` wires (§4.7: length, align, payload of whole bytes) force known boundaries; fixed-width fields advance the position; branches must agree on exit; nested structs are walked for their exit; counted arrays are position-tracked but not yet marked. Unknown never optimizes — a wrong "unknown" costs speed, never wire bytes.

In the corpus this marks exactly one field: `TestData.fixed_bytes [17]uint8`, declared immediately after an explicit `align`. Generated delta (both message modes):

```
-    for ( int32_t i = 0; i < 17; i++ )
-    {
-        write_bits( stream, value.fixed_bytes[i], 8 );
-    }
+    write_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
```

and the matching `read_bytes` on the read side.

## Verification

`make SERIALIZE=../serialize test` — all green:

- `schema_test` OK — includes the **wire goldens byte-for-byte** (`testdata/wire/*.bin` untouched by this PR; `git diff testdata/wire` is empty) and the wire oracle (generated bytes == hand-written classic serialize bytes)
- `schema_test_variant` OK, `schema_test_random` OK (2000 round-trip iterations)
- go / rust / cs conformance runners OK (cross-language wire agreement over the same goldens)
- `go test ./...` OK — source goldens re-pinned for the two `Wire.h` files (source pins may move; wire pins may not, and did not)
- New: `internal/ir/align_test.go` — an 18-type expectation table for the analysis: marked after align / after string / after bytes / whole-byte gaps / agreeing branches / aligned nested exits / byte-wide count prefixes; NOT marked at unknown entry, off-boundary, ranged elements, counted arrays, disagreeing branches, off-boundary or entry-dependent nested exits. Verified the test fails when an expectation is flipped.

The bench runner's own gate also passed: it refuses to produce numbers unless the binary's output matches the pinned wire goldens — the new binary benches.

## Measurement (M2, tonight — paired, median-of-7, interleaved runs x3)

Apple M2, Release (`-O3 -DNDEBUG -DSERIALIZE_RELEASE`, apple clang 21), serialize @ `6ad407d`, bench-harness v2 merged locally for measurement only (not in this diff). Predictions banked before running: write ~2.0x, read ~2.1x, everything else flat.

| bench | path | base (msgs/s, 3 runs) | new (msgs/s, 3 runs) | delta |
|---|---|---|---|---|
| testdata | write | 16.96M / 17.37M / 17.43M | 17.90M / 18.35M / 18.36M | **+5.3..5.6%** |
| testdata | read | 15.12M / 15.47M / 14.53M | 25.70M / 26.26M / 26.21M | **+70..80%** |
| chat | write / read | 109.1M / 137.4M | 107.3M / 136.0M | -1.7% / -1.0% (noise) |
| all other rows | | | | within +/-5% |

`message_batch` moved -7%/+11% in one pair but swings +/-20% between runs of the SAME binary (spreads up to 16.6%) and its generated code is byte-identical in both builds (`Messages.h` unchanged; the batch carries no `TestData`) — code-layout noise, not a regression.

**Refutation, plain:** the write prediction was wrong. Read delivered ~1.7-1.8x; write only +5.6%. Root cause, from the runtime source: at serialize `6ad407d`, `WriteBytes` at a byte-but-not-word boundary still pushes up to 15 of the 17 bytes through per-byte head/tail `WriteBits` — the emitter's loop moved into the runtime's loop. Re-paired against serialize PR #27's `optimize-bytes` (packed head/tail, `14ea61a`): write +14.4% (17.81M -> 20.37M), read +71.5%. So this PR plus serialize PR #27 is the write story so far, and the remaining gap says the EPYC's ~58%-of-write-cycles share does not transfer to the M2 write path as-is. The EPYC pairing is deliberately not run tonight (another session owns that box); worth a quiet-hours profile there before concluding more.

## Judgment calls

- **Fixed `[N]uint8` only.** `int8` and `bits(8)` would also be byte-exact on the wire, but their storage/cast paths differ and nothing profiles them; counted `[<= N]uint8` is position-tracked but not marked (the write side would need the count prefix emitted before the bulk call — mechanical, unconvicted). All noted in the analysis comments for when a profile convicts them.
- **The analysis lives in `internal/ir`** (target-independent wire math, the same charter as `MaxBits`) so the go/rust/cs backends — whose emitters still write these per-byte loops — can adopt the same proof later.
- **No SPEC change.** Nothing here alters or reinterprets the wire; §4.3/§4.7 already contain everything the proof needs.

## CI note

GitHub Actions is in a major outage today; verification above is local (M2), commands as quoted. The suite should re-run in CI when Actions recovers.
