### PR TITLE
ci: pin the five sibling runtimes to their released tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,29 @@ jobs:
       # special one. The Makefile's SERIALIZE* defaults already point here, and
       # the generated go.mod / Cargo.toml embed relative paths that only
       # resolve under this layout.
-      - name: Check out the serialize runtimes
+      #
+      # PINNED to each sibling's latest RELEASED tag, never main: a sibling
+      # merging to main mid-day must not change what a schema commit's CI
+      # proves — the sibling-HEAD race broke this gate three separate times
+      # (2026-08-16/17) with green schema commits going red on foreign pushes.
+      # One pin per sibling, exactly one place each (the env lines below).
+      # To bump a pin: edit that sibling's *_TAG line to the new release tag —
+      # nothing else changes. Find the newest tag with:
+      #   gh release list --repo mas-bandwidth/<repo> --limit 1
+      - name: Check out the serialize runtimes (pinned releases)
+        env:
+          SERIALIZE_TAG: v1.10.0
+          SERIALIZE_C_TAG: v1.4.0
+          SERIALIZE_GO_TAG: v1.10.1
+          SERIALIZE_RS_TAG: v2.1.1
+          SERIALIZE_CS_TAG: v1.3.1
         run: |
           cd ..
-          git clone --quiet --depth 1 https://github.com/mas-bandwidth/serialize.git    serialize
-          git clone --quiet --depth 1 https://github.com/mas-bandwidth/serialize.c.git  serialize.c
-          git clone --quiet --depth 1 https://github.com/mas-bandwidth/serialize.go.git serialize.go
-          git clone --quiet --depth 1 https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
-          git clone --quiet --depth 1 https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
+          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
+          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
 
       - uses: actions/setup-go@v7
         with:


### PR DESCRIPTION
The standing wire-pins debt (cairn 2a3ae0b6 item 8; noted in serialize.go#35): the sibling-HEAD race bit three separate times on 2026-08-16/17 — the test job cloned all five serialize runtimes at main, so a sibling merging mid-day flipped green schema commits red, and what a schema commit's CI proved depended on when it ran rather than what it contained.

Each sibling clone now pins that repo's latest RELEASED tag — all five cut in tonight's release wave:

| Sibling | Pin |
|---------|-----|
| serialize | v1.10.0 |
| serialize.c | v1.4.0 |
| serialize.go | v1.10.1 |
| serialize.rs | v2.1.1 |
| serialize.cs | v1.3.1 |

One pin per sibling, exactly one place each (the step's `env` lines). Bumping is a one-line edit; the workflow comment carries the convention and the one-command lookup (`gh release list --repo mas-bandwidth/<repo> --limit 1`).

This also insulates schema CI from the three in-flight check-model PRs (serialize.rs#47, serialize.cs#17, serialize.go#37) landing later: their merges change nothing here until a pin is deliberately bumped.

README's sibling-clone instructions for humans are deliberately unchanged: a developer tracking sibling mains is the working layout; CI pinning releases is the reproducibility contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
