### PR TITLE
CI: the lint toolchain is pinned, because a pinned linter cannot lint an unpinned Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,9 +166,19 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+      # PINNED to the module's own Go version, and it moves WITH the
+      # golangci-lint pin below. golangci-lint links a copy of the Go
+      # typechecker, so a linter release can only typecheck the toolchains
+      # that existed when it shipped: `stable` + a pinned linter is a pairing
+      # that goes red on its own, with no commit, the day Go releases. It did
+      # — 2026-08-20, Go 1.27.0 landing in `stable` against v2.12.2 (May),
+      # which reported `unknown field rfd in struct literal of type
+      # splicePipe` from the runner's OWN internal/poll. The identical commit
+      # had passed lint 55 minutes earlier in its PR. Bumping the linter is
+      # now a two-line, deliberate act: this version and that one, together.
       - uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: '1.26'
           cache: false
       - name: gofmt
         run: |


### PR DESCRIPTION
`main` went red on 236bb45 with no commit behind it. golangci-lint v2.12.2 reported `unknown field rfd in struct literal of type splicePipe` against `/opt/hostedtoolcache/go/1.27.0/.../internal/poll/splice_linux.go` — the runner's own standard library, not ours. The identical commit had passed lint 55 minutes earlier in its PR (run 32324302758). Nothing changed but the clock: Go 1.27.0 became `stable`.

golangci-lint links a copy of the Go typechecker, so a release can only typecheck the toolchains that existed when it shipped. Pinning the linter while leaving its Go on `stable` is a pairing that breaks by itself, on someone else's release schedule — which is the "randomly" the version pin's own comment exists to prevent.

The lint job now pins the module's Go version, the one the test job and `go.mod` already name. Bumping the linter becomes a deliberate two-line act: this version and that one, together. `vuln` and `windows` stay on `stable` on purpose — they run the real toolchain, where forward coverage is the point.

serialize.go carries the identical pairing and is latent-red: its last run was 2026-08-17, before 1.27 shipped, so it is green only because nothing has pushed to it. Same fix going there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
