### PR TITLE
The generated C spine can demand inlining — SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND, default off

### DIFF
--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -23,9 +23,45 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes BenchPacket. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_bench_packet( serialize_write_stream_t * stream, const BenchPacket * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_packet( serialize_write_stream_t * stream, const BenchPacket * value )
 {
     if ( (serialize_int64_t) value->a < -100LL || (serialize_int64_t) value->a > 100LL )
     {
@@ -102,7 +138,7 @@ static SCHEMA_UNUSED int write_bench_packet( serialize_write_stream_t * stream, 
 
 /* Reads BenchPacket. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_bench_packet( serialize_read_stream_t * stream, BenchPacket * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_packet( serialize_read_stream_t * stream, BenchPacket * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -217,7 +253,7 @@ static SCHEMA_UNUSED int read_bench_packet( serialize_read_stream_t * stream, Be
 
 /* Writes BenchInts. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_bench_ints( serialize_write_stream_t * stream, const BenchInts * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_ints( serialize_write_stream_t * stream, const BenchInts * value )
 {
     if ( (serialize_int64_t) value->f0 < -100LL || (serialize_int64_t) value->f0 > 100LL )
     {
@@ -304,7 +340,7 @@ static SCHEMA_UNUSED int write_bench_ints( serialize_write_stream_t * stream, co
 
 /* Reads BenchInts. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_bench_ints( serialize_read_stream_t * stream, BenchInts * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_stream_t * stream, BenchInts * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -451,7 +487,7 @@ static SCHEMA_UNUSED int read_bench_ints( serialize_read_stream_t * stream, Benc
 
 /* Writes BenchBits. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_bench_bits( serialize_write_stream_t * stream, const BenchBits * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_bits( serialize_write_stream_t * stream, const BenchBits * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->b7, 7 ) )
     {
@@ -497,7 +533,7 @@ static SCHEMA_UNUSED int write_bench_bits( serialize_write_stream_t * stream, co
 
 /* Reads BenchBits. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_bench_bits( serialize_read_stream_t * stream, BenchBits * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_bits( serialize_read_stream_t * stream, BenchBits * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -573,7 +609,7 @@ static SCHEMA_UNUSED int read_bench_bits( serialize_read_stream_t * stream, Benc
 
 /* Writes BenchMixed. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_bench_mixed( serialize_write_stream_t * stream, const BenchMixed * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_write_stream_t * stream, const BenchMixed * value )
 {
     if ( (serialize_int64_t) value->sequence < 0LL || (serialize_int64_t) value->sequence > 65535LL )
     {
@@ -651,7 +687,7 @@ static SCHEMA_UNUSED int write_bench_mixed( serialize_write_stream_t * stream, c
 
 /* Reads BenchMixed. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_bench_mixed( serialize_read_stream_t * stream, BenchMixed * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_stream_t * stream, BenchMixed * value )
 {
     {
         serialize_uint64_t offset_value = 0;

--- a/generated/c-ludicrous/LudicrousWire.h
+++ b/generated/c-ludicrous/LudicrousWire.h
@@ -23,9 +23,45 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes FixedProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_fixed_probe( serialize_write_stream_t * stream, const FixedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_write_stream_t * stream, const FixedProbe * value )
 {
     {
         serialize_int32_t fixed_value = value->angle;
@@ -73,7 +109,7 @@ static SCHEMA_UNUSED int write_fixed_probe( serialize_write_stream_t * stream, c
 
 /* Reads FixedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
 {
     {
         serialize_int32_t fixed_value;
@@ -131,7 +167,7 @@ static SCHEMA_UNUSED int read_fixed_probe( serialize_read_stream_t * stream, Fix
 
 /* Writes UnsignedProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_unsigned_probe( serialize_write_stream_t * stream, const UnsignedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_write_stream_t * stream, const UnsignedProbe * value )
 {
     {
         serialize_int64_t fixed_value = (serialize_int64_t) value->angle;
@@ -187,7 +223,7 @@ static SCHEMA_UNUSED int write_unsigned_probe( serialize_write_stream_t * stream
 
 /* Reads UnsignedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
 {
     {
         serialize_int64_t fixed_value = 0;
@@ -249,7 +285,7 @@ static SCHEMA_UNUSED int read_unsigned_probe( serialize_read_stream_t * stream, 
 
 /* Writes WideProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_wide_probe( serialize_write_stream_t * stream, const WideProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write_stream_t * stream, const WideProbe * value )
 {
     if ( !serialize_write_uint128( stream, value->entity_id ) )
     {
@@ -276,7 +312,7 @@ static SCHEMA_UNUSED int write_wide_probe( serialize_write_stream_t * stream, co
 
 /* Reads WideProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
 {
     if ( !serialize_read_uint128( stream, &value->entity_id ) )
     {
@@ -303,7 +339,7 @@ static SCHEMA_UNUSED int read_wide_probe( serialize_read_stream_t * stream, Wide
 
 /* Writes LudicrousState. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
 {
     if ( value->mode > 3 )
     {
@@ -351,7 +387,7 @@ static SCHEMA_UNUSED int write_ludicrous_state( serialize_write_stream_t * strea
 
 /* Reads LudicrousState. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_ludicrous_state( serialize_read_stream_t * stream, LudicrousState * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_read_stream_t * stream, LudicrousState * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -407,7 +443,7 @@ static SCHEMA_UNUSED int read_ludicrous_state( serialize_read_stream_t * stream,
 
 /* Writes DegenerateProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
 {
     if ( (serialize_int64_t) value->locked_fixed != -196608LL )
     {
@@ -430,7 +466,7 @@ static SCHEMA_UNUSED int write_degenerate_probe( serialize_write_stream_t * stre
 
 /* Reads DegenerateProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
 {
     value->locked_fixed = (int32_t) -196608LL;
     value->locked_int = (int32_t) (7);
@@ -448,7 +484,7 @@ static SCHEMA_UNUSED int read_degenerate_probe( serialize_read_stream_t * stream
 
 /* Writes FixedVec. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_fixed_vec( serialize_write_stream_t * stream, const FixedVec * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_stream_t * stream, const FixedVec * value )
 {
     {
         serialize_int64_t fixed_value = value->x;
@@ -476,7 +512,7 @@ static SCHEMA_UNUSED int write_fixed_vec( serialize_write_stream_t * stream, con
 
 /* Reads FixedVec. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
 {
     {
         serialize_int64_t fixed_value;
@@ -510,7 +546,7 @@ static SCHEMA_UNUSED int read_fixed_vec( serialize_read_stream_t * stream, Fixed
 
 /* Writes FixedQuat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_fixed_quat( serialize_write_stream_t * stream, const FixedQuat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write_stream_t * stream, const FixedQuat * value )
 {
     {
         serialize_int32_t fixed_value = value->x;
@@ -545,7 +581,7 @@ static SCHEMA_UNUSED int write_fixed_quat( serialize_write_stream_t * stream, co
 
 /* Reads FixedQuat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
 {
     {
         serialize_int32_t fixed_value;
@@ -587,7 +623,7 @@ static SCHEMA_UNUSED int read_fixed_quat( serialize_read_stream_t * stream, Fixe
 }
 
 /* Writes Body's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_body_data_deep( serialize_write_stream_t * stream, const BodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_body_data_deep( serialize_write_stream_t * stream, const BodyData_Deep * value )
 {
     if ( !write_fixed_vec( stream, &value->position ) )
     {
@@ -605,7 +641,7 @@ static SCHEMA_UNUSED int write_body_data_deep( serialize_write_stream_t * stream
 }
 
 /* Reads Body's DEEP view. */
-static SCHEMA_UNUSED int read_body_data_deep( serialize_read_stream_t * stream, BodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_body_data_deep( serialize_read_stream_t * stream, BodyData_Deep * value )
 {
     if ( !read_fixed_vec( stream, &value->position ) )
     {
@@ -623,7 +659,7 @@ static SCHEMA_UNUSED int read_body_data_deep( serialize_read_stream_t * stream, 
 }
 
 /* Writes Body's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_body_data_shallow( serialize_write_stream_t * stream, const BodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_body_data_shallow( serialize_write_stream_t * stream, const BodyData_Shallow * value )
 {
     if ( !write_fixed_vec( stream, &value->position ) )
     {
@@ -641,7 +677,7 @@ static SCHEMA_UNUSED int write_body_data_shallow( serialize_write_stream_t * str
 }
 
 /* Reads Body's SHALLOW view. */
-static SCHEMA_UNUSED int read_body_data_shallow( serialize_read_stream_t * stream, BodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_body_data_shallow( serialize_read_stream_t * stream, BodyData_Shallow * value )
 {
     if ( !read_fixed_vec( stream, &value->position ) )
     {
@@ -659,7 +695,7 @@ static SCHEMA_UNUSED int read_body_data_shallow( serialize_read_stream_t * strea
 }
 
 /* Writes NarrowBody's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_narrow_body_data_deep( serialize_write_stream_t * stream, const NarrowBodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_narrow_body_data_deep( serialize_write_stream_t * stream, const NarrowBodyData_Deep * value )
 {
     if ( !write_fixed_vec( stream, &value->position ) )
     {
@@ -677,7 +713,7 @@ static SCHEMA_UNUSED int write_narrow_body_data_deep( serialize_write_stream_t *
 }
 
 /* Reads NarrowBody's DEEP view. */
-static SCHEMA_UNUSED int read_narrow_body_data_deep( serialize_read_stream_t * stream, NarrowBodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_narrow_body_data_deep( serialize_read_stream_t * stream, NarrowBodyData_Deep * value )
 {
     if ( !read_fixed_vec( stream, &value->position ) )
     {
@@ -695,7 +731,7 @@ static SCHEMA_UNUSED int read_narrow_body_data_deep( serialize_read_stream_t * s
 }
 
 /* Writes NarrowBody's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_narrow_body_data_shallow( serialize_write_stream_t * stream, const NarrowBodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_narrow_body_data_shallow( serialize_write_stream_t * stream, const NarrowBodyData_Shallow * value )
 {
     if ( (serialize_int64_t) value->position_x < -25600000LL || (serialize_int64_t) value->position_x > 25600000LL )
     {
@@ -761,7 +797,7 @@ static SCHEMA_UNUSED int write_narrow_body_data_shallow( serialize_write_stream_
 }
 
 /* Reads NarrowBody's SHALLOW view. */
-static SCHEMA_UNUSED int read_narrow_body_data_shallow( serialize_read_stream_t * stream, NarrowBodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_narrow_body_data_shallow( serialize_read_stream_t * stream, NarrowBodyData_Shallow * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -855,7 +891,7 @@ static SCHEMA_UNUSED int read_narrow_body_data_shallow( serialize_read_stream_t 
 }
 
 /* The tag itself, over [0, MESSAGE_TYPE_MAX]. */
-static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, MessageType value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message_type( serialize_write_stream_t * stream, MessageType value )
 {
     if ( value > MESSAGE_TYPE_MAX )
     {
@@ -868,7 +904,7 @@ static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, 
     return 1;
 }
 
-static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, MessageType * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message_type( serialize_read_stream_t * stream, MessageType * value )
 {
     serialize_uint32_t raw = 0;
     if ( !serialize_read_bits( stream, &raw, 1 ) )
@@ -884,7 +920,7 @@ static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, Me
 }
 
 /* Writes the tag and then the selected arm. */
-static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const Message * message )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message( serialize_write_stream_t * stream, const Message * message )
 {
     switch ( message->type )
     {
@@ -902,7 +938,7 @@ static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const
 }
 
 /* Reads the tag, ZEROES the selected arm, then decodes into it (SPEC §5). */
-static SCHEMA_UNUSED int read_message( serialize_read_stream_t * stream, Message * message )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message( serialize_read_stream_t * stream, Message * message )
 {
     MessageType type = MESSAGE_TYPE_NONE;
     if ( !read_message_type( stream, &type ) )

--- a/generated/c/MessagesWire.h
+++ b/generated/c/MessagesWire.h
@@ -24,6 +24,42 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 /* string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -95,7 +131,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 
 /* Writes Heartbeat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
 {
     (void) stream;
     (void) value;
@@ -104,7 +140,7 @@ static SCHEMA_UNUSED int write_heartbeat( serialize_write_stream_t * stream, con
 
 /* Reads Heartbeat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_heartbeat( serialize_read_stream_t * stream, Heartbeat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_heartbeat( serialize_read_stream_t * stream, Heartbeat * value )
 {
     (void) stream;
     (void) value;
@@ -113,7 +149,7 @@ static SCHEMA_UNUSED int read_heartbeat( serialize_read_stream_t * stream, Heart
 
 /* Writes Test. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_test( serialize_write_stream_t * stream, const Test * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_stream_t * stream, const Test * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->test_a, 16 ) )
     {
@@ -148,7 +184,7 @@ static SCHEMA_UNUSED int write_test( serialize_write_stream_t * stream, const Te
 
 /* Reads Test. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_test( serialize_read_stream_t * stream, Test * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t * stream, Test * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -205,7 +241,7 @@ static SCHEMA_UNUSED int read_test( serialize_read_stream_t * stream, Test * val
 
 /* Writes Block. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_block( serialize_write_stream_t * stream, const Block * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_block( serialize_write_stream_t * stream, const Block * value )
 {
     if ( !serialize_write_int( stream, value->data_length, 0, 2000 ) )
     {
@@ -220,7 +256,7 @@ static SCHEMA_UNUSED int write_block( serialize_write_stream_t * stream, const B
 
 /* Reads Block. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_block( serialize_read_stream_t * stream, Block * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_t * stream, Block * value )
 {
     if ( !serialize_read_int( stream, &value->data_length, 0, 2000 ) )
     {
@@ -235,7 +271,7 @@ static SCHEMA_UNUSED int read_block( serialize_read_stream_t * stream, Block * v
 
 /* Writes Chat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_chat( serialize_write_stream_t * stream, const Chat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_stream_t * stream, const Chat * value )
 {
     serialize_assert( schema_utf8_valid_( (const serialize_uint8_t *) value->text, value->text_length ) );
     if ( !serialize_write_int( stream, value->text_length, 0, 256 ) )
@@ -251,7 +287,7 @@ static SCHEMA_UNUSED int write_chat( serialize_write_stream_t * stream, const Ch
 
 /* Reads Chat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_chat( serialize_read_stream_t * stream, Chat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t * stream, Chat * value )
 {
     if ( !serialize_read_int( stream, &value->text_length, 0, 256 ) )
     {
@@ -267,7 +303,7 @@ static SCHEMA_UNUSED int read_chat( serialize_read_stream_t * stream, Chat * val
 
 /* Writes Synchronize. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_synchronize( serialize_write_stream_t * stream, const Synchronize * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_synchronize( serialize_write_stream_t * stream, const Synchronize * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sync_frame ) )
     {
@@ -282,7 +318,7 @@ static SCHEMA_UNUSED int write_synchronize( serialize_write_stream_t * stream, c
 
 /* Reads Synchronize. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_synchronize( serialize_read_stream_t * stream, Synchronize * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_synchronize( serialize_read_stream_t * stream, Synchronize * value )
 {
     {
         serialize_uint64_t raw = 0;
@@ -305,7 +341,7 @@ static SCHEMA_UNUSED int read_synchronize( serialize_read_stream_t * stream, Syn
 
 /* Writes Timescale. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_timescale( serialize_write_stream_t * stream, const Timescale * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_timescale( serialize_write_stream_t * stream, const Timescale * value )
 {
     if ( !serialize_write_double( stream, value->scale ) )
     {
@@ -324,7 +360,7 @@ static SCHEMA_UNUSED int write_timescale( serialize_write_stream_t * stream, con
 
 /* Reads Timescale. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_timescale( serialize_read_stream_t * stream, Timescale * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_timescale( serialize_read_stream_t * stream, Timescale * value )
 {
     if ( !serialize_read_double( stream, &value->scale ) )
     {
@@ -350,7 +386,7 @@ static SCHEMA_UNUSED int read_timescale( serialize_read_stream_t * stream, Times
 }
 
 /* The tag itself, over [0, MESSAGE_TYPE_MAX]. */
-static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, MessageType value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message_type( serialize_write_stream_t * stream, MessageType value )
 {
     if ( value > MESSAGE_TYPE_MAX )
     {
@@ -363,7 +399,7 @@ static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, 
     return 1;
 }
 
-static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, MessageType * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message_type( serialize_read_stream_t * stream, MessageType * value )
 {
     serialize_uint32_t raw = 0;
     if ( !serialize_read_bits( stream, &raw, 3 ) )
@@ -379,7 +415,7 @@ static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, Me
 }
 
 /* Writes the tag and then the selected arm. */
-static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const Message * message )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message( serialize_write_stream_t * stream, const Message * message )
 {
     switch ( message->type )
     {
@@ -427,7 +463,7 @@ static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const
 }
 
 /* Reads the tag, ZEROES the selected arm, then decodes into it (SPEC §5). */
-static SCHEMA_UNUSED int read_message( serialize_read_stream_t * stream, Message * message )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message( serialize_read_stream_t * stream, Message * message )
 {
     MessageType type = MESSAGE_TYPE_NONE;
     if ( !read_message_type( stream, &type ) )

--- a/generated/c/ObjectsWire.h
+++ b/generated/c/ObjectsWire.h
@@ -26,8 +26,44 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes Ship's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_ship_data_deep( serialize_write_stream_t * stream, const ShipData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_data_deep( serialize_write_stream_t * stream, const ShipData_Deep * value )
 {
     if ( value->ship_type > 5 )
     {
@@ -149,7 +185,7 @@ static SCHEMA_UNUSED int write_ship_data_deep( serialize_write_stream_t * stream
 }
 
 /* Reads Ship's DEEP view. */
-static SCHEMA_UNUSED int read_ship_data_deep( serialize_read_stream_t * stream, ShipData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_data_deep( serialize_read_stream_t * stream, ShipData_Deep * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -295,7 +331,7 @@ static SCHEMA_UNUSED int read_ship_data_deep( serialize_read_stream_t * stream, 
 }
 
 /* Writes Ship's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_ship_data_shallow( serialize_write_stream_t * stream, const ShipData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_data_shallow( serialize_write_stream_t * stream, const ShipData_Shallow * value )
 {
     if ( value->ship_type > 5 )
     {
@@ -417,7 +453,7 @@ static SCHEMA_UNUSED int write_ship_data_shallow( serialize_write_stream_t * str
 }
 
 /* Reads Ship's SHALLOW view. */
-static SCHEMA_UNUSED int read_ship_data_shallow( serialize_read_stream_t * stream, ShipData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_data_shallow( serialize_read_stream_t * stream, ShipData_Shallow * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -599,7 +635,7 @@ static SCHEMA_UNUSED int read_ship_data_shallow( serialize_read_stream_t * strea
 }
 
 /* Writes Missile's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_missile_data_deep( serialize_write_stream_t * stream, const MissileData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_missile_data_deep( serialize_write_stream_t * stream, const MissileData_Deep * value )
 {
     if ( value->missile_type > 3 )
     {
@@ -637,7 +673,7 @@ static SCHEMA_UNUSED int write_missile_data_deep( serialize_write_stream_t * str
 }
 
 /* Reads Missile's DEEP view. */
-static SCHEMA_UNUSED int read_missile_data_deep( serialize_read_stream_t * stream, MissileData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_missile_data_deep( serialize_read_stream_t * stream, MissileData_Deep * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -687,7 +723,7 @@ static SCHEMA_UNUSED int read_missile_data_deep( serialize_read_stream_t * strea
 }
 
 /* Writes Missile's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_missile_data_shallow( serialize_write_stream_t * stream, const MissileData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_missile_data_shallow( serialize_write_stream_t * stream, const MissileData_Shallow * value )
 {
     if ( value->missile_type > 3 )
     {
@@ -793,7 +829,7 @@ static SCHEMA_UNUSED int write_missile_data_shallow( serialize_write_stream_t * 
 }
 
 /* Reads Missile's SHALLOW view. */
-static SCHEMA_UNUSED int read_missile_data_shallow( serialize_read_stream_t * stream, MissileData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_missile_data_shallow( serialize_read_stream_t * stream, MissileData_Shallow * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -951,7 +987,7 @@ static SCHEMA_UNUSED int read_missile_data_shallow( serialize_read_stream_t * st
 }
 
 /* Writes DynamicProp's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_dynamic_prop_data_deep( serialize_write_stream_t * stream, const DynamicPropData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_dynamic_prop_data_deep( serialize_write_stream_t * stream, const DynamicPropData_Deep * value )
 {
     if ( value->prop_type > 6 )
     {
@@ -989,7 +1025,7 @@ static SCHEMA_UNUSED int write_dynamic_prop_data_deep( serialize_write_stream_t 
 }
 
 /* Reads DynamicProp's DEEP view. */
-static SCHEMA_UNUSED int read_dynamic_prop_data_deep( serialize_read_stream_t * stream, DynamicPropData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_dynamic_prop_data_deep( serialize_read_stream_t * stream, DynamicPropData_Deep * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -1039,7 +1075,7 @@ static SCHEMA_UNUSED int read_dynamic_prop_data_deep( serialize_read_stream_t * 
 }
 
 /* Writes DynamicProp's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_dynamic_prop_data_shallow( serialize_write_stream_t * stream, const DynamicPropData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_dynamic_prop_data_shallow( serialize_write_stream_t * stream, const DynamicPropData_Shallow * value )
 {
     if ( value->prop_type > 6 )
     {
@@ -1145,7 +1181,7 @@ static SCHEMA_UNUSED int write_dynamic_prop_data_shallow( serialize_write_stream
 }
 
 /* Reads DynamicProp's SHALLOW view. */
-static SCHEMA_UNUSED int read_dynamic_prop_data_shallow( serialize_read_stream_t * stream, DynamicPropData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_dynamic_prop_data_shallow( serialize_read_stream_t * stream, DynamicPropData_Shallow * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -1303,7 +1339,7 @@ static SCHEMA_UNUSED int read_dynamic_prop_data_shallow( serialize_read_stream_t
 }
 
 /* Writes Turret's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_turret_data_deep( serialize_write_stream_t * stream, const TurretData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_turret_data_deep( serialize_write_stream_t * stream, const TurretData_Deep * value )
 {
     if ( !write_handle( stream, &value->parent ) )
     {
@@ -1329,7 +1365,7 @@ static SCHEMA_UNUSED int write_turret_data_deep( serialize_write_stream_t * stre
 }
 
 /* Reads Turret's DEEP view. */
-static SCHEMA_UNUSED int read_turret_data_deep( serialize_read_stream_t * stream, TurretData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_turret_data_deep( serialize_read_stream_t * stream, TurretData_Deep * value )
 {
     if ( !read_handle( stream, &value->parent ) )
     {
@@ -1365,7 +1401,7 @@ static SCHEMA_UNUSED int read_turret_data_deep( serialize_read_stream_t * stream
 }
 
 /* Writes Turret's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_turret_data_shallow( serialize_write_stream_t * stream, const TurretData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_turret_data_shallow( serialize_write_stream_t * stream, const TurretData_Shallow * value )
 {
     if ( !write_handle( stream, &value->parent ) )
     {
@@ -1419,7 +1455,7 @@ static SCHEMA_UNUSED int write_turret_data_shallow( serialize_write_stream_t * s
 }
 
 /* Reads Turret's SHALLOW view. */
-static SCHEMA_UNUSED int read_turret_data_shallow( serialize_read_stream_t * stream, TurretData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_turret_data_shallow( serialize_read_stream_t * stream, TurretData_Shallow * value )
 {
     if ( !read_handle( stream, &value->parent ) )
     {

--- a/generated/c/RenderWire.h
+++ b/generated/c/RenderWire.h
@@ -24,9 +24,45 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes RenderSprite. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_render_sprite( serialize_write_stream_t * stream, const RenderSprite * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_write_stream_t * stream, const RenderSprite * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sort_key ) )
     {
@@ -57,7 +93,7 @@ static SCHEMA_UNUSED int write_render_sprite( serialize_write_stream_t * stream,
 
 /* Reads RenderSprite. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
 {
     {
         serialize_uint64_t raw = 0;
@@ -108,7 +144,7 @@ static SCHEMA_UNUSED int read_render_sprite( serialize_read_stream_t * stream, R
 
 /* Writes RenderBlock. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_render_block( serialize_write_stream_t * stream, const RenderBlock * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_write_stream_t * stream, const RenderBlock * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->worker_index, 32 ) )
     {
@@ -137,7 +173,7 @@ static SCHEMA_UNUSED int write_render_block( serialize_write_stream_t * stream, 
 
 /* Reads RenderBlock. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_render_block( serialize_read_stream_t * stream, RenderBlock * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_block( serialize_read_stream_t * stream, RenderBlock * value )
 {
     {
         serialize_uint32_t raw = 0;

--- a/generated/c/TypesWire.h
+++ b/generated/c/TypesWire.h
@@ -25,9 +25,45 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes Vec3. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_vec3( serialize_write_stream_t * stream, const Vec3 * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_stream_t * stream, const Vec3 * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
     {
@@ -46,7 +82,7 @@ static SCHEMA_UNUSED int write_vec3( serialize_write_stream_t * stream, const Ve
 
 /* Reads Vec3. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
     {
@@ -65,7 +101,7 @@ static SCHEMA_UNUSED int read_vec3( serialize_read_stream_t * stream, Vec3 * val
 
 /* Writes Quat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quat( serialize_write_stream_t * stream, const Quat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_stream_t * stream, const Quat * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
     {
@@ -88,7 +124,7 @@ static SCHEMA_UNUSED int write_quat( serialize_write_stream_t * stream, const Qu
 
 /* Reads Quat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quat( serialize_read_stream_t * stream, Quat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t * stream, Quat * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
     {
@@ -111,7 +147,7 @@ static SCHEMA_UNUSED int read_quat( serialize_read_stream_t * stream, Quat * val
 
 /* Writes Handle. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_handle( serialize_write_stream_t * stream, const Handle * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_stream_t * stream, const Handle * value )
 {
     if ( (serialize_int64_t) value->object_id < 0LL || (serialize_int64_t) value->object_id > 9999LL )
     {
@@ -130,7 +166,7 @@ static SCHEMA_UNUSED int write_handle( serialize_write_stream_t * stream, const 
 
 /* Reads Handle. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_handle( serialize_read_stream_t * stream, Handle * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream_t * stream, Handle * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -159,7 +195,7 @@ static SCHEMA_UNUSED int read_handle( serialize_read_stream_t * stream, Handle *
 
 /* Writes QuantizedPosition. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
 {
     if ( (serialize_int64_t) value->x < -8388608LL || (serialize_int64_t) value->x > 8388608LL )
     {
@@ -190,7 +226,7 @@ static SCHEMA_UNUSED int write_quantized_position( serialize_write_stream_t * st
 
 /* Reads QuantizedPosition. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -239,7 +275,7 @@ static SCHEMA_UNUSED int read_quantized_position( serialize_read_stream_t * stre
 
 /* Writes QuantizedVelocity. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
 {
     if ( (serialize_int64_t) value->x < -2097152LL || (serialize_int64_t) value->x > 2097152LL )
     {
@@ -270,7 +306,7 @@ static SCHEMA_UNUSED int write_quantized_velocity( serialize_write_stream_t * st
 
 /* Reads QuantizedVelocity. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -319,7 +355,7 @@ static SCHEMA_UNUSED int read_quantized_velocity( serialize_read_stream_t * stre
 
 /* Writes QuantizedRotation. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
 {
     if ( (serialize_int64_t) value->x < -1024LL || (serialize_int64_t) value->x > 1024LL )
     {
@@ -358,7 +394,7 @@ static SCHEMA_UNUSED int write_quantized_rotation( serialize_write_stream_t * st
 
 /* Reads QuantizedRotation. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -421,7 +457,7 @@ static SCHEMA_UNUSED int read_quantized_rotation( serialize_read_stream_t * stre
 
 /* Writes RigidBody. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_rigid_body( serialize_write_stream_t * stream, const RigidBody * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_rigid_body( serialize_write_stream_t * stream, const RigidBody * value )
 {
     if ( !write_vec3( stream, &value->position ) )
     {
@@ -451,7 +487,7 @@ static SCHEMA_UNUSED int write_rigid_body( serialize_write_stream_t * stream, co
 
 /* Reads RigidBody. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_rigid_body( serialize_read_stream_t * stream, RigidBody * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_rigid_body( serialize_read_stream_t * stream, RigidBody * value )
 {
     if ( !read_vec3( stream, &value->position ) )
     {
@@ -486,7 +522,7 @@ static SCHEMA_UNUSED int read_rigid_body( serialize_read_stream_t * stream, Rigi
 
 /* Writes Input. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_input( serialize_write_stream_t * stream, const Input * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stream_t * stream, const Input * value )
 {
     if ( !serialize_write_float( stream, value->stick_x ) )
     {
@@ -545,7 +581,7 @@ static SCHEMA_UNUSED int write_input( serialize_write_stream_t * stream, const I
 
 /* Reads Input. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_input( serialize_read_stream_t * stream, Input * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_t * stream, Input * value )
 {
     if ( !serialize_read_float( stream, &value->stick_x ) )
     {
@@ -604,7 +640,7 @@ static SCHEMA_UNUSED int read_input( serialize_read_stream_t * stream, Input * v
 
 /* Writes InputPacket. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_input_packet( serialize_write_stream_t * stream, const InputPacket * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_write_stream_t * stream, const InputPacket * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->synchronize_sequence, 16 ) )
     {
@@ -637,7 +673,7 @@ static SCHEMA_UNUSED int write_input_packet( serialize_write_stream_t * stream, 
 
 /* Reads InputPacket. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_input_packet( serialize_read_stream_t * stream, InputPacket * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_stream_t * stream, InputPacket * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -682,7 +718,7 @@ static SCHEMA_UNUSED int read_input_packet( serialize_read_stream_t * stream, In
 
 /* Writes ShipCreate. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
 {
     if ( value->ship_type > 5 )
     {
@@ -748,7 +784,7 @@ static SCHEMA_UNUSED int write_ship_create( serialize_write_stream_t * stream, c
 
 /* Reads ShipCreate. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_ship_create( serialize_read_stream_t * stream, ShipCreate * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_stream_t * stream, ShipCreate * value )
 {
     {
         serialize_uint32_t enum_value = 0;

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -24,6 +24,42 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 /* string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -95,7 +131,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 
 /* Writes ProbeHeader. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) 171ULL, 8 ) /* const(171, 8) — SPEC §4.3 */ )
     {
@@ -122,7 +158,7 @@ static SCHEMA_UNUSED int write_probe_header( serialize_write_stream_t * stream, 
 
 /* Reads ProbeHeader. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_header( serialize_read_stream_t * stream, ProbeHeader * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_header( serialize_read_stream_t * stream, ProbeHeader * value )
 {
     {
         serialize_uint32_t const_value = 0;
@@ -171,7 +207,7 @@ static SCHEMA_UNUSED int read_probe_header( serialize_read_stream_t * stream, Pr
 
 /* Writes ProbeBits. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_bits( serialize_write_stream_t * stream, const ProbeBits * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write_stream_t * stream, const ProbeBits * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->small, 9 ) )
     {
@@ -219,7 +255,7 @@ static SCHEMA_UNUSED int write_probe_bits( serialize_write_stream_t * stream, co
 
 /* Reads ProbeBits. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -289,7 +325,7 @@ static SCHEMA_UNUSED int read_probe_bits( serialize_read_stream_t * stream, Prob
 
 /* Writes ProbeSample. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_sample( serialize_write_stream_t * stream, const ProbeSample * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_write_stream_t * stream, const ProbeSample * value )
 {
     if ( !serialize_write_bool( stream, value->active ) )
     {
@@ -355,7 +391,7 @@ static SCHEMA_UNUSED int write_probe_sample( serialize_write_stream_t * stream, 
 
 /* Reads ProbeSample. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_sample( serialize_read_stream_t * stream, ProbeSample * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_sample( serialize_read_stream_t * stream, ProbeSample * value )
 {
     if ( !serialize_read_bool( stream, &value->active ) )
     {
@@ -453,7 +489,7 @@ static SCHEMA_UNUSED int read_probe_sample( serialize_read_stream_t * stream, Pr
 
 /* Writes ProbeConfig. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_config( serialize_write_stream_t * stream, const ProbeConfig * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_write_stream_t * stream, const ProbeConfig * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->retries, 32 ) )
     {
@@ -472,7 +508,7 @@ static SCHEMA_UNUSED int write_probe_config( serialize_write_stream_t * stream, 
 
 /* Reads ProbeConfig. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -499,7 +535,7 @@ static SCHEMA_UNUSED int read_probe_config( serialize_read_stream_t * stream, Pr
 
 /* Writes ProbeArray. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_array( serialize_write_stream_t * stream, const ProbeArray * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_array( serialize_write_stream_t * stream, const ProbeArray * value )
 {
     {
         int32_t i;
@@ -520,7 +556,7 @@ static SCHEMA_UNUSED int write_probe_array( serialize_write_stream_t * stream, c
 
 /* Reads ProbeArray. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_array( serialize_read_stream_t * stream, ProbeArray * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_array( serialize_read_stream_t * stream, ProbeArray * value )
 {
     {
         int32_t i;
@@ -541,7 +577,7 @@ static SCHEMA_UNUSED int read_probe_array( serialize_read_stream_t * stream, Pro
 
 /* Writes ProbeReport. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_report( serialize_write_stream_t * stream, const ProbeReport * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_write_stream_t * stream, const ProbeReport * value )
 {
     if ( !write_probe_header( stream, &value->header ) )
     {
@@ -560,7 +596,7 @@ static SCHEMA_UNUSED int write_probe_report( serialize_write_stream_t * stream, 
 
 /* Reads ProbeReport. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_report( serialize_read_stream_t * stream, ProbeReport * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_stream_t * stream, ProbeReport * value )
 {
     if ( !read_probe_header( stream, &value->header ) )
     {
@@ -583,7 +619,7 @@ static SCHEMA_UNUSED int read_probe_report( serialize_read_stream_t * stream, Pr
 
 /* Writes TestData. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_test_data( serialize_write_stream_t * stream, const TestData * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_stream_t * stream, const TestData * value )
 {
     if ( (serialize_int64_t) value->a < -100LL || (serialize_int64_t) value->a > 100LL )
     {
@@ -726,7 +762,7 @@ static SCHEMA_UNUSED int write_test_data( serialize_write_stream_t * stream, con
 
 /* Reads TestData. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_test_data( serialize_read_stream_t * stream, TestData * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_stream_t * stream, TestData * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -941,7 +977,7 @@ static SCHEMA_UNUSED int read_test_data( serialize_read_stream_t * stream, TestD
 
 /* Writes CompressedProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_compressed_probe( serialize_write_stream_t * stream, const CompressedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize_write_stream_t * stream, const CompressedProbe * value )
 {
     if ( !serialize_write_compressed_float( stream, value->boundary, 0.0, 10.0, 0.01 ) )
     {
@@ -956,7 +992,7 @@ static SCHEMA_UNUSED int write_compressed_probe( serialize_write_stream_t * stre
 
 /* Reads CompressedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
 {
     if ( !serialize_read_compressed_float( stream, &value->boundary, 0.0, 10.0, 0.01 ) )
     {

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -463,6 +463,9 @@ var _ = big.NewInt
 // ---- wire header ----
 
 func (g *gen) emitWireHeader() {
+	if g.fileEmitsWire() {
+		g.emitSpineInlineMacros()
+	}
 	if fileHasStrings(g.file) {
 		g.emitUtf8Validator()
 	}
@@ -486,7 +489,7 @@ func (g *gen) emitWireHeader() {
 func (g *gen) emitWriteFunc(st *ir.Struct) {
 	g.pf("/* Writes %s. Returns 1 on success, 0 on failure — the stream latches the\n", st.Name)
 	g.pf("   error, so a caller may check once at the end of a message. */\n")
-	g.pf("static SCHEMA_UNUSED int write_%s( serialize_write_stream_t * stream, const %s * value )\n{\n", snake(st.Name), st.Name)
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_%s( serialize_write_stream_t * stream, const %s * value )\n{\n", snake(st.Name), st.Name)
 	// The early-out is keyed on ITEMS, not fields: a struct whose only items
 	// are reserved/const/align has no storage but DOES have wire bits, and
 	// keying on fields made C write nothing where C++ wrote the reserved
@@ -512,7 +515,7 @@ func (g *gen) emitWriteFunc(st *ir.Struct) {
 func (g *gen) emitReadFunc(st *ir.Struct) {
 	g.pf("/* Reads %s. Returns 1 on success, 0 on failure. Out-of-range values are\n", st.Name)
 	g.pf("   REFUSED, never clamped. */\n")
-	g.pf("static SCHEMA_UNUSED int read_%s( serialize_read_stream_t * stream, %s * value )\n{\n", snake(st.Name), st.Name)
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_%s( serialize_read_stream_t * stream, %s * value )\n{\n", snake(st.Name), st.Name)
 	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value;\n    return 1;\n}\n\n")
 		return

--- a/internal/codegen/c/dispatch.go
+++ b/internal/codegen/c/dispatch.go
@@ -158,20 +158,20 @@ func (g *gen) emitMessageTypes() {
 
 func (g *gen) emitMessageDispatch() {
 	g.pf("/* The tag itself, over [0, MESSAGE_TYPE_MAX]. */\n")
-	g.pf("static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, MessageType value )\n{\n")
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message_type( serialize_write_stream_t * stream, MessageType value )\n{\n")
 	bits := ir.BitsRequired(bigZero(), bigInt64(int64(len(g.unit.Messages))))
 	g.pf("    if ( value > MESSAGE_TYPE_MAX )\n    {\n        return 0;\n    }\n")
 	g.call("    ", fmt.Sprintf("serialize_write_bits( stream, (serialize_uint32_t) value, %d )", bits))
 	g.pf("    return 1;\n}\n\n")
 
-	g.pf("static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, MessageType * value )\n{\n")
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message_type( serialize_read_stream_t * stream, MessageType * value )\n{\n")
 	g.pf("    serialize_uint32_t raw = 0;\n")
 	g.call("    ", fmt.Sprintf("serialize_read_bits( stream, &raw, %d )", bits))
 	g.pf("    if ( raw > MESSAGE_TYPE_MAX )\n    {\n        return 0;\n    }\n")
 	g.pf("    *value = (MessageType) raw;\n    return 1;\n}\n\n")
 
 	g.pf("/* Writes the tag and then the selected arm. */\n")
-	g.pf("static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const Message * message )\n{\n")
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message( serialize_write_stream_t * stream, const Message * message )\n{\n")
 	g.pf("    switch ( message->type )\n    {\n")
 	g.pf("        case MESSAGE_TYPE_NONE:\n")
 	g.pf("            return write_message_type( stream, MESSAGE_TYPE_NONE ); /* the stream terminator */\n")
@@ -183,7 +183,7 @@ func (g *gen) emitMessageDispatch() {
 	g.pf("        default:\n            return 0;\n    }\n}\n\n")
 
 	g.pf("/* Reads the tag, ZEROES the selected arm, then decodes into it (SPEC §5). */\n")
-	g.pf("static SCHEMA_UNUSED int read_message( serialize_read_stream_t * stream, Message * message )\n{\n")
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message( serialize_read_stream_t * stream, Message * message )\n{\n")
 	g.pf("    MessageType type = MESSAGE_TYPE_NONE;\n")
 	g.call("    ", "read_message_type( stream, &type )")
 	g.pf("    message->type = type;\n")

--- a/internal/codegen/c/objects.go
+++ b/internal/codegen/c/objects.go
@@ -234,7 +234,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	// other four backends (WriteShipData_Deep -> write_ship_data_deep) — the
 	// object-name form this used to emit (write_ship_deep) lived outside the
 	// claimed-name registry and could collide with a user type (#23)
-	g.pf("static SCHEMA_UNUSED int write_%s( serialize_write_stream_t * stream, const %sData_Deep * value )\n{\n",
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_%s( serialize_write_stream_t * stream, const %sData_Deep * value )\n{\n",
 		snake(d.Name+"Data_Deep"), d.Name)
 	mark := g.body.Len()
 	for _, f := range deep {
@@ -244,7 +244,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	g.pf("    return 1;\n}\n\n")
 
 	g.pf("/* Reads %s's DEEP view. */\n", d.Name)
-	g.pf("static SCHEMA_UNUSED int read_%s( serialize_read_stream_t * stream, %sData_Deep * value )\n{\n",
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_%s( serialize_read_stream_t * stream, %sData_Deep * value )\n{\n",
 		snake(d.Name+"Data_Deep"), d.Name)
 	mark = g.body.Len()
 	for _, f := range deep {
@@ -254,7 +254,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	g.pf("    return 1;\n}\n\n")
 
 	g.pf("/* Writes %s's SHALLOW view — the quantized wire. */\n", d.Name)
-	g.pf("static SCHEMA_UNUSED int write_%s( serialize_write_stream_t * stream, const %sData_Shallow * value )\n{\n",
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_%s( serialize_write_stream_t * stream, const %sData_Shallow * value )\n{\n",
 		snake(d.Name+"Data_Shallow"), d.Name)
 	mark = g.body.Len()
 	for _, f := range interp {
@@ -264,7 +264,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	g.pf("    return 1;\n}\n\n")
 
 	g.pf("/* Reads %s's SHALLOW view. */\n", d.Name)
-	g.pf("static SCHEMA_UNUSED int read_%s( serialize_read_stream_t * stream, %sData_Shallow * value )\n{\n",
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_%s( serialize_read_stream_t * stream, %sData_Shallow * value )\n{\n",
 		snake(d.Name+"Data_Shallow"), d.Name)
 	mark = g.body.Len()
 	for _, f := range interp {

--- a/internal/codegen/c/spineinline.go
+++ b/internal/codegen/c/spineinline.go
@@ -1,0 +1,81 @@
+package c
+
+import "github.com/mas-bandwidth/schema/internal/ir"
+
+// fileEmitsWire reports whether this wire file will emit any read/write wire
+// function — struct wire pairs, object deep/shallow view pairs, or the owner
+// file's message dispatch surface. Files that only carry consts/enums/flags
+// emit no wire functions and no macro block.
+func (g *gen) fileEmitsWire() bool {
+	for _, d := range g.file.Decls {
+		switch d.(type) {
+		case *ir.Struct, *ir.Object:
+			return true
+		}
+	}
+	return g.file.Base == g.msgOwner && len(g.unit.Messages) > 0
+}
+
+// emitSpineInlineMacros emits the wire-spine inlining switches every generated
+// read/write function is spelled with (SCHEMA_C_READ_INLINE /
+// SCHEMA_C_WRITE_INLINE, beside `static SCHEMA_UNUSED`). Default OFF: both
+// expand to nothing, token-identical to what this emitter always produced, so
+// an undefined switch changes nothing. Armed (-DSCHEMA_C_READ_SPINE_DEMAND /
+// -DSCHEMA_C_WRITE_SPINE_DEMAND), the generated read / write spine demands
+// inlining the way the serialize family's per-field spines do (serialize.c
+// SERIALIZE_ALWAYS_INLINE — both halves; the C++ generated read spine's
+// SCHEMA_READ_SPINE_DEMAND, schema 99120c2).
+//
+// Why the demand exists (remark evidence, Apple clang 21, -O3, schema bench):
+// the generated per-message entries are header-static functions in the
+// consumer's own TU, and clang refuses to inline them into small-message call
+// sites at marginal cost over the hot-callsite inline threshold (250) — read
+// entries at cost=300 (read_probe_header) through 2345 (read_test_data),
+// write entries at cost=270 (write_test, twenty over the line) through 2910
+// (write_test_data). The identical generated C++ entries inline (thresholds
+// 250-325 with the same costs priced lower on the C++ spellings), which is
+// the measured C small-message call-boundary class: C rows 3-4.5x slower on
+// probe_header-sized messages. Unlike the C++ read-spine case this is not
+// the fallible-chain frequency decay — it is a plain cost-over-threshold
+// refusal, the same in both directions, hence a write twin the C++ switch
+// does not need. The demand is a DEMAND, not a branch-weight hint:
+// __builtin_expect-style cold hints were measured in this family to activate
+// the machine outliner and shred hot bodies (bits write -25%) — do not swap
+// this for hints. Guarded against redefinition because several wire headers
+// land in one translation unit.
+func (g *gen) emitSpineInlineMacros() {
+	g.pf("#ifndef SCHEMA_C_SPINE_INLINE_DEFINED\n#define SCHEMA_C_SPINE_INLINE_DEFINED\n")
+	g.pf("/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire\n")
+	g.pf("   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand\n")
+	g.pf("   to nothing — token-identical to what this emitter always produced.\n")
+	g.pf("   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make\n")
+	g.pf("   the generated read / write spine DEMAND inlining (always_inline /\n")
+	g.pf("   __forceinline), the serialize family's remedy for LLVM refusing the\n")
+	g.pf("   header-static per-message entries into small-message call sites at\n")
+	g.pf("   marginal cost over the hot-callsite inline threshold. Branch-weight\n")
+	g.pf("   hints are NOT the fix here — measured in this family to invite the\n")
+	g.pf("   machine outliner into the hot bodies. Do not add them. */\n")
+	g.pf("#if defined( SCHEMA_C_READ_SPINE_DEMAND )\n")
+	g.pf("#if defined( _MSC_VER )\n")
+	g.pf("#define SCHEMA_C_READ_INLINE __forceinline\n")
+	g.pf("#elif defined( __GNUC__ ) || defined( __clang__ )\n")
+	g.pf("#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_C_READ_INLINE\n")
+	g.pf("#endif\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_C_READ_INLINE\n")
+	g.pf("#endif\n")
+	g.pf("#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )\n")
+	g.pf("#if defined( _MSC_VER )\n")
+	g.pf("#define SCHEMA_C_WRITE_INLINE __forceinline\n")
+	g.pf("#elif defined( __GNUC__ ) || defined( __clang__ )\n")
+	g.pf("#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_C_WRITE_INLINE\n")
+	g.pf("#endif\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_C_WRITE_INLINE\n")
+	g.pf("#endif\n")
+	g.pf("#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */\n\n")
+}

--- a/testdata/golden/c/MessagesWire.h
+++ b/testdata/golden/c/MessagesWire.h
@@ -24,6 +24,42 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 /* string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -95,7 +131,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 
 /* Writes Heartbeat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
 {
     (void) stream;
     (void) value;
@@ -104,7 +140,7 @@ static SCHEMA_UNUSED int write_heartbeat( serialize_write_stream_t * stream, con
 
 /* Reads Heartbeat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_heartbeat( serialize_read_stream_t * stream, Heartbeat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_heartbeat( serialize_read_stream_t * stream, Heartbeat * value )
 {
     (void) stream;
     (void) value;
@@ -113,7 +149,7 @@ static SCHEMA_UNUSED int read_heartbeat( serialize_read_stream_t * stream, Heart
 
 /* Writes Test. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_test( serialize_write_stream_t * stream, const Test * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_stream_t * stream, const Test * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->test_a, 16 ) )
     {
@@ -148,7 +184,7 @@ static SCHEMA_UNUSED int write_test( serialize_write_stream_t * stream, const Te
 
 /* Reads Test. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_test( serialize_read_stream_t * stream, Test * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t * stream, Test * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -205,7 +241,7 @@ static SCHEMA_UNUSED int read_test( serialize_read_stream_t * stream, Test * val
 
 /* Writes Block. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_block( serialize_write_stream_t * stream, const Block * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_block( serialize_write_stream_t * stream, const Block * value )
 {
     if ( !serialize_write_int( stream, value->data_length, 0, 2000 ) )
     {
@@ -220,7 +256,7 @@ static SCHEMA_UNUSED int write_block( serialize_write_stream_t * stream, const B
 
 /* Reads Block. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_block( serialize_read_stream_t * stream, Block * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_t * stream, Block * value )
 {
     if ( !serialize_read_int( stream, &value->data_length, 0, 2000 ) )
     {
@@ -235,7 +271,7 @@ static SCHEMA_UNUSED int read_block( serialize_read_stream_t * stream, Block * v
 
 /* Writes Chat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_chat( serialize_write_stream_t * stream, const Chat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_stream_t * stream, const Chat * value )
 {
     serialize_assert( schema_utf8_valid_( (const serialize_uint8_t *) value->text, value->text_length ) );
     if ( !serialize_write_int( stream, value->text_length, 0, 256 ) )
@@ -251,7 +287,7 @@ static SCHEMA_UNUSED int write_chat( serialize_write_stream_t * stream, const Ch
 
 /* Reads Chat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_chat( serialize_read_stream_t * stream, Chat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t * stream, Chat * value )
 {
     if ( !serialize_read_int( stream, &value->text_length, 0, 256 ) )
     {
@@ -267,7 +303,7 @@ static SCHEMA_UNUSED int read_chat( serialize_read_stream_t * stream, Chat * val
 
 /* Writes Synchronize. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_synchronize( serialize_write_stream_t * stream, const Synchronize * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_synchronize( serialize_write_stream_t * stream, const Synchronize * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sync_frame ) )
     {
@@ -282,7 +318,7 @@ static SCHEMA_UNUSED int write_synchronize( serialize_write_stream_t * stream, c
 
 /* Reads Synchronize. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_synchronize( serialize_read_stream_t * stream, Synchronize * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_synchronize( serialize_read_stream_t * stream, Synchronize * value )
 {
     {
         serialize_uint64_t raw = 0;
@@ -305,7 +341,7 @@ static SCHEMA_UNUSED int read_synchronize( serialize_read_stream_t * stream, Syn
 
 /* Writes Timescale. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_timescale( serialize_write_stream_t * stream, const Timescale * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_timescale( serialize_write_stream_t * stream, const Timescale * value )
 {
     if ( !serialize_write_double( stream, value->scale ) )
     {
@@ -324,7 +360,7 @@ static SCHEMA_UNUSED int write_timescale( serialize_write_stream_t * stream, con
 
 /* Reads Timescale. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_timescale( serialize_read_stream_t * stream, Timescale * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_timescale( serialize_read_stream_t * stream, Timescale * value )
 {
     if ( !serialize_read_double( stream, &value->scale ) )
     {
@@ -350,7 +386,7 @@ static SCHEMA_UNUSED int read_timescale( serialize_read_stream_t * stream, Times
 }
 
 /* The tag itself, over [0, MESSAGE_TYPE_MAX]. */
-static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, MessageType value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message_type( serialize_write_stream_t * stream, MessageType value )
 {
     if ( value > MESSAGE_TYPE_MAX )
     {
@@ -363,7 +399,7 @@ static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, 
     return 1;
 }
 
-static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, MessageType * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message_type( serialize_read_stream_t * stream, MessageType * value )
 {
     serialize_uint32_t raw = 0;
     if ( !serialize_read_bits( stream, &raw, 3 ) )
@@ -379,7 +415,7 @@ static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, Me
 }
 
 /* Writes the tag and then the selected arm. */
-static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const Message * message )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message( serialize_write_stream_t * stream, const Message * message )
 {
     switch ( message->type )
     {
@@ -427,7 +463,7 @@ static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const
 }
 
 /* Reads the tag, ZEROES the selected arm, then decodes into it (SPEC §5). */
-static SCHEMA_UNUSED int read_message( serialize_read_stream_t * stream, Message * message )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message( serialize_read_stream_t * stream, Message * message )
 {
     MessageType type = MESSAGE_TYPE_NONE;
     if ( !read_message_type( stream, &type ) )

--- a/testdata/golden/c/ObjectsWire.h
+++ b/testdata/golden/c/ObjectsWire.h
@@ -26,8 +26,44 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes Ship's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_ship_data_deep( serialize_write_stream_t * stream, const ShipData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_data_deep( serialize_write_stream_t * stream, const ShipData_Deep * value )
 {
     if ( value->ship_type > 5 )
     {
@@ -149,7 +185,7 @@ static SCHEMA_UNUSED int write_ship_data_deep( serialize_write_stream_t * stream
 }
 
 /* Reads Ship's DEEP view. */
-static SCHEMA_UNUSED int read_ship_data_deep( serialize_read_stream_t * stream, ShipData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_data_deep( serialize_read_stream_t * stream, ShipData_Deep * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -295,7 +331,7 @@ static SCHEMA_UNUSED int read_ship_data_deep( serialize_read_stream_t * stream, 
 }
 
 /* Writes Ship's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_ship_data_shallow( serialize_write_stream_t * stream, const ShipData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_data_shallow( serialize_write_stream_t * stream, const ShipData_Shallow * value )
 {
     if ( value->ship_type > 5 )
     {
@@ -417,7 +453,7 @@ static SCHEMA_UNUSED int write_ship_data_shallow( serialize_write_stream_t * str
 }
 
 /* Reads Ship's SHALLOW view. */
-static SCHEMA_UNUSED int read_ship_data_shallow( serialize_read_stream_t * stream, ShipData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_data_shallow( serialize_read_stream_t * stream, ShipData_Shallow * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -599,7 +635,7 @@ static SCHEMA_UNUSED int read_ship_data_shallow( serialize_read_stream_t * strea
 }
 
 /* Writes Missile's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_missile_data_deep( serialize_write_stream_t * stream, const MissileData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_missile_data_deep( serialize_write_stream_t * stream, const MissileData_Deep * value )
 {
     if ( value->missile_type > 3 )
     {
@@ -637,7 +673,7 @@ static SCHEMA_UNUSED int write_missile_data_deep( serialize_write_stream_t * str
 }
 
 /* Reads Missile's DEEP view. */
-static SCHEMA_UNUSED int read_missile_data_deep( serialize_read_stream_t * stream, MissileData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_missile_data_deep( serialize_read_stream_t * stream, MissileData_Deep * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -687,7 +723,7 @@ static SCHEMA_UNUSED int read_missile_data_deep( serialize_read_stream_t * strea
 }
 
 /* Writes Missile's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_missile_data_shallow( serialize_write_stream_t * stream, const MissileData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_missile_data_shallow( serialize_write_stream_t * stream, const MissileData_Shallow * value )
 {
     if ( value->missile_type > 3 )
     {
@@ -793,7 +829,7 @@ static SCHEMA_UNUSED int write_missile_data_shallow( serialize_write_stream_t * 
 }
 
 /* Reads Missile's SHALLOW view. */
-static SCHEMA_UNUSED int read_missile_data_shallow( serialize_read_stream_t * stream, MissileData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_missile_data_shallow( serialize_read_stream_t * stream, MissileData_Shallow * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -951,7 +987,7 @@ static SCHEMA_UNUSED int read_missile_data_shallow( serialize_read_stream_t * st
 }
 
 /* Writes DynamicProp's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_dynamic_prop_data_deep( serialize_write_stream_t * stream, const DynamicPropData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_dynamic_prop_data_deep( serialize_write_stream_t * stream, const DynamicPropData_Deep * value )
 {
     if ( value->prop_type > 6 )
     {
@@ -989,7 +1025,7 @@ static SCHEMA_UNUSED int write_dynamic_prop_data_deep( serialize_write_stream_t 
 }
 
 /* Reads DynamicProp's DEEP view. */
-static SCHEMA_UNUSED int read_dynamic_prop_data_deep( serialize_read_stream_t * stream, DynamicPropData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_dynamic_prop_data_deep( serialize_read_stream_t * stream, DynamicPropData_Deep * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -1039,7 +1075,7 @@ static SCHEMA_UNUSED int read_dynamic_prop_data_deep( serialize_read_stream_t * 
 }
 
 /* Writes DynamicProp's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_dynamic_prop_data_shallow( serialize_write_stream_t * stream, const DynamicPropData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_dynamic_prop_data_shallow( serialize_write_stream_t * stream, const DynamicPropData_Shallow * value )
 {
     if ( value->prop_type > 6 )
     {
@@ -1145,7 +1181,7 @@ static SCHEMA_UNUSED int write_dynamic_prop_data_shallow( serialize_write_stream
 }
 
 /* Reads DynamicProp's SHALLOW view. */
-static SCHEMA_UNUSED int read_dynamic_prop_data_shallow( serialize_read_stream_t * stream, DynamicPropData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_dynamic_prop_data_shallow( serialize_read_stream_t * stream, DynamicPropData_Shallow * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -1303,7 +1339,7 @@ static SCHEMA_UNUSED int read_dynamic_prop_data_shallow( serialize_read_stream_t
 }
 
 /* Writes Turret's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_turret_data_deep( serialize_write_stream_t * stream, const TurretData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_turret_data_deep( serialize_write_stream_t * stream, const TurretData_Deep * value )
 {
     if ( !write_handle( stream, &value->parent ) )
     {
@@ -1329,7 +1365,7 @@ static SCHEMA_UNUSED int write_turret_data_deep( serialize_write_stream_t * stre
 }
 
 /* Reads Turret's DEEP view. */
-static SCHEMA_UNUSED int read_turret_data_deep( serialize_read_stream_t * stream, TurretData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_turret_data_deep( serialize_read_stream_t * stream, TurretData_Deep * value )
 {
     if ( !read_handle( stream, &value->parent ) )
     {
@@ -1365,7 +1401,7 @@ static SCHEMA_UNUSED int read_turret_data_deep( serialize_read_stream_t * stream
 }
 
 /* Writes Turret's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_turret_data_shallow( serialize_write_stream_t * stream, const TurretData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_turret_data_shallow( serialize_write_stream_t * stream, const TurretData_Shallow * value )
 {
     if ( !write_handle( stream, &value->parent ) )
     {
@@ -1419,7 +1455,7 @@ static SCHEMA_UNUSED int write_turret_data_shallow( serialize_write_stream_t * s
 }
 
 /* Reads Turret's SHALLOW view. */
-static SCHEMA_UNUSED int read_turret_data_shallow( serialize_read_stream_t * stream, TurretData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_turret_data_shallow( serialize_read_stream_t * stream, TurretData_Shallow * value )
 {
     if ( !read_handle( stream, &value->parent ) )
     {

--- a/testdata/golden/c/RenderWire.h
+++ b/testdata/golden/c/RenderWire.h
@@ -24,9 +24,45 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes RenderSprite. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_render_sprite( serialize_write_stream_t * stream, const RenderSprite * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_write_stream_t * stream, const RenderSprite * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sort_key ) )
     {
@@ -57,7 +93,7 @@ static SCHEMA_UNUSED int write_render_sprite( serialize_write_stream_t * stream,
 
 /* Reads RenderSprite. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
 {
     {
         serialize_uint64_t raw = 0;
@@ -108,7 +144,7 @@ static SCHEMA_UNUSED int read_render_sprite( serialize_read_stream_t * stream, R
 
 /* Writes RenderBlock. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_render_block( serialize_write_stream_t * stream, const RenderBlock * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_write_stream_t * stream, const RenderBlock * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->worker_index, 32 ) )
     {
@@ -137,7 +173,7 @@ static SCHEMA_UNUSED int write_render_block( serialize_write_stream_t * stream, 
 
 /* Reads RenderBlock. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_render_block( serialize_read_stream_t * stream, RenderBlock * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_block( serialize_read_stream_t * stream, RenderBlock * value )
 {
     {
         serialize_uint32_t raw = 0;

--- a/testdata/golden/c/TypesWire.h
+++ b/testdata/golden/c/TypesWire.h
@@ -25,9 +25,45 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes Vec3. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_vec3( serialize_write_stream_t * stream, const Vec3 * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_stream_t * stream, const Vec3 * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
     {
@@ -46,7 +82,7 @@ static SCHEMA_UNUSED int write_vec3( serialize_write_stream_t * stream, const Ve
 
 /* Reads Vec3. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
     {
@@ -65,7 +101,7 @@ static SCHEMA_UNUSED int read_vec3( serialize_read_stream_t * stream, Vec3 * val
 
 /* Writes Quat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quat( serialize_write_stream_t * stream, const Quat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_stream_t * stream, const Quat * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
     {
@@ -88,7 +124,7 @@ static SCHEMA_UNUSED int write_quat( serialize_write_stream_t * stream, const Qu
 
 /* Reads Quat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quat( serialize_read_stream_t * stream, Quat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t * stream, Quat * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
     {
@@ -111,7 +147,7 @@ static SCHEMA_UNUSED int read_quat( serialize_read_stream_t * stream, Quat * val
 
 /* Writes Handle. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_handle( serialize_write_stream_t * stream, const Handle * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_stream_t * stream, const Handle * value )
 {
     if ( (serialize_int64_t) value->object_id < 0LL || (serialize_int64_t) value->object_id > 9999LL )
     {
@@ -130,7 +166,7 @@ static SCHEMA_UNUSED int write_handle( serialize_write_stream_t * stream, const 
 
 /* Reads Handle. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_handle( serialize_read_stream_t * stream, Handle * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream_t * stream, Handle * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -159,7 +195,7 @@ static SCHEMA_UNUSED int read_handle( serialize_read_stream_t * stream, Handle *
 
 /* Writes QuantizedPosition. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
 {
     if ( (serialize_int64_t) value->x < -8388608LL || (serialize_int64_t) value->x > 8388608LL )
     {
@@ -190,7 +226,7 @@ static SCHEMA_UNUSED int write_quantized_position( serialize_write_stream_t * st
 
 /* Reads QuantizedPosition. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -239,7 +275,7 @@ static SCHEMA_UNUSED int read_quantized_position( serialize_read_stream_t * stre
 
 /* Writes QuantizedVelocity. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
 {
     if ( (serialize_int64_t) value->x < -2097152LL || (serialize_int64_t) value->x > 2097152LL )
     {
@@ -270,7 +306,7 @@ static SCHEMA_UNUSED int write_quantized_velocity( serialize_write_stream_t * st
 
 /* Reads QuantizedVelocity. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -319,7 +355,7 @@ static SCHEMA_UNUSED int read_quantized_velocity( serialize_read_stream_t * stre
 
 /* Writes QuantizedRotation. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
 {
     if ( (serialize_int64_t) value->x < -1024LL || (serialize_int64_t) value->x > 1024LL )
     {
@@ -358,7 +394,7 @@ static SCHEMA_UNUSED int write_quantized_rotation( serialize_write_stream_t * st
 
 /* Reads QuantizedRotation. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -421,7 +457,7 @@ static SCHEMA_UNUSED int read_quantized_rotation( serialize_read_stream_t * stre
 
 /* Writes RigidBody. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_rigid_body( serialize_write_stream_t * stream, const RigidBody * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_rigid_body( serialize_write_stream_t * stream, const RigidBody * value )
 {
     if ( !write_vec3( stream, &value->position ) )
     {
@@ -451,7 +487,7 @@ static SCHEMA_UNUSED int write_rigid_body( serialize_write_stream_t * stream, co
 
 /* Reads RigidBody. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_rigid_body( serialize_read_stream_t * stream, RigidBody * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_rigid_body( serialize_read_stream_t * stream, RigidBody * value )
 {
     if ( !read_vec3( stream, &value->position ) )
     {
@@ -486,7 +522,7 @@ static SCHEMA_UNUSED int read_rigid_body( serialize_read_stream_t * stream, Rigi
 
 /* Writes Input. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_input( serialize_write_stream_t * stream, const Input * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stream_t * stream, const Input * value )
 {
     if ( !serialize_write_float( stream, value->stick_x ) )
     {
@@ -545,7 +581,7 @@ static SCHEMA_UNUSED int write_input( serialize_write_stream_t * stream, const I
 
 /* Reads Input. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_input( serialize_read_stream_t * stream, Input * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_t * stream, Input * value )
 {
     if ( !serialize_read_float( stream, &value->stick_x ) )
     {
@@ -604,7 +640,7 @@ static SCHEMA_UNUSED int read_input( serialize_read_stream_t * stream, Input * v
 
 /* Writes InputPacket. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_input_packet( serialize_write_stream_t * stream, const InputPacket * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_write_stream_t * stream, const InputPacket * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->synchronize_sequence, 16 ) )
     {
@@ -637,7 +673,7 @@ static SCHEMA_UNUSED int write_input_packet( serialize_write_stream_t * stream, 
 
 /* Reads InputPacket. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_input_packet( serialize_read_stream_t * stream, InputPacket * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_stream_t * stream, InputPacket * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -682,7 +718,7 @@ static SCHEMA_UNUSED int read_input_packet( serialize_read_stream_t * stream, In
 
 /* Writes ShipCreate. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
 {
     if ( value->ship_type > 5 )
     {
@@ -748,7 +784,7 @@ static SCHEMA_UNUSED int write_ship_create( serialize_write_stream_t * stream, c
 
 /* Reads ShipCreate. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_ship_create( serialize_read_stream_t * stream, ShipCreate * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_stream_t * stream, ShipCreate * value )
 {
     {
         serialize_uint32_t enum_value = 0;

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -24,6 +24,42 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 #ifndef SCHEMA_UTF8_VALID_DEFINED
 #define SCHEMA_UTF8_VALID_DEFINED
 /* string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
@@ -95,7 +131,7 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 
 /* Writes ProbeHeader. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) 171ULL, 8 ) /* const(171, 8) — SPEC §4.3 */ )
     {
@@ -122,7 +158,7 @@ static SCHEMA_UNUSED int write_probe_header( serialize_write_stream_t * stream, 
 
 /* Reads ProbeHeader. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_header( serialize_read_stream_t * stream, ProbeHeader * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_header( serialize_read_stream_t * stream, ProbeHeader * value )
 {
     {
         serialize_uint32_t const_value = 0;
@@ -171,7 +207,7 @@ static SCHEMA_UNUSED int read_probe_header( serialize_read_stream_t * stream, Pr
 
 /* Writes ProbeBits. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_bits( serialize_write_stream_t * stream, const ProbeBits * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write_stream_t * stream, const ProbeBits * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->small, 9 ) )
     {
@@ -219,7 +255,7 @@ static SCHEMA_UNUSED int write_probe_bits( serialize_write_stream_t * stream, co
 
 /* Reads ProbeBits. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -289,7 +325,7 @@ static SCHEMA_UNUSED int read_probe_bits( serialize_read_stream_t * stream, Prob
 
 /* Writes ProbeSample. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_sample( serialize_write_stream_t * stream, const ProbeSample * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_write_stream_t * stream, const ProbeSample * value )
 {
     if ( !serialize_write_bool( stream, value->active ) )
     {
@@ -355,7 +391,7 @@ static SCHEMA_UNUSED int write_probe_sample( serialize_write_stream_t * stream, 
 
 /* Reads ProbeSample. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_sample( serialize_read_stream_t * stream, ProbeSample * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_sample( serialize_read_stream_t * stream, ProbeSample * value )
 {
     if ( !serialize_read_bool( stream, &value->active ) )
     {
@@ -453,7 +489,7 @@ static SCHEMA_UNUSED int read_probe_sample( serialize_read_stream_t * stream, Pr
 
 /* Writes ProbeConfig. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_config( serialize_write_stream_t * stream, const ProbeConfig * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_write_stream_t * stream, const ProbeConfig * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->retries, 32 ) )
     {
@@ -472,7 +508,7 @@ static SCHEMA_UNUSED int write_probe_config( serialize_write_stream_t * stream, 
 
 /* Reads ProbeConfig. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -499,7 +535,7 @@ static SCHEMA_UNUSED int read_probe_config( serialize_read_stream_t * stream, Pr
 
 /* Writes ProbeArray. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_array( serialize_write_stream_t * stream, const ProbeArray * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_array( serialize_write_stream_t * stream, const ProbeArray * value )
 {
     {
         int32_t i;
@@ -520,7 +556,7 @@ static SCHEMA_UNUSED int write_probe_array( serialize_write_stream_t * stream, c
 
 /* Reads ProbeArray. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_array( serialize_read_stream_t * stream, ProbeArray * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_array( serialize_read_stream_t * stream, ProbeArray * value )
 {
     {
         int32_t i;
@@ -541,7 +577,7 @@ static SCHEMA_UNUSED int read_probe_array( serialize_read_stream_t * stream, Pro
 
 /* Writes ProbeReport. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_probe_report( serialize_write_stream_t * stream, const ProbeReport * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_write_stream_t * stream, const ProbeReport * value )
 {
     if ( !write_probe_header( stream, &value->header ) )
     {
@@ -560,7 +596,7 @@ static SCHEMA_UNUSED int write_probe_report( serialize_write_stream_t * stream, 
 
 /* Reads ProbeReport. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_probe_report( serialize_read_stream_t * stream, ProbeReport * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_stream_t * stream, ProbeReport * value )
 {
     if ( !read_probe_header( stream, &value->header ) )
     {
@@ -583,7 +619,7 @@ static SCHEMA_UNUSED int read_probe_report( serialize_read_stream_t * stream, Pr
 
 /* Writes TestData. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_test_data( serialize_write_stream_t * stream, const TestData * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_stream_t * stream, const TestData * value )
 {
     if ( (serialize_int64_t) value->a < -100LL || (serialize_int64_t) value->a > 100LL )
     {
@@ -726,7 +762,7 @@ static SCHEMA_UNUSED int write_test_data( serialize_write_stream_t * stream, con
 
 /* Reads TestData. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_test_data( serialize_read_stream_t * stream, TestData * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_stream_t * stream, TestData * value )
 {
     {
         serialize_uint64_t offset_value = 0;
@@ -941,7 +977,7 @@ static SCHEMA_UNUSED int read_test_data( serialize_read_stream_t * stream, TestD
 
 /* Writes CompressedProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_compressed_probe( serialize_write_stream_t * stream, const CompressedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize_write_stream_t * stream, const CompressedProbe * value )
 {
     if ( !serialize_write_compressed_float( stream, value->boundary, 0.0, 10.0, 0.01 ) )
     {
@@ -956,7 +992,7 @@ static SCHEMA_UNUSED int write_compressed_probe( serialize_write_stream_t * stre
 
 /* Reads CompressedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
 {
     if ( !serialize_read_compressed_float( stream, &value->boundary, 0.0, 10.0, 0.01 ) )
     {

--- a/testdata/golden/ludicrous/c/LudicrousWire.h
+++ b/testdata/golden/ludicrous/c/LudicrousWire.h
@@ -23,9 +23,45 @@
 extern "C" {
 #endif
 
+#ifndef SCHEMA_C_SPINE_INLINE_DEFINED
+#define SCHEMA_C_SPINE_INLINE_DEFINED
+/* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
+   function is spelled, beside `static SCHEMA_UNUSED`. Default: both expand
+   to nothing — token-identical to what this emitter always produced.
+   Define SCHEMA_C_READ_SPINE_DEMAND / SCHEMA_C_WRITE_SPINE_DEMAND to make
+   the generated read / write spine DEMAND inlining (always_inline /
+   __forceinline), the serialize family's remedy for LLVM refusing the
+   header-static per-message entries into small-message call sites at
+   marginal cost over the hot-callsite inline threshold. Branch-weight
+   hints are NOT the fix here — measured in this family to invite the
+   machine outliner into the hot bodies. Do not add them. */
+#if defined( SCHEMA_C_READ_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_READ_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_READ_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#else
+#define SCHEMA_C_READ_INLINE
+#endif
+#if defined( SCHEMA_C_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_C_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_C_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#else
+#define SCHEMA_C_WRITE_INLINE
+#endif
+#endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
+
 /* Writes FixedProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_fixed_probe( serialize_write_stream_t * stream, const FixedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_write_stream_t * stream, const FixedProbe * value )
 {
     {
         serialize_int32_t fixed_value = value->angle;
@@ -73,7 +109,7 @@ static SCHEMA_UNUSED int write_fixed_probe( serialize_write_stream_t * stream, c
 
 /* Reads FixedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
 {
     {
         serialize_int32_t fixed_value;
@@ -131,7 +167,7 @@ static SCHEMA_UNUSED int read_fixed_probe( serialize_read_stream_t * stream, Fix
 
 /* Writes UnsignedProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_unsigned_probe( serialize_write_stream_t * stream, const UnsignedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_write_stream_t * stream, const UnsignedProbe * value )
 {
     {
         serialize_int64_t fixed_value = (serialize_int64_t) value->angle;
@@ -187,7 +223,7 @@ static SCHEMA_UNUSED int write_unsigned_probe( serialize_write_stream_t * stream
 
 /* Reads UnsignedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
 {
     {
         serialize_int64_t fixed_value = 0;
@@ -249,7 +285,7 @@ static SCHEMA_UNUSED int read_unsigned_probe( serialize_read_stream_t * stream, 
 
 /* Writes WideProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_wide_probe( serialize_write_stream_t * stream, const WideProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write_stream_t * stream, const WideProbe * value )
 {
     if ( !serialize_write_uint128( stream, value->entity_id ) )
     {
@@ -276,7 +312,7 @@ static SCHEMA_UNUSED int write_wide_probe( serialize_write_stream_t * stream, co
 
 /* Reads WideProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
 {
     if ( !serialize_read_uint128( stream, &value->entity_id ) )
     {
@@ -303,7 +339,7 @@ static SCHEMA_UNUSED int read_wide_probe( serialize_read_stream_t * stream, Wide
 
 /* Writes LudicrousState. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
 {
     if ( value->mode > 3 )
     {
@@ -351,7 +387,7 @@ static SCHEMA_UNUSED int write_ludicrous_state( serialize_write_stream_t * strea
 
 /* Reads LudicrousState. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_ludicrous_state( serialize_read_stream_t * stream, LudicrousState * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_read_stream_t * stream, LudicrousState * value )
 {
     {
         serialize_uint32_t enum_value = 0;
@@ -407,7 +443,7 @@ static SCHEMA_UNUSED int read_ludicrous_state( serialize_read_stream_t * stream,
 
 /* Writes DegenerateProbe. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
 {
     if ( (serialize_int64_t) value->locked_fixed != -196608LL )
     {
@@ -430,7 +466,7 @@ static SCHEMA_UNUSED int write_degenerate_probe( serialize_write_stream_t * stre
 
 /* Reads DegenerateProbe. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
 {
     value->locked_fixed = (int32_t) -196608LL;
     value->locked_int = (int32_t) (7);
@@ -448,7 +484,7 @@ static SCHEMA_UNUSED int read_degenerate_probe( serialize_read_stream_t * stream
 
 /* Writes FixedVec. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_fixed_vec( serialize_write_stream_t * stream, const FixedVec * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_stream_t * stream, const FixedVec * value )
 {
     {
         serialize_int64_t fixed_value = value->x;
@@ -476,7 +512,7 @@ static SCHEMA_UNUSED int write_fixed_vec( serialize_write_stream_t * stream, con
 
 /* Reads FixedVec. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
 {
     {
         serialize_int64_t fixed_value;
@@ -510,7 +546,7 @@ static SCHEMA_UNUSED int read_fixed_vec( serialize_read_stream_t * stream, Fixed
 
 /* Writes FixedQuat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
-static SCHEMA_UNUSED int write_fixed_quat( serialize_write_stream_t * stream, const FixedQuat * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write_stream_t * stream, const FixedQuat * value )
 {
     {
         serialize_int32_t fixed_value = value->x;
@@ -545,7 +581,7 @@ static SCHEMA_UNUSED int write_fixed_quat( serialize_write_stream_t * stream, co
 
 /* Reads FixedQuat. Returns 1 on success, 0 on failure. Out-of-range values are
    REFUSED, never clamped. */
-static SCHEMA_UNUSED int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
 {
     {
         serialize_int32_t fixed_value;
@@ -587,7 +623,7 @@ static SCHEMA_UNUSED int read_fixed_quat( serialize_read_stream_t * stream, Fixe
 }
 
 /* Writes Body's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_body_data_deep( serialize_write_stream_t * stream, const BodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_body_data_deep( serialize_write_stream_t * stream, const BodyData_Deep * value )
 {
     if ( !write_fixed_vec( stream, &value->position ) )
     {
@@ -605,7 +641,7 @@ static SCHEMA_UNUSED int write_body_data_deep( serialize_write_stream_t * stream
 }
 
 /* Reads Body's DEEP view. */
-static SCHEMA_UNUSED int read_body_data_deep( serialize_read_stream_t * stream, BodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_body_data_deep( serialize_read_stream_t * stream, BodyData_Deep * value )
 {
     if ( !read_fixed_vec( stream, &value->position ) )
     {
@@ -623,7 +659,7 @@ static SCHEMA_UNUSED int read_body_data_deep( serialize_read_stream_t * stream, 
 }
 
 /* Writes Body's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_body_data_shallow( serialize_write_stream_t * stream, const BodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_body_data_shallow( serialize_write_stream_t * stream, const BodyData_Shallow * value )
 {
     if ( !write_fixed_vec( stream, &value->position ) )
     {
@@ -641,7 +677,7 @@ static SCHEMA_UNUSED int write_body_data_shallow( serialize_write_stream_t * str
 }
 
 /* Reads Body's SHALLOW view. */
-static SCHEMA_UNUSED int read_body_data_shallow( serialize_read_stream_t * stream, BodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_body_data_shallow( serialize_read_stream_t * stream, BodyData_Shallow * value )
 {
     if ( !read_fixed_vec( stream, &value->position ) )
     {
@@ -659,7 +695,7 @@ static SCHEMA_UNUSED int read_body_data_shallow( serialize_read_stream_t * strea
 }
 
 /* Writes NarrowBody's DEEP view — the declared encodings. */
-static SCHEMA_UNUSED int write_narrow_body_data_deep( serialize_write_stream_t * stream, const NarrowBodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_narrow_body_data_deep( serialize_write_stream_t * stream, const NarrowBodyData_Deep * value )
 {
     if ( !write_fixed_vec( stream, &value->position ) )
     {
@@ -677,7 +713,7 @@ static SCHEMA_UNUSED int write_narrow_body_data_deep( serialize_write_stream_t *
 }
 
 /* Reads NarrowBody's DEEP view. */
-static SCHEMA_UNUSED int read_narrow_body_data_deep( serialize_read_stream_t * stream, NarrowBodyData_Deep * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_narrow_body_data_deep( serialize_read_stream_t * stream, NarrowBodyData_Deep * value )
 {
     if ( !read_fixed_vec( stream, &value->position ) )
     {
@@ -695,7 +731,7 @@ static SCHEMA_UNUSED int read_narrow_body_data_deep( serialize_read_stream_t * s
 }
 
 /* Writes NarrowBody's SHALLOW view — the quantized wire. */
-static SCHEMA_UNUSED int write_narrow_body_data_shallow( serialize_write_stream_t * stream, const NarrowBodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_narrow_body_data_shallow( serialize_write_stream_t * stream, const NarrowBodyData_Shallow * value )
 {
     if ( (serialize_int64_t) value->position_x < -25600000LL || (serialize_int64_t) value->position_x > 25600000LL )
     {
@@ -761,7 +797,7 @@ static SCHEMA_UNUSED int write_narrow_body_data_shallow( serialize_write_stream_
 }
 
 /* Reads NarrowBody's SHALLOW view. */
-static SCHEMA_UNUSED int read_narrow_body_data_shallow( serialize_read_stream_t * stream, NarrowBodyData_Shallow * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_narrow_body_data_shallow( serialize_read_stream_t * stream, NarrowBodyData_Shallow * value )
 {
     {
         serialize_uint32_t raw = 0;
@@ -855,7 +891,7 @@ static SCHEMA_UNUSED int read_narrow_body_data_shallow( serialize_read_stream_t 
 }
 
 /* The tag itself, over [0, MESSAGE_TYPE_MAX]. */
-static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, MessageType value )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message_type( serialize_write_stream_t * stream, MessageType value )
 {
     if ( value > MESSAGE_TYPE_MAX )
     {
@@ -868,7 +904,7 @@ static SCHEMA_UNUSED int write_message_type( serialize_write_stream_t * stream, 
     return 1;
 }
 
-static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, MessageType * value )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message_type( serialize_read_stream_t * stream, MessageType * value )
 {
     serialize_uint32_t raw = 0;
     if ( !serialize_read_bits( stream, &raw, 1 ) )
@@ -884,7 +920,7 @@ static SCHEMA_UNUSED int read_message_type( serialize_read_stream_t * stream, Me
 }
 
 /* Writes the tag and then the selected arm. */
-static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const Message * message )
+static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_message( serialize_write_stream_t * stream, const Message * message )
 {
     switch ( message->type )
     {
@@ -902,7 +938,7 @@ static SCHEMA_UNUSED int write_message( serialize_write_stream_t * stream, const
 }
 
 /* Reads the tag, ZEROES the selected arm, then decodes into it (SPEC §5). */
-static SCHEMA_UNUSED int read_message( serialize_read_stream_t * stream, Message * message )
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_message( serialize_read_stream_t * stream, Message * message )
 {
     MessageType type = MESSAGE_TYPE_NONE;
     if ( !read_message_type( stream, &type ) )


### PR DESCRIPTION
## What

Two compile-time switches, **OFF by default**, that let the generated C wire spine demand inlining: every generated wire function is now spelled with `SCHEMA_C_READ_INLINE` / `SCHEMA_C_WRITE_INLINE` beside `static SCHEMA_UNUSED` — both macros expand to **nothing**, token-identical to what the emitter always produced — unless the consumer defines `SCHEMA_C_READ_SPINE_DEMAND` / `SCHEMA_C_WRITE_SPINE_DEMAND`, in which case that half of the generated spine (per-type read/write pairs, object deep/shallow views, `write_message_type`/`read_message_type`, `write_message`/`read_message`) demands inlining with `always_inline`/`__forceinline`, mirroring serialize.c's per-field spine (`SERIALIZE_ALWAYS_INLINE` — both halves) and the C++ generated read spine's `SCHEMA_READ_SPINE_DEMAND` (#47).

This is the C-side mirror of #47, commissioned off the post-law verification pass (#51): the C small-message call-boundary class.

## Why (ledger + remark evidence, compile-only — NO timing claims in this PR)

The 2026-08-16 post-law pass (`bench/results/postlaw-air/`, shipped-pair CSV, 7 interleaved rounds, 0.6% controls) put the C generated small-message rows 3–4.5x behind C++ while both sides' `.inline` verdicts said `full` — the runtime inlines end to end on both sides; the boundary is the **generated entry itself**:

| row | C++ (M msg/s) | C (M msg/s) | C time as % of C++ |
|---|---|---|---|
| probe_header read | 1398.2 | 301.5 | **464%** |
| probe_header write | 1015.2 | 274.7 | **370%** |
| test write | 728.0 | 233.2 | **312%** |
| probebits read | 756.6 | 252.5 | **300%** |
| probearray read / write | 77.8 / 72.3 | 47.2 / 44.5 | 165% / 162% |
| rigidbody_moving read | 89.1 | 57.3 | 155% |
| ship_shallow write | 118.7 | 82.8 | 143% |
| testdata read / write | 27.1 / 27.3 | 20.4 / 21.5 | 133% / 127% |
| shipcreate write | 97.8 | 79.9 | 122% |

Compile-only reproduction with `-Rpass=inline|loop-unroll|loop-vectorize -Rpass-missed=inline|loop-unroll|loop-vectorize` (one alternation — clang keeps only the last `-Rpass=` flag), Apple clang 21, `-O3`, the bench's recorded flags, names the mechanism exactly. The generated C entries are header-static functions **in the consumer's own TU**, and clang refuses them into the timed loops at marginal cost over the **hot-callsite threshold (250)**:

```
'read_probe_header'      not inlined into 'bench_message_probe_header' (cost=300,  threshold=250)
'read_probe_bits'        not inlined into 'bench_message_probebits'    (cost=320,  threshold=250)
'read_probe_array'       not inlined into 'bench_message_probearray'   (cost=660,  threshold=250)
'read_rigid_body'        not inlined into 'bench_message_rigidbody*'   (cost=770,  threshold=250)
'read_ship_data_shallow' not inlined into 'bench_message_ship_shallow' (cost=825,  threshold=250)
'read_ship_create'       not inlined into 'bench_message_shipcreate'   (cost=875,  threshold=250)
'read_input_packet'      not inlined into 'bench_message_inputpacket'  (cost=960,  threshold=250)
'read_test_data'         not inlined into 'bench_message_testdata'     (cost=2345, threshold=250)
'write_test'             not inlined into 'bench_message_test'         (cost=270,  threshold=250)  <- twenty over the line
'write_probe_header'     not inlined into 'bench_message_probe_header' (cost=360,  threshold=250)
'write_probe_bits'       not inlined into 'bench_message_probebits'    (cost=530,  threshold=250)
'write_rigid_body'       not inlined into 'bench_message_rigidbody*'   (cost=965,  threshold=250)
'write_probe_array'      not inlined into 'bench_message_probearray'   (cost=1080, threshold=250)
'write_ship_data_shallow'not inlined into 'bench_message_ship_shallow' (cost=1250, threshold=250)
'write_ship_create'      not inlined into 'bench_message_shipcreate'   (cost=1345, threshold=250)
'write_input_packet'     not inlined into 'bench_message_inputpacket'  (cost=1410, threshold=250)
'write_test_data'        not inlined into 'bench_message_testdata'     (cost=2910, threshold=250)
'write_message'          not inlined into 'build_batch'                (cost=1850, threshold=250)
```

**Mechanism chosen, and why.** The strand is **not** a hard TU boundary — the C backend already emits its whole spine into the generated headers as `static` functions, so the serialize.c-#22 header-move shape does not apply; there is nothing left to move. And it is not the TU boundary to the runtime either: the pass's `c-lto` leg (whole-program LTO) left probe_header read at 301→305 M msg/s — softening every boundary changes nothing, because the refusal is the inliner's cost model, not visibility. The mechanism that kills the boundary is #47's exactly: a demand macro in the emitter's function spelling.

**Why a write twin.** #47's C++ strand was the fallible-chain frequency decay landing on the read dispatcher — C++'s write rows inline without help, so the C++ switch is read-only. The C strand is a plain cost-over-threshold refusal, identical in both directions (`write_test` at cost=270 is the marginal case of the whole class), so the write spine carries the same demand — as its own switch, so the A/B pass can arm and attribute each direction independently.

## Verification

- **OFF (default): byte-identical.** The bench C leg built from this branch's generated tree vs main's, same flags, no demand defines: the two binaries differ in **exactly 16 bytes — the LC_UUID load command** (which hashes input paths) — and in nothing else once signatures are removed; disassembly (`otool -tv`) identical.
- **ON:** all 18 stranded entries inline at `(cost=always)` into their timed loops; **zero** missed-inline remarks name any generated `read_*`/`write_*`; all 18 out-of-line entry symbols (plus `write_message`'s) **vanish** from the armed binary; **zero** `OUTLINED_FUNCTION_*` symbols — the machine outliner did not activate. No branch-weight hints anywhere (measured in this family to invite the outliner; the demand is a demand).
- **ON, correctness:** all three C conformance suites (`test/c`, `test/c-ludicrous`, `test/bench/c_main.c`) build under the strict flags and pass with both switches armed.
- `go test ./...` green; `make test` green (all five language legs); inline-gate `selftest`, `leg c`, and `leg cpp` all PASS; goldens regenerated via the repo flow — the only golden movement is the switch plumbing itself (OFF-state object code proven identical above).

**Rows this switch is expected to move** (the stranded set, for the A/B pass): probe_header r/w, probebits r/w, test write, rigidbody_moving r/w, rigidbody_at_rest r/w, inputpacket r/w, shipcreate r/w, ship_shallow r/w, probearray r/w, testdata r/w, message_batch write. Not in the class: chat (its partial:1 is a runtime `write_bytes` call), test read and message_batch read (`read_test` / `read_message` already inline — the last-call-to-static bonus #47 documented), the rt and bitpacker families.

## The Implementation Law (STANDARD.md, serialize@23807f7)

> **Speed is normative.** Among correct implementations of an operation, the fastest correct option is the conforming one. [...] a port that is slower than the reference for any reason other than a documented language necessity is defective [...] Performance parity is part of conformance in spirit: C and C++ at total parity; systems languages within a few percent, with every residual attributed to a named language mechanism.

C at 3–4.5x C++ time on small messages is not a documented language necessity — it is one inliner refusal, and this switch is the staged remedy.

## What this PR is NOT

It is not a claim that the switches are faster — that is exactly what has not been measured. They stay OFF until a quiet-window A/B pass under `bench/BENCH-STANDARD.md` validates them; the timing protocol rides with the pass analysis, not this repo. Draft until then; **do not merge before the pass runs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
