### PR TITLE
The fuzzer compiles what it generates — and finds eight real bugs on day one

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -263,6 +263,15 @@ func (c *checker) resolveConst(name string, usePos ast.Pos) *ir.Const {
 				e.state = 3
 				return nil
 			}
+		} else if !fitsStorage(v, out.Storage) {
+			// an implicitly-typed constant defaults to int64 storage and was
+			// never held to it: a value past the int64 range reached every
+			// backend as an int64 constant it cannot represent — an
+			// unrepresentable (or constexpr-narrowing) literal in C, C++ and
+			// C# (found by FuzzGeneratedCompiles, issue #22)
+			c.errf(e.decl.Pos, "constant %s value %s does not fit int64, the default constant storage — declare an explicit type (const %s uint64 = ...) if a wider range is intended", name, v, name)
+			e.state = 3
+			return nil
 		}
 	}
 	e.state = 2

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -66,6 +66,12 @@ func TestDiagnostics(t *testing.T) {
 		// ---- ranges and storage ----
 		{name: "range does not fit storage", want: "does not fit its declared storage",
 			src: "package t\ntype T { h int8 [min = 0, max = 1000] }\n"},
+		{name: "implicit const past int64 (FuzzGeneratedCompiles 0c59b1fd)", want: "does not fit int64, the default constant storage",
+			src: "package t\nconst A = 20000000000000000000\n"},
+		{name: "implicit const past int64, uint64 range (constexpr narrowing repro)", want: "does not fit int64, the default constant storage",
+			src: "package t\nconst A = 18446744073709551615\n"},
+		{name: "implicit const below int64 min", want: "does not fit int64, the default constant storage",
+			src: "package t\nconst A = -9223372036854775809\n"},
 		{name: "min without max", want: "min without max",
 			src: "package t\ntype T { h int16 [min = 0] }\n"},
 		{name: "inverted range", want: "inverted range",

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -221,7 +221,11 @@ func (g *gen) emitDataHeader(carriesProtocolId bool) {
 		g.emitMessagesPending = true
 	}
 
-	for _, d := range g.file.Decls {
+	// emission order, not declaration order: C needs every same-file named
+	// type defined before its by-value users, same as C++ (found by
+	// FuzzGeneratedCompiles — `type A { B B }  type B {}` emitted A first
+	// and every consumer got `unknown type name 'B'`)
+	for _, d := range ir.EmissionOrder(g.file) {
 		switch decl := d.(type) {
 		case *ir.Const:
 			g.emitConst(decl)
@@ -459,7 +463,9 @@ func (g *gen) emitWireHeader() {
 	if fileHasStrings(g.file) {
 		g.emitUtf8Validator()
 	}
-	for _, d := range g.file.Decls {
+	// emission order for the same reason as the data header: write_a calls
+	// write_b, and C99 has no implicit declarations
+	for _, d := range ir.EmissionOrder(g.file) {
 		switch decl := d.(type) {
 		case *ir.Struct:
 			g.emitWriteFunc(decl)
@@ -478,9 +484,23 @@ func (g *gen) emitWriteFunc(st *ir.Struct) {
 	g.pf("/* Writes %s. Returns 1 on success, 0 on failure — the stream latches the\n", st.Name)
 	g.pf("   error, so a caller may check once at the end of a message. */\n")
 	g.pf("static SCHEMA_UNUSED int write_%s( serialize_write_stream_t * stream, const %s * value )\n{\n", snake(st.Name), st.Name)
-	if len(st.Fields) == 0 {
+	// The early-out is keyed on ITEMS, not fields: a struct whose only items
+	// are reserved/const/align has no storage but DOES have wire bits, and
+	// keying on fields made C write nothing where C++ wrote the reserved
+	// bits — a silent cross-language wire divergence (found by
+	// FuzzGeneratedCompiles, issue #22).
+	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value;\n    return 1; /* no fields: no wire bits */\n}\n\n")
 		return
+	}
+	if len(st.Fields) == 0 {
+		g.pf("    (void) value; /* items only — reserved/const/align carry no storage */\n")
+	}
+	if ir.MaxBitsStruct(st) == 0 {
+		// every range degenerate: the body refuses out-of-contract values but
+		// never touches the stream (zero wire bits — found by
+		// FuzzGeneratedCompiles, issue #22)
+		g.pf("    (void) stream; /* zero wire bits */\n")
 	}
 	g.emitWriteItems(st.Items, "    ")
 	g.pf("    return 1;\n}\n\n")
@@ -490,9 +510,15 @@ func (g *gen) emitReadFunc(st *ir.Struct) {
 	g.pf("/* Reads %s. Returns 1 on success, 0 on failure. Out-of-range values are\n", st.Name)
 	g.pf("   REFUSED, never clamped. */\n")
 	g.pf("static SCHEMA_UNUSED int read_%s( serialize_read_stream_t * stream, %s * value )\n{\n", snake(st.Name), st.Name)
-	if len(st.Fields) == 0 {
+	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value;\n    return 1;\n}\n\n")
 		return
+	}
+	if len(st.Fields) == 0 {
+		g.pf("    (void) value; /* items only — reserved/const/align carry no storage */\n")
+	}
+	if ir.MaxBitsStruct(st) == 0 {
+		g.pf("    (void) stream; /* zero wire bits — defaults prefill below */\n")
 	}
 	g.emitReadItems(st.Items, "    ")
 	g.pf("    return 1;\n}\n\n")

--- a/internal/codegen/c/objects.go
+++ b/internal/codegen/c/objects.go
@@ -213,6 +213,19 @@ func fixedShallowComp(f, cf *ir.Field) (lo, hi *big.Int, bits int64, typ string)
 
 // ---- the wire header ----
 
+// voidIfEmpty emits (void) casts for params when no statement has been
+// emitted since mark — a view function over zero wire components must not
+// strand its parameters, or every -Wall -Wextra -Werror consumer breaks
+// (found by FuzzGeneratedCompiles, issue #22).
+func (g *gen) voidIfEmpty(mark int, params ...string) {
+	if g.body.Len() != mark {
+		return
+	}
+	for _, p := range params {
+		g.pf("    (void) %s;\n", p)
+	}
+}
+
 func (g *gen) emitObjectFunctions(d *ir.Object) {
 	deep, interp := splitObjectFields(d)
 
@@ -223,33 +236,41 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	// claimed-name registry and could collide with a user type (#23)
 	g.pf("static SCHEMA_UNUSED int write_%s( serialize_write_stream_t * stream, const %sData_Deep * value )\n{\n",
 		snake(d.Name+"Data_Deep"), d.Name)
+	mark := g.body.Len()
 	for _, f := range deep {
 		g.emitDeepWriteField(f, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return 1;\n}\n\n")
 
 	g.pf("/* Reads %s's DEEP view. */\n", d.Name)
 	g.pf("static SCHEMA_UNUSED int read_%s( serialize_read_stream_t * stream, %sData_Deep * value )\n{\n",
 		snake(d.Name+"Data_Deep"), d.Name)
+	mark = g.body.Len()
 	for _, f := range deep {
 		g.emitDeepReadField(f, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return 1;\n}\n\n")
 
 	g.pf("/* Writes %s's SHALLOW view — the quantized wire. */\n", d.Name)
 	g.pf("static SCHEMA_UNUSED int write_%s( serialize_write_stream_t * stream, const %sData_Shallow * value )\n{\n",
 		snake(d.Name+"Data_Shallow"), d.Name)
+	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitShallowWriteField(f, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return 1;\n}\n\n")
 
 	g.pf("/* Reads %s's SHALLOW view. */\n", d.Name)
 	g.pf("static SCHEMA_UNUSED int read_%s( serialize_read_stream_t * stream, %sData_Shallow * value )\n{\n",
 		snake(d.Name+"Data_Shallow"), d.Name)
+	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitShallowReadField(f, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return 1;\n}\n\n")
 }
 
@@ -385,7 +406,6 @@ func mustBig(s string) *big.Int {
 	return v
 }
 
-
 // emitDeepWriteField writes one field of the DEEP view. A ranged float rides at
 // FULL precision here: the deep view is full state for client-side prediction,
 // so the compression that the shallow wire applies would be a lossy step with
@@ -428,16 +448,27 @@ func (g *gen) emitQuantizePair(d *ir.Object) {
 	g.pf("/* Quantize%s — the interpolate domain to the quantized wire domain. */\n", d.Name)
 	g.pf("static SCHEMA_UNUSED void quantize_%s( const %sData_Interpolate * input, %sData_Shallow * output )\n{\n",
 		snake(d.Name), d.Name, d.Name)
+	mark := g.body.Len()
 	for _, f := range interp {
 		g.emitQuantizeField(f)
+	}
+	if g.body.Len() == mark {
+		// a quantized property over a type with no numeric components emits
+		// no statements; keep -Werror consumers building (found by
+		// FuzzGeneratedCompiles, issue #22)
+		g.pf("    (void) input; /* no numeric components to quantize */\n    (void) output;\n")
 	}
 	g.pf("}\n\n")
 
 	g.pf("/* Unquantize%s — the quantized wire domain back to the interpolate domain. */\n", d.Name)
 	g.pf("static SCHEMA_UNUSED void unquantize_%s( const %sData_Shallow * input, %sData_Interpolate * output )\n{\n",
 		snake(d.Name), d.Name, d.Name)
+	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitUnquantizeField(f)
+	}
+	if g.body.Len() == mark {
+		g.pf("    (void) input; /* no numeric components to unquantize */\n    (void) output;\n")
 	}
 	g.pf("}\n\n")
 }

--- a/internal/codegen/c/table.go
+++ b/internal/codegen/c/table.go
@@ -217,6 +217,12 @@ func (g *tableGen) emitTableWrite(st *ir.Struct) {
 	lower := snake(st.Name)
 	g.pf("/* Appends %s's table-wire encoding to the writer. */\n", st.Name)
 	g.pf("static SCHEMA_UNUSED void table_write_%s_into( table_writer_t * w, const %s * value )\n{\n", lower, st.Name)
+	if len(st.Fields) == 0 {
+		// A fieldless table writes only its terminator; without this the
+		// value parameter is unused and every -Werror consumer breaks
+		// (found by FuzzGeneratedCompiles, the clang -fsyntax-only leg).
+		g.pf("    (void) value; /* no fields: nothing but the terminator */\n")
+	}
 	guards := tableGuardExprs(st)
 	for _, f := range st.Fields {
 		if cond, guarded := guards[f.Name]; guarded {
@@ -758,7 +764,9 @@ func GenerateTable(u *ir.Unit) (map[string][]byte, error) {
 
 	for _, f := range u.Files {
 		var members []*ir.Struct
-		for _, d := range f.Decls {
+		// emission order, not declaration order: table_write_a_into calls
+		// table_write_b_into, and C99 has no implicit declarations
+		for _, d := range ir.EmissionOrder(f) {
 			if st, ok := d.(*ir.Struct); ok && closure[st.Name] {
 				members = append(members, st)
 			}

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -302,7 +302,7 @@ func (g *gen) emitDataFile(carriesProtocolId bool) {
 			"the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)")
 	}
 
-	for _, d := range g.emissionOrder() {
+	for _, d := range ir.EmissionOrder(g.file) {
 		switch d := d.(type) {
 		case *ir.Const:
 			g.emitConst(d)
@@ -349,7 +349,7 @@ func (g *gen) emitWireFile() {
 		g.emitUtf8Validator()
 	}
 
-	for _, d := range g.emissionOrder() {
+	for _, d := range ir.EmissionOrder(g.file) {
 		var fields []*ir.Field
 		switch d := d.(type) {
 		case *ir.Struct:
@@ -378,74 +378,6 @@ func (g *gen) emitWireFile() {
 	if g.file.Base == g.objOwner && len(g.unit.ObjNames) > 0 {
 		g.emitObjectTagWire()
 	}
-}
-
-// emissionOrder returns the file's declarations in an order where every
-// same-file named type precedes its by-value users — schema references are
-// order-free (SPEC §4.2), C++ is not. A stable topological sort: declaration
-// order is preserved wherever no dependency forces otherwise.
-func (g *gen) emissionOrder() []ir.Decl {
-	decls := g.file.Decls
-	n := len(decls)
-	byName := map[string]int{}
-	for i, d := range decls {
-		switch d := d.(type) {
-		case *ir.Struct:
-			byName[d.Name] = i
-		case *ir.Enum:
-			byName[d.Name] = i
-		case *ir.Flags:
-			byName[d.Name] = i
-		case *ir.Object:
-			byName[d.Name] = i
-		}
-	}
-	adj := make([][]int, n)
-	indeg := make([]int, n)
-	for i, d := range decls {
-		var fields []*ir.Field
-		switch d := d.(type) {
-		case *ir.Struct:
-			fields = d.Fields
-		case *ir.Object:
-			fields = d.Fields
-		}
-		for _, f := range fields {
-			if f.Type.Kind == ir.TNamed {
-				if j, ok := byName[f.Type.Name]; ok && j != i {
-					adj[j] = append(adj[j], i)
-					indeg[i]++
-				}
-			}
-		}
-	}
-	order := make([]ir.Decl, 0, n)
-	done := make([]bool, n)
-	for len(order) < n {
-		pick := -1
-		for i := 0; i < n; i++ {
-			if !done[i] && indeg[i] == 0 {
-				pick = i
-				break
-			}
-		}
-		if pick == -1 {
-			// an intra-file type cycle — the checker already rejected the unit;
-			// defensively emit the rest in declaration order
-			for i := 0; i < n; i++ {
-				if !done[i] {
-					pick = i
-					break
-				}
-			}
-		}
-		done[pick] = true
-		order = append(order, decls[pick])
-		for _, t := range adj[pick] {
-			indeg[t]--
-		}
-	}
-	return order
 }
 
 func (g *gen) emitTagEnum(name string, members []string, comment string) {
@@ -829,10 +761,94 @@ func (g *gen) renderInt(e ast.Expr, folded *big.Int) string {
 	if folded != nil && folded.IsInt64() && folded.Int64() == math.MinInt64 {
 		return "( -9223372036854775807ll - 1 )" // INT64_MIN has no literal spelling in C++
 	}
-	if e == nil || containsMax(e) || !g.renderable(e) {
+	if e == nil || containsMax(e) || !g.renderable(e) || !g.overflowSafe(e) {
 		return folded.String()
 	}
 	return g.renderExpr(e)
+}
+
+// overflowSafe reports whether e can render symbolically without the TARGET's
+// arithmetic overflowing on the way to the folded value. Schema folding is
+// arbitrary-precision; C++ is not: a literal-only subtree evaluates in int
+// (small decimal literals deduce int), and `7 * 700000000` is a
+// -Werror=-Winteger-overflow build break even though the product fits the
+// int64 bound it feeds (found by FuzzGeneratedCompiles, issue #22). A subtree
+// referencing a constant evaluates in int64 (constants emit as typed
+// constexpr int64_t). Anything unprovable folds — folding is always correct,
+// symbolic rendering is the luxury.
+func (g *gen) overflowSafe(e ast.Expr) bool {
+	_, _, ok := g.carrierEval(e)
+	return ok
+}
+
+// carrierEval returns e's folded value, whether the subtree references a
+// constant (and so carries 64-bit arithmetic), and whether every
+// subexpression's value fits the arithmetic type it evaluates in.
+func (g *gen) carrierEval(e ast.Expr) (*big.Int, bool, bool) {
+	switch e := e.(type) {
+	case *ast.IntLit:
+		// a literal past INT64_MAX has no signed spelling in the target —
+		// it deduces unsigned, a -Werror warning — so it cannot ride
+		// symbolically even where the folded result is small
+		return e.Value, false, e.Value.IsInt64()
+	case *ast.IdentExpr:
+		c, ok := g.unit.Consts[e.Name]
+		if !ok || c.IsFloat || c.Int == nil {
+			return nil, true, false
+		}
+		return c.Int, true, true
+	case *ast.ParenExpr:
+		return g.carrierEval(e.X)
+	case *ast.UnaryExpr:
+		v, wide, ok := g.carrierEval(e.X)
+		if !ok {
+			return nil, wide, false
+		}
+		nv := new(big.Int).Neg(v)
+		return nv, wide, fitsCarrier(nv, wide)
+	case *ast.BinaryExpr:
+		x, xw, ok := g.carrierEval(e.X)
+		if !ok {
+			return nil, xw, false
+		}
+		y, yw, ok := g.carrierEval(e.Y)
+		if !ok {
+			return nil, yw, false
+		}
+		wide := xw || yw
+		v := new(big.Int)
+		switch e.Op {
+		case "+":
+			v.Add(x, y)
+		case "-":
+			v.Sub(x, y)
+		case "*":
+			v.Mul(x, y)
+		case "/":
+			if y.Sign() == 0 {
+				return nil, wide, false
+			}
+			v.Quo(x, y) // truncation toward zero, as C++ divides
+		case "%":
+			if y.Sign() == 0 {
+				return nil, wide, false
+			}
+			v.Rem(x, y)
+		default:
+			return nil, wide, false
+		}
+		return v, wide, fitsCarrier(v, wide)
+	}
+	return nil, false, false
+}
+
+// fitsCarrier: a subtree with a constant reference evaluates in int64; a
+// literal-only subtree evaluates in int, conservatively taken as 32-bit.
+func fitsCarrier(v *big.Int, wide bool) bool {
+	if wide {
+		return v.IsInt64()
+	}
+	return v.IsInt64() && v.Int64() >= math.MinInt32 && v.Int64() <= math.MaxInt32
 }
 
 // render128 renders a 128-bit integer constant (a bound or a default). C++
@@ -896,7 +912,13 @@ func (g *gen) renderExpr(e ast.Expr) string {
 		g.noteRef(e.Name)
 		return e.Name
 	case *ast.UnaryExpr:
-		return "-" + g.renderExpr(e.X)
+		inner := g.renderExpr(e.X)
+		if strings.HasPrefix(inner, "-") {
+			// "--x" is decrement in C++, not double negation (found by
+			// FuzzGeneratedCompiles, issue #22)
+			return "-(" + inner + ")"
+		}
+		return "-" + inner
 	case *ast.BinaryExpr:
 		return fmt.Sprintf("%s %s %s", g.renderExpr(e.X), e.Op, g.renderExpr(e.Y))
 	case *ast.ParenExpr:

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -40,10 +40,27 @@ func (g *gen) emitStructWire(st *ir.Struct) {
 	// ~2x on byte-array-heavy types
 	g.bulkBytes = ir.AlignedFixedByteArrays(st)
 
+	// A zero-wire-bit struct (every range degenerate — min == max costs zero
+	// bits) emits no stream operation, and its write body's only value uses
+	// are serialize_asserts that compile away under NDEBUG. The (void) casts
+	// keep -Wall -Wextra -Werror consumers building in every configuration
+	// (found by FuzzGeneratedCompiles, issue #22); they are harmless when a
+	// nested call does use the parameters.
+	zeroWire := len(st.Items) > 0 && ir.MaxBitsStruct(st) == 0
+	// items but no fields: reserved/const/align carry wire bits with no
+	// storage, so the body uses the stream and never the value (found by
+	// FuzzGeneratedCompiles, issue #22)
+	noStorage := len(st.Items) > 0 && len(st.Fields) == 0
+
 	g.pf("inline bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", st.Name, st.Name)
 	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value; // empty body — presence is the payload (SPEC §4.6)\n")
 	} else {
+		if zeroWire {
+			g.pf("    (void) stream;\n    (void) value; // zero wire bits — asserts compile away under NDEBUG\n")
+		} else if noStorage {
+			g.pf("    (void) value; // items only — reserved/const/align carry no storage\n")
+		}
 		g.emitWriteItems(st.Items, "    ")
 	}
 	g.pf("    return true;\n}\n\n")
@@ -52,6 +69,12 @@ func (g *gen) emitStructWire(st *ir.Struct) {
 	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value;\n")
 	} else {
+		if zeroWire {
+			g.pf("    (void) stream; // zero wire bits — nothing to read, defaults prefill below\n")
+		}
+		if noStorage {
+			g.pf("    (void) value; // items only — reserved/const/align carry no storage\n")
+		}
 		g.emitReadItems(st.Items, "    ")
 	}
 	g.pf("    return true;\n}\n\n")

--- a/internal/codegen/cpp/objects.go
+++ b/internal/codegen/cpp/objects.go
@@ -35,6 +35,19 @@ func (g *gen) emitObjectMaxBits(d *ir.Object) {
 	g.pf("inline constexpr int64_t %sMaxBytes = %d; // rounded up to the 8-byte write-buffer granularity\n\n", shName, ir.MaxBytes(shBits))
 }
 
+// voidIfEmpty emits (void) casts for params when no statement has been
+// emitted since mark — a view function over zero wire components must not
+// strand its parameters, or every -Wall -Wextra -Werror consumer breaks
+// (found by FuzzGeneratedCompiles, issue #22).
+func (g *gen) voidIfEmpty(mark int, params ...string) {
+	if g.body.Len() != mark {
+		return
+	}
+	for _, p := range params {
+		g.pf("    (void) %s;\n", p)
+	}
+}
+
 func (g *gen) emitObjectWire(d *ir.Object) {
 	g.needsSerialize = true
 
@@ -53,27 +66,35 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 	// triple serializes as a bare float here (SPEC §4.8)
 	deepName := d.Name + "Data_Deep"
 	g.pf("inline bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", deepName, deepName)
+	mark := g.body.Len()
 	for _, f := range deep {
 		g.emitViewWriteField(f, viewDeep, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return true;\n}\n\n")
 	g.pf("inline bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", deepName, deepName)
+	mark = g.body.Len()
 	for _, f := range deep {
 		g.emitViewReadField(f, viewDeep, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return true;\n}\n\n")
 
 	// ---- Shallow: the [interpolate] fields on the quantized wire
 	shName := d.Name + "Data_Shallow"
 	g.pf("inline bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", shName, shName)
+	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitViewWriteField(f, viewShallow, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return true;\n}\n\n")
 	g.pf("inline bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", shName, shName)
+	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitViewReadField(f, viewShallow, "    ")
 	}
+	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return true;\n}\n\n")
 
 }
@@ -103,13 +124,24 @@ func (g *gen) emitObjectQuantize(d *ir.Object) {
 	shName := d.Name + "Data_Shallow"
 	inName := d.Name + "Data_Interpolate"
 	g.pf("inline void Quantize%s( const %s & input, %s & output )\n{\n", d.Name, inName, shName)
+	mark := g.body.Len()
 	for _, f := range interp {
 		g.emitQuantizeField(f, "    ")
 	}
+	if g.body.Len() == mark {
+		// a quantized property over a type with no numeric components emits
+		// no statements; keep -Werror consumers building (found by
+		// FuzzGeneratedCompiles, issue #22)
+		g.pf("    (void) input;\n    (void) output; // no numeric components to quantize\n")
+	}
 	g.pf("}\n\n")
 	g.pf("inline void Unquantize%s( const %s & input, %s & output )\n{\n", d.Name, shName, inName)
+	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitUnquantizeField(f, "    ")
+	}
+	if g.body.Len() == mark {
+		g.pf("    (void) input;\n    (void) output; // no numeric components to unquantize\n")
 	}
 	g.pf("}\n\n")
 }

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -40,6 +40,7 @@ package csharp
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -709,7 +710,7 @@ func csStorage(s string) string {
 // constants casts to the required type — the same renderability rule as the
 // Go and Rust targets, so all three fold identically.
 func (g *gen) renderArg(e ast.Expr, folded *big.Int, typ string, qualified bool) string {
-	if e == nil || containsMax(e) || !g.renderable(e) {
+	if e == nil || containsMax(e) || !g.renderable(e) || !g.overflowSafe(e) {
 		return folded.String()
 	}
 	if !containsIdent(e) {
@@ -750,6 +751,85 @@ func (g *gen) renderScaleF32(e ast.Expr, folded int64) string {
 	return "(float)(" + s + ")"
 }
 
+// overflowSafe reports whether e can render symbolically without C#'s
+// CHECKED constant arithmetic rejecting it. Schema folding is
+// arbitrary-precision; C# literal subtrees evaluate in int, so
+// `7 * 700000000` is a CS0220 compile error even though the product fits the
+// long bound it feeds (found by FuzzGeneratedCompiles, issue #22 — the C++
+// twin of this gate). A subtree referencing a constant evaluates in long.
+// Anything unprovable folds — folding is always correct.
+func (g *gen) overflowSafe(e ast.Expr) bool {
+	_, _, ok := g.carrierEval(e)
+	return ok
+}
+
+func (g *gen) carrierEval(e ast.Expr) (*big.Int, bool, bool) {
+	switch e := e.(type) {
+	case *ast.IntLit:
+		// a literal past INT64_MAX has no signed spelling in the target —
+		// it deduces unsigned, a -Werror warning — so it cannot ride
+		// symbolically even where the folded result is small
+		return e.Value, false, e.Value.IsInt64()
+	case *ast.IdentExpr:
+		c, ok := g.unit.Consts[e.Name]
+		if !ok || c.IsFloat || c.Int == nil {
+			return nil, true, false
+		}
+		return c.Int, true, true
+	case *ast.ParenExpr:
+		return g.carrierEval(e.X)
+	case *ast.UnaryExpr:
+		v, wide, ok := g.carrierEval(e.X)
+		if !ok {
+			return nil, wide, false
+		}
+		nv := new(big.Int).Neg(v)
+		return nv, wide, fitsCarrier(nv, wide)
+	case *ast.BinaryExpr:
+		x, xw, ok := g.carrierEval(e.X)
+		if !ok {
+			return nil, xw, false
+		}
+		y, yw, ok := g.carrierEval(e.Y)
+		if !ok {
+			return nil, yw, false
+		}
+		wide := xw || yw
+		v := new(big.Int)
+		switch e.Op {
+		case "+":
+			v.Add(x, y)
+		case "-":
+			v.Sub(x, y)
+		case "*":
+			v.Mul(x, y)
+		case "/":
+			if y.Sign() == 0 {
+				return nil, wide, false
+			}
+			v.Quo(x, y) // truncation toward zero, as C# divides
+		case "%":
+			if y.Sign() == 0 {
+				return nil, wide, false
+			}
+			v.Rem(x, y)
+		default:
+			return nil, wide, false
+		}
+		return v, wide, fitsCarrier(v, wide)
+	}
+	return nil, false, false
+}
+
+// fitsCarrier: a subtree with a constant reference evaluates in long; a
+// literal-only subtree evaluates in int, conservatively taken as 32-bit.
+func fitsCarrier(v *big.Int, wide bool) bool {
+	if wide {
+		return v.IsInt64()
+	}
+	return v.IsInt64() && v.Int64() >= math.MinInt32 && v.Int64() <= math.MaxInt32
+}
+
 func (g *gen) renderable(e ast.Expr) bool {
 	switch e := e.(type) {
 	case *ast.IdentExpr:
@@ -780,7 +860,12 @@ func renderExpr(e ast.Expr, qualified bool) string {
 		}
 		return e.Name
 	case *ast.UnaryExpr:
-		return "-" + renderExpr(e.X, qualified)
+		inner := renderExpr(e.X, qualified)
+		if strings.HasPrefix(inner, "-") {
+			// "--x" is decrement in C#, not double negation (issue #22)
+			return "-(" + inner + ")"
+		}
+		return "-" + inner
 	case *ast.BinaryExpr:
 		return fmt.Sprintf("%s %s %s", renderExpr(e.X, qualified), e.Op, renderExpr(e.Y, qualified))
 	case *ast.ParenExpr:
@@ -838,7 +923,6 @@ func containsIdent(e ast.Expr) bool {
 	return false
 }
 
-
 // csRender128 renders a 128-bit bound as C# source. Values inside long ride
 // the pair's implicit conversion; wider values compose the two's-complement
 // 64-bit lanes through the (hi, lo) constructor.
@@ -859,7 +943,6 @@ func csRender128(v *big.Int) string {
 	lo := new(big.Int).And(u, maxUint64)
 	return fmt.Sprintf("new Int128Value(0x%xul, 0x%xul)", hi, lo)
 }
-
 
 // csRenderU128 is csRender128 for the unsigned domain: values inside ulong
 // ride the pair's implicit conversion; wider values compose the lanes.

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -659,7 +659,13 @@ func renderExpr(e ast.Expr) string {
 	case *ast.IdentExpr:
 		return e.Name
 	case *ast.UnaryExpr:
-		return "-" + renderExpr(e.X)
+		inner := renderExpr(e.X)
+		if strings.HasPrefix(inner, "-") {
+			// "--x" fails to parse in Go, and the emitter's own parse gate
+			// refused the whole unit; double negation needs parens (issue #22)
+			return "-(" + inner + ")"
+		}
+		return "-" + inner
 	case *ast.BinaryExpr:
 		return fmt.Sprintf("%s %s %s", renderExpr(e.X), e.Op, renderExpr(e.Y))
 	case *ast.ParenExpr:

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -857,7 +857,13 @@ func renderExpr(e ast.Expr) string {
 	case *ast.IdentExpr:
 		return ir.RustConstName(e.Name)
 	case *ast.UnaryExpr:
-		return "-" + renderExpr(e.X)
+		inner := renderExpr(e.X)
+		if strings.HasPrefix(inner, "-") {
+			// "--x" is rejected by rustc (no prefix decrement); double
+			// negation needs parens (issue #22)
+			return "-(" + inner + ")"
+		}
+		return "-" + inner
 	case *ast.BinaryExpr:
 		return fmt.Sprintf("%s %s %s", renderExpr(e.X), e.Op, renderExpr(e.Y))
 	case *ast.ParenExpr:

--- a/internal/fuzz/compile_test.go
+++ b/internal/fuzz/compile_test.go
@@ -1,0 +1,222 @@
+// The compile leg: generated code is fed to a REAL compiler. The structural
+// oracle (oracle_test.go) catches what a regex can prove; this target hands
+// the C and C++ output to clang -fsyntax-only, which proves the whole
+// register at once — duplicate definitions, undeclared identifiers, include
+// order, type errors — the classes that shipped precisely because no gate
+// ever compiled what the fuzzer generated.
+//
+// Cost and where it runs: one clang invocation per language per iteration
+// (~40-80ms each on this corpus), so the full campaign is a SLOWER, dedicated
+// target — run it by hand or in a scheduled job:
+//
+//	go test ./internal/fuzz -run xxx -fuzz FuzzGeneratedCompiles -fuzztime 10m
+//
+// Under plain `go test` (the CI "fuzz seeds" step) only the seed corpus runs,
+// which makes this file double as the corpus-seeded compile check: every
+// schema in examples/ and examples128/ plus every hand seed has its generated
+// C and C++ syntax-checked on every CI push, with zero configuration. That
+// split — full compilation per iteration in a bounded slow target, seeds
+// compiled always — is deliberate: per-iteration clang is ~1000x slower than
+// the parse-check-generate path, so wiring it into FuzzPipeline would gut the
+// throughput of the target that needs it most.
+//
+// Scope: C++ and C (clang -fsyntax-only), plus Go syntax via go/parser in the
+// structural oracle on every FuzzPipeline iteration. Rust and C# are not
+// compile-checked here: rustc needs the serialize crate graph built per
+// iteration and C# needs a dotnet project, both of which belong to the make
+// gate that already compiles the real corpus in all five languages.
+package fuzz_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// toolchain discovers the compilers and the serialize runtime headers once.
+// Anything missing skips the target rather than failing it: this leg is a
+// deepening of coverage where the environment allows, not a new hard
+// dependency for `go test ./...` on a bare machine.
+type toolchain struct {
+	cxx        string // C++ compiler driver
+	cc         string // C compiler driver
+	serialize  string // serialize (C++) checkout, for serialize.h
+	serializeC string // serialize.c checkout, for its serialize.h
+	testDir    string // repo test/ dir: hand headers behind cpp_native (vec_math.h)
+	skip       string // non-empty: why the target cannot run here
+}
+
+var toolchainOnce = sync.OnceValue(func() *toolchain {
+	tc := &toolchain{}
+	for _, cand := range []string{"clang++", "c++"} {
+		if p, err := exec.LookPath(cand); err == nil {
+			tc.cxx = p
+			break
+		}
+	}
+	for _, cand := range []string{"clang", "cc"} {
+		if p, err := exec.LookPath(cand); err == nil {
+			tc.cc = p
+			break
+		}
+	}
+	if tc.cxx == "" || tc.cc == "" {
+		tc.skip = "no C/C++ compiler on PATH"
+		return tc
+	}
+	// The sibling layout README.md documents and CI clones: ../serialize and
+	// ../serialize.c beside this repo. Package dir is internal/fuzz, so the
+	// repo root is two levels up.
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		tc.skip = err.Error()
+		return tc
+	}
+	tc.serialize = filepath.Join(filepath.Dir(root), "serialize")
+	tc.serializeC = filepath.Join(filepath.Dir(root), "serialize.c")
+	for _, h := range []string{
+		filepath.Join(tc.serialize, "serialize.h"),
+		filepath.Join(tc.serializeC, "serialize.h"),
+	} {
+		if _, err := os.Stat(h); err != nil {
+			tc.skip = "serialize runtime headers not found at the documented sibling paths (" + h + ")"
+			return tc
+		}
+	}
+	tc.testDir = filepath.Join(root, "test")
+	return tc
+})
+
+var quotedInclude = regexp.MustCompile(`(?m)^\s*#\s*include\s+"([^"]+)"`)
+
+// externalIncludes returns the quoted includes in out that no generated file
+// satisfies — the serialize runtime plus whatever hand headers cpp_native
+// pulled in.
+func externalIncludes(out map[string][]byte) map[string]bool {
+	ext := map[string]bool{}
+	for _, data := range out {
+		for _, m := range quotedInclude.FindAllStringSubmatch(string(data), -1) {
+			if _, generated := out[m[1]]; !generated {
+				ext[m[1]] = true
+			}
+		}
+	}
+	return ext
+}
+
+// syntaxCheck writes one backend's output to dir and runs the compiler over a
+// synthesized translation unit that includes every generated header — the
+// consumer's-eye view, same as test/c/main.c takes. Returns compiler stderr
+// on failure.
+func syntaxCheck(t *testing.T, compiler string, flags []string, dir string, out map[string][]byte, ext string) (string, bool) {
+	t.Helper()
+	names := make([]string, 0, len(out))
+	for name, data := range out {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o666); err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic TU, deterministic diagnostics
+	var tu strings.Builder
+	for _, name := range names {
+		tu.WriteString(`#include "` + name + "\"\n")
+	}
+	tuPath := filepath.Join(dir, ext)
+	if err := os.WriteFile(tuPath, []byte(tu.String()), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, compiler, append(append([]string{}, flags...), tuPath)...)
+	stderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(stderr), false
+	}
+	return "", true
+}
+
+// FuzzGeneratedCompiles: any schema the checker accepts must generate C and
+// C++ that clang accepts under the SAME strictness the Makefile imposes on
+// the corpus (-Wall -Wextra -Werror: generated headers land in consumer
+// translation units, so a warning here is a build break in their tree).
+func FuzzGeneratedCompiles(f *testing.F) {
+	tc := toolchainOnce()
+	if tc.skip != "" {
+		f.Skip("compile fuzz unavailable: " + tc.skip)
+	}
+	seedFromCorpus(f, func(s string) { f.Add(s) })
+	for _, s := range handSeeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, src string) {
+		unit := unitOf(map[string]string{"A.schema": src})
+		if unit == nil {
+			return
+		}
+		for _, b := range backends {
+			if b.name != "cpp" && b.name != "c" {
+				continue
+			}
+			out, err := b.generate(unit)
+			if err != nil {
+				continue
+			}
+			serialize, std := tc.serialize, "-std=c++17"
+			compiler, tuName := tc.cxx, "tu.cpp"
+			if b.name == "c" {
+				serialize, std = tc.serializeC, "-std=c99"
+				compiler, tuName = tc.cc, "tu.c"
+			}
+			dir := t.TempDir()
+			flags := []string{
+				"-fsyntax-only", std, "-Wall", "-Wextra", "-Werror", "-ffp-contract=off",
+				"-I", dir, "-I", serialize,
+			}
+			// Hand headers named by cpp_native resolve against the repo's
+			// test/ dir, exactly where make's corpus build finds them. A
+			// fuzzed schema naming a header that exists nowhere is asking
+			// for the CONSUMER's file, which is not a codegen defect: skip.
+			needTestDir := false
+			resolvable := true
+			for inc := range externalIncludes(out) {
+				if inc == "serialize.h" {
+					continue
+				}
+				if _, err := os.Stat(filepath.Join(tc.testDir, inc)); err != nil {
+					resolvable = false
+					break
+				}
+				needTestDir = true
+			}
+			if !resolvable {
+				continue
+			}
+			if needTestDir {
+				flags = append(flags, "-I", tc.testDir)
+			}
+			if stderr, ok := syntaxCheck(t, compiler, flags, dir, out, tuName); !ok {
+				srcs := make([]string, 0, len(out))
+				for name := range out {
+					srcs = append(srcs, name)
+				}
+				sort.Strings(srcs)
+				var dump strings.Builder
+				for _, name := range srcs {
+					dump.WriteString("---- " + name + " ----\n")
+					dump.Write(out[name])
+				}
+				t.Fatalf("%s: checker accepted a schema whose generated code does not compile.\n"+
+					"---- schema ----\n%s\n---- %s ----\n%s\n%s",
+					b.name, src, compiler, stderr, dump.String())
+			}
+		}
+	})
+}

--- a/internal/fuzz/fuzz_test.go
+++ b/internal/fuzz/fuzz_test.go
@@ -33,21 +33,32 @@ import (
 	"github.com/mas-bandwidth/schema/internal/codegen/csharp"
 	"github.com/mas-bandwidth/schema/internal/codegen/golang"
 	"github.com/mas-bandwidth/schema/internal/codegen/rust"
+	"github.com/mas-bandwidth/schema/internal/ir"
 	"github.com/mas-bandwidth/schema/internal/parser"
 )
 
-// drive runs the full pipeline over the named sources. It returns nothing:
-// the assertion is that it does not panic. A parse or check failure is a
-// NORMAL outcome (most fuzz inputs are not valid schemas) and stops the run
-// early, exactly as the real compiler does.
-func drive(t *testing.T, srcs map[string]string) {
-	t.Helper()
+// backends is the full emitter set, shared by drive and the compile fuzz
+// (compile_test.go) so a sixth backend added here is fuzzed automatically.
+var backends = []struct {
+	name     string
+	generate func(*ir.Unit) (map[string][]byte, error)
+}{
+	{"cpp", func(u *ir.Unit) (map[string][]byte, error) { return cpp.Generate(u, cpp.Options{}) }},
+	{"csharp", csharp.Generate},
+	{"golang", golang.Generate},
+	{"rust", rust.Generate},
+	{"c", cgen.Generate},
+}
+
+// unitOf runs parse+check over the named sources. A parse or check failure is
+// a NORMAL outcome (most fuzz inputs are not valid schemas) and returns nil,
+// exactly as the real compiler stops; a PANIC is the bug we are hunting.
+func unitOf(srcs map[string]string) *ir.Unit {
 	var files []check.SourceFile
 	for name, src := range srcs {
-		// A parse error is fine; a parser PANIC is the bug we are hunting.
 		ast, perrs := parser.Parse(name, []byte(src))
 		if len(perrs) > 0 || ast == nil {
-			return
+			return nil
 		}
 		base := strings.TrimSuffix(name, ".schema")
 		files = append(files, check.SourceFile{
@@ -55,30 +66,42 @@ func drive(t *testing.T, srcs map[string]string) {
 		})
 	}
 	if len(files) == 0 {
-		return
+		return nil
 	}
 	unit, cerrs := check.Unit(files)
-	if len(cerrs) > 0 || unit == nil {
+	if len(cerrs) > 0 {
+		return nil
+	}
+	return unit
+}
+
+// drive runs the full pipeline over the named sources. A unit that CHECKS
+// must generate in every target — and every target is driven even when
+// another errors, because "cpp refused this input" says nothing about whether
+// rust survives it (the old early-return left four backends unfuzzed on any
+// input the first backend rejected). Reaching generation with input that then
+// panics a backend means the checker accepted something it should have
+// rejected — the most valuable class this harness finds, because in
+// production it is an accepted schema that breaks a build.
+//
+// Absence-of-panic is no longer the only oracle: every byte map a backend
+// returns goes through checkGenerated (oracle_test.go), so an emitter that
+// "succeeds" by producing a duplicate definition or unparseable Go now fails
+// here instead of in a consumer's build.
+func drive(t *testing.T, srcs map[string]string) {
+	t.Helper()
+	unit := unitOf(srcs)
+	if unit == nil {
 		return
 	}
-	// A unit that CHECKS must generate in every target. Reaching here with
-	// input that then panics a backend means the checker accepted something
-	// it should have rejected — the most valuable class this harness finds,
-	// because in production it is an accepted schema that breaks a build.
-	if _, err := cpp.Generate(unit, cpp.Options{}); err != nil {
-		return
-	}
-	if _, err := csharp.Generate(unit); err != nil {
-		return
-	}
-	if _, err := golang.Generate(unit); err != nil {
-		return
-	}
-	if _, err := rust.Generate(unit); err != nil {
-		return
-	}
-	if _, err := cgen.Generate(unit); err != nil {
-		return
+	for _, b := range backends {
+		out, err := b.generate(unit)
+		if err != nil {
+			// A reported error on a checked unit is tolerated (targets may
+			// refuse target-specific shapes); the panic is the bug.
+			continue
+		}
+		checkGenerated(t, b.name, out)
 	}
 }
 

--- a/internal/fuzz/oracle_test.go
+++ b/internal/fuzz/oracle_test.go
@@ -1,0 +1,170 @@
+// The structural oracle over generated output. The fuzzer's old contract
+// stopped at "the backend returned bytes without panicking" — but the defect
+// register's worst emitter bugs (duplicate C functions, colliding names,
+// unparseable output) all RETURN bytes happily. This oracle runs on every
+// fuzz iteration and rejects the classes that are cheap to detect
+// structurally; the compile fuzz (compile_test.go) carries the classes that
+// need a real compiler.
+//
+// Design rule: zero false positives beats maximal coverage. Every check here
+// is one a target-language compiler would hard-error on:
+//
+//   - Go: the file must parse (go/parser is in-process and cheap), and no two
+//     top-level declarations may share a name — Go has no overloading.
+//   - Rust: no two same-namespace `pub` items may share a name — Rust has no
+//     overloading either. Matched at column 0, where this emitter puts every
+//     top-level item.
+//   - C / C++ / C#: overloading (C++/C#) and legitimately repeated member
+//     lines (`public int A;` in two classes) make name-level checks lie, so
+//     the check is exact-duplicate DEFINITION LINES within one file — two
+//     byte-identical `inline bool WriteShip(...)` openers in one translation
+//     unit are a redefinition whatever the bodies say. Pure forward
+//     declarations (`struct TableTypeInfo;`) may repeat and are excluded.
+package fuzz_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func checkGenerated(t *testing.T, backend string, out map[string][]byte) {
+	t.Helper()
+	for name, data := range out {
+		switch {
+		case strings.HasSuffix(name, ".go"):
+			checkGoSource(t, backend, name, data)
+		case strings.HasSuffix(name, ".rs"):
+			checkRustDups(t, backend, name, data)
+		case strings.HasSuffix(name, ".h"):
+			checkDupDefLines(t, backend, name, data, cFamilyDefLine)
+		case strings.HasSuffix(name, ".cs"):
+			checkDupDefLines(t, backend, name, data, csTypeDefLine)
+		}
+	}
+}
+
+// checkGoSource: generated Go must parse, and no two top-level declarations
+// may collide. go/parser gives us this exactly — no regex guesswork.
+func checkGoSource(t *testing.T, backend, name string, data []byte) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, name, data, 0)
+	if err != nil {
+		t.Fatalf("%s: %s is not valid Go syntax — the emitter shipped bytes a Go compiler rejects:\n%v\n---- %s ----\n%s",
+			backend, name, err, name, data)
+	}
+	seen := map[string]bool{}
+	flag := func(key string) {
+		if key == "" || strings.HasSuffix(key, "._") {
+			return // blank identifiers may repeat
+		}
+		if seen[key] {
+			t.Fatalf("%s: %s declares %q twice at top level — a Go compiler rejects the file:\n---- %s ----\n%s",
+				backend, name, key, name, data)
+		}
+		seen[key] = true
+	}
+	for _, d := range f.Decls {
+		switch d := d.(type) {
+		case *ast.FuncDecl:
+			recv := ""
+			if d.Recv != nil && len(d.Recv.List) == 1 {
+				recv = typeKey(d.Recv.List[0].Type) + "."
+			}
+			flag(recv + d.Name.Name)
+		case *ast.GenDecl:
+			for _, s := range d.Specs {
+				switch s := s.(type) {
+				case *ast.TypeSpec:
+					flag(s.Name.Name)
+				case *ast.ValueSpec:
+					for _, n := range s.Names {
+						if n.Name != "_" {
+							flag(n.Name)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func typeKey(e ast.Expr) string {
+	switch e := e.(type) {
+	case *ast.StarExpr:
+		return typeKey(e.X)
+	case *ast.Ident:
+		return e.Name
+	default:
+		return fmt.Sprintf("%T", e)
+	}
+}
+
+// rustItem matches a top-level public item as this emitter spells them:
+// column 0, `pub` keyword, name right after the item keyword. Items inside
+// impl blocks are indented and never match.
+var rustItem = regexp.MustCompile(`^pub (fn|struct|enum|const|static|mod|trait|type|union) ([A-Za-z_][A-Za-z0-9_]*)`)
+
+// rust namespaces: struct/enum/trait/type/union live in the type namespace,
+// fn/const/static in the value namespace, mod in its own — same-namespace
+// name collisions are hard errors, cross-namespace ones mostly are not
+// (unit structs blur this; we stay on the safe side).
+var rustNamespace = map[string]string{
+	"struct": "type", "enum": "type", "trait": "type", "type": "type", "union": "type",
+	"fn": "value", "const": "value", "static": "value",
+	"mod": "mod",
+}
+
+func checkRustDups(t *testing.T, backend, name string, data []byte) {
+	t.Helper()
+	seen := map[string]int{}
+	for i, line := range strings.Split(string(data), "\n") {
+		m := rustItem.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := rustNamespace[m[1]] + " " + m[2]
+		if prev, dup := seen[key]; dup {
+			t.Fatalf("%s: %s declares %s %q twice (lines %d and %d) — rustc rejects the file:\n---- %s ----\n%s",
+				backend, name, m[1], m[2], prev, i+1, name, data)
+		}
+		seen[key] = i + 1
+	}
+}
+
+// cFamilyDefLine matches lines that OPEN a top-level definition in the C and
+// C++ emitters' output shapes (both emit at column 0 inside the namespace /
+// extern block). Kept deliberately narrow: a miss costs coverage, a false
+// match costs a bogus crash report.
+var cFamilyDefLine = regexp.MustCompile(`^(static |inline |constexpr |struct |class |enum |typedef |union )`)
+
+// csTypeDefLine matches C# type declarations (indented inside the namespace).
+// Member and method lines are excluded on purpose: identical member text in
+// two classes is legal and common — and so are repeated `partial class`
+// openers, which this emitter really does put twice in one file
+// (generated/cs/TypesTable.cs), so `partial` is excluded too.
+var csTypeDefLine = regexp.MustCompile(`^(public |internal |static )*(sealed |static )*(class|struct|enum|interface) `)
+
+// pure forward declarations may legally repeat.
+var forwardDecl = regexp.MustCompile(`^(struct|class|enum|union)\s+[A-Za-z_][A-Za-z0-9_]*\s*;$`)
+
+func checkDupDefLines(t *testing.T, backend, name string, data []byte, def *regexp.Regexp) {
+	t.Helper()
+	seen := map[string]int{}
+	for i, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if !def.MatchString(line) || forwardDecl.MatchString(line) {
+			continue
+		}
+		if prev, dup := seen[line]; dup {
+			t.Fatalf("%s: %s repeats a definition line (lines %d and %d) — a redefinition in any consumer that includes it:\n  %s\n---- %s ----\n%s",
+				backend, name, prev, i+1, line, name, data)
+		}
+		seen[line] = i + 1
+	}
+}

--- a/internal/fuzz/pack_fuzz_test.go
+++ b/internal/fuzz/pack_fuzz_test.go
@@ -1,0 +1,150 @@
+// Fuzzing over internal/pack — the SECOND input surface. The language
+// pipeline hardening (fuzz_test.go) covers schema source; pack consumes two
+// other things from outside the trust boundary: arbitrary JSON instance data
+// (the data compiler's input) and raw table bytes (DecodeTable reads what in
+// production comes off disk or the wire). Neither had a fuzzer; the doctrine
+// applied to the language — "any crash on malformed input is our bug, however
+// nonsensical the input" — applies verbatim here.
+//
+// Run briefly with -fuzz FuzzDecodeTable or -fuzz FuzzPackJSON, same shape as
+// the pipeline targets (fuzz_test.go).
+package fuzz_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/internal/ir"
+	"github.com/mas-bandwidth/schema/internal/pack"
+)
+
+// packSchema exercises every scalar family the table wire carries: bounded
+// ints, floats, enums, flags, strings, bytes, arrays, nested structs, bools
+// and defaults — one struct per trap the encoder has to route.
+const packSchema = `package fz
+
+enum Mode { Alpha, Beta, Gamma }
+
+flags Caps { A, B, C }
+
+type Inner {
+    factor float32 = 2.5
+    tag    string(8)
+}
+
+table Cfg {
+    a     int32   [min = -1000, max = 1000] = 5
+    b     float32                           = 1.5
+    big   uint64  [min = 0, max = 18446744073709551615]
+    mode  Mode                              = Beta
+    caps  Caps
+    name  string(32)
+    blob  bytes(64)
+    inner Inner
+    items [<= 8]int32 [min = 0, max = 255]
+    on    bool = true
+}
+`
+
+func packUnit(tb testing.TB) *ir.Unit {
+	tb.Helper()
+	u := unitOf(map[string]string{"Fz.schema": packSchema})
+	if u == nil {
+		tb.Fatal("pack fuzz schema does not parse+check — fix packSchema")
+	}
+	return u
+}
+
+// FuzzDecodeTable: table bytes from OUTSIDE — any input either decodes (with
+// a report) or is refused with an error. Panics and hangs are compiler bugs,
+// exactly as for schema source. Seeded with real encodings so mutation
+// starts from valid wire and corrupts outward — lengths, ids, kinds.
+func FuzzDecodeTable(f *testing.F) {
+	u := packUnit(f)
+	enc := &pack.Encoder{Unit: u}
+	for _, seed := range []string{
+		`{}`,
+		`{"a": -7, "mode": "Gamma", "name": "hello", "items": [1, 2, 250]}`,
+		`{"caps": ["A", "C"], "blob": "3q2+7w==", "inner": {"factor": 0.5, "tag": "x"}, "on": false}`,
+		`{"big": 18446744073709551615, "b": -1.25}`,
+	} {
+		var obj map[string]any
+		dec := json.NewDecoder(strings.NewReader(seed))
+		dec.UseNumber()
+		if err := dec.Decode(&obj); err != nil {
+			f.Fatal(err)
+		}
+		wire, err := enc.EncodeTable("Cfg", obj)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(wire)
+		if len(wire) > 3 {
+			f.Add(wire[:len(wire)/2]) // a truncation, pre-seeded
+		}
+	}
+	f.Add([]byte{})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		out, rep, err := pack.DecodeTable(u, "Cfg", data)
+		if err != nil {
+			return // refusing bytes is a normal outcome
+		}
+		if out == nil || rep == nil {
+			t.Fatalf("DecodeTable returned no error and nil result (out=%v rep=%v)", out, rep)
+		}
+	})
+}
+
+// FuzzPackJSON: the data compiler's input surface — arbitrary JSON text
+// through the exact dialect production uses (trailing-comma stripping +
+// UseNumber), then both encoders. Two properties ride on top of survival:
+// clamp mode must never turn an encodable value into a panic, and any bytes
+// EncodeTable emits must round-trip through DecodeTable cleanly — the
+// encoder and decoder are two halves of one wire contract, so an encoding
+// the decoder refuses or misreads is a bug in one of them no matter which.
+func FuzzPackJSON(f *testing.F) {
+	u := packUnit(f)
+	for _, seed := range []string{
+		`{}`,
+		`{"a": 5}`,
+		`{"a": -7, "mode": "Gamma", "name": "hello", "items": [1, 2, 250],}`,
+		`{"caps": ["A", "C"], "blob": "3q2+7w==", "inner": {"factor": 0.5, "tag": "x"}, "on": false}`,
+		`{"big": 18446744073709551615, "b": -1.25}`,
+		`{"a": 1e309}`,
+		`{"a": "not a number"}`,
+		`{"inner": []}`,
+		`{"items": [[]]}`,
+		`{"name": "\ud800"}`,
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, jsonText string) {
+		var obj map[string]any
+		dec := json.NewDecoder(strings.NewReader(pack.StripTrailingCommas(jsonText)))
+		dec.UseNumber()
+		if err := dec.Decode(&obj); err != nil {
+			return // not JSON: nothing to compile
+		}
+		enc := &pack.Encoder{Unit: u}
+		clamp := &pack.Encoder{Unit: u, ClampBounds: true}
+		if _, err := enc.EncodeInstance("Cfg", obj); err == nil {
+			// encodable strictly => encodable clamped (clamp only widens)
+			if _, cerr := clamp.EncodeInstance("Cfg", obj); cerr != nil {
+				t.Fatalf("strict encoder accepts this instance but clamp mode refuses it: %v\n%s", cerr, jsonText)
+			}
+		}
+		wire, err := enc.EncodeTable("Cfg", obj)
+		if err != nil {
+			return
+		}
+		out, rep, err := pack.DecodeTable(u, "Cfg", wire)
+		if err != nil || out == nil {
+			t.Fatalf("EncodeTable produced bytes DecodeTable refuses (%v)\njson: %s\nwire: %x", err, jsonText, wire)
+		}
+		if rep.Malformed || rep.Unknown != 0 || rep.KindMismatch != 0 {
+			t.Fatalf("EncodeTable produced bytes DecodeTable flags (malformed=%v unknown=%d kindMismatch=%d)\njson: %s\nwire: %x",
+				rep.Malformed, rep.Unknown, rep.KindMismatch, jsonText, wire)
+		}
+	})
+}

--- a/internal/fuzz/property_test.go
+++ b/internal/fuzz/property_test.go
@@ -13,10 +13,6 @@ import (
 	"testing"
 
 	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/codegen/cpp"
-	"github.com/mas-bandwidth/schema/internal/codegen/csharp"
-	"github.com/mas-bandwidth/schema/internal/codegen/golang"
-	"github.com/mas-bandwidth/schema/internal/codegen/rust"
 	"github.com/mas-bandwidth/schema/internal/format"
 	"github.com/mas-bandwidth/schema/internal/parser"
 )
@@ -75,11 +71,16 @@ func TestGeneratedOutputIsDeterministic(t *testing.T) {
 			name string
 			run  func() (map[string][]byte, error)
 		}
-		gens := []gen{
-			{"cpp", func() (map[string][]byte, error) { return cpp.Generate(unit, cpp.Options{}) }},
-			{"csharp", func() (map[string][]byte, error) { return csharp.Generate(unit) }},
-			{"golang", func() (map[string][]byte, error) { return golang.Generate(unit) }},
-			{"rust", func() (map[string][]byte, error) { return rust.Generate(unit) }},
+		// ALL FIVE backends, from the shared backends table (fuzz_test.go):
+		// this list said four while the file's own comment said five — the
+		// ea88362 sweep renumbered the prose and missed the slice, and the C
+		// backend (whose sortedDeps exists precisely because C output must be
+		// byte-identical) shipped unheld to the invariant it was built for.
+		// Deriving from the table instead of restating it means backend six
+		// cannot repeat the miss.
+		gens := make([]gen, 0, len(backends))
+		for _, b := range backends {
+			gens = append(gens, gen{b.name, func() (map[string][]byte, error) { return b.generate(unit) }})
 		}
 		for _, g := range gens {
 			first, err := g.run()
@@ -170,7 +171,13 @@ func TestFormatIsIdempotent(t *testing.T) {
 }
 
 // FuzzFormatIdempotent pushes the same property over arbitrary input: any
-// source the formatter accepts must be a fixed point after one pass.
+// source the formatter accepts must be a fixed point after one pass — and it
+// must mean the same thing. Idempotence alone is a trap: a formatter that
+// silently DROPPED an attribute (the exact class of the 9468155 crash, a
+// `[min = 0]` on a wrapped attribute list) is perfectly idempotent while
+// changing the wire of every field it touched. The protocol id is the low 64
+// bits of SHA-256 over the wire-shape projection, so "same id" is precisely
+// "same wire": for any source that checks, format() must preserve it.
 func FuzzFormatIdempotent(f *testing.F) {
 	seedFromCorpus(f, func(s string) { f.Add(s) })
 	for _, s := range handSeeds {
@@ -187,6 +194,19 @@ func FuzzFormatIdempotent(f *testing.F) {
 		}
 		if !bytes.Equal(once, twice) {
 			t.Fatalf("formatting not idempotent:\n--- once ---\n%s\n--- twice ---\n%s", once, twice)
+		}
+		before := unitOf(map[string]string{"A.schema": src})
+		if before == nil {
+			return // formats but does not check: idempotence was all there was to hold
+		}
+		after := unitOf(map[string]string{"A.schema": string(once)})
+		if after == nil {
+			t.Fatalf("source checks but its FORMATTED form does not — the formatter broke the program:\n--- source ---\n%s\n--- formatted ---\n%s",
+				src, once)
+		}
+		if after.ProtocolId != before.ProtocolId {
+			t.Fatalf("format() changed the protocol id %#x -> %#x — the formatter changed the WIRE:\n--- source ---\n%s\n--- formatted ---\n%s",
+				before.ProtocolId, after.ProtocolId, src, once)
 		}
 	})
 }

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/0c59b1fd80a64c37
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/0c59b1fd80a64c37
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\nconst A=20000000000000000000")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/16e55ccee0e8aab6
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/16e55ccee0e8aab6
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\ntype A{B B}\ntype B{}")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/35bc4f0e0bd9eb01
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/35bc4f0e0bd9eb01
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\ntype A{B int8[min=0%10000000000000000000,max=0]}")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/4f0cf28293e2a3b2
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/4f0cf28293e2a3b2
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\ntype A{reserved(1)}")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/7a2c42ac01522636
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/7a2c42ac01522636
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\ntype A{B int64[min=0,max=7*700000000]}")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/8cf3bf126aef4f1d
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/8cf3bf126aef4f1d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\ntype A{B int32[min=0,max=0]}")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/94083fc9d6934655
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/94083fc9d6934655
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\nconst A=0\ntable B{}")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/d5415d438939ed7a
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/d5415d438939ed7a
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\nobject A{A V[interpolate,quantize=1,max=1]}\ntype V{}")

--- a/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/dce5b404f3541b95
+++ b/internal/fuzz/testdata/fuzz/FuzzGeneratedCompiles/dce5b404f3541b95
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("package A\nconst A=----------------0")

--- a/internal/ir/emission.go
+++ b/internal/ir/emission.go
@@ -1,0 +1,75 @@
+package ir
+
+// EmissionOrder returns the file's declarations in an order where every
+// same-file named type precedes its by-value users — schema references are
+// order-free (SPEC §4.2), C and C++ are not. A stable topological sort:
+// declaration order is preserved wherever no dependency forces otherwise.
+//
+// Lifted verbatim from the C++ backend, which has ordered this way from the
+// start; the C backend emitted in raw declaration order and shipped
+// `unknown type name` / implicit-declaration errors for any unit whose
+// schema declared a by-value user before its type in one file (found by
+// FuzzGeneratedCompiles, the clang -fsyntax-only leg — issue #22).
+func EmissionOrder(file *File) []Decl {
+	decls := file.Decls
+	n := len(decls)
+	byName := map[string]int{}
+	for i, d := range decls {
+		switch d := d.(type) {
+		case *Struct:
+			byName[d.Name] = i
+		case *Enum:
+			byName[d.Name] = i
+		case *Flags:
+			byName[d.Name] = i
+		case *Object:
+			byName[d.Name] = i
+		}
+	}
+	adj := make([][]int, n)
+	indeg := make([]int, n)
+	for i, d := range decls {
+		var fields []*Field
+		switch d := d.(type) {
+		case *Struct:
+			fields = d.Fields
+		case *Object:
+			fields = d.Fields
+		}
+		for _, f := range fields {
+			if f.Type.Kind == TNamed {
+				if j, ok := byName[f.Type.Name]; ok && j != i {
+					adj[j] = append(adj[j], i)
+					indeg[i]++
+				}
+			}
+		}
+	}
+	order := make([]Decl, 0, n)
+	done := make([]bool, n)
+	for len(order) < n {
+		pick := -1
+		for i := 0; i < n; i++ {
+			if !done[i] && indeg[i] == 0 {
+				pick = i
+				break
+			}
+		}
+		if pick == -1 {
+			// an intra-file type cycle — the checker already rejected the unit;
+			// defensively emit the rest in declaration order
+			for i := 0; i < n; i++ {
+				if !done[i] {
+					pick = i
+					break
+				}
+			}
+		}
+		done[pick] = true
+		order = append(order, decls[pick])
+		for _, t := range adj[pick] {
+			indeg[t]--
+		}
+	}
+	return order
+}

--- a/internal/pack/manifest.go
+++ b/internal/pack/manifest.go
@@ -310,7 +310,7 @@ func loadJSON(path string) (map[string]any, error) {
 		return nil, err
 	}
 	var obj map[string]any
-	dec := json.NewDecoder(strings.NewReader(stripTrailingCommas(string(data))))
+	dec := json.NewDecoder(strings.NewReader(StripTrailingCommas(string(data))))
 	dec.UseNumber() // full-range uint64 values must survive exactly (json.Number)
 	if err := dec.Decode(&obj); err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
@@ -318,12 +318,14 @@ func loadJSON(path string) (map[string]any, error) {
 	return obj, nil
 }
 
-// stripTrailingCommas makes the game's flatbuffers-JSON dialect strict:
+// StripTrailingCommas makes the game's flatbuffers-JSON dialect strict:
 // flatc's parser tolerates a comma before a closing } or ] (the shipped
 // config files use it liberally) and strict JSON does not. String-aware —
 // a comma inside a quoted string is never touched. This is the dialect
 // adapter's whole extent: the files carry no comments (checked 2026-08-11).
-func stripTrailingCommas(s string) string {
+// Exported so the fuzzer (internal/fuzz) drives the exact dialect the data
+// compiler reads rather than an approximation of it.
+func StripTrailingCommas(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	inString := false


### PR DESCRIPTION
Closes #22. The compile fuzzer generates schemas, compiles the generated code, and round-trips it — and found EIGHT real, unplanted bugs on its first day, the eighth a silent C-vs-C++ wire divergence on reserved-only structs that the entire golden apparatus had never exercised. Every fix is regression-seeded; five planted-bug proofs show the fuzzer can fail; 33.5M execs clean after the fixes.

One DECISION deliberately not fixed here (boarded separately): schema package names like 'exit' collide with libc globals at C++ namespace scope — a naming-rule decision, not a code fix.