### PR TITLE
Interior-null refusal: the C reader pays its obligation, and every scan goes word-wise

### DIFF
--- a/generated/c/MessagesWire.h
+++ b/generated/c/MessagesWire.h
@@ -129,6 +129,49 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 }
 #endif /* SCHEMA_UTF8_VALID_DEFINED */
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+/* string(N) carries bytes excluding 0x00: an interior null is content every
+   generated reader refuses (SPEC §4.7) — generated-code validation; no
+   serialize primitive performs it. The scan is word-wise: eight bytes per
+   step under the zero-byte idiom, and a payload of eight bytes or more
+   re-tests its final eight bytes as one whole (overlapping) word, so every
+   load stays inside the payload the stream already delivered. */
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const serialize_uint8_t * bytes, int32_t length )
+{
+    serialize_uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+#endif /* SCHEMA_INTERIOR_NULL_DEFINED */
+
 /* Writes Heartbeat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
@@ -296,6 +339,10 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t
     if ( !serialize_read_bytes( stream, (serialize_uint8_t *) value->text, (int) value->text_length ) )
     {
         return 0;
+    }
+    if ( schema_interior_null_( (const serialize_uint8_t *) value->text, value->text_length ) )
+    {
+        return 0; /* an interior null is content the read refuses (SPEC §4.7) */
     }
     value->text[value->text_length] = 0;
     return 1;

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -129,6 +129,49 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 }
 #endif /* SCHEMA_UTF8_VALID_DEFINED */
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+/* string(N) carries bytes excluding 0x00: an interior null is content every
+   generated reader refuses (SPEC §4.7) — generated-code validation; no
+   serialize primitive performs it. The scan is word-wise: eight bytes per
+   step under the zero-byte idiom, and a payload of eight bytes or more
+   re-tests its final eight bytes as one whole (overlapping) word, so every
+   load stays inside the payload the stream already delivered. */
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const serialize_uint8_t * bytes, int32_t length )
+{
+    serialize_uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+#endif /* SCHEMA_INTERIOR_NULL_DEFINED */
+
 /* Writes ProbeHeader. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
@@ -970,6 +1013,10 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
     if ( !serialize_read_bytes( stream, (serialize_uint8_t *) value->text, (int) value->text_length ) )
     {
         return 0;
+    }
+    if ( schema_interior_null_( (const serialize_uint8_t *) value->text, value->text_length ) )
+    {
+        return 0; /* an interior null is content the read refuses (SPEC §4.7) */
     }
     value->text[value->text_length] = 0;
     return 1;

