### PR TITLE
The generated C++ write spine can demand inlining — SCHEMA_WRITE_SPINE_DEMAND, default off

### DIFF
--- a/generated/bench/cpp/BenchWire.h
+++ b/generated/bench/cpp/BenchWire.h
@@ -14,6 +14,30 @@
 
 namespace bench {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -38,7 +62,7 @@ namespace bench {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteBenchPacket( serialize::WriteStream & stream, const BenchPacket & value )
+SCHEMA_WRITE_INLINE bool WriteBenchPacket( serialize::WriteStream & stream, const BenchPacket & value )
 {
     serialize_assert( int32_t( value.a ) >= int32_t( -100 ) && int32_t( value.a ) <= int32_t( 100 ) );
     write_bits( stream, uint32_t( value.a ) - uint32_t( -100 ), 8 );
@@ -77,7 +101,7 @@ SCHEMA_READ_INLINE bool ReadBenchPacket( serialize::ReadStream & stream, BenchPa
     return true;
 }
 
-inline bool WriteBenchInts( serialize::WriteStream & stream, const BenchInts & value )
+SCHEMA_WRITE_INLINE bool WriteBenchInts( serialize::WriteStream & stream, const BenchInts & value )
 {
     serialize_assert( int32_t( value.f0 ) >= int32_t( -100 ) && int32_t( value.f0 ) <= int32_t( 100 ) );
     write_bits( stream, uint32_t( value.f0 ) - uint32_t( -100 ), 8 );
@@ -117,7 +141,7 @@ SCHEMA_READ_INLINE bool ReadBenchInts( serialize::ReadStream & stream, BenchInts
     return true;
 }
 
-inline bool WriteBenchBits( serialize::WriteStream & stream, const BenchBits & value )
+SCHEMA_WRITE_INLINE bool WriteBenchBits( serialize::WriteStream & stream, const BenchBits & value )
 {
     write_bits( stream, value.b7, 7 );
     write_bits( stream, value.b13, 13 );
@@ -143,7 +167,7 @@ SCHEMA_READ_INLINE bool ReadBenchBits( serialize::ReadStream & stream, BenchBits
     return true;
 }
 
-inline bool WriteBenchMixed( serialize::WriteStream & stream, const BenchMixed & value )
+SCHEMA_WRITE_INLINE bool WriteBenchMixed( serialize::WriteStream & stream, const BenchMixed & value )
 {
     serialize_assert( int32_t( value.sequence ) >= int32_t( 0 ) && int32_t( value.sequence ) <= int32_t( 65535 ) );
     write_bits( stream, uint32_t( value.sequence ), 16 );

--- a/generated/cpp/MessagesWire.h
+++ b/generated/cpp/MessagesWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -150,7 +174,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 }
 #endif // SCHEMA_INTERIOR_NULL_DEFINED
 
-inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
+SCHEMA_WRITE_INLINE bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
 {
     (void) stream;
     (void) value; // empty body — presence is the payload (SPEC §4.6)
@@ -164,7 +188,7 @@ SCHEMA_READ_INLINE bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat
     return true;
 }
 
-inline bool WriteTest( serialize::WriteStream & stream, const Test & value )
+SCHEMA_WRITE_INLINE bool WriteTest( serialize::WriteStream & stream, const Test & value )
 {
     write_bits( stream, value.test_a, 16 );
     serialize_assert( int32_t( value.test_b ) >= int32_t( 0 ) && int32_t( value.test_b ) <= int32_t( 1000 ) );
@@ -201,7 +225,7 @@ SCHEMA_READ_INLINE bool ReadTest( serialize::ReadStream & stream, Test & value )
     return true;
 }
 
-inline bool WriteBlock( serialize::WriteStream & stream, const Block & value )
+SCHEMA_WRITE_INLINE bool WriteBlock( serialize::WriteStream & stream, const Block & value )
 {
     serialize_assert( int32_t( value.data_length ) >= int32_t( 0 ) && int32_t( value.data_length ) <= int32_t( MaxBlockSize ) );
     write_bits( stream, uint32_t( value.data_length ), 11 );
@@ -216,7 +240,7 @@ SCHEMA_READ_INLINE bool ReadBlock( serialize::ReadStream & stream, Block & value
     return true;
 }
 
-inline bool WriteChat( serialize::WriteStream & stream, const Chat & value )
+SCHEMA_WRITE_INLINE bool WriteChat( serialize::WriteStream & stream, const Chat & value )
 {
     for ( int32_t i = 0; i < value.text_length; i++ )
     {
@@ -241,7 +265,7 @@ SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
     return true;
 }
 
-inline bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize & value )
+SCHEMA_WRITE_INLINE bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize & value )
 {
     write_bits( stream, value.sync_frame, 64 );
     write_bits( stream, value.sync_sequence, 16 );
@@ -259,7 +283,7 @@ SCHEMA_READ_INLINE bool ReadSynchronize( serialize::ReadStream & stream, Synchro
     return true;
 }
 
-inline bool WriteTimescale( serialize::WriteStream & stream, const Timescale & value )
+SCHEMA_WRITE_INLINE bool WriteTimescale( serialize::WriteStream & stream, const Timescale & value )
 {
     write_double( stream, value.scale );
     write_bits( stream, value.frame_a, 32 );
@@ -277,7 +301,7 @@ SCHEMA_READ_INLINE bool ReadTimescale( serialize::ReadStream & stream, Timescale
 
 // The message tag wire: MessageType in [0, 6], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
-inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
+SCHEMA_WRITE_INLINE bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value ), 3 );
@@ -292,7 +316,7 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
-inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
+SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
     {

--- a/generated/cpp/ObjectsWire.h
+++ b/generated/cpp/ObjectsWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -41,7 +65,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );
@@ -164,7 +188,7 @@ SCHEMA_READ_INLINE bool ReadShipData_Deep( serialize::ReadStream & stream, ShipD
     return true;
 }
 
-inline bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipData_Shallow & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );
@@ -275,7 +299,7 @@ SCHEMA_READ_INLINE bool ReadShipData_Shallow( serialize::ReadStream & stream, Sh
     return true;
 }
 
-inline bool WriteMissileData_Deep( serialize::WriteStream & stream, const MissileData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteMissileData_Deep( serialize::WriteStream & stream, const MissileData_Deep & value )
 {
     serialize_assert( int32_t( value.missile_type ) >= int32_t( 0 ) && int32_t( value.missile_type ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.missile_type ), 2 );
@@ -325,7 +349,7 @@ SCHEMA_READ_INLINE bool ReadMissileData_Deep( serialize::ReadStream & stream, Mi
     return true;
 }
 
-inline bool WriteMissileData_Shallow( serialize::WriteStream & stream, const MissileData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteMissileData_Shallow( serialize::WriteStream & stream, const MissileData_Shallow & value )
 {
     serialize_assert( int32_t( value.missile_type ) >= int32_t( 0 ) && int32_t( value.missile_type ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.missile_type ), 2 );
@@ -421,7 +445,7 @@ SCHEMA_READ_INLINE bool ReadMissileData_Shallow( serialize::ReadStream & stream,
     return true;
 }
 
-inline bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const DynamicPropData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const DynamicPropData_Deep & value )
 {
     serialize_assert( int32_t( value.prop_type ) >= int32_t( 0 ) && int32_t( value.prop_type ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.prop_type ), 3 );
@@ -471,7 +495,7 @@ SCHEMA_READ_INLINE bool ReadDynamicPropData_Deep( serialize::ReadStream & stream
     return true;
 }
 
-inline bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const DynamicPropData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const DynamicPropData_Shallow & value )
 {
     serialize_assert( int32_t( value.prop_type ) >= int32_t( 0 ) && int32_t( value.prop_type ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.prop_type ), 3 );
@@ -567,7 +591,7 @@ SCHEMA_READ_INLINE bool ReadDynamicPropData_Shallow( serialize::ReadStream & str
     return true;
 }
 
-inline bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretData_Deep & value )
 {
     if ( !WriteHandle( stream, value.parent ) )
     {
@@ -598,7 +622,7 @@ SCHEMA_READ_INLINE bool ReadTurretData_Deep( serialize::ReadStream & stream, Tur
     return true;
 }
 
-inline bool WriteTurretData_Shallow( serialize::WriteStream & stream, const TurretData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteTurretData_Shallow( serialize::WriteStream & stream, const TurretData_Shallow & value )
 {
     if ( !WriteHandle( stream, value.parent ) )
     {
@@ -651,7 +675,7 @@ SCHEMA_READ_INLINE bool ReadTurretData_Shallow( serialize::ReadStream & stream, 
 
 // The object tag wire: ObjectType in [0, 4], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
-inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
+SCHEMA_WRITE_INLINE bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value ), 3 );

--- a/generated/cpp/RenderWire.h
+++ b/generated/cpp/RenderWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -39,7 +63,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
+SCHEMA_WRITE_INLINE bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
 {
     write_bits( stream, value.sort_key, 64 );
     write_bits( stream, value.mesh_id, 32 );
@@ -68,7 +92,7 @@ SCHEMA_READ_INLINE bool ReadRenderSprite( serialize::ReadStream & stream, Render
     return true;
 }
 
-inline bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock & value )
+SCHEMA_WRITE_INLINE bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock & value )
 {
     write_bits( stream, value.worker_index, 32 );
     write_bits( stream, value.sprite_count_hint, 32 );

--- a/generated/cpp/TypesWire.h
+++ b/generated/cpp/TypesWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -41,7 +65,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
+SCHEMA_WRITE_INLINE bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
 {
     write_double( stream, value.x );
     write_double( stream, value.y );
@@ -57,7 +81,7 @@ SCHEMA_READ_INLINE bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
     return true;
 }
 
-inline bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
+SCHEMA_WRITE_INLINE bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
 {
     write_double( stream, value.x );
     write_double( stream, value.y );
@@ -75,7 +99,7 @@ SCHEMA_READ_INLINE bool ReadQuat( serialize::ReadStream & stream, Quat & value )
     return true;
 }
 
-inline bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
+SCHEMA_WRITE_INLINE bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
 {
     serialize_assert( int32_t( value.object_id ) >= int32_t( 0 ) && int32_t( value.object_id ) <= int32_t( MaxObjects - 1 ) );
     write_bits( stream, uint32_t( value.object_id ), 14 );
@@ -94,7 +118,7 @@ SCHEMA_READ_INLINE bool ReadHandle( serialize::ReadStream & stream, Handle & val
     return true;
 }
 
-inline bool WriteQuantizedPosition( serialize::WriteStream & stream, const QuantizedPosition & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedPosition( serialize::WriteStream & stream, const QuantizedPosition & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -MaxPositionUnits ) && int32_t( value.x ) <= int32_t( MaxPositionUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -MaxPositionUnits ), 25 );
@@ -113,7 +137,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedPosition( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteQuantizedVelocity( serialize::WriteStream & stream, const QuantizedVelocity & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedVelocity( serialize::WriteStream & stream, const QuantizedVelocity & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -MaxVelocityUnits ) && int32_t( value.x ) <= int32_t( MaxVelocityUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -MaxVelocityUnits ), 23 );
@@ -132,7 +156,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedVelocity( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteQuantizedRotation( serialize::WriteStream & stream, const QuantizedRotation & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedRotation( serialize::WriteStream & stream, const QuantizedRotation & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -RotationUnits ) && int32_t( value.x ) <= int32_t( RotationUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -RotationUnits ), 12 );
@@ -170,7 +194,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedRotation( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & value )
+SCHEMA_WRITE_INLINE bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & value )
 {
     if ( !WriteVec3( stream, value.position ) )
     {
@@ -225,7 +249,7 @@ SCHEMA_READ_INLINE bool ReadRigidBody( serialize::ReadStream & stream, RigidBody
     return true;
 }
 
-inline bool WriteInput( serialize::WriteStream & stream, const Input & value )
+SCHEMA_WRITE_INLINE bool WriteInput( serialize::WriteStream & stream, const Input & value )
 {
     write_float( stream, value.stick_x );
     write_float( stream, value.stick_y );
@@ -261,7 +285,7 @@ SCHEMA_READ_INLINE bool ReadInput( serialize::ReadStream & stream, Input & value
     return true;
 }
 
-inline bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket & value )
+SCHEMA_WRITE_INLINE bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket & value )
 {
     write_bits( stream, value.synchronize_sequence, 16 );
     write_bits( stream, value.current_frame, 64 );
@@ -298,7 +322,7 @@ SCHEMA_READ_INLINE bool ReadInputPacket( serialize::ReadStream & stream, InputPa
     return true;
 }
 
-inline bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate & value )
+SCHEMA_WRITE_INLINE bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -150,7 +174,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 }
 #endif // SCHEMA_INTERIOR_NULL_DEFINED
 
-inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
+SCHEMA_WRITE_INLINE bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {
     write_bits( stream, 171ull, 8 ); // const(171, 8) — SPEC §4.3
     write_bits( stream, value.version, 3 );
@@ -184,7 +208,7 @@ SCHEMA_READ_INLINE bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHe
     return true;
 }
 
-inline bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & value )
+SCHEMA_WRITE_INLINE bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & value )
 {
     write_bits( stream, value.small, 9 );
     write_bits( stream, value.boundary, 33 );
@@ -209,7 +233,7 @@ SCHEMA_READ_INLINE bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits
     return true;
 }
 
-inline bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample & value )
+SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample & value )
 {
     write_bool( stream, value.active );
     {
@@ -296,7 +320,7 @@ SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSa
     return true;
 }
 
-inline bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig & value )
+SCHEMA_WRITE_INLINE bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig & value )
 {
     write_bits( stream, uint32_t( value.retries ), 32 );
     serialize_assert( int32_t( value.preferred ) >= int32_t( 0 ) && int32_t( value.preferred ) <= int32_t( 15 ) );
@@ -319,7 +343,7 @@ SCHEMA_READ_INLINE bool ReadProbeConfig( serialize::ReadStream & stream, ProbeCo
     return true;
 }
 
-inline bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray & value )
+SCHEMA_WRITE_INLINE bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray & value )
 {
     for ( int32_t i = 0; i < 2; i++ )
     {
@@ -351,7 +375,7 @@ SCHEMA_READ_INLINE bool ReadProbeArray( serialize::ReadStream & stream, ProbeArr
     return true;
 }
 
-inline bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport & value )
+SCHEMA_WRITE_INLINE bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport & value )
 {
     if ( !WriteProbeHeader( stream, value.header ) )
     {
@@ -380,7 +404,7 @@ SCHEMA_READ_INLINE bool ReadProbeReport( serialize::ReadStream & stream, ProbeRe
     return true;
 }
 
-inline bool WriteTestData( serialize::WriteStream & stream, const TestData & value )
+SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const TestData & value )
 {
     serialize_assert( int32_t( value.a ) >= int32_t( -100 ) && int32_t( value.a ) <= int32_t( 100 ) );
     write_bits( stream, uint32_t( value.a ) - uint32_t( -100 ), 8 );
@@ -484,7 +508,7 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
     return true;
 }
 
-inline bool WriteCompressedProbe( serialize::WriteStream & stream, const CompressedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteCompressedProbe( serialize::WriteStream & stream, const CompressedProbe & value )
 {
     {
         float compressed_value = value.boundary;

--- a/generated/cpp/ludicrous/LudicrousWire.h
+++ b/generated/cpp/ludicrous/LudicrousWire.h
@@ -14,6 +14,30 @@
 
 namespace ludicrous {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -38,7 +62,7 @@ namespace ludicrous {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
 {
     {
         int32_t fixed_value = value.angle;
@@ -79,7 +103,7 @@ SCHEMA_READ_INLINE bool ReadFixedProbe( serialize::ReadStream & stream, FixedPro
     return true;
 }
 
-inline bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedProbe & value )
 {
     {
         uint32_t fixed_value = value.angle;
@@ -128,7 +152,7 @@ SCHEMA_READ_INLINE bool ReadUnsignedProbe( serialize::ReadStream & stream, Unsig
     return true;
 }
 
-inline bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & value )
+SCHEMA_WRITE_INLINE bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & value )
 {
     write_uint128( stream, value.entity_id );
     write_int128( stream, value.energy, -5000000000, 5000000000 );
@@ -148,7 +172,7 @@ SCHEMA_READ_INLINE bool ReadWideProbe( serialize::ReadStream & stream, WideProbe
     return true;
 }
 
-inline bool WriteLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
+SCHEMA_WRITE_INLINE bool WriteLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
 {
     serialize_assert( int32_t( value.mode ) >= int32_t( 0 ) && int32_t( value.mode ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.mode ), 2 );
@@ -206,7 +230,7 @@ SCHEMA_READ_INLINE bool ReadLudicrousState( serialize::ReadStream & stream, Ludi
     return true;
 }
 
-inline bool WriteDegenerateProbe( serialize::WriteStream & stream, const DegenerateProbe & value )
+SCHEMA_WRITE_INLINE bool WriteDegenerateProbe( serialize::WriteStream & stream, const DegenerateProbe & value )
 {
     serialize_assert( int64_t( value.locked_fixed ) == -196608ll );
     serialize_assert( int32_t( value.locked_int ) >= int32_t( 7 ) && int32_t( value.locked_int ) <= int32_t( 7 ) );
@@ -228,7 +252,7 @@ SCHEMA_READ_INLINE bool ReadDegenerateProbe( serialize::ReadStream & stream, Deg
     return true;
 }
 
-inline bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & value )
+SCHEMA_WRITE_INLINE bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & value )
 {
     {
         int64_t fixed_value = value.x;
@@ -253,7 +277,7 @@ SCHEMA_READ_INLINE bool ReadFixedVec( serialize::ReadStream & stream, FixedVec &
     return true;
 }
 
-inline bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & value )
+SCHEMA_WRITE_INLINE bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & value )
 {
     {
         int32_t fixed_value = value.x;
@@ -283,7 +307,7 @@ SCHEMA_READ_INLINE bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat
     return true;
 }
 
-inline bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_Deep & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -317,7 +341,7 @@ SCHEMA_READ_INLINE bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyD
     return true;
 }
 
-inline bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyData_Shallow & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -351,7 +375,7 @@ SCHEMA_READ_INLINE bool ReadBodyData_Shallow( serialize::ReadStream & stream, Bo
     return true;
 }
 
-inline bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const NarrowBodyData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const NarrowBodyData_Deep & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -385,7 +409,7 @@ SCHEMA_READ_INLINE bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream,
     return true;
 }
 
-inline bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const NarrowBodyData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const NarrowBodyData_Shallow & value )
 {
     serialize_assert( int32_t( value.position_x ) >= int32_t( -25600000 ) && int32_t( value.position_x ) <= int32_t( 25600000 ) );
     write_bits( stream, uint32_t( value.position_x ) - uint32_t( -25600000 ), 26 );
@@ -454,7 +478,7 @@ SCHEMA_READ_INLINE bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stre
 
 // The message tag wire: MessageType in [0, 1], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
-inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
+SCHEMA_WRITE_INLINE bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 1 ) );
     write_bits( stream, uint32_t( value ), 1 );
@@ -469,7 +493,7 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
-inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
+SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
     {
@@ -506,7 +530,7 @@ SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & m
 
 // The object tag wire: ObjectType in [0, 2], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
-inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
+SCHEMA_WRITE_INLINE bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value ), 2 );

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -344,7 +344,8 @@ func (g *gen) emitWireFile() {
 		}
 	}
 
-	if g.fileEmitsReads() {
+	if g.fileEmitsWire() {
+		g.emitWriteInlineMacro()
 		g.emitReadInlineMacro()
 	}
 

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -56,7 +56,7 @@ func (g *gen) emitStructWire(st *ir.Struct) {
 	// FuzzGeneratedCompiles, issue #22)
 	noStorage := len(st.Items) > 0 && len(st.Fields) == 0
 
-	g.pf("inline bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", st.Name, st.Name)
+	g.pf("SCHEMA_WRITE_INLINE bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", st.Name, st.Name)
 	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value; // empty body — presence is the payload (SPEC §4.6)\n")
 	} else {
@@ -652,7 +652,7 @@ func (g *gen) emitMessageWire() {
 	count := int64(len(g.unit.Messages))
 	g.pf("// The message tag wire: MessageType in [0, %d], minimal bits; None = 0 is a\n", count)
 	g.pf("// valid wire value meaning *no message* — the stream terminator (SPEC §4.8).\n")
-	g.pf("inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value )\n{\n")
+	g.pf("SCHEMA_WRITE_INLINE bool WriteMessageType( serialize::WriteStream & stream, MessageType value )\n{\n")
 	g.emitWriteRangedFold32("value", "0", fmt.Sprintf("%d", count),
 		bitsRequired(big.NewInt(0), big.NewInt(count)), true, "    ")
 	g.pf("    return true;\n}\n\n")
@@ -712,7 +712,7 @@ func (g *gen) emitMessageWireUnion() {
 	// dispatch validates BEFORE the tag rides the wire: an out-of-set type
 	// value writes nothing (a tag with no payload would desynchronize the
 	// stream), and the tag framing is the tag pair's — one source
-	g.pf("inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )\n{\n")
+	g.pf("SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )\n{\n")
 	g.pf("    switch ( message.type )\n    {\n")
 	g.pf("        case MessageType::None:\n            return WriteMessageType( stream, MessageType::None ); // the stream terminator (SPEC §4.8)\n")
 	for _, m := range msgs {
@@ -768,7 +768,7 @@ func (g *gen) emitMessageWireVariant() {
 
 	// the variant's index is always in-set, so no pre-validation is needed;
 	// the tag framing is the tag pair's — one source
-	g.pf("inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )\n{\n")
+	g.pf("SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )\n{\n")
 	g.pf("    if ( !WriteMessageType( stream, MessageType( message.index() ) ) )\n    {\n        return false;\n    }\n")
 	g.pf("    switch ( message.index() )\n    {\n")
 	g.pf("        case 0:\n            return true; // None — the stream terminator (SPEC §4.8)\n")

--- a/internal/codegen/cpp/objects.go
+++ b/internal/codegen/cpp/objects.go
@@ -65,7 +65,7 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 	// attributes describe the SHALLOW wire only, so an [interpolate] float
 	// triple serializes as a bare float here (SPEC §4.8)
 	deepName := d.Name + "Data_Deep"
-	g.pf("inline bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", deepName, deepName)
+	g.pf("SCHEMA_WRITE_INLINE bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", deepName, deepName)
 	mark := g.body.Len()
 	for _, f := range deep {
 		g.emitViewWriteField(f, viewDeep, "    ")
@@ -82,7 +82,7 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 
 	// ---- Shallow: the [interpolate] fields on the quantized wire
 	shName := d.Name + "Data_Shallow"
-	g.pf("inline bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", shName, shName)
+	g.pf("SCHEMA_WRITE_INLINE bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", shName, shName)
 	mark = g.body.Len()
 	for _, f := range interp {
 		g.emitViewWriteField(f, viewShallow, "    ")
@@ -358,7 +358,7 @@ func (g *gen) emitObjectTagWire() {
 	count := int64(len(g.unit.ObjNames))
 	g.pf("// The object tag wire: ObjectType in [0, %d], minimal bits; None = 0 is the\n", count)
 	g.pf("// null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).\n")
-	g.pf("inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )\n{\n")
+	g.pf("SCHEMA_WRITE_INLINE bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )\n{\n")
 	g.emitWriteRangedFold32("value", "0", fmt.Sprintf("%d", count),
 		bitsRequired(big.NewInt(0), big.NewInt(count)), true, "    ")
 	g.pf("    return true;\n}\n\n")

--- a/internal/codegen/cpp/readinline.go
+++ b/internal/codegen/cpp/readinline.go
@@ -2,11 +2,13 @@ package cpp
 
 import "github.com/mas-bandwidth/schema/internal/ir"
 
-// fileEmitsReads reports whether this wire file will emit any Read function —
-// struct/object wire pairs, or the owner files' message/object dispatch
-// surfaces. Files that only carry consts/enums/flags emit no reads and no
-// macro block.
-func (g *gen) fileEmitsReads() bool {
+// fileEmitsWire reports whether this wire file will emit any Write/Read wire
+// function — struct/object wire pairs, or the owner files' message/object
+// dispatch surfaces. Files that only carry consts/enums/flags emit no wire
+// functions and no macro blocks. (Named after the C backend's twin: every
+// file that emits one half of a wire pair emits the other, so one predicate
+// guards both macro blocks.)
+func (g *gen) fileEmitsWire() bool {
 	for _, d := range g.file.Decls {
 		switch d.(type) {
 		case *ir.Struct, *ir.Object:

--- a/internal/codegen/cpp/writeinline.go
+++ b/internal/codegen/cpp/writeinline.go
@@ -1,0 +1,54 @@
+package cpp
+
+// emitWriteInlineMacro emits the write-spine inlining switch every generated
+// Write function is spelled with (SCHEMA_WRITE_INLINE). Default OFF:
+// SCHEMA_WRITE_INLINE expands to plain `inline`, token-identical to what this
+// emitter always produced, so an undefined switch changes nothing. Armed
+// (-DSCHEMA_WRITE_SPINE_DEMAND), the generated write path demands inlining
+// the way the serialize family's per-field spines do (serialize.h's write
+// spine; serialize.c SERIALIZE_ALWAYS_INLINE — both halves; the C generated
+// spine's SCHEMA_C_WRITE_SPINE_DEMAND, schema ab268b5; the read twin here,
+// SCHEMA_READ_SPINE_DEMAND, schema 99120c2).
+//
+// Why the demand exists (remark evidence, Apple clang 21, -O3, schema bench,
+// tournament pass bench/results/tournament-air): the generated Write
+// functions are linkonce_odr header functions, and clang refuses them into
+// the timed write loops at cost over BOTH thresholds a call site can be held
+// to — WriteVec3 at cost=330 against the inline-hint threshold (325, five
+// over the line) and against the cold-callsite threshold (45) at
+// decay-priced sites, WriteProbeBits 445, WriteQuat 455, WriteInputPacket
+// 565, WriteShipData_Shallow 885, WriteShipCreate 1075, and the dispatch
+// surface itself, WriteMessage at cost=1555, into the batch build loop. The
+// C backend's identical entries armed with their write demand carry no such
+// boundary, which is the tournament's armed-vs-armed write gap (C ahead:
+// write 65%, batch write 84% of C++ time). No last-call-to-static bonus
+// exists for a linkonce_odr function, so unlike C's static entries these
+// sites never flatten on their own. The demand is a DEMAND, not a
+// branch-weight hint: __builtin_expect-style cold hints were measured in
+// this family to activate the machine outliner and shred hot bodies (bits
+// write -25%) — do not swap this for hints. Guarded against redefinition
+// because several wire headers can land in one translation unit.
+func (g *gen) emitWriteInlineMacro() {
+	g.pf("#ifndef SCHEMA_WRITE_INLINE_DEFINED\n#define SCHEMA_WRITE_INLINE_DEFINED\n")
+	g.pf("// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.\n")
+	g.pf("// Default: plain `inline`, exactly what this emitter always produced.\n")
+	g.pf("// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND\n")
+	g.pf("// inlining (always_inline / __forceinline), the serialize family's remedy\n")
+	g.pf("// for LLVM refusing the linkonce_odr Write entries into their call sites\n")
+	g.pf("// at cost over threshold — no last-call-to-static bonus exists for a\n")
+	g.pf("// header function, so unlike C's static entries these never flatten on\n")
+	g.pf("// their own. Branch-weight hints are NOT the fix here — measured in this\n")
+	g.pf("// family to invite the machine outliner into the hot bodies. Do not add them.\n")
+	g.pf("#if defined( SCHEMA_WRITE_SPINE_DEMAND )\n")
+	g.pf("#if defined( _MSC_VER )\n")
+	g.pf("#define SCHEMA_WRITE_INLINE __forceinline\n")
+	g.pf("#elif defined( __GNUC__ ) || defined( __clang__ )\n")
+	g.pf("#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_WRITE_INLINE inline\n")
+	g.pf("#endif\n")
+	g.pf("#else\n")
+	g.pf("#define SCHEMA_WRITE_INLINE inline\n")
+	g.pf("#endif\n")
+	g.pf("#endif // SCHEMA_WRITE_INLINE_DEFINED\n\n")
+}

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -110,8 +110,8 @@ func TestDispatchSurfaceEmittedOnce(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, needle := range []string{
-			"enum class MessageType", "inline bool WriteMessage(", "SCHEMA_READ_INLINE bool ReadMessage(",
-			"enum class ObjectType", "inline bool WriteObjectType(", "SCHEMA_READ_INLINE bool ReadObjectType(",
+			"enum class MessageType", "SCHEMA_WRITE_INLINE bool WriteMessage(", "SCHEMA_READ_INLINE bool ReadMessage(",
+			"enum class ObjectType", "SCHEMA_WRITE_INLINE bool WriteObjectType(", "SCHEMA_READ_INLINE bool ReadObjectType(",
 		} {
 			if got := countAcross(cppFiles, needle); got != 1 {
 				t.Errorf("C++ (%s): %q emitted %d times across the unit — a TU including both headers cannot compile unless it is exactly once", mode, needle, got)

--- a/internal/fuzz/oracle_test.go
+++ b/internal/fuzz/oracle_test.go
@@ -140,8 +140,10 @@ func checkRustDups(t *testing.T, backend, name string, data []byte) {
 // cFamilyDefLine matches lines that OPEN a top-level definition in the C and
 // C++ emitters' output shapes (both emit at column 0 inside the namespace /
 // extern block). Kept deliberately narrow: a miss costs coverage, a false
-// match costs a bogus crash report.
-var cFamilyDefLine = regexp.MustCompile(`^(static |inline |constexpr |struct |class |enum |typedef |union )`)
+// match costs a bogus crash report. The SCHEMA_*_INLINE spellings are the
+// C++ wire spine's demand macros (default `inline`) — without them here the
+// entire generated wire surface would be invisible to this check.
+var cFamilyDefLine = regexp.MustCompile(`^(static |inline |constexpr |struct |class |enum |typedef |union |SCHEMA_WRITE_INLINE |SCHEMA_READ_INLINE )`)
 
 // csTypeDefLine matches C# type declarations (indented inside the namespace).
 // Member and method lines are excluded on purpose: identical member text in

--- a/testdata/golden/ludicrous/union/LudicrousWire.h
+++ b/testdata/golden/ludicrous/union/LudicrousWire.h
@@ -14,6 +14,30 @@
 
 namespace ludicrous {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -38,7 +62,7 @@ namespace ludicrous {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
 {
     {
         int32_t fixed_value = value.angle;
@@ -79,7 +103,7 @@ SCHEMA_READ_INLINE bool ReadFixedProbe( serialize::ReadStream & stream, FixedPro
     return true;
 }
 
-inline bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedProbe & value )
 {
     {
         uint32_t fixed_value = value.angle;
@@ -128,7 +152,7 @@ SCHEMA_READ_INLINE bool ReadUnsignedProbe( serialize::ReadStream & stream, Unsig
     return true;
 }
 
-inline bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & value )
+SCHEMA_WRITE_INLINE bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & value )
 {
     write_uint128( stream, value.entity_id );
     write_int128( stream, value.energy, -5000000000, 5000000000 );
@@ -148,7 +172,7 @@ SCHEMA_READ_INLINE bool ReadWideProbe( serialize::ReadStream & stream, WideProbe
     return true;
 }
 
-inline bool WriteLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
+SCHEMA_WRITE_INLINE bool WriteLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
 {
     serialize_assert( int32_t( value.mode ) >= int32_t( 0 ) && int32_t( value.mode ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.mode ), 2 );
@@ -206,7 +230,7 @@ SCHEMA_READ_INLINE bool ReadLudicrousState( serialize::ReadStream & stream, Ludi
     return true;
 }
 
-inline bool WriteDegenerateProbe( serialize::WriteStream & stream, const DegenerateProbe & value )
+SCHEMA_WRITE_INLINE bool WriteDegenerateProbe( serialize::WriteStream & stream, const DegenerateProbe & value )
 {
     serialize_assert( int64_t( value.locked_fixed ) == -196608ll );
     serialize_assert( int32_t( value.locked_int ) >= int32_t( 7 ) && int32_t( value.locked_int ) <= int32_t( 7 ) );
@@ -228,7 +252,7 @@ SCHEMA_READ_INLINE bool ReadDegenerateProbe( serialize::ReadStream & stream, Deg
     return true;
 }
 
-inline bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & value )
+SCHEMA_WRITE_INLINE bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & value )
 {
     {
         int64_t fixed_value = value.x;
@@ -253,7 +277,7 @@ SCHEMA_READ_INLINE bool ReadFixedVec( serialize::ReadStream & stream, FixedVec &
     return true;
 }
 
-inline bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & value )
+SCHEMA_WRITE_INLINE bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & value )
 {
     {
         int32_t fixed_value = value.x;
@@ -283,7 +307,7 @@ SCHEMA_READ_INLINE bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat
     return true;
 }
 
-inline bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_Deep & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -317,7 +341,7 @@ SCHEMA_READ_INLINE bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyD
     return true;
 }
 
-inline bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyData_Shallow & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -351,7 +375,7 @@ SCHEMA_READ_INLINE bool ReadBodyData_Shallow( serialize::ReadStream & stream, Bo
     return true;
 }
 
-inline bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const NarrowBodyData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const NarrowBodyData_Deep & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -385,7 +409,7 @@ SCHEMA_READ_INLINE bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream,
     return true;
 }
 
-inline bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const NarrowBodyData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const NarrowBodyData_Shallow & value )
 {
     serialize_assert( int32_t( value.position_x ) >= int32_t( -25600000 ) && int32_t( value.position_x ) <= int32_t( 25600000 ) );
     write_bits( stream, uint32_t( value.position_x ) - uint32_t( -25600000 ), 26 );
@@ -454,7 +478,7 @@ SCHEMA_READ_INLINE bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stre
 
 // The message tag wire: MessageType in [0, 1], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
-inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
+SCHEMA_WRITE_INLINE bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 1 ) );
     write_bits( stream, uint32_t( value ), 1 );
@@ -469,7 +493,7 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
-inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
+SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
     {
@@ -506,7 +530,7 @@ SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & m
 
 // The object tag wire: ObjectType in [0, 2], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
-inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
+SCHEMA_WRITE_INLINE bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value ), 2 );

--- a/testdata/golden/ludicrous/variant/LudicrousWire.h
+++ b/testdata/golden/ludicrous/variant/LudicrousWire.h
@@ -14,6 +14,30 @@
 
 namespace ludicrous {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -38,7 +62,7 @@ namespace ludicrous {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteFixedProbe( serialize::WriteStream & stream, const FixedProbe & value )
 {
     {
         int32_t fixed_value = value.angle;
@@ -79,7 +103,7 @@ SCHEMA_READ_INLINE bool ReadFixedProbe( serialize::ReadStream & stream, FixedPro
     return true;
 }
 
-inline bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteUnsignedProbe( serialize::WriteStream & stream, const UnsignedProbe & value )
 {
     {
         uint32_t fixed_value = value.angle;
@@ -128,7 +152,7 @@ SCHEMA_READ_INLINE bool ReadUnsignedProbe( serialize::ReadStream & stream, Unsig
     return true;
 }
 
-inline bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & value )
+SCHEMA_WRITE_INLINE bool WriteWideProbe( serialize::WriteStream & stream, const WideProbe & value )
 {
     write_uint128( stream, value.entity_id );
     write_int128( stream, value.energy, -5000000000, 5000000000 );
@@ -148,7 +172,7 @@ SCHEMA_READ_INLINE bool ReadWideProbe( serialize::ReadStream & stream, WideProbe
     return true;
 }
 
-inline bool WriteLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
+SCHEMA_WRITE_INLINE bool WriteLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
 {
     serialize_assert( int32_t( value.mode ) >= int32_t( 0 ) && int32_t( value.mode ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.mode ), 2 );
@@ -206,7 +230,7 @@ SCHEMA_READ_INLINE bool ReadLudicrousState( serialize::ReadStream & stream, Ludi
     return true;
 }
 
-inline bool WriteDegenerateProbe( serialize::WriteStream & stream, const DegenerateProbe & value )
+SCHEMA_WRITE_INLINE bool WriteDegenerateProbe( serialize::WriteStream & stream, const DegenerateProbe & value )
 {
     serialize_assert( int64_t( value.locked_fixed ) == -196608ll );
     serialize_assert( int32_t( value.locked_int ) >= int32_t( 7 ) && int32_t( value.locked_int ) <= int32_t( 7 ) );
@@ -228,7 +252,7 @@ SCHEMA_READ_INLINE bool ReadDegenerateProbe( serialize::ReadStream & stream, Deg
     return true;
 }
 
-inline bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & value )
+SCHEMA_WRITE_INLINE bool WriteFixedVec( serialize::WriteStream & stream, const FixedVec & value )
 {
     {
         int64_t fixed_value = value.x;
@@ -253,7 +277,7 @@ SCHEMA_READ_INLINE bool ReadFixedVec( serialize::ReadStream & stream, FixedVec &
     return true;
 }
 
-inline bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & value )
+SCHEMA_WRITE_INLINE bool WriteFixedQuat( serialize::WriteStream & stream, const FixedQuat & value )
 {
     {
         int32_t fixed_value = value.x;
@@ -283,7 +307,7 @@ SCHEMA_READ_INLINE bool ReadFixedQuat( serialize::ReadStream & stream, FixedQuat
     return true;
 }
 
-inline bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteBodyData_Deep( serialize::WriteStream & stream, const BodyData_Deep & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -317,7 +341,7 @@ SCHEMA_READ_INLINE bool ReadBodyData_Deep( serialize::ReadStream & stream, BodyD
     return true;
 }
 
-inline bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteBodyData_Shallow( serialize::WriteStream & stream, const BodyData_Shallow & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -351,7 +375,7 @@ SCHEMA_READ_INLINE bool ReadBodyData_Shallow( serialize::ReadStream & stream, Bo
     return true;
 }
 
-inline bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const NarrowBodyData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteNarrowBodyData_Deep( serialize::WriteStream & stream, const NarrowBodyData_Deep & value )
 {
     if ( !WriteFixedVec( stream, value.position ) )
     {
@@ -385,7 +409,7 @@ SCHEMA_READ_INLINE bool ReadNarrowBodyData_Deep( serialize::ReadStream & stream,
     return true;
 }
 
-inline bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const NarrowBodyData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteNarrowBodyData_Shallow( serialize::WriteStream & stream, const NarrowBodyData_Shallow & value )
 {
     serialize_assert( int32_t( value.position_x ) >= int32_t( -25600000 ) && int32_t( value.position_x ) <= int32_t( 25600000 ) );
     write_bits( stream, uint32_t( value.position_x ) - uint32_t( -25600000 ), 26 );
@@ -454,7 +478,7 @@ SCHEMA_READ_INLINE bool ReadNarrowBodyData_Shallow( serialize::ReadStream & stre
 
 // The message tag wire: MessageType in [0, 1], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
-inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
+SCHEMA_WRITE_INLINE bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 1 ) );
     write_bits( stream, uint32_t( value ), 1 );
@@ -469,7 +493,7 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
-inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
+SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     if ( !WriteMessageType( stream, MessageType( message.index() ) ) )
     {
@@ -505,7 +529,7 @@ SCHEMA_READ_INLINE bool ReadMessage( serialize::ReadStream & stream, Message & m
 
 // The object tag wire: ObjectType in [0, 2], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
-inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
+SCHEMA_WRITE_INLINE bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value ), 2 );

--- a/testdata/golden/union/MessagesWire.h
+++ b/testdata/golden/union/MessagesWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -150,7 +174,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 }
 #endif // SCHEMA_INTERIOR_NULL_DEFINED
 
-inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
+SCHEMA_WRITE_INLINE bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
 {
     (void) stream;
     (void) value; // empty body — presence is the payload (SPEC §4.6)
@@ -164,7 +188,7 @@ SCHEMA_READ_INLINE bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat
     return true;
 }
 
-inline bool WriteTest( serialize::WriteStream & stream, const Test & value )
+SCHEMA_WRITE_INLINE bool WriteTest( serialize::WriteStream & stream, const Test & value )
 {
     write_bits( stream, value.test_a, 16 );
     serialize_assert( int32_t( value.test_b ) >= int32_t( 0 ) && int32_t( value.test_b ) <= int32_t( 1000 ) );
@@ -201,7 +225,7 @@ SCHEMA_READ_INLINE bool ReadTest( serialize::ReadStream & stream, Test & value )
     return true;
 }
 
-inline bool WriteBlock( serialize::WriteStream & stream, const Block & value )
+SCHEMA_WRITE_INLINE bool WriteBlock( serialize::WriteStream & stream, const Block & value )
 {
     serialize_assert( int32_t( value.data_length ) >= int32_t( 0 ) && int32_t( value.data_length ) <= int32_t( MaxBlockSize ) );
     write_bits( stream, uint32_t( value.data_length ), 11 );
@@ -216,7 +240,7 @@ SCHEMA_READ_INLINE bool ReadBlock( serialize::ReadStream & stream, Block & value
     return true;
 }
 
-inline bool WriteChat( serialize::WriteStream & stream, const Chat & value )
+SCHEMA_WRITE_INLINE bool WriteChat( serialize::WriteStream & stream, const Chat & value )
 {
     for ( int32_t i = 0; i < value.text_length; i++ )
     {
@@ -241,7 +265,7 @@ SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
     return true;
 }
 
-inline bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize & value )
+SCHEMA_WRITE_INLINE bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize & value )
 {
     write_bits( stream, value.sync_frame, 64 );
     write_bits( stream, value.sync_sequence, 16 );
@@ -259,7 +283,7 @@ SCHEMA_READ_INLINE bool ReadSynchronize( serialize::ReadStream & stream, Synchro
     return true;
 }
 
-inline bool WriteTimescale( serialize::WriteStream & stream, const Timescale & value )
+SCHEMA_WRITE_INLINE bool WriteTimescale( serialize::WriteStream & stream, const Timescale & value )
 {
     write_double( stream, value.scale );
     write_bits( stream, value.frame_a, 32 );
@@ -277,7 +301,7 @@ SCHEMA_READ_INLINE bool ReadTimescale( serialize::ReadStream & stream, Timescale
 
 // The message tag wire: MessageType in [0, 6], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
-inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
+SCHEMA_WRITE_INLINE bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value ), 3 );
@@ -292,7 +316,7 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
-inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
+SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
     {

--- a/testdata/golden/union/ObjectsWire.h
+++ b/testdata/golden/union/ObjectsWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -41,7 +65,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );
@@ -164,7 +188,7 @@ SCHEMA_READ_INLINE bool ReadShipData_Deep( serialize::ReadStream & stream, ShipD
     return true;
 }
 
-inline bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipData_Shallow & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );
@@ -275,7 +299,7 @@ SCHEMA_READ_INLINE bool ReadShipData_Shallow( serialize::ReadStream & stream, Sh
     return true;
 }
 
-inline bool WriteMissileData_Deep( serialize::WriteStream & stream, const MissileData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteMissileData_Deep( serialize::WriteStream & stream, const MissileData_Deep & value )
 {
     serialize_assert( int32_t( value.missile_type ) >= int32_t( 0 ) && int32_t( value.missile_type ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.missile_type ), 2 );
@@ -325,7 +349,7 @@ SCHEMA_READ_INLINE bool ReadMissileData_Deep( serialize::ReadStream & stream, Mi
     return true;
 }
 
-inline bool WriteMissileData_Shallow( serialize::WriteStream & stream, const MissileData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteMissileData_Shallow( serialize::WriteStream & stream, const MissileData_Shallow & value )
 {
     serialize_assert( int32_t( value.missile_type ) >= int32_t( 0 ) && int32_t( value.missile_type ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.missile_type ), 2 );
@@ -421,7 +445,7 @@ SCHEMA_READ_INLINE bool ReadMissileData_Shallow( serialize::ReadStream & stream,
     return true;
 }
 
-inline bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const DynamicPropData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const DynamicPropData_Deep & value )
 {
     serialize_assert( int32_t( value.prop_type ) >= int32_t( 0 ) && int32_t( value.prop_type ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.prop_type ), 3 );
@@ -471,7 +495,7 @@ SCHEMA_READ_INLINE bool ReadDynamicPropData_Deep( serialize::ReadStream & stream
     return true;
 }
 
-inline bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const DynamicPropData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const DynamicPropData_Shallow & value )
 {
     serialize_assert( int32_t( value.prop_type ) >= int32_t( 0 ) && int32_t( value.prop_type ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.prop_type ), 3 );
@@ -567,7 +591,7 @@ SCHEMA_READ_INLINE bool ReadDynamicPropData_Shallow( serialize::ReadStream & str
     return true;
 }
 
-inline bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretData_Deep & value )
 {
     if ( !WriteHandle( stream, value.parent ) )
     {
@@ -598,7 +622,7 @@ SCHEMA_READ_INLINE bool ReadTurretData_Deep( serialize::ReadStream & stream, Tur
     return true;
 }
 
-inline bool WriteTurretData_Shallow( serialize::WriteStream & stream, const TurretData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteTurretData_Shallow( serialize::WriteStream & stream, const TurretData_Shallow & value )
 {
     if ( !WriteHandle( stream, value.parent ) )
     {
@@ -651,7 +675,7 @@ SCHEMA_READ_INLINE bool ReadTurretData_Shallow( serialize::ReadStream & stream, 
 
 // The object tag wire: ObjectType in [0, 4], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
-inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
+SCHEMA_WRITE_INLINE bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value ), 3 );

--- a/testdata/golden/union/RenderWire.h
+++ b/testdata/golden/union/RenderWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -39,7 +63,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
+SCHEMA_WRITE_INLINE bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
 {
     write_bits( stream, value.sort_key, 64 );
     write_bits( stream, value.mesh_id, 32 );
@@ -68,7 +92,7 @@ SCHEMA_READ_INLINE bool ReadRenderSprite( serialize::ReadStream & stream, Render
     return true;
 }
 
-inline bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock & value )
+SCHEMA_WRITE_INLINE bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock & value )
 {
     write_bits( stream, value.worker_index, 32 );
     write_bits( stream, value.sprite_count_hint, 32 );

--- a/testdata/golden/union/TypesWire.h
+++ b/testdata/golden/union/TypesWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -41,7 +65,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
+SCHEMA_WRITE_INLINE bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
 {
     write_double( stream, value.x );
     write_double( stream, value.y );
@@ -57,7 +81,7 @@ SCHEMA_READ_INLINE bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
     return true;
 }
 
-inline bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
+SCHEMA_WRITE_INLINE bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
 {
     write_double( stream, value.x );
     write_double( stream, value.y );
@@ -75,7 +99,7 @@ SCHEMA_READ_INLINE bool ReadQuat( serialize::ReadStream & stream, Quat & value )
     return true;
 }
 
-inline bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
+SCHEMA_WRITE_INLINE bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
 {
     serialize_assert( int32_t( value.object_id ) >= int32_t( 0 ) && int32_t( value.object_id ) <= int32_t( MaxObjects - 1 ) );
     write_bits( stream, uint32_t( value.object_id ), 14 );
@@ -94,7 +118,7 @@ SCHEMA_READ_INLINE bool ReadHandle( serialize::ReadStream & stream, Handle & val
     return true;
 }
 
-inline bool WriteQuantizedPosition( serialize::WriteStream & stream, const QuantizedPosition & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedPosition( serialize::WriteStream & stream, const QuantizedPosition & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -MaxPositionUnits ) && int32_t( value.x ) <= int32_t( MaxPositionUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -MaxPositionUnits ), 25 );
@@ -113,7 +137,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedPosition( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteQuantizedVelocity( serialize::WriteStream & stream, const QuantizedVelocity & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedVelocity( serialize::WriteStream & stream, const QuantizedVelocity & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -MaxVelocityUnits ) && int32_t( value.x ) <= int32_t( MaxVelocityUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -MaxVelocityUnits ), 23 );
@@ -132,7 +156,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedVelocity( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteQuantizedRotation( serialize::WriteStream & stream, const QuantizedRotation & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedRotation( serialize::WriteStream & stream, const QuantizedRotation & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -RotationUnits ) && int32_t( value.x ) <= int32_t( RotationUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -RotationUnits ), 12 );
@@ -170,7 +194,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedRotation( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & value )
+SCHEMA_WRITE_INLINE bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & value )
 {
     if ( !WriteVec3( stream, value.position ) )
     {
@@ -225,7 +249,7 @@ SCHEMA_READ_INLINE bool ReadRigidBody( serialize::ReadStream & stream, RigidBody
     return true;
 }
 
-inline bool WriteInput( serialize::WriteStream & stream, const Input & value )
+SCHEMA_WRITE_INLINE bool WriteInput( serialize::WriteStream & stream, const Input & value )
 {
     write_float( stream, value.stick_x );
     write_float( stream, value.stick_y );
@@ -261,7 +285,7 @@ SCHEMA_READ_INLINE bool ReadInput( serialize::ReadStream & stream, Input & value
     return true;
 }
 
-inline bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket & value )
+SCHEMA_WRITE_INLINE bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket & value )
 {
     write_bits( stream, value.synchronize_sequence, 16 );
     write_bits( stream, value.current_frame, 64 );
@@ -298,7 +322,7 @@ SCHEMA_READ_INLINE bool ReadInputPacket( serialize::ReadStream & stream, InputPa
     return true;
 }
 
-inline bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate & value )
+SCHEMA_WRITE_INLINE bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );

--- a/testdata/golden/union/WireWire.h
+++ b/testdata/golden/union/WireWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -150,7 +174,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 }
 #endif // SCHEMA_INTERIOR_NULL_DEFINED
 
-inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
+SCHEMA_WRITE_INLINE bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {
     write_bits( stream, 171ull, 8 ); // const(171, 8) — SPEC §4.3
     write_bits( stream, value.version, 3 );
@@ -184,7 +208,7 @@ SCHEMA_READ_INLINE bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHe
     return true;
 }
 
-inline bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & value )
+SCHEMA_WRITE_INLINE bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & value )
 {
     write_bits( stream, value.small, 9 );
     write_bits( stream, value.boundary, 33 );
@@ -209,7 +233,7 @@ SCHEMA_READ_INLINE bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits
     return true;
 }
 
-inline bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample & value )
+SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample & value )
 {
     write_bool( stream, value.active );
     {
@@ -296,7 +320,7 @@ SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSa
     return true;
 }
 
-inline bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig & value )
+SCHEMA_WRITE_INLINE bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig & value )
 {
     write_bits( stream, uint32_t( value.retries ), 32 );
     serialize_assert( int32_t( value.preferred ) >= int32_t( 0 ) && int32_t( value.preferred ) <= int32_t( 15 ) );
@@ -319,7 +343,7 @@ SCHEMA_READ_INLINE bool ReadProbeConfig( serialize::ReadStream & stream, ProbeCo
     return true;
 }
 
-inline bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray & value )
+SCHEMA_WRITE_INLINE bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray & value )
 {
     for ( int32_t i = 0; i < 2; i++ )
     {
@@ -351,7 +375,7 @@ SCHEMA_READ_INLINE bool ReadProbeArray( serialize::ReadStream & stream, ProbeArr
     return true;
 }
 
-inline bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport & value )
+SCHEMA_WRITE_INLINE bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport & value )
 {
     if ( !WriteProbeHeader( stream, value.header ) )
     {
@@ -380,7 +404,7 @@ SCHEMA_READ_INLINE bool ReadProbeReport( serialize::ReadStream & stream, ProbeRe
     return true;
 }
 
-inline bool WriteTestData( serialize::WriteStream & stream, const TestData & value )
+SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const TestData & value )
 {
     serialize_assert( int32_t( value.a ) >= int32_t( -100 ) && int32_t( value.a ) <= int32_t( 100 ) );
     write_bits( stream, uint32_t( value.a ) - uint32_t( -100 ), 8 );
@@ -484,7 +508,7 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
     return true;
 }
 
-inline bool WriteCompressedProbe( serialize::WriteStream & stream, const CompressedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteCompressedProbe( serialize::WriteStream & stream, const CompressedProbe & value )
 {
     {
         float compressed_value = value.boundary;

--- a/testdata/golden/variant/MessagesWire.h
+++ b/testdata/golden/variant/MessagesWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -150,7 +174,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 }
 #endif // SCHEMA_INTERIOR_NULL_DEFINED
 
-inline bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
+SCHEMA_WRITE_INLINE bool WriteHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
 {
     (void) stream;
     (void) value; // empty body — presence is the payload (SPEC §4.6)
@@ -164,7 +188,7 @@ SCHEMA_READ_INLINE bool ReadHeartbeat( serialize::ReadStream & stream, Heartbeat
     return true;
 }
 
-inline bool WriteTest( serialize::WriteStream & stream, const Test & value )
+SCHEMA_WRITE_INLINE bool WriteTest( serialize::WriteStream & stream, const Test & value )
 {
     write_bits( stream, value.test_a, 16 );
     serialize_assert( int32_t( value.test_b ) >= int32_t( 0 ) && int32_t( value.test_b ) <= int32_t( 1000 ) );
@@ -201,7 +225,7 @@ SCHEMA_READ_INLINE bool ReadTest( serialize::ReadStream & stream, Test & value )
     return true;
 }
 
-inline bool WriteBlock( serialize::WriteStream & stream, const Block & value )
+SCHEMA_WRITE_INLINE bool WriteBlock( serialize::WriteStream & stream, const Block & value )
 {
     serialize_assert( int32_t( value.data_length ) >= int32_t( 0 ) && int32_t( value.data_length ) <= int32_t( MaxBlockSize ) );
     write_bits( stream, uint32_t( value.data_length ), 11 );
@@ -216,7 +240,7 @@ SCHEMA_READ_INLINE bool ReadBlock( serialize::ReadStream & stream, Block & value
     return true;
 }
 
-inline bool WriteChat( serialize::WriteStream & stream, const Chat & value )
+SCHEMA_WRITE_INLINE bool WriteChat( serialize::WriteStream & stream, const Chat & value )
 {
     for ( int32_t i = 0; i < value.text_length; i++ )
     {
@@ -241,7 +265,7 @@ SCHEMA_READ_INLINE bool ReadChat( serialize::ReadStream & stream, Chat & value )
     return true;
 }
 
-inline bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize & value )
+SCHEMA_WRITE_INLINE bool WriteSynchronize( serialize::WriteStream & stream, const Synchronize & value )
 {
     write_bits( stream, value.sync_frame, 64 );
     write_bits( stream, value.sync_sequence, 16 );
@@ -259,7 +283,7 @@ SCHEMA_READ_INLINE bool ReadSynchronize( serialize::ReadStream & stream, Synchro
     return true;
 }
 
-inline bool WriteTimescale( serialize::WriteStream & stream, const Timescale & value )
+SCHEMA_WRITE_INLINE bool WriteTimescale( serialize::WriteStream & stream, const Timescale & value )
 {
     write_double( stream, value.scale );
     write_bits( stream, value.frame_a, 32 );
@@ -277,7 +301,7 @@ SCHEMA_READ_INLINE bool ReadTimescale( serialize::ReadStream & stream, Timescale
 
 // The message tag wire: MessageType in [0, 6], minimal bits; None = 0 is a
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
-inline bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
+SCHEMA_WRITE_INLINE bool WriteMessageType( serialize::WriteStream & stream, MessageType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value ), 3 );
@@ -292,7 +316,7 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
-inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
+SCHEMA_WRITE_INLINE bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     if ( !WriteMessageType( stream, MessageType( message.index() ) ) )
     {

--- a/testdata/golden/variant/ObjectsWire.h
+++ b/testdata/golden/variant/ObjectsWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -41,7 +65,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteShipData_Deep( serialize::WriteStream & stream, const ShipData_Deep & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );
@@ -164,7 +188,7 @@ SCHEMA_READ_INLINE bool ReadShipData_Deep( serialize::ReadStream & stream, ShipD
     return true;
 }
 
-inline bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteShipData_Shallow( serialize::WriteStream & stream, const ShipData_Shallow & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );
@@ -275,7 +299,7 @@ SCHEMA_READ_INLINE bool ReadShipData_Shallow( serialize::ReadStream & stream, Sh
     return true;
 }
 
-inline bool WriteMissileData_Deep( serialize::WriteStream & stream, const MissileData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteMissileData_Deep( serialize::WriteStream & stream, const MissileData_Deep & value )
 {
     serialize_assert( int32_t( value.missile_type ) >= int32_t( 0 ) && int32_t( value.missile_type ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.missile_type ), 2 );
@@ -325,7 +349,7 @@ SCHEMA_READ_INLINE bool ReadMissileData_Deep( serialize::ReadStream & stream, Mi
     return true;
 }
 
-inline bool WriteMissileData_Shallow( serialize::WriteStream & stream, const MissileData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteMissileData_Shallow( serialize::WriteStream & stream, const MissileData_Shallow & value )
 {
     serialize_assert( int32_t( value.missile_type ) >= int32_t( 0 ) && int32_t( value.missile_type ) <= int32_t( 3 ) );
     write_bits( stream, uint32_t( value.missile_type ), 2 );
@@ -421,7 +445,7 @@ SCHEMA_READ_INLINE bool ReadMissileData_Shallow( serialize::ReadStream & stream,
     return true;
 }
 
-inline bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const DynamicPropData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteDynamicPropData_Deep( serialize::WriteStream & stream, const DynamicPropData_Deep & value )
 {
     serialize_assert( int32_t( value.prop_type ) >= int32_t( 0 ) && int32_t( value.prop_type ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.prop_type ), 3 );
@@ -471,7 +495,7 @@ SCHEMA_READ_INLINE bool ReadDynamicPropData_Deep( serialize::ReadStream & stream
     return true;
 }
 
-inline bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const DynamicPropData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteDynamicPropData_Shallow( serialize::WriteStream & stream, const DynamicPropData_Shallow & value )
 {
     serialize_assert( int32_t( value.prop_type ) >= int32_t( 0 ) && int32_t( value.prop_type ) <= int32_t( 6 ) );
     write_bits( stream, uint32_t( value.prop_type ), 3 );
@@ -567,7 +591,7 @@ SCHEMA_READ_INLINE bool ReadDynamicPropData_Shallow( serialize::ReadStream & str
     return true;
 }
 
-inline bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretData_Deep & value )
+SCHEMA_WRITE_INLINE bool WriteTurretData_Deep( serialize::WriteStream & stream, const TurretData_Deep & value )
 {
     if ( !WriteHandle( stream, value.parent ) )
     {
@@ -598,7 +622,7 @@ SCHEMA_READ_INLINE bool ReadTurretData_Deep( serialize::ReadStream & stream, Tur
     return true;
 }
 
-inline bool WriteTurretData_Shallow( serialize::WriteStream & stream, const TurretData_Shallow & value )
+SCHEMA_WRITE_INLINE bool WriteTurretData_Shallow( serialize::WriteStream & stream, const TurretData_Shallow & value )
 {
     if ( !WriteHandle( stream, value.parent ) )
     {
@@ -651,7 +675,7 @@ SCHEMA_READ_INLINE bool ReadTurretData_Shallow( serialize::ReadStream & stream, 
 
 // The object tag wire: ObjectType in [0, 4], minimal bits; None = 0 is the
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
-inline bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
+SCHEMA_WRITE_INLINE bool WriteObjectType( serialize::WriteStream & stream, ObjectType value )
 {
     serialize_assert( int32_t( value ) >= int32_t( 0 ) && int32_t( value ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value ), 3 );

--- a/testdata/golden/variant/RenderWire.h
+++ b/testdata/golden/variant/RenderWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -39,7 +63,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
+SCHEMA_WRITE_INLINE bool WriteRenderSprite( serialize::WriteStream & stream, const RenderSprite & value )
 {
     write_bits( stream, value.sort_key, 64 );
     write_bits( stream, value.mesh_id, 32 );
@@ -68,7 +92,7 @@ SCHEMA_READ_INLINE bool ReadRenderSprite( serialize::ReadStream & stream, Render
     return true;
 }
 
-inline bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock & value )
+SCHEMA_WRITE_INLINE bool WriteRenderBlock( serialize::WriteStream & stream, const RenderBlock & value )
 {
     write_bits( stream, value.worker_index, 32 );
     write_bits( stream, value.sprite_count_hint, 32 );

--- a/testdata/golden/variant/TypesWire.h
+++ b/testdata/golden/variant/TypesWire.h
@@ -17,6 +17,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -41,7 +65,7 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-inline bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
+SCHEMA_WRITE_INLINE bool WriteVec3( serialize::WriteStream & stream, const Vec3 & value )
 {
     write_double( stream, value.x );
     write_double( stream, value.y );
@@ -57,7 +81,7 @@ SCHEMA_READ_INLINE bool ReadVec3( serialize::ReadStream & stream, Vec3 & value )
     return true;
 }
 
-inline bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
+SCHEMA_WRITE_INLINE bool WriteQuat( serialize::WriteStream & stream, const Quat & value )
 {
     write_double( stream, value.x );
     write_double( stream, value.y );
@@ -75,7 +99,7 @@ SCHEMA_READ_INLINE bool ReadQuat( serialize::ReadStream & stream, Quat & value )
     return true;
 }
 
-inline bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
+SCHEMA_WRITE_INLINE bool WriteHandle( serialize::WriteStream & stream, const Handle & value )
 {
     serialize_assert( int32_t( value.object_id ) >= int32_t( 0 ) && int32_t( value.object_id ) <= int32_t( MaxObjects - 1 ) );
     write_bits( stream, uint32_t( value.object_id ), 14 );
@@ -94,7 +118,7 @@ SCHEMA_READ_INLINE bool ReadHandle( serialize::ReadStream & stream, Handle & val
     return true;
 }
 
-inline bool WriteQuantizedPosition( serialize::WriteStream & stream, const QuantizedPosition & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedPosition( serialize::WriteStream & stream, const QuantizedPosition & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -MaxPositionUnits ) && int32_t( value.x ) <= int32_t( MaxPositionUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -MaxPositionUnits ), 25 );
@@ -113,7 +137,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedPosition( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteQuantizedVelocity( serialize::WriteStream & stream, const QuantizedVelocity & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedVelocity( serialize::WriteStream & stream, const QuantizedVelocity & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -MaxVelocityUnits ) && int32_t( value.x ) <= int32_t( MaxVelocityUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -MaxVelocityUnits ), 23 );
@@ -132,7 +156,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedVelocity( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteQuantizedRotation( serialize::WriteStream & stream, const QuantizedRotation & value )
+SCHEMA_WRITE_INLINE bool WriteQuantizedRotation( serialize::WriteStream & stream, const QuantizedRotation & value )
 {
     serialize_assert( int32_t( value.x ) >= int32_t( -RotationUnits ) && int32_t( value.x ) <= int32_t( RotationUnits ) );
     write_bits( stream, uint32_t( value.x ) - uint32_t( -RotationUnits ), 12 );
@@ -170,7 +194,7 @@ SCHEMA_READ_INLINE bool ReadQuantizedRotation( serialize::ReadStream & stream, Q
     return true;
 }
 
-inline bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & value )
+SCHEMA_WRITE_INLINE bool WriteRigidBody( serialize::WriteStream & stream, const RigidBody & value )
 {
     if ( !WriteVec3( stream, value.position ) )
     {
@@ -225,7 +249,7 @@ SCHEMA_READ_INLINE bool ReadRigidBody( serialize::ReadStream & stream, RigidBody
     return true;
 }
 
-inline bool WriteInput( serialize::WriteStream & stream, const Input & value )
+SCHEMA_WRITE_INLINE bool WriteInput( serialize::WriteStream & stream, const Input & value )
 {
     write_float( stream, value.stick_x );
     write_float( stream, value.stick_y );
@@ -261,7 +285,7 @@ SCHEMA_READ_INLINE bool ReadInput( serialize::ReadStream & stream, Input & value
     return true;
 }
 
-inline bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket & value )
+SCHEMA_WRITE_INLINE bool WriteInputPacket( serialize::WriteStream & stream, const InputPacket & value )
 {
     write_bits( stream, value.synchronize_sequence, 16 );
     write_bits( stream, value.current_frame, 64 );
@@ -298,7 +322,7 @@ SCHEMA_READ_INLINE bool ReadInputPacket( serialize::ReadStream & stream, InputPa
     return true;
 }
 
-inline bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate & value )
+SCHEMA_WRITE_INLINE bool WriteShipCreate( serialize::WriteStream & stream, const ShipCreate & value )
 {
     serialize_assert( int32_t( value.ship_type ) >= int32_t( 0 ) && int32_t( value.ship_type ) <= int32_t( 5 ) );
     write_bits( stream, uint32_t( value.ship_type ), 3 );

--- a/testdata/golden/variant/WireWire.h
+++ b/testdata/golden/variant/WireWire.h
@@ -15,6 +15,30 @@
 
 namespace example {
 
+#ifndef SCHEMA_WRITE_INLINE_DEFINED
+#define SCHEMA_WRITE_INLINE_DEFINED
+// SCHEMA_WRITE_INLINE — how every generated Write function is spelled.
+// Default: plain `inline`, exactly what this emitter always produced.
+// Define SCHEMA_WRITE_SPINE_DEMAND to make the generated write path DEMAND
+// inlining (always_inline / __forceinline), the serialize family's remedy
+// for LLVM refusing the linkonce_odr Write entries into their call sites
+// at cost over threshold — no last-call-to-static bonus exists for a
+// header function, so unlike C's static entries these never flatten on
+// their own. Branch-weight hints are NOT the fix here — measured in this
+// family to invite the machine outliner into the hot bodies. Do not add them.
+#if defined( SCHEMA_WRITE_SPINE_DEMAND )
+#if defined( _MSC_VER )
+#define SCHEMA_WRITE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define SCHEMA_WRITE_INLINE inline __attribute__(( always_inline ))
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#else
+#define SCHEMA_WRITE_INLINE inline
+#endif
+#endif // SCHEMA_WRITE_INLINE_DEFINED
+
 #ifndef SCHEMA_READ_INLINE_DEFINED
 #define SCHEMA_READ_INLINE_DEFINED
 // SCHEMA_READ_INLINE — how every generated Read function is spelled.
@@ -150,7 +174,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
 }
 #endif // SCHEMA_INTERIOR_NULL_DEFINED
 
-inline bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
+SCHEMA_WRITE_INLINE bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {
     write_bits( stream, 171ull, 8 ); // const(171, 8) — SPEC §4.3
     write_bits( stream, value.version, 3 );
@@ -184,7 +208,7 @@ SCHEMA_READ_INLINE bool ReadProbeHeader( serialize::ReadStream & stream, ProbeHe
     return true;
 }
 
-inline bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & value )
+SCHEMA_WRITE_INLINE bool WriteProbeBits( serialize::WriteStream & stream, const ProbeBits & value )
 {
     write_bits( stream, value.small, 9 );
     write_bits( stream, value.boundary, 33 );
@@ -209,7 +233,7 @@ SCHEMA_READ_INLINE bool ReadProbeBits( serialize::ReadStream & stream, ProbeBits
     return true;
 }
 
-inline bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample & value )
+SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, const ProbeSample & value )
 {
     write_bool( stream, value.active );
     {
@@ -296,7 +320,7 @@ SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSa
     return true;
 }
 
-inline bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig & value )
+SCHEMA_WRITE_INLINE bool WriteProbeConfig( serialize::WriteStream & stream, const ProbeConfig & value )
 {
     write_bits( stream, uint32_t( value.retries ), 32 );
     serialize_assert( int32_t( value.preferred ) >= int32_t( 0 ) && int32_t( value.preferred ) <= int32_t( 15 ) );
@@ -319,7 +343,7 @@ SCHEMA_READ_INLINE bool ReadProbeConfig( serialize::ReadStream & stream, ProbeCo
     return true;
 }
 
-inline bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray & value )
+SCHEMA_WRITE_INLINE bool WriteProbeArray( serialize::WriteStream & stream, const ProbeArray & value )
 {
     for ( int32_t i = 0; i < 2; i++ )
     {
@@ -351,7 +375,7 @@ SCHEMA_READ_INLINE bool ReadProbeArray( serialize::ReadStream & stream, ProbeArr
     return true;
 }
 
-inline bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport & value )
+SCHEMA_WRITE_INLINE bool WriteProbeReport( serialize::WriteStream & stream, const ProbeReport & value )
 {
     if ( !WriteProbeHeader( stream, value.header ) )
     {
@@ -380,7 +404,7 @@ SCHEMA_READ_INLINE bool ReadProbeReport( serialize::ReadStream & stream, ProbeRe
     return true;
 }
 
-inline bool WriteTestData( serialize::WriteStream & stream, const TestData & value )
+SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const TestData & value )
 {
     serialize_assert( int32_t( value.a ) >= int32_t( -100 ) && int32_t( value.a ) <= int32_t( 100 ) );
     write_bits( stream, uint32_t( value.a ) - uint32_t( -100 ), 8 );
@@ -484,7 +508,7 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
     return true;
 }
 
-inline bool WriteCompressedProbe( serialize::WriteStream & stream, const CompressedProbe & value )
+SCHEMA_WRITE_INLINE bool WriteCompressedProbe( serialize::WriteStream & stream, const CompressedProbe & value )
 {
     {
         float compressed_value = value.boundary;


### PR DESCRIPTION
## What

One compile-time switch, **OFF by default**, that lets the generated C++ write spine demand inlining: every generated Write function is now spelled `SCHEMA_WRITE_INLINE` — which expands to plain `inline`, token-identical to what the emitter always produced — unless the consumer defines `SCHEMA_WRITE_SPINE_DEMAND`, in which case the generated write spine (per-type `Write` functions, object deep/shallow views, `WriteMessageType`, `WriteObjectType`, and the write half of the dispatch surface, `WriteMessage`) demands inlining with `always_inline`/`__forceinline`.

This is the exact twin of the merged precedents: #47 (`SCHEMA_READ_SPINE_DEMAND`, 99120c2 — the C++ read spine) and #52 (`SCHEMA_C_READ_SPINE_DEMAND`/`SCHEMA_C_WRITE_SPINE_DEMAND` — the C twins, which carry the demand both ways). It is the final missing switch the tournament pass (#54) named.

## Why (tournament table + remark evidence, compile-only — NO timing claims in this PR)

The tournament's armed-vs-armed verdict (`bench/results/tournament-air`, r2, 0.2% controls; reproduce with `go run ./bench/tools rel --cross-linkage bench/results/tournament-air/2026-08-16-arm64-macbook-air-power-tournament-r2-armed-pair-O3.csv`):

| backend | write | read | batch write | batch read |
|---|---:|---:|---:|---:|
| C++ | 100% | 100% | 100% | 100% |
| C | **65%** | **100%** | **84%** | **97%** |

(*Higher is slower: each cell is C++'s best rate divided by that language's — C at 65% write means C takes 65% of C++'s time.*) Read side: parity, exact — the war #47/#52 opened is closed. Write side: **C ahead 35% on the corpus and 16% on the batch**, and the absence this PR fills is the largest remaining term in the C-vs-C++ table.

The Phase-4 remarks already catalogued the stranded sites, and the tournament's armed cpp ledger (`…r2-cpp-armed-O3-pass.inline`) carries them verbatim. The generated Write functions are `linkonce_odr` header functions, and clang refuses them into the timed write loops at cost over BOTH thresholds a call site can be held to — the inline-hint threshold (325) at hot sites and the cold-callsite threshold (45) at decay-priced sites:

```
'WriteVec3'             not inlined (cost=330,  threshold=45 and 325)  <- five over the hot line
'WriteProbeBits'        not inlined (cost=445,  threshold=45)
'WriteQuat'             not inlined (cost=455,  threshold=45 and 325)
'WriteInputPacket'      not inlined (cost=565,  threshold=45 and 325)
'WriteProbeSample'      not inlined (cost=785,  threshold=45 and 325)
'WriteShipData_Shallow' not inlined (cost=885,  threshold=45 and 325)
'WriteShipCreate'       not inlined (cost=1075, threshold=45 and 325)
'WriteTestData'         not inlined (cost=2595, threshold=45)
'WriteMessage'          not inlined into 'build_batch' (cost=1555, threshold=325)  <- the batch loop
```

No last-call-to-static bonus exists for a `linkonce_odr` function, so unlike C's `static` entries (which flatten once their demand is armed) these sites never flatten on their own. The mechanism that kills the boundary is #47's and #52's exactly: a demand macro in the emitter's function spelling. No branch-weight hints anywhere — cold hints are measured in this family to activate the machine outliner and shred hot bodies (bits write -25%); the demand is a demand.

## Verification

- **OFF (default): byte-identical.** The bench C++ leg (`bench/cpp/bench_main.cpp`, the recorded Release flags, no demand defines) built from this branch's generated tree vs main's: the two Mach-O binaries are **byte-identical — zero differing bytes** (`cmp` clean, stronger than #52's 16-byte-LC_UUID bound); `otool -tv` disassembly identical.
- **ON:** one `-Rpass='inline|loop-unroll|loop-vectorize' -Rpass-missed='…'` regex alternation (clang keeps only the last flag), Apple clang 21, `-O3`: every catalogued site inlines at `(cost=always)` — `WriteVec3`, `WriteQuat`, `WriteProbeBits`, `WriteProbeSample`, `WriteInputPacket`, `WriteShipCreate`, `WriteShipData_Shallow`, `WriteTestData`, and `WriteMessage` into `build_batch`; **zero** missed-inline remarks name a generated `Write*` as callee (the only survivors are the runtime's `BitWriter::WriteBytes` bulk-bytes class inside `WriteChat`/`WriteTestData` — the known chat `partial:1`, out of this switch's scope); all **13** out-of-line `example::Write*` entry symbols **vanish** from the armed binary; **zero** `OUTLINED_FUNCTION_*` symbols.
- **ON, correctness:** all five C++ conformance legs (`schema_test`, `schema_test_variant`, `schema_test_random`, `schema_test_ludicrous`, `schema_test_bench`) build under the strict flags and pass armed — both write-only (`-DSCHEMA_WRITE_SPINE_DEMAND`) and write+read armed together.
- `go test ./...` green; `make test` green (all five language legs); inline-gate `selftest`, `leg cpp`, `leg c` all PASS; goldens re-pinned via `make update-goldens` — the only golden movement is the switch plumbing text itself (OFF-state object code proven identical above). Wire goldens untouched.
- In passing: the fuzz oracle's `cFamilyDefLine` regex learns the `SCHEMA_WRITE_INLINE`/`SCHEMA_READ_INLINE` spellings, so the generated wire surface stays visible to the duplicate-definition check (the read half had silently left its coverage in #47).

## The Implementation Law (STANDARD.md, serialize@23807f7)

> **Speed is normative.** Among correct implementations of an operation, the fastest correct option is the conforming one. [...] Performance parity is part of conformance in spirit: C and C++ at total parity; systems languages within a few percent, with every residual attributed to a named language mechanism.

C++ at 154% of C's write time armed-vs-armed is not a documented language necessity — it is one inliner refusal class, already catalogued, and this switch is the staged remedy and the last one the table demands.

## What this PR is NOT

It is not a claim that the switch is faster — that is exactly what has not been measured. It stays OFF until a quiet-window A/B pass under `bench/BENCH-STANDARD.md` validates it; the timing protocol rides with the pass analysis, not this repo. **Do not merge before the pass runs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
