### PR TITLE
bench: the post-law verification pass — era CSVs, verdicts stamped, checks caption retired

### DIFF
--- a/bench/c/bench_main.c
+++ b/bench/c/bench_main.c
@@ -95,13 +95,16 @@ static const char * g_wire_dir = "testdata/wire";
    while the cold and bulk-bytes paths stay in the compiled serialize.c
    translation unit, no LTO — plain `tu` would claim a call boundary the
    hot path no longer crosses, plain `hdr` would hide the one the bulk
-   paths still cross), checks CONTRACT
-   (§3.4's third value, added 2026-08-15: -DNDEBUG compiles serialize.c's
-   caller-error asserts away like `removed`, but the write-capacity check
-   that doubles as the sticky-error flag is unconditional by contract in
-   every build — serialize_write_bits keeps it as a real check where the
-   C++ BitWriter only asserts, and that hybrid was the entire C-vs-C++
-   write residual story; neither `removed` nor `always` could say it),
+   paths still cross), checks REMOVED
+   (§3.4: -DNDEBUG compiles serialize.c's asserts and checks away exactly
+   as the C++ build does. This runner said `contract` from 2026-08-15 to
+   2026-08-16, while serialize_write_bits kept an unconditional capacity
+   check the C++ BitWriter only asserts — serialize.c ruling #20 removed
+   it: "MINIMAL runtime checking in release, compiling to ZERO runtime
+   checking in release for C and C++", so the hybrid `contract` described
+   died and the two runners' check models are now the same word. With
+   both sides `removed`, the rel tool ratios C vs C++ without the checks
+   caption; the hdr+tu linkage caption still applies),
    opt from the build (run.sh sets BENCH_OPT beside the -O flag itself),
    inline unknown until the verdict pass (§4.2) backfills it. */
 #ifndef BENCH_OPT
@@ -109,7 +112,7 @@ static const char * g_wire_dir = "testdata/wire";
 #endif
 /* family is per ROW now (gen | rt | bits — §5.1); linkage/checks/opt/inline
    stay per-runner constants */