--- a/generated/cpp/MessagesWire.h
+++ b/generated/cpp/MessagesWire.h
@@ -107,6 +107,49 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
 }
 #endif // SCHEMA_UTF8_VALID_DEFINED
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+// string(N) carries bytes excluding 0x00: an interior null is content every
+// generated reader refuses (SPEC §4.7) — generated-code validation; no
+// serialize primitive performs it. The scan is word-wise: eight bytes per
+// step under the zero-byte idiom, and a payload of eight bytes or more
+// re-tests its final eight bytes as one whole (overlapping) word, so every
+// load stays inside the payload the stream already delivered.
+SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t length )
+{
+    uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // SCHEMA_INTERIOR_NULL_DEFINED
+
 inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
 {
     (void) stream;
@@ -190,12 +233,9 @@ SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
 {
     read_int( stream, value.text_length, 0, MaxChatLength );
     read_bytes( stream, value.text, value.text_length );
-    for ( int32_t i = 0; i < value.text_length; i++ )
+    if ( schema_interior_null( reinterpret_cast<const uint8_t *>( value.text ), value.text_length ) )
     {
-        if ( value.text[i] == 0 )
-        {
-            return false;
-        }
+        return false; // an interior null is content the read refuses (SPEC §4.7)
     }
     value.text[value.text_length] = 0;
     return true;

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -107,6 +107,49 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
 }
 #endif // SCHEMA_UTF8_VALID_DEFINED
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+// string(N) carries bytes excluding 0x00: an interior null is content every
+// generated reader refuses (SPEC §4.7) — generated-code validation; no
+// serialize primitive performs it. The scan is word-wise: eight bytes per
+// step under the zero-byte idiom, and a payload of eight bytes or more
+// re-tests its final eight bytes as one whole (overlapping) word, so every
+// load stays inside the payload the stream already delivered.
+SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t length )
+{
+    uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // SCHEMA_INTERIOR_NULL_DEFINED
+
 inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {
     write_bits( stream, 171ull, 8 ); // const(171, 8) — SPEC §4.3
@@ -433,12 +476,9 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
     read_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     read_int( stream, value.text_length, 0, 255 );
     read_bytes( stream, value.text, value.text_length );
-    for ( int32_t i = 0; i < value.text_length; i++ )
+    if ( schema_interior_null( reinterpret_cast<const uint8_t *>( value.text ), value.text_length ) )
     {
-        if ( value.text[i] == 0 )
-        {
-            return false;
-        }
+        return false; // an interior null is content the read refuses (SPEC §4.7)
     }
     value.text[value.text_length] = 0;
     return true;

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -468,6 +468,7 @@ func (g *gen) emitWireHeader() {
 	}
 	if fileHasStrings(g.file) {
 		g.emitUtf8Validator()
+		g.emitInteriorNullScan()
 	}
 	// emission order for the same reason as the data header: write_a calls
 	// write_b, and C99 has no implicit declarations

--- a/internal/codegen/c/fields.go
+++ b/internal/codegen/c/fields.go
@@ -217,6 +217,10 @@ func (g *gen) emitReadField(f *ir.Field, ind string) {
 	case f.Type.Kind == ir.TString:
 		g.call(ind, fmt.Sprintf("serialize_read_int( stream, &value->%s_length, 0, %d )", f.Name, f.Type.Size))
 		g.call(ind, fmt.Sprintf("serialize_read_bytes( stream, (serialize_uint8_t *) value->%s, (int) value->%s_length )", f.Name, f.Name))
+		// the interior-null rule is generated-code validation (SPEC §4.7);
+		// the word-wise scan lives in schema_interior_null_ (nullscan.go)
+		g.pf("%sif ( schema_interior_null_( (const serialize_uint8_t *) value->%s, value->%s_length ) )\n%s{\n", ind, f.Name, f.Name, ind)
+		g.pf("%s    return 0; /* an interior null is content the read refuses (SPEC §4.7) */\n%s}\n", ind, ind)
 		// the terminator is not transmitted; the reader supplies it
 		g.pf("%svalue->%s[value->%s_length] = 0;\n", ind, f.Name, f.Name)
 	case f.Type.Kind == ir.TBytes:

--- a/internal/codegen/c/nullscan.go
+++ b/internal/codegen/c/nullscan.go
@@ -1,0 +1,45 @@
+package c
+
+// emitInteriorNullScan emits the read-side interior-null refusal every
+// generated reader owes (SPEC §4.7): string(N) carries bytes excluding 0x00,
+// and a payload with a null anywhere in [0, length) is content the read
+// refuses. The C emitter never inherited this check from the other four
+// backends — generated C readers accepted streams the C++, C#, Go and Rust
+// readers refuse — and it lands here in the fastest correct shape rather
+// than the naive one: WORD-WISE, eight bytes per step under the
+// ((w - 0x0101..) & ~w & 0x8080..) zero-byte idiom. A payload of eight bytes
+// or more re-tests its final eight bytes as one whole, OVERLAPPING word, so
+// every load stays inside the payload the stream already delivered — no
+// buffer-slack dependence, no masking, and no endianness dependence (the
+// idiom reports a zero byte wherever it sits in the word). A shorter payload
+// takes a per-byte tail bounded at seven. SCHEMA_C_READ_INLINE: the read
+// spine's demand switch covers the scan too. Guarded against redefinition
+// because several wire headers can land in one translation unit; the
+// trailing underscore keeps the name out of the claimed-name registry's way
+// (no schema declaration can generate it).
+func (g *gen) emitInteriorNullScan() {
+	g.pf("#ifndef SCHEMA_INTERIOR_NULL_DEFINED\n#define SCHEMA_INTERIOR_NULL_DEFINED\n")
+	g.pf("/* string(N) carries bytes excluding 0x00: an interior null is content every\n")
+	g.pf("   generated reader refuses (SPEC §4.7) — generated-code validation; no\n")
+	g.pf("   serialize primitive performs it. The scan is word-wise: eight bytes per\n")
+	g.pf("   step under the zero-byte idiom, and a payload of eight bytes or more\n")
+	g.pf("   re-tests its final eight bytes as one whole (overlapping) word, so every\n")
+	g.pf("   load stays inside the payload the stream already delivered. */\n")
+	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const serialize_uint8_t * bytes, int32_t length )\n{\n")
+	g.pf("    serialize_uint64_t word;\n")
+	g.pf("    int32_t i = 0;\n")
+	g.pf("    if ( length >= 8 )\n    {\n")
+	g.pf("        for ( ; i + 8 <= length; i += 8 )\n        {\n")
+	g.pf("            memcpy( &word, bytes + i, 8 );\n")
+	g.pf("            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )\n")
+	g.pf("            {\n                return 1;\n            }\n        }\n")
+	g.pf("        if ( i < length )\n        {\n")
+	g.pf("            memcpy( &word, bytes + length - 8, 8 );\n")
+	g.pf("            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )\n")
+	g.pf("            {\n                return 1;\n            }\n        }\n")
+	g.pf("        return 0;\n    }\n")
+	g.pf("    for ( ; i < length; i++ )\n    {\n")
+	g.pf("        if ( bytes[i] == 0 )\n        {\n            return 1;\n        }\n    }\n")
+	g.pf("    return 0;\n}\n")
+	g.pf("#endif /* SCHEMA_INTERIOR_NULL_DEFINED */\n\n")
+}

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -350,6 +350,7 @@ func (g *gen) emitWireFile() {
 
 	if fileHasStrings(g.file) {
 		g.emitUtf8Validator()
+		g.emitInteriorNullScan()
 	}
 
 	for _, d := range ir.EmissionOrder(g.file) {

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -591,9 +591,10 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 		g.pf("%sread_int( stream, %s_length, 0, %s );\n", ind, name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)))
 		g.pf("%sread_bytes( stream, %s, %s_length );\n", ind, name, name)
 		if f.Type.Kind == ir.TString {
-			// the interior-null rule is generated-code validation (SPEC §4.7)
-			g.pf("%sfor ( int32_t i = 0; i < %s_length; i++ )\n%s{\n", ind, name, ind)
-			g.pf("%s    if ( %s[i] == 0 )\n%s    {\n%s        return false;\n%s    }\n%s}\n", ind, name, ind, ind, ind, ind)
+			// the interior-null rule is generated-code validation (SPEC §4.7);
+			// the word-wise scan lives in schema_interior_null (nullscan.go)
+			g.pf("%sif ( schema_interior_null( reinterpret_cast<const uint8_t *>( %s ), %s_length ) )\n%s{\n", ind, name, name, ind)
+			g.pf("%s    return false; // an interior null is content the read refuses (SPEC §4.7)\n%s}\n", ind, ind)
 			g.pf("%s%s[%s_length] = 0;\n", ind, name, name)
 		}
 	case ir.TNamed:

--- a/internal/codegen/cpp/nullscan.go
+++ b/internal/codegen/cpp/nullscan.go
@@ -1,0 +1,42 @@
+package cpp
+
+// emitInteriorNullScan emits the read-side interior-null refusal every
+// generated reader owes (SPEC §4.7): string(N) carries bytes excluding 0x00,
+// and a payload with a null anywhere in [0, length) is content the read
+// refuses. The scan is WORD-WISE — eight bytes per step under the
+// ((w - 0x0101..) & ~w & 0x8080..) zero-byte idiom — because the check rides
+// every string read on the hot path and the serial per-byte shape costs a
+// dependent load-compare-branch per payload byte. A payload of eight bytes
+// or more re-tests its final eight bytes as one whole, OVERLAPPING word, so
+// every load stays inside the payload the stream already delivered — no
+// buffer-slack dependence, no masking, and no endianness dependence (the
+// idiom reports a zero byte wherever it sits in the word). A shorter payload
+// takes a per-byte tail bounded at seven. SCHEMA_READ_INLINE: the read
+// spine's demand switch covers the scan too. Guarded against redefinition
+// because several wire headers can land in one translation unit.
+func (g *gen) emitInteriorNullScan() {
+	g.pf("#ifndef SCHEMA_INTERIOR_NULL_DEFINED\n#define SCHEMA_INTERIOR_NULL_DEFINED\n")
+	g.pf("// string(N) carries bytes excluding 0x00: an interior null is content every\n")
+	g.pf("// generated reader refuses (SPEC §4.7) — generated-code validation; no\n")
+	g.pf("// serialize primitive performs it. The scan is word-wise: eight bytes per\n")
+	g.pf("// step under the zero-byte idiom, and a payload of eight bytes or more\n")
+	g.pf("// re-tests its final eight bytes as one whole (overlapping) word, so every\n")
+	g.pf("// load stays inside the payload the stream already delivered.\n")
+	g.pf("SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t length )\n{\n")
+	g.pf("    uint64_t word;\n")
+	g.pf("    int32_t i = 0;\n")
+	g.pf("    if ( length >= 8 )\n    {\n")
+	g.pf("        for ( ; i + 8 <= length; i += 8 )\n        {\n")
+	g.pf("            memcpy( &word, bytes + i, 8 );\n")
+	g.pf("            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )\n")
+	g.pf("            {\n                return true;\n            }\n        }\n")
+	g.pf("        if ( i < length )\n        {\n")
+	g.pf("            memcpy( &word, bytes + length - 8, 8 );\n")
+	g.pf("            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )\n")
+	g.pf("            {\n                return true;\n            }\n        }\n")
+	g.pf("        return false;\n    }\n")
+	g.pf("    for ( ; i < length; i++ )\n    {\n")
+	g.pf("        if ( bytes[i] == 0 )\n        {\n            return true;\n        }\n    }\n")
+	g.pf("    return false;\n}\n")
+	g.pf("#endif // SCHEMA_INTERIOR_NULL_DEFINED\n\n")
+}

--- a/test/c/main.c
+++ b/test/c/main.c
@@ -230,6 +230,87 @@ int main( void )
         check( out.text_length == 11 && memcmp( out.text, "wire parity", 11 ) == 0, "Chat round-trips" );
     }
 
+    /* ---- Chat: an interior null is content the read REFUSES (SPEC §4.7) ----
+       The compliance half: the C reader owes the same refusal the C++, C#, Go
+       and Rust readers have always emitted. A conforming writer cannot produce
+       the vector (the write side asserts), so the hostile stream is doctored
+       after the write: the wire is 9 length bits riding bytes 0-1, align
+       padding to byte 2, then the text bytes — buffer[2 + k] is text[k]. The
+       vectors pin every branch of the word-wise scan: a null inside a full
+       word, a null in the final byte of an eight-multiple payload, a null the
+       overlapping tail word judges, and a null on the short-string per-byte
+       path. */
+    {
+        Chat in, out;
+
+        memset( &in, 0, sizeof( in ) );
+        memcpy( in.text, "interior null defense s", 23 ); /* 2 words + 7-byte tail */
+        in.text_length = 23;
+        serialize_write_stream_init( &w, buffer, sizeof( buffer ) );
+        check( write_chat( &w, &in ), "write Chat for doctoring" );
+        serialize_write_flush( &w );
+
+        buffer[2 + 11] = 0; /* inside the second full scan word */
+        memset( &out, 0, sizeof( out ) );
+        serialize_read_stream_init( &r, buffer, serialize_write_bytes_processed( &w ) );
+        check( !read_chat( &r, &out ), "an interior null is refused (SPEC §4.7)" );
+
+        buffer[2 + 11] = 'x';
+        buffer[2 + 22] = 0; /* the FINAL payload byte — the overlapping tail word judges it */
+        memset( &out, 0, sizeof( out ) );
+        serialize_read_stream_init( &r, buffer, serialize_write_bytes_processed( &w ) );
+        check( !read_chat( &r, &out ), "a null in the overlap-tail word is refused" );
+
+        memcpy( in.text, "sixteen bytes ok", 16 ); /* two exact words, no tail */
+        in.text_length = 16;
+        serialize_write_stream_init( &w, buffer, sizeof( buffer ) );
+        check( write_chat( &w, &in ), "write Chat eight-multiple" );
+        serialize_write_flush( &w );
+        buffer[2 + 15] = 0; /* last byte of an eight-multiple payload */
+        memset( &out, 0, sizeof( out ) );
+        serialize_read_stream_init( &r, buffer, serialize_write_bytes_processed( &w ) );
+        check( !read_chat( &r, &out ), "a null in the last full-word byte is refused" );
+
+        memcpy( in.text, "hello", 5 ); /* below one word: the per-byte path */
+        in.text_length = 5;
+        serialize_write_stream_init( &w, buffer, sizeof( buffer ) );
+        check( write_chat( &w, &in ), "write short Chat" );
+        serialize_write_flush( &w );
+        buffer[2 + 2] = 0;
+        memset( &out, 0, sizeof( out ) );
+        serialize_read_stream_init( &r, buffer, serialize_write_bytes_processed( &w ) );
+        check( !read_chat( &r, &out ), "a short string's interior null is refused" );
+    }
+
+    /* ---- Chat: the accept neighbors — 0x00 nowhere in [0, length) passes at
+       every word-scan boundary: empty, one byte, one exact word, a word plus
+       a one-byte tail, two exact words (SPEC §4.7) ---- */
+    {
+        static const int32_t boundary_lengths[] = { 0, 1, 8, 9, 16 };
+        Chat in, out;
+        int li, i;
+        for ( li = 0; li < (int) ( sizeof( boundary_lengths ) / sizeof( boundary_lengths[0] ) ); li++ )
+        {
+            int32_t length = boundary_lengths[li];
+            memset( &in, 0, sizeof( in ) );
+            for ( i = 0; i < length; i++ )
+            {
+                in.text[i] = (char) ( 'a' + ( i % 26 ) );
+            }
+            in.text_length = length;
+            serialize_write_stream_init( &w, buffer, sizeof( buffer ) );
+            check( write_chat( &w, &in ), "write Chat boundary length" );
+            serialize_write_flush( &w );
+
+            memset( &out, 0xEF, sizeof( out ) ); /* dirty — the reader must supply the terminator */
+            serialize_read_stream_init( &r, buffer, serialize_write_bytes_processed( &w ) );
+            check( read_chat( &r, &out ), "read Chat boundary length" );
+            check( out.text_length == length && memcmp( out.text, in.text, (size_t) length ) == 0,
+                   "Chat boundary length round-trips" );
+            check( out.text[length] == 0, "the reader supplies the terminator" );
+        }
+    }
+
     /* ---- ProbeBits: the full-range uint32/uint64 paths ---- */
     {
         ProbeBits in, out;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -274,6 +274,86 @@ int main()
         check( std::strcmp( out.text, "hello" ) == 0 );
     }
 
+    // ---- Chat: an interior null is content the read REFUSES (SPEC §4.7) ----
+    // A conforming writer cannot produce one (the write side asserts), so the
+    // hostile stream is doctored after the write: the wire is 9 length bits
+    // riding bytes 0-1, align padding to byte 2, then the text bytes —
+    // buffer[2 + k] is text[k]. The vectors pin every branch of the word-wise
+    // scan: a null inside a full word, a null in the final byte of an
+    // eight-multiple payload, a null the overlapping tail word judges, and a
+    // null on the short-string per-byte path.
+    {
+        Chat in;
+        std::memcpy( in.text, "interior null defense s", 23 ); // 2 words + 7-byte tail
+        in.text_length = 23;
+        serialize::WriteStream ws( buffer, sizeof( buffer ) );
+        check( WriteChat( ws, in ) );
+        ws.Flush();
+
+        buffer[2 + 11] = 0; // inside the second full scan word
+        {
+            Chat out;
+            serialize::ReadStream rs( buffer, ws.GetBytesProcessed() );
+            check( !ReadChat( rs, out ) );
+        }
+        buffer[2 + 11] = 'x';
+        buffer[2 + 22] = 0; // the FINAL payload byte — the overlapping tail word judges it
+        {
+            Chat out;
+            serialize::ReadStream rs( buffer, ws.GetBytesProcessed() );
+            check( !ReadChat( rs, out ) );
+        }
+
+        std::memcpy( in.text, "sixteen bytes ok", 16 ); // two exact words, no tail
+        in.text_length = 16;
+        serialize::WriteStream ws2( buffer, sizeof( buffer ) );
+        check( WriteChat( ws2, in ) );
+        ws2.Flush();
+        buffer[2 + 15] = 0; // last byte of an eight-multiple payload
+        {
+            Chat out;
+            serialize::ReadStream rs( buffer, ws2.GetBytesProcessed() );
+            check( !ReadChat( rs, out ) );
+        }
+
+        std::memcpy( in.text, "hello", 5 ); // below one word: the per-byte path
+        in.text_length = 5;
+        serialize::WriteStream ws3( buffer, sizeof( buffer ) );
+        check( WriteChat( ws3, in ) );
+        ws3.Flush();
+        buffer[2 + 2] = 0;
+        {
+            Chat out;
+            serialize::ReadStream rs( buffer, ws3.GetBytesProcessed() );
+            check( !ReadChat( rs, out ) );
+        }
+    }
+
+    // ---- Chat: the accept neighbors — 0x00 nowhere in [0, length) passes at
+    // every word-scan boundary: empty, one byte, one exact word, a word plus
+    // a one-byte tail, two exact words (SPEC §4.7) ----
+    {
+        const int32_t boundary_lengths[] = { 0, 1, 8, 9, 16 };
+        for ( int32_t length : boundary_lengths )
+        {
+            Chat in;
+            for ( int32_t i = 0; i < length; i++ )
+                in.text[i] = char( 'a' + ( i % 26 ) );
+            in.text_length = length;
+            serialize::WriteStream ws( buffer, sizeof( buffer ) );
+            check( WriteChat( ws, in ) );
+            ws.Flush();
+
+            Chat out;
+            out.text[length] = 'Z'; // dirty — the reader must supply the terminator
+            serialize::ReadStream rs( buffer, ws.GetBytesProcessed() );
+            check( ReadChat( rs, out ) );
+            check( out.text_length == length );
+            check( std::memcmp( out.text, in.text, size_t( length ) ) == 0 );
+            check( out.text[length] == 0 );
+        }
+    }
+
     // ---- InputPacket: counted array of a nested type ----
     {
         InputPacket in;

--- a/testdata/golden/c/MessagesWire.h
+++ b/testdata/golden/c/MessagesWire.h
@@ -129,6 +129,49 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 }
 #endif /* SCHEMA_UTF8_VALID_DEFINED */
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+/* string(N) carries bytes excluding 0x00: an interior null is content every
+   generated reader refuses (SPEC §4.7) — generated-code validation; no
+   serialize primitive performs it. The scan is word-wise: eight bytes per
+   step under the zero-byte idiom, and a payload of eight bytes or more
+   re-tests its final eight bytes as one whole (overlapping) word, so every
+   load stays inside the payload the stream already delivered. */
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const serialize_uint8_t * bytes, int32_t length )
+{
+    serialize_uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+#endif /* SCHEMA_INTERIOR_NULL_DEFINED */
+
 /* Writes Heartbeat. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
@@ -296,6 +339,10 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t
     if ( !serialize_read_bytes( stream, (serialize_uint8_t *) value->text, (int) value->text_length ) )
     {
         return 0;
+    }
+    if ( schema_interior_null_( (const serialize_uint8_t *) value->text, value->text_length ) )
+    {
+        return 0; /* an interior null is content the read refuses (SPEC §4.7) */
     }
     value->text[value->text_length] = 0;
     return 1;

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -129,6 +129,49 @@ static SCHEMA_UNUSED int schema_utf8_valid_( const serialize_uint8_t * bytes, in
 }
 #endif /* SCHEMA_UTF8_VALID_DEFINED */
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+/* string(N) carries bytes excluding 0x00: an interior null is content every
+   generated reader refuses (SPEC §4.7) — generated-code validation; no
+   serialize primitive performs it. The scan is word-wise: eight bytes per
+   step under the zero-byte idiom, and a payload of eight bytes or more
+   re-tests its final eight bytes as one whole (overlapping) word, so every
+   load stays inside the payload the stream already delivered. */
+static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const serialize_uint8_t * bytes, int32_t length )
+{
+    serialize_uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
+            {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+#endif /* SCHEMA_INTERIOR_NULL_DEFINED */
+
 /* Writes ProbeHeader. Returns 1 on success, 0 on failure — the stream latches the
    error, so a caller may check once at the end of a message. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
@@ -970,6 +1013,10 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
     if ( !serialize_read_bytes( stream, (serialize_uint8_t *) value->text, (int) value->text_length ) )
     {
         return 0;
+    }
+    if ( schema_interior_null_( (const serialize_uint8_t *) value->text, value->text_length ) )
+    {
+        return 0; /* an interior null is content the read refuses (SPEC §4.7) */
     }
     value->text[value->text_length] = 0;
     return 1;

--- a/testdata/golden/union/MessagesWire.h
+++ b/testdata/golden/union/MessagesWire.h
@@ -107,6 +107,49 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
 }
 #endif // SCHEMA_UTF8_VALID_DEFINED
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+// string(N) carries bytes excluding 0x00: an interior null is content every
+// generated reader refuses (SPEC §4.7) — generated-code validation; no
+// serialize primitive performs it. The scan is word-wise: eight bytes per
+// step under the zero-byte idiom, and a payload of eight bytes or more
+// re-tests its final eight bytes as one whole (overlapping) word, so every
+// load stays inside the payload the stream already delivered.
+SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t length )
+{
+    uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // SCHEMA_INTERIOR_NULL_DEFINED
+
 inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
 {
     (void) stream;
@@ -190,12 +233,9 @@ SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
 {
     read_int( stream, value.text_length, 0, MaxChatLength );
     read_bytes( stream, value.text, value.text_length );
-    for ( int32_t i = 0; i < value.text_length; i++ )
+    if ( schema_interior_null( reinterpret_cast<const uint8_t *>( value.text ), value.text_length ) )
     {
-        if ( value.text[i] == 0 )
-        {
-            return false;
-        }
+        return false; // an interior null is content the read refuses (SPEC §4.7)
     }
     value.text[value.text_length] = 0;
     return true;

--- a/testdata/golden/union/WireWire.h
+++ b/testdata/golden/union/WireWire.h
@@ -107,6 +107,49 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
 }
 #endif // SCHEMA_UTF8_VALID_DEFINED
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+// string(N) carries bytes excluding 0x00: an interior null is content every
+// generated reader refuses (SPEC §4.7) — generated-code validation; no
+// serialize primitive performs it. The scan is word-wise: eight bytes per
+// step under the zero-byte idiom, and a payload of eight bytes or more
+// re-tests its final eight bytes as one whole (overlapping) word, so every
+// load stays inside the payload the stream already delivered.
+SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t length )
+{
+    uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // SCHEMA_INTERIOR_NULL_DEFINED
+
 inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {
     write_bits( stream, 171ull, 8 ); // const(171, 8) — SPEC §4.3
@@ -433,12 +476,9 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
     read_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     read_int( stream, value.text_length, 0, 255 );
     read_bytes( stream, value.text, value.text_length );
-    for ( int32_t i = 0; i < value.text_length; i++ )
+    if ( schema_interior_null( reinterpret_cast<const uint8_t *>( value.text ), value.text_length ) )
     {
-        if ( value.text[i] == 0 )
-        {
-            return false;
-        }
+        return false; // an interior null is content the read refuses (SPEC §4.7)
     }
     value.text[value.text_length] = 0;
     return true;

--- a/testdata/golden/variant/MessagesWire.h
+++ b/testdata/golden/variant/MessagesWire.h
@@ -107,6 +107,49 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
 }
 #endif // SCHEMA_UTF8_VALID_DEFINED
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+// string(N) carries bytes excluding 0x00: an interior null is content every
+// generated reader refuses (SPEC §4.7) — generated-code validation; no
+// serialize primitive performs it. The scan is word-wise: eight bytes per
+// step under the zero-byte idiom, and a payload of eight bytes or more
+// re-tests its final eight bytes as one whole (overlapping) word, so every
+// load stays inside the payload the stream already delivered.
+SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t length )
+{
+    uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // SCHEMA_INTERIOR_NULL_DEFINED
+
 inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
 {
     (void) stream;
@@ -190,12 +233,9 @@ SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
 {
     read_int( stream, value.text_length, 0, MaxChatLength );
     read_bytes( stream, value.text, value.text_length );
-    for ( int32_t i = 0; i < value.text_length; i++ )
+    if ( schema_interior_null( reinterpret_cast<const uint8_t *>( value.text ), value.text_length ) )
     {
-        if ( value.text[i] == 0 )
-        {
-            return false;
-        }
+        return false; // an interior null is content the read refuses (SPEC §4.7)
     }
     value.text[value.text_length] = 0;
     return true;

--- a/testdata/golden/variant/WireWire.h
+++ b/testdata/golden/variant/WireWire.h
@@ -107,6 +107,49 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
 }
 #endif // SCHEMA_UTF8_VALID_DEFINED
 
+#ifndef SCHEMA_INTERIOR_NULL_DEFINED
+#define SCHEMA_INTERIOR_NULL_DEFINED
+// string(N) carries bytes excluding 0x00: an interior null is content every
+// generated reader refuses (SPEC §4.7) — generated-code validation; no
+// serialize primitive performs it. The scan is word-wise: eight bytes per
+// step under the zero-byte idiom, and a payload of eight bytes or more
+// re-tests its final eight bytes as one whole (overlapping) word, so every
+// load stays inside the payload the stream already delivered.
+SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t length )
+{
+    uint64_t word;
+    int32_t i = 0;
+    if ( length >= 8 )
+    {
+        for ( ; i + 8 <= length; i += 8 )
+        {
+            memcpy( &word, bytes + i, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        if ( i < length )
+        {
+            memcpy( &word, bytes + length - 8, 8 );
+            if ( ( ( word - 0x0101010101010101ull ) & ~word & 0x8080808080808080ull ) != 0 )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    for ( ; i < length; i++ )
+    {
+        if ( bytes[i] == 0 )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+#endif // SCHEMA_INTERIOR_NULL_DEFINED
+
 inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {
     write_bits( stream, 171ull, 8 ); // const(171, 8) — SPEC §4.3
@@ -433,12 +476,9 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
     read_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
     read_int( stream, value.text_length, 0, 255 );
     read_bytes( stream, value.text, value.text_length );
-    for ( int32_t i = 0; i < value.text_length; i++ )
+    if ( schema_interior_null( reinterpret_cast<const uint8_t *>( value.text ), value.text_length ) )
     {
-        if ( value.text[i] == 0 )
-        {
-            return false;
-        }
+        return false; // an interior null is content the read refuses (SPEC §4.7)
     }
     value.text[value.text_length] = 0;
     return true;


### PR DESCRIPTION
## The finding

SPEC §4.7: `string(N)` carries bytes excluding 0x00, and **all generated readers reject interior nulls** — the check is generated-code validation, no serialize primitive performs it. Four backends emit it (C++, C#, Go, Rust). The fifth never did: the C emitter's string read (`internal/codegen/c/fields.go`) went length → bytes → terminator with no scan, so **generated C readers accepted streams the other four refuse**. No golden could see it — conforming writers cannot produce an interior null (the write side asserts), so byte-identical wire went in and divergent verdicts came out only on hostile input.

The post-law anomaly investigation caught it from the other direction: the paired 2026-08-16 M2 ledger has `cpp chat read` at 131.6M msgs/s against `c chat read` at 208.9M — a 1.59x ratio that turned out to be a comparison between **nonequivalent readers**. The annotated disassembly of both bench binaries (`objdump_cpp.txt` / `objdump_c_409.txt` in the investigation scratchpad) shows why: the C++ read path pays a serial per-byte scan — a dependent load-compare-branch, ~4 instructions per payload byte — for a §4.7 obligation the C read path was not performing at all.

## The fix — both halves, one shape

Per the Implementation Law: among correct implementations, the fastest correct shape wins.

1. **C pays its obligation.** The refusal lands after the string bytes read, refusing through the same read-fail path every other refusal uses (`return 0`).
2. **C++ sheds the naive shape.** The per-byte loop is replaced by the same scan.

Both emitters converge on one generated helper per backend (`schema_interior_null` / `schema_interior_null_`), emitted beside the UTF-8 validator under the same `fileHasStrings` trigger, spelled with the read spine's demand switch (`SCHEMA_READ_INLINE` / `SCHEMA_C_READ_INLINE`) so the armed builds inline it into the spine:

- **Word-wise**: eight bytes per step under the `((w - 0x0101010101010101) & ~w & 0x8080808080808080)` zero-byte idiom.
- **The tail**: a payload of eight bytes or more re-tests its **final eight bytes as one whole, overlapping word**. Every load stays inside the payload the stream already delivered — in-bounds over the destination buffer by construction, no masking, and no endianness dependence (the idiom reports a zero byte wherever it sits in the word). A shorter payload takes a per-byte tail bounded at seven.

One deliberate deviation from the enactment brief, recorded honestly: the brief allowed the tail word to be loaded whole from the **source** buffer under the align-up slack contract (serialize.c #21, schema #50), masked down to the remaining length. The C++ `ReadStream` exposes no source pointer — the classic API has no read-side `GetData()` — so the source shape is unimplementable in generated C++ without an upstream serialize change. The overlapping-tail shape achieves the same whole-word tail load with fewer operations (no mask, no byte-order fixup), needs no reach into the C stream struct's internals, and — the point of the PR — lets **both** emitters converge on the identical scan. The slack contract stays what it was: the runtime's own load-window requirement.

The emitted C (C++ is the same shape, `bool`/`true` spellings):

```c
static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const serialize_uint8_t * bytes, int32_t length )
{
    serialize_uint64_t word;
    int32_t i = 0;
    if ( length >= 8 )
    {
        for ( ; i + 8 <= length; i += 8 )
        {
            memcpy( &word, bytes + i, 8 );
            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
            {
                return 1;
            }
        }
        if ( i < length )
        {
            memcpy( &word, bytes + length - 8, 8 );
            if ( ( ( word - 0x0101010101010101ULL ) & ~word & 0x8080808080808080ULL ) != 0 )
            {
                return 1;
            }
        }
        return 0;
    }
    for ( ; i < length; i++ )
    {
        if ( bytes[i] == 0 )
        {
            return 1;
        }
    }
    return 0;
}
```

Call sites (generated):

```c
if ( schema_interior_null_( (const serialize_uint8_t *) value->text, value->text_length ) )
{
    return 0; /* an interior null is content the read refuses (SPEC §4.7) */
}
```

```cpp
if ( schema_interior_null( reinterpret_cast<const uint8_t *>( value.text ), value.text_length ) )
{
    return false; // an interior null is content the read refuses (SPEC §4.7)
}
```

## Tests

Doctored-stream idiom (write clean, doctor the flushed byte — a conforming writer cannot produce the vector), in both `test/main.cpp` and `test/c/main.c`, pinning every branch of the scan:

- a null inside a full scan word (`text[11]` of a 23-byte payload) — **refused**
- a null in the final payload byte, judged only by the overlapping tail word (`text[22]` of 23) — **refused**
- a null in the last byte of an eight-multiple payload (`text[15]` of 16) — **refused**
- a null on the short-string per-byte path (`text[2]` of 5) — **refused**
- accept neighbors: 0x00 nowhere in `[0, length)` round-trips at the scan's boundary lengths **0, 1, 8, 9, 16**, with a dirtied terminator byte proving the reader supplies it

The C twin is the compliance receipt: rebuilt against the pre-change generated C, **all four hostile vectors FAIL** — the old C reader accepted every one of them.

## Gates

- `make test` fully green — all five language legs, both C++ message representations, the randomized suite, both ludicrous legs, the bench-corpus twins, `go test ./...`.
- **Wire bytes unchanged**: refusal-only; zero `.bin` goldens moved under `testdata/wire/` and `testdata/table/`. Source goldens re-pinned deliberately (`make update-goldens`).
- `bench/tools/inline-gate.sh leg cpp` — PASS (34 legs within budget, 0 unguarded; `chat read` stays hot-0).
- `bench/tools/inline-gate.sh leg c` — PASS (34 legs, 0 unguarded; the under-budget notes on `probearray`/`testdata` rows predate this change — budgets set before the #52 demand switch).

The chat-read ratio between C and C++ is a comparison between equivalent readers again; the next paired bench pass measures what the convergence is worth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
