### PR TITLE
Generated Go carries its own compressed-float constants: the runtime's per-field derivation folds into the call site

### DIFF
--- a/generated/bench/go/realworld/RealWorld.go
+++ b/generated/bench/go/realworld/RealWorld.go
@@ -212,8 +212,14 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeBits(&offsetValue, 21)
 	}
 	{
-		compressedValue := value.F004Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 2000.0, 0.1)
+		normalizedValue := value.F004Cf32 / 2000.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*20000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 15)
 	}
 	{
 		rangeValue := int32(value.F005Uint)
@@ -312,8 +318,14 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	stream.SerializeBits(&value.F026Bits, 9)
 	{
-		compressedValue := value.F027Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, -2.0, 2.0, 0.25)
+		normalizedValue := (value.F027Cf32 - (-2.0)) / 4.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*16.0) + 0.5)
+		stream.SerializeBits(&integerValue, 5)
 	}
 	stream.SerializeBits(&value.F028Bits, 4)
 	{
@@ -458,8 +470,14 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeFloat64(&value.F059F64)
 	stream.SerializeBits(&value.F060Bits, 8)
 	{
-		compressedValue := value.F061Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, -90.0, 90.0, 0.5)
+		normalizedValue := (value.F061Cf32 - (-90.0)) / 180.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*360.0) + 0.5)
+		stream.SerializeBits(&integerValue, 9)
 	}
 	{
 		rangeValue := int32(value.F062Uint)
@@ -486,20 +504,38 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		}
 	}
 	{
-		compressedValue := value.F065Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 30.0, 0.5)
+		normalizedValue := value.F065Cf32 / 30.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*60.0) + 0.5)
+		stream.SerializeBits(&integerValue, 6)
 	}
 	{
 		fixedValue := int64(value.F066Ufixed)
 		stream.SerializeFixed64(&fixedValue, 2, 14, 0, 2)
 	}
 	{
-		compressedValue := value.F067Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, -100.0, 100.0, 0.25)
+		normalizedValue := (value.F067Cf32 - (-100.0)) / 200.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*800.0) + 0.5)
+		stream.SerializeBits(&integerValue, 10)
 	}
 	{
-		compressedValue := value.F068Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 2000.0, 1.0)
+		normalizedValue := value.F068Cf32 / 2000.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*2000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 11)
 	}
 	stream.SerializeBits(&value.F069Bits, 11)
 	{
@@ -513,12 +549,24 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		}
 	}
 	{
-		compressedValue := value.F071Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 10.0, 0.02)
+		normalizedValue := value.F071Cf32 / 10.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*500.0) + 0.5)
+		stream.SerializeBits(&integerValue, 9)
 	}
 	{
-		compressedValue := value.F072Cf32
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 100.0, 0.01)
+		normalizedValue := value.F072Cf32 / 100.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*10000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 14)
 	}
 	{
 		rangeValue := int32(value.F073Int)
@@ -638,7 +686,18 @@ func ReadRealPacket(stream *serialize.ReadStream, value *RealPacket) error {
 	stream.SerializeInt(&value.F001Int, -805495, 805495)
 	stream.SerializeFloat64(&value.F002F64)
 	stream.SerializeInt(&value.F003Int, -835897, 835897)
-	stream.SerializeCompressedFloat32(&value.F004Cf32, 0.0, 2000.0, 0.1)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 15)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 20000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 20000.0
+		value.F004Cf32 = float32(normalizedValue * 2000.0)
+	}
 	{
 		rangeValue := int32(0)
 		stream.SerializeInt(&rangeValue, 0, 7316)
@@ -709,7 +768,18 @@ func ReadRealPacket(stream *serialize.ReadStream, value *RealPacket) error {
 		value.F025Fixed = int16(fixedValue)
 	}
 	stream.SerializeBits(&value.F026Bits, 9)
-	stream.SerializeCompressedFloat32(&value.F027Cf32, -2.0, 2.0, 0.25)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 5)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 16 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 16.0
+		value.F027Cf32 = float32(normalizedValue*4.0) + (-2.0)
+	}
 	stream.SerializeBits(&value.F028Bits, 4)
 	{
 		rawValue := uint64(0)
@@ -809,7 +879,18 @@ func ReadRealPacket(stream *serialize.ReadStream, value *RealPacket) error {
 	stream.SerializeFloat32(&value.F058F32)
 	stream.SerializeFloat64(&value.F059F64)
 	stream.SerializeBits(&value.F060Bits, 8)
-	stream.SerializeCompressedFloat32(&value.F061Cf32, -90.0, 90.0, 0.5)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 9)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 360 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 360.0
+		value.F061Cf32 = float32(normalizedValue*180.0) + (-90.0)
+	}
 	{
 		rangeValue := int32(0)
 		stream.SerializeInt(&rangeValue, 0, 503)
@@ -825,22 +906,77 @@ func ReadRealPacket(stream *serialize.ReadStream, value *RealPacket) error {
 		stream.SerializeInt(&rangeValue, 0, 299)
 		value.F064Uint = uint16(rangeValue)
 	}
-	stream.SerializeCompressedFloat32(&value.F065Cf32, 0.0, 30.0, 0.5)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 6)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 60 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 60.0
+		value.F065Cf32 = float32(normalizedValue * 30.0)
+	}
 	{
 		fixedValue := int64(0)
 		stream.SerializeFixed64(&fixedValue, 2, 14, 0, 2)
 		value.F066Ufixed = uint16(fixedValue)
 	}
