### PR TITLE
cpp: the write-spine demand stops at the dispatch arms

### DIFF
--- a/generated/bench/cpp/BenchWire.h
+++ b/generated/bench/cpp/BenchWire.h
@@ -17,7 +17,8 @@ namespace bench {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/generated/bench/cpp/RealWorldWire.h
+++ b/generated/bench/cpp/RealWorldWire.h
@@ -17,7 +17,8 @@ namespace realworld {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/generated/cpp/MessagesWire.h
+++ b/generated/cpp/MessagesWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a
@@ -307,12 +308,54 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
+// The dispatch arms: one forwarder per message, standing between WriteMessage
+// and that message's Write spine. Spelled plain `inline`, NOT
+// SCHEMA_WRITE_INLINE, and that is the whole point — an inlining demand is
+// transitive across a call, so a dispatch calling the spines directly would
+// drag every message body into its own body whatever the cost, which is what
+// made the batch build loop pay for the demand. Behind a plain-inline
+// forwarder the demand still flattens the spine into the arm, and the
+// compiler then decides per arm — on cost, the way it decided before the
+// demand existed — whether that arm lands inside the dispatch body or stays
+// a call. Do not spell these SCHEMA_WRITE_INLINE; that is the shape this
+// exists to avoid.
+inline bool WriteMessageArmBlock( serialize::WriteStream & stream, const Block & value )
+{
+    return WriteBlock( stream, value );
+}
+
+inline bool WriteMessageArmChat( serialize::WriteStream & stream, const Chat & value )
+{
+    return WriteChat( stream, value );
+}
+
+inline bool WriteMessageArmHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
+{
+    return WriteHeartbeat( stream, value );
+}
+
+inline bool WriteMessageArmSynchronize( serialize::WriteStream & stream, const Synchronize & value )
+{
+    return WriteSynchronize( stream, value );
+}
+
+inline bool WriteMessageArmTest( serialize::WriteStream & stream, const Test & value )
+{
+    return WriteTest( stream, value );
+}
+
+inline bool WriteMessageArmTimescale( serialize::WriteStream & stream, const Timescale & value )
+{
+    return WriteTimescale( stream, value );
+}
+
 // WriteMessage is deliberately OUTSIDE the write-spine demand: plain `inline`,
-// not SCHEMA_WRITE_INLINE. Its callees (every per-message Write) flatten into
-// its body, but the dispatch switch itself stays a call boundary — demanding
-// it into a batch build loop was measured to slow that loop ~21% while every
-// per-message row kept its win with the boundary in place. The compiler
-// remains free to inline it where that pays.
+// not SCHEMA_WRITE_INLINE — demanding it into a batch build loop was measured
+// to slow that loop ~21% while every per-message row kept its win with the
+// boundary in place. It reaches each message through the WriteMessageArm*
+// forwarders above rather than calling the demanded spines directly, so no
+// spine body is forced into this one. The compiler remains free to inline
+// this — and any arm — where that pays.
 inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
@@ -324,37 +367,37 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
             {
                 return false;
             }
-            return WriteBlock( stream, message.block );
+            return WriteMessageArmBlock( stream, message.block );
         case MessageType::Chat:
             if ( !WriteMessageType( stream, MessageType::Chat ) )
             {
                 return false;
             }
-            return WriteChat( stream, message.chat );
+            return WriteMessageArmChat( stream, message.chat );
         case MessageType::Heartbeat:
             if ( !WriteMessageType( stream, MessageType::Heartbeat ) )
             {
                 return false;
             }
-            return WriteHeartbeat( stream, message.heartbeat );
+            return WriteMessageArmHeartbeat( stream, message.heartbeat );
         case MessageType::Synchronize:
             if ( !WriteMessageType( stream, MessageType::Synchronize ) )
             {
                 return false;
             }
-            return WriteSynchronize( stream, message.synchronize );
+            return WriteMessageArmSynchronize( stream, message.synchronize );
         case MessageType::Test:
             if ( !WriteMessageType( stream, MessageType::Test ) )
             {
                 return false;
             }
-            return WriteTest( stream, message.test );
+            return WriteMessageArmTest( stream, message.test );
         case MessageType::Timescale:
             if ( !WriteMessageType( stream, MessageType::Timescale ) )
             {
                 return false;
             }
-            return WriteTimescale( stream, message.timescale );
+            return WriteMessageArmTimescale( stream, message.timescale );
     }
     return false; // not a message type; nothing was written
 }

