### PR TITLE
cpp: the generated read path can demand inlining — SCHEMA_READ_SPINE_DEMAND, default off

### DIFF
--- a/generated/bench/cpp/BenchWire.h
+++ b/generated/bench/cpp/BenchWire.h
@@ -14,6 +14,30 @@
 
 namespace bench {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteBenchPacket( serialize::WriteStream & stream, const BenchPacket & value )
 {
     serialize_assert( int32_t( value.a ) >= int32_t( -100 ) && int32_t( value.a ) <= int32_t( 100 ) );
@@ -35,7 +59,7 @@ inline bool WriteBenchPacket( serialize::WriteStream & stream, const BenchPacket
     return true;
 }
 
-inline bool ReadBenchPacket( serialize::ReadStream & stream, BenchPacket & value )
+SCHEMA_READ_INLINE bool ReadBenchPacket( serialize::ReadStream & stream, BenchPacket & value )
 {
     read_int( stream, value.a, -100, 100 );
     read_int( stream, value.b, 0, 65535 );
@@ -78,7 +102,7 @@ inline bool WriteBenchInts( serialize::WriteStream & stream, const BenchInts & v
     return true;
 }
 
-inline bool ReadBenchInts( serialize::ReadStream & stream, BenchInts & value )
+SCHEMA_READ_INLINE bool ReadBenchInts( serialize::ReadStream & stream, BenchInts & value )
 {
     read_int( stream, value.f0, -100, 100 );
     read_int( stream, value.f1, 0, 65535 );
@@ -106,7 +130,7 @@ inline bool WriteBenchBits( serialize::WriteStream & stream, const BenchBits & v
     return true;
 }
 
-inline bool ReadBenchBits( serialize::ReadStream & stream, BenchBits & value )
+SCHEMA_READ_INLINE bool ReadBenchBits( serialize::ReadStream & stream, BenchBits & value )
 {
     read_bits( stream, value.b7, 7 );
     read_bits( stream, value.b13, 13 );
@@ -140,7 +164,7 @@ inline bool WriteBenchMixed( serialize::WriteStream & stream, const BenchMixed &
     return true;
 }
 
-inline bool ReadBenchMixed( serialize::ReadStream & stream, BenchMixed & value )
+SCHEMA_READ_INLINE bool ReadBenchMixed( serialize::ReadStream & stream, BenchMixed & value )
 {
     read_int( stream, value.sequence, 0, 65535 );
     read_bits( stream, value.ack_bits, 32 );

--- a/generated/cpp/MessagesWire.h
+++ b/generated/cpp/MessagesWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -90,7 +114,7 @@ inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & v
     return true;
 }
 
-inline bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat & value )
+SCHEMA_READ_INLINE bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat & value )
 {
     (void) stream;
     (void) value;
@@ -109,7 +133,7 @@ inline bool WriteTest( serialize::WriteStream & stream, const Test & value )
     return true;
 }
 
-inline bool ReadTest( serialize::ReadStream & stream, Test & value )
+SCHEMA_READ_INLINE bool ReadTest( serialize::ReadStream & stream, Test & value )
 {
     {
         uint32_t raw_value = 0;
@@ -142,7 +166,7 @@ inline bool WriteBlock( serialize::WriteStream & stream, const Block & value )
     return true;
 }
 
-inline bool ReadBlock( serialize::ReadStream & stream, Block & value )
+SCHEMA_READ_INLINE bool ReadBlock( serialize::ReadStream & stream, Block & value )
 {
     read_int( stream, value.data_length, 0, MaxBlockSize );
     read_bytes( stream, value.data, value.data_length );
@@ -162,7 +186,7 @@ inline bool WriteChat( serialize::WriteStream & stream, const Chat & value )
     return true;
 }
 
-inline bool ReadChat( serialize::ReadStream & stream, Chat & value )
+SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
 {
     read_int( stream, value.text_length, 0, MaxChatLength );
     read_bytes( stream, value.text, value.text_length );
@@ -184,7 +208,7 @@ inline bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize
     return true;
 }
 
-inline bool ReadSynchronize( serialize::ReadStream & stream, Synchronize & value )
+SCHEMA_READ_INLINE bool ReadSynchronize( serialize::ReadStream & stream, Synchronize & value )
 {
     read_bits( stream, value.sync_frame, 64 );
     {
@@ -203,7 +227,7 @@ inline bool WriteTimescale( serialize::WriteStream & stream, const Timescale & v
     return true;
 }
 
-inline bool ReadTimescale( serialize::ReadStream & stream, Timescale & value )
+SCHEMA_READ_INLINE bool ReadTimescale( serialize::ReadStream & stream, Timescale & value )
 {
     read_double( stream, value.scale );
     read_bits( stream, value.frame_a, 32 );
@@ -220,7 +244,7 @@ inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value
     return true;
 }
 
-inline bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
+SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 6 );
@@ -274,7 +298,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
     return false; // not a message type; nothing was written
 }
 
-inline bool ReadMessage( serialize::ReadStream & stream, Message & message )
+SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )
 {
     MessageType tag_value = MessageType::None;
     if ( !ReadMessageType( stream, tag_value ) )

--- a/generated/cpp/ObjectsWire.h
+++ b/generated/cpp/ObjectsWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
@@ -73,7 +97,7 @@ inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_
     return true;
 }
 
-inline bool ReadShipData_Deep( serialize::ReadStream & stream, ShipData_Deep & value )
+SCHEMA_READ_INLINE bool ReadShipData_Deep( serialize::ReadStream & stream, ShipData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -175,7 +199,7 @@ inline bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipDa
     return true;
 }
 
-inline bool ReadShipData_Shallow( serialize::ReadStream & stream, ShipData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadShipData_Shallow( serialize::ReadStream & stream, ShipData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -273,7 +297,7 @@ inline bool WriteMissileData_Deep( serialize::WriteStream & stream, const Missil
     return true;
 }
 
-inline bool ReadMissileData_Deep( serialize::ReadStream & stream, MissileData_Deep & value )
+SCHEMA_READ_INLINE bool ReadMissileData_Deep( serialize::ReadStream & stream, MissileData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -331,7 +355,7 @@ inline bool WriteMissileData_Shallow( serialize::WriteStream & stream, const Mis
     return true;
 }
 
-inline bool ReadMissileData_Shallow( serialize::ReadStream & stream, MissileData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadMissileData_Shallow( serialize::ReadStream & stream, MissileData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -419,7 +443,7 @@ inline bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const Dy
     return true;
 }
 
-inline bool ReadDynamicPropData_Deep( serialize::ReadStream & stream, DynamicPropData_Deep & value )
+SCHEMA_READ_INLINE bool ReadDynamicPropData_Deep( serialize::ReadStream & stream, DynamicPropData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -477,7 +501,7 @@ inline bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const
     return true;
 }
 
-inline bool ReadDynamicPropData_Shallow( serialize::ReadStream & stream, DynamicPropData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadDynamicPropData_Shallow( serialize::ReadStream & stream, DynamicPropData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -559,7 +583,7 @@ inline bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretD
     return true;
 }
 
-inline bool ReadTurretData_Deep( serialize::ReadStream & stream, TurretData_Deep & value )
+SCHEMA_READ_INLINE bool ReadTurretData_Deep( serialize::ReadStream & stream, TurretData_Deep & value )
 {
     if ( !ReadHandle( stream, value.parent ) )
     {
@@ -594,7 +618,7 @@ inline bool WriteTurretData_Shallow( serialize::WriteStream & stream, const Turr
     return true;
 }
 
-inline bool ReadTurretData_Shallow( serialize::ReadStream & stream, TurretData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadTurretData_Shallow( serialize::ReadStream & stream, TurretData_Shallow & value )
 {
     if ( !ReadHandle( stream, value.parent ) )
     {
@@ -634,7 +658,7 @@ inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
     return true;
 }
 
-inline bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
+SCHEMA_READ_INLINE bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 4 );

--- a/generated/cpp/RenderWire.h
+++ b/generated/cpp/RenderWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
 {
     write_bits( stream, value.sort_key, 64 );
@@ -26,7 +50,7 @@ inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSpri
     return true;
 }
 
-inline bool ReadRenderSprite( serialize::ReadStream & stream, RenderSprite & value )
+SCHEMA_READ_INLINE bool ReadRenderSprite( serialize::ReadStream & stream, RenderSprite & value )
 {
     read_bits( stream, value.sort_key, 64 );
     read_bits( stream, value.mesh_id, 32 );
@@ -60,7 +84,7 @@ inline bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock
     return true;
 }
 
-inline bool ReadRenderBlock( serialize::ReadStream & stream, RenderBlock & value )
+SCHEMA_READ_INLINE bool ReadRenderBlock( serialize::ReadStream & stream, RenderBlock & value )
 {
     read_bits( stream, value.worker_index, 32 );
     read_bits( stream, value.sprite_count_hint, 32 );

--- a/generated/cpp/TypesWire.h
+++ b/generated/cpp/TypesWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
 {
     write_double( stream, value.x );
@@ -25,7 +49,7 @@ inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
     return true;
 }
 
-inline bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
+SCHEMA_READ_INLINE bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
 {
     read_double( stream, value.x );
     read_double( stream, value.y );
@@ -42,7 +66,7 @@ inline bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
     return true;
 }
 
-inline bool ReadQuat( serialize::ReadStream & stream, Quat & value )
+SCHEMA_READ_INLINE bool ReadQuat( serialize::ReadStream & stream, Quat & value )
 {
     read_double( stream, value.x );
     read_double( stream, value.y );
@@ -59,7 +83,7 @@ inline bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
     return true;
 }
 
-inline bool ReadHandle( serialize::ReadStream & stream, Handle & value )
+SCHEMA_READ_INLINE bool ReadHandle( serialize::ReadStream & stream, Handle & value )
 {
     read_int( stream, value.object_id, 0, MaxObjects - 1 );
     {
@@ -81,7 +105,7 @@ inline bool WriteQuantizedPosition( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedPosition( serialize::ReadStream & stream, QuantizedPosition & value )
+SCHEMA_READ_INLINE bool ReadQuantizedPosition( serialize::ReadStream & stream, QuantizedPosition & value )
 {
     read_int( stream, value.x, -MaxPositionUnits, MaxPositionUnits );
     read_int( stream, value.y, -MaxPositionUnits, MaxPositionUnits );
@@ -100,7 +124,7 @@ inline bool WriteQuantizedVelocity( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedVelocity( serialize::ReadStream & stream, QuantizedVelocity & value )
+SCHEMA_READ_INLINE bool ReadQuantizedVelocity( serialize::ReadStream & stream, QuantizedVelocity & value )
 {
     read_int( stream, value.x, -MaxVelocityUnits, MaxVelocityUnits );
     read_int( stream, value.y, -MaxVelocityUnits, MaxVelocityUnits );
@@ -121,7 +145,7 @@ inline bool WriteQuantizedRotation( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedRotation( serialize::ReadStream & stream, QuantizedRotation & value )
+SCHEMA_READ_INLINE bool ReadQuantizedRotation( serialize::ReadStream & stream, QuantizedRotation & value )
 {
     {
         int32_t range_value = 0;
@@ -171,7 +195,7 @@ inline bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & v
     return true;
 }
 
-inline bool ReadRigidBody( serialize::ReadStream & stream, RigidBody & value )
+SCHEMA_READ_INLINE bool ReadRigidBody( serialize::ReadStream & stream, RigidBody & value )
 {
     if ( !ReadVec3( stream, value.position ) )
     {
@@ -219,7 +243,7 @@ inline bool WriteInput( serialize::WriteStream & stream, const Input & value )
     return true;
 }
 
-inline bool ReadInput( serialize::ReadStream & stream, Input & value )
+SCHEMA_READ_INLINE bool ReadInput( serialize::ReadStream & stream, Input & value )
 {
     read_float( stream, value.stick_x );
     read_float( stream, value.stick_y );
@@ -254,7 +278,7 @@ inline bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket
     return true;
 }
 
-inline bool ReadInputPacket( serialize::ReadStream & stream, InputPacket & value )
+SCHEMA_READ_INLINE bool ReadInputPacket( serialize::ReadStream & stream, InputPacket & value )
 {
     {
         uint32_t raw_value = 0;
@@ -306,7 +330,7 @@ inline bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate &
     return true;
 }
 
-inline bool ReadShipCreate( serialize::ReadStream & stream, ShipCreate & value )
+SCHEMA_READ_INLINE bool ReadShipCreate( serialize::ReadStream & stream, ShipCreate & value )
 {
     {
         int32_t enum_value = 0;

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -93,7 +117,7 @@ inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader
     return true;
 }
 
-inline bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHeader & value )
+SCHEMA_READ_INLINE bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHeader & value )
 {
     {
         uint64_t const_value = 0;
@@ -128,7 +152,7 @@ inline bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & v
     return true;
 }
 
-inline bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits & value )
+SCHEMA_READ_INLINE bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits & value )
 {
     read_bits( stream, value.small, 9 );
     read_bits( stream, value.boundary, 33 );
@@ -174,7 +198,7 @@ inline bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample
     return true;
 }
 
-inline bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
+SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
 {
     read_bool( stream, value.active );
     serialize_compressed_float( stream, value.orientation, -180.0f, 180.0f, 0.01f );
@@ -237,7 +261,7 @@ inline bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig
     return true;
 }
 
-inline bool ReadProbeConfig( serialize::ReadStream & stream, ProbeConfig & value )
+SCHEMA_READ_INLINE bool ReadProbeConfig( serialize::ReadStream & stream, ProbeConfig & value )
 {
     {
         uint32_t raw_value = 0;
@@ -268,7 +292,7 @@ inline bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray &
     return true;
 }
 
-inline bool ReadProbeArray( serialize::ReadStream & stream, ProbeArray & value )
+SCHEMA_READ_INLINE bool ReadProbeArray( serialize::ReadStream & stream, ProbeArray & value )
 {
     for ( int32_t i = 0; i < 2; i++ )
     {
@@ -299,7 +323,7 @@ inline bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport
     return true;
 }
 
-inline bool ReadProbeReport( serialize::ReadStream & stream, ProbeReport & value )
+SCHEMA_READ_INLINE bool ReadProbeReport( serialize::ReadStream & stream, ProbeReport & value )
 {
     if ( !ReadProbeHeader( stream, value.header ) )
     {
@@ -360,7 +384,7 @@ inline bool WriteTestData( serialize::WriteStream & stream, const TestData & val
     return true;
 }
 
-inline bool ReadTestData( serialize::ReadStream & stream, TestData & value )
+SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData & value )
 {
     read_int( stream, value.a, -100, 100 );
     read_int( stream, value.b, -100, 100 );
@@ -433,7 +457,7 @@ inline bool WriteCompressedProbe( serialize::WriteStream & stream, const Compres
     return true;
 }
 
-inline bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
+SCHEMA_READ_INLINE bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
 {
     serialize_compressed_float( stream, value.boundary, 0.0f, 10.0f, 0.01f );
     serialize_compressed_float( stream, value.offset, -5.0f, 5.0f, 0.001f );

--- a/generated/cpp/ludicrous/LudicrousWire.h
+++ b/generated/cpp/ludicrous/LudicrousWire.h
@@ -14,6 +14,30 @@
 
 namespace ludicrous {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
 {
     {
@@ -42,7 +66,7 @@ inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe &
     return true;
 }
 
-inline bool ReadFixedProbe( serialize::ReadStream & stream, FixedProbe & value )
+SCHEMA_READ_INLINE bool ReadFixedProbe( serialize::ReadStream & stream, FixedProbe & value )
 {
     read_fixed( stream, value.angle, 16, 16, -180, 180 );
     read_fixed( stream, value.position, 48, 16, -MaxWorldUnits, MaxWorldUnits );
@@ -85,7 +109,7 @@ inline bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedP
     return true;
 }
 
-inline bool ReadUnsignedProbe( serialize::ReadStream & stream, UnsignedProbe & value )
+SCHEMA_READ_INLINE bool ReadUnsignedProbe( serialize::ReadStream & stream, UnsignedProbe & value )
 {
     read_fixed( stream, value.angle, 16, 16, 0, 360 );
     read_fixed( stream, value.span, 48, 16, 0, 281474976710655 );
@@ -114,7 +138,7 @@ inline bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & v
     return true;
 }
 
-inline bool ReadWideProbe( serialize::ReadStream & stream, WideProbe & value )
+SCHEMA_READ_INLINE bool ReadWideProbe( serialize::ReadStream & stream, WideProbe & value )
 {
     read_uint128( stream, value.entity_id );
     read_int128( stream, value.energy, -5000000000, 5000000000 );
@@ -150,7 +174,7 @@ inline bool WriteLudicrousState( serialize::WriteStream & stream, const Ludicrou
     return true;
 }
 
-inline bool ReadLudicrousState( serialize::ReadStream & stream, LudicrousState & value )
+SCHEMA_READ_INLINE bool ReadLudicrousState( serialize::ReadStream & stream, LudicrousState & value )
 {
     {
         int32_t enum_value = 0;
@@ -191,7 +215,7 @@ inline bool WriteDegenerateProbe( serialize::WriteStream & stream, const Degener
     return true;
 }
 
-inline bool ReadDegenerateProbe( serialize::ReadStream & stream, DegenerateProbe & value )
+SCHEMA_READ_INLINE bool ReadDegenerateProbe( serialize::ReadStream & stream, DegenerateProbe & value )
 {
     value.locked_fixed = int32_t( -196608ll );
     value.locked_int = int32_t( 7 );
@@ -221,7 +245,7 @@ inline bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & val
     return true;
 }
 
-inline bool ReadFixedVec( serialize::ReadStream & stream, FixedVec & value )
+SCHEMA_READ_INLINE bool ReadFixedVec( serialize::ReadStream & stream, FixedVec & value )
 {
     read_fixed( stream, value.x, 48, 16, -100000, 100000 );
     read_fixed( stream, value.y, 48, 16, -100000, 100000 );
@@ -250,7 +274,7 @@ inline bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & v
     return true;
 }
 
-inline bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat & value )
+SCHEMA_READ_INLINE bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat & value )
 {
     read_fixed( stream, value.x, 2, 30, -1, 1 );
     read_fixed( stream, value.y, 2, 30, -1, 1 );
@@ -276,7 +300,7 @@ inline bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_
     return true;
 }
 
-inline bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyData_Deep & value )
+SCHEMA_READ_INLINE bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyData_Deep & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -310,7 +334,7 @@ inline bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyDa
     return true;
 }
 
-inline bool ReadBodyData_Shallow( serialize::ReadStream & stream, BodyData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadBodyData_Shallow( serialize::ReadStream & stream, BodyData_Shallow & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -344,7 +368,7 @@ inline bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const Nar
     return true;
 }
 
-inline bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream, NarrowBodyData_Deep & value )
+SCHEMA_READ_INLINE bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream, NarrowBodyData_Deep & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -384,7 +408,7 @@ inline bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const 
     return true;
 }
 
-inline bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stream, NarrowBodyData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stream, NarrowBodyData_Shallow & value )
 {
     {
         int32_t component_value = 0;
@@ -437,7 +461,7 @@ inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value
     return true;
 }
 
-inline bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
+SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 1 );
@@ -461,7 +485,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
     return false; // not a message type; nothing was written
 }
 
-inline bool ReadMessage( serialize::ReadStream & stream, Message & message )
+SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )
 {
     MessageType tag_value = MessageType::None;
     if ( !ReadMessageType( stream, tag_value ) )
@@ -489,7 +513,7 @@ inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
     return true;
 }
 
-inline bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
+SCHEMA_READ_INLINE bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 2 );

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -344,6 +344,10 @@ func (g *gen) emitWireFile() {
 		}
 	}
 
+	if g.fileEmitsReads() {
+		g.emitReadInlineMacro()
+	}
+
 	if fileHasStrings(g.file) {
 		g.emitUtf8Validator()
 	}

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -64,7 +64,7 @@ func (g *gen) emitStructWire(st *ir.Struct) {
 	}
 	g.pf("    return true;\n}\n\n")
 
-	g.pf("inline bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", st.Name, st.Name)
+	g.pf("SCHEMA_READ_INLINE bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", st.Name, st.Name)
 	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value;\n")
 	} else {
@@ -650,7 +650,7 @@ func (g *gen) emitMessageWire() {
 	g.emitWriteRangedFold32("value", "0", fmt.Sprintf("%d", count),
 		bitsRequired(big.NewInt(0), big.NewInt(count)), true, "    ")
 	g.pf("    return true;\n}\n\n")
-	g.pf("inline bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )\n{\n")
+	g.pf("SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )\n{\n")
 	g.pf("    int32_t tag_value = 0;\n")
 	g.pf("    read_int( stream, tag_value, 0, %d );\n", count)
 	g.pf("    value = MessageType( tag_value );\n    return true;\n}\n\n")
@@ -716,7 +716,7 @@ func (g *gen) emitMessageWireUnion() {
 	}
 	g.pf("    }\n    return false; // not a message type; nothing was written\n}\n\n")
 
-	g.pf("inline bool ReadMessage( serialize::ReadStream & stream, Message & message )\n{\n")
+	g.pf("SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )\n{\n")
 	g.pf("    MessageType tag_value = MessageType::None;\n")
 	g.pf("    if ( !ReadMessageType( stream, tag_value ) )\n    {\n        return false;\n    }\n")
 	g.pf("    message.type = tag_value;\n")
@@ -771,7 +771,7 @@ func (g *gen) emitMessageWireVariant() {
 	}
 	g.pf("    }\n    return false;\n}\n\n")
 
-	g.pf("inline bool ReadMessage( serialize::ReadStream & stream, Message & message )\n{\n")
+	g.pf("SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )\n{\n")
 	g.pf("    MessageType tag_value = MessageType::None;\n")
 	g.pf("    if ( !ReadMessageType( stream, tag_value ) )\n    {\n        return false;\n    }\n")
 	g.pf("    switch ( int32_t( tag_value ) )\n    {\n")

--- a/internal/codegen/cpp/objects.go
+++ b/internal/codegen/cpp/objects.go
@@ -72,7 +72,7 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 	}
 	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return true;\n}\n\n")
-	g.pf("inline bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", deepName, deepName)
+	g.pf("SCHEMA_READ_INLINE bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", deepName, deepName)
 	mark = g.body.Len()
 	for _, f := range deep {
 		g.emitViewReadField(f, viewDeep, "    ")
@@ -89,7 +89,7 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 	}
 	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return true;\n}\n\n")
-	g.pf("inline bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", shName, shName)
+	g.pf("SCHEMA_READ_INLINE bool Read%s( serialize::ReadStream & stream, %s & value )\n{\n", shName, shName)
 	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitViewReadField(f, viewShallow, "    ")
@@ -362,7 +362,7 @@ func (g *gen) emitObjectTagWire() {
 	g.emitWriteRangedFold32("value", "0", fmt.Sprintf("%d", count),
 		bitsRequired(big.NewInt(0), big.NewInt(count)), true, "    ")
 	g.pf("    return true;\n}\n\n")
-	g.pf("inline bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )\n{\n")
+	g.pf("SCHEMA_READ_INLINE bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )\n{\n")
 	g.pf("    int32_t tag_value = 0;\n")
 	g.pf("    read_int( stream, tag_value, 0, %d );\n", count)
 	g.pf("    value = ObjectType( tag_value );\n    return true;\n}\n\n")

--- a/internal/codegen/cpp/readinline.go
+++ b/internal/codegen/cpp/readinline.go
@@ -1,0 +1,69 @@
+package cpp
+
+import "github.com/mas-bandwidth/schema/internal/ir"
+
+// fileEmitsReads reports whether this wire file will emit any Read function —
+// struct/object wire pairs, or the owner files' message/object dispatch
+// surfaces. Files that only carry consts/enums/flags emit no reads and no
+// macro block.
+func (g *gen) fileEmitsReads() bool {
+	for _, d := range g.file.Decls {
+		switch d.(type) {
+		case *ir.Struct, *ir.Object:
+			return true
+		}
+	}
+	if g.file.Base == g.msgOwner && len(g.unit.Messages) > 0 {
+		return true
+	}
+	if g.file.Base == g.objOwner && len(g.unit.ObjNames) > 0 {
+		return true
+	}
+	return false
+}
+
+// emitReadInlineMacro emits the read-spine inlining switch every generated
+// Read function is spelled with (SCHEMA_READ_INLINE). Default OFF:
+// SCHEMA_READ_INLINE expands to plain `inline`, token-identical to what this
+// emitter always produced, so an undefined switch changes nothing. Armed
+// (-DSCHEMA_READ_SPINE_DEMAND), the generated read path demands inlining the
+// way the serialize family's per-field spines do (serialize.c
+// SERIALIZE_ALWAYS_INLINE; serialize.h's write spine).
+//
+// Why the demand exists (remark evidence, Apple clang 21, -O3, schema bench):
+// a read chain is fallible, LLVM prices each Ok/Err split at ~even odds, so
+// block frequency decays geometrically down the chain and later call sites
+// are held to the cold-callsite inline threshold (45, vs 250+ hot). The
+// batch-read dispatch loop shows it exactly: ReadMessage is refused into the
+// timed loop at cost=1055 against threshold=45, while the C backend's
+// read_message — static in one TU — inlines into its identical loop
+// (last-call-to-static, cost=-13285) and carries no per-message call at all.
+// The demand is a DEMAND, not a branch-weight hint: __builtin_expect-style
+// cold hints were measured in this family to activate the machine outliner
+// and shred hot bodies (bits write -25%) — do not swap this for hints.
+// Guarded against redefinition because several wire headers can land in one
+// translation unit.
+func (g *gen) emitReadInlineMacro() {
+	g.pf("#ifndef SCHEMA_READ_INLINE_DEFINED\n#define SCHEMA_READ_INLINE_DEFINED\n")
+	g.pf("// SCHEMA_READ_INLINE — how every generated Read function is spelled.\n")
+	g.pf("// Default: plain `inline`, exactly what this emitter always produced.\n")
+	g.pf("// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND\n")
+	g.pf("// inlining (always_inline / __forceinline), the serialize family's remedy\n")
+	g.pf("// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced\n")
+	g.pf("// at ~even odds, block frequency decays geometrically down a read chain,\n")
+	g.pf("// and later call sites are held to the cold-callsite inline threshold.\n")
+	g.pf("// Branch-weight hints are NOT the fix here — measured in this family to\n")
+	g.pf("// invite the machine outliner into the hot bodies. Do not add them.\n")
+	g.pf("#if defined( SCHEMA_READ_SPINE_DEMAND )\n")
+	g.pf("#if defined( _MSC_VER )\n")
+	g.pf("#define SCHEMA_READ_INLINE __forceinline\n")
+	g.pf("#elif defined( __GNUC__ ) || defined( __clang__ )\n")
+	g.pf("#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_READ_INLINE inline\n")
+	g.pf("#endif\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_READ_INLINE inline\n")
+	g.pf("#endif\n")
+	g.pf("#endif // SCHEMA_READ_INLINE_DEFINED\n\n")
+}

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -110,8 +110,8 @@ func TestDispatchSurfaceEmittedOnce(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, needle := range []string{
-			"enum class MessageType", "inline bool WriteMessage(", "inline bool ReadMessage(",
-			"enum class ObjectType", "inline bool WriteObjectType(",
+			"enum class MessageType", "inline bool WriteMessage(", "SCHEMA_READ_INLINE bool ReadMessage(",
+			"enum class ObjectType", "inline bool WriteObjectType(", "SCHEMA_READ_INLINE bool ReadObjectType(",
 		} {
 			if got := countAcross(cppFiles, needle); got != 1 {
 				t.Errorf("C++ (%s): %q emitted %d times across the unit — a TU including both headers cannot compile unless it is exactly once", mode, needle, got)

--- a/testdata/golden/ludicrous/union/LudicrousWire.h
+++ b/testdata/golden/ludicrous/union/LudicrousWire.h
@@ -14,6 +14,30 @@
 
 namespace ludicrous {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
 {
     {
@@ -42,7 +66,7 @@ inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe &
     return true;
 }
 
-inline bool ReadFixedProbe( serialize::ReadStream & stream, FixedProbe & value )
+SCHEMA_READ_INLINE bool ReadFixedProbe( serialize::ReadStream & stream, FixedProbe & value )
 {
     read_fixed( stream, value.angle, 16, 16, -180, 180 );
     read_fixed( stream, value.position, 48, 16, -MaxWorldUnits, MaxWorldUnits );
@@ -85,7 +109,7 @@ inline bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedP
     return true;
 }
 
-inline bool ReadUnsignedProbe( serialize::ReadStream & stream, UnsignedProbe & value )
+SCHEMA_READ_INLINE bool ReadUnsignedProbe( serialize::ReadStream & stream, UnsignedProbe & value )
 {
     read_fixed( stream, value.angle, 16, 16, 0, 360 );
     read_fixed( stream, value.span, 48, 16, 0, 281474976710655 );
@@ -114,7 +138,7 @@ inline bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & v
     return true;
 }
 
-inline bool ReadWideProbe( serialize::ReadStream & stream, WideProbe & value )
+SCHEMA_READ_INLINE bool ReadWideProbe( serialize::ReadStream & stream, WideProbe & value )
 {
     read_uint128( stream, value.entity_id );
     read_int128( stream, value.energy, -5000000000, 5000000000 );
@@ -150,7 +174,7 @@ inline bool WriteLudicrousState( serialize::WriteStream & stream, const Ludicrou
     return true;
 }
 
-inline bool ReadLudicrousState( serialize::ReadStream & stream, LudicrousState & value )
+SCHEMA_READ_INLINE bool ReadLudicrousState( serialize::ReadStream & stream, LudicrousState & value )
 {
     {
         int32_t enum_value = 0;
@@ -191,7 +215,7 @@ inline bool WriteDegenerateProbe( serialize::WriteStream & stream, const Degener
     return true;
 }
 
-inline bool ReadDegenerateProbe( serialize::ReadStream & stream, DegenerateProbe & value )
+SCHEMA_READ_INLINE bool ReadDegenerateProbe( serialize::ReadStream & stream, DegenerateProbe & value )
 {
     value.locked_fixed = int32_t( -196608ll );
     value.locked_int = int32_t( 7 );
@@ -221,7 +245,7 @@ inline bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & val
     return true;
 }
 
-inline bool ReadFixedVec( serialize::ReadStream & stream, FixedVec & value )
+SCHEMA_READ_INLINE bool ReadFixedVec( serialize::ReadStream & stream, FixedVec & value )
 {
     read_fixed( stream, value.x, 48, 16, -100000, 100000 );
     read_fixed( stream, value.y, 48, 16, -100000, 100000 );
@@ -250,7 +274,7 @@ inline bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & v
     return true;
 }
 
-inline bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat & value )
+SCHEMA_READ_INLINE bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat & value )
 {
     read_fixed( stream, value.x, 2, 30, -1, 1 );
     read_fixed( stream, value.y, 2, 30, -1, 1 );
@@ -276,7 +300,7 @@ inline bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_
     return true;
 }
 
-inline bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyData_Deep & value )
+SCHEMA_READ_INLINE bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyData_Deep & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -310,7 +334,7 @@ inline bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyDa
     return true;
 }
 
-inline bool ReadBodyData_Shallow( serialize::ReadStream & stream, BodyData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadBodyData_Shallow( serialize::ReadStream & stream, BodyData_Shallow & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -344,7 +368,7 @@ inline bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const Nar
     return true;
 }
 
-inline bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream, NarrowBodyData_Deep & value )
+SCHEMA_READ_INLINE bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream, NarrowBodyData_Deep & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -384,7 +408,7 @@ inline bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const 
     return true;
 }
 
-inline bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stream, NarrowBodyData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stream, NarrowBodyData_Shallow & value )
 {
     {
         int32_t component_value = 0;
@@ -437,7 +461,7 @@ inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value
     return true;
 }
 
-inline bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
+SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 1 );
@@ -461,7 +485,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
     return false; // not a message type; nothing was written
 }
 
-inline bool ReadMessage( serialize::ReadStream & stream, Message & message )
+SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )
 {
     MessageType tag_value = MessageType::None;
     if ( !ReadMessageType( stream, tag_value ) )
@@ -489,7 +513,7 @@ inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
     return true;
 }
 
-inline bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
+SCHEMA_READ_INLINE bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 2 );

--- a/testdata/golden/ludicrous/variant/LudicrousWire.h
+++ b/testdata/golden/ludicrous/variant/LudicrousWire.h
@@ -14,6 +14,30 @@
 
 namespace ludicrous {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
 {
     {
@@ -42,7 +66,7 @@ inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe &
     return true;
 }
 
-inline bool ReadFixedProbe( serialize::ReadStream & stream, FixedProbe & value )
+SCHEMA_READ_INLINE bool ReadFixedProbe( serialize::ReadStream & stream, FixedProbe & value )
 {
     read_fixed( stream, value.angle, 16, 16, -180, 180 );
     read_fixed( stream, value.position, 48, 16, -MaxWorldUnits, MaxWorldUnits );
@@ -85,7 +109,7 @@ inline bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedP
     return true;
 }
 
-inline bool ReadUnsignedProbe( serialize::ReadStream & stream, UnsignedProbe & value )
+SCHEMA_READ_INLINE bool ReadUnsignedProbe( serialize::ReadStream & stream, UnsignedProbe & value )
 {
     read_fixed( stream, value.angle, 16, 16, 0, 360 );
     read_fixed( stream, value.span, 48, 16, 0, 281474976710655 );
@@ -114,7 +138,7 @@ inline bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & v
     return true;
 }
 
-inline bool ReadWideProbe( serialize::ReadStream & stream, WideProbe & value )
+SCHEMA_READ_INLINE bool ReadWideProbe( serialize::ReadStream & stream, WideProbe & value )
 {
     read_uint128( stream, value.entity_id );
     read_int128( stream, value.energy, -5000000000, 5000000000 );
@@ -150,7 +174,7 @@ inline bool WriteLudicrousState( serialize::WriteStream & stream, const Ludicrou
     return true;
 }
 
-inline bool ReadLudicrousState( serialize::ReadStream & stream, LudicrousState & value )
+SCHEMA_READ_INLINE bool ReadLudicrousState( serialize::ReadStream & stream, LudicrousState & value )
 {
     {
         int32_t enum_value = 0;
@@ -191,7 +215,7 @@ inline bool WriteDegenerateProbe( serialize::WriteStream & stream, const Degener
     return true;
 }
 
-inline bool ReadDegenerateProbe( serialize::ReadStream & stream, DegenerateProbe & value )
+SCHEMA_READ_INLINE bool ReadDegenerateProbe( serialize::ReadStream & stream, DegenerateProbe & value )
 {
     value.locked_fixed = int32_t( -196608ll );
     value.locked_int = int32_t( 7 );
@@ -221,7 +245,7 @@ inline bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & val
     return true;
 }
 
-inline bool ReadFixedVec( serialize::ReadStream & stream, FixedVec & value )
+SCHEMA_READ_INLINE bool ReadFixedVec( serialize::ReadStream & stream, FixedVec & value )
 {
     read_fixed( stream, value.x, 48, 16, -100000, 100000 );
     read_fixed( stream, value.y, 48, 16, -100000, 100000 );
@@ -250,7 +274,7 @@ inline bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & v
     return true;
 }
 
-inline bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat & value )
+SCHEMA_READ_INLINE bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat & value )
 {
     read_fixed( stream, value.x, 2, 30, -1, 1 );
     read_fixed( stream, value.y, 2, 30, -1, 1 );
@@ -276,7 +300,7 @@ inline bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_
     return true;
 }
 
-inline bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyData_Deep & value )
+SCHEMA_READ_INLINE bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyData_Deep & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -310,7 +334,7 @@ inline bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyDa
     return true;
 }
 
-inline bool ReadBodyData_Shallow( serialize::ReadStream & stream, BodyData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadBodyData_Shallow( serialize::ReadStream & stream, BodyData_Shallow & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -344,7 +368,7 @@ inline bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const Nar
     return true;
 }
 
-inline bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream, NarrowBodyData_Deep & value )
+SCHEMA_READ_INLINE bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream, NarrowBodyData_Deep & value )
 {
     if ( !ReadFixedVec( stream, value.position ) )
     {
@@ -384,7 +408,7 @@ inline bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const 
     return true;
 }
 
-inline bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stream, NarrowBodyData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stream, NarrowBodyData_Shallow & value )
 {
     {
         int32_t component_value = 0;
@@ -437,7 +461,7 @@ inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value
     return true;
 }
 
-inline bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
+SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 1 );
@@ -461,7 +485,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
     return false;
 }
 
-inline bool ReadMessage( serialize::ReadStream & stream, Message & message )
+SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )
 {
     MessageType tag_value = MessageType::None;
     if ( !ReadMessageType( stream, tag_value ) )
@@ -488,7 +512,7 @@ inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
     return true;
 }
 
-inline bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
+SCHEMA_READ_INLINE bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 2 );

--- a/testdata/golden/union/MessagesWire.h
+++ b/testdata/golden/union/MessagesWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -90,7 +114,7 @@ inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & v
     return true;
 }
 
-inline bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat & value )
+SCHEMA_READ_INLINE bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat & value )
 {
     (void) stream;
     (void) value;
@@ -109,7 +133,7 @@ inline bool WriteTest( serialize::WriteStream & stream, const Test & value )
     return true;
 }
 
-inline bool ReadTest( serialize::ReadStream & stream, Test & value )
+SCHEMA_READ_INLINE bool ReadTest( serialize::ReadStream & stream, Test & value )
 {
     {
         uint32_t raw_value = 0;
@@ -142,7 +166,7 @@ inline bool WriteBlock( serialize::WriteStream & stream, const Block & value )
     return true;
 }
 
-inline bool ReadBlock( serialize::ReadStream & stream, Block & value )
+SCHEMA_READ_INLINE bool ReadBlock( serialize::ReadStream & stream, Block & value )
 {
     read_int( stream, value.data_length, 0, MaxBlockSize );
     read_bytes( stream, value.data, value.data_length );
@@ -162,7 +186,7 @@ inline bool WriteChat( serialize::WriteStream & stream, const Chat & value )
     return true;
 }
 
-inline bool ReadChat( serialize::ReadStream & stream, Chat & value )
+SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
 {
     read_int( stream, value.text_length, 0, MaxChatLength );
     read_bytes( stream, value.text, value.text_length );
@@ -184,7 +208,7 @@ inline bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize
     return true;
 }
 
-inline bool ReadSynchronize( serialize::ReadStream & stream, Synchronize & value )
+SCHEMA_READ_INLINE bool ReadSynchronize( serialize::ReadStream & stream, Synchronize & value )
 {
     read_bits( stream, value.sync_frame, 64 );
     {
@@ -203,7 +227,7 @@ inline bool WriteTimescale( serialize::WriteStream & stream, const Timescale & v
     return true;
 }
 
-inline bool ReadTimescale( serialize::ReadStream & stream, Timescale & value )
+SCHEMA_READ_INLINE bool ReadTimescale( serialize::ReadStream & stream, Timescale & value )
 {
     read_double( stream, value.scale );
     read_bits( stream, value.frame_a, 32 );
@@ -220,7 +244,7 @@ inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value
     return true;
 }
 
-inline bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
+SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 6 );
@@ -274,7 +298,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
     return false; // not a message type; nothing was written
 }
 
-inline bool ReadMessage( serialize::ReadStream & stream, Message & message )
+SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )
 {
     MessageType tag_value = MessageType::None;
     if ( !ReadMessageType( stream, tag_value ) )

--- a/testdata/golden/union/ObjectsWire.h
+++ b/testdata/golden/union/ObjectsWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
@@ -73,7 +97,7 @@ inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_
     return true;
 }
 
-inline bool ReadShipData_Deep( serialize::ReadStream & stream, ShipData_Deep & value )
+SCHEMA_READ_INLINE bool ReadShipData_Deep( serialize::ReadStream & stream, ShipData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -175,7 +199,7 @@ inline bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipDa
     return true;
 }
 
-inline bool ReadShipData_Shallow( serialize::ReadStream & stream, ShipData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadShipData_Shallow( serialize::ReadStream & stream, ShipData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -273,7 +297,7 @@ inline bool WriteMissileData_Deep( serialize::WriteStream & stream, const Missil
     return true;
 }
 
-inline bool ReadMissileData_Deep( serialize::ReadStream & stream, MissileData_Deep & value )
+SCHEMA_READ_INLINE bool ReadMissileData_Deep( serialize::ReadStream & stream, MissileData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -331,7 +355,7 @@ inline bool WriteMissileData_Shallow( serialize::WriteStream & stream, const Mis
     return true;
 }
 
-inline bool ReadMissileData_Shallow( serialize::ReadStream & stream, MissileData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadMissileData_Shallow( serialize::ReadStream & stream, MissileData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -419,7 +443,7 @@ inline bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const Dy
     return true;
 }
 
-inline bool ReadDynamicPropData_Deep( serialize::ReadStream & stream, DynamicPropData_Deep & value )
+SCHEMA_READ_INLINE bool ReadDynamicPropData_Deep( serialize::ReadStream & stream, DynamicPropData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -477,7 +501,7 @@ inline bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const
     return true;
 }
 
-inline bool ReadDynamicPropData_Shallow( serialize::ReadStream & stream, DynamicPropData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadDynamicPropData_Shallow( serialize::ReadStream & stream, DynamicPropData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -559,7 +583,7 @@ inline bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretD
     return true;
 }
 
-inline bool ReadTurretData_Deep( serialize::ReadStream & stream, TurretData_Deep & value )
+SCHEMA_READ_INLINE bool ReadTurretData_Deep( serialize::ReadStream & stream, TurretData_Deep & value )
 {
     if ( !ReadHandle( stream, value.parent ) )
     {
@@ -594,7 +618,7 @@ inline bool WriteTurretData_Shallow( serialize::WriteStream & stream, const Turr
     return true;
 }
 
-inline bool ReadTurretData_Shallow( serialize::ReadStream & stream, TurretData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadTurretData_Shallow( serialize::ReadStream & stream, TurretData_Shallow & value )
 {
     if ( !ReadHandle( stream, value.parent ) )
     {
@@ -634,7 +658,7 @@ inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
     return true;
 }
 
-inline bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
+SCHEMA_READ_INLINE bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 4 );

--- a/testdata/golden/union/RenderWire.h
+++ b/testdata/golden/union/RenderWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
 {
     write_bits( stream, value.sort_key, 64 );
@@ -26,7 +50,7 @@ inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSpri
     return true;
 }
 
-inline bool ReadRenderSprite( serialize::ReadStream & stream, RenderSprite & value )
+SCHEMA_READ_INLINE bool ReadRenderSprite( serialize::ReadStream & stream, RenderSprite & value )
 {
     read_bits( stream, value.sort_key, 64 );
     read_bits( stream, value.mesh_id, 32 );
@@ -60,7 +84,7 @@ inline bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock
     return true;
 }
 
-inline bool ReadRenderBlock( serialize::ReadStream & stream, RenderBlock & value )
+SCHEMA_READ_INLINE bool ReadRenderBlock( serialize::ReadStream & stream, RenderBlock & value )
 {
     read_bits( stream, value.worker_index, 32 );
     read_bits( stream, value.sprite_count_hint, 32 );

--- a/testdata/golden/union/TypesWire.h
+++ b/testdata/golden/union/TypesWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
 {
     write_double( stream, value.x );
@@ -25,7 +49,7 @@ inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
     return true;
 }
 
-inline bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
+SCHEMA_READ_INLINE bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
 {
     read_double( stream, value.x );
     read_double( stream, value.y );
@@ -42,7 +66,7 @@ inline bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
     return true;
 }
 
-inline bool ReadQuat( serialize::ReadStream & stream, Quat & value )
+SCHEMA_READ_INLINE bool ReadQuat( serialize::ReadStream & stream, Quat & value )
 {
     read_double( stream, value.x );
     read_double( stream, value.y );
@@ -59,7 +83,7 @@ inline bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
     return true;
 }
 
-inline bool ReadHandle( serialize::ReadStream & stream, Handle & value )
+SCHEMA_READ_INLINE bool ReadHandle( serialize::ReadStream & stream, Handle & value )
 {
     read_int( stream, value.object_id, 0, MaxObjects - 1 );
     {
@@ -81,7 +105,7 @@ inline bool WriteQuantizedPosition( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedPosition( serialize::ReadStream & stream, QuantizedPosition & value )
+SCHEMA_READ_INLINE bool ReadQuantizedPosition( serialize::ReadStream & stream, QuantizedPosition & value )
 {
     read_int( stream, value.x, -MaxPositionUnits, MaxPositionUnits );
     read_int( stream, value.y, -MaxPositionUnits, MaxPositionUnits );
@@ -100,7 +124,7 @@ inline bool WriteQuantizedVelocity( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedVelocity( serialize::ReadStream & stream, QuantizedVelocity & value )
+SCHEMA_READ_INLINE bool ReadQuantizedVelocity( serialize::ReadStream & stream, QuantizedVelocity & value )
 {
     read_int( stream, value.x, -MaxVelocityUnits, MaxVelocityUnits );
     read_int( stream, value.y, -MaxVelocityUnits, MaxVelocityUnits );
@@ -121,7 +145,7 @@ inline bool WriteQuantizedRotation( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedRotation( serialize::ReadStream & stream, QuantizedRotation & value )
+SCHEMA_READ_INLINE bool ReadQuantizedRotation( serialize::ReadStream & stream, QuantizedRotation & value )
 {
     {
         int32_t range_value = 0;
@@ -171,7 +195,7 @@ inline bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & v
     return true;
 }
 
-inline bool ReadRigidBody( serialize::ReadStream & stream, RigidBody & value )
+SCHEMA_READ_INLINE bool ReadRigidBody( serialize::ReadStream & stream, RigidBody & value )
 {
     if ( !ReadVec3( stream, value.position ) )
     {
@@ -219,7 +243,7 @@ inline bool WriteInput( serialize::WriteStream & stream, const Input & value )
     return true;
 }
 
-inline bool ReadInput( serialize::ReadStream & stream, Input & value )
+SCHEMA_READ_INLINE bool ReadInput( serialize::ReadStream & stream, Input & value )
 {
     read_float( stream, value.stick_x );
     read_float( stream, value.stick_y );
@@ -254,7 +278,7 @@ inline bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket
     return true;
 }
 
-inline bool ReadInputPacket( serialize::ReadStream & stream, InputPacket & value )
+SCHEMA_READ_INLINE bool ReadInputPacket( serialize::ReadStream & stream, InputPacket & value )
 {
     {
         uint32_t raw_value = 0;
@@ -306,7 +330,7 @@ inline bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate &
     return true;
 }
 
-inline bool ReadShipCreate( serialize::ReadStream & stream, ShipCreate & value )
+SCHEMA_READ_INLINE bool ReadShipCreate( serialize::ReadStream & stream, ShipCreate & value )
 {
     {
         int32_t enum_value = 0;

--- a/testdata/golden/union/WireWire.h
+++ b/testdata/golden/union/WireWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -93,7 +117,7 @@ inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader
     return true;
 }
 
-inline bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHeader & value )
+SCHEMA_READ_INLINE bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHeader & value )
 {
     {
         uint64_t const_value = 0;
@@ -128,7 +152,7 @@ inline bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & v
     return true;
 }
 
-inline bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits & value )
+SCHEMA_READ_INLINE bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits & value )
 {
     read_bits( stream, value.small, 9 );
     read_bits( stream, value.boundary, 33 );
@@ -174,7 +198,7 @@ inline bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample
     return true;
 }
 
-inline bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
+SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
 {
     read_bool( stream, value.active );
     serialize_compressed_float( stream, value.orientation, -180.0f, 180.0f, 0.01f );
@@ -237,7 +261,7 @@ inline bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig
     return true;
 }
 
-inline bool ReadProbeConfig( serialize::ReadStream & stream, ProbeConfig & value )
+SCHEMA_READ_INLINE bool ReadProbeConfig( serialize::ReadStream & stream, ProbeConfig & value )
 {
     {
         uint32_t raw_value = 0;
@@ -268,7 +292,7 @@ inline bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray &
     return true;
 }
 
-inline bool ReadProbeArray( serialize::ReadStream & stream, ProbeArray & value )
+SCHEMA_READ_INLINE bool ReadProbeArray( serialize::ReadStream & stream, ProbeArray & value )
 {
     for ( int32_t i = 0; i < 2; i++ )
     {
@@ -299,7 +323,7 @@ inline bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport
     return true;
 }
 
-inline bool ReadProbeReport( serialize::ReadStream & stream, ProbeReport & value )
+SCHEMA_READ_INLINE bool ReadProbeReport( serialize::ReadStream & stream, ProbeReport & value )
 {
     if ( !ReadProbeHeader( stream, value.header ) )
     {
@@ -360,7 +384,7 @@ inline bool WriteTestData( serialize::WriteStream & stream, const TestData & val
     return true;
 }
 
-inline bool ReadTestData( serialize::ReadStream & stream, TestData & value )
+SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData & value )
 {
     read_int( stream, value.a, -100, 100 );
     read_int( stream, value.b, -100, 100 );
@@ -433,7 +457,7 @@ inline bool WriteCompressedProbe( serialize::WriteStream & stream, const Compres
     return true;
 }
 
-inline bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
+SCHEMA_READ_INLINE bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
 {
     serialize_compressed_float( stream, value.boundary, 0.0f, 10.0f, 0.01f );
     serialize_compressed_float( stream, value.offset, -5.0f, 5.0f, 0.001f );

--- a/testdata/golden/variant/MessagesWire.h
+++ b/testdata/golden/variant/MessagesWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -90,7 +114,7 @@ inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & v
     return true;
 }
 
-inline bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat & value )
+SCHEMA_READ_INLINE bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat & value )
 {
     (void) stream;
     (void) value;
@@ -109,7 +133,7 @@ inline bool WriteTest( serialize::WriteStream & stream, const Test & value )
     return true;
 }
 
-inline bool ReadTest( serialize::ReadStream & stream, Test & value )
+SCHEMA_READ_INLINE bool ReadTest( serialize::ReadStream & stream, Test & value )
 {
     {
         uint32_t raw_value = 0;
@@ -142,7 +166,7 @@ inline bool WriteBlock( serialize::WriteStream & stream, const Block & value )
     return true;
 }
 
-inline bool ReadBlock( serialize::ReadStream & stream, Block & value )
+SCHEMA_READ_INLINE bool ReadBlock( serialize::ReadStream & stream, Block & value )
 {
     read_int( stream, value.data_length, 0, MaxBlockSize );
     read_bytes( stream, value.data, value.data_length );
@@ -162,7 +186,7 @@ inline bool WriteChat( serialize::WriteStream & stream, const Chat & value )
     return true;
 }
 
-inline bool ReadChat( serialize::ReadStream & stream, Chat & value )
+SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
 {
     read_int( stream, value.text_length, 0, MaxChatLength );
     read_bytes( stream, value.text, value.text_length );
@@ -184,7 +208,7 @@ inline bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize
     return true;
 }
 
-inline bool ReadSynchronize( serialize::ReadStream & stream, Synchronize & value )
+SCHEMA_READ_INLINE bool ReadSynchronize( serialize::ReadStream & stream, Synchronize & value )
 {
     read_bits( stream, value.sync_frame, 64 );
     {
@@ -203,7 +227,7 @@ inline bool WriteTimescale( serialize::WriteStream & stream, const Timescale & v
     return true;
 }
 
-inline bool ReadTimescale( serialize::ReadStream & stream, Timescale & value )
+SCHEMA_READ_INLINE bool ReadTimescale( serialize::ReadStream & stream, Timescale & value )
 {
     read_double( stream, value.scale );
     read_bits( stream, value.frame_a, 32 );
@@ -220,7 +244,7 @@ inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value
     return true;
 }
 
-inline bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
+SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, MessageType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 6 );
@@ -254,7 +278,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
     return false;
 }
 
-inline bool ReadMessage( serialize::ReadStream & stream, Message & message )
+SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & message )
 {
     MessageType tag_value = MessageType::None;
     if ( !ReadMessageType( stream, tag_value ) )

--- a/testdata/golden/variant/ObjectsWire.h
+++ b/testdata/golden/variant/ObjectsWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
@@ -73,7 +97,7 @@ inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_
     return true;
 }
 
-inline bool ReadShipData_Deep( serialize::ReadStream & stream, ShipData_Deep & value )
+SCHEMA_READ_INLINE bool ReadShipData_Deep( serialize::ReadStream & stream, ShipData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -175,7 +199,7 @@ inline bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipDa
     return true;
 }
 
-inline bool ReadShipData_Shallow( serialize::ReadStream & stream, ShipData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadShipData_Shallow( serialize::ReadStream & stream, ShipData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -273,7 +297,7 @@ inline bool WriteMissileData_Deep( serialize::WriteStream & stream, const Missil
     return true;
 }
 
-inline bool ReadMissileData_Deep( serialize::ReadStream & stream, MissileData_Deep & value )
+SCHEMA_READ_INLINE bool ReadMissileData_Deep( serialize::ReadStream & stream, MissileData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -331,7 +355,7 @@ inline bool WriteMissileData_Shallow( serialize::WriteStream & stream, const Mis
     return true;
 }
 
-inline bool ReadMissileData_Shallow( serialize::ReadStream & stream, MissileData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadMissileData_Shallow( serialize::ReadStream & stream, MissileData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -419,7 +443,7 @@ inline bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const Dy
     return true;
 }
 
-inline bool ReadDynamicPropData_Deep( serialize::ReadStream & stream, DynamicPropData_Deep & value )
+SCHEMA_READ_INLINE bool ReadDynamicPropData_Deep( serialize::ReadStream & stream, DynamicPropData_Deep & value )
 {
     {
         int32_t enum_value = 0;
@@ -477,7 +501,7 @@ inline bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const
     return true;
 }
 
-inline bool ReadDynamicPropData_Shallow( serialize::ReadStream & stream, DynamicPropData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadDynamicPropData_Shallow( serialize::ReadStream & stream, DynamicPropData_Shallow & value )
 {
     {
         int32_t enum_value = 0;
@@ -559,7 +583,7 @@ inline bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretD
     return true;
 }
 
-inline bool ReadTurretData_Deep( serialize::ReadStream & stream, TurretData_Deep & value )
+SCHEMA_READ_INLINE bool ReadTurretData_Deep( serialize::ReadStream & stream, TurretData_Deep & value )
 {
     if ( !ReadHandle( stream, value.parent ) )
     {
@@ -594,7 +618,7 @@ inline bool WriteTurretData_Shallow( serialize::WriteStream & stream, const Turr
     return true;
 }
 
-inline bool ReadTurretData_Shallow( serialize::ReadStream & stream, TurretData_Shallow & value )
+SCHEMA_READ_INLINE bool ReadTurretData_Shallow( serialize::ReadStream & stream, TurretData_Shallow & value )
 {
     if ( !ReadHandle( stream, value.parent ) )
     {
@@ -634,7 +658,7 @@ inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
     return true;
 }
 
-inline bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
+SCHEMA_READ_INLINE bool ReadObjectType( serialize::ReadStream & stream, ObjectType & value )
 {
     int32_t tag_value = 0;
     read_int( stream, tag_value, 0, 4 );

--- a/testdata/golden/variant/RenderWire.h
+++ b/testdata/golden/variant/RenderWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
 {
     write_bits( stream, value.sort_key, 64 );
@@ -26,7 +50,7 @@ inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSpri
     return true;
 }
 
-inline bool ReadRenderSprite( serialize::ReadStream & stream, RenderSprite & value )
+SCHEMA_READ_INLINE bool ReadRenderSprite( serialize::ReadStream & stream, RenderSprite & value )
 {
     read_bits( stream, value.sort_key, 64 );
     read_bits( stream, value.mesh_id, 32 );
@@ -60,7 +84,7 @@ inline bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock
     return true;
 }
 
-inline bool ReadRenderBlock( serialize::ReadStream & stream, RenderBlock & value )
+SCHEMA_READ_INLINE bool ReadRenderBlock( serialize::ReadStream & stream, RenderBlock & value )
 {
     read_bits( stream, value.worker_index, 32 );
     read_bits( stream, value.sprite_count_hint, 32 );

--- a/testdata/golden/variant/TypesWire.h
+++ b/testdata/golden/variant/TypesWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
 {
     write_double( stream, value.x );
@@ -25,7 +49,7 @@ inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
     return true;
 }
 
-inline bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
+SCHEMA_READ_INLINE bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
 {
     read_double( stream, value.x );
     read_double( stream, value.y );
@@ -42,7 +66,7 @@ inline bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
     return true;
 }
 
-inline bool ReadQuat( serialize::ReadStream & stream, Quat & value )
+SCHEMA_READ_INLINE bool ReadQuat( serialize::ReadStream & stream, Quat & value )
 {
     read_double( stream, value.x );
     read_double( stream, value.y );
@@ -59,7 +83,7 @@ inline bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
     return true;
 }
 
-inline bool ReadHandle( serialize::ReadStream & stream, Handle & value )
+SCHEMA_READ_INLINE bool ReadHandle( serialize::ReadStream & stream, Handle & value )
 {
     read_int( stream, value.object_id, 0, MaxObjects - 1 );
     {
@@ -81,7 +105,7 @@ inline bool WriteQuantizedPosition( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedPosition( serialize::ReadStream & stream, QuantizedPosition & value )
+SCHEMA_READ_INLINE bool ReadQuantizedPosition( serialize::ReadStream & stream, QuantizedPosition & value )
 {
     read_int( stream, value.x, -MaxPositionUnits, MaxPositionUnits );
     read_int( stream, value.y, -MaxPositionUnits, MaxPositionUnits );
@@ -100,7 +124,7 @@ inline bool WriteQuantizedVelocity( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedVelocity( serialize::ReadStream & stream, QuantizedVelocity & value )
+SCHEMA_READ_INLINE bool ReadQuantizedVelocity( serialize::ReadStream & stream, QuantizedVelocity & value )
 {
     read_int( stream, value.x, -MaxVelocityUnits, MaxVelocityUnits );
     read_int( stream, value.y, -MaxVelocityUnits, MaxVelocityUnits );
@@ -121,7 +145,7 @@ inline bool WriteQuantizedRotation( serialize::WriteStream & stream, const Quant
     return true;
 }
 
-inline bool ReadQuantizedRotation( serialize::ReadStream & stream, QuantizedRotation & value )
+SCHEMA_READ_INLINE bool ReadQuantizedRotation( serialize::ReadStream & stream, QuantizedRotation & value )
 {
     {
         int32_t range_value = 0;
@@ -171,7 +195,7 @@ inline bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & v
     return true;
 }
 
-inline bool ReadRigidBody( serialize::ReadStream & stream, RigidBody & value )
+SCHEMA_READ_INLINE bool ReadRigidBody( serialize::ReadStream & stream, RigidBody & value )
 {
     if ( !ReadVec3( stream, value.position ) )
     {
@@ -219,7 +243,7 @@ inline bool WriteInput( serialize::WriteStream & stream, const Input & value )
     return true;
 }
 
-inline bool ReadInput( serialize::ReadStream & stream, Input & value )
+SCHEMA_READ_INLINE bool ReadInput( serialize::ReadStream & stream, Input & value )
 {
     read_float( stream, value.stick_x );
     read_float( stream, value.stick_y );
@@ -254,7 +278,7 @@ inline bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket
     return true;
 }
 
-inline bool ReadInputPacket( serialize::ReadStream & stream, InputPacket & value )
+SCHEMA_READ_INLINE bool ReadInputPacket( serialize::ReadStream & stream, InputPacket & value )
 {
     {
         uint32_t raw_value = 0;
@@ -306,7 +330,7 @@ inline bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate &
     return true;
 }
 
-inline bool ReadShipCreate( serialize::ReadStream & stream, ShipCreate & value )
+SCHEMA_READ_INLINE bool ReadShipCreate( serialize::ReadStream & stream, ShipCreate & value )
 {
     {
         int32_t enum_value = 0;

--- a/testdata/golden/variant/WireWire.h
+++ b/testdata/golden/variant/WireWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_READ_INLINE_DEFINED
+#define SCHEMA_READ_INLINE_DEFINED
+// SCHEMA_READ_INLINE — how every generated Read function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_READ_SPINE_DEMAND to make the generated read path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM's fallible-chain frequency decay: each Ok/Err split is priced
+// at ~even odds, block frequency decays geometrically down a read chain,
+// and later call sites are held to the cold-callsite inline threshold.
+// Branch-weight hints are NOT the fix here — measured in this family to
+// invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#else
+#define SCHEMA_READ_INLINE inline
+#endif
+#endif // SCHEMA_READ_INLINE_DEFINED
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -93,7 +117,7 @@ inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader
     return true;
 }
 
-inline bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHeader & value )
+SCHEMA_READ_INLINE bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHeader & value )
 {
     {
         uint64_t const_value = 0;
@@ -128,7 +152,7 @@ inline bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & v
     return true;
 }
 
-inline bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits & value )
+SCHEMA_READ_INLINE bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits & value )
 {
     read_bits( stream, value.small, 9 );
     read_bits( stream, value.boundary, 33 );
@@ -174,7 +198,7 @@ inline bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample
     return true;
 }
 
-inline bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
+SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
 {
     read_bool( stream, value.active );
     serialize_compressed_float( stream, value.orientation, -180.0f, 180.0f, 0.01f );
@@ -237,7 +261,7 @@ inline bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig
     return true;
 }
 
-inline bool ReadProbeConfig( serialize::ReadStream & stream, ProbeConfig & value )
+SCHEMA_READ_INLINE bool ReadProbeConfig( serialize::ReadStream & stream, ProbeConfig & value )
 {
     {
         uint32_t raw_value = 0;
@@ -268,7 +292,7 @@ inline bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray &
     return true;
 }
 
-inline bool ReadProbeArray( serialize::ReadStream & stream, ProbeArray & value )
+SCHEMA_READ_INLINE bool ReadProbeArray( serialize::ReadStream & stream, ProbeArray & value )
 {
     for ( int32_t i = 0; i < 2; i++ )
     {
@@ -299,7 +323,7 @@ inline bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport
     return true;
 }
 
-inline bool ReadProbeReport( serialize::ReadStream & stream, ProbeReport & value )
+SCHEMA_READ_INLINE bool ReadProbeReport( serialize::ReadStream & stream, ProbeReport & value )
 {
     if ( !ReadProbeHeader( stream, value.header ) )
     {
@@ -360,7 +384,7 @@ inline bool WriteTestData( serialize::WriteStream & stream, const TestData & val
     return true;
 }
 
-inline bool ReadTestData( serialize::ReadStream & stream, TestData & value )
+SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData & value )
 {
     read_int( stream, value.a, -100, 100 );
     read_int( stream, value.b, -100, 100 );
@@ -433,7 +457,7 @@ inline bool WriteCompressedProbe( serialize::WriteStream & stream, const Compres
     return true;
 }
 
-inline bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
+SCHEMA_READ_INLINE bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
 {
     serialize_compressed_float( stream, value.boundary, 0.0f, 10.0f, 0.01f );
     serialize_compressed_float( stream, value.offset, -5.0f, 5.0f, 0.001f );


### PR DESCRIPTION
## What

A compile-time switch, **OFF by default**, that lets the generated C++ read path demand inlining: every generated `Read*` function is now spelled `SCHEMA_READ_INLINE`, which expands to plain `inline` — token-identical to what the emitter always produced — unless the consumer defines `SCHEMA_READ_SPINE_DEMAND`, in which case the generated read spine (per-type readers, arm readers, `ReadMessageType`, `ReadMessage`, object views, `ReadObjectType`) demands inlining with `always_inline`/`__forceinline`, mirroring serialize.c's read spine and serialize.h's write spine.

Emitter change, regenerated headers, and goldens land together; the dispatch-surface test pins the new spelling.

## Why (remark evidence, compile-only — NO timing claims in this PR)

On the 2026-08-15 Studio postlane O3 pass, C batch read leads C++ by 30% while carrying wire-contract checks C++ compiles out. Compile-only reproduction with `-Rpass=inline -Rpass-missed=inline` (Apple clang 21, `-O3`, the bench's recorded flags) names the boundary:

- C++: `'example::ReadMessage(...)' not inlined into 'main' because too costly to inline (cost=1055, threshold=45)` — the batch read loop's per-message dispatch call site is held to clang's **cold-callsite threshold (45)**: the family's known fallible-chain frequency decay, landing on the generated dispatcher rather than the runtime.
- C: `'read_message' inlined into 'bench_batch' with (cost=-13285, threshold=250)` — `read_message` is `static` in one TU, and LLVM's **last-call-to-static bonus** flattens the whole dispatcher into the timed loop. C's loop carries **zero** per-message calls; a `linkonce_odr` header function can never earn that bonus, so C++ pays a call boundary per message that C does not have.
- Inside the out-of-line `ReadMessage`, every arm reader inlines at fresh thresholds (325/487) — the decay does not reach inside an outlined callee, which is why the `.inline` runtime verdicts said `full` on both sides while the generated boundary differed.

## Verification

- **OFF (default): byte-identical.** The bench leg built from this branch's generated tree disassembles identically (`otool -tv`) to one built from main's.
- **ON:** `'example::ReadMessage(...)' inlined into 'bench_batch()' with (cost=always)`; the `ReadMessage` symbol vanishes from the armed binary (0 emitted call sites vs 1 symbol + 2 `bl` sites default) — C's flat shape, achieved on C++.
- **ON:** zero `OUTLINED_FUNCTION_*` symbols — the machine outliner did not activate. No branch-weight hints anywhere (cold hints are measured in this family to invite the outliner; the demand is a demand).
- `go test ./...` green, goldens regenerated via `make update-goldens`.

## What this PR is NOT

It is not a claim that the switch is faster — that is exactly what has not been measured. The switch stays OFF until a quiet-window A/B pass under `bench/BENCH-STANDARD.md` validates it; the staged timing protocol (legs, era discipline, decision rule) lives with the Phase-4 analysis. Draft until then; do not merge before the pass runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