-	stream.SerializeCompressedFloat32(&value.F067Cf32, -100.0, 100.0, 0.25)
-	stream.SerializeCompressedFloat32(&value.F068Cf32, 0.0, 2000.0, 1.0)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 10)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 800 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 800.0
+		value.F067Cf32 = float32(normalizedValue*200.0) + (-100.0)
+	}
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 11)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 2000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 2000.0
+		value.F068Cf32 = float32(normalizedValue * 2000.0)
+	}
 	stream.SerializeBits(&value.F069Bits, 11)
 	{
 		rangeValue := int32(0)
 		stream.SerializeInt(&rangeValue, 0, 2)
 		value.F070Uint = uint8(rangeValue)
 	}
-	stream.SerializeCompressedFloat32(&value.F071Cf32, 0.0, 10.0, 0.02)
-	stream.SerializeCompressedFloat32(&value.F072Cf32, 0.0, 100.0, 0.01)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 9)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 500 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 500.0
+		value.F071Cf32 = float32(normalizedValue * 10.0)
+	}
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 14)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 10000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 10000.0
+		value.F072Cf32 = float32(normalizedValue * 100.0)
+	}
 	{
 		rangeValue := int32(0)
 		stream.SerializeInt(&rangeValue, -4, 4)

--- a/generated/go/Wire.go
+++ b/generated/go/Wire.go
@@ -195,8 +195,14 @@ const ProbeSampleMaxBytes = 40
 func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 	stream.SerializeBool(&value.Active)
 	{
-		compressedValue := value.Orientation
-		stream.SerializeCompressedFloat32(&compressedValue, -180.0, 180.0, 0.01)
+		normalizedValue := (value.Orientation - (-180.0)) / 360.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*36000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 16)
 	}
 	{
 		rawValue := uint32(value.RawDelta)
@@ -248,7 +254,18 @@ func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 
 func ReadProbeSample(stream *serialize.ReadStream, value *ProbeSample) error {
 	stream.SerializeBool(&value.Active)
-	stream.SerializeCompressedFloat32(&value.Orientation, -180.0, 180.0, 0.01)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 16)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 36000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 36000.0
+		value.Orientation = float32(normalizedValue*360.0) + (-180.0)
+	}
 	{
 		rawValue := uint32(0)
 		stream.SerializeBits(&rawValue, 32)
@@ -519,8 +536,14 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 	}
 	stream.SerializeFloat32(&value.FloatValue)
 	{
-		compressedValue := value.CompressedFloatValue
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 10.0, 0.01)
+		normalizedValue := value.CompressedFloatValue / 10.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*1000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 10)
 	}
 	stream.SerializeFloat64(&value.DoubleValue)
 	{
@@ -584,7 +607,18 @@ func ReadTestData(stream *serialize.ReadStream, value *TestData) error {
 		stream.SerializeInt(&value.Items[i], 0, 255)
 	}
 	stream.SerializeFloat32(&value.FloatValue)
-	stream.SerializeCompressedFloat32(&value.CompressedFloatValue, 0.0, 10.0, 0.01)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 10)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 1000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 1000.0
+		value.CompressedFloatValue = float32(normalizedValue * 10.0)
+	}
 	stream.SerializeFloat64(&value.DoubleValue)
 	{
 		rawValue := uint32(0)
@@ -645,18 +679,52 @@ const CompressedProbeMaxBytes = 8
 
 func WriteCompressedProbe(stream *serialize.WriteStream, value *CompressedProbe) error {
 	{
-		compressedValue := value.Boundary
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 10.0, 0.01)
+		normalizedValue := value.Boundary / 10.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*1000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 10)
 	}
 	{
-		compressedValue := value.Offset
-		stream.SerializeCompressedFloat32(&compressedValue, -5.0, 5.0, 0.001)
+		normalizedValue := (value.Offset - (-5.0)) / 10.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*10000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 14)
 	}
 	return stream.Err()
 }
 
 func ReadCompressedProbe(stream *serialize.ReadStream, value *CompressedProbe) error {
-	stream.SerializeCompressedFloat32(&value.Boundary, 0.0, 10.0, 0.01)
-	stream.SerializeCompressedFloat32(&value.Offset, -5.0, 5.0, 0.001)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 10)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 1000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 1000.0
+		value.Boundary = float32(normalizedValue * 10.0)
+	}
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 14)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 10000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 10000.0
+		value.Offset = float32(normalizedValue*10.0) + (-5.0)
+	}
 	return stream.Err()
 }