--- a/generated/cpp/ObjectsWire.h
+++ b/generated/cpp/ObjectsWire.h
@@ -20,7 +20,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/generated/cpp/RenderWire.h
+++ b/generated/cpp/RenderWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/generated/cpp/TypesWire.h
+++ b/generated/cpp/TypesWire.h
@@ -20,7 +20,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/generated/cpp/ludicrous/LudicrousWire.h
+++ b/generated/cpp/ludicrous/LudicrousWire.h
@@ -17,7 +17,8 @@ namespace ludicrous {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a
@@ -484,12 +485,29 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
+// The dispatch arms: one forwarder per message, standing between WriteMessage
+// and that message's Write spine. Spelled plain `inline`, NOT
+// SCHEMA_WRITE_INLINE, and that is the whole point — an inlining demand is
+// transitive across a call, so a dispatch calling the spines directly would
+// drag every message body into its own body whatever the cost, which is what
+// made the batch build loop pay for the demand. Behind a plain-inline
+// forwarder the demand still flattens the spine into the arm, and the
+// compiler then decides per arm — on cost, the way it decided before the
+// demand existed — whether that arm lands inside the dispatch body or stays
+// a call. Do not spell these SCHEMA_WRITE_INLINE; that is the shape this
+// exists to avoid.
+inline bool WriteMessageArmLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
+{
+    return WriteLudicrousState( stream, value );
+}
+
 // WriteMessage is deliberately OUTSIDE the write-spine demand: plain `inline`,
-// not SCHEMA_WRITE_INLINE. Its callees (every per-message Write) flatten into
-// its body, but the dispatch switch itself stays a call boundary — demanding
-// it into a batch build loop was measured to slow that loop ~21% while every
-// per-message row kept its win with the boundary in place. The compiler
-// remains free to inline it where that pays.
+// not SCHEMA_WRITE_INLINE — demanding it into a batch build loop was measured
+// to slow that loop ~21% while every per-message row kept its win with the
+// boundary in place. It reaches each message through the WriteMessageArm*
+// forwarders above rather than calling the demanded spines directly, so no
+// spine body is forced into this one. The compiler remains free to inline
+// this — and any arm — where that pays.
 inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
@@ -501,7 +519,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
             {
                 return false;
             }
-            return WriteLudicrousState( stream, message.ludicrous_state );
+            return WriteMessageArmLudicrousState( stream, message.ludicrous_state );
     }
     return false; // not a message type; nothing was written
 }

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2125,6 +2125,9 @@ func (c *checker) checkClaimedNames() {
 			c.addStructSymbols(add, addRust, name, d.DeclPos())
 			// the Rust tag constant is associated (MessageType::NAME) — no flat claim
 			add("MessageType"+name, fmt.Sprintf("message %s's generated tag constant", name), d.DeclPos())
+			// the C++ dispatch reaches each message through a per-message arm
+			// forwarder, so the arm name is a claimed unit-level symbol too
+			add("WriteMessageArm"+name, fmt.Sprintf("message %s's generated C++ dispatch arm", name), d.DeclPos())
 		case *ast.ObjectDecl:
 			pos := d.DeclPos()
 			why := fmt.Sprintf("object %s's generated family", name)

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -661,10 +661,26 @@ func (g *gen) emitMessageWire() {
 	g.pf("    read_int( stream, tag_value, 0, %d );\n", count)
 	g.pf("    value = MessageType( tag_value );\n    return true;\n}\n\n")
 
+	g.emitMessageArmForwarders()
+
 	if g.opts.MessageRepr == "variant" {
 		g.emitMessageWireVariant()
 	} else {
 		g.emitMessageWireUnion()
+	}
+}
+
+// emitMessageArmForwarders emits the dispatch arms — one forwarder per
+// message, shared by both dispatch surfaces (union and variant call the same
+// arms, since both hand the arm a const reference to the message value).
+// They exist for their SPELLING: plain `inline`, so the write-spine demand
+// stops here instead of propagating into the dispatch body. See
+// emitWriteArmComment for the mechanism and the measurement.
+func (g *gen) emitMessageArmForwarders() {
+	g.emitWriteArmComment()
+	for _, m := range g.unit.Messages {
+		g.pf("inline bool WriteMessageArm%s( serialize::WriteStream & stream, const %s & value )\n{\n", m, m)
+		g.pf("    return Write%s( stream, value );\n}\n\n", m)
 	}
 }
 
@@ -719,7 +735,7 @@ func (g *gen) emitMessageWireUnion() {
 	for _, m := range msgs {
 		g.pf("        case MessageType::%s:\n", m)
 		g.pf("            if ( !WriteMessageType( stream, MessageType::%s ) )\n            {\n                return false;\n            }\n", m)
-		g.pf("            return Write%s( stream, message.%s );\n", m, camelToSnake(m))
+		g.pf("            return WriteMessageArm%s( stream, message.%s );\n", m, camelToSnake(m))
 	}
 	g.pf("    }\n    return false; // not a message type; nothing was written\n}\n\n")
 
@@ -775,7 +791,7 @@ func (g *gen) emitMessageWireVariant() {
 	g.pf("    switch ( message.index() )\n    {\n")
 	g.pf("        case 0:\n            return true; // None — the stream terminator (SPEC §4.8)\n")
 	for i, m := range msgs {
-		g.pf("        case %d:\n            return Write%s( stream, *std::get_if<%s>( &message ) );\n", i+1, m, m)
+		g.pf("        case %d:\n            return WriteMessageArm%s( stream, *std::get_if<%s>( &message ) );\n", i+1, m, m)
 	}
 	g.pf("    }\n    return false;\n}\n\n")
 

--- a/internal/codegen/cpp/writeinline.go
+++ b/internal/codegen/cpp/writeinline.go
@@ -6,10 +6,12 @@ package cpp
 // spines demand it (serialize.h's write spine; serialize.c
 // SERIALIZE_ALWAYS_INLINE — both halves; the C generated spine's
 // SCHEMA_C_WRITE_INLINE; the read twin here, SCHEMA_READ_INLINE). Every one
-// except WriteMessage, the dispatch surface, which emitWriteDispatchComment
-// below documents and which is spelled plain `inline` in functions.go —
-// that scoping is part of the winner. Compilers with neither spelling fall
-// back to plain `inline` and lose only the optimization.
+// except the two pieces of the message dispatch surface — WriteMessage
+// itself and its per-message arm forwarders, both spelled plain `inline` in
+// functions.go and documented by emitWriteDispatchComment /
+// emitWriteArmComment below. That scoping is part of the winner. Compilers
+// with neither spelling fall back to plain `inline` and lose only the
+// optimization.
 //
 // Why the demand exists (remark evidence, Apple clang 21, -O3, schema bench,
 // tournament pass bench/results/tournament-air): the generated Write
@@ -26,14 +28,15 @@ package cpp
 // (SCHEMA_WRITE_SPINE_DEMAND, #55). Blanket — WriteMessage included — it
 // swept the per-message write rows but demanded the dispatcher (inline cost
 // ~1555) whole into the batch build loop and regressed it. Scoped —
-// WriteMessage exempted, its callees still flattening into its outlined
-// body — it won the cross-architecture tournament (eras space-55-scoped /
-// air-55-scoped: blended geomean 81.8 vs 99.7 off on Zen 4 gcc, 100.8 vs
-// 137.8 off on Apple M-series clang, % of the C baseline), so per the
-// feature lifecycle the winner became unconditional code and the switch was
-// deleted. The accepted residual: message_batch write +7-16% vs the old off
-// state on both architectures — bounded, and bought back many times over by
-// the per-message rows. The demand is a DEMAND, not a branch-weight hint:
+// WriteMessage exempted — it won the cross-architecture tournament (eras
+// space-55-scoped / air-55-scoped: blended geomean 81.8 vs 99.7 off on Zen 4
+// gcc, 100.8 vs 137.8 off on Apple M-series clang, % of the C baseline), so
+// per the feature lifecycle the winner became unconditional code and the
+// switch was deleted. The scoping is now BOTH pieces of the dispatch
+// surface: exempting WriteMessage alone still let the demand propagate
+// through it into its own body, and the arm forwarders
+// (emitWriteArmComment) close that. The demand is a DEMAND, not a
+// branch-weight hint:
 // __builtin_expect-style cold hints were measured in this family to
 // activate the machine outliner and shred hot bodies (bits write -25%) — do
 // not swap this for hints. Guarded against redefinition because several
@@ -41,7 +44,8 @@ package cpp
 func (g *gen) emitWriteInlineMacro() {
 	g.pf("#ifndef SCHEMA_WRITE_INLINE_DEFINED\n#define SCHEMA_WRITE_INLINE_DEFINED\n")
 	g.pf("// SCHEMA_WRITE_INLINE — how every generated Write function is spelled,\n")
-	g.pf("// EXCEPT the WriteMessage dispatch surface (see the comment on it): an\n")
+	g.pf("// EXCEPT the message dispatch surface: WriteMessage and its per-message arm\n")
+	g.pf("// forwarders (see the comments on them). It is an\n")
 	g.pf("// inlining DEMAND (always_inline / __forceinline), the serialize family's\n")
 	g.pf("// remedy for LLVM refusing the linkonce_odr Write entries into their call\n")
 	g.pf("// sites at cost over threshold — no last-call-to-static bonus exists for a\n")
@@ -65,13 +69,44 @@ func (g *gen) emitWriteInlineMacro() {
 // every per-message write row but regressed the batch dispatch loop
 // (message_batch write +21%, Zen 4 gcc -O3) — WriteMessage at inline cost
 // ~1555 forced whole into the loop body. Exempting the dispatcher keeps the
-// per-message spines flattening INTO WriteMessage's outlined body (its
-// callees carry the demand) while the loop keeps a call boundary.
+// loop's call boundary; the arm forwarders below (emitWriteArmComment) keep
+// the spine bodies from being FORCED into the dispatch body behind it.
 func (g *gen) emitWriteDispatchComment() {
 	g.pf("// WriteMessage is deliberately OUTSIDE the write-spine demand: plain `inline`,\n")
-	g.pf("// not SCHEMA_WRITE_INLINE. Its callees (every per-message Write) flatten into\n")
-	g.pf("// its body, but the dispatch switch itself stays a call boundary — demanding\n")
-	g.pf("// it into a batch build loop was measured to slow that loop ~21%% while every\n")
-	g.pf("// per-message row kept its win with the boundary in place. The compiler\n")
-	g.pf("// remains free to inline it where that pays.\n")
+	g.pf("// not SCHEMA_WRITE_INLINE — demanding it into a batch build loop was measured\n")
+	g.pf("// to slow that loop ~21%% while every per-message row kept its win with the\n")
+	g.pf("// boundary in place. It reaches each message through the WriteMessageArm*\n")
+	g.pf("// forwarders above rather than calling the demanded spines directly, so no\n")
+	g.pf("// spine body is forced into this one. The compiler remains free to inline\n")
+	g.pf("// this — and any arm — where that pays.\n")
+}
+
+// emitWriteArmComment is the emitted rationale for the dispatch arms: the
+// per-message forwarders WriteMessage calls instead of the demanded spines.
+// The residual #60 shipped and accepted (message_batch write +7-16% vs the
+// pre-demand state on both architectures) was the demand propagating THROUGH
+// the dispatch: always_inline is transitive across a call, so exempting
+// WriteMessage bought a call boundary for the loop but still dragged every
+// message body into WriteMessage's own body. Measured on the schema bench
+// (Apple clang -O3, examples corpus): the dispatch body ran 1832 bytes armed
+// against 1288 pre-demand, the 544-byte difference being exactly the two
+// spines — WriteTest 324, WriteTimescale 332 — the compiler had declined on
+// cost and the demand then forced in. A plain-`inline` forwarder per arm
+// breaks the propagation without weakening the demand anywhere: the spine
+// still flattens into its arm, and the arm is then an ordinary inline
+// candidate the compiler judges on cost at the dispatch site, exactly as it
+// judged the spine itself before the demand existed. It reconstructs the
+// pre-demand dispatch body to the byte.
+func (g *gen) emitWriteArmComment() {
+	g.pf("// The dispatch arms: one forwarder per message, standing between WriteMessage\n")
+	g.pf("// and that message's Write spine. Spelled plain `inline`, NOT\n")
+	g.pf("// SCHEMA_WRITE_INLINE, and that is the whole point — an inlining demand is\n")
+	g.pf("// transitive across a call, so a dispatch calling the spines directly would\n")
+	g.pf("// drag every message body into its own body whatever the cost, which is what\n")
+	g.pf("// made the batch build loop pay for the demand. Behind a plain-inline\n")
+	g.pf("// forwarder the demand still flattens the spine into the arm, and the\n")
+	g.pf("// compiler then decides per arm — on cost, the way it decided before the\n")
+	g.pf("// demand existed — whether that arm lands inside the dispatch body or stays\n")
+	g.pf("// a call. Do not spell these SCHEMA_WRITE_INLINE; that is the shape this\n")
+	g.pf("// exists to avoid.\n")
 }

--- a/internal/codegen/cpp/writeinline.go
+++ b/internal/codegen/cpp/writeinline.go
@@ -36,11 +36,10 @@ package cpp
 // surface: exempting WriteMessage alone still let the demand propagate
 // through it into its own body, and the arm forwarders
 // (emitWriteArmComment) close that. The demand is a DEMAND, not a
-// branch-weight hint:
-// __builtin_expect-style cold hints were measured in this family to
-// activate the machine outliner and shred hot bodies (bits write -25%) — do
-// not swap this for hints. Guarded against redefinition because several
-// wire headers can land in one translation unit.
+// branch-weight hint: __builtin_expect-style cold hints were measured in
+// this family to activate the machine outliner and shred hot bodies (bits
+// write -25%) — do not swap this for hints. Guarded against redefinition
+// because several wire headers can land in one translation unit.
 func (g *gen) emitWriteInlineMacro() {
 	g.pf("#ifndef SCHEMA_WRITE_INLINE_DEFINED\n#define SCHEMA_WRITE_INLINE_DEFINED\n")
 	g.pf("// SCHEMA_WRITE_INLINE — how every generated Write function is spelled,\n")

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -114,9 +114,26 @@ func TestDispatchSurfaceEmittedOnce(t *testing.T) {
 			// outside the write-spine demand (see cpp emitWriteDispatchComment)
 			"enum class MessageType", "inline bool WriteMessage(", "SCHEMA_READ_INLINE bool ReadMessage(",
 			"enum class ObjectType", "SCHEMA_WRITE_INLINE bool WriteObjectType(", "SCHEMA_READ_INLINE bool ReadObjectType(",
+			// the dispatch arms, one per message, likewise plain `inline`: the
+			// demand must stop at the arm instead of propagating into the
+			// dispatch body (see cpp emitWriteArmComment)
+			"inline bool WriteMessageArmPing(", "inline bool WriteMessageArmPong(",
 		} {
 			if got := countAcross(cppFiles, needle); got != 1 {
 				t.Errorf("C++ (%s): %q emitted %d times across the unit — a TU including both headers cannot compile unless it is exactly once", mode, needle, got)
+			}
+		}
+		// the arms must be what the dispatch actually calls, and must NOT
+		// carry the demand — either mistake puts the message bodies back
+		// inside WriteMessage, which is the shape the arms exist to avoid
+		for _, banned := range []string{"SCHEMA_WRITE_INLINE bool WriteMessageArm"} {
+			if got := countAcross(cppFiles, banned); got != 0 {
+				t.Errorf("C++ (%s): %q emitted %d times — a demanded arm flattens the message body back into WriteMessage", mode, banned, got)
+			}
+		}
+		for _, msg := range []string{"Ping", "Pong"} {
+			if got := countAcross(cppFiles, "return WriteMessageArm"+msg+"( stream,"); got != 1 {
+				t.Errorf("C++ (%s): the %s dispatch case does not call WriteMessageArm%s — the demand propagates into the dispatch body", mode, msg, msg)
 			}
 		}
 		// the owner file must include the other message file: the dispatch

--- a/testdata/golden/ludicrous/union/LudicrousWire.h
+++ b/testdata/golden/ludicrous/union/LudicrousWire.h
@@ -17,7 +17,8 @@ namespace ludicrous {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a
@@ -484,12 +485,29 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
+// The dispatch arms: one forwarder per message, standing between WriteMessage
+// and that message's Write spine. Spelled plain `inline`, NOT
+// SCHEMA_WRITE_INLINE, and that is the whole point — an inlining demand is
+// transitive across a call, so a dispatch calling the spines directly would
+// drag every message body into its own body whatever the cost, which is what
+// made the batch build loop pay for the demand. Behind a plain-inline
+// forwarder the demand still flattens the spine into the arm, and the
+// compiler then decides per arm — on cost, the way it decided before the
+// demand existed — whether that arm lands inside the dispatch body or stays
+// a call. Do not spell these SCHEMA_WRITE_INLINE; that is the shape this
+// exists to avoid.
+inline bool WriteMessageArmLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
+{
+    return WriteLudicrousState( stream, value );
+}
+
 // WriteMessage is deliberately OUTSIDE the write-spine demand: plain `inline`,
-// not SCHEMA_WRITE_INLINE. Its callees (every per-message Write) flatten into
-// its body, but the dispatch switch itself stays a call boundary — demanding
-// it into a batch build loop was measured to slow that loop ~21% while every
-// per-message row kept its win with the boundary in place. The compiler
-// remains free to inline it where that pays.
+// not SCHEMA_WRITE_INLINE — demanding it into a batch build loop was measured
+// to slow that loop ~21% while every per-message row kept its win with the
+// boundary in place. It reaches each message through the WriteMessageArm*
+// forwarders above rather than calling the demanded spines directly, so no
+// spine body is forced into this one. The compiler remains free to inline
+// this — and any arm — where that pays.
 inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
@@ -501,7 +519,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
             {
                 return false;
             }
-            return WriteLudicrousState( stream, message.ludicrous_state );
+            return WriteMessageArmLudicrousState( stream, message.ludicrous_state );
     }
     return false; // not a message type; nothing was written
 }

--- a/testdata/golden/ludicrous/variant/LudicrousWire.h
+++ b/testdata/golden/ludicrous/variant/LudicrousWire.h
@@ -17,7 +17,8 @@ namespace ludicrous {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a
@@ -484,12 +485,29 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
+// The dispatch arms: one forwarder per message, standing between WriteMessage
+// and that message's Write spine. Spelled plain `inline`, NOT
+// SCHEMA_WRITE_INLINE, and that is the whole point — an inlining demand is
+// transitive across a call, so a dispatch calling the spines directly would
+// drag every message body into its own body whatever the cost, which is what
+// made the batch build loop pay for the demand. Behind a plain-inline
+// forwarder the demand still flattens the spine into the arm, and the
+// compiler then decides per arm — on cost, the way it decided before the
+// demand existed — whether that arm lands inside the dispatch body or stays
+// a call. Do not spell these SCHEMA_WRITE_INLINE; that is the shape this
+// exists to avoid.
+inline bool WriteMessageArmLudicrousState( serialize::WriteStream & stream, const LudicrousState & value )
+{
+    return WriteLudicrousState( stream, value );
+}
+
 // WriteMessage is deliberately OUTSIDE the write-spine demand: plain `inline`,
-// not SCHEMA_WRITE_INLINE. Its callees (every per-message Write) flatten into
-// its body, but the dispatch switch itself stays a call boundary — demanding
-// it into a batch build loop was measured to slow that loop ~21% while every
-// per-message row kept its win with the boundary in place. The compiler
-// remains free to inline it where that pays.
+// not SCHEMA_WRITE_INLINE — demanding it into a batch build loop was measured
+// to slow that loop ~21% while every per-message row kept its win with the
+// boundary in place. It reaches each message through the WriteMessageArm*
+// forwarders above rather than calling the demanded spines directly, so no
+// spine body is forced into this one. The compiler remains free to inline
+// this — and any arm — where that pays.
 inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     if ( !WriteMessageType( stream, MessageType( message.index() ) ) )
@@ -501,7 +519,7 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
         case 0:
             return true; // None — the stream terminator (SPEC §4.8)
         case 1:
-            return WriteLudicrousState( stream, *std::get_if<LudicrousState>( &message ) );
+            return WriteMessageArmLudicrousState( stream, *std::get_if<LudicrousState>( &message ) );
     }
     return false;
 }

--- a/testdata/golden/union/MessagesWire.h
+++ b/testdata/golden/union/MessagesWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a
@@ -307,12 +308,54 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
+// The dispatch arms: one forwarder per message, standing between WriteMessage
+// and that message's Write spine. Spelled plain `inline`, NOT
+// SCHEMA_WRITE_INLINE, and that is the whole point — an inlining demand is
+// transitive across a call, so a dispatch calling the spines directly would
+// drag every message body into its own body whatever the cost, which is what
+// made the batch build loop pay for the demand. Behind a plain-inline
+// forwarder the demand still flattens the spine into the arm, and the
+// compiler then decides per arm — on cost, the way it decided before the
+// demand existed — whether that arm lands inside the dispatch body or stays
+// a call. Do not spell these SCHEMA_WRITE_INLINE; that is the shape this
+// exists to avoid.
+inline bool WriteMessageArmBlock( serialize::WriteStream & stream, const Block & value )
+{
+    return WriteBlock( stream, value );
+}
+
+inline bool WriteMessageArmChat( serialize::WriteStream & stream, const Chat & value )
+{
+    return WriteChat( stream, value );
+}
+
+inline bool WriteMessageArmHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
+{
+    return WriteHeartbeat( stream, value );
+}
+
+inline bool WriteMessageArmSynchronize( serialize::WriteStream & stream, const Synchronize & value )
+{
+    return WriteSynchronize( stream, value );
+}
+
+inline bool WriteMessageArmTest( serialize::WriteStream & stream, const Test & value )
+{
+    return WriteTest( stream, value );
+}
+
+inline bool WriteMessageArmTimescale( serialize::WriteStream & stream, const Timescale & value )
+{
+    return WriteTimescale( stream, value );
+}
+
 // WriteMessage is deliberately OUTSIDE the write-spine demand: plain `inline`,
-// not SCHEMA_WRITE_INLINE. Its callees (every per-message Write) flatten into
-// its body, but the dispatch switch itself stays a call boundary — demanding
-// it into a batch build loop was measured to slow that loop ~21% while every
-// per-message row kept its win with the boundary in place. The compiler
-// remains free to inline it where that pays.
+// not SCHEMA_WRITE_INLINE — demanding it into a batch build loop was measured
+// to slow that loop ~21% while every per-message row kept its win with the
+// boundary in place. It reaches each message through the WriteMessageArm*
+// forwarders above rather than calling the demanded spines directly, so no
+// spine body is forced into this one. The compiler remains free to inline
+// this — and any arm — where that pays.
 inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     switch ( message.type )
@@ -324,37 +367,37 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
             {
                 return false;
             }
-            return WriteBlock( stream, message.block );
+            return WriteMessageArmBlock( stream, message.block );
         case MessageType::Chat:
             if ( !WriteMessageType( stream, MessageType::Chat ) )
             {
                 return false;
             }
-            return WriteChat( stream, message.chat );
+            return WriteMessageArmChat( stream, message.chat );
         case MessageType::Heartbeat:
             if ( !WriteMessageType( stream, MessageType::Heartbeat ) )
             {
                 return false;
             }
-            return WriteHeartbeat( stream, message.heartbeat );
+            return WriteMessageArmHeartbeat( stream, message.heartbeat );
         case MessageType::Synchronize:
             if ( !WriteMessageType( stream, MessageType::Synchronize ) )
             {
                 return false;
             }
-            return WriteSynchronize( stream, message.synchronize );
+            return WriteMessageArmSynchronize( stream, message.synchronize );
         case MessageType::Test:
             if ( !WriteMessageType( stream, MessageType::Test ) )
             {
                 return false;
             }
-            return WriteTest( stream, message.test );
+            return WriteMessageArmTest( stream, message.test );
         case MessageType::Timescale:
             if ( !WriteMessageType( stream, MessageType::Timescale ) )
             {
                 return false;
             }
-            return WriteTimescale( stream, message.timescale );
+            return WriteMessageArmTimescale( stream, message.timescale );
     }
     return false; // not a message type; nothing was written
 }

--- a/testdata/golden/union/ObjectsWire.h
+++ b/testdata/golden/union/ObjectsWire.h
@@ -20,7 +20,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/testdata/golden/union/RenderWire.h
+++ b/testdata/golden/union/RenderWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/testdata/golden/union/TypesWire.h
+++ b/testdata/golden/union/TypesWire.h
@@ -20,7 +20,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/testdata/golden/union/WireWire.h
+++ b/testdata/golden/union/WireWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/testdata/golden/variant/MessagesWire.h
+++ b/testdata/golden/variant/MessagesWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a
@@ -307,12 +308,54 @@ SCHEMA_READ_INLINE bool ReadMessageType( serialize::ReadStream & stream, Message
     return true;
 }
 
+// The dispatch arms: one forwarder per message, standing between WriteMessage
+// and that message's Write spine. Spelled plain `inline`, NOT
+// SCHEMA_WRITE_INLINE, and that is the whole point — an inlining demand is
+// transitive across a call, so a dispatch calling the spines directly would
+// drag every message body into its own body whatever the cost, which is what
+// made the batch build loop pay for the demand. Behind a plain-inline
+// forwarder the demand still flattens the spine into the arm, and the
+// compiler then decides per arm — on cost, the way it decided before the
+// demand existed — whether that arm lands inside the dispatch body or stays
+// a call. Do not spell these SCHEMA_WRITE_INLINE; that is the shape this
+// exists to avoid.
+inline bool WriteMessageArmBlock( serialize::WriteStream & stream, const Block & value )
+{
+    return WriteBlock( stream, value );
+}
+
+inline bool WriteMessageArmChat( serialize::WriteStream & stream, const Chat & value )
+{
+    return WriteChat( stream, value );
+}
+
+inline bool WriteMessageArmHeartbeat( serialize::WriteStream & stream, const Heartbeat & value )
+{
+    return WriteHeartbeat( stream, value );
+}
+
+inline bool WriteMessageArmSynchronize( serialize::WriteStream & stream, const Synchronize & value )
+{
+    return WriteSynchronize( stream, value );
+}
+
+inline bool WriteMessageArmTest( serialize::WriteStream & stream, const Test & value )
+{
+    return WriteTest( stream, value );
+}
+
+inline bool WriteMessageArmTimescale( serialize::WriteStream & stream, const Timescale & value )
+{
+    return WriteTimescale( stream, value );
+}
+
 // WriteMessage is deliberately OUTSIDE the write-spine demand: plain `inline`,
-// not SCHEMA_WRITE_INLINE. Its callees (every per-message Write) flatten into
-// its body, but the dispatch switch itself stays a call boundary — demanding
-// it into a batch build loop was measured to slow that loop ~21% while every
-// per-message row kept its win with the boundary in place. The compiler
-// remains free to inline it where that pays.
+// not SCHEMA_WRITE_INLINE — demanding it into a batch build loop was measured
+// to slow that loop ~21% while every per-message row kept its win with the
+// boundary in place. It reaches each message through the WriteMessageArm*
+// forwarders above rather than calling the demanded spines directly, so no
+// spine body is forced into this one. The compiler remains free to inline
+// this — and any arm — where that pays.
 inline bool WriteMessage( serialize::WriteStream & stream, const Message & message )
 {
     if ( !WriteMessageType( stream, MessageType( message.index() ) ) )
@@ -324,17 +367,17 @@ inline bool WriteMessage( serialize::WriteStream & stream, const Message & messa
         case 0:
             return true; // None — the stream terminator (SPEC §4.8)
         case 1:
-            return WriteBlock( stream, *std::get_if<Block>( &message ) );
+            return WriteMessageArmBlock( stream, *std::get_if<Block>( &message ) );
         case 2:
-            return WriteChat( stream, *std::get_if<Chat>( &message ) );
+            return WriteMessageArmChat( stream, *std::get_if<Chat>( &message ) );
         case 3:
-            return WriteHeartbeat( stream, *std::get_if<Heartbeat>( &message ) );
+            return WriteMessageArmHeartbeat( stream, *std::get_if<Heartbeat>( &message ) );
         case 4:
-            return WriteSynchronize( stream, *std::get_if<Synchronize>( &message ) );
+            return WriteMessageArmSynchronize( stream, *std::get_if<Synchronize>( &message ) );
         case 5:
-            return WriteTest( stream, *std::get_if<Test>( &message ) );
+            return WriteMessageArmTest( stream, *std::get_if<Test>( &message ) );
         case 6:
-            return WriteTimescale( stream, *std::get_if<Timescale>( &message ) );
+            return WriteMessageArmTimescale( stream, *std::get_if<Timescale>( &message ) );
     }
     return false;
 }

--- a/testdata/golden/variant/ObjectsWire.h
+++ b/testdata/golden/variant/ObjectsWire.h
@@ -20,7 +20,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/testdata/golden/variant/RenderWire.h
+++ b/testdata/golden/variant/RenderWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/testdata/golden/variant/TypesWire.h
+++ b/testdata/golden/variant/TypesWire.h
@@ -20,7 +20,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a

--- a/testdata/golden/variant/WireWire.h
+++ b/testdata/golden/variant/WireWire.h
@@ -18,7 +18,8 @@ namespace example {
 #ifndef SCHEMA_WRITE_INLINE_DEFINED
 #define SCHEMA_WRITE_INLINE_DEFINED
 // SCHEMA_WRITE_INLINE — how every generated Write function is spelled,
-// EXCEPT the WriteMessage dispatch surface (see the comment on it): an
+// EXCEPT the message dispatch surface: WriteMessage and its per-message arm
+// forwarders (see the comments on them). It is an
 // inlining DEMAND (always_inline / __forceinline), the serialize family's
 // remedy for LLVM refusing the linkonce_odr Write entries into their call
 // sites at cost over threshold — no last-call-to-static bonus exists for a


### PR DESCRIPTION
The accepted residual from #60, taken at the mechanism it was attributed to.

## The lever, and why this one

#60 exempted `WriteMessage` from the write-spine demand so the batch build loop
would keep a call boundary. It does. But **an inlining demand is transitive
across a call**: `always_inline` on every `Write<Message>` meant the dispatch
still dragged every message body into its own body, whatever the cost model
said. The boundary moved; the fat did not. That is the +7-16% `message_batch`
write residual, and it is a property of the dispatch body, not the loop.

The fix is one forwarder per message arm, spelled **plain `inline`**:

```cpp
inline bool WriteMessageArmTest( serialize::WriteStream & stream, const Test & value )
{
    return WriteTest( stream, value );
}
```

and the dispatch case calls the arm instead of the spine. The demand still
flattens the spine into its arm — nothing is weakened anywhere — but the arm is
then an ordinary inline candidate the compiler judges **on cost at the dispatch
site, exactly as it judged the spine itself before the demand existed**. Both
representations (union and variant) share one set of arms.

Two candidates were built and measured before choosing:

| | dispatch body | arms outlined |
|---|---|---|
| `noinline` on every arm (a hard boundary) | 844 B | all 6, including an **8-byte** `Heartbeat` arm — pure call overhead |
| **plain `inline` forwarder (this PR)** | **1288 B** | the 2 the compiler had actually declined |

The hard boundary over-corrects: it forces out arms the compiler wanted inline
even in the pre-demand state. The forwarder restores the *decision*, not a
verdict — which is why it reaches the pre-demand number rather than overshooting
it.

No new macro, no compiler-specific attribute: `inline` is the whole mechanism.

## Mechanism proof

Apple clang 21.0.0, arm64, `-O3`, the `bench/run.sh` Release flags, one TU
(`bench/cpp/bench_main.cpp`), `examples/` corpus. Three builds: **off** = the
pre-demand state, reproduced with no code change by
`-DSCHEMA_WRITE_INLINE_DEFINED -DSCHEMA_WRITE_INLINE=inline`; **main**;
**branch**. `nm -n` sizes of the `example::` write symbols:

| symbol | off (pre-demand) | main | branch |
|---|---|---|---|
| `WriteMessage` | **1288** | **1832** | **1288** |
| `WriteTest` / arm | 324 | *(forced in)* | 324 |
| `WriteTimescale` / arm | 332 | *(forced in)* | 332 |

**1832 − 1288 = 544 = 324 + 332 − 112**, the two call sequences the flattening
removed. The residual's mechanism is not inferred here; it is the arithmetic.

The branch reproduces the pre-demand dispatch body **to the byte**, and the two
spines the compiler had declined on cost are outlined again at exactly their
pre-demand sizes. Disassembly shows the dispatch reaches them by **tail call**,
so the restored boundary costs no call frame:

```
example::WriteMessage:
  ...
  0000000100019160  b   example::WriteMessageArmTimescale(serialize::WriteStream&, example::Timescale const&)
  00000001000190c4  b   example::WriteMessageArmTest(serialize::WriteStream&, example::Test const&)
```

**No call was added to the loop.** `bl` sites into `example::WriteMessage`
across the whole binary: **7 before, 7 after.** The batch loop still makes
exactly one call per message; only the callee's body changed, and the two arms
it now declines are reached by tail branch from inside it.

**The per-message win is untouched.** In the *off* build 12 `example::Write*`
spines stand outlined beside `WriteMessage` — the compiler refusing them at
cost, which is the whole reason the demand exists. Ten of them are nothing to do
with the dispatch: `WriteTestData` 2444, `WriteShipData_Shallow` 1144,
`WriteProbeSample` 992, `WriteInput` 984, `WriteShipCreate` 944,
`WriteProbeBits` 588, `WriteQuat` 576, `WriteInputPacket` 568, `WriteVec3` 448,
`WriteQuantizedRotation` 328. In **both** main and this branch all ten are
absent — still flattened into their direct callers by the demand. The only
symbols this PR adds to the binary are the two arms the dispatch declined.

## What the inline gate says

Not run as a leg: `inline-gate.sh leg cpp` runs a bench round, which belongs on
the quiet machine at review. What was run, statically:

- **`bench/tools/inline-gate.sh selftest` — green**, all 15 adversarial fixtures
  ("the machinery can fail where it must").
- The **real** counting machinery (`count_calls`, sourced from
  `inline-verdict.sh` under `INLINE_VERDICT_LIB=1`, with the cpp `RT`/`HELPER`
  regexes) over all three disassemblies: `example::WriteMessage` reports
  **transitive hot runtime calls = 0** in off, main and branch alike, and both
  new arms report **0**. The arms contain no `serialize::` call for the
  attribution to lose.
- Whole-binary total transitive runtime calls (hot + cold), every symbol:
  **27 before, 27 after.** The out-of-line runtime-call structure is unchanged;
  only the dispatch body's shape moved.

So `cpp message_batch write O3 2` (and its `O2 2` twin) should re-measure
unchanged. Confirming that against a real leg is part of the review below.

*Noted, not fixed:* `count_calls` follows `bl`/`blr` and not a tail-branch `b`
into a generated helper. It does not bite here (the arms hold zero runtime
calls), and it is not new — the pre-demand state tail-branched to
`WriteTest`/`WriteTimescale` the same way, which is the shape the budget was
seeded under on 2026-08-15. Flagging it as a real blind spot in the machinery
for a separate decision.

## C is deliberately untouched — and it complicates the story, honestly

The same shape does not exist there. C's `write_message` carries
`SCHEMA_C_WRITE_INLINE` **itself** (`internal/codegen/c/dispatch.go:174`) — the
dispatcher is demanded, not exempted, so there is no outlined dispatch body for
spines to fatten. Checked, not assumed: the C bench binary built at the same
`-O3` has **zero** outlined generated `write_*`/`read_*` symbols, `write_message`
included. The whole dispatch is inline in the batch loop. `bench/inline-budget.txt`
agrees: `c message_batch write O3 0`. There is no lever here to pull.

That is worth stating plainly rather than burying, because it cuts against a
naive reading of this PR: C is the leg that **leads C++ 2.1x** on this very row
(era realworld-air, 211.4), and C does it with the fully-flattened shape. So
"flattened dispatch is bad" is *not* what the evidence says. Three distinct
shapes are in play:

| | calls per message | dispatch body |
|---|---|---|
| C | **0** — dispatch inline in the loop | in the loop, specialized per call site |
| C++ main | 1 | outlined, **1832 B**, every arm forced in |
| C++ this branch | 1 (+ tail branch) | outlined, **1288 B**, arms by cost |

C++ cannot simply copy C's shape: #55/#60 measured the blanket demand
(dispatch inlined into the loop, C's shape) at **21% worse** on Zen 4 — the
generated C++ entries are `linkonce_odr` header functions with no
last-call-to-static bonus, unlike C's `static` entries, so the two languages'
inliners are not making the same trade. What this PR claims is narrower and
testable: **within** the C++ shape, the dispatch body should not be fattened by
force. Whether closing that closes the whole C-vs-C++ gap on this row is a
separate question, and the issue's own comment says the base Air deficit is
unattributed.

## Wire proof

`testdata/wire/` and `testdata/table/`: **zero changes.** The non-comment diff
in the generated headers is exactly the six arm forwarders plus the six dispatch
cases that now call them, in both representations. Everything else is comment.

## Gates green locally

`make test` whole: `schema_test`, `schema_test_variant`, `schema_test_random`,
`schema_test_ludicrous`, `schema_test_c`, `schema_test_c_ludicrous`,
`schema_test_bench`, `schema_test_bench_c`, the Go / Rust / C# / JS legs and
their ludicrous twins, `go test ./...`. Plus `make generated-current`
("generated/ tree is current") and the inline-gate selftest.

The multi-file dispatch test now pins the arms the way it pins the rest of the
dispatch surface: one arm per message, plain `inline`, called by its dispatch
case, and **never** spelled `SCHEMA_WRITE_INLINE` — that last assertion is the
one that keeps this from being undone by accident.

`WriteMessageArm<Name>` is registered in the checker's claimed-name registry
beside the other per-message generated symbols, so a user declaration that
collides is a compile error naming the mechanism, not a broken header.

---

# BENCH PENDING AT REVIEW

**Not run here** — sibling children were building concurrently on this box and
would contaminate the numbers. Every claim above is static (symbol sizes,
disassembly, call counts); nothing in this PR asserts a timing.

The three-way A/B needs no code edits — the pre-demand arm is a build-flag
override:

| arm | how |
|---|---|
| **off** (pre-demand) | any commit + `-DSCHEMA_WRITE_INLINE_DEFINED -DSCHEMA_WRITE_INLINE=inline` |
| **main** | `main` as it stands |
| **branch** | this branch |

### The rows that decide it

| lang | bench | path | opt | arch | expectation |
|---|---|---|---|---|---|
| cpp | `message_batch` | **write** | O3 | Air (Apple clang, arm64) | branch ≈ **off**; the +7-16% vs off closes |
| cpp | `message_batch` | **write** | O3 | space (Zen 4, gcc) | same |
| cpp | `message_batch` | **write** | O2 | both | same (the budget pins O2 too) |

### Controls that must NOT move

| lang | bench | path | why |
|---|---|---|---|
| cpp | `message_batch` | **read** | `ReadMessage` is untouched — any movement is noise or box |
| cpp | every per-message **write** row (`shipcreate`, `ship_shallow`, `inputpacket`, `probebits`, `probearray`, `probe_header`, `testdata`, `chat`, `test`, `rigidbody_moving`, `rigidbody_at_rest`) | write | generated code **byte-identical** to main; branch must equal main, and both must beat off. This is the half #60 bought and this PR must not spend |
| c | `message_batch` | write | untouched language — the cross-check that the box is quiet |

### Reading the result

- branch ≈ off **and** branch ≈ main on the per-message rows → the residual is
  closed and the lever is the whole story.
- branch ≈ main on `message_batch` write → the dispatch body was not the cost;
  the mechanism above is still real, but the time is elsewhere, and the issue's
  own comment names the suspects (I-cache thrash across cycling message types,
  clang/arm64 dispatch shape, or measurement).

**Air caveat, from the issue's comment:** `message_batch` write on Air is the
noisiest row in the suite — 25% same-binary spread measured, era wander
173→211 with no code change — and its **base** deficit is unattributed and
separate from anything this PR touches. Tame the spread (twin gates / §2.6.1)
before believing an Air delta either way. The Zen 4 leg is the one that can
resolve a 7-16% effect cleanly.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
