### PR TITLE
CI pins the sibling runtimes at the current releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
         env:
           SERIALIZE_TAG: v1.10.0
           SERIALIZE_C_TAG: v1.4.0
-          SERIALIZE_GO_TAG: v1.10.1
-          SERIALIZE_RS_TAG: v2.1.1
-          SERIALIZE_CS_TAG: v1.3.1
+          SERIALIZE_GO_TAG: v1.11.0
+          SERIALIZE_RS_TAG: v2.1.2
+          SERIALIZE_CS_TAG: v1.4.0
           SERIALIZE_JS_TAG: v1.1.0
         run: |
           cd ..


### PR DESCRIPTION
Bumps the three sibling-runtime tag pins one release forward, as one commit with one CI run: SERIALIZE_GO_TAG v1.10.1→v1.11.0, SERIALIZE_RS_TAG v2.1.1→v2.1.2, SERIALIZE_CS_TAG v1.3.1→v1.4.0 — the pins went one behind when tonight's release wave cut all three (schema itself shipped v1.9.0 in the same wave). The dated era archive under bench/results/ deliberately keeps the old tags: it records what was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)