--- a/internal/codegen/golang/functions.go
+++ b/internal/codegen/golang/functions.go
@@ -264,6 +264,75 @@ func (g *gen) emitWriteRangedFold64(expr, lo, hi string, bits int64, loZero bool
 	g.pf("%s\tstream.SerializeBits64(&offsetValue, %d)\n%s}\n", ind, bits, ind)
 }
 
+// emitWriteCompressedFold quantizes a ranged float onto its step count in a
+// generation-time bit count — serialize_compressed_float's own arithmetic with
+// the declaration folded, the way the ranged-integer folds carry their bounds.
+// The step count, wire width and delta depend only on (min, max, resolution),
+// which are compile-time constants of the call site, so the runtime's per-field
+// derivation (a float32 divide, a clamp, a Ceil and a BitsRequired) is paid once
+// here instead of on every field of every message.
+//
+// The float32() around the product is LOAD BEARING, exactly as it is in the
+// runtime and in internal/pack: STANDARD.md pins this arithmetic to float32 with
+// TWO roundings, and Go permits fusing a multiply into an add unless a
+// conversion forces the intermediate rounding. arm64 takes that permission, so a
+// fused line writes different bytes for 0.005 over [0, 10] at resolution 0.01.
+// Do not "simplify" it.
+//
+// uint32() truncates toward zero, which is the runtime's Floor: the clamp leaves
+// normalizedValue in [0, 1] (its !>= form sends NaN to 0), so the product plus
+// 0.5 is always positive, where truncation and floor agree.
+func (g *gen) emitWriteCompressedFold(f *ir.Field, name, ind string) {
+	steps, bits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
+	min32 := float32(f.FMin)
+	delta := float32(f.FMax) - min32
+	g.pf("%s{\n", ind)
+	if min32 == 0 {
+		g.pf("%s\tnormalizedValue := %s / %s\n", ind, name, f32lit(delta))
+	} else {
+		g.pf("%s\tnormalizedValue := (%s - (%s)) / %s\n", ind, name, f32lit(min32), f32lit(delta))
+	}
+	g.pf("%s\tif !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too\n", ind)
+	g.pf("%s\t\tnormalizedValue = 0\n%s\t} else if !(normalizedValue <= 1) {\n%s\t\tnormalizedValue = 1\n%s\t}\n", ind, ind, ind, ind)
+	g.pf("%s\tintegerValue := uint32(float32(normalizedValue*%s) + 0.5)\n", ind, f32lit(float32(steps)))
+	g.pf("%s\tstream.SerializeBits(&integerValue, %d)\n%s}\n", ind, bits, ind)
+}
+
+// emitReadCompressedFold is the read twin: the quantized value at its
+// generation-time width, the runtime's headroom refusal folded, then the
+// dequantization. The refusal is elided where the step count fills its bit width
+// exactly — there is no headroom to smuggle a value into.
+//
+// The float32() around the product is LOAD BEARING for the reader's own reason:
+// fused, integer 384 over [-100, 100] at resolution 0.01 decodes to -96.159996
+// where two roundings give -96.160004, so an arm64 reader would disagree with
+// every other runtime about what it just read.
+func (g *gen) emitReadCompressedFold(f *ir.Field, name, ind string) {
+	steps, bits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
+	min32 := float32(f.FMin)
+	delta := float32(f.FMax) - min32
+	g.pf("%s{\n%s\tintegerValue := uint32(0)\n", ind, ind)
+	g.pf("%s\tstream.SerializeBits(&integerValue, %d)\n", ind, bits)
+	if steps != uint64(1)<<uint(bits)-1 {
+		g.pf("%s\tif stream.Err() != nil {\n%s\t\treturn stream.Err()\n%s\t}\n", ind, ind, ind)
+		g.pf("%s\tif integerValue > %d { // a value smuggled into the bit headroom is refused (SPEC §4.3)\n", ind, steps)
+		g.pf("%s\t\treturn ErrValidation\n%s\t}\n", ind, ind)
+	}
+	g.pf("%s\tnormalizedValue := float32(integerValue) / %s\n", ind, f32lit(float32(steps)))
+	if min32 == 0 {
+		g.pf("%s\t%s = float32(normalizedValue * %s)\n%s}\n", ind, name, f32lit(delta), ind)
+	} else {
+		g.pf("%s\t%s = float32(normalizedValue*%s) + (%s)\n%s}\n", ind, name, f32lit(delta), f32lit(min32), ind)
+	}
+}
+
+// f32lit prints a float32 as a Go literal that converts back to exactly that
+// value — the folded constants are float32 quantities, and the wire depends on
+// their exact bits.
+func f32lit(v float32) string {
+	return formatFloat32(float64(v))
+}
+
 // maxUint64 is 2^64 - 1, the top of unsigned-64 storage — the bound against
 // which a range guard becomes vacuous.
 var maxUint64 = new(big.Int).SetUint64(math.MaxUint64)
