### PR TITLE
C emitter: bulk [N]uint8 paths at statically byte-aligned positions, read and write

### DIFF
--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -109,15 +109,9 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_packet( serialize_wri
     {
         return 0;
     }
+    if ( !serialize_write_bytes( stream, value->blob, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
-        int32_t i;
-        for ( i = 0; i < 17; i++ )
-        {
-            if ( !serialize_write_bits( stream, (serialize_uint32_t) value->blob[i], 8 ) )
-            {
-                return 0;
-            }
-        }
+        return 0;
     }
     return 1;
 }
@@ -220,19 +214,9 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_packet( serialize_read_
     {
         return 0;
     }
+    if ( !serialize_read_bytes( stream, value->blob, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
-        int32_t i;
-        for ( i = 0; i < 17; i++ )
-        {
-            {
-                serialize_uint32_t raw = 0;
-                if ( !serialize_read_bits( stream, &raw, 8 ) )
-                {
-                    return 0;
-                }
-                value->blob[i] = (uint8_t) raw;
-            }
-        }
+        return 0;
     }
     return 1;
 }

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -767,15 +767,9 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     {
         return 0;
     }
+    if ( !serialize_write_bytes( stream, value->fixed_bytes, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
-        int32_t i;
-        for ( i = 0; i < 17; i++ )
-        {
-            if ( !serialize_write_bits( stream, (serialize_uint32_t) value->fixed_bytes[i], 8 ) )
-            {
-                return 0;
-            }
-        }
+        return 0;
     }
     serialize_assert( schema_utf8_valid_( (const serialize_uint8_t *) value->text, value->text_length ) );
     if ( !serialize_write_int( stream, value->text_length, 0, 255 ) )
@@ -978,19 +972,9 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
     {
         return 0;
     }
+    if ( !serialize_read_bytes( stream, value->fixed_bytes, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
-        int32_t i;
-        for ( i = 0; i < 17; i++ )
-        {
-            {
-                serialize_uint32_t raw = 0;
-                if ( !serialize_read_bits( stream, &raw, 8 ) )
-                {
-                    return 0;
-                }
-                value->fixed_bytes[i] = (uint8_t) raw;
-            }
-        }
+        return 0;
     }
     if ( !serialize_read_int( stream, &value->text_length, 0, 255 ) )
     {

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -121,6 +121,12 @@ type gen struct {
 	deps                []string
 	wire                bool
 	body                strings.Builder
+
+	// fixed [N]uint8 arrays of the struct being emitted whose element bytes
+	// are statically byte-aligned (ir.AlignedFixedByteArrays) — the same map
+	// the C++ backend consults, reloaded per function so it never outlives
+	// its struct
+	bulkBytes map[*ir.Field]bool
 }
 
 func (g *gen) pf(format string, args ...any) {
@@ -488,6 +494,12 @@ func (g *gen) emitWireHeader() {
 }
 
 func (g *gen) emitWriteFunc(st *ir.Struct) {
+	// fixed [N]uint8 arrays at statically byte-aligned positions take
+	// serialize.c's bulk-bytes path instead of a per-byte loop — the bulk
+	// call's internal align contributes zero bits at a boundary, so the wire
+	// is byte-identical (the same switch, off the same analysis, as the C++
+	// backend)
+	g.bulkBytes = ir.AlignedFixedByteArrays(st)
 	g.pf("/* Writes %s. Returns 1 on success, 0 on failure — the stream latches the\n", st.Name)
 	g.pf("   error, so a caller may check once at the end of a message. */\n")
 	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_%s( serialize_write_stream_t * stream, const %s * value )\n{\n", snake(st.Name), st.Name)
@@ -514,6 +526,7 @@ func (g *gen) emitWriteFunc(st *ir.Struct) {
 }
 
 func (g *gen) emitReadFunc(st *ir.Struct) {
+	g.bulkBytes = ir.AlignedFixedByteArrays(st) // see emitWriteFunc
 	g.pf("/* Reads %s. Returns 1 on success, 0 on failure. Out-of-range values are\n", st.Name)
 	g.pf("   REFUSED, never clamped. */\n")
 	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_%s( serialize_read_stream_t * stream, %s * value )\n{\n", snake(st.Name), st.Name)

--- a/internal/codegen/c/c_test.go
+++ b/internal/codegen/c/c_test.go
@@ -88,12 +88,11 @@ func wireBodies(t *testing.T, header string) map[string]string {
 			if i < 0 {
 				t.Fatalf("generated C has no %s%s function:\n%s", prefix, name, header)
 			}
-			rest := header[i:]
-			end := strings.Index(rest, "\n}\n")
-			if end < 0 {
+			body, _, ok := strings.Cut(header[i:], "\n}\n")
+			if !ok {
 				t.Fatalf("%s%s function body is unterminated", prefix, name)
 			}
-			out[prefix+name] = rest[:end]
+			out[prefix+name] = body
 		}
 	}
 	return out

--- a/internal/codegen/c/c_test.go
+++ b/internal/codegen/c/c_test.go
@@ -1,0 +1,190 @@
+// Emitter-shape tests for the C backend.
+//
+// The bulk-bytes path is a WIRE-SENSITIVE optimization: at a statically
+// byte-aligned position, N unranged 8-bit writes and one aligned bulk copy
+// are the same bytes (SPEC §4.3, and serialize.c's align contributes zero
+// bits when already aligned) — but ANYWHERE ELSE the bulk path's internal
+// align would insert padding the pinned encoding does not have. So the test
+// that matters is not "does C use the bulk call" but "does C use it at
+// exactly the positions the shared analysis marks, and nowhere else" — and
+// that set must be the same set the C++ backend switches on, since the two
+// are held to one golden.
+package c
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/internal/check"
+	"github.com/mas-bandwidth/schema/internal/ir"
+	"github.com/mas-bandwidth/schema/internal/parser"
+)
+
+func unitFromSource(t *testing.T, name, src string) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse(name, []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: name, Name: name, Base: strings.TrimSuffix(name, ".schema"),
+		Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	return u
+}
+
+// The same shapes internal/ir/align_test.go pins the ANALYSIS on, carried up
+// to the EMISSION: each type holds one fixed [N]uint8 named data, and the
+// name says whether the C wire functions may bulk-copy it.
+const bulkCorpus = `package bulktest
+
+type MarkedAfterAlign {
+    lead bits(3)
+    align
+    data [17]uint8
+}
+
+type MarkedAfterString {
+    s    string(31)
+    data [3]uint8
+}
+
+type UnmarkedAtEntry {
+    data [17]uint8
+}
+
+type UnmarkedOffBoundary {
+    align
+    flag bool
+    data [4]uint8
+}
+
+type UnmarkedRanged {
+    align
+    data [4]uint8 [min = 0, max = 255]
+}
+
+type UnmarkedCounted {
+    align
+    data [<= 8]uint8
+}
+`
+
+// wireBodies splits the generated wire header into the write_<type> and
+// read_<type> function bodies, keyed by snake-cased type name.
+func wireBodies(t *testing.T, header string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, prefix := range []string{"write_", "read_"} {
+		for _, name := range []string{
+			"marked_after_align", "marked_after_string", "unmarked_at_entry",
+			"unmarked_off_boundary", "unmarked_ranged", "unmarked_counted",
+		} {
+			open := "int " + prefix + name + "( "
+			i := strings.Index(header, open)
+			if i < 0 {
+				t.Fatalf("generated C has no %s%s function:\n%s", prefix, name, header)
+			}
+			rest := header[i:]
+			end := strings.Index(rest, "\n}\n")
+			if end < 0 {
+				t.Fatalf("%s%s function body is unterminated", prefix, name)
+			}
+			out[prefix+name] = rest[:end]
+		}
+	}
+	return out
+}
+
+// TestBulkBytesEmission pins that the C emitter takes serialize.c's bulk
+// bytes path for statically byte-aligned fixed [N]uint8 arrays and keeps the
+// per-byte loop everywhere else. Before the bulk path landed, EVERY case here
+// was a per-byte loop — correct on the wire but a byte at a time.
+func TestBulkBytesEmission(t *testing.T) {
+	u := unitFromSource(t, "Bulk.schema", bulkCorpus)
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := string(files["BulkWire.h"])
+	bodies := wireBodies(t, header)
+
+	bulkWrite := "serialize_write_bytes( stream, value->data, 17 )"
+	perByteWrite := "serialize_write_bits( stream, (serialize_uint32_t) value->data[i], 8 )"
+	bulkRead := "serialize_read_bytes( stream, value->data, 17 )"
+	perByteRead := "serialize_read_bits( stream, &raw, 8 )"
+
+	// ---- marked: the bulk call, and NOT the loop
+	if body := bodies["write_marked_after_align"]; !strings.Contains(body, bulkWrite) {
+		t.Errorf("write_marked_after_align must bulk-copy its byte-aligned [17]uint8:\nwant %q in:\n%s", bulkWrite, body)
+	}
+	if body := bodies["read_marked_after_align"]; !strings.Contains(body, bulkRead) {
+		t.Errorf("read_marked_after_align must bulk-copy its byte-aligned [17]uint8:\nwant %q in:\n%s", bulkRead, body)
+	}
+	if body := bodies["write_marked_after_align"]; strings.Contains(body, perByteWrite) {
+		t.Errorf("write_marked_after_align still packs its byte array one byte at a time:\n%s", body)
+	}
+	if body := bodies["read_marked_after_align"]; strings.Contains(body, perByteRead) {
+		t.Errorf("read_marked_after_align still unpacks its byte array one byte at a time:\n%s", body)
+	}
+	if body := bodies["write_marked_after_string"]; !strings.Contains(body, "serialize_write_bytes( stream, value->data, 3 )") {
+		t.Errorf("write_marked_after_string must bulk-copy the [3]uint8 that follows a string (§4.7 ends aligned):\n%s", body)
+	}
+	if body := bodies["read_marked_after_string"]; !strings.Contains(body, "serialize_read_bytes( stream, value->data, 3 )") {
+		t.Errorf("read_marked_after_string must bulk-copy the [3]uint8 that follows a string (§4.7 ends aligned):\n%s", body)
+	}
+
+	// ---- unmarked: the loop stays, because the bulk path's align would put
+	// padding bits on a wire that has none
+	for _, name := range []string{"unmarked_at_entry", "unmarked_off_boundary", "unmarked_ranged", "unmarked_counted"} {
+		for _, prefix := range []string{"write_", "read_"} {
+			body := bodies[prefix+name]
+			call := "serialize_write_bytes( stream, value->data"
+			if prefix == "read_" {
+				call = "serialize_read_bytes( stream, value->data"
+			}
+			if strings.Contains(body, call) {
+				t.Errorf("%s%s bulk-copied a byte array that is NOT statically byte-aligned — that moves the wire:\n%s", prefix, name, body)
+			}
+			if !strings.Contains(body, "for ( i = 0; i < ") {
+				t.Errorf("%s%s must keep the per-byte loop:\n%s", prefix, name, body)
+			}
+		}
+	}
+}
+
+// TestBulkBytesMatchesAnalysis pins the emitter to the SHARED analysis rather
+// than to a predicate of its own: for every struct in the corpus, the fields
+// the C wire functions bulk-copy are exactly ir.AlignedFixedByteArrays — the
+// same set the C++ backend consults, which is what keeps the two byte-equal.
+func TestBulkBytesMatchesAnalysis(t *testing.T) {
+	u := unitFromSource(t, "Bulk.schema", bulkCorpus)
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := string(files["BulkWire.h"])
+	bodies := wireBodies(t, header)
+
+	for _, d := range u.Files[0].Decls {
+		st, ok := d.(*ir.Struct)
+		if !ok {
+			continue
+		}
+		marked := ir.AlignedFixedByteArrays(st)
+		for _, f := range st.Fields {
+			want := marked[f]
+			for _, prefix := range []string{"write_", "read_"} {
+				body := bodies[prefix+snake(st.Name)]
+				call := "serialize_" + strings.TrimSuffix(prefix, "_") + "_bytes( stream, value->" + f.Name
+				if got := strings.Contains(body, call); got != want {
+					t.Errorf("%s%s: field %s bulk=%v, ir.AlignedFixedByteArrays says %v:\n%s",
+						prefix, st.Name, f.Name, got, want, body)
+				}
+			}
+		}
+	}
+}

--- a/internal/codegen/c/fields.go
+++ b/internal/codegen/c/fields.go
@@ -37,6 +37,11 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 		g.pf("%s{\n%s    int32_t i;\n%s    for ( i = 0; i < value->%s_count; i++ )\n%s    {\n", ind, ind, ind, f.Name, ind)
 		g.emitWriteScalar(f, fmt.Sprintf("value->%s[i]", f.Name), ind+"        ")
 		g.pf("%s    }\n%s}\n", ind, ind)
+	case f.Array == ir.ArrayFixed && g.bulkBytes[f]:
+		// statically byte-aligned [N]uint8: the bulk path is byte-identical
+		// to the per-byte loop (its internal align is zero bits here) and
+		// memcpys instead of 8-bit packing
+		g.call(ind, fmt.Sprintf("serialize_write_bytes( stream, value->%s, %d ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */", f.Name, f.ArrayBound))
 	case f.Array == ir.ArrayFixed:
 		g.pf("%s{\n%s    int32_t i;\n%s    for ( i = 0; i < %d; i++ )\n%s    {\n", ind, ind, ind, f.ArrayBound, ind)
 		g.emitWriteScalar(f, fmt.Sprintf("value->%s[i]", f.Name), ind+"        ")
@@ -231,6 +236,8 @@ func (g *gen) emitReadField(f *ir.Field, ind string) {
 		g.pf("%s{\n%s    int32_t i;\n%s    for ( i = 0; i < value->%s_count; i++ )\n%s    {\n", ind, ind, ind, f.Name, ind)
 		g.emitReadScalar(f, fmt.Sprintf("value->%s[i]", f.Name), ind+"        ")
 		g.pf("%s    }\n%s}\n", ind, ind)
+	case f.Array == ir.ArrayFixed && g.bulkBytes[f]:
+		g.call(ind, fmt.Sprintf("serialize_read_bytes( stream, value->%s, %d ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */", f.Name, f.ArrayBound))
 	case f.Array == ir.ArrayFixed:
 		g.pf("%s{\n%s    int32_t i;\n%s    for ( i = 0; i < %d; i++ )\n%s    {\n", ind, ind, ind, f.ArrayBound, ind)
 		g.emitReadScalar(f, fmt.Sprintf("value->%s[i]", f.Name), ind+"        ")

--- a/internal/codegen/c/objects.go
+++ b/internal/codegen/c/objects.go
@@ -227,6 +227,12 @@ func (g *gen) voidIfEmpty(mark int, params ...string) {
 }
 
 func (g *gen) emitObjectFunctions(d *ir.Object) {
+	// no bulk-bytes marks for a view: the analysis walks a struct's ITEMS,
+	// and a view's field set is assembled from the object declaration, so no
+	// view field's position is statically proven. The per-byte loop is the
+	// correct emission for every one of them — same as the C++ backend.
+	g.bulkBytes = nil
+
 	deep, interp := splitObjectFields(d)
 
 	g.pf("/* Writes %s's DEEP view — the declared encodings. */\n", d.Name)

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -767,15 +767,9 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     {
         return 0;
     }
+    if ( !serialize_write_bytes( stream, value->fixed_bytes, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
-        int32_t i;
-        for ( i = 0; i < 17; i++ )
-        {
-            if ( !serialize_write_bits( stream, (serialize_uint32_t) value->fixed_bytes[i], 8 ) )
-            {
-                return 0;
-            }
-        }
+        return 0;
     }
     serialize_assert( schema_utf8_valid_( (const serialize_uint8_t *) value->text, value->text_length ) );
     if ( !serialize_write_int( stream, value->text_length, 0, 255 ) )
@@ -978,19 +972,9 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
     {
         return 0;
     }
+    if ( !serialize_read_bytes( stream, value->fixed_bytes, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
     {
-        int32_t i;
-        for ( i = 0; i < 17; i++ )
-        {
-            {
-                serialize_uint32_t raw = 0;
-                if ( !serialize_read_bits( stream, &raw, 8 ) )
-                {
-                    return 0;
-                }
-                value->fixed_bytes[i] = (uint8_t) raw;
-            }
-        }
+        return 0;
     }
     if ( !serialize_read_int( stream, &value->text_length, 0, 255 ) )
     {


### PR DESCRIPTION
The C emitter emitted a per-byte loop for fixed `[N]uint8` arrays where the C++ emitter has emitted a bulk call since ce1e888 (`generated/c/WireWire.h:772` and `:985` at 976f942, both directions). This closes that gap, read and write.

## The bulk API, and its version pin

`serialize_write_bytes( stream, data, bytes )` and `serialize_read_bytes( stream, data, bytes )`, from **serialize.c v1.4.0**. That is the tag `.github/workflows/ci.yml` pins as `SERIALIZE_C_TAG`, and the version this branch was built and tested against locally. Both functions were reworked in mas-bandwidth/serialize.c#26, now merged, into the shape that makes them worth calling from generated code: the write half moves the partial scratch word as one 8-byte store and then the whole payload as one bulk copy, rather than pushing the block's head and tail through the packer a byte at a time, and the read half is an align plus one copy on the read spine.

The generated C now reads like its C++ sibling:

```c
/* C, this branch */
if ( !serialize_write_bytes( stream, value->fixed_bytes, 17 ) /* byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop */ )
{
    return 0;
}
```
```cpp
// C++, generated/cpp/WireWire.h:433
write_bytes( stream, value.fixed_bytes, 17 ); // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
```

The comment rides inside the call the way this emitter's `const` and `reserved` items already carry theirs (`generated/c/WireWire.h:165`, `:173`), so the line matches neighboring generated C as well as the C++ twin.

There is no new analysis. The C backend consults the same `ir.AlignedFixedByteArrays` the C++ backend consults, loaded per struct in `emitWriteFunc`/`emitReadFunc` and cleared for object views. A view's field set is assembled from the object declaration rather than walked as struct items, so no view field's position is statically proven, and the per-byte loop stays there exactly as it does in C++.

## Wire-compat proof

The wire decision is ce1e888's, unchanged. `serialize_write_bytes` and `serialize_read_bytes` align first, and that align contributes zero bits at a byte boundary, so N unranged 8-bit operations and one aligned bulk copy are the same bytes (SPEC §4.3 pins bit *i* of the stream to byte *i*/8). Only statically-provable positions switch. Everywhere else the loop stays, because there the bulk path's align *would* insert padding the pinned encoding does not have.

Failure semantics match too, which is the other half of "identical". On write, capacity is the writer's contract under `serialize_assert` in both `serialize_write_bits` and `serialize_write_bytes`, following serialize.c#52's ruling that "C should match C++ and have no checks on write at all (except assert)"; neither shape has a runtime capacity check to lose. On read, `serialize_read_bytes` refuses past `bits_limit` via `serialize_read_fail` exactly where the per-byte `serialize_read_bits` would, and the align's zero-padding check has nothing to check at a boundary.

Receipts, all on this branch:

* No wire golden moved. `git diff HEAD~2 -- testdata/wire testdata/table testdata/golden/id.txt` is empty. The protocol id did not move either.
* The C leg proves both directions against the C++-pinned bytes. `test/c/main.c` fills `fixed_bytes[i] = i * 3` in `fill_test_data`, writes `TestData`, byte-compares the result against `testdata/wire/testdata.bin` (the same file the C++, C#, Go, Rust and JS legs are held to), and only then reads those verified bytes back and `memcmp`s `fixed_bytes`. Write direction against the golden, read direction against bytes already proven equal to it.
* Only the C source golden re-pinned: `testdata/golden/c/WireWire.h`, two hunks, the write and read halves of `write_test_data` and `read_test_data`.
* `make test` green end to end across C++, C, Go, Rust, C#, JS, both corpora, plus `go test ./...`. `make generated-current` green. `gofmt`, `golangci-lint` under the repo's v2.12.2 config, and CI's `modernize` analyzer all clean.

Corpus effect is two generated functions each way: `TestData.fixed_bytes[17]` in the main corpus, declared after an explicit `align`, and `BenchPacket.blob[17]` in the bench corpus, the same shape.

## The new guard

`internal/codegen/c/c_test.go` is red before this change and green after, verified by checking the three emitter files back to `HEAD~1` and re-running. `TestBulkBytesEmission` requires the marked positions (after `align`, and after a `string` whose wire ends aligned by §4.7) to take the bulk call and to no longer hold the loop, and requires the unmarked ones (at struct entry, off a byte boundary, ranged `[min,max]`, counted `[<= N]`) to keep it, because bulk-copying those moves the wire. `TestBulkBytesMatchesAnalysis` then requires that for every struct in the test corpus, the set of fields the C wire functions bulk-copy equals `ir.AlignedFixedByteArrays` field for field. That second one is what matters long-term: it pins C to the shared analysis rather than to a predicate of its own, which is what keeps C and C++ on one golden. `internal/ir/align_test.go` already pins the analysis itself; this is the emission half of the same property, now held on both backends.

## BENCH PENDING AT REVIEW

No benchmark was run on this branch, because siblings were building concurrently on the same machine. The A/B belongs on a quiet box at review.

One note for reading the numbers. The change also shrinks the two affected generated bodies by a 17-iteration loop each, which lowers their cost at the call site, and `internal/codegen/c/spineinline.go` records the remark evidence that prices `read_test_data` at 2345 and `write_test_data` at 2910 against a hot-callsite inline threshold of 250. So a `testdata` delta has two plausible sources, the bulk copy itself and a cheaper body to inline, and the controls below are what separate either of them from noise.

Rows to run, C against C++, both directions:

* `testdata`, the row this change exists for, and the only generated message row in the bench harness whose type carries a fixed `[N]uint8`. This is the row where C++ led C's read by 83% in era cfixes-air (`space:~/rowan-bench-quick/results/`). Read is the headline; write should move too.
* `chat`, a bulk-heavy control that must *not* move: its payload is a `string`, which already took `serialize_write_bytes` and `serialize_read_bytes` before this change. If `chat` moves, the run is measuring the machine rather than the patch.
* `real_packet`, the §1.7 realistic snapshot, at 0% bulk share by bits by construction (`bench/corpus/RealWorld.schema` carries zero string, bytes, wstring or `[N]uint8` fields). Flat control.
* `probe_header` and `probebits`, small bit-packed generated rows with no byte arrays. Flat controls.
* The family rt rows (`bench_packet`, `bench_ints`, `bench_bits`, `bench_mixed`), which are hand-written runtime calls rather than generated code, so an emitter change cannot touch them at all. These are the null control, and they calibrate how much of any `testdata` delta is real.

Closes #63
