### PR TITLE
bench: the tournament pass — winners named, read parity reached armed

### DIFF
--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-armed-pair-O3.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-armed-pair-O3.csv
@@ -1,0 +1,109 @@
+# schema bench results
+# date: 2026-08-16T12:28:07Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -DSCHEMA_READ_SPINE_DEMAND -DSERIALIZE_READ_SPINE_DEMAND -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-armed] tournament, hotel window, Air on external power, machine exclusively ours during rounds
+# schema commit: 194c17c
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.10 1.57 1.60
+# load_end: 2.22 1.97 1.77
+# load_max: 2.31
+# control_start_median: 103791359   control_end_median: 103544559
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema 194c17c
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+# era: PAIR FILE — cpp rows are leg cpp-armed, c rows are leg c-armed, same pass, same rounds, same window;
+# era:   assembled row-for-row from the stamped leg CSVs for the cross-language ratio read.
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,58421618,58222015,58643962,5850.10,0.72,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,308379737,307929338,308510553,30879.85,0.19,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,104561154,100995808,107062829,5683.89,5.80,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,487086805,485647781,487778549,26477.76,0.44,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,98430352,98079272,101089937,1220.32,3.06,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,227512143,226588732,233169919,2820.64,2.89,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,765991060,759719561,769040767,4383.04,1.22,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1040653695,1031974638,1044188099,5954.67,1.17,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66078761,65820305,66257607,3844.07,0.66,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,136710948,136499603,136836148,7953.04,0.25,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,99746180,98295042,99780236,2663.51,1.49,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,217430817,199229903,223612815,5806.03,11.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,121427917,104353583,121570597,3242.48,14.18,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,266247050,235051289,268119820,7109.56,12.42,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1059679222,1041642122,1086211301,10105.89,4.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1430130312,1428408691,1431137014,13638.79,0.19,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,188587799,186151684,189907046,4676.13,1.99,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,774807065,771745472,775704489,19211.75,0.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73896404,73840644,73997256,3312.24,0.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,139413950,139124103,139986054,6248.91,0.62,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,28008070,27985507,28024836,2457.37,0.14,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,69450976,69377120,69677990,6093.49,0.43,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,message_batch,write,26214400,25,7,91924121,69719018,93791263,2191.64,26.19,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,126073880,125473078,136485972,3005.84,8.74,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,80227554,79507896,83920733,3749.04,5.50,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,137126671,136592245,137616060,6407.94,0.75,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,183818003,181752365,187634825,2454.24,3.20,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191495677,191429464,191634782,2556.74,0.11,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,186021967,180559876,190364861,3548.09,5.27,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,205006719,199019312,233224157,3910.19,16.68,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,150118030,146856244,153986271,3006.44,4.75,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,180620714,164899890,187379557,3617.32,12.45,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,62049,60606,62253,3877.00,2.65,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,94183,93479,96043,5884.82,2.72,6b118770d85af4f6,bits,hdr,removed,O3,full
+c,rigidbody_moving,write,24000000,105,7,607764189,581705365,617553972,60858.96,5.90,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,456065673,454829724,461565089,45668.50,1.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,826254230,819903147,828157346,44914.71,1.00,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,484966052,482305420,485400076,26362.48,0.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75112904,75062513,75196451,931.23,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,188799471,188459968,191896376,2340.69,1.82,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,764842729,759956619,766421172,4376.47,0.85,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1043920793,1037086651,1045262023,5973.36,0.78,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,101614399,101521554,101693838,5911.33,0.17,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,242747907,242009892,243087207,14121.65,0.44,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,457737916,452591084,462167275,12222.92,2.09,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,253387072,249569103,255132549,6766.16,2.20,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,434522840,433293163,436210964,11603.01,0.67,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,288918182,286399599,290483928,7714.95,1.41,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,1085444863,1053424245,1099798083,10351.61,4.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,1431319049,1422838787,1432320080,13650.12,0.66,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,597438483,594767901,601294663,14813.81,1.09,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,771865502,770142536,775113997,19138.82,0.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,81226191,79062946,81326930,3640.78,2.79,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,146207381,145602796,146637242,6553.41,0.71,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,28984877,28959486,29026102,2543.08,0.23,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,55733593,55711858,55771671,4889.96,0.11,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,89729556,77350746,128712696,2139.32,57.24,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,read,26214400,25,7,125044242,110225123,138517305,2981.29,22.63,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84997649,84922535,85073802,3971.94,0.18,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,121684108,117463091,121933097,5686.30,3.67,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,191781216,188465888,192177418,2560.56,1.94,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,161037727,160411938,161130492,2150.09,0.45,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192447247,191987713,192600915,3670.64,0.32,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,220910057,219058051,221091177,4213.52,0.92,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159259127,158971139,159603545,3189.51,0.40,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171315014,171076886,171504523,3430.95,0.25,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,61943,60582,62226,3870.37,2.65,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,53034,52977,53073,3313.71,0.18,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-armed-pair-O3.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-armed-pair-O3.inline
@@ -1,0 +1,159 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-cpp-armed-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:40:08Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 24 1 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=45)
+remark 3 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=45)
+remark 3 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=45)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into '_ZL11build_batchRxPhi' because too costly to inline (cost=1555, threshold=325)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr STATS groups 178 untimed 161 unattributed 0 unroll-dedup 1
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read full hot=0 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 6 17 1 0 0
+symbol _bench_message_testdata 4 4 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+symbol _build_batch 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N chat write 1 0
+attr N testdata write 1 0
+attr N message_batch write 1 0
+attr STATS groups 103 untimed 99 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:1 hot=1 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-armed-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-armed-O3-pass.csv
@@ -1,0 +1,73 @@
+# schema bench results
+# date: 2026-08-16T12:28:07Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -DSCHEMA_C_READ_SPINE_DEMAND -DSCHEMA_C_WRITE_SPINE_DEMAND -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg c-armed] tournament, hotel window, Air on external power, machine exclusively ours during rounds
+# schema commit: 194c17c
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.10 1.57 1.60
+# load_end: 2.22 1.97 1.77
+# load_max: 2.31
+# control_start_median: 103791359   control_end_median: 103544559
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema 194c17c
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,rigidbody_moving,write,24000000,105,7,607764189,581705365,617553972,60858.96,5.90,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,456065673,454829724,461565089,45668.50,1.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,826254230,819903147,828157346,44914.71,1.00,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,484966052,482305420,485400076,26362.48,0.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75112904,75062513,75196451,931.23,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,188799471,188459968,191896376,2340.69,1.82,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,764842729,759956619,766421172,4376.47,0.85,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1043920793,1037086651,1045262023,5973.36,0.78,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,101614399,101521554,101693838,5911.33,0.17,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,242747907,242009892,243087207,14121.65,0.44,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,457737916,452591084,462167275,12222.92,2.09,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,253387072,249569103,255132549,6766.16,2.20,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,434522840,433293163,436210964,11603.01,0.67,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,288918182,286399599,290483928,7714.95,1.41,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,1085444863,1053424245,1099798083,10351.61,4.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,1431319049,1422838787,1432320080,13650.12,0.66,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,597438483,594767901,601294663,14813.81,1.09,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,771865502,770142536,775113997,19138.82,0.64,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,81226191,79062946,81326930,3640.78,2.79,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,146207381,145602796,146637242,6553.41,0.71,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,28984877,28959486,29026102,2543.08,0.23,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,55733593,55711858,55771671,4889.96,0.11,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,89729556,77350746,128712696,2139.32,57.24,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,read,26214400,25,7,125044242,110225123,138517305,2981.29,22.63,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84997649,84922535,85073802,3971.94,0.18,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,121684108,117463091,121933097,5686.30,3.67,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,191781216,188465888,192177418,2560.56,1.94,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,161037727,160411938,161130492,2150.09,0.45,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192447247,191987713,192600915,3670.64,0.32,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,220910057,219058051,221091177,4213.52,0.92,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159259127,158971139,159603545,3189.51,0.40,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171315014,171076886,171504523,3430.95,0.25,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,61943,60582,62226,3870.37,2.65,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,53034,52977,53073,3313.71,0.18,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-armed-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-armed-O3-pass.inline
@@ -1,0 +1,63 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-c-armed-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:40:12Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 6 17 1 0 0
+symbol _bench_message_testdata 4 4 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+symbol _build_batch 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N chat write 1 0
+attr N testdata write 1 0
+attr N message_batch write 1 0
+attr STATS groups 103 untimed 99 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:1 hot=1 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-off-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-off-O3-pass.csv
@@ -1,0 +1,73 @@
+# schema bench results
+# date: 2026-08-16T12:28:07Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg c-off] tournament, hotel window, Air on external power, machine exclusively ours during rounds
+# schema commit: 194c17c
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.10 1.57 1.60
+# load_end: 2.22 1.97 1.77
+# load_max: 2.31
+# control_start_median: 103791359   control_end_median: 103544559
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema 194c17c
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,rigidbody_moving,write,24000000,105,7,55132997,54800651,55167087,5520.79,0.66,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,57910027,51925573,60209831,5798.87,14.31,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,109335174,108914665,109475067,5943.40,0.51,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,115637433,112431004,116907362,6285.99,3.87,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75467545,75415374,75497101,935.63,0.11,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,170236309,170139160,171218828,2110.55,0.63,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,764879292,763504486,768233543,4376.67,0.62,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1043047437,1036442843,1046247405,5968.37,0.94,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,73831047,73719810,73858994,4295.06,0.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,43230391,43174864,44766765,2514.89,3.68,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,83546769,83487699,83641544,2230.94,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,111020907,110901246,111261004,2964.58,0.32,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,86133572,86072871,86201555,2300.01,0.15,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,113782633,113719149,114012085,3038.32,0.26,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,305319840,304028617,306030108,2911.76,0.66,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,319836883,319772562,320234171,3050.20,0.14,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,190482993,188942160,190548497,4723.13,0.84,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,258757318,258219656,258980870,6416.03,0.29,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,77196531,77155731,77268407,3460.16,0.15,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,77190870,76712413,78555830,3459.90,2.39,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,24310937,24157799,24418012,2132.99,1.07,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,23583237,23199232,23967955,2069.15,3.26,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,82798440,71107060,85121914,1974.07,16.93,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,102104058,93681408,104875639,2434.35,10.96,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84974401,84935608,85006907,3970.86,0.08,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,123585048,118984763,124136861,5775.13,4.17,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,191945948,190047227,192097124,2562.75,1.07,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,160763304,160490459,161862061,2146.42,0.85,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192581596,191978498,193106889,3673.20,0.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,219863776,211066944,221161466,4193.57,4.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159096966,158684820,159277517,3186.26,0.37,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171108354,170973781,171679714,3426.81,0.41,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,62269,60713,62382,3890.74,2.68,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,53021,51624,53066,3312.90,2.72,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-off-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-c-off-O3-pass.inline
@@ -1,0 +1,83 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-c-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:40:10Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 24 1 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_test_data 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N chat write 1 0
+attr N chat read 0 0
+attr N probebits write 0 0
+attr N testdata write 1 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 0 0
+attr STATS groups 167 untimed 143 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-armed-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-armed-O3-pass.csv
@@ -1,0 +1,73 @@
+# schema bench results
+# date: 2026-08-16T12:28:07Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -DSCHEMA_READ_SPINE_DEMAND -DSERIALIZE_READ_SPINE_DEMAND -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-armed] tournament, hotel window, Air on external power, machine exclusively ours during rounds
+# schema commit: 194c17c
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.10 1.57 1.60
+# load_end: 2.22 1.97 1.77
+# load_max: 2.31
+# control_start_median: 103791359   control_end_median: 103544559
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema 194c17c
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,58421618,58222015,58643962,5850.10,0.72,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,308379737,307929338,308510553,30879.85,0.19,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,104561154,100995808,107062829,5683.89,5.80,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,487086805,485647781,487778549,26477.76,0.44,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,98430352,98079272,101089937,1220.32,3.06,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,227512143,226588732,233169919,2820.64,2.89,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,765991060,759719561,769040767,4383.04,1.22,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1040653695,1031974638,1044188099,5954.67,1.17,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66078761,65820305,66257607,3844.07,0.66,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,136710948,136499603,136836148,7953.04,0.25,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,99746180,98295042,99780236,2663.51,1.49,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,217430817,199229903,223612815,5806.03,11.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,121427917,104353583,121570597,3242.48,14.18,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,266247050,235051289,268119820,7109.56,12.42,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1059679222,1041642122,1086211301,10105.89,4.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1430130312,1428408691,1431137014,13638.79,0.19,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,188587799,186151684,189907046,4676.13,1.99,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,774807065,771745472,775704489,19211.75,0.51,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73896404,73840644,73997256,3312.24,0.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,139413950,139124103,139986054,6248.91,0.62,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,28008070,27985507,28024836,2457.37,0.14,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,69450976,69377120,69677990,6093.49,0.43,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,message_batch,write,26214400,25,7,91924121,69719018,93791263,2191.64,26.19,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,126073880,125473078,136485972,3005.84,8.74,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,80227554,79507896,83920733,3749.04,5.50,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,137126671,136592245,137616060,6407.94,0.75,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,183818003,181752365,187634825,2454.24,3.20,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191495677,191429464,191634782,2556.74,0.11,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,186021967,180559876,190364861,3548.09,5.27,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,205006719,199019312,233224157,3910.19,16.68,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,150118030,146856244,153986271,3006.44,4.75,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,180620714,164899890,187379557,3617.32,12.45,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,62049,60606,62253,3877.00,2.65,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,94183,93479,96043,5884.82,2.72,6b118770d85af4f6,bits,hdr,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-armed-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-armed-O3-pass.inline
@@ -1,0 +1,108 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-cpp-armed-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:40:08Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 24 1 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=45)
+remark 3 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=45)
+remark 3 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=45)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into '_ZL11build_batchRxPhi' because too costly to inline (cost=1555, threshold=325)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr STATS groups 178 untimed 161 unattributed 0 unroll-dedup 1
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read full hot=0 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-off-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-off-O3-pass.csv
@@ -1,0 +1,73 @@
+# schema bench results
+# date: 2026-08-16T12:28:07Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-off] tournament, hotel window, Air on external power, machine exclusively ours during rounds
+# schema commit: 194c17c
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.10 1.57 1.60
+# load_end: 2.22 1.97 1.77
+# load_max: 2.31
+# control_start_median: 103791359   control_end_median: 103544559
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema 194c17c
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,59692435,59465099,60075908,5977.35,1.02,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,92785194,91413887,93768940,9291.12,2.54,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,105880577,104681427,107019787,5755.61,2.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,141493191,135344754,141983690,7691.49,4.69,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,94960162,94251733,98582205,1177.29,4.56,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,227548409,226684683,232926978,2821.09,2.74,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,757925779,755009803,767118709,4336.89,1.60,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1040255960,1037823584,1045573197,5952.39,0.74,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66049221,65665653,66087438,3842.36,0.64,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,47696821,44479539,48054885,2774.72,7.50,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,100025384,99893031,100270836,2670.97,0.38,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,115561708,113773261,118826496,3085.83,4.37,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,125533210,123906401,125956854,3352.10,1.63,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,125207293,123966742,126345880,3343.40,1.90,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1067248464,1045876780,1095033552,10178.07,4.61,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1429803829,1415269382,1431331727,13635.67,1.12,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,188185699,186828687,189836352,4666.16,1.60,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,776337669,773597751,781045810,19249.71,0.96,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73820862,72280285,73914690,3308.85,2.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,76081559,72245918,82209053,3410.18,13.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27813486,27791171,27833320,2440.30,0.15,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,33169358,33115787,33195853,2910.21,0.24,6b118770d85af4f6,gen,hdr,removed,O3,partial:5
+cpp,message_batch,write,26214400,25,7,86099162,69241060,93812534,2052.76,28.54,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,75176115,73944359,76892098,1792.34,3.92,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,82536306,82319745,82642174,3856.93,0.39,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,113146687,110334872,113244906,5287.35,2.57,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,183276375,181624105,186340069,2447.00,2.57,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191363449,176719686,191600666,2554.98,7.78,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,181689370,180542247,189376349,3465.45,4.86,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,229467674,210747848,241174874,4376.75,13.26,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,151385556,148989132,154034476,3031.82,3.33,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,177824572,167349808,187061940,3561.32,11.09,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,61074,60512,62245,3816.08,2.84,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,94467,93339,96136,5902.57,2.96,6b118770d85af4f6,bits,hdr,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-off-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-cpp-off-O3-pass.inline
@@ -1,0 +1,117 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-cpp-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:40:06Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 34 1 0 0
+symbol __ZN7example12ReadTestDataERN9serialize10ReadStreamERNS_8TestDataE 5 5 0 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=505, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example20ReadShipData_ShallowERN9serialize10ReadStreamERNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=750, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=45)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=325)
+remark 2 '_ZN7example15ReadInputPacketERN9serialize10ReadStreamERNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=335, threshold=325)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 5 0
+attr STATS groups 204 untimed 177 unattributed 0 unroll-dedup 3
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read partial:5 hot=5 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-off-pair-O3.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-off-pair-O3.csv
@@ -1,0 +1,109 @@
+# schema bench results
+# date: 2026-08-16T12:28:07Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-off] tournament, hotel window, Air on external power, machine exclusively ours during rounds
+# schema commit: 194c17c
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.10 1.57 1.60
+# load_end: 2.22 1.97 1.77
+# load_max: 2.31
+# control_start_median: 103791359   control_end_median: 103544559
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema 194c17c
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+# era: PAIR FILE — cpp rows are leg cpp-off, c rows are leg c-off, same pass, same rounds, same window;
+# era:   assembled row-for-row from the stamped leg CSVs for the cross-language ratio read.
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,59692435,59465099,60075908,5977.35,1.02,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,92785194,91413887,93768940,9291.12,2.54,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,105880577,104681427,107019787,5755.61,2.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,141493191,135344754,141983690,7691.49,4.69,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,94960162,94251733,98582205,1177.29,4.56,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,227548409,226684683,232926978,2821.09,2.74,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,757925779,755009803,767118709,4336.89,1.60,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1040255960,1037823584,1045573197,5952.39,0.74,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66049221,65665653,66087438,3842.36,0.64,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,47696821,44479539,48054885,2774.72,7.50,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,100025384,99893031,100270836,2670.97,0.38,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,115561708,113773261,118826496,3085.83,4.37,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,125533210,123906401,125956854,3352.10,1.63,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,125207293,123966742,126345880,3343.40,1.90,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1067248464,1045876780,1095033552,10178.07,4.61,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1429803829,1415269382,1431331727,13635.67,1.12,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,188185699,186828687,189836352,4666.16,1.60,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,776337669,773597751,781045810,19249.71,0.96,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73820862,72280285,73914690,3308.85,2.21,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,76081559,72245918,82209053,3410.18,13.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27813486,27791171,27833320,2440.30,0.15,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,33169358,33115787,33195853,2910.21,0.24,6b118770d85af4f6,gen,hdr,removed,O3,partial:5
+cpp,message_batch,write,26214400,25,7,86099162,69241060,93812534,2052.76,28.54,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,75176115,73944359,76892098,1792.34,3.92,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,82536306,82319745,82642174,3856.93,0.39,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,113146687,110334872,113244906,5287.35,2.57,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,183276375,181624105,186340069,2447.00,2.57,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191363449,176719686,191600666,2554.98,7.78,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,181689370,180542247,189376349,3465.45,4.86,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,229467674,210747848,241174874,4376.75,13.26,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,151385556,148989132,154034476,3031.82,3.33,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,177824572,167349808,187061940,3561.32,11.09,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,61074,60512,62245,3816.08,2.84,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,94467,93339,96136,5902.57,2.96,6b118770d85af4f6,bits,hdr,removed,O3,full
+c,rigidbody_moving,write,24000000,105,7,55132997,54800651,55167087,5520.79,0.66,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,57910027,51925573,60209831,5798.87,14.31,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,109335174,108914665,109475067,5943.40,0.51,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,115637433,112431004,116907362,6285.99,3.87,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75467545,75415374,75497101,935.63,0.11,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,170236309,170139160,171218828,2110.55,0.63,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,764879292,763504486,768233543,4376.67,0.62,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1043047437,1036442843,1046247405,5968.37,0.94,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,73831047,73719810,73858994,4295.06,0.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,43230391,43174864,44766765,2514.89,3.68,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,83546769,83487699,83641544,2230.94,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,111020907,110901246,111261004,2964.58,0.32,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,86133572,86072871,86201555,2300.01,0.15,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,113782633,113719149,114012085,3038.32,0.26,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,305319840,304028617,306030108,2911.76,0.66,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,319836883,319772562,320234171,3050.20,0.14,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,190482993,188942160,190548497,4723.13,0.84,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,258757318,258219656,258980870,6416.03,0.29,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,77196531,77155731,77268407,3460.16,0.15,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,77190870,76712413,78555830,3459.90,2.39,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,24310937,24157799,24418012,2132.99,1.07,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,23583237,23199232,23967955,2069.15,3.26,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,82798440,71107060,85121914,1974.07,16.93,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,102104058,93681408,104875639,2434.35,10.96,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84974401,84935608,85006907,3970.86,0.08,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,123585048,118984763,124136861,5775.13,4.17,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,191945948,190047227,192097124,2562.75,1.07,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,160763304,160490459,161862061,2146.42,0.85,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192581596,191978498,193106889,3673.20,0.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,219863776,211066944,221161466,4193.57,4.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159096966,158684820,159277517,3186.26,0.37,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171108354,170973781,171679714,3426.81,0.41,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,62269,60713,62382,3890.74,2.68,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,53021,51624,53066,3312.90,2.72,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-off-pair-O3.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-off-pair-O3.inline
@@ -1,0 +1,188 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-cpp-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:40:06Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 34 1 0 0
+symbol __ZN7example12ReadTestDataERN9serialize10ReadStreamERNS_8TestDataE 5 5 0 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=505, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example20ReadShipData_ShallowERN9serialize10ReadStreamERNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=750, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=45)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=325)
+remark 2 '_ZN7example15ReadInputPacketERN9serialize10ReadStreamERNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=335, threshold=325)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 5 0
+attr STATS groups 204 untimed 177 unattributed 0 unroll-dedup 3
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read partial:5 hot=5 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 24 1 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_test_data 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N chat write 1 0
+attr N chat read 0 0
+attr N probebits write 0 0
+attr N testdata write 1 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 0 0
+attr STATS groups 167 untimed 143 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-armed-pair-O3.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-armed-pair-O3.csv
@@ -1,0 +1,111 @@
+# schema bench results
+# date: 2026-08-16T12:43:09Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -DSCHEMA_READ_SPINE_DEMAND -DSERIALIZE_READ_SPINE_DEMAND -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-armed] tournament r2 — the re-measure the armed-pair refusal prescribed; same binaries, fresh window
+# schema commit: bbb0e38
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.44 2.03 1.85
+# load_end: 1.92 1.84 1.82
+# load_max: 2.44
+# control_start_median: 103278508   control_end_median: 103454386
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT R2 — the re-measure the §5.3 refusal prescribed (r1 armed c batch write spread 57.2% INVALID,
+# era:   layout-noise class; r1 rides in the same directory as the failure record). Same binaries, fresh window.
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema bbb0e38
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+# era: PAIR FILE — cpp rows are leg cpp-armed, c rows are leg c-armed, same pass, same rounds, same window;
+# era:   assembled row-for-row from the stamped leg CSVs for the cross-language ratio read.
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,58481177,58402319,58781172,5856.06,0.65,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,308642305,307968856,308748350,30906.15,0.25,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,106463233,101263593,107385343,5787.28,5.75,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,486630955,445364555,487556209,26452.98,8.67,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,98275059,98184783,101065983,1218.39,2.93,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,226650788,226140507,232501018,2809.96,2.81,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,764764663,760405327,770460466,4376.02,1.31,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1043272016,1037058643,1044935634,5969.65,0.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66048687,65816672,66072257,3842.33,0.39,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,136712213,133784392,137090370,7953.11,2.42,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,99720057,99602084,99773794,2662.81,0.17,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,217541183,217150047,217757809,5808.98,0.28,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,121399009,121181730,121450575,3241.70,0.22,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,266256096,264413915,266831213,7109.80,0.91,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1075669044,1052683339,1086014121,10258.38,3.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1429262659,1421462789,1432986209,13630.51,0.81,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,189077221,187983935,189829877,4688.27,0.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,775386917,766404918,777928112,19226.13,1.49,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73887588,73872305,73936641,3311.84,0.09,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,139429257,139160727,139638883,6249.59,0.34,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27999044,27974286,28051962,2456.58,0.28,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,69441079,69342793,69870877,6092.62,0.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,message_batch,write,26214400,25,7,87793720,72060632,93684672,2093.17,24.63,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,126792592,119499291,134549142,3022.97,11.87,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,83681680,79595126,83916588,3910.45,5.16,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,135904212,119274124,137673219,6350.81,13.54,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,185829206,183087869,187821204,2481.09,2.55,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191498963,191393321,191810337,2556.79,0.22,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,181731044,176991776,189830021,3466.24,7.06,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,233807273,194960640,240527456,4459.52,19.49,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,151484214,149286550,153692412,3033.80,2.91,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,177038120,161524197,184826371,3545.57,13.16,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,61558,60558,62223,3846.32,2.70,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,94435,93566,96175,5900.57,2.76,6b118770d85af4f6,bits,hdr,removed,O3,full
+c,rigidbody_moving,write,24000000,105,7,609369049,581071594,615858355,61019.66,5.71,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,457857987,456490729,459145606,45847.98,0.58,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,825231451,810639645,827664695,44859.12,2.06,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,484855832,484320134,488907903,26356.49,0.95,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75047608,74930689,75122544,930.42,0.26,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,188910928,188393397,191214491,2342.07,1.49,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,765864768,764943287,771003831,4382.31,0.79,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1040329003,1038095959,1045837078,5952.81,0.74,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,101618916,101422450,102102677,5911.59,0.67,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,242343461,221269534,242722129,14098.12,8.85,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,455166135,448719746,461720487,12154.25,2.86,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,254232575,251380629,254535909,6788.74,1.24,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,434581851,423336420,435202436,11604.59,2.73,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,288912965,285070332,290033716,7714.81,1.72,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,1080433186,1056018481,1097323132,10303.81,3.82,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,1430615166,1415443819,1431999596,13643.41,1.16,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,597090119,594199131,602219745,14805.17,1.34,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,773628924,769623906,775640055,19182.54,0.78,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,79021399,78934074,79490624,3541.95,0.70,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,146167845,145947051,146345390,6551.64,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,29011365,28945445,29062692,2545.40,0.40,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,55723888,55699834,56294816,4889.10,1.07,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,109762674,98670561,111153796,2616.95,11.37,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,read,26214400,25,7,125558717,123474026,139148159,2993.55,12.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84939441,84888968,85006681,3969.22,0.14,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,121543142,121455492,121679944,5679.72,0.18,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,190867013,189774027,192085132,2548.35,1.21,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,160849931,160509779,161289022,2147.58,0.48,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192604006,192377830,192998187,3673.63,0.32,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,220619665,219606264,220999563,4207.99,0.63,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159333349,158786868,159676177,3190.99,0.56,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171344368,169583503,171454535,3431.54,1.09,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,61906,60429,62222,3868.06,2.90,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,52785,51615,53057,3298.16,2.73,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-armed-pair-O3.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-armed-pair-O3.inline
@@ -1,0 +1,159 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-armed-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:55:16Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 24 1 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=45)
+remark 3 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=45)
+remark 3 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=45)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into '_ZL11build_batchRxPhi' because too costly to inline (cost=1555, threshold=325)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr STATS groups 178 untimed 161 unattributed 0 unroll-dedup 1
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read full hot=0 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 6 17 1 0 0
+symbol _bench_message_testdata 4 4 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+symbol _build_batch 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N chat write 1 0
+attr N testdata write 1 0
+attr N message_batch write 1 0
+attr STATS groups 103 untimed 99 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:1 hot=1 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-armed-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-armed-O3-pass.csv
@@ -1,0 +1,75 @@
+# schema bench results
+# date: 2026-08-16T12:43:09Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -DSCHEMA_C_READ_SPINE_DEMAND -DSCHEMA_C_WRITE_SPINE_DEMAND -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg c-armed] tournament r2 — the re-measure the armed-pair refusal prescribed; same binaries, fresh window
+# schema commit: bbb0e38
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.44 2.03 1.85
+# load_end: 1.92 1.84 1.82
+# load_max: 2.44
+# control_start_median: 103278508   control_end_median: 103454386
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT R2 — the re-measure the §5.3 refusal prescribed (r1 armed c batch write spread 57.2% INVALID,
+# era:   layout-noise class; r1 rides in the same directory as the failure record). Same binaries, fresh window.
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema bbb0e38
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,rigidbody_moving,write,24000000,105,7,609369049,581071594,615858355,61019.66,5.71,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,457857987,456490729,459145606,45847.98,0.58,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,825231451,810639645,827664695,44859.12,2.06,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,484855832,484320134,488907903,26356.49,0.95,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75047608,74930689,75122544,930.42,0.26,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,188910928,188393397,191214491,2342.07,1.49,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,765864768,764943287,771003831,4382.31,0.79,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1040329003,1038095959,1045837078,5952.81,0.74,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,101618916,101422450,102102677,5911.59,0.67,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,242343461,221269534,242722129,14098.12,8.85,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,455166135,448719746,461720487,12154.25,2.86,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,254232575,251380629,254535909,6788.74,1.24,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,434581851,423336420,435202436,11604.59,2.73,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,288912965,285070332,290033716,7714.81,1.72,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,1080433186,1056018481,1097323132,10303.81,3.82,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,1430615166,1415443819,1431999596,13643.41,1.16,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,597090119,594199131,602219745,14805.17,1.34,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,773628924,769623906,775640055,19182.54,0.78,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,79021399,78934074,79490624,3541.95,0.70,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,146167845,145947051,146345390,6551.64,0.27,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,29011365,28945445,29062692,2545.40,0.40,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,55723888,55699834,56294816,4889.10,1.07,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,109762674,98670561,111153796,2616.95,11.37,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,message_batch,read,26214400,25,7,125558717,123474026,139148159,2993.55,12.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84939441,84888968,85006681,3969.22,0.14,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,121543142,121455492,121679944,5679.72,0.18,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,190867013,189774027,192085132,2548.35,1.21,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,160849931,160509779,161289022,2147.58,0.48,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192604006,192377830,192998187,3673.63,0.32,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,220619665,219606264,220999563,4207.99,0.63,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159333349,158786868,159676177,3190.99,0.56,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171344368,169583503,171454535,3431.54,1.09,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,61906,60429,62222,3868.06,2.90,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,52785,51615,53057,3298.16,2.73,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-armed-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-armed-O3-pass.inline
@@ -1,0 +1,63 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-r2-c-armed-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:55:19Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 6 17 1 0 0
+symbol _bench_message_testdata 4 4 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+symbol _build_batch 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N chat write 1 0
+attr N testdata write 1 0
+attr N message_batch write 1 0
+attr STATS groups 103 untimed 99 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:1 hot=1 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-off-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-off-O3-pass.csv
@@ -1,0 +1,75 @@
+# schema bench results
+# date: 2026-08-16T12:43:09Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg c-off] tournament r2 — the re-measure the armed-pair refusal prescribed; same binaries, fresh window
+# schema commit: bbb0e38
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.44 2.03 1.85
+# load_end: 1.92 1.84 1.82
+# load_max: 2.44
+# control_start_median: 103278508   control_end_median: 103454386
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT R2 — the re-measure the §5.3 refusal prescribed (r1 armed c batch write spread 57.2% INVALID,
+# era:   layout-noise class; r1 rides in the same directory as the failure record). Same binaries, fresh window.
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema bbb0e38
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,rigidbody_moving,write,24000000,105,7,55094775,54055637,55178502,5516.96,2.04,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,57848052,53571070,60221313,5792.66,11.50,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,109290737,109105167,109455970,5940.98,0.32,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,114627550,108417978,118201563,6231.09,8.54,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75412886,75397012,75531791,934.95,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,170280395,168187950,171127265,2111.10,1.73,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,766155099,764772659,769971126,4383.97,0.68,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1044437554,1039630498,1045381538,5976.32,0.55,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,73830706,73548340,73888668,4295.04,0.46,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,43271545,43200043,43535046,2517.28,0.77,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,83613569,83523872,83660787,2232.72,0.16,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,110997416,110908165,111079099,2963.95,0.15,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,86103674,86028906,86179269,2299.22,0.17,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,113785869,113720362,113861580,3038.41,0.12,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,305391957,304154682,306815008,2912.44,0.87,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,319869653,317506778,319956806,3050.51,0.77,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,190378735,190339950,190497451,4720.54,0.08,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,258767257,258594740,259086235,6416.27,0.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,77225742,77199809,77260647,3461.47,0.08,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,77438340,77306637,78314362,3470.99,1.30,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,24352453,24227227,24437778,2136.64,0.86,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,23607804,23554976,23668849,2071.30,0.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,78846466,69826675,86396129,1879.85,21.01,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,101407710,97984937,110572892,2417.75,12.41,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84992005,84981848,85017973,3971.68,0.04,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,123472986,116861680,123541153,5769.90,5.41,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,191088584,189471092,192516869,2551.31,1.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,160639345,160475650,161999068,2144.77,0.95,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192320791,192195270,193044758,3668.23,0.44,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,220231978,218216535,220668349,4200.59,1.11,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159261663,158849927,159400654,3189.56,0.35,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171069570,170227978,171662769,3426.04,0.84,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,60969,60550,62214,3809.52,2.73,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,53033,52069,53082,3313.65,1.91,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-off-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-c-off-O3-pass.inline
@@ -1,0 +1,83 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-r2-c-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:55:17Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 24 1 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_test_data 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N chat write 1 0
+attr N chat read 0 0
+attr N probebits write 0 0
+attr N testdata write 1 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 0 0
+attr STATS groups 167 untimed 143 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-armed-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-armed-O3-pass.csv
@@ -1,0 +1,75 @@
+# schema bench results
+# date: 2026-08-16T12:43:09Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -DSCHEMA_READ_SPINE_DEMAND -DSERIALIZE_READ_SPINE_DEMAND -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-armed] tournament r2 — the re-measure the armed-pair refusal prescribed; same binaries, fresh window
+# schema commit: bbb0e38
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.44 2.03 1.85
+# load_end: 1.92 1.84 1.82
+# load_max: 2.44
+# control_start_median: 103278508   control_end_median: 103454386
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT R2 — the re-measure the §5.3 refusal prescribed (r1 armed c batch write spread 57.2% INVALID,
+# era:   layout-noise class; r1 rides in the same directory as the failure record). Same binaries, fresh window.
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema bbb0e38
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,58481177,58402319,58781172,5856.06,0.65,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,308642305,307968856,308748350,30906.15,0.25,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,106463233,101263593,107385343,5787.28,5.75,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,486630955,445364555,487556209,26452.98,8.67,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,98275059,98184783,101065983,1218.39,2.93,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,226650788,226140507,232501018,2809.96,2.81,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,764764663,760405327,770460466,4376.02,1.31,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1043272016,1037058643,1044935634,5969.65,0.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66048687,65816672,66072257,3842.33,0.39,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,136712213,133784392,137090370,7953.11,2.42,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,99720057,99602084,99773794,2662.81,0.17,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,217541183,217150047,217757809,5808.98,0.28,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,121399009,121181730,121450575,3241.70,0.22,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,266256096,264413915,266831213,7109.80,0.91,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1075669044,1052683339,1086014121,10258.38,3.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1429262659,1421462789,1432986209,13630.51,0.81,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,189077221,187983935,189829877,4688.27,0.98,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,775386917,766404918,777928112,19226.13,1.49,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73887588,73872305,73936641,3311.84,0.09,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,139429257,139160727,139638883,6249.59,0.34,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27999044,27974286,28051962,2456.58,0.28,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,69441079,69342793,69870877,6092.62,0.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,message_batch,write,26214400,25,7,87793720,72060632,93684672,2093.17,24.63,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,126792592,119499291,134549142,3022.97,11.87,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,83681680,79595126,83916588,3910.45,5.16,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,135904212,119274124,137673219,6350.81,13.54,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,185829206,183087869,187821204,2481.09,2.55,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191498963,191393321,191810337,2556.79,0.22,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,181731044,176991776,189830021,3466.24,7.06,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,233807273,194960640,240527456,4459.52,19.49,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,151484214,149286550,153692412,3033.80,2.91,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,177038120,161524197,184826371,3545.57,13.16,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,61558,60558,62223,3846.32,2.70,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,94435,93566,96175,5900.57,2.76,6b118770d85af4f6,bits,hdr,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-armed-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-armed-O3-pass.inline
@@ -1,0 +1,108 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-armed-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:55:16Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 24 1 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=45)
+remark 3 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=45)
+remark 3 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=45)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into '_ZL11build_batchRxPhi' because too costly to inline (cost=1555, threshold=325)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+remark 2 '_ZL9run_statsPdi' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=65, threshold=45)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr STATS groups 178 untimed 161 unattributed 0 unroll-dedup 1
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read full hot=0 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-off-O3-pass.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-off-O3-pass.csv
@@ -1,0 +1,75 @@
+# schema bench results
+# date: 2026-08-16T12:43:09Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-off] tournament r2 — the re-measure the armed-pair refusal prescribed; same binaries, fresh window
+# schema commit: bbb0e38
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.44 2.03 1.85
+# load_end: 1.92 1.84 1.82
+# load_max: 2.44
+# control_start_median: 103278508   control_end_median: 103454386
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT R2 — the re-measure the §5.3 refusal prescribed (r1 armed c batch write spread 57.2% INVALID,
+# era:   layout-noise class; r1 rides in the same directory as the failure record). Same binaries, fresh window.
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema bbb0e38
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,59802577,59450357,60000919,5988.38,0.92,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,93224323,89424192,93578865,9335.09,4.46,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,105670778,104035803,107020354,5744.20,2.82,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,141836480,137945107,141960778,7710.15,2.83,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,94712377,94099573,96484570,1174.22,2.52,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,226862265,226450344,232878291,2812.59,2.83,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,763689988,753792273,764685599,4369.87,1.43,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1039355903,1031828829,1044710099,5947.24,1.24,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66025452,65370403,66104890,3840.97,1.11,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,47742394,43837208,47779087,2777.37,8.26,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,99995508,99596065,100149115,2670.17,0.55,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,115586075,113122972,116316704,3086.48,2.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,125658212,122424249,125956771,3355.44,2.81,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,125116360,124195197,125372608,3340.97,0.94,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1085400567,1069594123,1093071167,10351.19,2.16,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1424387491,1415524370,1431650900,13584.02,1.13,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,188429682,187836292,189427714,4672.21,0.84,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,776635014,773087495,778391133,19257.08,0.68,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73875181,73788077,73999892,3311.28,0.29,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,81933788,74028731,82488726,3672.49,10.33,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27805072,27714194,27811351,2439.56,0.35,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,33150728,32986131,33250346,2908.58,0.80,6b118770d85af4f6,gen,hdr,removed,O3,partial:5
+cpp,message_batch,write,26214400,25,7,82226615,78197727,91011451,1960.44,15.58,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,74669575,70614911,75173241,1780.26,6.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,82492786,79861739,82516779,3854.89,3.22,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,113181771,112303031,113252788,5288.99,0.84,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,183931125,180161920,186089752,2455.75,3.22,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191455385,191136483,191776159,2556.21,0.33,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,181304886,180502191,186001423,3458.12,3.03,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,218600886,210343610,240064968,4169.48,13.60,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,151280828,149933701,153136425,3029.73,2.12,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,183490728,167064111,190122088,3674.80,12.57,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,61204,60511,62231,3824.20,2.81,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,93581,93418,95939,5847.21,2.69,6b118770d85af4f6,bits,hdr,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-off-O3-pass.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-off-O3-pass.inline
@@ -1,0 +1,117 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:55:13Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 34 1 0 0
+symbol __ZN7example12ReadTestDataERN9serialize10ReadStreamERNS_8TestDataE 5 5 0 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=505, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example20ReadShipData_ShallowERN9serialize10ReadStreamERNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=750, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=45)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=325)
+remark 2 '_ZN7example15ReadInputPacketERN9serialize10ReadStreamERNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=335, threshold=325)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 5 0
+attr STATS groups 204 untimed 177 unattributed 0 unroll-dedup 3
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read partial:5 hot=5 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-off-pair-O3.csv
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-off-pair-O3.csv
@@ -1,0 +1,111 @@
+# schema bench results
+# date: 2026-08-16T12:43:09Z
+# host: macbook  arch: arm64  os: Darwin 25.5.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Itest -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -I/private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.26.5 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.97.1 (c980f4866 2026-06-30); rustc 1.97.1 (8bab26f4f 2026-07-14) (cargo run --release: opt-level 3, no LTO)
+# dotnet: 10.0.302 (dotnet run -c Release, workstation GC)
+# pinning: none
+# noise: [leg cpp-off] tournament r2 — the re-measure the armed-pair refusal prescribed; same binaries, fresh window
+# schema commit: bbb0e38
+# serialize commit: b6f4c2c (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize]
+# serialize.c commit: 80e5457 (main) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-working-rowan-new/2a3ae0b6-7621-44cd-a9b7-ab68b69bf06c/scratchpad/serialize.c]
+# serialize.go commit: a094849 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: eac4d71 (debug-assert-check-model) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 2faa767 (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# rounds: 7   interleaved: yes (four tournament legs per round)
+# load_start: 2.44 2.03 1.85
+# load_end: 1.92 1.84 1.82
+# load_max: 2.44
+# control_start_median: 103278508   control_end_median: 103454386
+# control_delta_pct: 0.2   window: OK
+# era: TOURNAMENT R2 — the re-measure the §5.3 refusal prescribed (r1 armed c batch write spread 57.2% INVALID,
+# era:   layout-noise class; r1 rides in the same directory as the failure record). Same binaries, fresh window.
+# era: TOURNAMENT — the four-leg switch tournament under the night mandate (C/C++ complete parity;
+# era:   winners become shipped defaults, losers get removed). Air-on-external-power hotel window, 2026-08-16,
+# era:   machine exclusively ours during rounds.
+# era: mains: serialize.c 80e5457 (#22 fixed/compressed-float join the demand set; #23 SERIALIZE_WORD_COPY,
+# era:   all five bitpacker groups unroll), serialize b6f4c2c, schema bbb0e38
+# era:   (#52 C-side spine-demand switches; #53 interior-null refusal — BOTH emitters word-wise scan,
+# era:   C readers now pay SPEC 4.7, so chat reads are equivalent work for the first time).
+# era: legs: cpp-off | cpp-armed (SCHEMA_READ_SPINE_DEMAND + SERIALIZE_READ_SPINE_DEMAND) |
+# era:   c-off | c-armed (SCHEMA_C_READ_SPINE_DEMAND + SCHEMA_C_WRITE_SPINE_DEMAND); same-language legs
+# era:   differ ONLY by those defines. NOT comparable to phase4-air, postlaw-air, or any other era/host
+# era:   (§5.3 rule 8). checks=removed both languages (post-#20); linkage hdr vs hdr+tu caption applies.
+# corpus_id: 6b118770d85af4f6
+# era: PAIR FILE — cpp rows are leg cpp-off, c rows are leg c-off, same pass, same rounds, same window;
+# era:   assembled row-for-row from the stamped leg CSVs for the cross-language ratio read.
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,rigidbody_moving,write,24000000,105,7,59802577,59450357,60000919,5988.38,0.92,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_moving,read,24000000,105,7,93224323,89424192,93578865,9335.09,4.46,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,write,32000000,57,7,105670778,104035803,107020354,5744.20,2.82,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,rigidbody_at_rest,read,32000000,57,7,141836480,137945107,141960778,7710.15,2.83,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,write,48000000,13,7,94712377,94099573,96484570,1174.22,2.52,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,chat,read,48000000,13,7,226862265,226450344,232878291,2812.59,2.83,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,write,192000000,6,7,763689988,753792273,764685599,4369.87,1.43,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,test,read,192000000,6,7,1039355903,1031828829,1044710099,5947.24,1.24,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,write,16000000,61,7,66025452,65370403,66104890,3840.97,1.11,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,inputpacket,read,16000000,61,7,47742394,43837208,47779087,2777.37,8.26,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,write,32000000,28,7,99995508,99596065,100149115,2670.17,0.55,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,shipcreate,read,32000000,28,7,115586075,113122972,116316704,3086.48,2.76,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,write,32000000,28,7,125658212,122424249,125956771,3355.44,2.81,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,ship_shallow,read,32000000,28,7,125116360,124195197,125372608,3340.97,0.94,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,write,256000000,10,7,1085400567,1069594123,1093071167,10351.19,2.16,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probe_header,read,256000000,10,7,1424387491,1415524370,1431650900,13584.02,1.13,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,write,128000000,26,7,188429682,187836292,189427714,4672.21,0.84,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probebits,read,128000000,26,7,776635014,773087495,778391133,19257.08,0.68,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,write,20000000,47,7,73875181,73788077,73999892,3311.28,0.29,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,probearray,read,20000000,47,7,81933788,74028731,82488726,3672.49,10.33,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,testdata,write,8000000,92,7,27805072,27714194,27811351,2439.56,0.35,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,testdata,read,8000000,92,7,33150728,32986131,33250346,2908.58,0.80,6b118770d85af4f6,gen,hdr,removed,O3,partial:5
+cpp,message_batch,write,26214400,25,7,82226615,78197727,91011451,1960.44,15.58,6b118770d85af4f6,gen,hdr,removed,O3,partial:2
+cpp,message_batch,read,26214400,25,7,74669575,70614911,75173241,1780.26,6.10,6b118770d85af4f6,gen,hdr,removed,O3,full
+cpp,bench_packet,write,32000000,49,7,82492786,79861739,82516779,3854.89,3.22,6b118770d85af4f6,rt,hdr,removed,O3,partial:1
+cpp,bench_packet,read,32000000,49,7,113181771,112303031,113252788,5288.99,0.84,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,write,40000000,14,7,183931125,180161920,186089752,2455.75,3.22,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_ints,read,40000000,14,7,191455385,191136483,191776159,2556.21,0.33,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,write,48000000,20,7,181304886,180502191,186001423,3458.12,3.03,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_bits,read,48000000,20,7,218600886,210343610,240064968,4169.48,13.60,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,write,40000000,21,7,151280828,149933701,153136425,3029.73,2.12,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bench_mixed,read,40000000,21,7,183490728,167064111,190122088,3674.80,12.57,6b118770d85af4f6,rt,hdr,removed,O3,full
+cpp,bitpacker,write,24576,65518,7,61204,60511,62231,3824.20,2.81,6b118770d85af4f6,bits,hdr,removed,O3,full
+cpp,bitpacker,read,24576,65518,7,93581,93418,95939,5847.21,2.69,6b118770d85af4f6,bits,hdr,removed,O3,full
+c,rigidbody_moving,write,24000000,105,7,55094775,54055637,55178502,5516.96,2.04,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_moving,read,24000000,105,7,57848052,53571070,60221313,5792.66,11.50,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,write,32000000,57,7,109290737,109105167,109455970,5940.98,0.32,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,rigidbody_at_rest,read,32000000,57,7,114627550,108417978,118201563,6231.09,8.54,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,chat,write,48000000,13,7,75412886,75397012,75531791,934.95,0.18,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,chat,read,48000000,13,7,170280395,168187950,171127265,2111.10,1.73,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,write,192000000,6,7,766155099,764772659,769971126,4383.97,0.68,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,test,read,192000000,6,7,1044437554,1039630498,1045381538,5976.32,0.55,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,write,16000000,61,7,73830706,73548340,73888668,4295.04,0.46,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,inputpacket,read,16000000,61,7,43271545,43200043,43535046,2517.28,0.77,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,write,32000000,28,7,83613569,83523872,83660787,2232.72,0.16,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,shipcreate,read,32000000,28,7,110997416,110908165,111079099,2963.95,0.15,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,write,32000000,28,7,86103674,86028906,86179269,2299.22,0.17,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,ship_shallow,read,32000000,28,7,113785869,113720362,113861580,3038.41,0.12,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,write,256000000,10,7,305391957,304154682,306815008,2912.44,0.87,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probe_header,read,256000000,10,7,319869653,317506778,319956806,3050.51,0.77,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,write,128000000,26,7,190378735,190339950,190497451,4720.54,0.08,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probebits,read,128000000,26,7,258767257,258594740,259086235,6416.27,0.19,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,write,20000000,47,7,77225742,77199809,77260647,3461.47,0.08,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,probearray,read,20000000,47,7,77438340,77306637,78314362,3470.99,1.30,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,testdata,write,8000000,92,7,24352453,24227227,24437778,2136.64,0.86,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:1
+c,testdata,read,8000000,92,7,23607804,23554976,23668849,2071.30,0.48,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,message_batch,write,26214400,25,7,78846466,69826675,86396129,1879.85,21.01,6b118770d85af4f6,gen,hdr+tu,removed,O3,partial:2
+c,message_batch,read,26214400,25,7,101407710,97984937,110572892,2417.75,12.41,6b118770d85af4f6,gen,hdr+tu,removed,O3,full
+c,bench_packet,write,32000000,49,7,84992005,84981848,85017973,3971.68,0.04,6b118770d85af4f6,rt,hdr+tu,removed,O3,partial:1
+c,bench_packet,read,32000000,49,7,123472986,116861680,123541153,5769.90,5.41,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,write,40000000,14,7,191088584,189471092,192516869,2551.31,1.59,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_ints,read,40000000,14,7,160639345,160475650,161999068,2144.77,0.95,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,write,48000000,20,7,192320791,192195270,193044758,3668.23,0.44,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_bits,read,48000000,20,7,220231978,218216535,220668349,4200.59,1.11,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,write,40000000,21,7,159261663,158849927,159400654,3189.56,0.35,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bench_mixed,read,40000000,21,7,171069570,170227978,171662769,3426.04,0.84,6b118770d85af4f6,rt,hdr+tu,removed,O3,full
+c,bitpacker,write,24576,65518,7,60969,60550,62214,3809.52,2.73,6b118770d85af4f6,bits,hdr+tu,removed,O3,full
+c,bitpacker,read,24576,65518,7,53033,52069,53082,3313.65,1.91,6b118770d85af4f6,bits,hdr+tu,removed,O3,full