@@ -435,10 +504,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		g.pf("%sstream.SerializeBool(&%s)\n", ind, name)
 	case ir.TFloat32:
 		if f.HasFloatRange {
-			// a temp so the wire quantization cannot write back into the input
-			g.pf("%s{\n%s\tcompressedValue := %s\n", ind, ind, name)
-			g.pf("%s\tstream.SerializeCompressedFloat32(&compressedValue, %s, %s, %s)\n%s}\n",
-				ind, formatFloat32(f.FMin), formatFloat32(f.FMax), formatFloat32(f.Resolution), ind)
+			g.emitWriteCompressedFold(f, name, ind)
 			return
 		}
 		g.pf("%sstream.SerializeFloat32(&%s)\n", ind, name)
@@ -635,8 +701,7 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 		g.pf("%sstream.SerializeBool(&%s)\n", ind, name)
 	case ir.TFloat32:
 		if f.HasFloatRange {
-			g.pf("%sstream.SerializeCompressedFloat32(&%s, %s, %s, %s)\n",
-				ind, name, formatFloat32(f.FMin), formatFloat32(f.FMax), formatFloat32(f.Resolution))
+			g.emitReadCompressedFold(f, name, ind)
 			return
 		}
 		g.pf("%sstream.SerializeFloat32(&%s)\n", ind, name)

