### PR TITLE
The generated crate speaks serialize.rs 2.0.0

### DIFF
--- a/generated/bench/rust/src/bench.rs
+++ b/generated/bench/rust/src/bench.rs
@@ -21,6 +21,14 @@ impl From<serialize::Error> for Error {
     }
 }
 
+// serialize.rs 2.0.0 writes are infallible: their Result carries an
+// uninhabited error, and `?` on one needs this vacuous conversion.
+impl From<core::convert::Infallible> for Error {
+    fn from(e: core::convert::Infallible) -> Error {
+        match e {}
+    }
+}
+
 pub type Result<T = ()> = core::result::Result<T, Error>;
 
 // type BenchPacket
@@ -131,7 +139,7 @@ pub fn write_bench_packet(stream: &mut WriteStream<'_>, value: &BenchPacket) -> 
         stream.serialize_bits64(&mut raw_value, 64)?;
     }
     stream.serialize_align()?;
-    stream.write_bytes(&value.blob)?; // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop
+    stream.write_bytes(&value.blob); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
 }
 

--- a/generated/rust-ludicrous/src/ludicrous.rs
+++ b/generated/rust-ludicrous/src/ludicrous.rs
@@ -21,6 +21,14 @@ impl From<serialize::Error> for Error {
     }
 }
 
+// serialize.rs 2.0.0 writes are infallible: their Result carries an
+// uninhabited error, and `?` on one needs this vacuous conversion.
+impl From<core::convert::Infallible> for Error {
+    fn from(e: core::convert::Infallible) -> Error {
+        match e {}
+    }
+}
+
 pub type Result<T = ()> = core::result::Result<T, Error>;
 
 // MessageType: the message set, extracted by the compiler — None = 0, then each message sorted by name (SPEC §4.8)

--- a/generated/rust/src/constants.rs
+++ b/generated/rust/src/constants.rs
@@ -19,6 +19,14 @@ impl From<serialize::Error> for Error {
     }
 }
 
+// serialize.rs 2.0.0 writes are infallible: their Result carries an
+// uninhabited error, and `?` on one needs this vacuous conversion.
+impl From<core::convert::Infallible> for Error {
+    fn from(e: core::convert::Infallible) -> Error {
+        match e {}
+    }
+}
+
 pub type Result<T = ()> = core::result::Result<T, Error>;
 
 pub const POSITION_UNITS: i64 = 1024;

--- a/generated/rust/src/messages.rs
+++ b/generated/rust/src/messages.rs
@@ -162,7 +162,7 @@ pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
         let mut offset_value = value.data_length as u32;
         stream.serialize_bits(&mut offset_value, 11)?; // the length guards the slice (§6.3)
     }
-    stream.write_bytes(&value.data[..value.data_length as usize])?; // borrowed in place: the write side never mutates
+    stream.write_bytes(&value.data[..value.data_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
 }
 
@@ -209,7 +209,7 @@ pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 9)?; // the length guards the slice (§6.3)
     }
-    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
+    stream.write_bytes(&value.text[..value.text_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
 }
 

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -714,7 +714,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         stream.serialize_bits64(&mut offset_value, 41)?;
     }
     stream.serialize_align()?;
-    stream.write_bytes(&value.fixed_bytes)?; // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop
+    stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
     if value.text_length < 0 || value.text_length > 255 { // refused, not wrapped or panicked: guards the slice too
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -726,7 +726,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 8)?; // the length guards the slice (§6.3)
     }
