### PR TITLE
cpp: constants join emissionOrder's graph

### DIFF
--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -383,13 +383,21 @@ func (g *gen) emitWireFile() {
 // emissionOrder returns the file's declarations in an order where every
 // same-file named type precedes its by-value users — schema references are
 // order-free (SPEC §4.2), C++ is not. A stable topological sort: declaration
-// order is preserved wherever no dependency forces otherwise.
+// order is preserved wherever no dependency forces otherwise. Constants are
+// nodes too: a const named in an expression the data header renders
+// symbolically (a const initializer, an array bound, a range bound, a
+// default) must precede its user, or renderInt finds it un-emitted and folds
+// to the literal — silently, and only under some declaration orders (the
+// defect behind issue #29). The expression list mirrors ir.FileDeps: EVERY
+// expression a backend renders symbolically is an ordering edge.
 func (g *gen) emissionOrder() []ir.Decl {
 	decls := g.file.Decls
 	n := len(decls)
 	byName := map[string]int{}
 	for i, d := range decls {
 		switch d := d.(type) {
+		case *ir.Const:
+			byName[d.Name] = i
 		case *ir.Struct:
 			byName[d.Name] = i
 		case *ir.Enum:
@@ -402,9 +410,32 @@ func (g *gen) emissionOrder() []ir.Decl {
 	}
 	adj := make([][]int, n)
 	indeg := make([]int, n)
+	var noteExpr func(i int, e ast.Expr)
+	noteExpr = func(i int, e ast.Expr) {
+		switch e := e.(type) {
+		case *ast.IdentExpr:
+			if j, ok := byName[e.Name]; ok && j != i {
+				adj[j] = append(adj[j], i)
+				indeg[i]++
+			}
+		case *ast.MaxExpr:
+			// E.Max always folds to a literal (no C++ twin) — no edge
+		case *ast.UnaryExpr:
+			noteExpr(i, e.X)
+		case *ast.BinaryExpr:
+			noteExpr(i, e.X)
+			noteExpr(i, e.Y)
+		case *ast.ParenExpr:
+			noteExpr(i, e.X)
+		}
+	}
 	for i, d := range decls {
 		var fields []*ir.Field
 		switch d := d.(type) {
+		case *ir.Const:
+			if d.Expr != nil {
+				noteExpr(i, d.Expr)
+			}
 		case *ir.Struct:
 			fields = d.Fields
 		case *ir.Object:
@@ -415,6 +446,19 @@ func (g *gen) emissionOrder() []ir.Decl {
 				if j, ok := byName[f.Type.Name]; ok && j != i {
 					adj[j] = append(adj[j], i)
 					indeg[i]++
+				}
+			}
+			for _, e := range []ast.Expr{
+				f.ArrayExpr,
+				f.Type.SizeExpr,
+				f.DefExpr,
+				f.IntMinExpr,
+				f.IntMaxExpr,
+				f.QuantScaleExpr,
+				f.QuantMaxExpr,
+			} {
+				if e != nil {
+					noteExpr(i, e)
 				}
 			}
 		}

--- a/internal/codegen/cpp/cpp_test.go
+++ b/internal/codegen/cpp/cpp_test.go
@@ -1,0 +1,87 @@
+// The declaration-order test: schema references are order-free (SPEC §4.2),
+// so the C++ data header must be a function of the schema's MEANING, not of
+// the order the author wrote the constants in. Before emissionOrder gained
+// const nodes (issue #29), a const referenced by an earlier-declared entity
+// emitted as the folded literal — values identical, the symbolic link that
+// makes the header maintainable silently lost, and only under some
+// declaration orders.
+package cpp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/internal/check"
+	"github.com/mas-bandwidth/schema/internal/ir"
+	"github.com/mas-bandwidth/schema/internal/parser"
+)
+
+func unitFromSources(t *testing.T, sources map[string]string) *ir.Unit {
+	t.Helper()
+	var files []check.SourceFile
+	for name, src := range sources {
+		f, perrs := parser.Parse(name, []byte(src))
+		if len(perrs) > 0 {
+			t.Fatalf("parse: %v", perrs[0])
+		}
+		files = append(files, check.SourceFile{
+			Path: name, Name: name, Base: strings.TrimSuffix(name, ".schema"),
+			Bytes: []byte(src), AST: f,
+		})
+	}
+	u, cerrs := check.Unit(files)
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	return u
+}
+
+// TestConstEmissionOrderFree pins that forward references TO a constant —
+// from a const initializer and from a struct's symbolically-rendered field
+// expressions — render symbolically in the data header regardless of
+// declaration order. Every reference here names a const declared LATER in
+// the same file; before the fix each one folded to its literal.
+func TestConstEmissionOrderFree(t *testing.T) {
+	u := unitFromSources(t, map[string]string{
+		"Forward.schema": `package t
+
+// the earlier-declared entities: every constant they name is declared below
+const MaxItems = MaxSlots + 2
+
+type Probe {
+    items   [MaxItems]uint8
+    text    string(MaxText)
+    reserve uint8 = MinReserve
+}
+
+const MaxSlots   = 14
+const MaxText    = 32
+const MinReserve = 3
+`,
+	})
+	files, err := Generate(u, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := string(files["Forward.h"])
+
+	for _, want := range []string{
+		// const -> const: symbolic, never the folded 16
+		"inline constexpr int64_t MaxItems = MaxSlots + 2;",
+		// struct field expressions -> const: array bound, string size, default
+		"uint8_t items[MaxItems]",
+		"char text[MaxText + 1]",
+		"uint8_t reserve = MinReserve;",
+	} {
+		if !strings.Contains(h, want) {
+			t.Errorf("data header lost the symbolic reference: want %q in Forward.h\n%s", want, h)
+		}
+	}
+	// the dependency must have been emitted ABOVE its user, or C++ cannot compile
+	if slots, items := strings.Index(h, "MaxSlots ="), strings.Index(h, "MaxItems ="); slots == -1 || items == -1 || slots > items {
+		t.Errorf("MaxSlots must be emitted before MaxItems (got MaxSlots at %d, MaxItems at %d)\n%s", slots, items, h)
+	}
+	if folded := "MaxItems = 16;"; strings.Contains(h, folded) {
+		t.Errorf("data header folded a renderable const reference: %q present\n%s", folded, h)
+	}
+}


### PR DESCRIPTION
Closes #29. Constants join the dependency graph, so the data header no longer folds on declaration order. Forward-reference test proven failing-then-fixed; ZERO generated bytes changed.