--- a/testdata/golden/go/Wire.go
+++ b/testdata/golden/go/Wire.go
@@ -195,8 +195,14 @@ const ProbeSampleMaxBytes = 40
 func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 	stream.SerializeBool(&value.Active)
 	{
-		compressedValue := value.Orientation
-		stream.SerializeCompressedFloat32(&compressedValue, -180.0, 180.0, 0.01)
+		normalizedValue := (value.Orientation - (-180.0)) / 360.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*36000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 16)
 	}
 	{
 		rawValue := uint32(value.RawDelta)
@@ -248,7 +254,18 @@ func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 
 func ReadProbeSample(stream *serialize.ReadStream, value *ProbeSample) error {
 	stream.SerializeBool(&value.Active)
-	stream.SerializeCompressedFloat32(&value.Orientation, -180.0, 180.0, 0.01)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 16)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 36000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 36000.0
+		value.Orientation = float32(normalizedValue*360.0) + (-180.0)
+	}
 	{
 		rawValue := uint32(0)
 		stream.SerializeBits(&rawValue, 32)
@@ -519,8 +536,14 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 	}
 	stream.SerializeFloat32(&value.FloatValue)
 	{
-		compressedValue := value.CompressedFloatValue
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 10.0, 0.01)
+		normalizedValue := value.CompressedFloatValue / 10.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*1000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 10)
 	}
 	stream.SerializeFloat64(&value.DoubleValue)
 	{
@@ -584,7 +607,18 @@ func ReadTestData(stream *serialize.ReadStream, value *TestData) error {
 		stream.SerializeInt(&value.Items[i], 0, 255)
 	}
 	stream.SerializeFloat32(&value.FloatValue)
-	stream.SerializeCompressedFloat32(&value.CompressedFloatValue, 0.0, 10.0, 0.01)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 10)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 1000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 1000.0
+		value.CompressedFloatValue = float32(normalizedValue * 10.0)
+	}
 	stream.SerializeFloat64(&value.DoubleValue)
 	{
 		rawValue := uint32(0)
@@ -645,18 +679,52 @@ const CompressedProbeMaxBytes = 8
 
 func WriteCompressedProbe(stream *serialize.WriteStream, value *CompressedProbe) error {
 	{
-		compressedValue := value.Boundary
-		stream.SerializeCompressedFloat32(&compressedValue, 0.0, 10.0, 0.01)
+		normalizedValue := value.Boundary / 10.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*1000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 10)
 	}
 	{
-		compressedValue := value.Offset
-		stream.SerializeCompressedFloat32(&compressedValue, -5.0, 5.0, 0.001)
+		normalizedValue := (value.Offset - (-5.0)) / 10.0
+		if !(normalizedValue >= 0) { // the runtime's clamp form — it forces NaN into range too
+			normalizedValue = 0
+		} else if !(normalizedValue <= 1) {
+			normalizedValue = 1
+		}
+		integerValue := uint32(float32(normalizedValue*10000.0) + 0.5)
+		stream.SerializeBits(&integerValue, 14)
 	}
 	return stream.Err()
 }
 
 func ReadCompressedProbe(stream *serialize.ReadStream, value *CompressedProbe) error {
-	stream.SerializeCompressedFloat32(&value.Boundary, 0.0, 10.0, 0.01)
-	stream.SerializeCompressedFloat32(&value.Offset, -5.0, 5.0, 0.001)
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 10)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 1000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 1000.0
+		value.Boundary = float32(normalizedValue * 10.0)
+	}
+	{
+		integerValue := uint32(0)
+		stream.SerializeBits(&integerValue, 14)
+		if stream.Err() != nil {
+			return stream.Err()
+		}
+		if integerValue > 10000 { // a value smuggled into the bit headroom is refused (SPEC §4.3)
+			return ErrValidation
+		}
+		normalizedValue := float32(integerValue) / 10000.0
+		value.Offset = float32(normalizedValue*10.0) + (-5.0)
+	}
 	return stream.Err()
 }


### PR DESCRIPTION
Partial fix for #28: the schema-emitter half, Go backend.

## Route A (emitter only), and the code says it is the only right one

`compressedFloatParams` depends solely on `(min, max, resolution)`, which are
compile-time constants at every generated call site. The Go backend now folds
them at generation time, printing step count, wire width and delta as float32
literals, and does the quantization inline against an ordinary `SerializeBits`.
**No runtime API is added or changed**, so the five-runtime contract question
Route B would have raised does not arise.

