### PR TITLE
v5 EPYC leg: harvested — restrict refuted on Zen 4, the relative table is target-dependent, and the C# tiered-JIT single-core artifact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,4 +71,10 @@
   accelerating, zero regressions). `message_batch` swings ±20% between byte-identical
   binaries (layout noise) — pair same-sitting, discard contaminated runs whole, file
   unattributed movements instead of claiming them. One bench at a time per machine:
-  check for sibling bench processes and wait for a quiet window.
+  check for sibling bench processes and wait for a quiet window. **A tiered-JIT runtime
+  benched on a single shared core measures tier-up contention, not codegen** (EPYC v5:
+  ten of twelve C# write medians sat at tier-0, spreads to 385%, and one row was
+  uniformly slow at 11.6% spread — so a low spread does not clear a row; proven by a
+  labelled `DOTNET_TieredCompilation=0` intervention, 1.98–4.90x). On a single core,
+  settle or disable the tier and LABEL the config divergence; medians-against-min is
+  the tell to check first.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ verification before it is believed. The remaining gaps are decomposed, cause by 
 [bench/results/2026-08-07-gap-ledger.md](bench/results/2026-08-07-gap-ledger.md) — treat the
 table as a dated snapshot, not a verdict.
 
+**And it is a snapshot of a (compiler, microarchitecture) pair, not of the languages.**
+The x86 leg (AMD EPYC 9124 / Zen 4, serial on a reserved core, measured 2026-08-07,
+harvested 2026-08-11) tells a different story: the C++ writer's restrict win — the
+biggest C++ lever on arm64/apple-clang — measured **1.00x under both g++-13 and
+clang-18** there, so against g++ the ports sit near write parity while reads sit further
+away; and clang-18 beats g++ by up to 4.3x on tiny-message writes, which moves every
+relative cell by double digits when the reference compiler changes. Same code, same wire,
+different target, different table:
+
+| backend (EPYC, vs g++ 13.3) | write | read | batch write | batch read |
+|---|---:|---:|---:|---:|
+| C++ | 100% | 100% | 100% | 100% |
+| Rust | 108% | 274% | 103% | 125% |
+| C# * | 137% | 198% | 120% | 150% |
+| Go | 177% | 370% | 196% | 108% |
+
+\* C# from a labelled steady-state diagnostic — the default-config run surfaced a benching
+law worth knowing: a tiered-JIT runtime benched on a single shared core measures tier-up
+contention, not generated code. Full tables, both compilers, the restrict A/B and the
+artifact record: [bench/results/2026-08-07-four-language-v5-epyc.md](bench/results/2026-08-07-four-language-v5-epyc.md).
+
 `notes/` holds extracted API references for the three target runtimes, gathered 2026-08-04 as
 design inputs — re-verify against each library's source at implementation time.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -16,6 +16,8 @@ per the contract below.
 
     bench/run.sh                 # Release, results in bench/results/<date>-<arch>-<host>.csv
     bench/run.sh --debug         # also the Debug pair (matched-pair methodology)
+    bench/run.sh --only cpp|go|rust|cs   # one language leg — serial one-profile-at-a-time
+                                         # passes on shared boxes (the EPYC discipline)
     SERIALIZE=path/to/serialize bench/run.sh
     BENCH_NOISE="NOISY: ..." bench/run.sh    # label a noisy host in the preamble
 

--- a/bench/results/2026-08-06-four-language-v2.md
+++ b/bench/results/2026-08-06-four-language-v2.md
@@ -103,6 +103,15 @@ a process-inspection-verified quiet window, and the write-control (writes
 0.94-1.12x of v1, mostly within 1%) confirms clean conditions. Raw CSV:
 `2026-08-06-four-language-v2-x86_64-epyc.csv`.
 
+> **CORRECTION, 2026-08-11: the C# write cells in the table below — and any relative row
+> derived from this CSV — are RETRACTED as language verdicts.** The v5 EPYC harvest
+> proved by intervention (`DOTNET_TieredCompilation=0`, 1.98–4.90x median moves) that
+> .NET tiered-JIT promotion competing for the single shared core poisons the C# write
+> medians on this host; this CSV carries the same artifact (same rows, spreads 33–156%),
+> and a low spread does not clear a row (a uniformly-slow row measured 2.67x off at
+> 11.6% spread). The C# READ rows are mostly clean. Mechanism, evidence and the rule:
+> `2026-08-07-four-language-v5-epyc.md`.
+
 | bench | path | B/msg | C++ M msg/s | C++ MB/s | Rust M msg/s | Rust MB/s | Go M msg/s | Go MB/s | C# M msg/s | C# MB/s |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | rigidbody_moving | write | 105 | 23.36 | 2339 | 16.83 | 1685 | 10.32 | 1033 | 10.02 | 1003 |

