### PR TITLE
ir: expression rendering is public — a declared bound renders as the author's spelling

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -583,6 +583,29 @@ share are functions there rather than per-backend arithmetic — `ir.BitsRequire
 `ir.AlignedFixedByteArrays`, `ir.FieldId` — so a new target computes the same
 widths as the old ones by construction, not by care.
 
+Constants fold, but the author's spelling survives: every declared bound,
+size, and default keeps its source expression on the IR (`Const.Expr`,
+`Field.IntMinExpr`/`IntMaxExpr`, `ArrayExpr`, `DefExpr`,
+`FieldType.SizeExpr`), and the expression surface renders it, so generated
+output can say `MaxObjects - 1` where the resolved field alone could only
+say `9999`:
+
+```go
+// object_id int32 [min = 0, max = MaxObjects - 1]
+f := handle.Fields[0]
+ir.RenderExpr(f.IntMaxExpr)                        // "MaxObjects - 1" — schema spelling, for comments
+ir.RenderExprIdent(f.IntMaxExpr, nil)              // "MaxObjects - 1" — a target that keeps the name
+ir.RenderExprIdent(f.IntMaxExpr, ir.RustConstName) // "MAX_OBJECTS - 1" — a SCREAMING_SNAKE target
+```
+
+Whether a bound should render symbolically at all is your target's call, made
+on two facts: `ir.ExprConsts` lists the constants an expression references
+(check each against `unit.Consts` by your target's own rules — the built-in
+backends disagree with each other here), and `ir.ExprHasEnumMax` reports an
+`E.Max` reference, which has no twin in any generated target — fold those to
+the resolved value and keep the schema form in a comment, as the built-in
+backends do.
+
 ### The data compiler
 
 `schema pack` is a driver call too, and like `Generate` it hands back bytes:

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -406,7 +406,7 @@ func (g *gen) emitConst(d *ir.Const) {
 	if !d.Int.IsInt64() {
 		// above INT64_MAX a bare decimal literal is ill-formed C++ — only a
 		// uint64-typed constant can hold such a value, so the suffix is right
-		g.pf("inline constexpr %s %s = %sull; // = %s\n", typ, d.Name, d.Int.String(), schemaExpr(d.Expr))
+		g.pf("inline constexpr %s %s = %sull; // = %s\n", typ, d.Name, d.Int.String(), ir.RenderExpr(d.Expr))
 		g.emitted[d.Name] = true
 		return
 	}
@@ -417,8 +417,8 @@ func (g *gen) emitConst(d *ir.Const) {
 // foldComment returns a trailing comment carrying the schema expression when
 // the rendered C++ had to fold it (an E.Max reference has no C++ twin).
 func (g *gen) foldComment(e ast.Expr) string {
-	if containsMax(e) {
-		return fmt.Sprintf(" // = %s", schemaExpr(e))
+	if ir.ExprHasEnumMax(e) {
+		return fmt.Sprintf(" // = %s", ir.RenderExpr(e))
 	}
 	return ""
 }
@@ -562,7 +562,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		st := f.Type.Ref.(*ir.Struct)
 		if f.FixedShallow {
 			g.pf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
-				f.Name, f.Type.Name, f.QuantShift, schemaExpr(f.QuantScaleExpr))
+				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
 			g.pf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, _, typ := fixedShallowComp(f, comp)
@@ -571,7 +571,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 			return
 		}
 		g.pf("    // %s: %s quantized by %s, max %s — per-component int in [-%d, %d]\n",
-			f.Name, f.Type.Name, schemaExpr(f.QuantScaleExpr), schemaExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
+			f.Name, f.Type.Name, ir.RenderExpr(f.QuantScaleExpr), ir.RenderExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
 		typ := cppInt(smallestSigned(f.QuantBound))
 		for _, comp := range st.Fields {
 			g.pf("    %s %s_%s = 0;\n", typ, f.Name, comp.Name)
@@ -605,11 +605,11 @@ func (g *gen) emitStorageField(f *ir.Field) {
 	switch {
 	case f.Type.Kind == ir.TString:
 		g.pf("    char %s[%s + 1] = {}; // string(%s): max length, used length beside it (SPEC §4.7)\n",
-			f.Name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), schemaExpr(f.Type.SizeExpr))
+			f.Name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("    int32_t %s_length = 0;\n", f.Name)
 	case f.Type.Kind == ir.TBytes:
 		g.pf("    uint8_t %s[%s] = {}; // bytes(%s): fixed buffer, used length beside it (SPEC §4.7)\n",
-			f.Name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), schemaExpr(f.Type.SizeExpr))
+			f.Name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("    int32_t %s_length = 0;\n", f.Name)
 	case f.Array == ir.ArrayFixed:
 		g.pf("    %s %s[%s] = {};%s\n", typ, f.Name, g.renderInt(f.ArrayExpr, big.NewInt(f.ArrayBound)), g.fieldComment(f))
@@ -780,7 +780,7 @@ func (g *gen) renderInt(e ast.Expr, folded *big.Int) string {
 	if folded != nil && folded.IsInt64() && folded.Int64() == math.MinInt64 {
 		return "( -9223372036854775807ll - 1 )" // INT64_MIN has no literal spelling in C++
 	}
-	if e == nil || containsMax(e) || !g.renderable(e) || !g.overflowSafe(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !g.overflowSafe(e) {
 		return folded.String()
 	}
 	return g.renderExpr(e)
@@ -900,85 +900,29 @@ func (g *gen) render128(e ast.Expr, folded *big.Int, signed bool) string {
 	return composed
 }
 
+// renderable: C++ needs every referenced constant declared before use in the
+// translation unit — same-file references render only after their declaration
+// is emitted; a cross-file reference is carried by the include graph.
 func (g *gen) renderable(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.IdentExpr:
-		base, ok := g.unit.DeclFile[e.Name]
+	for _, name := range ir.ExprConsts(e) {
+		base, ok := g.unit.DeclFile[name]
 		if !ok {
 			return false
 		}
-		if base == g.file.Base {
-			return g.emitted[e.Name] // same file: only if already emitted above
+		if base == g.file.Base && !g.emitted[name] {
+			return false
 		}
-		return true // cross-file: the include carries it
-	case *ast.UnaryExpr:
-		return g.renderable(e.X)
-	case *ast.BinaryExpr:
-		return g.renderable(e.X) && g.renderable(e.Y)
-	case *ast.ParenExpr:
-		return g.renderable(e.X)
 	}
 	return true
 }
 
+// renderExpr renders an expression in C++ form: constants keep the schema
+// spelling, and every reference is noted for the include graph.
 func (g *gen) renderExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		g.noteRef(e.Name)
-		return e.Name
-	case *ast.UnaryExpr:
-		inner := g.renderExpr(e.X)
-		if strings.HasPrefix(inner, "-") {
-			// "--x" is decrement in C++, not double negation (found by
-			// FuzzGeneratedCompiles, issue #22)
-			return "-(" + inner + ")"
-		}
-		return "-" + inner
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", g.renderExpr(e.X), e.Op, g.renderExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + g.renderExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-// schemaExpr renders an expression in schema source form, for comments.
-func schemaExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		return e.Name
-	case *ast.MaxExpr:
-		return e.Enum + ".Max"
-	case *ast.UnaryExpr:
-		return "-" + schemaExpr(e.X)
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", schemaExpr(e.X), e.Op, schemaExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + schemaExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-func containsMax(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.MaxExpr:
-		return true
-	case *ast.UnaryExpr:
-		return containsMax(e.X)
-	case *ast.BinaryExpr:
-		return containsMax(e.X) || containsMax(e.Y)
-	case *ast.ParenExpr:
-		return containsMax(e.X)
-	}
-	return false
+	return ir.RenderExprIdent(e, func(name string) string {
+		g.noteRef(name)
+		return name
+	})
 }
 
 func cppConstType(storage string) string {

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -300,8 +300,8 @@ func (g *gen) emitConst(d *ir.Const) {
 // foldComment returns a trailing comment carrying the schema expression when
 // the rendered C# had to fold it (an E.Max reference has no C# twin).
 func (g *gen) foldComment(e ast.Expr) string {
-	if e != nil && containsMax(e) {
-		return fmt.Sprintf(" // = %s", schemaExpr(e))
+	if e != nil && ir.ExprHasEnumMax(e) {
+		return fmt.Sprintf(" // = %s", ir.RenderExpr(e))
 	}
 	return ""
 }
@@ -502,7 +502,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		st := f.Type.Ref.(*ir.Struct)
 		if f.FixedShallow {
 			g.tf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
-				f.Name, f.Type.Name, f.QuantShift, schemaExpr(f.QuantScaleExpr))
+				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
 			g.tf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, typ, _ := fixedShallowComp(f, comp)
@@ -511,7 +511,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 			return
 		}
 		g.tf("    // %s: %s quantized by %s, max %s — per-component int in [-%d, %d]\n",
-			f.Name, f.Type.Name, schemaExpr(f.QuantScaleExpr), schemaExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
+			f.Name, f.Type.Name, ir.RenderExpr(f.QuantScaleExpr), ir.RenderExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
 		typ := csInt(smallestSigned(f.QuantBound))
 		for _, comp := range st.Fields {
 			g.tf("    public %s %s;\n", typ, g.m(ir.GoExportName(f.Name)+ir.GoExportName(comp.Name)))
@@ -543,18 +543,18 @@ func (g *gen) emitStorageField(f *ir.Field) {
 	switch {
 	case f.Type.Kind == ir.TString:
 		g.tf("    public byte[] %s = new byte[%s]; // string(%s): max length, used length beside it (SPEC §4.7)\n",
-			name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "", true), schemaExpr(f.Type.SizeExpr))
+			name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "", true), ir.RenderExpr(f.Type.SizeExpr))
 		g.tf("    public int %s;\n", g.m(name+"Length"))
 	case f.Type.Kind == ir.TBytes:
 		g.tf("    public byte[] %s = new byte[%s]; // bytes(%s): fixed buffer, used length beside it (SPEC §4.7)\n",
-			name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "", true), schemaExpr(f.Type.SizeExpr))
+			name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "", true), ir.RenderExpr(f.Type.SizeExpr))
 		g.tf("    public int %s;\n", g.m(name+"Length"))
 	case f.Array == ir.ArrayFixed:
 		g.tf("    public %s[] %s = new %s[%s];%s\n",
 			typ, name, typ, g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "", true), g.fieldComment(f))
 	case f.Array == ir.ArrayCounted:
 		g.tf("    public %s[] %s = new %s[%s]; // used count beside it; wire count in [%d, %s]\n",
-			typ, name, typ, g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "", true), f.ArrayMin, schemaExpr(f.ArrayExpr))
+			typ, name, typ, g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "", true), f.ArrayMin, ir.RenderExpr(f.ArrayExpr))
 		g.tf("    public int %s;\n", g.m(name+"Count"))
 	default:
 		init := ""
@@ -717,7 +717,7 @@ func csStorage(s string) string {
 // constants casts to the required type — the same renderability rule as the
 // Go and Rust targets, so all three fold identically.
 func (g *gen) renderArg(e ast.Expr, folded *big.Int, typ string, qualified bool) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !g.overflowSafe(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !g.overflowSafe(e) {
 		return folded.String()
 	}
 	if !containsIdent(e) {
@@ -736,7 +736,7 @@ func (g *gen) renderArg(e ast.Expr, folded *big.Int, typ string, qualified bool)
 // renderScaleF64 renders a quantization scale in double arithmetic: symbolic
 // consts cast ((double)PositionUnits), folded values become double literals.
 func (g *gen) renderScaleF64(e ast.Expr, folded int64) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !containsIdent(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !containsIdent(e) {
 		return strconv.FormatInt(folded, 10) + ".0"
 	}
 	s := renderExpr(e, false)
@@ -748,7 +748,7 @@ func (g *gen) renderScaleF64(e ast.Expr, folded int64) string {
 
 // renderScaleF32 is renderScaleF64's float twin, for float component division.
 func (g *gen) renderScaleF32(e ast.Expr, folded int64) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !containsIdent(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !containsIdent(e) {
 		return strconv.FormatInt(folded, 10) + ".0f"
 	}
 	s := renderExpr(e, false)
@@ -837,17 +837,15 @@ func fitsCarrier(v *big.Int, wide bool) bool {
 	return v.IsInt64() && v.Int64() >= math.MinInt32 && v.Int64() <= math.MaxInt32
 }
 
+// renderable: every referenced constant must be a BARE (untyped) integer
+// schema const — a typed const is a typed C# const, which forces casts at
+// use sites of other types.
 func (g *gen) renderable(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.IdentExpr:
-		c, ok := g.unit.Consts[e.Name]
-		return ok && !c.IsFloat && !c.Explicit
-	case *ast.UnaryExpr:
-		return g.renderable(e.X)
-	case *ast.BinaryExpr:
-		return g.renderable(e.X) && g.renderable(e.Y)
-	case *ast.ParenExpr:
-		return g.renderable(e.X)
+	for _, name := range ir.ExprConsts(e) {
+		c, ok := g.unit.Consts[name]
+		if !ok || c.IsFloat || c.Explicit {
+			return false
+		}
 	}
 	return true
 }
@@ -856,78 +854,16 @@ func (g *gen) renderable(e ast.Expr) bool {
 // references with "Schema." for render sites outside the Schema class (class
 // field initializers) — inside Schema the bare name resolves.
 func renderExpr(e ast.Expr, qualified bool) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		if qualified {
-			return "Schema." + e.Name
-		}
-		return e.Name
-	case *ast.UnaryExpr:
-		inner := renderExpr(e.X, qualified)
-		if strings.HasPrefix(inner, "-") {
-			// "--x" is decrement in C#, not double negation (issue #22)
-			return "-(" + inner + ")"
-		}
-		return "-" + inner
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", renderExpr(e.X, qualified), e.Op, renderExpr(e.Y, qualified))
-	case *ast.ParenExpr:
-		return "(" + renderExpr(e.X, qualified) + ")"
+	if qualified {
+		return ir.RenderExprIdent(e, func(name string) string { return "Schema." + name })
 	}
-	return "?"
+	return ir.RenderExprIdent(e, nil)
 }
 
-// schemaExpr renders an expression in schema source form, for comments.
-func schemaExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		return e.Name
-	case *ast.MaxExpr:
-		return e.Enum + ".Max"
-	case *ast.UnaryExpr:
-		return "-" + schemaExpr(e.X)
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", schemaExpr(e.X), e.Op, schemaExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + schemaExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-func containsMax(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.MaxExpr:
-		return true
-	case *ast.UnaryExpr:
-		return containsMax(e.X)
-	case *ast.BinaryExpr:
-		return containsMax(e.X) || containsMax(e.Y)
-	case *ast.ParenExpr:
-		return containsMax(e.X)
-	}
-	return false
-}
-
+// containsIdent reports whether e references any named constant — a literal
+// expression renders no better than its folded value.
 func containsIdent(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.IdentExpr:
-		return true
-	case *ast.UnaryExpr:
-		return containsIdent(e.X)
-	case *ast.BinaryExpr:
-		return containsIdent(e.X) || containsIdent(e.Y)
-	case *ast.ParenExpr:
-		return containsIdent(e.X)
-	}
-	return false
+	return len(ir.ExprConsts(e)) > 0
 }
 
 // csRender128 renders a 128-bit bound as C# source. Values inside long ride

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -224,8 +224,8 @@ func (g *gen) emitConst(d *ir.Const) {
 // foldComment returns a trailing comment carrying the schema expression when
 // the rendered Go had to fold it (an E.Max reference has no Go twin).
 func (g *gen) foldComment(e ast.Expr) string {
-	if e != nil && containsMax(e) {
-		return fmt.Sprintf(" // = %s", schemaExpr(e))
+	if e != nil && ir.ExprHasEnumMax(e) {
+		return fmt.Sprintf(" // = %s", ir.RenderExpr(e))
 	}
 	return ""
 }
@@ -491,7 +491,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		st := f.Type.Ref.(*ir.Struct)
 		if f.FixedShallow {
 			g.pf("\t// %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
-				f.Name, f.Type.Name, f.QuantShift, schemaExpr(f.QuantScaleExpr))
+				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
 			g.pf("\t// quantized units; bounds are the component's whole-unit [min, max] scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, _, typ, _ := fixedShallowComp(f, comp)
@@ -500,7 +500,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 			return
 		}
 		g.pf("\t// %s: %s quantized by %s, max %s — per-component int in [-%d, %d]\n",
-			f.Name, f.Type.Name, schemaExpr(f.QuantScaleExpr), schemaExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
+			f.Name, f.Type.Name, ir.RenderExpr(f.QuantScaleExpr), ir.RenderExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
 		typ := goInt(smallestSigned(f.QuantBound))
 		for _, comp := range st.Fields {
 			g.pf("\t%s%s %s\n", name, ir.GoExportName(comp.Name), typ)
@@ -532,11 +532,11 @@ func (g *gen) emitStorageField(f *ir.Field) {
 	switch {
 	case f.Type.Kind == ir.TString:
 		g.pf("\t%s [%s]byte // string(%s): max length, used length beside it (SPEC §4.7)\n",
-			name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), schemaExpr(f.Type.SizeExpr))
+			name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("\t%sLength int32\n", name)
 	case f.Type.Kind == ir.TBytes:
 		g.pf("\t%s [%s]byte // bytes(%s): fixed buffer, used length beside it (SPEC §4.7)\n",
-			name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), schemaExpr(f.Type.SizeExpr))
+			name, g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("\t%sLength int32\n", name)
 	case f.Array == ir.ArrayFixed:
 		g.pf("\t%s [%s]%s%s\n", name, g.renderInt(f.ArrayExpr, big.NewInt(f.ArrayBound)), typ, g.fieldComment(f))
@@ -636,84 +636,29 @@ func (g *gen) goFieldType(t ir.FieldType) string {
 // folds to the computed value otherwise (typed consts would force conversions;
 // an E.Max reference always folds; the schema source rides in a comment).
 func (g *gen) renderInt(e ast.Expr, folded *big.Int) string {
-	if e == nil || containsMax(e) || !g.renderable(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) {
 		return folded.String()
 	}
 	return renderExpr(e)
 }
 
+// renderable: every referenced constant must be a BARE (untyped) integer
+// schema const — a typed const is a typed Go const, which forces conversions
+// at use sites of other types.
 func (g *gen) renderable(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.IdentExpr:
-		c, ok := g.unit.Consts[e.Name]
-		return ok && !c.IsFloat && !c.Explicit
-	case *ast.UnaryExpr:
-		return g.renderable(e.X)
-	case *ast.BinaryExpr:
-		return g.renderable(e.X) && g.renderable(e.Y)
-	case *ast.ParenExpr:
-		return g.renderable(e.X)
+	for _, name := range ir.ExprConsts(e) {
+		c, ok := g.unit.Consts[name]
+		if !ok || c.IsFloat || c.Explicit {
+			return false
+		}
 	}
 	return true
 }
 
+// renderExpr renders an expression in Go form: constants keep the schema
+// spelling, since the Go target emits them under their declared names.
 func renderExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		return e.Name
-	case *ast.UnaryExpr:
-		inner := renderExpr(e.X)
-		if strings.HasPrefix(inner, "-") {
-			// "--x" fails to parse in Go, and the emitter's own parse gate
-			// refused the whole unit; double negation needs parens (issue #22)
-			return "-(" + inner + ")"
-		}
-		return "-" + inner
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", renderExpr(e.X), e.Op, renderExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + renderExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-// schemaExpr renders an expression in schema source form, for comments.
-func schemaExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		return e.Name
-	case *ast.MaxExpr:
-		return e.Enum + ".Max"
-	case *ast.UnaryExpr:
-		return "-" + schemaExpr(e.X)
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", schemaExpr(e.X), e.Op, schemaExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + schemaExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-func containsMax(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.MaxExpr:
-		return true
-	case *ast.UnaryExpr:
-		return containsMax(e.X)
-	case *ast.BinaryExpr:
-		return containsMax(e.X) || containsMax(e.Y)
-	case *ast.ParenExpr:
-		return containsMax(e.X)
-	}
-	return false
+	return ir.RenderExprIdent(e, nil)
 }
 
 func goInt2(signed bool, width int) string {

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -332,8 +332,8 @@ func fitsSafeInteger(v *big.Int) bool {
 // foldComment returns a trailing comment carrying the schema expression when
 // the rendered JS had to fold it (an E.Max reference has no JS twin).
 func (g *gen) foldComment(e ast.Expr) string {
-	if e != nil && containsMax(e) {
-		return fmt.Sprintf(" // = %s", schemaExpr(e))
+	if e != nil && ir.ExprHasEnumMax(e) {
+		return fmt.Sprintf(" // = %s", ir.RenderExpr(e))
 	}
 	return ""
 }
@@ -424,11 +424,11 @@ func (g *gen) emitStorageField(f *ir.Field) {
 	switch {
 	case f.Type.Kind == ir.TString:
 		g.pf("    this.%s = new Uint8Array(%s); // string(%s): max length, used length beside it (SPEC §4.7)\n",
-			name, g.renderNum(f.Type.SizeExpr, big.NewInt(f.Type.Size)), schemaExpr(f.Type.SizeExpr))
+			name, g.renderNum(f.Type.SizeExpr, big.NewInt(f.Type.Size)), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("    this.%sLength = 0;\n", name)
 	case f.Type.Kind == ir.TBytes:
 		g.pf("    this.%s = new Uint8Array(%s); // bytes(%s): fixed buffer, used length beside it (SPEC §4.7)\n",
-			name, g.renderNum(f.Type.SizeExpr, big.NewInt(f.Type.Size)), schemaExpr(f.Type.SizeExpr))
+			name, g.renderNum(f.Type.SizeExpr, big.NewInt(f.Type.Size)), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("    this.%sLength = 0;\n", name)
 	case f.Array != ir.ArrayNone:
 		bound := g.renderNum(f.ArrayExpr, big.NewInt(f.ArrayBound))
@@ -576,7 +576,7 @@ func bigLit(v *big.Int) string {
 // non-exact division subtree must fold); the computed literal otherwise.
 // Folding is always correct.
 func (g *gen) renderNum(e ast.Expr, folded *big.Int) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !g.numExact(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !g.numExact(e) {
 		return folded.String()
 	}
 	return g.renderExpr(e)
@@ -648,80 +648,26 @@ func (g *gen) numEval(e ast.Expr) (*big.Int, bool) {
 	return nil, false
 }
 
+// renderable: every referenced constant must be a BARE (untyped) integer
+// schema const — an explicitly 64-bit const stores as BigInt here
+// (constIsBig), which cannot mix with Number arithmetic.
 func (g *gen) renderable(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.IdentExpr:
-		c, ok := g.unit.Consts[e.Name]
-		return ok && !c.IsFloat && !c.Explicit
-	case *ast.UnaryExpr:
-		return g.renderable(e.X)
-	case *ast.BinaryExpr:
-		return g.renderable(e.X) && g.renderable(e.Y)
-	case *ast.ParenExpr:
-		return g.renderable(e.X)
+	for _, name := range ir.ExprConsts(e) {
+		c, ok := g.unit.Consts[name]
+		if !ok || c.IsFloat || c.Explicit {
+			return false
+		}
 	}
 	return true
 }
 
-// renderExpr renders an expression in JS form, importing referenced
-// constants where they live in another file.
+// renderExpr renders an expression in JS form: constants keep the schema
+// spelling, imported where they live in another file.
 func (g *gen) renderExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		g.addRef(e.Name, e.Name)
-		return e.Name
-	case *ast.UnaryExpr:
-		inner := g.renderExpr(e.X)
-		if strings.HasPrefix(inner, "-") {
-			// "--x" is decrement in JS, not double negation (issue #22's twin)
-			return "-(" + inner + ")"
-		}
-		return "-" + inner
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", g.renderExpr(e.X), e.Op, g.renderExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + g.renderExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-// schemaExpr renders an expression in schema source form, for comments.
-func schemaExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		return e.Name
-	case *ast.MaxExpr:
-		return e.Enum + ".Max"
-	case *ast.UnaryExpr:
-		return "-" + schemaExpr(e.X)
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", schemaExpr(e.X), e.Op, schemaExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + schemaExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-func containsMax(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.MaxExpr:
-		return true
-	case *ast.UnaryExpr:
-		return containsMax(e.X)
-	case *ast.BinaryExpr:
-		return containsMax(e.X) || containsMax(e.Y)
-	case *ast.ParenExpr:
-		return containsMax(e.X)
-	}
-	return false
+	return ir.RenderExprIdent(e, func(name string) string {
+		g.addRef(name, name)
+		return name
+	})
 }
 
 func formatFloat(v float64) string {

--- a/internal/codegen/js/objects.go
+++ b/internal/codegen/js/objects.go
@@ -122,7 +122,7 @@ func (g *gen) emitViewStorageField(f *ir.Field, v view) {
 		st := f.Type.Ref.(*ir.Struct)
 		if f.FixedShallow {
 			g.pf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
-				f.Name, f.Type.Name, f.QuantShift, schemaExpr(f.QuantScaleExpr))
+				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
 			g.pf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, width := fixedShallowComp(f, comp)
@@ -132,7 +132,7 @@ func (g *gen) emitViewStorageField(f *ir.Field, v view) {
 			return
 		}
 		g.pf("    // %s: %s quantized by %s, max %s — per-component int in [-%d, %d]\n",
-			f.Name, f.Type.Name, schemaExpr(f.QuantScaleExpr), schemaExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
+			f.Name, f.Type.Name, ir.RenderExpr(f.QuantScaleExpr), ir.RenderExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
 		for _, comp := range st.Fields {
 			g.pf("    this.%s%s = %s;\n", name, ir.GoExportName(comp.Name), zeroForWidth(smallestSigned(f.QuantBound)))
 		}

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -305,14 +305,14 @@ func (g *gen) emitWriteRangedFold64(expr string, exprIsU64, exprIsU32 bool, lo s
 // into an unconstrained literal, so `(-100) as u32` refuses to compile — while
 // a symbolic render keeps its own typing through the referenced consts.
 func (g *gen) foldArg32(e ast.Expr, folded *big.Int) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !containsIdent(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !containsIdent(e) {
 		return folded.String() + "_i32"
 	}
 	return g.renderArg(e, folded, "i32")
 }
 
 func (g *gen) foldArg64(e ast.Expr, folded *big.Int) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !containsIdent(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !containsIdent(e) {
 		return folded.String() + "_i64"
 	}
 	return g.renderArg(e, folded, "i64")

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -299,8 +299,8 @@ func (g *gen) emitConst(d *ir.Const) {
 // foldComment returns a trailing comment carrying the schema expression when
 // the rendered Rust had to fold it (an E.Max reference has no Rust twin).
 func (g *gen) foldComment(e ast.Expr) string {
-	if e != nil && containsMax(e) {
-		return fmt.Sprintf(" // = %s", schemaExpr(e))
+	if e != nil && ir.ExprHasEnumMax(e) {
+		return fmt.Sprintf(" // = %s", ir.RenderExpr(e))
 	}
 	return ""
 }
@@ -652,7 +652,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		st := f.Type.Ref.(*ir.Struct)
 		if f.FixedShallow {
 			g.pf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
-				f.Name, f.Type.Name, f.QuantShift, schemaExpr(f.QuantScaleExpr))
+				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
 			g.pf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, _, typ, _ := fixedShallowComp(f, comp)
@@ -661,7 +661,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 			return
 		}
 		g.pf("    // %s: %s quantized by %s, max %s — per-component int in [-%d, %d]\n",
-			f.Name, f.Type.Name, schemaExpr(f.QuantScaleExpr), schemaExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
+			f.Name, f.Type.Name, ir.RenderExpr(f.QuantScaleExpr), ir.RenderExpr(f.QuantMaxExpr), f.QuantBound, f.QuantBound)
 		typ := rustInt(smallestSigned(f.QuantBound))
 		for _, comp := range st.Fields {
 			g.pf("    pub %s_%s: %s,\n", f.Name, comp.Name, typ)
@@ -692,17 +692,17 @@ func (g *gen) emitStorageField(f *ir.Field) {
 	switch {
 	case f.Type.Kind == ir.TString:
 		g.pf("    pub %s: [u8; %s], // string(%s): max length, used length beside it (SPEC §4.7)\n",
-			f.Name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "usize"), schemaExpr(f.Type.SizeExpr))
+			f.Name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "usize"), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("    pub %s_length: i32,\n", f.Name)
 	case f.Type.Kind == ir.TBytes:
 		g.pf("    pub %s: [u8; %s], // bytes(%s): fixed buffer, used length beside it (SPEC §4.7)\n",
-			f.Name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "usize"), schemaExpr(f.Type.SizeExpr))
+			f.Name, g.renderArg(f.Type.SizeExpr, big.NewInt(f.Type.Size), "usize"), ir.RenderExpr(f.Type.SizeExpr))
 		g.pf("    pub %s_length: i32,\n", f.Name)
 	case f.Array == ir.ArrayFixed:
 		g.pf("    pub %s: [%s; %s],%s\n", f.Name, typ, g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "usize"), g.fieldComment(f))
 	case f.Array == ir.ArrayCounted:
 		g.pf("    pub %s: [%s; %s], // used count beside it; wire count in [%d, %s]\n",
-			f.Name, typ, g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "usize"), f.ArrayMin, schemaExpr(f.ArrayExpr))
+			f.Name, typ, g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "usize"), f.ArrayMin, ir.RenderExpr(f.ArrayExpr))
 		g.pf("    pub %s_count: i32,\n", f.Name)
 	default:
 		g.pf("    pub %s: %s,%s\n", f.Name, typ, g.fieldComment(f))
@@ -800,7 +800,7 @@ func rustStorage(s string) string {
 // (untyped-in-schema, i64-in-Rust) constants casts to the required type — the
 // same renderability rule as the Go target, so both fold identically.
 func (g *gen) renderArg(e ast.Expr, folded *big.Int, typ string) string {
-	if e == nil || containsMax(e) || !g.renderable(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) {
 		return folded.String()
 	}
 	if !containsIdent(e) {
@@ -819,7 +819,7 @@ func (g *gen) renderArg(e ast.Expr, folded *big.Int, typ string) string {
 // renderScaleF64 renders a quantization scale in f64 arithmetic: symbolic
 // consts cast (`POSITION_UNITS as f64`), folded values become float literals.
 func (g *gen) renderScaleF64(e ast.Expr, folded int64) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !containsIdent(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !containsIdent(e) {
 		return strconv.FormatInt(folded, 10) + ".0"
 	}
 	s := renderExpr(e)
@@ -831,7 +831,7 @@ func (g *gen) renderScaleF64(e ast.Expr, folded int64) string {
 
 // renderScaleF32 is renderScaleF64's f32 twin, for f32 component division.
 func (g *gen) renderScaleF32(e ast.Expr, folded int64) string {
-	if e == nil || containsMax(e) || !g.renderable(e) || !containsIdent(e) {
+	if e == nil || ir.ExprHasEnumMax(e) || !g.renderable(e) || !containsIdent(e) {
 		return strconv.FormatInt(folded, 10) + ".0"
 	}
 	s := renderExpr(e)
@@ -841,92 +841,29 @@ func (g *gen) renderScaleF32(e ast.Expr, folded int64) string {
 	return "(" + s + ") as f32"
 }
 
+// renderable: every referenced constant must be a BARE (untyped) integer
+// schema const — a typed const is a typed Rust const, which forces `as`
+// casts at use sites of other types.
 func (g *gen) renderable(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.IdentExpr:
-		c, ok := g.unit.Consts[e.Name]
-		return ok && !c.IsFloat && !c.Explicit
-	case *ast.UnaryExpr:
-		return g.renderable(e.X)
-	case *ast.BinaryExpr:
-		return g.renderable(e.X) && g.renderable(e.Y)
-	case *ast.ParenExpr:
-		return g.renderable(e.X)
+	for _, name := range ir.ExprConsts(e) {
+		c, ok := g.unit.Consts[name]
+		if !ok || c.IsFloat || c.Explicit {
+			return false
+		}
 	}
 	return true
 }
 
+// renderExpr renders an expression in Rust form: constants are spelled
+// SCREAMING_SNAKE, the way the Rust target declares them.
 func renderExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		return ir.RustConstName(e.Name)
-	case *ast.UnaryExpr:
-		inner := renderExpr(e.X)
-		if strings.HasPrefix(inner, "-") {
-			// "--x" is rejected by rustc (no prefix decrement); double
-			// negation needs parens (issue #22)
-			return "-(" + inner + ")"
-		}
-		return "-" + inner
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", renderExpr(e.X), e.Op, renderExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + renderExpr(e.X) + ")"
-	}
-	return "?"
+	return ir.RenderExprIdent(e, ir.RustConstName)
 }
 
-// schemaExpr renders an expression in schema source form, for comments.
-func schemaExpr(e ast.Expr) string {
-	switch e := e.(type) {
-	case *ast.IntLit:
-		return e.Text
-	case *ast.FloatLit:
-		return e.Text
-	case *ast.IdentExpr:
-		return e.Name
-	case *ast.MaxExpr:
-		return e.Enum + ".Max"
-	case *ast.UnaryExpr:
-		return "-" + schemaExpr(e.X)
-	case *ast.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", schemaExpr(e.X), e.Op, schemaExpr(e.Y))
-	case *ast.ParenExpr:
-		return "(" + schemaExpr(e.X) + ")"
-	}
-	return "?"
-}
-
-func containsMax(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.MaxExpr:
-		return true
-	case *ast.UnaryExpr:
-		return containsMax(e.X)
-	case *ast.BinaryExpr:
-		return containsMax(e.X) || containsMax(e.Y)
-	case *ast.ParenExpr:
-		return containsMax(e.X)
-	}
-	return false
-}
-
+// containsIdent reports whether e references any named constant — a literal
+// expression renders no better than its folded value.
 func containsIdent(e ast.Expr) bool {
-	switch e := e.(type) {
-	case *ast.IdentExpr:
-		return true
-	case *ast.UnaryExpr:
-		return containsIdent(e.X)
-	case *ast.BinaryExpr:
-		return containsIdent(e.X) || containsIdent(e.Y)
-	case *ast.ParenExpr:
-		return containsIdent(e.X)
-	}
-	return false
+	return len(ir.ExprConsts(e)) > 0
 }
 
 func rustInt(width int) string  { return fmt.Sprintf("i%d", width) }

--- a/internal/publicapi/publicapi_test.go
+++ b/internal/publicapi/publicapi_test.go
@@ -328,5 +328,22 @@ func wantClientOutput(t *testing.T) string {
 		fmt.Fprintf(&b, "%s %d bits %d bytes %d fields\n",
 			name, ir.MaxBitsStruct(st), ir.MaxBytes(ir.MaxBitsStruct(st)), len(st.Fields))
 	}
+	// the issue #89 surface: declared bounds rendered as source expressions,
+	// mirrored line for line in the external module's widths generator
+	structs := make([]string, 0, len(u.Structs))
+	for name := range u.Structs {
+		structs = append(structs, name)
+	}
+	sort.Strings(structs)
+	for _, name := range structs {
+		for _, f := range u.Structs[name].Fields {
+			if len(ir.ExprConsts(f.IntMaxExpr)) == 0 || ir.ExprHasEnumMax(f.IntMaxExpr) {
+				continue
+			}
+			fmt.Fprintf(&b, "bound %s.%s max = %s | %s = %s\n", name, f.Name,
+				ir.RenderExpr(f.IntMaxExpr),
+				ir.RenderExprIdent(f.IntMaxExpr, ir.RustConstName), f.IntMax)
+		}
+	}
 	return b.String()
 }

--- a/internal/publicapi/testdata/client/main.go
+++ b/internal/publicapi/testdata/client/main.go
@@ -12,6 +12,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/mas-bandwidth/schema/compiler"
@@ -20,9 +21,11 @@ import (
 
 // widths is a generator that emits nothing a language would compile — it
 // reports each message's worst-case wire width, the bound the emitters
-// advertise (SPEC §6.1 item 4). The point is the shape: a type outside this
-// module satisfying compiler.Generator, reading the IR through the public
-// derived-parameter helpers.
+// advertise (SPEC §6.1 item 4), then every symbolically-declared range bound
+// in the author's own spelling and a target spelling (issue #89). The point
+// is the shape: a type outside this module satisfying compiler.Generator,
+// reading the IR through the public derived-parameter helpers and rendering
+// declared expressions through the public expression surface.
 type widths struct{}
 
 // Names registers this generator as `--lang widths`.
@@ -39,6 +42,26 @@ func (widths) Generate(u *ir.Unit, _ compiler.Options) (map[string][]byte, error
 		}
 		bits := ir.MaxBitsStruct(st)
 		fmt.Fprintf(&b, "%s %d bits %d bytes %d fields\n", name, bits, ir.MaxBytes(bits), len(st.Fields))
+	}
+	// Every range bound the author declared through named constants, rendered
+	// as the source expression the resolved IntMax alone cannot give back —
+	// once in the schema spelling, once the way a SCREAMING_SNAKE target
+	// would emit it. An E.Max bound has no target twin, so it folds, exactly
+	// as the built-in backends fold it.
+	structs := make([]string, 0, len(u.Structs))
+	for name := range u.Structs {
+		structs = append(structs, name)
+	}
+	sort.Strings(structs)
+	for _, name := range structs {
+		for _, f := range u.Structs[name].Fields {
+			if len(ir.ExprConsts(f.IntMaxExpr)) == 0 || ir.ExprHasEnumMax(f.IntMaxExpr) {
+				continue
+			}
+			fmt.Fprintf(&b, "bound %s.%s max = %s | %s = %s\n", name, f.Name,
+				ir.RenderExpr(f.IntMaxExpr),
+				ir.RenderExprIdent(f.IntMaxExpr, ir.RustConstName), f.IntMax)
+		}
 	}
 	return map[string][]byte{"widths.txt": []byte(b.String())}, nil
 }

--- a/ir/expr.go
+++ b/ir/expr.go
@@ -1,0 +1,124 @@
+package ir
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/internal/ast"
+)
+
+// RenderExpr renders a kept expression in schema source form: literals keep
+// their source spelling (0x10 stays 0x10), constant references keep the
+// author's names, an enum max reference renders as E.Max, operators and
+// author parentheses are explicit. This is the target-language-neutral form
+// the built-in backends carry in comments beside folded values, and the form
+// an external generator emits where its target shares schema's spelling.
+//
+// Anything the parser cannot put in a kept expression — nil included —
+// renders as "?": a spelling no target compiles, so a defect is a loud build
+// failure in the consumer's tree, never a silently wrong bound.
+func RenderExpr(e Expr) string {
+	switch e := e.(type) {
+	case *ast.IntLit:
+		return e.Text
+	case *ast.FloatLit:
+		return e.Text
+	case *ast.IdentExpr:
+		return e.Name
+	case *ast.MaxExpr:
+		return e.Enum + ".Max"
+	case *ast.UnaryExpr:
+		return "-" + RenderExpr(e.X)
+	case *ast.BinaryExpr:
+		return fmt.Sprintf("%s %s %s", RenderExpr(e.X), e.Op, RenderExpr(e.Y))
+	case *ast.ParenExpr:
+		return "(" + RenderExpr(e.X) + ")"
+	}
+	return "?"
+}
+
+// RenderExprIdent renders e for a generated target, spelling every constant
+// reference through ident — the one point where the targets differ (Go and
+// C++ keep the schema spelling, Rust wants [RustConstName], a namespaced
+// target qualifies). A nil ident keeps the schema spelling. Two rules the
+// neutral [RenderExpr] form does not need:
+//
+//   - Doubled unary minus parenthesizes ("-(-x)"): "--" is a decrement
+//     operator in the C family and a parse error in Go and Rust, so the bare
+//     concatenation compiles somewhere as the wrong program (issue #22).
+//   - An enum max reference renders as "?": E.Max has no cross-target
+//     spelling. Callers fold expressions containing one to the resolved
+//     value first — [ExprHasEnumMax] is that test — as every built-in
+//     backend does, carrying the schema form in a comment via [RenderExpr].
+//
+// Whether a bound should render symbolically at all is the caller's own
+// policy, built on [ExprConsts]; the built-in backends disagree with each
+// other here (typed constants, same-file emission order), so no single
+// answer belongs in this function.
+func RenderExprIdent(e Expr, ident func(name string) string) string {
+	switch e := e.(type) {
+	case *ast.IntLit:
+		return e.Text
+	case *ast.FloatLit:
+		return e.Text
+	case *ast.IdentExpr:
+		if ident == nil {
+			return e.Name
+		}
+		return ident(e.Name)
+	case *ast.UnaryExpr:
+		inner := RenderExprIdent(e.X, ident)
+		if strings.HasPrefix(inner, "-") {
+			return "-(" + inner + ")"
+		}
+		return "-" + inner
+	case *ast.BinaryExpr:
+		return fmt.Sprintf("%s %s %s", RenderExprIdent(e.X, ident), e.Op, RenderExprIdent(e.Y, ident))
+	case *ast.ParenExpr:
+		return "(" + RenderExprIdent(e.X, ident) + ")"
+	}
+	return "?"
+}
+
+// ExprConsts returns the constant names e references, in source order, one
+// entry per occurrence; nil when the expression is literal. The names index
+// [Unit.Consts]. A generator deciding whether to render a bound symbolically
+// checks each referenced constant against its own target's rules — an
+// expression with no references always renders exactly as its folded value.
+func ExprConsts(e Expr) []string {
+	var names []string
+	var walk func(e Expr)
+	walk = func(e Expr) {
+		switch e := e.(type) {
+		case *ast.IdentExpr:
+			names = append(names, e.Name)
+		case *ast.UnaryExpr:
+			walk(e.X)
+		case *ast.BinaryExpr:
+			walk(e.X)
+			walk(e.Y)
+		case *ast.ParenExpr:
+			walk(e.X)
+		}
+	}
+	walk(e)
+	return names
+}
+
+// ExprHasEnumMax reports whether e contains an enum max reference. E.Max has
+// no twin in any generated target, so a backend folds any expression
+// containing one to the resolved value and keeps the schema form in a
+// comment ([RenderExpr]).
+func ExprHasEnumMax(e Expr) bool {
+	switch e := e.(type) {
+	case *ast.MaxExpr:
+		return true
+	case *ast.UnaryExpr:
+		return ExprHasEnumMax(e.X)
+	case *ast.BinaryExpr:
+		return ExprHasEnumMax(e.X) || ExprHasEnumMax(e.Y)
+	case *ast.ParenExpr:
+		return ExprHasEnumMax(e.X)
+	}
+	return false
+}

--- a/ir/expr_test.go
+++ b/ir/expr_test.go
@@ -1,0 +1,186 @@
+// Tests for the public expression-rendering surface (issue #89): an external
+// generator holding a checked unit must be able to render every kept bound,
+// size, and default expression as the author's own source spelling — the
+// same capability the built-in backends use for symbolic emission. The
+// corpus goes in as schema text and comes out through the public IR only,
+// the way an external consumer sees it.
+package ir_test
+
+import (
+	"testing"
+
+	"github.com/mas-bandwidth/schema/internal/check"
+	"github.com/mas-bandwidth/schema/internal/parser"
+	"github.com/mas-bandwidth/schema/ir"
+)
+
+const exprCorpus = `package exprtest
+
+const MaxObjects = 256
+const MaxUnits = 1024
+
+// every operator, literal spelling, and nesting the grammar allows
+const HalfObjects = MaxObjects / 2
+const Remainder = MaxObjects % 5
+const Area = MaxObjects * MaxObjects
+const Grouped = (MaxObjects + 1) * 2
+const Negated = -MaxUnits
+const DoubleNeg = --3
+const DoubleNegIdent = --MaxUnits
+
+// enum max references — no twin in any generated target
+enum Team { Red, Blue, Green }
+const NumTeams = Team.Max
+const TeamsPlus = Team.Max + 1
+
+type Bounds {
+    object_id int32 [min = 0, max = MaxObjects - 1]
+    delta     int32 [min = -MaxUnits, max = MaxUnits]
+    hexed     int32 [min = 0, max = 0x10]
+    counted   [<= MaxObjects]uint8
+    name      string(MaxUnits)
+    retries   int32 [min = 0, max = MaxObjects] = HalfObjects
+}
+`
+
+func loadExprCorpus(t *testing.T) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse("Expr.schema", []byte(exprCorpus))
+	if len(perrs) > 0 {
+		t.Fatalf("test corpus does not parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path:  "Expr.schema",
+		Name:  "Expr.schema",
+		Base:  "Expr",
+		Bytes: []byte(exprCorpus),
+		AST:   f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("test corpus does not check: %v", cerrs[0])
+	}
+	return u
+}
+
+// TestRenderConstExprs pins the rendering of every constant declaration's
+// kept expression: the neutral schema form, the target form under the nil
+// (keep-the-spelling) and RustConstName identifier hooks, the referenced
+// constant names, and the enum-max fact.
+func TestRenderConstExprs(t *testing.T) {
+	u := loadExprCorpus(t)
+	tests := []struct {
+		name      string   // const declaration
+		neutral   string   // RenderExpr
+		ident     string   // RenderExprIdent with nil (schema spelling)
+		screaming string   // RenderExprIdent with ir.RustConstName
+		consts    []string // ExprConsts, source order, per occurrence
+		hasMax    bool     // ExprHasEnumMax
+	}{
+		{"MaxObjects", "256", "256", "256", nil, false},
+		{"HalfObjects", "MaxObjects / 2", "MaxObjects / 2", "MAX_OBJECTS / 2", []string{"MaxObjects"}, false},
+		{"Remainder", "MaxObjects % 5", "MaxObjects % 5", "MAX_OBJECTS % 5", []string{"MaxObjects"}, false},
+		{"Area", "MaxObjects * MaxObjects", "MaxObjects * MaxObjects", "MAX_OBJECTS * MAX_OBJECTS", []string{"MaxObjects", "MaxObjects"}, false},
+		{"Grouped", "(MaxObjects + 1) * 2", "(MaxObjects + 1) * 2", "(MAX_OBJECTS + 1) * 2", []string{"MaxObjects"}, false},
+		{"Negated", "-MaxUnits", "-MaxUnits", "-MAX_UNITS", []string{"MaxUnits"}, false},
+		// the neutral form keeps the author's doubled minus (it is a comment
+		// spelling); the target form parenthesizes, since "--" is a decrement
+		// operator in the C family and a parse error in Go and Rust
+		{"DoubleNeg", "--3", "-(-3)", "-(-3)", nil, false},
+		{"DoubleNegIdent", "--MaxUnits", "-(-MaxUnits)", "-(-MAX_UNITS)", []string{"MaxUnits"}, false},
+		// E.Max renders neutrally for comments and refuses a target form
+		{"NumTeams", "Team.Max", "?", "?", nil, true},
+		{"TeamsPlus", "Team.Max + 1", "? + 1", "? + 1", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, ok := u.Consts[tt.name]
+			if !ok {
+				t.Fatalf("const %s missing from the unit", tt.name)
+			}
+			if got := ir.RenderExpr(c.Expr); got != tt.neutral {
+				t.Errorf("RenderExpr = %q, want %q", got, tt.neutral)
+			}
+			if got := ir.RenderExprIdent(c.Expr, nil); got != tt.ident {
+				t.Errorf("RenderExprIdent(nil) = %q, want %q", got, tt.ident)
+			}
+			if got := ir.RenderExprIdent(c.Expr, ir.RustConstName); got != tt.screaming {
+				t.Errorf("RenderExprIdent(RustConstName) = %q, want %q", got, tt.screaming)
+			}
+			got := ir.ExprConsts(c.Expr)
+			if len(got) != len(tt.consts) {
+				t.Errorf("ExprConsts = %v, want %v", got, tt.consts)
+			} else {
+				for i := range got {
+					if got[i] != tt.consts[i] {
+						t.Errorf("ExprConsts = %v, want %v", got, tt.consts)
+						break
+					}
+				}
+			}
+			if got := ir.ExprHasEnumMax(c.Expr); got != tt.hasMax {
+				t.Errorf("ExprHasEnumMax = %v, want %v", got, tt.hasMax)
+			}
+		})
+	}
+}
+
+// TestRenderFieldExprs proves every kept expression slot on a field renders
+// the author's spelling: range bounds, the array bound, the string size, and
+// the specified default.
+func TestRenderFieldExprs(t *testing.T) {
+	u := loadExprCorpus(t)
+	st, ok := u.Structs["Bounds"]
+	if !ok {
+		t.Fatal("type Bounds missing from the unit")
+	}
+	fields := map[string]*ir.Field{}
+	for _, f := range st.Fields {
+		fields[f.Name] = f
+	}
+	tests := []struct {
+		field string
+		expr  func(f *ir.Field) ir.Expr
+		want  string
+	}{
+		{"object_id", func(f *ir.Field) ir.Expr { return f.IntMaxExpr }, "MaxObjects - 1"},
+		{"object_id", func(f *ir.Field) ir.Expr { return f.IntMinExpr }, "0"},
+		{"delta", func(f *ir.Field) ir.Expr { return f.IntMinExpr }, "-MaxUnits"},
+		{"hexed", func(f *ir.Field) ir.Expr { return f.IntMaxExpr }, "0x10"}, // source spelling survives
+		{"counted", func(f *ir.Field) ir.Expr { return f.ArrayExpr }, "MaxObjects"},
+		{"name", func(f *ir.Field) ir.Expr { return f.Type.SizeExpr }, "MaxUnits"},
+		{"retries", func(f *ir.Field) ir.Expr { return f.DefExpr }, "HalfObjects"},
+	}
+	for _, tt := range tests {
+		f, ok := fields[tt.field]
+		if !ok {
+			t.Errorf("field %s missing from Bounds", tt.field)
+			continue
+		}
+		e := tt.expr(f)
+		if e == nil {
+			t.Errorf("%s: kept expression is nil, want %q", tt.field, tt.want)
+			continue
+		}
+		if got := ir.RenderExpr(e); got != tt.want {
+			t.Errorf("%s: RenderExpr = %q, want %q", tt.field, got, tt.want)
+		}
+	}
+}
+
+// TestRenderExprHostile pins the behavior on inputs no checked unit hands
+// out: nil renders as the "?" poison — a spelling no target compiles — and
+// the fact functions answer without panicking.
+func TestRenderExprHostile(t *testing.T) {
+	if got := ir.RenderExpr(nil); got != "?" {
+		t.Errorf("RenderExpr(nil) = %q, want %q", got, "?")
+	}
+	if got := ir.RenderExprIdent(nil, nil); got != "?" {
+		t.Errorf("RenderExprIdent(nil, nil) = %q, want %q", got, "?")
+	}
+	if got := ir.ExprConsts(nil); got != nil {
+		t.Errorf("ExprConsts(nil) = %v, want nil", got)
+	}
+	if ir.ExprHasEnumMax(nil) {
+		t.Error("ExprHasEnumMax(nil) = true, want false")
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -15,10 +15,12 @@ import (
 // — beside the resolved value in the fields next to it. The concrete node
 // types are the parser's, and stay unexported from this module: an expression
 // is produced by parsing schema text and is never constructed by a caller, and
-// freezing the parse tree under semver buys nothing the numbers beside it do
+// freezing the parse tree under semver buys nothing the functions beside it do
 // not already give. A generator outside this module reads the resolved
-// numeric fields and treats a non-nil Expr as the fact that the author wrote
-// something symbolic here.
+// numeric fields, renders the author's spelling with [RenderExpr] or
+// [RenderExprIdent], and asks [ExprConsts] and [ExprHasEnumMax] the two
+// questions a fold-or-render decision turns on — the same doors the built-in
+// backends go through.
 type Expr = ast.Expr
 
 type Unit struct {


### PR DESCRIPTION
Closes #89.

## The problem

The v1.10.0 public API exposes a declared bound only as its folded value: `ir.Expr`'s concrete nodes are internal and carry no renderer, so an external generator built on `compiler/` + `ir/` could only emit the literal. The built-in backends meanwhile each carried a private copy of the same rendering machinery — exactly the class of surface the #85 discipline says may be exported: something schema itself uses.

**Before** (all the public API allowed):

```go
health int16 [min = 0, max = MaxHealth]   // schema source
```
```
Health int16 // wire [0, 1000]            // external generator: folded, name lost
```

**After**:

```go
ir.RenderExpr(f.IntMaxExpr)                        // "MaxHealth"  — schema spelling, for comments
ir.RenderExprIdent(f.IntMaxExpr, nil)              // "MaxHealth"  — a target that keeps the name
ir.RenderExprIdent(f.IntMaxExpr, ir.RustConstName) // "MAX_HEALTH" — a SCREAMING_SNAKE target
```

so an external generator emits the same named-constant expressions the built-in emitters emit — `MaxObjects - 1`, not `9999`.

## The API (additive only, package `ir`)

```go
func RenderExpr(e Expr) string
func RenderExprIdent(e Expr, ident func(name string) string) string
func ExprConsts(e Expr) []string
func ExprHasEnumMax(e Expr) bool
```

- `RenderExpr` — target-language-neutral schema source form: literal spellings survive (`0x10` stays `0x10`), names preserved, `E.Max` explicit, operators and parens explicit. This is the form the built-in backends put in fold comments.
- `RenderExprIdent` — the target form. Identifier spelling is the caller's hook (the one point the five built-in backends differ: bare names, `RustConstName`, `Schema.` qualification, ref-noting closures). Doubled unary minus parenthesizes (`--` is a decrement operator in the C family and a parse error in Go/Rust — issue #22's class); `E.Max` renders as the `?` poison rather than folding silently, since it has no target twin.
- `ExprConsts` / `ExprHasEnumMax` — the two facts a fold-or-render decision turns on. The render policy itself stays per-target (the built-ins disagree with each other: typed constants, same-file emission order), so no single answer is baked in.

`ir.Expr` stays an opaque alias — no parse-tree freeze under semver.

## The refactor is the proof

The five symbolic backends' private copies (`schemaExpr` ×5, the `renderExpr` skeleton ×5, `containsMax` ×5, `containsIdent` ×2, `renderable`'s ident scan ×5) are deleted; the backends now go through the public surface, net −408/+491 including tests and docs. `make test` regenerates the entire committed `generated/` tree in place and it is **byte-identical** — the mechanism moved, the product did not, which is the acceptance the issue set.

## Tests

- `ir/expr_test.go` — `TestRenderConstExprs`, `TestRenderFieldExprs`, `TestRenderExprHostile`: source-to-rendered over every grammar shape (all operators, hex spelling, nested parens, doubled minus, `E.Max`, every kept field slot: range bounds, array bound, string size, default) plus the nil poison.
- `internal/publicapi` — the external client module now renders every symbolic bound through the new surface from **outside** the module boundary, compared line for line against the in-module walk (`TestExternalGeneratorRegisters`).
- Falsification pass, run and restored: dropping paren handling → `TestRenderConstExprs/Grouped` red; dropping the doubled-minus rule → `DoubleNeg`/`DoubleNegIdent` red. Notably the golden corpus contains neither shape, so these tests are the only gate on them.
- Full suite: `make test` green (all six language legs against the pinned sibling releases), `go vet`, `gofmt`, `go mod tidy -diff`, `modernize`, `golangci-lint` v2.12.2 — all clean; `generated/` tree current.

`USAGE.md` teaches the surface beside the custom-generator example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