This is not a new pattern in the repo. It is the pattern:

- the Go backend already folds ranged-int bounds, enum bounds, string lengths
  and fixed-point ranges the same way (`// the runtime range refusal, folded
  (SPEC §5)`), and the generated output reads identically to its neighbors;
- `internal/pack/encode.go` and `internal/codegen/js/flat.go` **already** derive
  compressed-float parameters from `ir.CompressedFloatParams` at generation
  time. This change makes the Go backend the third caller of the same IR helper;
- SPEC §6.1's IR preservation invariant already sanctions it verbatim:
  *"compressed floats keep `(min, max, resolution)` with derived step count"*.
  No spec change.

## Why Go, and only Go, in this sitting

The issue warned that the Go mechanism needed its own investigation rather than
a transplant. It does, and the inline ledger is the diagnosis:

| | verdict on `probearray` (the compressed-float-carrying gen bench) |
|---|---|
| **go** | **partial:12**. gc **refuses** `SerializeCompressedFloat32`: read cost **199**, write **187**, against budget **80** |
| cpp | full (0 hot runtime calls per op), at both O2 and O3 |
| c | full (0), at both O2 and O3 |
| rust | full (0) |
| cs | partial:3 |

C, C++ and Rust already measure **zero hot runtime calls per op** on that
benchmark. Their compilers have inlined the call and constant-folded the
derivation already, exactly as #28's caveat predicted, so folding in those
emitters would be churn carrying wire risk for no measured gain. C# is the only
other candidate, and CLAUDE.md already records this class of fold measuring
**0.97-1.04x** there because the JIT had inlined and lzcnt-folded it, which
makes it a measure-first proposition rather than a mechanical drop-in. Go is the
outlier at partial:12, and it is the one fixed here.

## Wire compatibility: unchanged, and proven four ways

1. **`testdata/wire/` is untouched** (`git status --porcelain testdata/wire` is
   empty). The C++ leg writes those pins; the Go and go-ludicrous legs
   byte-compare them and pass.
2. **The gate-7 FMA-discriminating vectors ride the Go leg.** `compressed_probe`
   pins `0.005` over `[0, 10]` at `0.01` (step 1 unfused, 0 fused) and `-4.8585`
   over `[-5, 5]` at `0.001` (142 vs 141), and the C++ leg asserts the
   discrimination property itself so the vectors cannot quietly stop
   discriminating.
3. **`internal/pack`'s independent encoder** packs the same pinned instances and
   byte-compares. Green.
4. **A dedicated differential**: the *generated* fold against the runtime call it
   replaced, over 16 declarations (every compressed-float declaration in
   `examples/`, `bench/corpus/RealWorld.schema` and serialize.go's own packet
   bench, plus degenerate and million-step ones). **1,120,178 checks**, wire
   bytes and decoded float32 bit patterns identical on every one. Inputs: dense
   in-range sweeps with overshoot, all specials (NaN, ±Inf, subnormals,
   ±MaxFloat32, exact bounds, ±resolution/2), 400k uniform random float32 **bit
   patterns**, 400k in-range randoms, and every representable quantized code
   including the bit headroom for each narrow field.
   The differential was **mutation-verified**. Dropping the writer's `float32()`
   round makes it fail with different wire bytes on the documented `0.005` case;
   dropping the reader's round fails on decode; dropping the headroom refusal
   fails on the read sweep.

`make test` (all six language legs) is green. `go vet`, `make generated-current`,
fuzz seeds, `make check`, fmt-drift and the inline gate (`selftest` plus
`leg go`, 34 legs within budget) are all green. Only the Go **source** golden is
re-pinned.

Both `float32()` conversions are carried across verbatim and are load bearing in
both directions, because Go fuses a multiply into an add unless a conversion
forces the intermediate rounding, and arm64 takes that permission. `uint32()`
truncates where the runtime floors, and they agree because the clamp leaves the
product non-negative.

## Numbers