--- a/bench/results/2026-08-07-four-language-v5-epyc.md
+++ b/bench/results/2026-08-07-four-language-v5-epyc.md
@@ -1,0 +1,126 @@
+# 2026-08-07 — four-language v5, EPYC leg (IN FLIGHT — WHERE I STOPPED)
+
+**State: the measurement pass is RUNNING on the EPYC, unharvested.** The
+session ended mid-pass with the box's network flaking (ssh timeouts in both
+directions all afternoon). Everything below is what a next session needs to
+finish without re-deriving anything. Nothing in this file is a measured v5
+EPYC number yet — the reference numbers quoted are prior records, labelled.
+
+## What this pass is
+
+The deferred x86 leg of the two-day optimization program, authorized by
+Glenn verbatim: *"You can do the 'ssh space' pass now, as long as you gate
+one profile at a time it should work OK on the one available core. That
+core does no work for the space game, it is reserved (core 0)."* Core 0 is
+RESERVED for bench (his word); the game server owns isolated cores 1–15.
+
+## The pins (fresh-pulled mains, 2026-08-07 ~15:30Z, GitHub ssh flaky — 3 retries)
+
+| repo | main | note |
+|---|---|---|
+| schema | `914f43b96` | the v5 merge exactly — no lanes moved past v5, so this stays a **v5** pass |
+| serialize | `040d28647` | #31 docs-only on top of #30 restrict |
+| serialize.go | `68ce62432` | |
+| serialize.rs | `422e4fa03` | |
+| serialize.cs | `e2bda998b` | |
+
+schema main vs the M2 v5 pin (`3baa6fd`) differs by results/docs only
+(verified `git diff --stat` — bench/run.sh + results files), so the code
+measured here is exactly the code the M2 v5 tables measured.
+
+**Suite gate: GREEN on the mac at this pin** — `make SERIALIZE=../serialize
+test` at `epyc-pass` (= main + the `--only` harness flag), all four language
+test legs OK, exit 0, before anything was staged.
+
+## What is running on the box (launched 2026-08-07 ~16:05Z)
+
+- Staged by rsync (git-archive exports, no .git):
+  `~/rowan-bench/v5-epyc/{schema, serialize-cs-port/{serialize,serialize.go,serialize.rs,serialize.cs}, serialize-pre-restrict, pass.sh}`.
+  `serialize-pre-restrict` = serialize @ `561e81d` (the commit before the
+  #30 merge): verified 0 "restrict qualified this" sites vs main's 3 — the
+  A/B isolates #30 exactly.
+- Toolchains verified on the box before launch, all identical to every
+  prior table: g++ 13.3.0, clang 18.1.3, go1.26.5, cargo/rustc 1.97.1
+  (needs `RUSTUP_HOME=~/rowan-bench/rustup CARGO_HOME=~/rowan-bench/cargo`),
+  dotnet 10.0.302 (`DOTNET_ROOT=~/rowan-bench/dotnet`).
+- Quiet window verified at launch: launcher's busy threads all on PSR 1–15,
+  none of ours running, core 0 clean.
+- `nohup ~/rowan-bench/v5-epyc/pass.sh` (pid 97642) runs EIGHT legs
+  STRICTLY SERIALLY — Glenn's one-profile-at-a-time gate — each leg its own
+  `bench/run.sh --only LANG` invocation (the flag added this branch;
+  orchestration only, measurement code and flags untouched), with a ps
+  quiet-window gate + core-0 /proc/stat snapshot between legs, all logged
+  to `~/rowan-bench/v5-epyc/results/pass.log`:
+
+| # | leg | csv | what it answers |
+|---|---|---|---|
+| 1 | cpp-gcc-start | `results/cpp-gcc-start.csv` | main-table C++ rows + **write-control A** |
+| 2 | go | `results/go.csv` | main table |
+| 3 | rust | `results/rust.csv` | main table |
+| 4 | cs | `results/cs.csv` | main table |
+| 5 | cpp-clang | `results/cpp-clang.csv` | open item (c), clang pair |
+| 6 | cpp-gcc-prerestrict | `results/cpp-gcc-prerestrict.csv` | open item (a): #30 A/B on g++/Zen 4 |
+| 7 | cpp-clang-prerestrict | `results/cpp-clang-prerestrict.csv` | open item (a): #30 A/B on clang-18/Zen 4 |
+| 8 | cpp-gcc-end | `results/cpp-gcc-end.csv` | **write-control B** — window stability per the house law |
+
+`~/rowan-bench/v5-epyc/results/PASS.done` appears when all eight finish;
+`FAILED-<leg>` markers on any failure. BENCH_NOISE label in every preamble:
+core 0 reserved for bench, no game work, still the sole general-purpose
+core (irqs, ssh, systemd).
+
+## To finish (the next session's checklist)
+
+1. `rsync space:rowan-bench/v5-epyc/results/ <somewhere>` (retry — the
+   network drops for minutes at a time; the run itself is immune, it is
+   nohup'd on the box).
+2. Check `pass.log` quiet-window entries + no FAILED markers; golden gate
+   is per-runner (a runner that fails self-check refuses to bench).
+3. Write-control: cpp-gcc-start vs cpp-gcc-end, per-row ratios within
+   spread ⇒ window stable.
+4. Main table CSV = legs 1–4 concatenated →
+   `2026-08-07-four-language-v5-x86_64-epyc.csv` (+ `-clang`,
+   `-restrict-ab`, `-write-control` files); replace this doc with the real
+   tables (absolute + THE RELATIVE TABLE, C++ = 100%, M2 v5 beside it).
+5. Relative-table math (validated this session against the published M2 v5
+   table — reproduces 177/204/121/153 // 199/214/140/175 // 323/387/204/198
+   exactly): per bench, ratio = cpp_median / lang_median × 100; column =
+   median of the 11 corpus ratios; batch cells separately. Release rows
+   only (the 2026-08-06 gcc morning CSV carries a Debug section — filter on
+   the `# build:` preamble).
+
+## Reference numbers the verdicts compare against (prior records, labelled)
+
+- **(a) restrict x86**: serialize #30 isolated pairing (arm64/apple-clang)
+  +152% rigidbody_moving write, +128% at_rest, +86% probebits, +76%
+  inputpacket, +74% ship_shallow, +68% probearray, +52% shipcreate, +38%
+  testdata, ~0 chat/test/probe_header/batch (predicted byte-copy/inline
+  dominated); composed v3→v4 M2: +158/+143/+91/+76/+68/+65/+53/+38%.
+  Theory: boundary-aliasing, compiler-dependent — legs 6/7 vs 1/5 price it
+  on g++/Zen 4 and clang-18/Zen 4.
+- **(c) the g++-vs-clang tiny gap** (morning 2026-08-06 baseline, EPYC,
+  pre-everything, `2026-08-06-x86_64-ryzen-{gcc,clang}.csv` — filenames say
+  ryzen, preambles say EPYC): clang/g++ probe_header write **4.01x**, test
+  write **3.62x**, probebits read 2.16x; g++ AHEAD on probebits write
+  (0.74x) and batch write (0.87x). Question: post-const-emit (schema #8),
+  is it still 4x? Legs 1 vs 5.
+- **(b) lane composition on x86**: EPYC v2 (2026-08-06, pre-everything,
+  g++) relative table computed this session from
+  `2026-08-06-four-language-v2-x86_64-epyc.csv`: Rust 139/313/171/258,
+  C# 293/320/502/193, Go 291/490/254/131 (write/read/batch-write/batch-read
+  vs that run's C++). M2 v5 finals beside it: Rust 177/204/121/153,
+  C# 199/214/140/175, Go 323/387/204/198. Go write rows were flat v1→v4 on
+  M2, C# write rows flat v1→v4, rust testdata read flat v1→v4 — so on the
+  EPYC, v2→v5 per-row deltas on those rows read as the lanes' composed
+  effect (stated with that provenance, not as isolated pairings).
+
+## Judgment calls on record
+
+- `--only` added to `bench/run.sh` (this branch) so the serial gate could
+  be honored per-leg without touching measurement code; each leg carries
+  the full preamble.
+- Both compilers for C++ (g++ primary, clang-18 pair) per the original
+  baseline; the restrict A/B runs under BOTH — the theory says the win is
+  compiler-dependent, so one compiler would not answer (a).
+- Naming stays **v5** (mains did not move past the v5 merge).
+- MSBuild node-reuse disabled + `dotnet build-server shutdown` after the
+  cs leg so lingering build servers cannot trip the between-leg ps gate.

--- a/bench/results/2026-08-07-four-language-v5-epyc.md
+++ b/bench/results/2026-08-07-four-language-v5-epyc.md
@@ -1,20 +1,29 @@
-# 2026-08-07 — four-language v5, EPYC leg (IN FLIGHT — WHERE I STOPPED)
+# 2026-08-07 — four-language v5, EPYC leg (measured 2026-08-07, harvested 2026-08-11)
 
-**State: the measurement pass is RUNNING on the EPYC, unharvested.** The
-session ended mid-pass with the box's network flaking (ssh timeouts in both
-directions all afternoon). Everything below is what a next session needs to
-finish without re-deriving anything. Nothing in this file is a measured v5
-EPYC number yet — the reference numbers quoted are prior records, labelled.
+**The deferred x86 leg of the optimization program, run and landed.** The pass ran to
+completion unattended on 2026-08-07 (legs `15:55:37Z → 15:59:30Z`, `PASS.done` stamped
+`15:59:38Z`); the session that launched it ended mid-pass with the box's network flaking,
+and the results sat on the box until this harvest (2026-08-11). Verified at harvest:
+`PASS.done` present, **zero `FAILED-*` markers**, all nine between-leg quiet-window checks
+`clean: none of ours running`, core-0 `/proc/stat` snapshots quiet. Raw log committed as
+`2026-08-07-v5-epyc-pass.log` — it is the evidence that the serial gate held.
 
 ## What this pass is
 
-The deferred x86 leg of the two-day optimization program, authorized by
-Glenn verbatim: *"You can do the 'ssh space' pass now, as long as you gate
-one profile at a time it should work OK on the one available core. That
-core does no work for the space game, it is reserved (core 0)."* Core 0 is
-RESERVED for bench (his word); the game server owns isolated cores 1–15.
+The x86 composition leg, authorized by Glenn verbatim: *"You can do the 'ssh space' pass
+now, as long as you gate one profile at a time it should work OK on the one available
+core. That core does no work for the space game, it is reserved (core 0)."* Core 0 is
+RESERVED for bench (his word); the game server owns isolated cores 1–15. Eight legs ran
+STRICTLY SERIALLY (`bench/tools/epyc-pass-driver.sh`, each leg its own
+`bench/run.sh --only LANG` invocation), with a ps quiet-window gate + core-0 snapshot
+between legs.
 
-## The pins (fresh-pulled mains, 2026-08-07 ~15:30Z, GitHub ssh flaky — 3 retries)
+Host: AMD EPYC 9124 (Zen 4), Linux 6.8.0, `taskset -c 0`, the sole general-purpose core
+(irqs, ssh, systemd — the `BENCH_NOISE` label rides every preamble). Toolchains identical
+to every prior table: g++ 13.3.0, clang 18.1.3, go1.26.5, cargo/rustc 1.97.1, dotnet
+10.0.302.
+
+## The pins (fresh-pulled mains, 2026-08-07 ~15:30Z)
 
 | repo | main | note |
 |---|---|---|
@@ -24,103 +33,250 @@ RESERVED for bench (his word); the game server owns isolated cores 1–15.
 | serialize.rs | `422e4fa03` | |
 | serialize.cs | `e2bda998b` | |
 
-schema main vs the M2 v5 pin (`3baa6fd`) differs by results/docs only
-(verified `git diff --stat` — bench/run.sh + results files), so the code
-measured here is exactly the code the M2 v5 tables measured.
+schema main vs the M2 v5 pin (`3baa6fd`) differs by results/docs only, so the code
+measured here is exactly the code the M2 v5 tables measured. Suite gate was GREEN on the
+mac at this pin before anything was staged. `serialize-pre-restrict` = serialize @
+`561e81d` (the commit before the #30 merge), verified 0 restrict sites vs main's 3.
 
-**Suite gate: GREEN on the mac at this pin** — `make SERIALIZE=../serialize
-test` at `epyc-pass` (= main + the `--only` harness flag), all four language
-test legs OK, exit 0, before anything was staged.
+## Write-control (window stability): STABLE, one row flagged
 
-## What is running on the box (launched 2026-08-07 ~16:05Z)
+`cpp-gcc-start` vs `cpp-gcc-end` (legs 1 and 8, the pass's bookends): **23 of 24 rows at
+0.98–1.05x** — the window held across all eight legs. The one mover: **test write 1.13x**
+(118.14 → 133.20 M msg/s, beyond both spreads 3.1%/8.4%) — the known unattributed
+layout-band class (v4 finding-4 family; the v2 EPYC doc flagged this same bench's write
+cell moving 1.30x between sittings). Filed, not chased. Raw:
+`2026-08-07-four-language-v5-x86_64-epyc-write-control.csv`.
 
-- Staged by rsync (git-archive exports, no .git):
-  `~/rowan-bench/v5-epyc/{schema, serialize-cs-port/{serialize,serialize.go,serialize.rs,serialize.cs}, serialize-pre-restrict, pass.sh}`.
-  `serialize-pre-restrict` = serialize @ `561e81d` (the commit before the
-  #30 merge): verified 0 "restrict qualified this" sites vs main's 3 — the
-  A/B isolates #30 exactly.
-- Toolchains verified on the box before launch, all identical to every
-  prior table: g++ 13.3.0, clang 18.1.3, go1.26.5, cargo/rustc 1.97.1
-  (needs `RUSTUP_HOME=~/rowan-bench/rustup CARGO_HOME=~/rowan-bench/cargo`),
-  dotnet 10.0.302 (`DOTNET_ROOT=~/rowan-bench/dotnet`).
-- Quiet window verified at launch: launcher's busy threads all on PSR 1–15,
-  none of ours running, core 0 clean.
-- `nohup ~/rowan-bench/v5-epyc/pass.sh` (pid 97642) runs EIGHT legs
-  STRICTLY SERIALLY — Glenn's one-profile-at-a-time gate — each leg its own
-  `bench/run.sh --only LANG` invocation (the flag added this branch;
-  orchestration only, measurement code and flags untouched), with a ps
-  quiet-window gate + core-0 /proc/stat snapshot between legs, all logged
-  to `~/rowan-bench/v5-epyc/results/pass.log`:
+## THE ARTIFACT FIRST: the C# default-config write rows are not a language measurement
 
-| # | leg | csv | what it answers |
-|---|---|---|---|
-| 1 | cpp-gcc-start | `results/cpp-gcc-start.csv` | main-table C++ rows + **write-control A** |
-| 2 | go | `results/go.csv` | main table |
-| 3 | rust | `results/rust.csv` | main table |
-| 4 | cs | `results/cs.csv` | main table |
-| 5 | cpp-clang | `results/cpp-clang.csv` | open item (c), clang pair |
-| 6 | cpp-gcc-prerestrict | `results/cpp-gcc-prerestrict.csv` | open item (a): #30 A/B on g++/Zen 4 |
-| 7 | cpp-clang-prerestrict | `results/cpp-clang-prerestrict.csv` | open item (a): #30 A/B on clang-18/Zen 4 |
-| 8 | cpp-gcc-end | `results/cpp-gcc-end.csv` | **write-control B** — window stability per the house law |
+**The evidence.** In the main-table cs leg, ten of twelve write rows carry within-run
+spreads of 67–385%, and on the worst rows the MEDIAN sits against the MIN while one or
+two runs hit 2–4x higher — the exact inverse of the M2 desched class (where medians sat
+against max and one outlier run sat low). inputpacket write: med 6.29 M msg/s, max 22.94.
+probearray write: med 5.02, max 24.24. shipcreate write: med 9.88, max 34.43.
 
-`~/rowan-bench/v5-epyc/results/PASS.done` appears when all eight finish;
-`FAILED-<leg>` markers on any failure. BENCH_NOISE label in every preamble:
-core 0 reserved for bench, no game work, still the sole general-purpose
-core (irqs, ssh, systemd).
+**The intervention (2026-08-11, labelled DIAGNOSTIC, serial, alone on core 0):** one cs
+leg re-run with `DOTNET_TieredCompilation=0`, nothing else changed. Every poisoned row
+snapped to the neighborhood of its former max and the spreads collapsed:
 
-## To finish (the next session's checklist)
+| bench | path | default M msg/s | notiered M msg/s | notiered/default | spread default% | spread notiered% |
+|---|---|---:|---:|---:|---:|---:|
+| rigidbody_moving | write | 11.83 | 23.48 | **1.98x** | 80.9 | 3.1 |
+| rigidbody_moving | read | 13.36 | 25.39 | **1.90x** | 105.2 | 12.4 |
+| rigidbody_at_rest | write | 35.03 | 35.62 | **1.02x** | 2.8 | 9.2 |
+| rigidbody_at_rest | read | 39.89 | 38.66 | **0.97x** | 12.2 | 9.0 |
+| chat | write | 24.97 | 24.58 | **0.98x** | 85.4 | 7.8 |
+| chat | read | 54.66 | 46.87 | **0.86x** | 4.1 | 3.8 |
+| test | write | 76.21 | 79.14 | **1.04x** | 72.4 | 5.0 |
+| test | read | 105.13 | 96.44 | **0.92x** | 2.0 | 7.4 |
+| inputpacket | write | 6.29 | 23.20 | **3.69x** | 270.6 | 4.7 |
+| inputpacket | read | 20.90 | 19.38 | **0.93x** | 3.5 | 7.7 |
+| shipcreate | write | 9.88 | 33.74 | **3.42x** | 255.2 | 8.3 |
+| shipcreate | read | 39.15 | 34.29 | **0.88x** | 15.0 | 2.5 |
+| ship_shallow | write | 11.27 | 30.85 | **2.74x** | 226.7 | 7.8 |
+| ship_shallow | read | 40.18 | 37.54 | **0.93x** | 7.7 | 4.0 |
+| probe_header | write | 70.15 | 71.30 | **1.02x** | 67.8 | 4.9 |
+| probe_header | read | 81.84 | 83.97 | **1.03x** | 6.1 | 1.5 |
+| probebits | write | 21.01 | 56.15 | **2.67x** | 11.6 | 13.4 |
+| probebits | read | 68.62 | 71.65 | **1.04x** | 74.4 | 4.8 |
+| probearray | write | 5.02 | 24.60 | **4.90x** | 385.3 | 15.5 |
+| probearray | read | 29.42 | 26.51 | **0.90x** | 14.1 | 4.7 |
+| testdata | write | 3.01 | 9.99 | **3.32x** | 236.4 | 0.9 |
+| testdata | read | 8.76 | 13.97 | **1.60x** | 13.5 | 12.8 |
+| message_batch | write | 24.75 | 51.27 | **2.07x** | 174.9 | 5.2 |
+| message_batch | read | 20.67 | 27.90 | **1.35x** | 8.5 | 2.1 |
 
-1. `rsync space:rowan-bench/v5-epyc/results/ <somewhere>` (retry — the
-   network drops for minutes at a time; the run itself is immune, it is
-   nohup'd on the box).
-2. Check `pass.log` quiet-window entries + no FAILED markers; golden gate
-   is per-runner (a runner that fails self-check refuses to bench).
-3. Write-control: cpp-gcc-start vs cpp-gcc-end, per-row ratios within
-   spread ⇒ window stable.
-4. Main table CSV = legs 1–4 concatenated →
-   `2026-08-07-four-language-v5-x86_64-epyc.csv` (+ `-clang`,
-   `-restrict-ab`, `-write-control` files); replace this doc with the real
-   tables (absolute + THE RELATIVE TABLE, C++ = 100%, M2 v5 beside it).
-5. Relative-table math (validated this session against the published M2 v5
-   table — reproduces 177/204/121/153 // 199/214/140/175 // 323/387/204/198
-   exactly): per bench, ratio = cpp_median / lang_median × 100; column =
-   median of the 11 corpus ratios; batch cells separately. Release rows
-   only (the 2026-08-06 gcc morning CSV carries a Debug section — filter on
-   the `# build:` preamble).
+**The mechanism.** .NET tiered compilation promotes hot methods to optimized code on
+BACKGROUND threads. Pinned to one shared core, the tier-up work competes with the bench
+loop for the only core there is: runs where promotion landed early hit the fast steady
+state, runs where it landed late (or not at all inside the window) measured tier-0 code.
+On the unpinned multi-core M2 the promotion always completed benignly beside the loop,
+which is why four M2 passes never saw this.
 
-## Reference numbers the verdicts compare against (prior records, labelled)
+**Three consequences, stated plainly:**
 
-- **(a) restrict x86**: serialize #30 isolated pairing (arm64/apple-clang)
-  +152% rigidbody_moving write, +128% at_rest, +86% probebits, +76%
-  inputpacket, +74% ship_shallow, +68% probearray, +52% shipcreate, +38%
-  testdata, ~0 chat/test/probe_header/batch (predicted byte-copy/inline
-  dominated); composed v3→v4 M2: +158/+143/+91/+76/+68/+65/+53/+38%.
-  Theory: boundary-aliasing, compiler-dependent — legs 6/7 vs 1/5 price it
-  on g++/Zen 4 and clang-18/Zen 4.
-- **(c) the g++-vs-clang tiny gap** (morning 2026-08-06 baseline, EPYC,
-  pre-everything, `2026-08-06-x86_64-ryzen-{gcc,clang}.csv` — filenames say
-  ryzen, preambles say EPYC): clang/g++ probe_header write **4.01x**, test
-  write **3.62x**, probebits read 2.16x; g++ AHEAD on probebits write
-  (0.74x) and batch write (0.87x). Question: post-const-emit (schema #8),
-  is it still 4x? Legs 1 vs 5.
-- **(b) lane composition on x86**: EPYC v2 (2026-08-06, pre-everything,
-  g++) relative table computed this session from
-  `2026-08-06-four-language-v2-x86_64-epyc.csv`: Rust 139/313/171/258,
-  C# 293/320/502/193, Go 291/490/254/131 (write/read/batch-write/batch-read
-  vs that run's C++). M2 v5 finals beside it: Rust 177/204/121/153,
-  C# 199/214/140/175, Go 323/387/204/198. Go write rows were flat v1→v4 on
-  M2, C# write rows flat v1→v4, rust testdata read flat v1→v4 — so on the
-  EPYC, v2→v5 per-row deltas on those rows read as the lanes' composed
-  effect (stated with that provenance, not as isolated pairings).
+1. **The default-config C# write column on this host is a measurement of tier-up
+   contention, not of the generated code.** It is retracted as a language verdict.
+2. **Low spread does NOT clear a row**: probebits write sat at 11.6% spread and still
+   moved 2.67x under the intervention — all seven runs were uniformly pre-tier. Spread
+   filtering cannot identify the affected rows; only the intervention could.
+3. **RETROACTIVE: the v2 EPYC C# rows carried the same artifact** (same write rows,
+   spreads 33–156%, `2026-08-06-four-language-v2-x86_64-epyc.csv`), so the published v2
+   EPYC C# relative row (293/320/502/193) is likewise retracted as a language verdict — a
+   dated correction note now sits in the v2 doc.
 
-## Judgment calls on record
+The diagnostic is **not comparable to the M2 tables** (different runtime config: M2 ran
+default tiering, benignly) and tiering-off is not uniformly better — tier-1's
+profile-guided reads are visibly lost on some rows (chat read 0.86x, test read 0.92x). It
+is *stable*, which is what a single-core table needs. Raw:
+`2026-08-11-cs-tiered-jit-diagnostic-x86_64-epyc.csv`.
 
-- `--only` added to `bench/run.sh` (this branch) so the serial gate could
-  be honored per-leg without touching measurement code; each leg carries
-  the full preamble.
-- Both compilers for C++ (g++ primary, clang-18 pair) per the original
-  baseline; the restrict A/B runs under BOTH — the theory says the win is
-  compiler-dependent, so one compiler would not answer (a).
-- Naming stays **v5** (mains did not move past the v5 merge).
-- MSBuild node-reuse disabled + `dotnet build-server shutdown` after the
-  cs leg so lingering build servers cannot trip the between-leg ps gate.
+## Absolute table (as measured — C++ = g++ 13.3; C# = default-config leg, write rows ✝)
+
+✝ the C# write cells below (except rigidbody_at_rest and probebits — and probebits is
+poisoned too, see consequence 2) are the artifact, kept as measured; steady-state C#
+writes are in the diagnostic table above. Raw: `2026-08-07-four-language-v5-x86_64-epyc.csv`
+(legs 1–4 concatenated, per-leg preambles kept).
+
+| bench | path | B/msg | C++ M msg/s | C++ MB/s | Rust M msg/s | Rust MB/s | Go M msg/s | Go MB/s | C# M msg/s | C# MB/s |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| rigidbody_moving | write | 105 | 24.59 | 2462 | 19.99 | 2002 | 13.86 | 1387 | 11.83✝ | 1185 |
+| rigidbody_moving | read | 105 | 30.43 | 3047 | 36.18 | 3623 | 15.77 | 1579 | 13.36✝ | 1338 |
+| rigidbody_at_rest | write | 57 | 40.92 | 2224 | 32.02 | 1741 | 24.89 | 1353 | 35.03 | 1904 |
+| rigidbody_at_rest | read | 57 | 59.71 | 3246 | 64.67 | 3515 | 27.70 | 1506 | 39.89 | 2168 |
+| chat | write | 13 | 35.71 | 443 | 41.91 | 520 | 24.44 | 303 | 24.97✝ | 310 |
+| chat | read | 13 | 75.21 | 932 | 41.74 | 518 | 47.79 | 592 | 54.66 | 678 |
+| test | write | 6 | 118.14 | 676 | 132.93 | 761 | 69.48 | 398 | 76.21✝ | 436 |
+| test | read | 6 | 226.01 | 1293 | 64.08 | 367 | 54.98 | 315 | 105.13 | 602 |
+| inputpacket | write | 61 | 31.88 | 1855 | 28.63 | 1665 | 11.91 | 693 | 6.29✝ | 366 |
+| inputpacket | read | 61 | 36.48 | 2122 | 12.29 | 715 | 11.78 | 685 | 20.90 | 1216 |
+| shipcreate | write | 28 | 34.32 | 917 | 41.00 | 1095 | 19.72 | 527 | 9.88✝ | 264 |
+| shipcreate | read | 28 | 74.55 | 1991 | 26.81 | 716 | 14.70 | 392 | 39.15 | 1045 |
+| ship_shallow | write | 28 | 55.86 | 1492 | 50.64 | 1352 | 22.32 | 596 | 11.27✝ | 301 |
+| ship_shallow | read | 28 | 77.89 | 2080 | 19.79 | 529 | 16.83 | 449 | 40.18 | 1073 |
+| probe_header | write | 10 | 120.98 | 1154 | 112.50 | 1073 | 51.92 | 495 | 70.15✝ | 669 |
+| probe_header | read | 10 | 180.68 | 1723 | 55.88 | 533 | 48.83 | 466 | 81.84 | 781 |
+| probebits | write | 26 | 83.35 | 2067 | 55.09 | 1366 | 38.03 | 943 | 21.01✝ | 521 |
+| probebits | read | 26 | 142.00 | 3521 | 51.75 | 1283 | 38.69 | 959 | 68.62✝ | 1701 |
+| probearray | write | 47 | 25.70 | 1152 | 23.97 | 1075 | 12.94 | 580 | 5.02✝ | 225 |
+| probearray | read | 47 | 57.29 | 2568 | 29.15 | 1307 | 11.01 | 493 | 29.42 | 1319 |
+| testdata | write | 92 | 9.18 | 805 | 10.30 | 903 | 6.78 | 595 | 3.01✝ | 264 |
+| testdata | read | 92 | 25.42 | 2230 | 9.70 | 851 | 6.26 | 550 | 8.76 | 768 |
+| message_batch | write | 25 | 61.41 | 1464 | 59.36 | 1415 | 31.31 | 747 | 24.75✝ | 590 |
+| message_batch | read | 25 | 41.96 | 1000 | 33.59 | 801 | 38.68 | 922 | 20.67 | 493 |
+
+## THE RELATIVE TABLE — and the headline: it is TARGET-DEPENDENT
+
+Time relative to C++ (C++ = 100%, higher is slower), medians across the 11 corpus
+benches, batch separately. The M2 v5 finals sit beside for the cross-host read.
+
+**Against g++ 13.3 (this pass's primary reference), C# from the steady-state diagnostic:**
+
+| backend | write | M2 v5 | read | M2 v5 | batch write | M2 v5 | batch read | M2 v5 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| C++ (g++) | 100% | 100% | 100% | 100% | 100% | 100% | 100% | 100% |
+| Rust | **108%** | 177% | **274%** | 204% | **103%** | 121% | **125%** | 153% |
+| C# * | **137%** | 199% | **198%** | 214% | **120%** | 140% | **150%** | 175% |
+| Go | **177%** | 323% | **370%** | 387% | **196%** | 204% | **108%** | 198% |
+
+\* C# row from the labelled `TieredCompilation=0` diagnostic — the default-config row
+computes to 305/195/248/203 and its write/batch-write cells are the artifact above, not
+the language. (Reads barely differ between configs: 195 vs 198.)
+
+**Against clang-18 as the C++ reference (same go/rust legs, C# steady-state):**
+
+| backend | write | read | batch write | batch read |
+|---|---:|---:|---:|---:|
+| C++ (clang-18) | 100% | 100% | 100% | 100% |
+| Rust | **147%** | **287%** | **102%** | **154%** |
+| C# * | **156%** | **221%** | **118%** | **185%** |
+| Go | **267%** | **477%** | **193%** | **133%** |
+
+**What the two tables say together:** the M2 relative story does not transfer to this
+host. Against g++, the ports sit near WRITE parity (Rust 108%!) — because the C++
+reference never received its restrict boost here (verdict (a) below) — while READS sit
+further away than on the M2 (Go 370–477%). And "C++ = 100%" names a different C++
+depending on compiler: clang-18 beats g++ by up to 4.3x on tiny-message writes (verdict
+(c)), so every relative cell moves by double-digit points when the denominator changes
+compiler. **A relative table is a fact about a (code, compiler, microarchitecture)
+triple, never about a language.** The README's "dated snapshot, not a verdict" warning
+was written for time; this pass proves it for space too.
+
+## Verdict (a): the restrict win is REFUTED on Zen 4 — under BOTH compilers
+
+serialize #30 (restrict-qualifying the writer's `this`) measured +38%…+158% composed on
+the C++ write rows on arm64/apple-clang — the single biggest C++ write lever of the
+program. The A/B here isolates exactly #30 (`serialize` main vs `561e81d`), write rows:
+
+| bench (write) | g++ pre | g++ post | post/pre | clang pre | clang post | post/pre |
+|---|---:|---:|---:|---:|---:|---:|
+| rigidbody_moving | 24.24 | 24.59 | **1.01x** | 24.45 | 24.69 | **1.01x** |
+| rigidbody_at_rest | 40.96 | 40.92 | **1.00x** | 50.46 | 50.54 | **1.00x** |
+| chat | 35.69 | 35.71 | **1.00x** | 65.38 | 65.52 | **1.00x** |
+| test | 118.37 | 118.14 | **1.00x** | 505.49 | 505.04 | **1.00x** |
+| inputpacket | 31.79 | 31.88 | **1.00x** | 31.13 | 31.13 | **1.00x** |
+| shipcreate | 31.63 | 34.32 | **1.09x** | 52.52 | 52.63 | **1.00x** |
+| ship_shallow | 55.68 | 55.86 | **1.00x** | 61.36 | 61.35 | **1.00x** |
+| probe_header | 122.34 | 120.98 | **0.99x** | 496.36 | 501.82 | **1.01x** |
+| probebits | 83.35 | 83.35 | **1.00x** | 89.49 | 89.99 | **1.01x** |
+| probearray | 29.71 | 25.70 | **0.87x** | 36.54 | 35.27 | **0.97x** |
+| testdata | 9.06 | 9.18 | **1.01x** | 14.09 | 14.09 | **1.00x** |
+| message_batch | 61.06 | 61.41 | **1.01x** | 60.58 | 60.37 | **1.00x** |
+
+The rows that moved +128%…+152% isolated on arm64 (the rigidbody pair) move **1.01x**
+here. Nothing anywhere approaches the arm64 class; the three small movers (shipcreate
++9%, probearray −13%, testdata read +11% in the full table) are the layout band. The
+theory going in was "boundary-aliasing, compiler-dependent" — the measurement is stronger:
+**absent on this target under both g++-13 and clang-18.** The M2 write table's C++
+dominance is in material part an apple-clang/arm64 aliasing win, not a property of the
+generated code. (Confirmed independently by the v2→v5 composed C++ rows here: mostly
+1.00–1.12x, vs the M2's 1.6–2.4x writes — the C++ program's composed effect on this host
+is bulk-bytes and const-emit, not restrict.) Raws:
+`2026-08-07-four-language-v5-x86_64-epyc-restrict-ab-{gcc,clang}.csv`.
+
+## Verdict (c): the g++-vs-clang tiny-message gap PERSISTS post-const-emit
+
+Pre-everything (2026-08-06 baseline) the gap was probe_header write **4.01x**, test write
+**3.62x**. Post const-emit (schema #8, generation-time bit-count folding) it is
+probe_header **4.15x**, test **4.27x** — unchanged to slightly wider. clang-18 leads 19
+of 24 rows, up to 1.90x on reads (rigidbody_moving 1.90x, probebits 1.89x); g++ holds
+only testdata read (1.19x the other way), probearray read, and two batch-write ties.
+Full pairing in the harvest analysis; raw legs 1 vs 5.
+
+**Interpretation:** the folding schema's generator does (bit counts known at generation
+time) is not the folding clang does (whole-header store merging across consecutive
+fields) — const-emit removed the outlined runtime calls and the 4x remained, so the 4x
+lives in instruction selection and store merging, not in bit-count arithmetic. **Open
+question routed to the gap ledger:** whether x86 tables should adopt clang-18 as the
+reference compiler (g++ stays primary in this pass per the original baseline; both are
+committed).
+
+## Verdict (b): lane composition on x86 — Go transfers almost row for row
+
+Per-language v2→v5 absolute deltas on this host (v2 EPYC, 2026-08-06 pre-everything, is
+the only prior x86 record; v2 predates the go READ lane as well, so go reads state that
+provenance):
+
+- **Go writes: the lane transfers.** ship_shallow **1.89x** (M2 composed: 1.83x),
+  shipcreate **1.79x** (1.79x — exact), test 1.77x (1.61x), testdata 1.61x (1.37x),
+  inputpacket 1.40x (1.30x), probebits 1.38x (1.39x), probearray 1.39x (1.35x),
+  probe_header 1.23x (1.26x). Same mechanism, same shape, second microarchitecture —
+  serialize.go #19 + schema #13 are portable, unlike restrict. Go reads gained
+  1.26–2.13x v2→v5 (that includes serialize.go #17's read lane, which is v2→v3).
+- **Rust: the write lane transfers, one x86-specific regression filed.** The
+  serialize.rs #19/#20 + schema #5/#6 rows: inputpacket write 2.05x, shipcreate 2.06x,
+  ship_shallow 2.18x; batch read **2.08x** (read_message_into). But chat write composed
+  only **1.16x** here vs 1.70–1.78x on M2 — the 256B–2KB array-copy kill pays less on
+  Zen 4 — and **inputpacket read regressed 0.85x** (14.51 → 12.29, beyond spreads
+  2.3%/1.9%), unattributed, filed with the ledger's rust-read items.
+- **C#: write composition is UNMEASURABLE on this host under default config** (the
+  artifact sits on both sides of the v2→v5 compare). The read rows, which are mostly
+  clean both sides, composed 1.60–2.08x on seven of twelve (rigidbody_at_rest 2.08x,
+  inputpacket 2.06x, shipcreate 2.04x, probearray 2.02x, ship_shallow 1.81x, testdata
+  1.63x, probebits 1.60x†spready). The steady-state diagnostic cannot be compared to v2
+  (different runtime config).
+- **C++: quiet, as verdict (a) predicts.** Mostly ≤1.12x; testdata read **1.33x** (the
+  bulk-bytes #7 win, portable), test read 1.12x, test write 1.10x; probearray write
+  0.93x / batch write 0.94x small down-moves within the band.
+
+## Caveats
+
+- Everything here shares core 0 with irqs, ssh and systemd — the label rides every
+  preamble. This is the quietest x86 we have, not a quiet x86.
+- The clang leg's reads are spready in places (rigidbody_at_rest 25.9%, chat 26.6%,
+  probebits 32.1%) — medians sit against max; read its read cells with that in mind.
+- One write-control row moved beyond spread (test write +13%) — the same bench's write
+  cell moved 1.30x between sittings in the v2 EPYC doc; treated as the layout band.
+- The diagnostic leg ran 2026-08-11, four days after the pass, same box, same pins,
+  serial and alone; it is mechanism proof, not a fifth table.
+- v5 is pinned by SHA above; anything merged after the pull is out of v5.
+
+## Files
+
+- `2026-08-07-four-language-v5-x86_64-epyc.csv` — main table (legs 1–4 concatenated)
+- `2026-08-07-four-language-v5-x86_64-epyc-clang.csv` — leg 5 (clang-18 C++)
+- `2026-08-07-four-language-v5-x86_64-epyc-restrict-ab-gcc.csv` — leg 6
+- `2026-08-07-four-language-v5-x86_64-epyc-restrict-ab-clang.csv` — leg 7
+- `2026-08-07-four-language-v5-x86_64-epyc-write-control.csv` — leg 8
+- `2026-08-11-cs-tiered-jit-diagnostic-x86_64-epyc.csv` — the labelled diagnostic
+- `2026-08-07-v5-epyc-pass.log` — the serial-gate evidence (quiet windows, core-0 snapshots)

--- a/bench/results/2026-08-07-four-language-v5-x86_64-epyc-clang.csv
+++ b/bench/results/2026-08-07-four-language-v5-x86_64-epyc-clang.csv
@@ -1,0 +1,39 @@
+# schema bench results
+# date: 2026-08-07T15:58:10Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: Ubuntu clang version 18.1.3 (1ubuntu1)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-cs-port/serialize
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct
+cpp,rigidbody_moving,write,2000000,105,7,24691894,24646541,25571802,2472.54,3.75
+cpp,rigidbody_moving,read,2000000,105,7,57713242,57428144,58284427,5779.16,1.48
+cpp,rigidbody_at_rest,write,4000000,57,7,50539891,50343309,52465252,2747.32,4.20
+cpp,rigidbody_at_rest,read,4000000,57,7,85551712,68880121,91056888,4650.54,25.92
+cpp,chat,write,4000000,13,7,65515051,65274210,68694000,812.24,5.22
+cpp,chat,read,4000000,13,7,87704773,70711593,94059546,1087.34,26.62
+cpp,test,write,16000000,6,7,505036326,498816222,554973165,2889.84,11.12
+cpp,test,read,16000000,6,7,377323560,368403968,401988458,2159.06,8.90
+cpp,inputpacket,write,2000000,61,7,31127221,30745961,32584422,1810.80,5.91
+cpp,inputpacket,read,2000000,61,7,42384588,42265340,45182289,2465.69,6.88
+cpp,shipcreate,write,4000000,28,7,52625498,47343694,54675064,1405.25,13.93
+cpp,shipcreate,read,4000000,28,7,77021552,72895673,77206133,2056.70,5.60
+cpp,ship_shallow,write,4000000,28,7,61354151,54512943,61500467,1638.33,11.39
+cpp,ship_shallow,read,4000000,28,7,80336878,80049991,80498852,2145.23,0.56
+cpp,probe_header,write,16000000,10,7,501820096,484913355,550165524,4785.73,13.00
+cpp,probe_header,read,16000000,10,7,302326290,287283594,303337936,2883.21,5.31
+cpp,probebits,write,4000000,26,7,89993926,88971784,96160477,2231.45,7.99
+cpp,probebits,read,4000000,26,7,268904358,259988935,346441307,6667.63,32.15
+cpp,probearray,write,2000000,47,7,35269741,31909482,36767503,1580.88,13.77
+cpp,probearray,read,2000000,47,7,54976837,50897400,55072421,2464.21,7.59
+cpp,testdata,write,1000000,92,7,14089050,12343214,14166759,1236.15,12.94
+cpp,testdata,read,1000000,92,7,21238258,20046505,22593643,1863.40,11.99
+cpp,message_batch,write,3276800,25,7,60365347,56082506,60583914,1439.22,7.46
+cpp,message_batch,read,3276800,25,7,51639559,46032897,54686702,1231.18,16.76

--- a/bench/results/2026-08-07-four-language-v5-x86_64-epyc-restrict-ab-clang.csv
+++ b/bench/results/2026-08-07-four-language-v5-x86_64-epyc-restrict-ab-clang.csv
@@ -1,0 +1,39 @@
+# schema bench results
+# date: 2026-08-07T15:58:54Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: Ubuntu clang version 18.1.3 (1ubuntu1)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-pre-restrict
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct
+cpp,rigidbody_moving,write,2000000,105,7,24452518,23289750,24495133,2448.57,4.93
+cpp,rigidbody_moving,read,2000000,105,7,57703950,53101057,58125288,5778.23,8.71
+cpp,rigidbody_at_rest,write,4000000,57,7,50459863,50394920,52483439,2742.97,4.14
+cpp,rigidbody_at_rest,read,4000000,57,7,85098683,69952576,92168120,4625.92,26.11
+cpp,chat,write,4000000,13,7,65380510,65234914,68846555,810.57,5.52
+cpp,chat,read,4000000,13,7,88023768,87646813,93790922,1091.30,6.98
+cpp,test,write,16000000,6,7,505494430,500759107,559063933,2892.46,11.53
+cpp,test,read,16000000,6,7,383196991,325596853,414954885,2192.67,23.32
+cpp,inputpacket,write,2000000,61,7,31133813,25814901,32578864,1811.18,21.73
+cpp,inputpacket,read,2000000,61,7,42172670,39709337,44945261,2453.36,12.42
+cpp,shipcreate,write,4000000,28,7,52520822,52371304,54687932,1402.46,4.41
+cpp,shipcreate,read,4000000,28,7,76897640,72854715,77273119,2053.39,5.75
+cpp,ship_shallow,write,4000000,28,7,61361038,48299460,64228977,1638.52,25.96
+cpp,ship_shallow,read,4000000,28,7,80454868,79512831,80550865,2148.38,1.29
+cpp,probe_header,write,16000000,10,7,496360224,477448772,502682589,4733.66,5.08
+cpp,probe_header,read,16000000,10,7,302343443,250367936,302979749,2883.37,17.40
+cpp,probebits,write,4000000,26,7,89494721,89003643,95952573,2219.07,7.76
+cpp,probebits,read,4000000,26,7,263515878,252443359,341511703,6534.02,33.80
+cpp,probearray,write,2000000,47,7,36541068,34763320,36668149,1637.87,5.21
+cpp,probearray,read,2000000,47,7,54912098,50889266,55027726,2461.31,7.54
+cpp,testdata,write,1000000,92,7,14089018,12235097,14159680,1236.14,13.66
+cpp,testdata,read,1000000,92,7,21230376,21098105,22563585,1862.71,6.90
+cpp,message_batch,write,3276800,25,7,60584990,57128687,60771735,1444.46,6.01
+cpp,message_batch,read,3276800,25,7,53415806,47157185,56212459,1273.53,16.95

--- a/bench/results/2026-08-07-four-language-v5-x86_64-epyc-restrict-ab-gcc.csv
+++ b/bench/results/2026-08-07-four-language-v5-x86_64-epyc-restrict-ab-gcc.csv
@@ -1,0 +1,39 @@
+# schema bench results
+# date: 2026-08-07T15:58:30Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-pre-restrict -Wno-class-memaccess -Wno-type-limits
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct
+cpp,rigidbody_moving,write,2000000,105,7,24237330,24209652,24262678,2427.02,0.22
+cpp,rigidbody_moving,read,2000000,105,7,30231814,26912230,30257376,3027.29,11.06
+cpp,rigidbody_at_rest,write,4000000,57,7,40958902,37749843,42205185,2226.50,10.88
+cpp,rigidbody_at_rest,read,4000000,57,7,59795990,59716648,59874004,3250.48,0.26
+cpp,chat,write,4000000,13,7,35690339,35630840,36647430,442.48,2.85
+cpp,chat,read,4000000,13,7,75575811,62528291,75666643,936.97,17.38
+cpp,test,write,16000000,6,7,118374686,115075532,119318435,677.35,3.58
+cpp,test,read,16000000,6,7,223661860,215289765,224017842,1279.80,3.90
+cpp,inputpacket,write,2000000,61,7,31785782,29516051,33476342,1849.11,12.46
+cpp,inputpacket,read,2000000,61,7,36438622,34625317,36502998,2119.79,5.15
+cpp,shipcreate,write,4000000,28,7,31632921,30554133,33088324,844.69,8.01
+cpp,shipcreate,read,4000000,28,7,74440370,69763836,74557643,1987.77,6.44
+cpp,ship_shallow,write,4000000,28,7,55676790,53639559,55863276,1486.73,3.99
+cpp,ship_shallow,read,4000000,28,7,77741085,64003861,77815899,2075.91,17.77
+cpp,probe_header,write,16000000,10,7,122336642,111918449,123877202,1166.69,9.78
+cpp,probe_header,read,16000000,10,7,179918282,173973380,180751555,1715.83,3.77
+cpp,probebits,write,4000000,26,7,83349763,79964121,88642030,2066.70,10.41
+cpp,probebits,read,4000000,26,7,140517367,139925681,156783521,3484.20,12.00
+cpp,probearray,write,2000000,47,7,29710956,28498281,29815004,1331.73,4.43
+cpp,probearray,read,2000000,47,7,58385698,53962668,58522501,2617.00,7.81
+cpp,testdata,write,1000000,92,7,9058085,9022382,9289253,794.74,2.95
+cpp,testdata,read,1000000,92,7,22991196,22813300,24627752,2017.20,7.89
+cpp,message_batch,write,3276800,25,7,61061463,58032069,61286557,1455.82,5.33
+cpp,message_batch,read,3276800,25,7,42198302,41876372,43777114,1006.09,4.50

--- a/bench/results/2026-08-07-four-language-v5-x86_64-epyc-write-control.csv
+++ b/bench/results/2026-08-07-four-language-v5-x86_64-epyc-write-control.csv
@@ -1,0 +1,39 @@
+# schema bench results
+# date: 2026-08-07T15:59:14Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-cs-port/serialize -Wno-class-memaccess -Wno-type-limits
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct
+cpp,rigidbody_moving,write,2000000,105,7,24553162,24443009,25415424,2458.65,3.96
+cpp,rigidbody_moving,read,2000000,105,7,30388551,30252870,31784449,3042.98,5.04
+cpp,rigidbody_at_rest,write,4000000,57,7,40849432,36651534,42145450,2220.55,13.45
+cpp,rigidbody_at_rest,read,4000000,57,7,59762788,59591580,59859380,3248.67,0.45
+cpp,chat,write,4000000,13,7,35615435,33176684,36612767,441.55,9.65
+cpp,chat,read,4000000,13,7,74098041,70373333,74307711,918.65,5.31
+cpp,test,write,16000000,6,7,133198927,122206203,133396332,762.17,8.40
+cpp,test,read,16000000,6,7,221046419,193262877,221913543,1264.84,12.96
+cpp,inputpacket,write,2000000,61,7,31901737,28505137,33293077,1855.86,15.01
+cpp,inputpacket,read,2000000,61,7,35910101,34629829,36484304,2089.04,5.16
+cpp,shipcreate,write,4000000,28,7,34200591,34134788,34248914,913.25,0.33
+cpp,shipcreate,read,4000000,28,7,74187112,65608568,74289609,1981.01,11.70
+cpp,ship_shallow,write,4000000,28,7,55521178,53340259,55617669,1482.58,4.10
+cpp,ship_shallow,read,4000000,28,7,77429807,73224441,77584823,2067.60,5.63
+cpp,probe_header,write,16000000,10,7,124174258,117062704,127391699,1184.22,8.32
+cpp,probe_header,read,16000000,10,7,180146319,170114679,180548415,1718.01,5.79
+cpp,probebits,write,4000000,26,7,82999695,76440386,83196298,2058.02,8.14
+cpp,probebits,read,4000000,26,7,140937764,139515099,157476818,3494.63,12.74
+cpp,probearray,write,2000000,47,7,26998017,25397268,28043325,1210.12,9.80
+cpp,probearray,read,2000000,47,7,57596147,53155683,57638653,2581.61,7.78
+cpp,testdata,write,1000000,92,7,9133276,8561753,9383863,801.34,9.00
+cpp,testdata,read,1000000,92,7,25460382,23803695,25602027,2233.84,7.06
+cpp,message_batch,write,3276800,25,7,61059102,57898085,61266716,1455.76,5.52
+cpp,message_batch,read,3276800,25,7,41984162,36778247,43699126,1000.98,16.48

--- a/bench/results/2026-08-07-four-language-v5-x86_64-epyc.csv
+++ b/bench/results/2026-08-07-four-language-v5-x86_64-epyc.csv
@@ -1,0 +1,153 @@
+# schema bench results
+# date: 2026-08-07T15:55:37Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-cs-port/serialize -Wno-class-memaccess -Wno-type-limits
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct
+cpp,rigidbody_moving,write,2000000,105,7,24585721,21621396,25497820,2461.91,15.77
+cpp,rigidbody_moving,read,2000000,105,7,30425128,30334471,31828653,3046.64,4.91
+cpp,rigidbody_at_rest,write,4000000,57,7,40920240,40869348,42178447,2224.40,3.20
+cpp,rigidbody_at_rest,read,4000000,57,7,59708811,51168884,59959546,3245.74,14.72
+cpp,chat,write,4000000,13,7,35713488,35603249,36554476,442.77,2.66
+cpp,chat,read,4000000,13,7,75210612,62214291,75336035,932.44,17.45
+cpp,test,write,16000000,6,7,118141804,114919301,118604967,676.01,3.12
+cpp,test,read,16000000,6,7,226011204,194848957,226741553,1293.25,14.11
+cpp,inputpacket,write,2000000,61,7,31883871,31756694,33359110,1854.82,5.03
+cpp,inputpacket,read,2000000,61,7,36475170,34677961,36544837,2121.91,5.12
+cpp,shipcreate,write,4000000,28,7,34323472,34296722,34346111,916.54,0.14
+cpp,shipcreate,read,4000000,28,7,74545764,70701531,74670550,1990.59,5.32
+cpp,ship_shallow,write,4000000,28,7,55864334,53728145,55981741,1491.74,4.03
+cpp,ship_shallow,read,4000000,28,7,77887072,77737663,78052991,2079.81,0.40
+cpp,probe_header,write,16000000,10,7,120978284,119716689,122162746,1153.74,2.02
+cpp,probe_header,read,16000000,10,7,180683606,160681601,181054052,1723.13,11.28
+cpp,probebits,write,4000000,26,7,83354558,83104077,88705205,2066.82,6.72
+cpp,probebits,read,4000000,26,7,142001017,140861126,158187155,3520.99,12.20
+cpp,probearray,write,2000000,47,7,25704491,24451964,28124744,1152.14,14.29
+cpp,probearray,read,2000000,47,7,57287282,52988078,57440980,2567.77,7.77
+cpp,testdata,write,1000000,92,7,9177811,9137440,9403016,805.24,2.89
+cpp,testdata,read,1000000,92,7,25421534,23694171,25475528,2230.44,7.01
+cpp,message_batch,write,3276800,25,7,61411825,50965962,61759040,1464.17,17.57
+cpp,message_batch,read,3276800,25,7,41964087,41609933,43579300,1000.50,4.69
+# schema bench results
+# date: 2026-08-07T15:56:02Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: c++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-cs-port/serialize
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+go,rigidbody_moving,write,2000000,105,7,13855801,13110462,14145536,1387.46,7.47
+go,rigidbody_moving,read,2000000,105,7,15765153,14877126,16131158,1578.66,7.95
+go,rigidbody_at_rest,write,4000000,57,7,24891073,23647988,25340454,1353.06,6.80
+go,rigidbody_at_rest,read,4000000,57,7,27703621,26191629,28249836,1505.95,7.43
+go,chat,write,4000000,13,7,24441078,24404750,24885133,303.01,1.97
+go,chat,read,4000000,13,7,47791230,39445888,47894651,592.50,17.68
+go,test,write,16000000,6,7,69479113,68098651,70292297,397.56,3.16
+go,test,read,16000000,6,7,54983134,53393834,55570391,314.62,3.96
+go,inputpacket,write,2000000,61,7,11910167,11388918,11953970,692.86,4.74
+go,inputpacket,read,2000000,61,7,11779165,11589565,11791358,685.24,1.71
+go,shipcreate,write,4000000,28,7,19720998,18770329,19831700,526.61,5.38
+go,shipcreate,read,4000000,28,7,14695292,14148116,14894286,392.41,5.08
+go,ship_shallow,write,4000000,28,7,22322346,21833477,22947071,596.07,4.99
+go,ship_shallow,read,4000000,28,7,16827212,16293458,17048235,449.34,4.49
+go,probe_header,write,16000000,10,7,51923589,50580327,52526885,495.18,3.75
+go,probe_header,read,16000000,10,7,48829344,47686312,49199949,465.67,3.10
+go,probebits,write,4000000,26,7,38029440,37177889,38222462,942.96,2.75
+go,probebits,read,4000000,26,7,38692125,35100754,38765610,959.39,9.47
+go,probearray,write,2000000,47,7,12941959,11470237,13023618,580.09,12.00
+go,probearray,read,2000000,47,7,11008598,10535771,11022780,493.44,4.42
+go,testdata,write,1000000,92,7,6780947,6418354,6908948,594.95,7.23
+go,testdata,read,1000000,92,7,6262906,6122790,6379261,549.50,4.10
+go,message_batch,write,3276800,25,7,31311868,28375684,31385736,746.53,9.61
+go,message_batch,read,3276800,25,7,38681331,37385615,38854915,922.23,3.80
+# schema bench results
+# date: 2026-08-07T15:56:45Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: c++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-cs-port/serialize
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+rust,rigidbody_moving,write,2000000,105,7,19988626,19850664,20160096,2001.58,1.55
+rust,rigidbody_moving,read,2000000,105,7,36180298,34552760,36574317,3622.94,5.59
+rust,rigidbody_at_rest,write,4000000,57,7,32019305,30914721,32780362,1740.55,5.83
+rust,rigidbody_at_rest,read,4000000,57,7,64666291,64389251,67917338,3515.22,5.46
+rust,chat,write,4000000,13,7,41914953,41762691,43254208,519.65,3.56
+rust,chat,read,4000000,13,7,41741388,41693954,43119677,517.50,3.42
+rust,test,write,16000000,6,7,132932974,121574819,133022461,760.65,8.61
+rust,test,read,16000000,6,7,64079408,61416440,64170373,366.67,4.30
+rust,inputpacket,write,2000000,61,7,28625547,24710648,28743421,1665.27,14.09
+rust,inputpacket,read,2000000,61,7,12285991,12270004,12509154,714.73,1.95
+rust,shipcreate,write,4000000,28,7,41001462,37824497,42294836,1094.86,10.90
+rust,shipcreate,read,4000000,28,7,26814038,25438673,26841307,716.01,5.23
+rust,ship_shallow,write,4000000,28,7,50642296,50456065,52561980,1352.30,4.16
+rust,ship_shallow,read,4000000,28,7,19792737,18523618,19830340,528.52,6.60
+rust,probe_header,write,16000000,10,7,112501532,111300481,115126384,1072.90,3.40
+rust,probe_header,read,16000000,10,7,55879768,54691997,56297678,532.91,2.87
+rust,probebits,write,4000000,26,7,55092491,52888120,55167053,1366.05,4.14
+rust,probebits,read,4000000,26,7,51754771,46701494,53788170,1283.29,13.69
+rust,probearray,write,2000000,47,7,23974597,23899213,23998405,1074.61,0.41
+rust,probearray,read,2000000,47,7,29154836,24986247,29191240,1306.80,14.42
+rust,testdata,write,1000000,92,7,10296582,10272462,10619351,903.40,3.37
+rust,testdata,read,1000000,92,7,9698826,8536841,9703658,850.96,12.03
+rust,message_batch,write,3276800,25,7,59361391,52871056,59698554,1415.29,11.50
+rust,message_batch,read,3276800,25,7,33594158,33327223,34499987,800.95,3.49
+# schema bench results
+# date: 2026-08-07T15:57:17Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: c++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-cs-port/serialize
+# go: go version go1.26.5 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)
+# schema commit: unknown
+# serialize commit: unknown
+cs,rigidbody_moving,write,2000000,105,7,11834383,2406220,11985191,1185.05,80.94
+cs,rigidbody_moving,read,2000000,105,7,13359875,13004857,27057485,1337.80,105.19
+cs,rigidbody_at_rest,write,4000000,57,7,35030196,34961520,35955573,1904.22,2.84
+cs,rigidbody_at_rest,read,4000000,57,7,39889307,35066126,39917411,2168.36,12.16
+cs,chat,write,4000000,13,7,24965594,4110996,25426950,309.52,85.38
+cs,chat,read,4000000,13,7,54662731,52609012,54874502,677.70,4.14
+cs,test,write,16000000,6,7,76205209,22106641,77274639,436.05,72.39
+cs,test,read,16000000,6,7,105130154,103118297,105239202,601.56,2.02
+cs,inputpacket,write,2000000,61,7,6286772,5925452,22940305,365.73,270.65
+cs,inputpacket,read,2000000,61,7,20899035,20836068,21574228,1215.78,3.53
+cs,shipcreate,write,4000000,28,7,9876521,9231298,34431734,263.73,255.15
+cs,shipcreate,read,4000000,28,7,39149554,33372518,39234188,1045.41,14.97
+cs,ship_shallow,write,4000000,28,7,11271330,10856862,36407822,300.98,226.69
+cs,ship_shallow,read,4000000,28,7,40182469,37138170,40239222,1072.99,7.72
+cs,probe_header,write,16000000,10,7,70150363,23746320,71286666,669.01,67.77
+cs,probe_header,read,16000000,10,7,81842144,78084318,83112825,780.51,6.14
+cs,probebits,write,4000000,26,7,21008183,18702058,21141727,520.91,11.61
+cs,probebits,read,4000000,26,7,68616166,21182076,72249898,1701.37,74.43
+cs,probearray,write,2000000,47,7,5017702,4905261,24239134,224.91,385.31
+cs,probearray,read,2000000,47,7,29424270,25308126,29470185,1318.88,14.14
+cs,testdata,write,1000000,92,7,3010326,2861303,9976864,264.12,236.37
+cs,testdata,read,1000000,92,7,8756912,7826079,9006964,768.31,13.49
+cs,message_batch,write,3276800,25,7,24749974,13079654,56380874,590.09,174.95
+cs,message_batch,read,3276800,25,7,20667428,19346946,21100894,492.75,8.49

--- a/bench/results/2026-08-07-gap-ledger.md
+++ b/bench/results/2026-08-07-gap-ledger.md
@@ -10,6 +10,19 @@ measurement of an isolated effect — then the PR is cited and said so. Where
 v3 moved a number relative to an earlier doc, v3 is preferred and the move
 is stated.
 
+> **2026-08-11 — the EPYC leg landed** (`2026-08-07-four-language-v5-epyc.md`), and it
+> re-scopes several items below: **restrict (#30) is REFUTED on Zen 4 under both g++-13
+> and clang-18** (1.00x across the write rows — the ledger's restrict attributions are
+> arm64/apple-clang facts, not portable laws); **the tiny-message compiler gap persists
+> post-const-emit** (clang-18 up to 4.3x g++ on probe_header/test writes — the
+> whole-header-folding floor now has a second compiler on a second microarchitecture,
+> and "should x86 tables adopt clang-18 as reference?" is an open call); the
+> quiet-x86-profile items below can now use the box (serial, core 0, one profile at a
+> time, `bench/run.sh --only`); benching C# there surfaced the **tiered-JIT single-core
+> artifact** (v2 EPYC C# rows retracted as language verdicts). One new unattributed
+> item: **rust inputpacket read regressed 0.85x v2→v5 on EPYC**, beyond spreads — files
+> with the rust read column's never-had-a-read-pass items.
+
 **The v3 scoreboard** (M2, time relative to C++ = 100%, medians across the
 11 corpus benches; batch separately; EPYC deferred on Glenn's word):
 

--- a/bench/results/2026-08-07-v5-epyc-pass.log
+++ b/bench/results/2026-08-07-v5-epyc-pass.log
@@ -1,0 +1,313 @@
+===== v5 EPYC pass START 2026-08-07T15:55:32Z host=spacegame =====
+toolchains: g++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0 | Ubuntu clang version 18.1.3 (1ubuntu1) | go version go1.26.5 linux/amd64 | cargo 1.97.1 (c980f4866 2026-06-30) / rustc 1.97.1 (8bab26f4f 2026-07-14) | dotnet 10.0.302
+isolated cpus: 1-15
+--- pscheck [before-cpp-gcc-start] 2026-08-07T15:55:32Z load=6.35 5.90 5.58
+  clean: none of ours running
+  cpu0 pre : cpu0 51426909 121122 19748851 1838903340 40608 0 317796 0 0 0
+  cpu0 post: cpu0 51426999 121122 19748855 1838903749 40608 0 317796 0 0 0
+=== leg cpp-gcc-start START 2026-08-07T15:55:37Z (--only cpp --compiler g++)
+== cpp: build (Release) ==
+== cpp: run (Release) ==
+schema bench (cpp, Release)
+rigidbody_moving   write      24.59 M msg/s     2461.9 MB/s   (min 21.62, max 25.50, spread 15.8%)
+rigidbody_moving   read       30.43 M msg/s     3046.6 MB/s   (min 30.33, max 31.83, spread 4.9%)
+rigidbody_at_rest  write      40.92 M msg/s     2224.4 MB/s   (min 40.87, max 42.18, spread 3.2%)
+rigidbody_at_rest  read       59.71 M msg/s     3245.7 MB/s   (min 51.17, max 59.96, spread 14.7%)
+chat               write      35.71 M msg/s      442.8 MB/s   (min 35.60, max 36.55, spread 2.7%)
+chat               read       75.21 M msg/s      932.4 MB/s   (min 62.21, max 75.34, spread 17.4%)
+test               write     118.14 M msg/s      676.0 MB/s   (min 114.92, max 118.60, spread 3.1%)
+test               read      226.01 M msg/s     1293.2 MB/s   (min 194.85, max 226.74, spread 14.1%)
+inputpacket        write      31.88 M msg/s     1854.8 MB/s   (min 31.76, max 33.36, spread 5.0%)
+inputpacket        read       36.48 M msg/s     2121.9 MB/s   (min 34.68, max 36.54, spread 5.1%)
+shipcreate         write      34.32 M msg/s      916.5 MB/s   (min 34.30, max 34.35, spread 0.1%)
+shipcreate         read       74.55 M msg/s     1990.6 MB/s   (min 70.70, max 74.67, spread 5.3%)
+ship_shallow       write      55.86 M msg/s     1491.7 MB/s   (min 53.73, max 55.98, spread 4.0%)
+ship_shallow       read       77.89 M msg/s     2079.8 MB/s   (min 77.74, max 78.05, spread 0.4%)
+probe_header       write     120.98 M msg/s     1153.7 MB/s   (min 119.72, max 122.16, spread 2.0%)
+probe_header       read      180.68 M msg/s     1723.1 MB/s   (min 160.68, max 181.05, spread 11.3%)
+probebits          write      83.35 M msg/s     2066.8 MB/s   (min 83.10, max 88.71, spread 6.7%)
+probebits          read      142.00 M msg/s     3521.0 MB/s   (min 140.86, max 158.19, spread 12.2%)
+probearray         write      25.70 M msg/s     1152.1 MB/s   (min 24.45, max 28.12, spread 14.3%)
+probearray         read       57.29 M msg/s     2567.8 MB/s   (min 52.99, max 57.44, spread 7.8%)
+testdata           write       9.18 M msg/s      805.2 MB/s   (min 9.14, max 9.40, spread 2.9%)
+testdata           read       25.42 M msg/s     2230.4 MB/s   (min 23.69, max 25.48, spread 7.0%)
+message_batch      write      61.41 M msg/s     1464.2 MB/s   (min 50.97, max 61.76, spread 17.6%)
+message_batch      read       41.96 M msg/s     1000.5 MB/s   (min 41.61, max 43.58, spread 4.7%)
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/cpp-gcc-start.csv
+=== leg cpp-gcc-start OK 2026-08-07T15:55:53Z
+--- pscheck [before-go] 2026-08-07T15:55:56Z load=5.97 5.87 5.58
+  clean: none of ours running
+  cpu0 pre : cpu0 51428646 121122 19748887 1838903996 40608 0 317796 0 0 0
+  cpu0 post: cpu0 51428729 121122 19748891 1838904405 40608 0 317796 0 0 0
+=== leg go START 2026-08-07T15:56:01Z (--only go)
+== go: run ==
+schema bench (go)
+rigidbody_moving   write      13.86 M msg/s     1387.5 MB/s   (min 13.11, max 14.15, spread 7.5%)
+rigidbody_moving   read       15.77 M msg/s     1578.7 MB/s   (min 14.88, max 16.13, spread 8.0%)
+alloc note: rigidbody_moving one pass (256 ops/path): write 0 allocs, read 0 allocs
+rigidbody_at_rest  write      24.89 M msg/s     1353.1 MB/s   (min 23.65, max 25.34, spread 6.8%)
+rigidbody_at_rest  read       27.70 M msg/s     1506.0 MB/s   (min 26.19, max 28.25, spread 7.4%)
+alloc note: rigidbody_at_rest one pass (256 ops/path): write 0 allocs, read 0 allocs
+chat               write      24.44 M msg/s      303.0 MB/s   (min 24.40, max 24.89, spread 2.0%)
+chat               read       47.79 M msg/s      592.5 MB/s   (min 39.45, max 47.89, spread 17.7%)
+alloc note: chat one pass (256 ops/path): write 0 allocs, read 0 allocs
+test               write      69.48 M msg/s      397.6 MB/s   (min 68.10, max 70.29, spread 3.2%)
+test               read       54.98 M msg/s      314.6 MB/s   (min 53.39, max 55.57, spread 4.0%)
+alloc note: test one pass (256 ops/path): write 0 allocs, read 0 allocs
+inputpacket        write      11.91 M msg/s      692.9 MB/s   (min 11.39, max 11.95, spread 4.7%)
+inputpacket        read       11.78 M msg/s      685.2 MB/s   (min 11.59, max 11.79, spread 1.7%)
+alloc note: inputpacket one pass (256 ops/path): write 0 allocs, read 0 allocs
+shipcreate         write      19.72 M msg/s      526.6 MB/s   (min 18.77, max 19.83, spread 5.4%)
+shipcreate         read       14.70 M msg/s      392.4 MB/s   (min 14.15, max 14.89, spread 5.1%)
+alloc note: shipcreate one pass (256 ops/path): write 0 allocs, read 0 allocs
+ship_shallow       write      22.32 M msg/s      596.1 MB/s   (min 21.83, max 22.95, spread 5.0%)
+ship_shallow       read       16.83 M msg/s      449.3 MB/s   (min 16.29, max 17.05, spread 4.5%)
+alloc note: ship_shallow one pass (256 ops/path): write 0 allocs, read 0 allocs
+probe_header       write      51.92 M msg/s      495.2 MB/s   (min 50.58, max 52.53, spread 3.7%)
+probe_header       read       48.83 M msg/s      465.7 MB/s   (min 47.69, max 49.20, spread 3.1%)
+alloc note: probe_header one pass (256 ops/path): write 0 allocs, read 0 allocs
+probebits          write      38.03 M msg/s      943.0 MB/s   (min 37.18, max 38.22, spread 2.7%)
+probebits          read       38.69 M msg/s      959.4 MB/s   (min 35.10, max 38.77, spread 9.5%)
+alloc note: probebits one pass (256 ops/path): write 0 allocs, read 0 allocs
+probearray         write      12.94 M msg/s      580.1 MB/s   (min 11.47, max 13.02, spread 12.0%)
+probearray         read       11.01 M msg/s      493.4 MB/s   (min 10.54, max 11.02, spread 4.4%)
+alloc note: probearray one pass (256 ops/path): write 0 allocs, read 0 allocs
+testdata           write       6.78 M msg/s      594.9 MB/s   (min 6.42, max 6.91, spread 7.2%)
+testdata           read        6.26 M msg/s      549.5 MB/s   (min 6.12, max 6.38, spread 4.1%)
+alloc note: testdata one pass (256 ops/path): write 0 allocs, read 0 allocs
+message_batch      write      31.31 M msg/s      746.5 MB/s   (min 28.38, max 31.39, spread 9.6%)
+message_batch      read       38.68 M msg/s      922.2 MB/s   (min 37.39, max 38.85, spread 3.8%)
+alloc note: message_batch one pass (4096 msgs): write 0 allocs, read 0 allocs
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/go.csv
+=== leg go OK 2026-08-07T15:56:37Z
+--- pscheck [before-rust] 2026-08-07T15:56:40Z load=6.10 5.91 5.61
+  clean: none of ours running
+  cpu0 pre : cpu0 51432245 121122 19748947 1838904650 40608 0 317797 0 0 0
+  cpu0 post: cpu0 51432334 121122 19748950 1838905059 40608 0 317797 0 0 0
+=== leg rust START 2026-08-07T15:56:45Z (--only rust)
+== rust: run ==
+schema bench (rust)
+rigidbody_moving   write      19.99 M msg/s     2001.6 MB/s   (min 19.85, max 20.16, spread 1.5%)
+rigidbody_moving   read       36.18 M msg/s     3622.9 MB/s   (min 34.55, max 36.57, spread 5.6%)
+rigidbody_at_rest  write      32.02 M msg/s     1740.6 MB/s   (min 30.91, max 32.78, spread 5.8%)
+rigidbody_at_rest  read       64.67 M msg/s     3515.2 MB/s   (min 64.39, max 67.92, spread 5.5%)
+chat               write      41.91 M msg/s      519.7 MB/s   (min 41.76, max 43.25, spread 3.6%)
+chat               read       41.74 M msg/s      517.5 MB/s   (min 41.69, max 43.12, spread 3.4%)
+test               write     132.93 M msg/s      760.6 MB/s   (min 121.57, max 133.02, spread 8.6%)
+test               read       64.08 M msg/s      366.7 MB/s   (min 61.42, max 64.17, spread 4.3%)
+inputpacket        write      28.63 M msg/s     1665.3 MB/s   (min 24.71, max 28.74, spread 14.1%)
+inputpacket        read       12.29 M msg/s      714.7 MB/s   (min 12.27, max 12.51, spread 1.9%)
+shipcreate         write      41.00 M msg/s     1094.9 MB/s   (min 37.82, max 42.29, spread 10.9%)
+shipcreate         read       26.81 M msg/s      716.0 MB/s   (min 25.44, max 26.84, spread 5.2%)
+ship_shallow       write      50.64 M msg/s     1352.3 MB/s   (min 50.46, max 52.56, spread 4.2%)
+ship_shallow       read       19.79 M msg/s      528.5 MB/s   (min 18.52, max 19.83, spread 6.6%)
+probe_header       write     112.50 M msg/s     1072.9 MB/s   (min 111.30, max 115.13, spread 3.4%)
+probe_header       read       55.88 M msg/s      532.9 MB/s   (min 54.69, max 56.30, spread 2.9%)
+probebits          write      55.09 M msg/s     1366.0 MB/s   (min 52.89, max 55.17, spread 4.1%)
+probebits          read       51.75 M msg/s     1283.3 MB/s   (min 46.70, max 53.79, spread 13.7%)
+probearray         write      23.97 M msg/s     1074.6 MB/s   (min 23.90, max 24.00, spread 0.4%)
+probearray         read       29.15 M msg/s     1306.8 MB/s   (min 24.99, max 29.19, spread 14.4%)
+testdata           write      10.30 M msg/s      903.4 MB/s   (min 10.27, max 10.62, spread 3.4%)
+testdata           read        9.70 M msg/s      851.0 MB/s   (min 8.54, max 9.70, spread 12.0%)
+message_batch      write      59.36 M msg/s     1415.3 MB/s   (min 52.87, max 59.70, spread 11.5%)
+message_batch      read       33.59 M msg/s      800.9 MB/s   (min 33.33, max 34.50, spread 3.5%)
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/rust.csv
+=== leg rust OK 2026-08-07T15:57:09Z
+--- pscheck [before-cs] 2026-08-07T15:57:12Z load=8.21 6.44 5.79
+  clean: none of ours running
+  cpu0 pre : cpu0 51434759 121122 19749003 1838905304 40608 0 317797 0 0 0
+  cpu0 post: cpu0 51434845 121122 19749008 1838905713 40608 0 317797 0 0 0
+=== leg cs START 2026-08-07T15:57:17Z (--only cs)
+== cs: run ==
+schema bench (cs, workstation GC)
+rigidbody_moving   write      11.83 M msg/s     1185.0 MB/s   (min 2.41, max 11.99, spread 80.9%)
+rigidbody_moving   read       13.36 M msg/s     1337.8 MB/s   (min 13.00, max 27.06, spread 105.2%)
+alloc note: rigidbody_moving one pass (256 ops/path): write 0 bytes, read 0 bytes
+rigidbody_at_rest  write      35.03 M msg/s     1904.2 MB/s   (min 34.96, max 35.96, spread 2.8%)
+rigidbody_at_rest  read       39.89 M msg/s     2168.4 MB/s   (min 35.07, max 39.92, spread 12.2%)
+alloc note: rigidbody_at_rest one pass (256 ops/path): write 0 bytes, read 0 bytes
+chat               write      24.97 M msg/s      309.5 MB/s   (min 4.11, max 25.43, spread 85.4%)
+chat               read       54.66 M msg/s      677.7 MB/s   (min 52.61, max 54.87, spread 4.1%)
+alloc note: chat one pass (256 ops/path): write 0 bytes, read 0 bytes
+test               write      76.21 M msg/s      436.0 MB/s   (min 22.11, max 77.27, spread 72.4%)
+test               read      105.13 M msg/s      601.6 MB/s   (min 103.12, max 105.24, spread 2.0%)
+alloc note: test one pass (256 ops/path): write 0 bytes, read 0 bytes
+inputpacket        write       6.29 M msg/s      365.7 MB/s   (min 5.93, max 22.94, spread 270.6%)
+inputpacket        read       20.90 M msg/s     1215.8 MB/s   (min 20.84, max 21.57, spread 3.5%)
+alloc note: inputpacket one pass (256 ops/path): write 0 bytes, read 0 bytes
+shipcreate         write       9.88 M msg/s      263.7 MB/s   (min 9.23, max 34.43, spread 255.2%)
+shipcreate         read       39.15 M msg/s     1045.4 MB/s   (min 33.37, max 39.23, spread 15.0%)
+alloc note: shipcreate one pass (256 ops/path): write 0 bytes, read 0 bytes
+ship_shallow       write      11.27 M msg/s      301.0 MB/s   (min 10.86, max 36.41, spread 226.7%)
+ship_shallow       read       40.18 M msg/s     1073.0 MB/s   (min 37.14, max 40.24, spread 7.7%)
+alloc note: ship_shallow one pass (256 ops/path): write 0 bytes, read 0 bytes
+probe_header       write      70.15 M msg/s      669.0 MB/s   (min 23.75, max 71.29, spread 67.8%)
+probe_header       read       81.84 M msg/s      780.5 MB/s   (min 78.08, max 83.11, spread 6.1%)
+alloc note: probe_header one pass (256 ops/path): write 0 bytes, read 0 bytes
+probebits          write      21.01 M msg/s      520.9 MB/s   (min 18.70, max 21.14, spread 11.6%)
+probebits          read       68.62 M msg/s     1701.4 MB/s   (min 21.18, max 72.25, spread 74.4%)
+alloc note: probebits one pass (256 ops/path): write 0 bytes, read 0 bytes
+probearray         write       5.02 M msg/s      224.9 MB/s   (min 4.91, max 24.24, spread 385.3%)
+probearray         read       29.42 M msg/s     1318.9 MB/s   (min 25.31, max 29.47, spread 14.1%)
+alloc note: probearray one pass (256 ops/path): write 0 bytes, read 0 bytes
+testdata           write       3.01 M msg/s      264.1 MB/s   (min 2.86, max 9.98, spread 236.4%)
+testdata           read        8.76 M msg/s      768.3 MB/s   (min 7.83, max 9.01, spread 13.5%)
+alloc note: testdata one pass (256 ops/path): write 0 bytes, read 0 bytes
+message_batch      write      24.75 M msg/s      590.1 MB/s   (min 13.08, max 56.38, spread 175.0%)
+message_batch      read       20.67 M msg/s      492.7 MB/s   (min 19.35, max 21.10, spread 8.5%)
+alloc note: message_batch one pass (4096 msgs): write 0 bytes (0 gen0), read 0 bytes (0 gen0)
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/cs.csv
+=== leg cs OK 2026-08-07T15:58:02Z
+Shutting down MSBuild server...
+Shutting down VB/C# compiler server...
+MSBuild server shut down successfully.
+VB/C# compiler server shut down successfully.
+--- pscheck [before-cpp-clang] 2026-08-07T15:58:05Z load=4.71 5.75 5.59
+  clean: none of ours running
+  cpu0 pre : cpu0 51439296 121122 19749114 1838905964 40608 0 317798 0 0 0
+  cpu0 post: cpu0 51439377 121122 19749119 1838906373 40608 0 317798 0 0 0
+=== leg cpp-clang START 2026-08-07T15:58:10Z (--only cpp --compiler /usr/bin/clang++-18)
+== cpp: build (Release) ==
+== cpp: run (Release) ==
+schema bench (cpp, Release)
+rigidbody_moving   write      24.69 M msg/s     2472.5 MB/s   (min 24.65, max 25.57, spread 3.7%)
+rigidbody_moving   read       57.71 M msg/s     5779.2 MB/s   (min 57.43, max 58.28, spread 1.5%)
+rigidbody_at_rest  write      50.54 M msg/s     2747.3 MB/s   (min 50.34, max 52.47, spread 4.2%)
+rigidbody_at_rest  read       85.55 M msg/s     4650.5 MB/s   (min 68.88, max 91.06, spread 25.9%)
+chat               write      65.52 M msg/s      812.2 MB/s   (min 65.27, max 68.69, spread 5.2%)
+chat               read       87.70 M msg/s     1087.3 MB/s   (min 70.71, max 94.06, spread 26.6%)
+test               write     505.04 M msg/s     2889.8 MB/s   (min 498.82, max 554.97, spread 11.1%)
+test               read      377.32 M msg/s     2159.1 MB/s   (min 368.40, max 401.99, spread 8.9%)
+inputpacket        write      31.13 M msg/s     1810.8 MB/s   (min 30.75, max 32.58, spread 5.9%)
+inputpacket        read       42.38 M msg/s     2465.7 MB/s   (min 42.27, max 45.18, spread 6.9%)
+shipcreate         write      52.63 M msg/s     1405.3 MB/s   (min 47.34, max 54.68, spread 13.9%)
+shipcreate         read       77.02 M msg/s     2056.7 MB/s   (min 72.90, max 77.21, spread 5.6%)
+ship_shallow       write      61.35 M msg/s     1638.3 MB/s   (min 54.51, max 61.50, spread 11.4%)
+ship_shallow       read       80.34 M msg/s     2145.2 MB/s   (min 80.05, max 80.50, spread 0.6%)
+probe_header       write     501.82 M msg/s     4785.7 MB/s   (min 484.91, max 550.17, spread 13.0%)
+probe_header       read      302.33 M msg/s     2883.2 MB/s   (min 287.28, max 303.34, spread 5.3%)
+probebits          write      89.99 M msg/s     2231.4 MB/s   (min 88.97, max 96.16, spread 8.0%)
+probebits          read      268.90 M msg/s     6667.6 MB/s   (min 259.99, max 346.44, spread 32.1%)
+probearray         write      35.27 M msg/s     1580.9 MB/s   (min 31.91, max 36.77, spread 13.8%)
+probearray         read       54.98 M msg/s     2464.2 MB/s   (min 50.90, max 55.07, spread 7.6%)
+testdata           write      14.09 M msg/s     1236.1 MB/s   (min 12.34, max 14.17, spread 12.9%)
+testdata           read       21.24 M msg/s     1863.4 MB/s   (min 20.05, max 22.59, spread 12.0%)
+message_batch      write      60.37 M msg/s     1439.2 MB/s   (min 56.08, max 60.58, spread 7.5%)
+message_batch      read       51.64 M msg/s     1231.2 MB/s   (min 46.03, max 54.69, spread 16.8%)
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/cpp-clang.csv
+=== leg cpp-clang OK 2026-08-07T15:58:22Z
+--- pscheck [before-cpp-gcc-prerestrict] 2026-08-07T15:58:25Z load=7.00 6.20 5.74
+  clean: none of ours running
+  cpu0 pre : cpu0 51440579 121122 19749148 1838906619 40608 0 317798 0 0 0
+  cpu0 post: cpu0 51440663 121122 19749153 1838907030 40608 0 317798 0 0 0
+=== leg cpp-gcc-prerestrict START 2026-08-07T15:58:30Z (--only cpp --compiler g++)
+== cpp: build (Release) ==
+== cpp: run (Release) ==
+schema bench (cpp, Release)
+rigidbody_moving   write      24.24 M msg/s     2427.0 MB/s   (min 24.21, max 24.26, spread 0.2%)
+rigidbody_moving   read       30.23 M msg/s     3027.3 MB/s   (min 26.91, max 30.26, spread 11.1%)
+rigidbody_at_rest  write      40.96 M msg/s     2226.5 MB/s   (min 37.75, max 42.21, spread 10.9%)
+rigidbody_at_rest  read       59.80 M msg/s     3250.5 MB/s   (min 59.72, max 59.87, spread 0.3%)
+chat               write      35.69 M msg/s      442.5 MB/s   (min 35.63, max 36.65, spread 2.8%)
+chat               read       75.58 M msg/s      937.0 MB/s   (min 62.53, max 75.67, spread 17.4%)
+test               write     118.37 M msg/s      677.3 MB/s   (min 115.08, max 119.32, spread 3.6%)
+test               read      223.66 M msg/s     1279.8 MB/s   (min 215.29, max 224.02, spread 3.9%)
+inputpacket        write      31.79 M msg/s     1849.1 MB/s   (min 29.52, max 33.48, spread 12.5%)
+inputpacket        read       36.44 M msg/s     2119.8 MB/s   (min 34.63, max 36.50, spread 5.2%)
+shipcreate         write      31.63 M msg/s      844.7 MB/s   (min 30.55, max 33.09, spread 8.0%)
+shipcreate         read       74.44 M msg/s     1987.8 MB/s   (min 69.76, max 74.56, spread 6.4%)
+ship_shallow       write      55.68 M msg/s     1486.7 MB/s   (min 53.64, max 55.86, spread 4.0%)
+ship_shallow       read       77.74 M msg/s     2075.9 MB/s   (min 64.00, max 77.82, spread 17.8%)
+probe_header       write     122.34 M msg/s     1166.7 MB/s   (min 111.92, max 123.88, spread 9.8%)
+probe_header       read      179.92 M msg/s     1715.8 MB/s   (min 173.97, max 180.75, spread 3.8%)
+probebits          write      83.35 M msg/s     2066.7 MB/s   (min 79.96, max 88.64, spread 10.4%)
+probebits          read      140.52 M msg/s     3484.2 MB/s   (min 139.93, max 156.78, spread 12.0%)
+probearray         write      29.71 M msg/s     1331.7 MB/s   (min 28.50, max 29.82, spread 4.4%)
+probearray         read       58.39 M msg/s     2617.0 MB/s   (min 53.96, max 58.52, spread 7.8%)
+testdata           write       9.06 M msg/s      794.7 MB/s   (min 9.02, max 9.29, spread 2.9%)
+testdata           read       22.99 M msg/s     2017.2 MB/s   (min 22.81, max 24.63, spread 7.9%)
+message_batch      write      61.06 M msg/s     1455.8 MB/s   (min 58.03, max 61.29, spread 5.3%)
+message_batch      read       42.20 M msg/s     1006.1 MB/s   (min 41.88, max 43.78, spread 4.5%)
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/cpp-gcc-prerestrict.csv
+=== leg cpp-gcc-prerestrict OK 2026-08-07T15:58:46Z
+--- pscheck [before-cpp-clang-prerestrict] 2026-08-07T15:58:49Z load=6.52 6.15 5.74
+  clean: none of ours running
+  cpu0 pre : cpu0 51442312 121122 19749185 1838907276 40608 0 317798 0 0 0
+  cpu0 post: cpu0 51442401 121122 19749188 1838907683 40608 0 317798 0 0 0
+=== leg cpp-clang-prerestrict START 2026-08-07T15:58:54Z (--only cpp --compiler /usr/bin/clang++-18)
+== cpp: build (Release) ==
+== cpp: run (Release) ==
+schema bench (cpp, Release)
+rigidbody_moving   write      24.45 M msg/s     2448.6 MB/s   (min 23.29, max 24.50, spread 4.9%)
+rigidbody_moving   read       57.70 M msg/s     5778.2 MB/s   (min 53.10, max 58.13, spread 8.7%)
+rigidbody_at_rest  write      50.46 M msg/s     2743.0 MB/s   (min 50.39, max 52.48, spread 4.1%)
+rigidbody_at_rest  read       85.10 M msg/s     4625.9 MB/s   (min 69.95, max 92.17, spread 26.1%)
+chat               write      65.38 M msg/s      810.6 MB/s   (min 65.23, max 68.85, spread 5.5%)
+chat               read       88.02 M msg/s     1091.3 MB/s   (min 87.65, max 93.79, spread 7.0%)
+test               write     505.49 M msg/s     2892.5 MB/s   (min 500.76, max 559.06, spread 11.5%)
+test               read      383.20 M msg/s     2192.7 MB/s   (min 325.60, max 414.95, spread 23.3%)
+inputpacket        write      31.13 M msg/s     1811.2 MB/s   (min 25.81, max 32.58, spread 21.7%)
+inputpacket        read       42.17 M msg/s     2453.4 MB/s   (min 39.71, max 44.95, spread 12.4%)
+shipcreate         write      52.52 M msg/s     1402.5 MB/s   (min 52.37, max 54.69, spread 4.4%)
+shipcreate         read       76.90 M msg/s     2053.4 MB/s   (min 72.85, max 77.27, spread 5.7%)
+ship_shallow       write      61.36 M msg/s     1638.5 MB/s   (min 48.30, max 64.23, spread 26.0%)
+ship_shallow       read       80.45 M msg/s     2148.4 MB/s   (min 79.51, max 80.55, spread 1.3%)
+probe_header       write     496.36 M msg/s     4733.7 MB/s   (min 477.45, max 502.68, spread 5.1%)
+probe_header       read      302.34 M msg/s     2883.4 MB/s   (min 250.37, max 302.98, spread 17.4%)
+probebits          write      89.49 M msg/s     2219.1 MB/s   (min 89.00, max 95.95, spread 7.8%)
+probebits          read      263.52 M msg/s     6534.0 MB/s   (min 252.44, max 341.51, spread 33.8%)
+probearray         write      36.54 M msg/s     1637.9 MB/s   (min 34.76, max 36.67, spread 5.2%)
+probearray         read       54.91 M msg/s     2461.3 MB/s   (min 50.89, max 55.03, spread 7.5%)
+testdata           write      14.09 M msg/s     1236.1 MB/s   (min 12.24, max 14.16, spread 13.7%)
+testdata           read       21.23 M msg/s     1862.7 MB/s   (min 21.10, max 22.56, spread 6.9%)
+message_batch      write      60.58 M msg/s     1444.5 MB/s   (min 57.13, max 60.77, spread 6.0%)
+message_batch      read       53.42 M msg/s     1273.5 MB/s   (min 47.16, max 56.21, spread 17.0%)
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/cpp-clang-prerestrict.csv
+=== leg cpp-clang-prerestrict OK 2026-08-07T15:59:06Z
+--- pscheck [before-cpp-gcc-end] 2026-08-07T15:59:09Z load=5.24 5.88 5.66
+  clean: none of ours running
+  cpu0 pre : cpu0 51443601 121122 19749218 1838907930 40608 0 317798 0 0 0
+  cpu0 post: cpu0 51443682 121122 19749223 1838908338 40608 0 317798 0 0 0
+=== leg cpp-gcc-end START 2026-08-07T15:59:14Z (--only cpp --compiler g++)
+== cpp: build (Release) ==
+== cpp: run (Release) ==
+schema bench (cpp, Release)
+rigidbody_moving   write      24.55 M msg/s     2458.7 MB/s   (min 24.44, max 25.42, spread 4.0%)
+rigidbody_moving   read       30.39 M msg/s     3043.0 MB/s   (min 30.25, max 31.78, spread 5.0%)
+rigidbody_at_rest  write      40.85 M msg/s     2220.6 MB/s   (min 36.65, max 42.15, spread 13.4%)
+rigidbody_at_rest  read       59.76 M msg/s     3248.7 MB/s   (min 59.59, max 59.86, spread 0.4%)
+chat               write      35.62 M msg/s      441.6 MB/s   (min 33.18, max 36.61, spread 9.6%)
+chat               read       74.10 M msg/s      918.7 MB/s   (min 70.37, max 74.31, spread 5.3%)
+test               write     133.20 M msg/s      762.2 MB/s   (min 122.21, max 133.40, spread 8.4%)
+test               read      221.05 M msg/s     1264.8 MB/s   (min 193.26, max 221.91, spread 13.0%)
+inputpacket        write      31.90 M msg/s     1855.9 MB/s   (min 28.51, max 33.29, spread 15.0%)
+inputpacket        read       35.91 M msg/s     2089.0 MB/s   (min 34.63, max 36.48, spread 5.2%)
+shipcreate         write      34.20 M msg/s      913.3 MB/s   (min 34.13, max 34.25, spread 0.3%)
+shipcreate         read       74.19 M msg/s     1981.0 MB/s   (min 65.61, max 74.29, spread 11.7%)
+ship_shallow       write      55.52 M msg/s     1482.6 MB/s   (min 53.34, max 55.62, spread 4.1%)
+ship_shallow       read       77.43 M msg/s     2067.6 MB/s   (min 73.22, max 77.58, spread 5.6%)
+probe_header       write     124.17 M msg/s     1184.2 MB/s   (min 117.06, max 127.39, spread 8.3%)
+probe_header       read      180.15 M msg/s     1718.0 MB/s   (min 170.11, max 180.55, spread 5.8%)
+probebits          write      83.00 M msg/s     2058.0 MB/s   (min 76.44, max 83.20, spread 8.1%)
+probebits          read      140.94 M msg/s     3494.6 MB/s   (min 139.52, max 157.48, spread 12.7%)
+probearray         write      27.00 M msg/s     1210.1 MB/s   (min 25.40, max 28.04, spread 9.8%)
+probearray         read       57.60 M msg/s     2581.6 MB/s   (min 53.16, max 57.64, spread 7.8%)
+testdata           write       9.13 M msg/s      801.3 MB/s   (min 8.56, max 9.38, spread 9.0%)
+testdata           read       25.46 M msg/s     2233.8 MB/s   (min 23.80, max 25.60, spread 7.1%)
+message_batch      write      61.06 M msg/s     1455.8 MB/s   (min 57.90, max 61.27, spread 5.5%)
+message_batch      read       41.98 M msg/s     1001.0 MB/s   (min 36.78, max 43.70, spread 16.5%)
+OK
+results: /home/ubuntu/rowan-bench/v5-epyc/results/cpp-gcc-end.csv
+=== leg cpp-gcc-end OK 2026-08-07T15:59:30Z
+--- pscheck [after-all] 2026-08-07T15:59:33Z load=5.22 5.85 5.65
+  clean: none of ours running
+  cpu0 pre : cpu0 51445316 121122 19749259 1838908586 40608 0 317799 0 0 0
+  cpu0 post: cpu0 51445404 121122 19749263 1838908995 40608 0 317799 0 0 0
+===== v5 EPYC pass DONE 2026-08-07T15:59:38Z =====

--- a/bench/results/2026-08-11-cs-tiered-jit-diagnostic-x86_64-epyc.csv
+++ b/bench/results/2026-08-11-cs-tiered-jit-diagnostic-x86_64-epyc.csv
@@ -1,0 +1,38 @@
+# schema bench results
+# date: 2026-08-11T08:01:33Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: c++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -I../serialize-cs-port/serialize
+# go: not present (go run, default optimized build)
+# rust: not present (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: taskset -c 0
+# noise: DIAGNOSTIC leg, NOT a table row: DOTNET_TieredCompilation=0 to test the tiered-JIT theory for the cs write spreads; core 0 reserved for bench, serial, alone
+# schema commit: unknown
+# serialize commit: unknown
+cs,rigidbody_moving,write,2000000,105,7,23482998,22785557,23522936,2351.49,3.14
+cs,rigidbody_moving,read,2000000,105,7,25390474,23138079,26293682,2542.50,12.43
+cs,rigidbody_at_rest,write,4000000,57,7,35620781,33242415,36534018,1936.33,9.24
+cs,rigidbody_at_rest,read,4000000,57,7,38662808,35289053,38781448,2101.69,9.03
+cs,chat,write,4000000,13,7,24578298,23175871,25101677,304.72,7.84
+cs,chat,read,4000000,13,7,46865956,45251121,47034476,581.03,3.81
+cs,test,write,16000000,6,7,79141904,75407104,79326400,452.85,4.95
+cs,test,read,16000000,6,7,96444280,90868252,97999403,551.86,7.39
+cs,inputpacket,write,2000000,61,7,23199380,22202807,23283890,1349.60,4.66
+cs,inputpacket,read,2000000,61,7,19384541,17952596,19435987,1127.68,7.65
+cs,shipcreate,write,4000000,28,7,33737196,30995282,33783213,900.88,8.26
+cs,shipcreate,read,4000000,28,7,34285264,33493628,34336650,915.52,2.46
+cs,ship_shallow,write,4000000,28,7,30846989,29147721,31553655,823.70,7.80
+cs,ship_shallow,read,4000000,28,7,37536833,36515674,38005401,1002.34,3.97
+cs,probe_header,write,16000000,10,7,71297244,68772687,72255184,679.94,4.88
+cs,probe_header,read,16000000,10,7,83966097,82881757,84136088,800.76,1.49
+cs,probebits,write,4000000,26,7,56152567,48796912,56323114,1392.33,13.40
+cs,probebits,read,4000000,26,7,71651202,68283856,71686386,1776.63,4.75
+cs,probearray,write,2000000,47,7,24604513,21786018,25604326,1102.84,15.52
+cs,probearray,read,2000000,47,7,26510291,26171228,27404468,1188.26,4.65
+cs,testdata,write,1000000,92,7,9987127,9921875,10015233,876.25,0.93
+cs,testdata,read,1000000,92,7,13969602,12249093,14033197,1225.67,12.77
+cs,message_batch,write,3276800,25,7,51265524,51046859,53684854,1222.27,5.15
+cs,message_batch,read,3276800,25,7,27896824,27454164,28035208,665.11,2.08

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -7,12 +7,17 @@
 # missing are SKIPPED with the reason printed — the go/rust/cs runners land
 # with the serialize ports (see bench/README.md for the runner contract).
 #
-# usage: bench/run.sh [--debug] [--out FILE] [--compiler CXX]
+# usage: bench/run.sh [--debug] [--out FILE] [--compiler CXX] [--only LANG]
 #   --debug       also build and run the Debug pair (matched-pair methodology;
 #                 only Release numbers are meaningful, Debug is recorded so
 #                 pathological debug regressions are visible)
 #   --out FILE    results CSV (default bench/results/<date>-<arch>-<host>.csv)
 #   --compiler    C++ compiler (default: $CXX, else c++)
+#   --only LANG   run a single language leg (cpp|go|rust|cs). For shared boxes
+#                 under one-profile-at-a-time discipline: a driver runs the
+#                 legs serially with quiet-window checks between them. Each
+#                 leg's CSV carries the full preamble; measurement code and
+#                 flags are identical to the all-language invocation.
 #
 # environment:
 #   SERIALIZE     path to the classic serialize runtime checkout
@@ -27,16 +32,22 @@ cd "$(dirname "$0")/.."     # repo root
 
 DEBUG=0
 OUT=""
+ONLY=""
 CXX_BIN="${CXX:-c++}"
 while [ $# -gt 0 ]; do
     case "$1" in
         --debug) DEBUG=1 ;;
         --out) OUT="$2"; shift ;;
         --compiler) CXX_BIN="$2"; shift ;;
+        --only) ONLY="$2"; shift ;;
         *) echo "unknown argument: $1" >&2; exit 1 ;;
     esac
     shift
 done
+case "$ONLY" in
+    ""|cpp|go|rust|cs) ;;
+    *) echo "unknown --only language: $ONLY (cpp|go|rust|cs)" >&2; exit 1 ;;
+esac
 
 SERIALIZE="${SERIALIZE:-../serialize-cs-port/serialize}"
 if [ ! -f "$SERIALIZE/serialize.h" ]; then
@@ -113,58 +124,67 @@ emit_preamble() {
     } >> "$OUT"
 }
 
-# ---- C++ (the reference runner) ----
-echo "== cpp: build (Release) ==" >&2
-$CXX_BIN $RELEASE_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp
-
 : > "$OUT"
 emit_preamble Release
-echo "== cpp: run (Release) ==" >&2
-$PIN ./build/bench/schema_bench_cpp --csv >> "$OUT"
 
-if [ "$DEBUG" = 1 ]; then
-    echo "== cpp: build (Debug) ==" >&2
-    $CXX_BIN $DEBUG_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp_debug
-    echo "" >> "$OUT"
-    emit_preamble Debug
-    echo "== cpp: run (Debug) ==" >&2
-    $PIN ./build/bench/schema_bench_cpp_debug --csv >> "$OUT"
+# ---- C++ (the reference runner) ----
+if [ -z "$ONLY" ] || [ "$ONLY" = cpp ]; then
+    echo "== cpp: build (Release) ==" >&2
+    $CXX_BIN $RELEASE_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp
+
+    echo "== cpp: run (Release) ==" >&2
+    $PIN ./build/bench/schema_bench_cpp --csv >> "$OUT"
+
+    if [ "$DEBUG" = 1 ]; then
+        echo "== cpp: build (Debug) ==" >&2
+        $CXX_BIN $DEBUG_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp_debug
+        echo "" >> "$OUT"
+        emit_preamble Debug
+        echo "== cpp: run (Debug) ==" >&2
+        $PIN ./build/bench/schema_bench_cpp_debug --csv >> "$OUT"
+    fi
 fi
 
 # ---- Go (lands with the serialize.go port) ----
-if [ -f bench/go/main.go ]; then
-    if command -v go >/dev/null 2>&1; then
-        echo "== go: run ==" >&2
-        ( cd bench/go && $PIN go run . --csv ) >> "$OUT"
+if [ -z "$ONLY" ] || [ "$ONLY" = go ]; then
+    if [ -f bench/go/main.go ]; then
+        if command -v go >/dev/null 2>&1; then
+            echo "== go: run ==" >&2
+            ( cd bench/go && $PIN go run . --csv ) >> "$OUT"
+        else
+            echo "SKIP go: runner present but no go toolchain" >&2
+        fi
     else
-        echo "SKIP go: runner present but no go toolchain" >&2
+        echo "SKIP go: runner not landed yet (bench/go/main.go — see bench/go/README.md)" >&2
     fi
-else
-    echo "SKIP go: runner not landed yet (bench/go/main.go — see bench/go/README.md)" >&2
 fi
 
 # ---- Rust (lands with the serialize.rs port) ----
-if [ -f bench/rust/Cargo.toml ]; then
-    if command -v cargo >/dev/null 2>&1 || [ -x /opt/homebrew/opt/rustup/bin/cargo ]; then
-        echo "== rust: run ==" >&2
-        ( cd bench/rust && PATH="/opt/homebrew/opt/rustup/bin:$PATH" $PIN cargo run --release --quiet -- --csv ) >> "$OUT"
+if [ -z "$ONLY" ] || [ "$ONLY" = rust ]; then
+    if [ -f bench/rust/Cargo.toml ]; then
+        if command -v cargo >/dev/null 2>&1 || [ -x /opt/homebrew/opt/rustup/bin/cargo ]; then
+            echo "== rust: run ==" >&2
+            ( cd bench/rust && PATH="/opt/homebrew/opt/rustup/bin:$PATH" $PIN cargo run --release --quiet -- --csv ) >> "$OUT"
+        else
+            echo "SKIP rust: runner present but no cargo" >&2
+        fi
     else
-        echo "SKIP rust: runner present but no cargo" >&2
+        echo "SKIP rust: runner not landed yet (bench/rust/Cargo.toml — see bench/rust/README.md)" >&2
     fi
-else
-    echo "SKIP rust: runner not landed yet (bench/rust/Cargo.toml — see bench/rust/README.md)" >&2
 fi
 
 # ---- C# (lands with the serialize.cs port) ----
-if ls bench/cs/*.csproj >/dev/null 2>&1; then
-    if command -v dotnet >/dev/null 2>&1; then
-        echo "== cs: run ==" >&2
-        ( cd bench/cs && $PIN dotnet run -c Release -- --csv ) >> "$OUT"
+if [ -z "$ONLY" ] || [ "$ONLY" = cs ]; then
+    if ls bench/cs/*.csproj >/dev/null 2>&1; then
+        if command -v dotnet >/dev/null 2>&1; then
+            echo "== cs: run ==" >&2
+            ( cd bench/cs && $PIN dotnet run -c Release -- --csv ) >> "$OUT"
+        else
+            echo "SKIP cs: runner present but no dotnet" >&2
+        fi
     else
-        echo "SKIP cs: runner present but no dotnet" >&2
+        echo "SKIP cs: runner not landed yet (bench/cs/*.csproj — see bench/cs/README.md)" >&2
     fi
-else
-    echo "SKIP cs: runner not landed yet (bench/cs/*.csproj — see bench/cs/README.md)" >&2
 fi
 
 echo "results: $OUT" >&2

--- a/bench/tools/epyc-pass-driver.sh
+++ b/bench/tools/epyc-pass-driver.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# v5 EPYC pass driver — 2026-08-07
+#
+# Glenn's gate: ONE PROFILE AT A TIME on reserved core 0 (core 0 does no game
+# work; the game server owns isolated cores 1-15). The four languages run
+# SERIALLY, each as its own bench/run.sh --only invocation; between legs we
+# verify none of our tooling is still running (ps) and snapshot core 0's
+# /proc/stat. A C++ g++ write-control runs at start and end to prove the
+# window was stable, per the house law.
+#
+# Legs, in order:
+#   1. cpp-gcc-start        C++ g++ (main table row source + write-control A)
+#   2. go                   Go
+#   3. rust                 Rust
+#   4. cs                   C#
+#   5. cpp-clang            C++ clang-18 (open item: the g++-vs-clang tiny gap)
+#   6. cpp-gcc-prerestrict  C++ g++ vs serialize @ 561e81d (pre-#30 restrict)
+#   7. cpp-clang-prerestrict C++ clang-18 vs serialize @ 561e81d
+#   8. cpp-gcc-end          C++ g++ (write-control B)
+set -u
+
+ROOT="$HOME/rowan-bench/v5-epyc"
+R="$ROOT/results"
+LOG="$R/pass.log"
+mkdir -p "$R"
+
+export PATH="$HOME/rowan-bench/go/bin:$HOME/rowan-bench/cargo/bin:$HOME/rowan-bench/dotnet:$PATH"
+export RUSTUP_HOME="$HOME/rowan-bench/rustup"
+export CARGO_HOME="$HOME/rowan-bench/cargo"
+export DOTNET_ROOT="$HOME/rowan-bench/dotnet"
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_CLI_USE_MSBUILD_SERVER=0
+export MSBUILDDISABLENODEREUSE=1
+export BENCH_NOISE="RESERVED core 0: game server owns isolated cores 1-15 (one pinned thread each); core 0 does no game work - reserved for bench (Glenn, 2026-08-07) - but remains the sole general-purpose core (irqs, ssh, systemd)"
+
+CLANGXX="$(command -v clang++-18 || command -v clang++)"
+
+log() { echo "$*" >> "$LOG"; }
+
+# processes of ours that must NOT be running between legs
+ours() {
+    ps -eo pid,psr,pcpu,etimes,comm,args --no-headers 2>/dev/null \
+      | grep -E "schema_bench|benchgo|go run|cargo|rustc|cc1plus|clang\+\+|dotnet|bench_main" \
+      | grep -vE "grep|pass\.sh" || true
+}
+
+pscheck() {
+    log "--- pscheck [$1] $(date -u +%FT%TZ) load=$(cut -d' ' -f1-3 /proc/loadavg)"
+    local b; b="$(ours)"
+    if [ -n "$b" ]; then
+        log "  WAITING: ours still running:"; log "$b"
+        local i=0
+        while [ -n "$(ours)" ] && [ $i -lt 180 ]; do sleep 10; i=$((i+1)); done
+        if [ -n "$(ours)" ]; then log "  WARNING: never went quiet after 30m; proceeding, flagged"; fi
+    else
+        log "  clean: none of ours running"
+    fi
+    # core 0 utilization over a 5s window (100Hz ticks: user nice system idle iowait irq softirq)
+    local s1 s2
+    s1=$(grep '^cpu0 ' /proc/stat); sleep 5; s2=$(grep '^cpu0 ' /proc/stat)
+    log "  cpu0 pre : $s1"
+    log "  cpu0 post: $s2"
+}
+
+leg() {
+    local name="$1"; shift
+    pscheck "before-$name"
+    log "=== leg $name START $(date -u +%FT%TZ) ($*)"
+    if ( cd "$ROOT/schema" && bench/run.sh --out "$R/$name.csv" "$@" ) >> "$LOG" 2>&1; then
+        log "=== leg $name OK $(date -u +%FT%TZ)"
+    else
+        log "=== leg $name FAILED $(date -u +%FT%TZ)"
+        touch "$R/FAILED-$name"
+    fi
+    sleep 3
+}
+
+log "===== v5 EPYC pass START $(date -u +%FT%TZ) host=$(hostname) ====="
+log "toolchains: $(g++ --version | head -1) | $($CLANGXX --version | head -1) | $(go version) | $(cargo --version) / $(rustc --version) | dotnet $(dotnet --version)"
+log "isolated cpus: $(cat /sys/devices/system/cpu/isolated 2>/dev/null)"
+
+leg cpp-gcc-start         --only cpp  --compiler g++
+leg go                    --only go
+leg rust                  --only rust
+leg cs                    --only cs
+dotnet build-server shutdown >> "$LOG" 2>&1 || true
+leg cpp-clang             --only cpp  --compiler "$CLANGXX"
+export SERIALIZE=../serialize-pre-restrict
+leg cpp-gcc-prerestrict   --only cpp  --compiler g++
+leg cpp-clang-prerestrict --only cpp  --compiler "$CLANGXX"
+unset SERIALIZE
+leg cpp-gcc-end           --only cpp  --compiler g++
+
+pscheck "after-all"
+log "===== v5 EPYC pass DONE $(date -u +%FT%TZ) ====="
+touch "$R/PASS.done"

--- a/bench/tools/relative.py
+++ b/bench/tools/relative.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""v5 EPYC pass analysis: absolute tables, THE RELATIVE TABLE, A/B deltas."""
+import csv, statistics, sys, io
+
+CORPUS = ["rigidbody_moving","rigidbody_at_rest","chat","test","inputpacket",
+          "shipcreate","ship_shallow","probe_header","probebits","probearray","testdata"]
+BATCH = "message_batch"
+ORDER = CORPUS + [BATCH]
+
+def load(path):
+    """-> dict[(lang,bench,path)] = row dict; skips preamble lines; keeps only Release
+    (Debug rows would follow a second preamble — we never run --debug here)."""
+    rows = {}
+    meta = []
+    build = "Release"
+    for line in open(path):
+        line = line.strip()
+        if not line: continue
+        if line.startswith("#"):
+            meta.append(line)
+            if line.startswith("# build:"): build = line.split(":",1)[1].strip()
+            continue
+        if line.startswith("lang,"): continue
+        if build != "Release": continue
+        f = line.split(",")
+        lang, bench, p = f[0], f[1], f[2]
+        rows[(lang,bench,p)] = dict(iters=int(f[3]), bytes=int(f[4]), runs=int(f[5]),
+            med=float(f[6]), mn=float(f[7]), mx=float(f[8]), mb=float(f[9]), spread=float(f[10]))
+    return rows, meta
+
+def merge(*paths):
+    allrows = {}
+    for p in paths:
+        r,_ = load(p)
+        allrows.update(r)
+    return allrows
+
+def rel(rows, lang, path_, benches=CORPUS):
+    """median over benches of cpp_time/lang_time... wait: time rel to C++ = cpp_rate/lang_rate."""
+    ratios = []
+    for b in benches:
+        c = rows.get(("cpp",b,path_)); l = rows.get((lang,b,path_))
+        if not c or not l: return None
+        ratios.append(c["med"]/l["med"]*100.0)
+    return statistics.median(ratios)
+
+def relative_table(rows):
+    out = ["| backend | write | read | batch write | batch read |","|---|---:|---:|---:|---:|",
+           "| C++ | 100% | 100% | 100% | 100% |"]
+    for lang,name in [("rust","Rust"),("cs","C#"),("go","Go")]:
+        w = rel(rows,lang,"write"); r = rel(rows,lang,"read")
+        bw = rows[("cpp",BATCH,"write")]["med"]/rows[(lang,BATCH,"write")]["med"]*100
+        br = rows[("cpp",BATCH,"read")]["med"]/rows[(lang,BATCH,"read")]["med"]*100
+        out.append(f"| {name} | **{w:.0f}%** | **{r:.0f}%** | **{bw:.0f}%** | **{br:.0f}%** |")
+    return "\n".join(out)
+
+def absolute_table(rows):
+    hdr = "| bench | path | B/msg | C++ M msg/s | C++ MB/s | Rust M msg/s | Rust MB/s | Go M msg/s | Go MB/s | C# M msg/s | C# MB/s |"
+    out = [hdr, "|---|---|---:|" + "---:|"*8]
+    for b in ORDER:
+        for p in ["write","read"]:
+            c = rows.get(("cpp",b,p))
+            cells = [b, p, str(c["bytes"]) if c else "?"]
+            for lang in ["cpp","rust","go","cs"]:
+                x = rows.get((lang,b,p))
+                cells += [f"{x['med']/1e6:.2f}", f"{x['mb']:.0f}"] if x else ["—","—"]
+            out.append("| " + " | ".join(cells) + " |")
+    return "\n".join(out)
+
+def ab(rows_a, rows_b, lang="cpp", label_a="A", label_b="B", paths=("write","read")):
+    """per-row B/A rate multipliers + spreads: is the move beyond both spreads?"""
+    out = [f"| bench | path | {label_a} M msg/s | {label_b} M msg/s | {label_b}/{label_a} | spread {label_a}% | spread {label_b}% |",
+           "|---|---|---:|---:|---:|---:|---:|"]
+    for b in ORDER:
+        for p in paths:
+            a = rows_a.get((lang,b,p)); bb = rows_b.get((lang,b,p))
+            if not a or not bb: continue
+            out.append(f"| {b} | {p} | {a['med']/1e6:.2f} | {bb['med']/1e6:.2f} | **{bb['med']/a['med']:.2f}x** | {a['spread']:.1f} | {bb['spread']:.1f} |")
+    return "\n".join(out)
+
+def spreads_over(rows, pct):
+    return [(k, v["spread"]) for k,v in sorted(rows.items()) if v["spread"] > pct]
+
+if __name__ == "__main__":
+    cmd = sys.argv[1]
+    if cmd == "rel":
+        print(relative_table(merge(*sys.argv[2:])))
+    elif cmd == "abs":
+        print(absolute_table(merge(*sys.argv[2:])))
+    elif cmd == "ab":
+        a,_ = load(sys.argv[2]); b,_ = load(sys.argv[3])
+        lang = sys.argv[4] if len(sys.argv)>4 else "cpp"
+        la = sys.argv[5] if len(sys.argv)>5 else "A"
+        lb = sys.argv[6] if len(sys.argv)>6 else "B"
+        print(ab(a,b,lang,la,lb))
+    elif cmd == "spreads":
+        rows = merge(*sys.argv[3:])
+        for k,s in spreads_over(rows, float(sys.argv[2])):
+            print(k, s)


### PR DESCRIPTION
The deferred x86 leg of the optimization program, completed on the box 2026-08-07 (8 serial legs on reserved core 0, one profile at a time per Glenn's gate, zero FAILED markers, all quiet windows clean) and harvested 2026-08-11.

**The three open-item verdicts:**
- **(a) restrict: REFUTED on Zen 4 under BOTH g++-13 and clang-18** (1.00x across the write rows vs +38–158% composed on arm64/apple-clang). The M2 C++ write dominance is in material part an apple-clang/arm64 effect.
- **(c) the tiny-message compiler gap persists post-const-emit**: clang-18 up to 4.27x g++ (test write), 4.15x (probe_header write) — const-emit did not close it; question routed to the gap ledger whether x86 tables should adopt clang-18 as reference.
- **(b) composition on x86: the Go write lane transfers almost row for row** (ship_shallow 1.89x vs 1.83x M2-composed, shipcreate 1.79x exact); rust write lane transfers, one x86 regression filed (inputpacket read 0.85x, unattributed).

**And one benching law, proven by intervention:** the default-config C# write medians measured .NET tiered-JIT promotion competing for the single shared core, not the generated code (DOTNET_TieredCompilation=0 diagnostic: 1.98–4.90x median moves, spreads 385%→≤15.5%; one poisoned row sat at 11.6% spread, so spread cannot clear a row). v2 EPYC C# rows retracted retroactively with a dated correction note; rule added to CLAUDE.md.

Headline relative table (vs g++ 13.3; C# from the labelled steady-state diagnostic): Rust 108/274/103/125 · C# 137/198/120/150 · Go 177/370/196/108 — against clang-18 every cell moves by double digits. Same code, same wire, different target, different table.

Docs + CSVs + pass.log only; no code or emitter changes (the --only harness flag was already on the branch, pre-launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)