--- a/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-off-pair-O3.inline
+++ b/bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-off-pair-O3.inline
@@ -1,0 +1,188 @@
+# 2026-08-16-arm64-macbook-air-power-tournament-r2-cpp-off-O3-pass.inline — per-symbol inline ledger (BENCH-STANDARD.md §4)
+# generated: 2026-08-16T12:55:13Z on macbook (Darwin arm64)
+# ground truth: call instructions into the serialize runtime, counted in
+# the emitted code and propagated transitively through out-of-line
+# generated helpers, classified HOT or COLD by target (§4.2: cold =
+# split cold-path symbol, #[cold]-marked fn, or a documented per-
+# language equivalent; no signal = hot, never guessed). Compiler
+# remarks are advisory; the disassembly is the verdict. CSV verdicts
+# count HOT calls only: full = zero hot runtime calls per op,
+# partial:N = N hot calls remain PER OP (§4.2 — loop unrolling
+# divided back out), unknown = not attributable (stays un-ratioable).
+# The cold count rides beside every row here, never in the CSV shape.
+== cpp (otool -tv of build/bench/schema_bench_cpp; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 0 34 1 0 0
+symbol __ZN7example12ReadTestDataERN9serialize10ReadStreamERNS_8TestDataE 5 5 0 0 0
+symbol __ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE 2 2 0 0 0
+symbol __ZL11build_batchRxPhi 0 2 0 0 0
+symbol __ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE 1 1 0 0 0
+symbol __ZN12_GLOBAL__N_126rt_bench_packet_write_loopERNS_13RtBenchPacketElRy 0 1 0 0 0
+symbol __ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_ 1 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 18 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=45)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=325)
+remark 8 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=785, threshold=325)
+remark 6 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into 'main' because too costly to inline (cost=330, threshold=325)
+remark 6 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=45)
+remark 6 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=45)
+remark 5 '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' not inlined into 'main' because too costly to inline (cost=1555, threshold=325)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=330, threshold=45)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EZ4mainE3$_0EvPKcSG_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into '_ZL13bench_messageIN7example9RigidBodyEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=455, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into 'main' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example21WriteShipData_ShallowERN9serialize11WriteStreamERKNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=885, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into 'main' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example16WriteInputPacketERN9serialize11WriteStreamERKNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=565, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into 'main' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15WriteShipCreateERN9serialize11WriteStreamERKNS_10ShipCreateE' not inlined into '_ZL13bench_messageIN7example10ShipCreateEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=1075, threshold=325)
+remark 4 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into '_ZL13bench_messageIN7example10ProbeArrayEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=505, threshold=325)
+remark 4 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into '_ZL13bench_messageIN7example9ProbeBitsEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=445, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into 'main' because too costly to inline (cost=2595, threshold=325)
+remark 4 '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' not inlined into '_ZL13bench_messageIN7example8TestDataEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=2595, threshold=325)
+remark 3 '_ZN7example9WriteVec3ERN9serialize11WriteStreamERKNS_4Vec3E' not inlined into '_ZN7example14WriteRigidBodyERN9serialize11WriteStreamERKNS_9RigidBodyE' because too costly to inline (cost=485, threshold=325)
+remark 3 '_ZN7example14WriteProbeBitsERN9serialize11WriteStreamERKNS_9ProbeBitsE' not inlined into 'main' because too costly to inline (cost=445, threshold=45)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_113RtBenchPacket9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_13RtBenchPacketEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=1155, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_112RtBenchMixed9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_12RtBenchMixedEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=665, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchInts9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchIntsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=550, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into 'main' because too costly to inline (cost=480, threshold=250)
+remark 3 '_ZN12_GLOBAL__N_111RtBenchBits9SerializeIN9serialize11WriteStreamEEEbRT_' not inlined into '_ZN12_GLOBAL__N_18bench_rtINS_11RtBenchBitsEPFbRS1_lRyEPFbS2_lxEPFvS2_yEEEvPKclRKT_T0_T1_T2_' because too costly to inline (cost=480, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example13WriteTestDataERN9serialize11WriteStreamERKNS_8TestDataE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN9serialize9BitWriter10WriteBytesEPKhx' not inlined into '_ZN7example12WriteMessageERN9serialize11WriteStreamERKNS_7MessageE' because too costly to inline (cost=345, threshold=250)
+remark 2 '_ZN7example9WriteQuatERN9serialize11WriteStreamERKNS_4QuatE' not inlined into 'main' because too costly to inline (cost=455, threshold=325)
+remark 2 '_ZN7example20ReadShipData_ShallowERN9serialize10ReadStreamERNS_16ShipData_ShallowE' not inlined into '_ZL13bench_messageIN7example16ShipData_ShallowEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=750, threshold=325)
+remark 2 '_ZN7example16WriteProbeSampleERN9serialize11WriteStreamERKNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=785, threshold=325)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=45)
+remark 2 '_ZN7example15ReadProbeSampleERN9serialize10ReadStreamERNS_11ProbeSampleE' not inlined into 'main' because too costly to inline (cost=505, threshold=325)
+remark 2 '_ZN7example15ReadInputPacketERN9serialize10ReadStreamERNS_11InputPacketE' not inlined into '_ZL13bench_messageIN7example11InputPacketEPFbRN9serialize11WriteStreamERKS1_EPFbRNS2_10ReadStreamERS1_EPFvSB_yEEvPKcSH_lRKT_T0_T1_T2_' because too costly to inline (cost=335, threshold=325)
+# cpp per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N probebits write 0 0
+attr N testdata write 2 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 5 0
+attr STATS groups 204 untimed 177 unattributed 0 unroll-dedup 3
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row cpp rigidbody_moving write full hot=0 cold=0
+row cpp rigidbody_moving read full hot=0 cold=0
+row cpp rigidbody_at_rest write full hot=0 cold=0
+row cpp rigidbody_at_rest read full hot=0 cold=0
+row cpp chat write full hot=0 cold=0
+row cpp chat read full hot=0 cold=0
+row cpp test write full hot=0 cold=0
+row cpp test read full hot=0 cold=0
+row cpp inputpacket write full hot=0 cold=0
+row cpp inputpacket read full hot=0 cold=0
+row cpp shipcreate write full hot=0 cold=0
+row cpp shipcreate read full hot=0 cold=0
+row cpp ship_shallow write full hot=0 cold=0
+row cpp ship_shallow read full hot=0 cold=0
+row cpp probe_header write full hot=0 cold=0
+row cpp probe_header read full hot=0 cold=0
+row cpp probebits write full hot=0 cold=0
+row cpp probebits read full hot=0 cold=0
+row cpp probearray write full hot=0 cold=0
+row cpp probearray read full hot=0 cold=0
+row cpp testdata write partial:2 hot=2 cold=0
+row cpp testdata read partial:5 hot=5 cold=0
+row cpp message_batch write partial:2 hot=2 cold=0
+row cpp message_batch read full hot=0 cold=0
+row cpp bench_packet write partial:1 hot=1 cold=0
+row cpp bench_packet read full hot=0 cold=0
+row cpp bench_ints write full hot=0 cold=0
+row cpp bench_ints read full hot=0 cold=0
+row cpp bench_bits write full hot=0 cold=0
+row cpp bench_bits read full hot=0 cold=0
+row cpp bench_mixed write full hot=0 cold=0
+row cpp bench_mixed read full hot=0 cold=0
+row cpp bitpacker write full hot=0 cold=0
+row cpp bitpacker read full hot=0 cold=0
+== c (otool -tv of build/bench/schema_bench_c; clang -Rpass=inline shadow compile; cold = split .cold/.cold.N symbols)
+# symbol / direct-hot / transitive-hot / indirect / direct-cold / transitive-cold (nonzero only)
+symbol _main 4 24 1 0 0
+symbol _build_batch 0 2 0 0 0
+symbol _write_test_data 1 1 0 0 0
+symbol _write_message 1 1 0 0 0
+symbol _serialize_write_string 1 1 0 0 0
+symbol _rt_write_bench_packet 1 1 0 0 0
+symbol _rt_bench_packet_write_loop 0 1 0 0 0
+# missed-inline remarks naming serialize (callee, caller, cost where reported):
+remark 1 'serialize_write_bytes' not inlined into 'serialize_write_string' because too costly to inline (cost=515, threshold=250)
+# c per-row attribution (atos inline stacks over the -g shadow;
+# untimed = call sites in setup/self-check/variant code, excluded):
+attr N probebits read 0 0
+attr N probe_header write 0 0
+attr N rigidbody_moving read 0 0
+attr N shipcreate read 0 0
+attr N probe_header read 0 0
+attr N ship_shallow read 0 0
+attr N message_batch read 0 0
+attr N ship_shallow write 0 0
+attr N inputpacket write 0 0
+attr N probearray write 0 0
+attr N rigidbody_at_rest read 0 0
+attr N probearray read 0 0
+attr N chat write 1 0
+attr N chat read 0 0
+attr N probebits write 0 0
+attr N testdata write 1 0
+attr N inputpacket read 0 0
+attr N message_batch write 2 0
+attr N shipcreate write 0 0
+attr N rigidbody_moving write 0 0
+attr N rigidbody_at_rest write 0 0
+attr N testdata read 0 0
+attr STATS groups 167 untimed 143 unattributed 0 unroll-dedup 0
+# per-row verdicts (hot is the CSV verdict; cold is recorded debt off the hot path):
+row c rigidbody_moving write full hot=0 cold=0
+row c rigidbody_moving read full hot=0 cold=0
+row c rigidbody_at_rest write full hot=0 cold=0
+row c rigidbody_at_rest read full hot=0 cold=0
+row c chat write partial:1 hot=1 cold=0
+row c chat read full hot=0 cold=0
+row c test write full hot=0 cold=0
+row c test read full hot=0 cold=0
+row c inputpacket write full hot=0 cold=0
+row c inputpacket read full hot=0 cold=0
+row c shipcreate write full hot=0 cold=0
+row c shipcreate read full hot=0 cold=0
+row c ship_shallow write full hot=0 cold=0
+row c ship_shallow read full hot=0 cold=0
+row c probe_header write full hot=0 cold=0
+row c probe_header read full hot=0 cold=0
+row c probebits write full hot=0 cold=0
+row c probebits read full hot=0 cold=0
+row c probearray write full hot=0 cold=0
+row c probearray read full hot=0 cold=0
+row c testdata write partial:1 hot=1 cold=0
+row c testdata read full hot=0 cold=0
+row c message_batch write partial:2 hot=2 cold=0
+row c message_batch read full hot=0 cold=0
+row c bench_packet write partial:1 hot=1 cold=0
+row c bench_packet read full hot=0 cold=0
+row c bench_ints write full hot=0 cold=0
+row c bench_ints read full hot=0 cold=0
+row c bench_bits write full hot=0 cold=0
+row c bench_bits read full hot=0 cold=0
+row c bench_mixed write full hot=0 cold=0
+row c bench_mixed read full hot=0 cold=0
+row c bitpacker write full hot=0 cold=0
+row c bitpacker read full hot=0 cold=0


### PR DESCRIPTION
The four-leg tournament under the night mandate: r1 refused by spread policy (the record stays), r2 clean at 0.2% controls. Armed vs armed: **read 100%, batch read 97%** — read-side parity. Both languages' demand switches sweep their A/Bs with zero regressions; the one missing piece is a C++ generated-WRITE demand (write 65%, C ahead), target sites already catalogued. Scorecard: 20/34 rows in band including five exact-100s and bitpacker write back at 100% (#23 confirmed). chat read anomaly RESOLVED as predicted — equivalent readers for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)