**Caveat, loudly: these are Air numbers.** arm64 MacBook Air (M2), shared
desktop core, no pinning, idle apps resident. This is **not** the certification
box, and per `bench/README.md` a bare `bench/run.sh` invocation is **not a
publishable pass** (a publishable pass is a driver pass). These are **relative
signals from two independent same-sitting A/B pairs**, offered as conviction
rather than as publishable rows. Each row is the runner's own median of 7 after
a warmup.

    bench/run.sh --only go --out <before|after>.csv     # x4, sequential

Compressed-float-carrying rows, each pair normalized by that pair's own control
median (28 control rows), so baseline drift between sittings divides out:

| row | pair 1 | pair 2 |
|---|---|---|
| `probearray` write | **+12.0%** | **+12.0%** |
| `probearray` read | **+8.0%** | **+8.0%** |
| `testdata` read | +2.0% | +1.8% |
| `testdata` write | +0.9% | -0.1% |

Raw medians (M msg/s), pair 1 then pair 2: `probearray` write 20.53 to 22.88,
and 20.41 to 22.82; `probearray` read 17.60 to 18.91, and 17.49 to 18.85.

`probearray` carries 2 compressed floats out of ~26 field ops. `testdata`
carries 1 out of ~25 and is bulk/string-dominated, which is why its signal is
small. The 28 control rows sat at median ratio 0.995 and 0.998.

**Banked predictions, and one refutation.** Predicted before measuring:
(1) hot-call verdict drops 12 to 10 on `probearray`; (2) `probearray` +4-10%;
(3) `testdata` 0-3%; (4) no systematic control movement.

**Prediction 1 is REFUTED.** The verdict did not move; it is still partial:12.
`SerializeBits` *does* inline (cost 73/80), but its body calls
`readBits`/`writeBits`, which do not. So the fold trades one out-of-line call
for another and deletes the arithmetic between them, rather than removing a
call. Throughput moved anyway, and above the predicted band on write.
**Consequence: `bench/inline-budget.txt` needs no edit, and the gate passes
unchanged.**

**Two unattributed movements, filed rather than claimed**, per CLAUDE.md's
instrument-honesty rule:

- `probe_header read` moved **+20.5% and +18.3%**, reproducibly in both pairs.
  `ProbeHeader` contains **no compressed float** (`const`, `bits`, `reserved`,
  `align`, `uint64`), so this cannot be the change's semantics. It is almost
  certainly code layout, since the fold shrinks `Wire.go`'s generated code and
  shifts alignment for everything after it. It reproduces because it is a
  property of the two binaries rather than of the sitting. **Not claimed as part
  of this fix.**
- `message_batch` moved -2.1%/-2.8% in pair 1 and -0.8%/+0.7% in pair 2. It does
  not reproduce, which is consistent with the documented ±20% layout noise on
  that row. Filed, not claimed.

## What remains for #28

This closes the Go emitter half only. Left open, with what was measured:

- **C, C++, Rust**: no work indicated. Measured full (0 hot calls per op) on
  `probearray`, so already inlined and constant-folded. Folding would be churn
  with wire risk for no gain.
- **C#**: the only other candidate (partial:3). Needs its own measurement first,
  given the recorded 0.97-1.04x for this class of fold there.
- **JS**: already folded (`js/flat.go`), and flat is THE js path.
- **The runtimes themselves are untouched.** #28's headline number, 30.8% of
  Go's read profile, is a **serialize.go-side** profile of that repo's own
  packet benchmark (7 compressed floats in a 133-byte packet). Nothing in this
  PR can move it, because a hand-written caller of `SerializeCompressedFloat32`
  still pays the per-field derivation. Whether the runtime should gain a
  precomputed-params entry point is the five-runtime family decision #28
  describes, and is deliberately **not** taken here.
- **A measurement gap worth its own issue.** schema's Go, Rust and C# bench
  runners have **no `real_packet` row**; only cpp, c and js do, even though
  `generated/bench/go/realworld/` is generated and rides `make test`.
  `real_packet` is the compressed-float-dense workload (7 fields), so the
  backend with the largest compressed-float cost is measured on the corpus with
  the least of it. `probearray` (2 fields) is the densest Go row available today.
- **Diagnosis lanes for Go and C#**, #28's second half, are not addressed here.

Refs #28 (partial: Go emitter only).