-    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
+    stream.write_bytes(&value.text[..value.text_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
 }
 

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -390,7 +390,7 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 			// to the per-byte loop (its internal align is zero bits here) and
 			// block-copies instead of 8-bit packing; borrowed in place via
 			// WriteStream::write_bytes, as the length-prefixed fields already are
-			g.pf("%sstream.write_bytes(&%s)?; // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop\n", ind, name)
+			g.pf("%sstream.write_bytes(&%s); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)\n", ind, name)
 			return
 		}
 		if f.Array == ir.ArrayCounted {
@@ -544,7 +544,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		// takes &[u8] (same wire as serialize_bytes — align, then the block copy),
 		// where the unified &mut signature forced a whole-array copy into a mutable
 		// local first — 256 B per chat, 2 KB per block, visible in perf (2026-08-06)
-		g.pf("%sstream.write_bytes(&%s[..%s_length as usize])?; // borrowed in place: the write side never mutates\n", ind, name, name)
+		g.pf("%sstream.write_bytes(&%s[..%s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)\n", ind, name, name)
 	case ir.TNamed:
 		switch ref := f.Type.Ref.(type) {
 		case *ir.Enum:

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -206,6 +206,10 @@ func (g *gen) emitFile(carriesProtocolId bool) {
 		g.pf("pub enum Error {\n    Stream(serialize::Error),\n    Validation,\n}\n\n")
 		g.pf("impl From<serialize::Error> for Error {\n")
 		g.pf("    fn from(e: serialize::Error) -> Error {\n        Error::Stream(e)\n    }\n}\n\n")
+		g.pf("// serialize.rs 2.0.0 writes are infallible: their Result carries an\n")
+		g.pf("// uninhabited error, and `?` on one needs this vacuous conversion.\n")
+		g.pf("impl From<core::convert::Infallible> for Error {\n")
+		g.pf("    fn from(e: core::convert::Infallible) -> Error {\n        match e {}\n    }\n}\n\n")
 		g.pf("pub type Result<T = ()> = core::result::Result<T, Error>;\n\n")
 	}
 

--- a/testdata/golden/ludicrous/rust/ludicrous.rs
+++ b/testdata/golden/ludicrous/rust/ludicrous.rs
@@ -21,6 +21,14 @@ impl From<serialize::Error> for Error {
     }
 }
 
+// serialize.rs 2.0.0 writes are infallible: their Result carries an
+// uninhabited error, and `?` on one needs this vacuous conversion.
+impl From<core::convert::Infallible> for Error {
+    fn from(e: core::convert::Infallible) -> Error {
+        match e {}
+    }
+}
+
 pub type Result<T = ()> = core::result::Result<T, Error>;
 
 // MessageType: the message set, extracted by the compiler — None = 0, then each message sorted by name (SPEC §4.8)

--- a/testdata/golden/rust/constants.rs
+++ b/testdata/golden/rust/constants.rs
@@ -19,6 +19,14 @@ impl From<serialize::Error> for Error {
     }
 }
 
+// serialize.rs 2.0.0 writes are infallible: their Result carries an
+// uninhabited error, and `?` on one needs this vacuous conversion.
+impl From<core::convert::Infallible> for Error {
+    fn from(e: core::convert::Infallible) -> Error {
+        match e {}
+    }
+}
+
 pub type Result<T = ()> = core::result::Result<T, Error>;
 
 pub const POSITION_UNITS: i64 = 1024;

--- a/testdata/golden/rust/messages.rs
+++ b/testdata/golden/rust/messages.rs
@@ -162,7 +162,7 @@ pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
         let mut offset_value = value.data_length as u32;
         stream.serialize_bits(&mut offset_value, 11)?; // the length guards the slice (§6.3)
     }
-    stream.write_bytes(&value.data[..value.data_length as usize])?; // borrowed in place: the write side never mutates
+    stream.write_bytes(&value.data[..value.data_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
 }
 
@@ -209,7 +209,7 @@ pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 9)?; // the length guards the slice (§6.3)
     }
-    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
+    stream.write_bytes(&value.text[..value.text_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
 }
 

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -714,7 +714,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         stream.serialize_bits64(&mut offset_value, 41)?;
     }
     stream.serialize_align()?;
-    stream.write_bytes(&value.fixed_bytes)?; // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop
+    stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
     if value.text_length < 0 || value.text_length > 255 { // refused, not wrapped or panicked: guards the slice too
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -726,7 +726,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut offset_value = value.text_length as u32;
         stream.serialize_bits(&mut offset_value, 8)?; // the length guards the slice (§6.3)
     }
-    stream.write_bytes(&value.text[..value.text_length as usize])?; // borrowed in place: the write side never mutates
+    stream.write_bytes(&value.text[..value.text_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
 }
 


### PR DESCRIPTION
Family-compat fix, mid-wave: serialize.rs 2.0.0 (infallible writes) landed tonight and schema's CI builds against sibling HEAD, so every schema PR's Rust leg went red. Two codegen adaptations, regenerated through goldens and the committed generated trees:

- the generated Error gains the vacuous From<Infallible> (mirroring serialize.rs's own impl), so ? on an infallible write compiles;
- the two direct write_bytes emissions drop their ? — write_bytes returns plain () in 2.0.0.

Proven locally against serialize.rs main: full make test, zero errors, including the bench and corpus Rust legs that were red. Merge this FIRST — the open schema PRs then pick it up via their main-merges. (The unpinned-sibling-HEAD debt this rode in on is already boarded in the runbook's remains.)