### PR TITLE
bench/results: the invalid candidate pass is quarantined, and older passes say what era they are

### DIFF
--- a/bench/results/2026-08-15-arm64-macbook-O2-pass.csv
+++ b/bench/results/2026-08-15-arm64-macbook-O2-pass.csv
@@ -1,4 +1,12 @@
 # schema bench results
+# era: harness schema 20c11f1 — PRE-7db74ef verdicts, PRE-ab2165a stride (stamped 2026-08-15, issue #20)
+# era: the six cpp `partial:1` verdicts below are unroll-inflated and genuinely full —
+# era:   7db74ef (attribution stops overcounting unrolled loops) closed this in the
+# era:   harness, not in this artifact; quoting them understates C++ inlining.
+# era: five verdicts remain `unknown` — closed in the harness by 7db74ef, still
+# era:   un-ratioable here under BENCH-STANDARD.md §5.3 rule 7.
+# era: rates predate ab2165a (read buffers to 4096+64 stride) — comparable only within
+# era:   the pre-ab2165a era; the two eras never share a table.
 # date: 2026-08-14T13:56:47Z
 # host: macbook  arch: arm64  os: Darwin 25.5.0
 # cpu: Apple M2

--- a/bench/results/2026-08-15-arm64-macbook-O2-pass.inline
+++ b/bench/results/2026-08-15-arm64-macbook-O2-pass.inline
@@ -1,4 +1,8 @@
 # 2026-08-15-arm64-macbook-O2-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# era: harness schema 20c11f1 — PRE-7db74ef attribution (stamped 2026-08-15, issue #20):
+# era:   per-op transitive counts in this ledger overcount unrolled loops, and six gen
+# era:   verdicts were still unattributable — 7db74ef fixed the harness, not this artifact;
+# era:   the paired CSV's era header governs any use of these numbers.
 # generated: 2026-08-14T14:13:00Z on macbook (Darwin arm64)
 # ground truth: call instructions into the serialize runtime, counted in
 # the emitted code and propagated transitively through out-of-line

--- a/bench/results/2026-08-15-arm64-macbook-O3-pass.csv
+++ b/bench/results/2026-08-15-arm64-macbook-O3-pass.csv
@@ -1,4 +1,12 @@
 # schema bench results
+# era: harness schema 20c11f1 — PRE-7db74ef verdicts, PRE-ab2165a stride (stamped 2026-08-15, issue #20)
+# era: the five cpp `partial:1` verdicts below are unroll-inflated and genuinely full —
+# era:   7db74ef (attribution stops overcounting unrolled loops) closed this in the
+# era:   harness, not in this artifact; quoting them understates C++ inlining.
+# era: six verdicts remain `unknown` — closed in the harness by 7db74ef, still
+# era:   un-ratioable here under BENCH-STANDARD.md §5.3 rule 7.
+# era: rates predate ab2165a (read buffers to 4096+64 stride) — comparable only within
+# era:   the pre-ab2165a era; the two eras never share a table.
 # date: 2026-08-14T13:21:41Z
 # host: macbook  arch: arm64  os: Darwin 25.5.0
 # cpu: Apple M2

--- a/bench/results/2026-08-15-arm64-macbook-O3-pass.inline
+++ b/bench/results/2026-08-15-arm64-macbook-O3-pass.inline
@@ -1,4 +1,8 @@
 # 2026-08-15-arm64-macbook-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# era: harness schema 20c11f1 — PRE-7db74ef attribution (stamped 2026-08-15, issue #20):
+# era:   per-op transitive counts in this ledger overcount unrolled loops, and six gen
+# era:   verdicts were still unattributable — 7db74ef fixed the harness, not this artifact;
+# era:   the paired CSV's era header governs any use of these numbers.
 # generated: 2026-08-14T13:55:07Z on macbook (Darwin arm64)
 # ground truth: call instructions into the serialize runtime, counted in
 # the emitted code and propagated transitively through out-of-line

--- a/bench/results/invalid/2026-08-15-arm64-macbook-candidate-O2-pass.csv
+++ b/bench/results/invalid/2026-08-15-arm64-macbook-candidate-O2-pass.csv
@@ -1,3 +1,11 @@
+# INVALID — QUARANTINED (issue #20, 2026-08-15). Evidence, never data.
+# This candidate pass claims fix-branch runtimes with ZERO [build-verified] tags on its
+# runtime commit lines (its candidate-O3 sibling carries five), and its rust read rows
+# spread 62.25 and 44.35 — both over §2.3's 40% invalid threshold — with the rust read
+# rates sitting at the pre-fix baseline shape. Same signature as the bad O3 candidate,
+# which was caught only because its verdict column disagreed with the claimed branch.
+# Provenance unverified + statistically invalid: no row in this file publishes, ever.
+# Kept under results/invalid/ as evidence for the harness post-mortem, not as data.
 # schema bench results
 # date: 2026-08-14T20:20:35Z
 # host: macbook  arch: arm64  os: Darwin 25.5.0
@@ -27,6 +35,7 @@
 # foreign_procs: 8
 # control_start_median: 98701288   control_end_median: 99966202
 # control_delta_pct: 1.3   window: OK
+# window: INVALID — quarantine verdict (issue #20): provenance unverified (zero build-verified tags) and rust read spreads 62.25/44.35 exceed §2.3's 40%; the OK on the line above records only that the two control legs agreed
 # corpus_id: 6b118770d85af4f6
 lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
 cpp,rigidbody_moving,write,24000000,105,7,55690151,46111374,56864486,5576.58,19.31,6b118770d85af4f6,gen,hdr,removed,O2,full

--- a/bench/results/invalid/2026-08-15-arm64-macbook-candidate-O2-pass.inline
+++ b/bench/results/invalid/2026-08-15-arm64-macbook-candidate-O2-pass.inline
@@ -1,3 +1,6 @@
+# INVALID — QUARANTINED (issue #20, 2026-08-15). Evidence, never data.
+# Sibling of the quarantined candidate-O2 pass CSV: provenance unverified (zero
+# [build-verified] tags), rust rows statistically invalid. See the CSV's banner.
 # 2026-08-15-arm64-macbook-candidate-O2-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
 # generated: 2026-08-14T20:36:06Z on macbook (Darwin arm64)
 # ground truth: call instructions into the serialize runtime, counted in


### PR DESCRIPTION
Closes #20. The invalid candidate O2 pass is quarantined with a mechanical kill-switch the refusal tool honors; the pre-fix passes carry era headers so nobody ratios across eras by accident.