-#define CsvSuffix "hdr+tu,contract," BENCH_OPT ",unknown"
+#define CsvSuffix "hdr+tu,removed," BENCH_OPT ",unknown"
 #define MaxCsvRows 64
 #define MaxGoldens 24
 static char g_csv_rows[MaxCsvRows][256];

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-armed-pair-O3.csv
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-armed-pair-O3.csv
@@ -1,0 +1,106 @@
+# schema bench results
+# date: 2026-08-16T11:08:14Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -DSCHEMA_READ_SPINE_DEMAND -DSERIALIZE_READ_SPINE_DEMAND -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-AB] post-law hotel window, Air on external power, machine quiet by Glenn's word; all other workers stopped
+# schema commit: 6550f33
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 409bdaf (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four post-law legs per round)
+# load_start: 3.20 2.79 2.62
+# load_end: 2.80 2.82 2.68
+# load_max: 3.34
+# control_start_median: 101005796   control_end_median: 101602120
+# control_delta_pct: 0.6   window: OK
+# era: POST-LAW — serialize.c a2a561f (#20: zero release validation, checks=removed by ruling) +
+# era:   409bdaf (#21: align-up buffer contract, tail-window machinery gone, reader is C++'s
+# era:   BitReader load-for-load); schema 6550f33 with #50 (C legs adopt the contract).
+# era: Air-on-external-power hotel window, 2026-08-16, machine quiet by Glenn's word.
+# era: NOT comparable to the phase4-air airport rows (pre-law serialize.c v1.3.0), nor to any other
+# era:   host or era (§5.3 rule 8). cpp-off and cpp-AB differ ONLY by the two READ_SPINE_DEMAND defines.
+# era: c checks metadata is 'removed' as of this pass — the post-#20 truth; 'contract' died with the
+# era:   write-capacity check. Linkage stays hdr+tu, and that caption still applies to C-vs-C++ ratios.
+# corpus_id: 6b118770d85af4f6
+# era: PAIR FILE — cpp rows are leg cpp-AB, c rows are leg c-main, same pass, same rounds, same window;
+# era:   assembled row-for-row from the stamped leg CSVs for the cross-language ratio read.
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,57546096,48864681,57833393,5762.42,15.59,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,301992996,298190201,302741387,30240.31,1.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,103410040,102891533,104722194,5621.31,1.77,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,476668685,472294810,477927295,25911.44,1.18,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,96222434,94846680,96447315,1192.94,1.66,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,131623868,129263043,132233834,1631.84,2.26,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,727625860,725052940,730218381,4163.51,0.71,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1015816802,1010637571,1018509106,5812.55,0.77,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,64676092,64384029,64737730,3762.48,0.55,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,132487209,132037441,132875513,7707.33,0.63,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,97244844,97115972,97343252,2596.72,0.23,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,212795139,211761650,213374823,5682.24,0.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,118670996,118609635,119772489,3168.86,0.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,260651412,260188164,263854055,6960.14,1.41,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1008981643,1000770777,1019940803,9622.40,1.90,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1398090597,1391377448,1411443632,13333.23,1.44,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,184654935,183804700,186259686,4578.62,1.33,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,756666459,745348122,759126382,18761.95,1.82,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,72335859,60166918,73161910,3242.29,17.96,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,139251281,139109750,139725178,6241.62,0.44,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27273239,27213839,27521231,2392.90,1.13,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,53088228,52634753,53465467,4657.86,1.56,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,message_batch,write,26214400,25,7,88264407,84372482,92736438,2104.39,9.48,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,108754472,107310851,110551694,2592.91,2.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,81821822,81039748,82041833,3823.54,1.22,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,129243778,122090533,130859788,6039.57,6.79,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,181815186,180904920,184349885,2427.49,1.89,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,184403498,181991798,186250269,2462.05,2.31,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,183382870,181001475,184848786,3497.75,2.10,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,223926856,217469524,231127404,4271.07,6.10,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,149603061,149309002,150440320,2996.12,0.76,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,178756469,172632405,180087601,3579.98,4.17,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,59317,52576,59392,3706.29,11.49,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,91258,90860,91736,5702.06,0.96,6b118770d85af4f6,bits,hdr,removed,O3,full
+c,rigidbody_moving,write,24000000,105,7,51270658,51235633,51309899,5134.03,0.14,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,57345341,56827734,57511065,5742.32,1.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,100769945,100408537,100929816,5477.80,0.52,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,114277144,113257899,115447196,6212.04,1.92,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,70710523,70309170,70812753,876.65,0.71,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,208932745,208778256,210410037,2590.30,0.78,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,233157413,232902867,233532606,1334.14,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,886500263,885625196,888062497,5072.60,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,63215621,62949003,63351534,3677.51,0.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,51409752,51079045,52403520,2990.72,2.58,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,79876591,79816820,79956623,2132.94,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,108489287,108309725,108832432,2896.98,0.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,82784884,80737741,82892106,2210.59,2.60,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,111183303,108621123,111359350,2968.91,2.46,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,274730876,246807649,274925308,2620.04,10.23,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,301519849,299499975,307456542,2875.52,2.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,173289343,172997754,173511092,4296.80,0.30,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,252518776,229188601,253142026,6261.34,9.49,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,44518840,44335576,44575695,1995.45,0.54,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,probearray,read,20000000,47,7,47164361,47052845,47227175,2114.03,0.37,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,testdata,write,8000000,92,7,21481412,21399873,21518681,1884.74,0.55,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,testdata,read,8000000,92,7,20390322,20305496,20547541,1789.01,1.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,write,26214400,25,7,84929696,82683531,87944471,2024.88,6.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,139692419,133234394,145740813,3330.53,8.95,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,77293753,77197536,77644650,3611.94,0.58,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,118824823,116985574,120442929,5552.69,2.91,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,166885704,166124685,167186338,2228.16,0.64,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,156516567,155324726,157222198,2089.72,1.21,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,172372310,172280746,174052412,3287.74,1.03,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,210920404,209832397,213185525,4022.99,1.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,142077240,141157207,142664546,2845.40,1.06,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,166195779,165329564,167820432,3328.43,1.50,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,32828,32745,33000,2051.19,0.78,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,50244,50179,50524,3139.39,0.69,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-armed-pair-O3.inline
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-armed-pair-O3.inline
@@ -1,0 +1,187 @@
+# 2026-08-16-arm64-macbook-air-power-postlaw-cpp-AB-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T11:22:33Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 24 1 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=45)
+remark 3 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=45)
+remark 3 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=45)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into '_ZL11build_batchRxPhi' because too costly to inline (cost=1555, threshold=325)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr STATS groups 178 untimed 161 unattributed 0 unroll-dedup 1
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read full hot=0 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 38 1 0 0
+symbol _write_test_data 2 2 0 0 0
+symbol _serialize_read_fixed64 2 2 0 0 0
+symbol _serialize_read_fixed32 2 2 0 0 0
+symbol _serialize_read_fixed128 2 2 0 0 0
+symbol _read_probe_array 2 2 0 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_probe_array 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+symbol _read_test_data 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=545, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed64' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed32' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed128' because too costly to inline (cost=260, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 1 0
+attr N rigidbody_at_rest read 0 0
+attr N chat write 1 0
+attr N probearray read 2 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N test write 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 1 0
+attr STATS groups 179 untimed 156 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write partial:1 hot=1 cold=0
+row c probearray read partial:2 hot=2 cold=0
+row c testdata write partial:2 hot=2 cold=0
+row c testdata read partial:1 hot=1 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-lto-O3-pass.csv
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-lto-O3-pass.csv
@@ -1,0 +1,70 @@
+# schema bench results
+# date: 2026-08-16T11:08:14Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -flto -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg c-lto] post-law hotel window, Air on external power, machine quiet by Glenn's word; all other workers stopped
+# schema commit: 6550f33
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 409bdaf (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four post-law legs per round)
+# load_start: 3.20 2.79 2.62
+# load_end: 2.80 2.82 2.68
+# load_max: 3.34
+# control_start_median: 101005796   control_end_median: 101602120
+# control_delta_pct: 0.6   window: OK
+# era: POST-LAW — serialize.c a2a561f (#20: zero release validation, checks=removed by ruling) +
+# era:   409bdaf (#21: align-up buffer contract, tail-window machinery gone, reader is C++'s
+# era:   BitReader load-for-load); schema 6550f33 with #50 (C legs adopt the contract).
+# era: Air-on-external-power hotel window, 2026-08-16, machine quiet by Glenn's word.
+# era: NOT comparable to the phase4-air airport rows (pre-law serialize.c v1.3.0), nor to any other
+# era:   host or era (§5.3 rule 8). cpp-off and cpp-AB differ ONLY by the two READ_SPINE_DEMAND defines.
+# era: c checks metadata is 'removed' as of this pass — the post-#20 truth; 'contract' died with the
+# era:   write-capacity check. Linkage stays hdr+tu, and that caption still applies to C-vs-C++ ratios.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,rigidbody_moving,write,24000000,105,7,54753393,54673565,54991385,5482.77,0.58,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,54435594,53482371,54604402,5450.95,2.06,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,105361241,105104809,105839706,5727.38,0.70,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,110043914,98643954,110423266,5981.93,10.70,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,71805551,66756231,71957329,890.23,7.24,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,208886375,195831242,209298067,2589.72,6.45,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,258275580,257149975,258725588,1477.86,0.61,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,887241741,885743679,893971281,5076.84,0.93,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,65572696,65416396,66113517,3814.63,1.06,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,54178335,53958351,54704782,3151.78,1.38,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,79917884,79822196,80498487,2134.04,0.85,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,110367662,110273720,110530443,2947.13,0.23,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,82842106,82652953,82986691,2212.12,0.40,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,111786878,109729585,112505713,2985.03,2.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,292090064,291409122,293958915,2785.59,0.87,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,304695162,304195522,308786049,2905.80,1.51,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,195586469,194137944,196092550,4849.67,1.00,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,254839461,251322881,255538497,6318.88,1.65,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,67480709,66815442,67729799,3024.67,1.35,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,66210915,65482524,66483173,2967.75,1.51,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,write,8000000,92,7,21435251,18987312,21477836,1880.69,11.62,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,21032098,20678353,21307594,1845.31,2.99,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,write,26214400,25,7,82560359,71925699,84696182,1968.39,15.47,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,164468062,161996280,168001179,3921.22,3.65,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,83053029,78327512,83200083,3881.07,5.87,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_packet,read,32000000,49,7,119698211,115470524,120977955,5593.50,4.60,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,180671737,146901121,181365592,2412.23,19.08,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,157402234,142200481,158369428,2101.55,10.27,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192147569,158774788,193238271,3664.92,17.94,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,212453305,211018693,213173217,4052.23,1.01,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,153719631,151696728,154234707,3078.57,1.65,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,166883615,163872638,167418656,3342.20,2.12,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,32215,31757,32375,2012.88,1.92,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,50354,46993,50449,3146.26,6.86,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-lto-O3-pass.inline
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-lto-O3-pass.inline
@@ -1,0 +1,84 @@
+# 2026-08-16-arm64-macbook-air-power-postlaw-c-lto-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T11:22:36Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 17 1 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_test_data 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _read_test_data 1 1 0 0 0
+symbol _read_probe_array 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=545, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed64' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed32' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed128' because too costly to inline (cost=260, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N chat write 1 0
+attr N probearray read 1 0
+attr N probebits write 0 0
+attr N testdata write 1 0
+attr N inputpacket read 0 0
+attr N test write 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 1 0
+attr STATS groups 168 untimed 145 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read partial:1 hot=1 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read partial:1 hot=1 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write full hot=0 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-main-O3-pass.csv
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-main-O3-pass.csv
@@ -1,0 +1,70 @@
+# schema bench results
+# date: 2026-08-16T11:08:14Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg c-main] post-law hotel window, Air on external power, machine quiet by Glenn's word; all other workers stopped
+# schema commit: 6550f33
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 409bdaf (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four post-law legs per round)
+# load_start: 3.20 2.79 2.62
+# load_end: 2.80 2.82 2.68
+# load_max: 3.34
+# control_start_median: 101005796   control_end_median: 101602120
+# control_delta_pct: 0.6   window: OK
+# era: POST-LAW — serialize.c a2a561f (#20: zero release validation, checks=removed by ruling) +
+# era:   409bdaf (#21: align-up buffer contract, tail-window machinery gone, reader is C++'s
+# era:   BitReader load-for-load); schema 6550f33 with #50 (C legs adopt the contract).
+# era: Air-on-external-power hotel window, 2026-08-16, machine quiet by Glenn's word.
+# era: NOT comparable to the phase4-air airport rows (pre-law serialize.c v1.3.0), nor to any other
+# era:   host or era (§5.3 rule 8). cpp-off and cpp-AB differ ONLY by the two READ_SPINE_DEMAND defines.
+# era: c checks metadata is 'removed' as of this pass — the post-#20 truth; 'contract' died with the
+# era:   write-capacity check. Linkage stays hdr+tu, and that caption still applies to C-vs-C++ ratios.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,rigidbody_moving,write,24000000,105,7,51270658,51235633,51309899,5134.03,0.14,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,57345341,56827734,57511065,5742.32,1.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,100769945,100408537,100929816,5477.80,0.52,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,114277144,113257899,115447196,6212.04,1.92,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,70710523,70309170,70812753,876.65,0.71,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,208932745,208778256,210410037,2590.30,0.78,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,233157413,232902867,233532606,1334.14,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,886500263,885625196,888062497,5072.60,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,63215621,62949003,63351534,3677.51,0.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,51409752,51079045,52403520,2990.72,2.58,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,79876591,79816820,79956623,2132.94,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,108489287,108309725,108832432,2896.98,0.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,82784884,80737741,82892106,2210.59,2.60,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,111183303,108621123,111359350,2968.91,2.46,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,274730876,246807649,274925308,2620.04,10.23,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,301519849,299499975,307456542,2875.52,2.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,173289343,172997754,173511092,4296.80,0.30,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,252518776,229188601,253142026,6261.34,9.49,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,44518840,44335576,44575695,1995.45,0.54,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,probearray,read,20000000,47,7,47164361,47052845,47227175,2114.03,0.37,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,testdata,write,8000000,92,7,21481412,21399873,21518681,1884.74,0.55,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,testdata,read,8000000,92,7,20390322,20305496,20547541,1789.01,1.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,write,26214400,25,7,84929696,82683531,87944471,2024.88,6.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,139692419,133234394,145740813,3330.53,8.95,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,77293753,77197536,77644650,3611.94,0.58,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,118824823,116985574,120442929,5552.69,2.91,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,166885704,166124685,167186338,2228.16,0.64,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,156516567,155324726,157222198,2089.72,1.21,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,172372310,172280746,174052412,3287.74,1.03,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,210920404,209832397,213185525,4022.99,1.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,142077240,141157207,142664546,2845.40,1.06,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,166195779,165329564,167820432,3328.43,1.50,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,32828,32745,33000,2051.19,0.78,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,50244,50179,50524,3139.39,0.69,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-main-O3-pass.inline
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-c-main-O3-pass.inline
@@ -1,0 +1,91 @@
+# 2026-08-16-arm64-macbook-air-power-postlaw-c-main-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T11:22:35Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 38 1 0 0
+symbol _write_test_data 2 2 0 0 0
+symbol _serialize_read_fixed64 2 2 0 0 0
+symbol _serialize_read_fixed32 2 2 0 0 0
+symbol _serialize_read_fixed128 2 2 0 0 0
+symbol _read_probe_array 2 2 0 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_probe_array 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+symbol _read_test_data 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=545, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed64' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed32' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed128' because too costly to inline (cost=260, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 1 0
+attr N rigidbody_at_rest read 0 0
+attr N chat write 1 0
+attr N probearray read 2 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N test write 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 1 0
+attr STATS groups 179 untimed 156 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write partial:1 hot=1 cold=0
+row c probearray read partial:2 hot=2 cold=0
+row c testdata write partial:2 hot=2 cold=0
+row c testdata read partial:1 hot=1 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-AB-O3-pass.csv
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-AB-O3-pass.csv
@@ -1,0 +1,70 @@
+# schema bench results
+# date: 2026-08-16T11:08:14Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -DSCHEMA_READ_SPINE_DEMAND -DSERIALIZE_READ_SPINE_DEMAND -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-AB] post-law hotel window, Air on external power, machine quiet by Glenn's word; all other workers stopped
+# schema commit: 6550f33
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 409bdaf (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four post-law legs per round)
+# load_start: 3.20 2.79 2.62
+# load_end: 2.80 2.82 2.68
+# load_max: 3.34
+# control_start_median: 101005796   control_end_median: 101602120
+# control_delta_pct: 0.6   window: OK
+# era: POST-LAW — serialize.c a2a561f (#20: zero release validation, checks=removed by ruling) +
+# era:   409bdaf (#21: align-up buffer contract, tail-window machinery gone, reader is C++'s
+# era:   BitReader load-for-load); schema 6550f33 with #50 (C legs adopt the contract).
+# era: Air-on-external-power hotel window, 2026-08-16, machine quiet by Glenn's word.
+# era: NOT comparable to the phase4-air airport rows (pre-law serialize.c v1.3.0), nor to any other
+# era:   host or era (§5.3 rule 8). cpp-off and cpp-AB differ ONLY by the two READ_SPINE_DEMAND defines.
+# era: c checks metadata is 'removed' as of this pass — the post-#20 truth; 'contract' died with the
+# era:   write-capacity check. Linkage stays hdr+tu, and that caption still applies to C-vs-C++ ratios.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,57546096,48864681,57833393,5762.42,15.59,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,301992996,298190201,302741387,30240.31,1.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,103410040,102891533,104722194,5621.31,1.77,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,476668685,472294810,477927295,25911.44,1.18,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,96222434,94846680,96447315,1192.94,1.66,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,131623868,129263043,132233834,1631.84,2.26,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,727625860,725052940,730218381,4163.51,0.71,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1015816802,1010637571,1018509106,5812.55,0.77,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,64676092,64384029,64737730,3762.48,0.55,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,132487209,132037441,132875513,7707.33,0.63,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,97244844,97115972,97343252,2596.72,0.23,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,212795139,211761650,213374823,5682.24,0.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,118670996,118609635,119772489,3168.86,0.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,260651412,260188164,263854055,6960.14,1.41,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1008981643,1000770777,1019940803,9622.40,1.90,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1398090597,1391377448,1411443632,13333.23,1.44,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,184654935,183804700,186259686,4578.62,1.33,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,756666459,745348122,759126382,18761.95,1.82,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,72335859,60166918,73161910,3242.29,17.96,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,139251281,139109750,139725178,6241.62,0.44,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27273239,27213839,27521231,2392.90,1.13,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,53088228,52634753,53465467,4657.86,1.56,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,message_batch,write,26214400,25,7,88264407,84372482,92736438,2104.39,9.48,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,108754472,107310851,110551694,2592.91,2.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,81821822,81039748,82041833,3823.54,1.22,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,129243778,122090533,130859788,6039.57,6.79,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,181815186,180904920,184349885,2427.49,1.89,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,184403498,181991798,186250269,2462.05,2.31,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,183382870,181001475,184848786,3497.75,2.10,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,223926856,217469524,231127404,4271.07,6.10,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,149603061,149309002,150440320,2996.12,0.76,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,178756469,172632405,180087601,3579.98,4.17,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,59317,52576,59392,3706.29,11.49,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,91258,90860,91736,5702.06,0.96,6b118770d85af4f6,bits,hdr,removed,O3,full

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-AB-O3-pass.inline
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-AB-O3-pass.inline
@@ -1,0 +1,108 @@
+# 2026-08-16-arm64-macbook-air-power-postlaw-cpp-AB-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T11:22:33Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 24 1 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=45)
+remark 3 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=45)
+remark 3 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=45)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into '_ZL11build_batchRxPhi' because too costly to inline (cost=1555, threshold=325)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr STATS groups 178 untimed 161 unattributed 0 unroll-dedup 1
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read full hot=0 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-off-O3-pass.csv
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-off-O3-pass.csv
@@ -1,0 +1,70 @@
+# schema bench results
+# date: 2026-08-16T11:08:14Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-off] post-law hotel window, Air on external power, machine quiet by Glenn's word; all other workers stopped
+# schema commit: 6550f33
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 409bdaf (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four post-law legs per round)
+# load_start: 3.20 2.79 2.62
+# load_end: 2.80 2.82 2.68
+# load_max: 3.34
+# control_start_median: 101005796   control_end_median: 101602120
+# control_delta_pct: 0.6   window: OK
+# era: POST-LAW — serialize.c a2a561f (#20: zero release validation, checks=removed by ruling) +
+# era:   409bdaf (#21: align-up buffer contract, tail-window machinery gone, reader is C++'s
+# era:   BitReader load-for-load); schema 6550f33 with #50 (C legs adopt the contract).
+# era: Air-on-external-power hotel window, 2026-08-16, machine quiet by Glenn's word.
+# era: NOT comparable to the phase4-air airport rows (pre-law serialize.c v1.3.0), nor to any other
+# era:   host or era (§5.3 rule 8). cpp-off and cpp-AB differ ONLY by the two READ_SPINE_DEMAND defines.
+# era: c checks metadata is 'removed' as of this pass — the post-#20 truth; 'contract' died with the
+# era:   write-capacity check. Linkage stays hdr+tu, and that caption still applies to C-vs-C++ ratios.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,58124979,54953773,58354092,5820.39,5.85,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,89050375,87544766,89731129,8917.13,2.46,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,103806257,99540726,104163827,5642.85,4.45,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,135821268,130563683,137059227,7383.17,4.78,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,94756292,91013176,94897536,1174.77,4.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,130948033,128366572,131780233,1623.46,2.61,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,727963465,714875236,736532506,4165.44,2.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1016400038,988013477,1026587455,5815.89,3.80,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,64634408,64410563,64671092,3760.05,0.40,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,46542797,40241377,46659201,2707.59,13.79,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,97771236,97496139,97890548,2610.77,0.40,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,112844147,112466205,113160192,3013.26,0.61,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,118730144,118416275,119026512,3170.44,0.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,121999263,121447637,122243415,3257.73,0.65,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1015199403,1008385653,1026188688,9681.70,1.75,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1398194323,1385759120,1400286662,13334.22,1.04,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,184480240,182061340,184854729,4574.29,1.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,756585771,724062784,760588067,18759.95,4.83,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,72284258,71672418,72673428,3239.98,1.38,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,77780835,76226690,79621189,3486.35,4.36,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27276187,27213360,27344670,2393.16,0.48,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,27080108,25776770,27106075,2375.96,4.91,6b118770d85af4f6,gen,hdr,removed,O3,partial:5
+cpp,message_batch,write,26214400,25,7,91231612,88362315,92592204,2175.13,4.64,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,77809279,77484144,79488953,1855.12,2.58,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,81936676,77310761,82137676,3828.90,5.89,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,110550649,95632794,110693560,5166.04,13.62,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,182333273,176206796,182728781,2434.41,3.58,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,186459215,180816295,188701573,2489.50,4.23,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,182579679,159215356,183238512,3482.43,13.16,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,227239015,222635928,228952471,4334.24,2.78,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,149288454,148979745,150088223,2989.82,0.74,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,181702209,179616318,183713949,3638.98,2.26,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,59290,59129,59451,3704.61,0.54,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,91137,90748,91227,5694.50,0.53,6b118770d85af4f6,bits,hdr,removed,O3,full

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-off-O3-pass.inline
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-cpp-off-O3-pass.inline
@@ -1,0 +1,117 @@
+# 2026-08-16-arm64-macbook-air-power-postlaw-cpp-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T11:22:30Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 34 1 0 0
+symbol __ZN7example12ReadTestDataERN9serialize10ReadStreamERNS_8TestDataE 5 5 0 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=505, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example20ReadShipData_ShallowERN9serialize10ReadStreamERNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=750, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=45)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=325)
+remark 2 '_ZN7example15ReadInputPacketERN9serialize10ReadStreamERNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=335, threshold=325)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 5 0
+attr STATS groups 203 untimed 176 unattributed 0 unroll-dedup 3
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read partial:5 hot=5 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-shipped-pair-O3.csv
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-shipped-pair-O3.csv
@@ -1,0 +1,106 @@
+# schema bench results
+# date: 2026-08-16T11:08:14Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-off] post-law hotel window, Air on external power, machine quiet by Glenn's word; all other workers stopped
+# schema commit: 6550f33
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 409bdaf (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four post-law legs per round)
+# load_start: 3.20 2.79 2.62
+# load_end: 2.80 2.82 2.68
+# load_max: 3.34
+# control_start_median: 101005796   control_end_median: 101602120
+# control_delta_pct: 0.6   window: OK
+# era: POST-LAW — serialize.c a2a561f (#20: zero release validation, checks=removed by ruling) +
+# era:   409bdaf (#21: align-up buffer contract, tail-window machinery gone, reader is C++'s
+# era:   BitReader load-for-load); schema 6550f33 with #50 (C legs adopt the contract).
+# era: Air-on-external-power hotel window, 2026-08-16, machine quiet by Glenn's word.
+# era: NOT comparable to the phase4-air airport rows (pre-law serialize.c v1.3.0), nor to any other
+# era:   host or era (§5.3 rule 8). cpp-off and cpp-AB differ ONLY by the two READ_SPINE_DEMAND defines.
+# era: c checks metadata is 'removed' as of this pass — the post-#20 truth; 'contract' died with the
+# era:   write-capacity check. Linkage stays hdr+tu, and that caption still applies to C-vs-C++ ratios.
+# corpus_id: 6b118770d85af4f6
+# era: PAIR FILE — cpp rows are leg cpp-off, c rows are leg c-main, same pass, same rounds, same window;
+# era:   assembled row-for-row from the stamped leg CSVs for the cross-language ratio read.
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,58124979,54953773,58354092,5820.39,5.85,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,89050375,87544766,89731129,8917.13,2.46,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,103806257,99540726,104163827,5642.85,4.45,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,135821268,130563683,137059227,7383.17,4.78,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,94756292,91013176,94897536,1174.77,4.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,130948033,128366572,131780233,1623.46,2.61,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,727963465,714875236,736532506,4165.44,2.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1016400038,988013477,1026587455,5815.89,3.80,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,64634408,64410563,64671092,3760.05,0.40,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,46542797,40241377,46659201,2707.59,13.79,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,97771236,97496139,97890548,2610.77,0.40,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,112844147,112466205,113160192,3013.26,0.61,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,118730144,118416275,119026512,3170.44,0.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,121999263,121447637,122243415,3257.73,0.65,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1015199403,1008385653,1026188688,9681.70,1.75,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1398194323,1385759120,1400286662,13334.22,1.04,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,184480240,182061340,184854729,4574.29,1.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,756585771,724062784,760588067,18759.95,4.83,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,72284258,71672418,72673428,3239.98,1.38,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,77780835,76226690,79621189,3486.35,4.36,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27276187,27213360,27344670,2393.16,0.48,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,27080108,25776770,27106075,2375.96,4.91,6b118770d85af4f6,gen,hdr,removed,O3,partial:5
+cpp,message_batch,write,26214400,25,7,91231612,88362315,92592204,2175.13,4.64,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,77809279,77484144,79488953,1855.12,2.58,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,81936676,77310761,82137676,3828.90,5.89,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,110550649,95632794,110693560,5166.04,13.62,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,182333273,176206796,182728781,2434.41,3.58,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,186459215,180816295,188701573,2489.50,4.23,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,182579679,159215356,183238512,3482.43,13.16,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,227239015,222635928,228952471,4334.24,2.78,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,149288454,148979745,150088223,2989.82,0.74,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,181702209,179616318,183713949,3638.98,2.26,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,59290,59129,59451,3704.61,0.54,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,91137,90748,91227,5694.50,0.53,6b118770d85af4f6,bits,hdr,removed,O3,full
+c,rigidbody_moving,write,24000000,105,7,51270658,51235633,51309899,5134.03,0.14,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,57345341,56827734,57511065,5742.32,1.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,100769945,100408537,100929816,5477.80,0.52,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,114277144,113257899,115447196,6212.04,1.92,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,70710523,70309170,70812753,876.65,0.71,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,208932745,208778256,210410037,2590.30,0.78,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,233157413,232902867,233532606,1334.14,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,886500263,885625196,888062497,5072.60,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,63215621,62949003,63351534,3677.51,0.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,51409752,51079045,52403520,2990.72,2.58,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,79876591,79816820,79956623,2132.94,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,108489287,108309725,108832432,2896.98,0.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,82784884,80737741,82892106,2210.59,2.60,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,111183303,108621123,111359350,2968.91,2.46,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,274730876,246807649,274925308,2620.04,10.23,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,301519849,299499975,307456542,2875.52,2.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,173289343,172997754,173511092,4296.80,0.30,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,252518776,229188601,253142026,6261.34,9.49,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,44518840,44335576,44575695,1995.45,0.54,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,probearray,read,20000000,47,7,47164361,47052845,47227175,2114.03,0.37,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,testdata,write,8000000,92,7,21481412,21399873,21518681,1884.74,0.55,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,testdata,read,8000000,92,7,20390322,20305496,20547541,1789.01,1.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,write,26214400,25,7,84929696,82683531,87944471,2024.88,6.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,139692419,133234394,145740813,3330.53,8.95,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,77293753,77197536,77644650,3611.94,0.58,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,118824823,116985574,120442929,5552.69,2.91,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,166885704,166124685,167186338,2228.16,0.64,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,156516567,155324726,157222198,2089.72,1.21,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,172372310,172280746,174052412,3287.74,1.03,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,210920404,209832397,213185525,4022.99,1.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,142077240,141157207,142664546,2845.40,1.06,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,166195779,165329564,167820432,3328.43,1.50,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,32828,32745,33000,2051.19,0.78,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,50244,50179,50524,3139.39,0.69,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-shipped-pair-O3.inline
+++ b/bench/results/postlaw-air/2026-08-16-arm64-macbook-air-power-postlaw-shipped-pair-O3.inline
@@ -1,0 +1,196 @@
+# 2026-08-16-arm64-macbook-air-power-postlaw-cpp-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T11:22:30Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 34 1 0 0
+symbol __ZN7example12ReadTestDataERN9serialize10ReadStreamERNS_8TestDataE 5 5 0 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=505, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example20ReadShipData_ShallowERN9serialize10ReadStreamERNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=750, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=45)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=325)
+remark 2 '_ZN7example15ReadInputPacketERN9serialize10ReadStreamERNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=335, threshold=325)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 5 0
+attr STATS groups 203 untimed 176 unattributed 0 unroll-dedup 3
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read partial:5 hot=5 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 38 1 0 0
+symbol _write_test_data 2 2 0 0 0
+symbol _serialize_read_fixed64 2 2 0 0 0
+symbol _serialize_read_fixed32 2 2 0 0 0
+symbol _serialize_read_fixed128 2 2 0 0 0
+symbol _read_probe_array 2 2 0 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_probe_array 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+symbol _read_test_data 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=545, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed64' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed32' because too costly to inline (cost=260, threshold=250)
+remark 1 'serialize_read_fixed_core' not inlined into 'serialize_read_fixed128' because too costly to inline (cost=260, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 1 0
+attr N rigidbody_at_rest read 0 0
+attr N chat write 1 0
+attr N probearray read 2 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N test write 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 1 0
+attr STATS groups 179 untimed 156 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write partial:1 hot=1 cold=0
+row c probearray read partial:2 hot=2 cold=0
+row c testdata write partial:2 hot=2 cold=0
+row c testdata read partial:1 hot=1 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0


### PR DESCRIPTION
The C-vs-C++ verification pass Glenn asked for, against serialize.c a2a561f+409bdaf: 7×4 interleaved rounds, 0.6% controls, verdicts stamped from the start, zero unknown rows. Includes the bench/c metadata truth-up (checks: contract → removed, dead by ruling #20) — the tables now print with only the linkage caption. Results in bench/results/postlaw-air/; tables in the pass ledgers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)