### PR TITLE
inline-verdict: count tail-branch calls into generated helpers (issue #86)

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -740,6 +740,12 @@ with its tier — a method inlined into all its callers does not appear.
 > on arm64 and `call` on x86-64. Go: `go tool objdump -s <symbol>`. C#: count `bl`/`blr`
 > in the `DOTNET_JitDisasm` output.
 >
+> A tail branch counts as a call (issue #86): a `b` on arm64 (`jmp` on x86-64,
+> `JMP name(SB)` in Go objdump) whose target is **another function's symbol** is a
+> transfer into a callee that was *not* inlined — it just reused the caller's frame.
+> A branch to a local label or raw address inside the same function is control flow,
+> not a call, and never counts.
+>
 > A fully inlined chain has **zero** calls into the serialize runtime inside the loop
 > body. This is language-independent and compiler-version-independent, and it is the
 > number the standard actually cares about.

--- a/bench/inline-budget.txt
+++ b/bench/inline-budget.txt
@@ -110,8 +110,14 @@ rust probearray write O3 0
 rust probearray read O3 0
 rust testdata write O3 3
 rust testdata read O3 2
-rust message_batch write O3 1
-rust message_batch read O3 1
+# The two rows below moved 1 -> 2 and 1 -> 3 in the same commit that taught
+# count_calls to see tail branches (#86): the extra hot calls were ALWAYS in
+# the binary as tail-called serialize-chain helpers and the old 1 was pinned
+# on the instrument's blind spot, not on a faster tree. Nothing regressed;
+# the measurement got honest. Whether these tails should inline is #77's
+# territory (the rust spine inline demand, measured on PR #88).
+rust message_batch write O3 2
+rust message_batch read O3 3
 rust bench_packet write O3 0
 rust bench_packet read O3 0
 rust bench_ints write O3 0

--- a/bench/tools/inline-gate.sh
+++ b/bench/tools/inline-gate.sh
@@ -14,7 +14,10 @@
 #       machinery from inline-verdict.sh (INLINE_VERDICT_LIB=1) and attack
 #       it: a known out-of-line call MUST produce partial:N, a cold-classified
 #       call MUST NOT count hot, a call with no cold signal MUST NOT be
-#       guessed cold, the helper-namespace join failure (the 4dc9b62 false
+#       guessed cold, a tail-branch b into the runtime or a helper MUST count
+#       as a call while local control flow MUST NOT (issue #86), the
+#       objdump/JitDisasm translators MUST carry tail transfers through, the
+#       helper-namespace join failure (the 4dc9b62 false
 #       full) MUST be caught, unroll division MUST divide or refuse, and the
 #       budget check itself MUST fail on over-budget, unknown, and absent
 #       legs. Exit non-zero if the machinery cannot fail where it must.
@@ -330,7 +333,111 @@ EOF
         fail "join self-test rejected a well-formed helper join"
     fi
 
-    # ---- 6. the namespace-join failure MUST be caught (the 4dc9b62 false
+    # ---- 6. tail-branch calls MUST count (issue #86): a b whose target is
+    # another function's symbol is a call the verdict must count — the callee
+    # was NOT inlined, the transfer just reused the caller's frame. And
+    # intra-function control flow must NOT count: a b to a raw address (otool
+    # prints local targets as hex), a b.cond, a b back to the function's own
+    # entry (its loop backedge), a b between a function and its own split
+    # .cold chunk (one logical function), and a b to a symbol outside the
+    # runtime/helper sets (the bl policy, mirrored). ----
+    cat > "$ST/tail.disasm" <<'EOF'
+_rt_fix_write_loop:
+0000000100000100	bl	_serialize_write_bits
+0000000100000104	b	_rt_fix_tailee
+_rt_fix_tailee:
+0000000100000200	bl	_serialize_write_bits
+0000000100000204	b	_serialize_flush
+EOF
+    count_calls "$RT" "$HELPER" "$COLD_SPLIT" < "$ST/tail.disasm" > "$VD/counts.txt"
+    n="$(perop_for '^_rt_fix_write_loop$')"
+    m="$(count_for '^_rt_fix_tailee$')"
+    if [ "${m:-0}" = 2 ] && [ "${n:-0}" = 3 ]; then
+        ok "tail-branch fixture: b into the runtime counts direct, b into a helper is an edge (tailee 2, loop 3)"
+    else
+        fail "tail-branch fixture: the tailee must count 2 (bl + tail b into the runtime) and the loop 3 (bl + tail edge through the tailee), got tailee=$m loop=$n — a helper reached by tail call is invisible and its green is a partial wearing a full's face (issue #86)"
+    fi
+    if selftest_join "$ST/tail.disasm" "$VD/counts.txt" "$HELPER"; then
+        ok "join self-test accepts the tail-branch helper join"
+    else
+        fail "join self-test rejected a well-formed tail-branch helper join"
+    fi
+    cat > "$ST/tail-local.disasm" <<'EOF'
+_rt_fix_write_loop:
+0000000100000100	bl	_serialize_write_bits
+0000000100000104	b.ne	0x100000100
+0000000100000108	b	0x100000100
+000000010000010c	b	_rt_fix_write_loop
+0000000100000110	b	_memcpy
+EOF
+    count_calls "$RT" "$HELPER" "$COLD_SPLIT" < "$ST/tail-local.disasm" > "$VD/counts.txt"
+    n="$(perop_for '^_rt_fix_write_loop$')"
+    if [ "${n:-0}" = 1 ]; then
+        ok "tail-branch fixture: local/conditional/self/foreign b forms stay control flow (partial:1 from the bl alone)"
+    else
+        fail "tail-branch fixture: only the bl may count — a hex-target b, a b.cond, a self-branch, and a b outside the runtime/helper sets are not calls (got hot=$n) — counting control flow as calls is the false-partial direction"
+    fi
+    cat > "$ST/tail-cold.disasm" <<'EOF'
+_rt_fix_write_loop:
+0000000100000100	bl	_serialize_write_bits
+0000000100000104	b	_rt_fix_write_loop.cold
+_rt_fix_write_loop.cold:
+0000000100000200	bl	_serialize_write_bits
+_rt_fix_read_loop:
+0000000100000300	b	_serialize_check_overflow.cold
+EOF
+    count_calls "$RT" "$HELPER" "$COLD_SPLIT" < "$ST/tail-cold.disasm" > "$VD/counts.txt"
+    n="$(perop_for '^_rt_fix_write_loop$')"
+    h="$(perop_for '^_rt_fix_read_loop$')"
+    c="$(perop_cold_for '^_rt_fix_read_loop$')"
+    if [ "${n:-0}" = 1 ] && [ "${h:-1}" = 0 ] && [ "${c:-0}" = 1 ]; then
+        ok "tail-branch fixture: own split chunk is control flow (hot 1); a tail b into another function's cold chunk counts cold (hot 0, cold 1)"
+    else
+        fail "tail-branch fixture: a b into the function's own .cold chunk must not count (want hot 1, got hot=$n) and a tail b into another function's cold chunk must count cold, never hot (want hot 0 cold 1, got hot=$h cold=$c)"
+    fi
+
+    # ---- 7. the translated surfaces carry tail transfers too (issue #86):
+    # go tool objdump spells a tail call JMP name(SB) — the n(PC) and (Rn)
+    # forms are intra-function control flow and trampolines, never calls;
+    # JitDisasm spells one b to a method or a raw address — G_M insGroup
+    # labels are intra-method control flow, and an address target is as
+    # opaque as blr, so it counts the same way blr does (§4.1's C# rule:
+    # silently dropping an opaque target would fake a full). ----
+    cat > "$ST/go-tail.objdump" <<'EOF'
+TEXT main.rtFixWriteLoop(SB) /x/main.go
+  main.go:5	0x100	97ffffe0	CALL main.fixHelper(SB)
+  main.go:6	0x104	14000000	JMP main.fixTail(SB)
+  main.go:7	0x108	17fffffe	JMP 2(PC)
+  main.go:8	0x10c	d61f0360	JMP (R27)
+TEXT main.fixTail(SB) /x/main.go
+  main.go:9	0x200	97ffffe0	CALL serialize%2ego.WriteBits(SB)
+EOF
+    go_translate < "$ST/go-tail.objdump" > "$ST/go-tail.calls"
+    count_calls 'serialize%2ego[.]' '^example[.]|^main[.]' '' < "$ST/go-tail.calls" > "$VD/counts.txt"
+    n="$(count_for '^main[.]rtFixWriteLoop$')"
+    if [ "${n:-0}" = 1 ]; then
+        ok "go translation: JMP name(SB) becomes a tail edge carrying the callee's runtime call; n(PC)/(Rn) forms do not"
+    else
+        fail "go translation: a JMP into a generated helper must carry that helper's 1 runtime call to the caller, and n(PC)/(Rn) jumps must not count (got transitive=$n) — the objdump translator drops tail calls (issue #86)"
+    fi
+    cat > "$ST/cs-tail.jit" <<'EOF'
+; Assembly listing for method Program:RtFixWriteLoop() (FullOpts)
+        bl      CORINFO_HELP_ASSIGN_REF
+        b       G_M12345_IG04
+        b       0x16E5B7A0
+EOF
+    cs_translate < "$ST/cs-tail.jit" > "$ST/cs-tail.calls"
+    count_calls '.' '(Example[.]Schema|Program):' '' < "$ST/cs-tail.calls" > "$VD/counts.txt"
+    awk '$1 == "SYM" { $4 += $5 } { print }' "$VD/counts.txt" > "$VD/counts.folded" \
+        && mv "$VD/counts.folded" "$VD/counts.txt"
+    n="$(count_for '^Program:RtFixWriteLoop$')"
+    if [ "${n:-0}" = 2 ]; then
+        ok "cs translation: a tail b past the insGroup labels counts like blr (bl + opaque tail = 2); G_M labels do not"
+    else
+        fail "cs translation: one bl plus one opaque tail b must count 2 with indirect folded, and the G_M label must not count (got $n) — JitDisasm tail transfers are invisible (issue #86)"
+    fi
+
+    # ---- 8. the namespace-join failure MUST be caught (the 4dc9b62 false
     # full: call targets in a namespace the symbol headers never joined) ----
     cat > "$ST/badjoin.disasm" <<'EOF'
 _rt_fix_write_loop:
@@ -345,7 +452,7 @@ EOF
         ok "namespace-join fixture: selftest_join fires on the 4dc9b62 failure class"
     fi
 
-    # ---- 7. unroll division: an unrolled loop divides back to per-op, and a
+    # ---- 9. unroll division: an unrolled loop divides back to per-op, and a
     # count that does not divide REFUSES (unknown) rather than guessing ----
     cat > "$ST/unroll.disasm" <<'EOF'
 _rt_fix_write_loop:
@@ -391,7 +498,7 @@ EOF
         fail "unroll fixture: 7 calls against unroll witness 4 must refuse (-2), got '$n'"
     fi
 
-    # ---- 8. the rust #[cold] source scan: a #[cold] fn is matched by its
+    # ---- 10. the rust #[cold] source scan: a #[cold] fn is matched by its
     # mangled token, a hot fn is not ----
     mkdir -p "$ST/crate/src"
     cat > "$ST/crate/src/lib.rs" <<'EOF'
@@ -407,7 +514,7 @@ EOF
         fail "rust cold scan: regex '$RE' must match the #[cold] fn's mangled token and not the hot fn"
     fi
 
-    # ---- 9. the budget assertion itself must be able to fail ----
+    # ---- 11. the budget assertion itself must be able to fail ----
     cat > "$ST/budget.txt" <<'EOF'
 # lang bench path opt max-hot
 fixture chat write O3 1
@@ -438,7 +545,7 @@ EOF
         fail "budget check: within-budget verdicts must pass"
     fi
 
-    # ---- 10. end-to-end on this host where the toolchain allows: a compiled
+    # ---- 12. end-to-end on this host where the toolchain allows: a compiled
     # binary with a known noinline callee must count as out of line ----
     if command -v otool > /dev/null 2>&1 && command -v cc > /dev/null 2>&1; then
         cat > "$ST/e2e.c" <<'EOF'

--- a/bench/tools/inline-verdict.sh
+++ b/bench/tools/inline-verdict.sh
@@ -36,7 +36,10 @@
 #
 # Ground truth is the §4.1 universal fallback: call instructions counted in
 # the emitted code (otool -tv on this arm64 Mac; go tool objdump for Go;
-# DOTNET_JitDisasm for C#). Compiler remarks are advisory ledger content;
+# DOTNET_JitDisasm for C#) — bl/blr, AND a tail-branch b into another
+# function (issue #86: the callee was not inlined, the transfer just reused
+# the caller's frame; a b to a local label is control flow, never a call).
+# Compiler remarks are advisory ledger content;
 # the disassembly is the verdict. For C# the count follows §4.1 literally —
 # every bl/blr in the method body — because indirect targets are opaque to
 # static counting and silently dropping them would fake a full.
@@ -76,7 +79,7 @@ if [ -z "${INLINE_VERDICT_LIB:-}" ]; then
     . bench/tools/runtime-paths.sh
     runtime_paths_init
 
-    # The native-binary parsing below is otool/arm64-shaped (bl/blr). On a
+    # The native-binary parsing below is otool/arm64-shaped (bl/blr/b). On a
     # machine without otool (the x86-64 EPYC box) the C/C++/Rust verdicts would
     # silently count zero and fake a full — refuse instead; inline stays unknown
     # there until the objdump/x86 adapter is written.
@@ -116,8 +119,12 @@ bench_mixed rt_bench_mixed rtBenchMixed RtBenchMixed
 bitpacker bitpacker bitpacker Bitpacker'
 
 # ---- per-symbol transitive runtime-call counting ----
-# stdin: "sym:" header lines and "addr <bl|blr> target" instruction lines
-# (otool -tv shape; the go/cs branches translate into it). RTPAT = runtime
+# stdin: "sym:" header lines and "addr <bl|blr|b> target" instruction lines
+# (otool -tv shape; the go/cs branches translate into it). A bare b whose
+# target is another function's symbol is a TAIL CALL and counts exactly as
+# bl (issue #86); a b to a raw hex address, to the function's own entry, or
+# between a function and its own split .cold chunk is intra-function control
+# flow and never counts. RTPAT = runtime
 # target regex, HELPER = generated helper regex, COLD = cold-target regex
 # ("" = no cold signal in this language; everything stays hot). The awk-side
 # name is RTPAT, never RT: RT is a BUILT-IN in gawk (the record terminator,
@@ -139,17 +146,32 @@ bitpacker bitpacker bitpacker Bitpacker'
 count_calls() {
     awk -v RTPAT="$1" -v HELPER="$2" -v COLD="${3:-}" '
         function iscold(t) { return COLD != "" && t ~ COLD }
-        /^[^ \t].*:$/ { sym = substr($0, 1, length($0) - 1); syms[sym] = 1; next }
-        $2 == "bl" && sym != "" {
-            t = $3
-            # cold first: a compiler-split chunk of a helper matches both
-            # HELPER and COLD, and must count cold, never become a hot edge
+        # one call-target policy for bl and tail-branch b (issue #86).
+        # cold first: a compiler-split chunk of a helper matches both
+        # HELPER and COLD, and must count cold, never become a hot edge.
+        # helper next: the cs branch passes a catch-all RTPAT, and helper
+        # calls must become edges, never direct counts (the regexes are
+        # disjoint for every other language)
+        function count_target(t) {
             if (iscold(t)) { if (t ~ RTPAT || t ~ HELPER) coldn[sym]++ }
-            # helper next: the cs branch passes a catch-all RTPAT, and helper
-            # calls must become edges, never direct counts (the regexes are
-            # disjoint for every other language)
             else if (t ~ HELPER) edge[sym SUBSEP t]++
             else if (t ~ RTPAT) direct[sym]++
+        }
+        /^[^ \t].*:$/ { sym = substr($0, 1, length($0) - 1); syms[sym] = 1; next }
+        $2 == "bl" && sym != "" { count_target($3) }
+        # a tail branch into another function is a call the verdict must
+        # count (issue #86): the callee was NOT inlined — the transfer just
+        # reused the caller frame. Only a b whose target is ANOTHER function
+        # symbol is a call: a b to a raw address (otool prints intra-function
+        # targets as hex), a b back to the function own entry (its loop
+        # backedge), and a b between a function and its own split chunk
+        # (foo <-> foo.cold/.cold.N — one logical function) are control
+        # flow; b.cond forms never match $2 == "b" at all.
+        $2 == "b" && sym != "" {
+            t = $3
+            if (t ~ /^0x/ || t == sym) next
+            if (index(t, sym ".") == 1 || index(sym, t ".") == 1) next
+            count_target(t)
         }
         $2 == "blr" && sym != "" { indirect[sym]++ }
         END {
@@ -178,24 +200,36 @@ count_calls() {
 # shape count_calls parses.
 
 # go tool objdump: TEXT headers become symbol headers; CALL name(SB) is a
-# direct call, CALL Rn an indirect one.
+# direct call, CALL Rn an indirect one; JMP name(SB) is a tail transfer
+# into another function and counts as a call (issue #86) — the n(PC) and
+# (Rn) JMP forms are intra-function control flow and trampolines, dropped.
 go_translate() {
     awk '
         /^TEXT / { name = $2; sub(/\(SB\)$/, "", name); print name ":"; next }
         {
-            for (i = 1; i <= NF; i++)
+            for (i = 1; i <= NF; i++) {
                 if ($i == "CALL") {
                     t = $(i + 1); sub(/\(SB\)$/, "", t)
                     if (t ~ /^[A-Z]+[0-9]*$/) print "0 blr " t   # CALL R26: indirect
                     else print "0 bl " t
                     break
                 }
+                if ($i == "JMP") {
+                    t = $(i + 1)
+                    if (t ~ /\(SB\)$/) { sub(/\(SB\)$/, "", t); print "0 b " t }
+                    break
+                }
+            }
         }'
 }
 
 # DOTNET_JitDisasm: method-listing headers become symbol headers; bl and blr
 # lines pass through (per §4.1 the C# count is bl AND blr in the method body;
 # blr targets are opaque, so they are counted rather than silently dropped).
+# A b past the G_M insGroup labels is a tail transfer out of the method
+# (issue #86): every intra-method branch in JitDisasm goes to a G_M label,
+# so a named target counts as a call and a raw-address target is as opaque
+# as blr and counts the same way — dropping either would fake a full.
 cs_translate() {
     awk '
         /^; Assembly listing for method / {
@@ -203,7 +237,14 @@ cs_translate() {
             print m ":"; next
         }
         $1 == "bl"  { print "0 bl " $2 }
-        $1 == "blr" { print "0 blr indirect" }'
+        $1 == "blr" { print "0 blr indirect" }
+        $1 == "b" {
+            t = $2
+            if (t ~ /^G_M/) next            # insGroup label: control flow
+            gsub(/[][]/, "", t)
+            if (t ~ /^0x/ || t ~ /^[0-9]/) print "0 blr indirect"
+            else print "0 b " t
+        }'
 }
 
 # verdict from a transitive HOT count: 0 -> full, N -> partial:N
@@ -270,6 +311,11 @@ selftest_join() {
         }
         /^[^ \t].*:$/ { sym = substr($0, 1, length($0) - 1); next }
         $2 == "bl" && sym != "" && $3 ~ HELPER { edge[sym SUBSEP $3] = 1; tgt[$3] = 1; nedge++ }
+        # tail-branch helper edges (issue #86), under the same guards
+        # count_calls applies — the join proof must see the same edge set
+        $2 == "b" && sym != "" && $3 !~ /^0x/ && $3 != sym && \
+            index($3, sym ".") != 1 && index(sym, $3 ".") != 1 && \
+            $3 ~ HELPER { edge[sym SUBSEP $3] = 1; tgt[$3] = 1; nedge++ }
         END {
             if (nedge == 0) exit 0      # no helper edges anywhere: nothing to prove
             resolved = 0
@@ -480,10 +526,16 @@ c|cpp)
         count_calls "$RT" "$HELPER" "$COLD_SPLIT" < "$VD/shadow-disasm.txt" > "$VD/shadow-counts.txt"
         selftest_join "$VD/shadow-disasm.txt" "$VD/shadow-counts.txt" "$HELPER" || exit 1
 
-        # every remaining runtime/helper call site in the shadow text
+        # every remaining runtime/helper call site in the shadow text —
+        # tail-branch b sites included (issue #86), under the same guards
+        # count_calls applies: raw-address, own-entry, and own-split-chunk
+        # b forms are control flow, not call sites
         awk -v RTPAT="$RT" -v HELPER="$HELPER" '
-            /^[^ \t].*:$/ { next }
+            /^[^ \t].*:$/ { sym = substr($0, 1, length($0) - 1); next }
             $2 == "bl" && ($3 ~ RTPAT || $3 ~ HELPER) { print $1, $3 }
+            $2 == "b" && $3 !~ /^0x/ && $3 != sym && \
+                index($3, sym ".") != 1 && index(sym, $3 ".") != 1 && \
+                ($3 ~ RTPAT || $3 ~ HELPER) { print $1, $3 }
         ' "$VD/shadow-disasm.txt" > "$VD/addrs.txt"
 
         # drift guard, as cpp: hot+cold totals must match the measured binary
@@ -662,10 +714,16 @@ c|cpp)
         count_calls "$RT" "$HELPER" "$COLD_SPLIT" < "$VD/shadow-disasm.txt" > "$VD/shadow-counts.txt"
         selftest_join "$VD/shadow-disasm.txt" "$VD/shadow-counts.txt" "$HELPER" || exit 1
 
-        # every remaining runtime/helper call site in the shadow text
+        # every remaining runtime/helper call site in the shadow text —
+        # tail-branch b sites included (issue #86), under the same guards
+        # count_calls applies: raw-address, own-entry, and own-split-chunk
+        # b forms are control flow, not call sites
         awk -v RTPAT="$RT" -v HELPER="$HELPER" '
-            /^[^ \t].*:$/ { next }
+            /^[^ \t].*:$/ { sym = substr($0, 1, length($0) - 1); next }
             $2 == "bl" && ($3 ~ RTPAT || $3 ~ HELPER) { print $1, $3 }
+            $2 == "b" && $3 !~ /^0x/ && $3 != sym && \
+                index($3, sym ".") != 1 && index(sym, $3 ".") != 1 && \
+                ($3 ~ RTPAT || $3 ~ HELPER) { print $1, $3 }
         ' "$VD/shadow-disasm.txt" > "$VD/addrs.txt"
 
         # drift guard: the shadow must have the same call structure as the
@@ -875,7 +933,7 @@ go)
     # as a call target should be one -m=2 could not inline, or one whose
     # callers ran out of budget — and the ledger says which.
     : > "$VD/crosscheck.txt"
-    awk '$2 == "bl" && $3 ~ /serialize%2ego\./ { print $3 }' "$VD/calls.txt" | sort -u | while read -r target; do
+    awk '($2 == "bl" || $2 == "b") && $3 ~ /serialize%2ego\./ { print $3 }' "$VD/calls.txt" | sort -u | while read -r target; do
         short="${target##*serialize%2ego.}"
         if grep -qF "cannot inline $short" "$VD/serialize-remarks.txt"; then
             echo "AGREE: $short is a call target and -m=2 says cannot inline" >> "$VD/crosscheck.txt"
@@ -970,6 +1028,11 @@ rust)
         }
         $2 == "bl"  { print $1 " bl CRATE_" firstcrate($3) "_" $3; next }
         $2 == "blr" { print $1 " blr indirect"; next }
+        # tail branches (issue #86): a b to a raw address is intra-function
+        # control flow, dropped here; a b to a symbol gets the same crate
+        # rename as bl targets so count_calls sees one namespace (its own
+        # self/own-chunk guards then apply on the renamed names)
+        $2 == "b" && $3 !~ /^0x/ { print $1 " b CRATE_" firstcrate($3) "_" $3; next }
     ' > "$VD/disasm.txt"
     count_calls '^CRATE_serialize_' '^CRATE_(example|benchrust)_' "$COLD_RS" < "$VD/disasm.txt" > "$VD/counts.txt"
     selftest_join "$VD/disasm.txt" "$VD/counts.txt" '^CRATE_(example|benchrust)_' || exit 1

--- a/bench/tools/inline-verdict.sh
+++ b/bench/tools/inline-verdict.sh
@@ -172,6 +172,40 @@ count_calls() {
         }'
 }
 
+# ---- objdump/JitDisasm -> otool-shape translation ----
+# Library functions (the gate's selftest fixtures attack these, not copies):
+# each turns one toolchain's disassembly into the "sym:" / "addr op target"
+# shape count_calls parses.
+
+# go tool objdump: TEXT headers become symbol headers; CALL name(SB) is a
+# direct call, CALL Rn an indirect one.
+go_translate() {
+    awk '
+        /^TEXT / { name = $2; sub(/\(SB\)$/, "", name); print name ":"; next }
+        {
+            for (i = 1; i <= NF; i++)
+                if ($i == "CALL") {
+                    t = $(i + 1); sub(/\(SB\)$/, "", t)
+                    if (t ~ /^[A-Z]+[0-9]*$/) print "0 blr " t   # CALL R26: indirect
+                    else print "0 bl " t
+                    break
+                }
+        }'
+}
+
+# DOTNET_JitDisasm: method-listing headers become symbol headers; bl and blr
+# lines pass through (per §4.1 the C# count is bl AND blr in the method body;
+# blr targets are opaque, so they are counted rather than silently dropped).
+cs_translate() {
+    awk '
+        /^; Assembly listing for method / {
+            m = $0; sub(/^; Assembly listing for method /, "", m); sub(/\(.*/, "", m)
+            print m ":"; next
+        }
+        $1 == "bl"  { print "0 bl " $2 }
+        $1 == "blr" { print "0 blr indirect" }'
+}
+
 # verdict from a transitive HOT count: 0 -> full, N -> partial:N
 verdict_of() {
     if [ "$1" -eq 0 ]; then echo "full"; else echo "partial:$1"; fi
@@ -825,17 +859,7 @@ go)
     go tool objdump "$VD/benchgo" > "$VD/objdump.txt" 2>/dev/null
 
     # translate objdump into the otool shape count_calls parses
-    awk '
-        /^TEXT / { name = $2; sub(/\(SB\)$/, "", name); print name ":"; next }
-        {
-            for (i = 1; i <= NF; i++)
-                if ($i == "CALL") {
-                    t = $(i + 1); sub(/\(SB\)$/, "", t)
-                    if (t ~ /^[A-Z]+[0-9]*$/) print "0 blr " t   # CALL R26: indirect
-                    else print "0 bl " t
-                    break
-                }
-        }' "$VD/objdump.txt" > "$VD/calls.txt"
+    go_translate < "$VD/objdump.txt" > "$VD/calls.txt"
     # COLD is empty: gc has no cold attribute, no section split, and no
     # remark that marks a callee cold — §4.2's hot-default applies to every
     # Go call, and the ledger note below says so out loud.
@@ -1028,17 +1052,10 @@ cs)
       dotnet run -c Release --no-build -- --round 0 > /dev/null 2>&1 ) || true
     [ -s "$JIT" ] || { echo "JitDisasm produced nothing — is the Release build present?" >&2; exit 1; }
 
-    # translate JitDisasm blocks into the otool shape. Per §4.1 the C# count
-    # is bl AND blr in the method body; blr targets are opaque, so they are
-    # counted as runtime calls rather than silently dropped.
-    awk '
-        /^; Assembly listing for method / {
-            m = $0; sub(/^; Assembly listing for method /, "", m); sub(/\(.*/, "", m)
-            print m ":"; next
-        }
-        $1 == "bl"  { print "0 bl " $2 }
-        $1 == "blr" { print "0 blr indirect" }
-    ' "$JIT" > "$VD/calls.txt"
+    # translate JitDisasm blocks into the otool shape (cs_translate above:
+    # per §4.1 the C# count is bl AND blr in the method body; blr targets
+    # are opaque, so they are counted rather than silently dropped)
+    cs_translate < "$JIT" > "$VD/calls.txt"
     # COLD is empty: JitDisasm names no cold blocks or targets on this
     # surface — §4.2's hot-default applies to every C# call, said out loud
     # in the section header below.


### PR DESCRIPTION
The inline gate's `count_calls` followed `bl`/`blr` but not a tail-branch `b` into a generated helper, so a generated function reached by tail call was invisible to the transitive hot-call count — a partial green wearing a full's face, in the one instrument whose whole job is refusing that verdict.

**The parsing change.** `count_calls` now runs one call-target policy for `bl` and bare `b`: a `b` whose target is *another function's symbol* is a tail call — the callee was not inlined, the transfer just reused the caller's frame — and counts exactly as `bl` (runtime target → direct, helper target → transitive edge, cold target → cold). A `b` to a raw hex address (otool's spelling of intra-function targets), to the function's own entry (loop backedge), or between a function and its own split `.cold` chunk stays control flow; `b.cond` forms never match. The translated surfaces carry tail transfers through: `go_translate` turns `JMP name(SB)` into a `b` line (`n(PC)`/`(Rn)` forms dropped), `cs_translate` passes a `b` past the `G_M` insGroup labels (named target as `b`, raw-address target as `blr`-opaque per the C# §4.1 rule), the rust translator crate-renames `b` targets like `bl` targets, and the c/cpp atos attribution collectors, `selftest_join`, and the go remark crosscheck see the same sites under the same guards. BENCH-STANDARD.md §4.1 states the ruling.

**Falsification, built in (red first — commit e6bce27, then the fix f43e107).** New adversarial fixtures against the unfixed machinery:

```
SELFTEST FAIL: tail-branch fixture: ... got tailee=1 loop=1 (want 2/3) — a helper reached by tail call is invisible
SELFTEST FAIL: tail-branch fixture: ... cold tail: got hot=0 cold=0 (want cold 1)
SELFTEST FAIL: go translation: ... got transitive=0 (want 1) — the objdump translator drops tail calls
SELFTEST FAIL: cs translation: ... got 1 (want 2) — JitDisasm tail transfers are invisible
inline-gate selftest: 4 FAILURES
```

After the fix: 21/21 fixtures green. The fixtures cover: a tail `b` into a generated helper (edge, propagated) and into the runtime (direct); local-hex `b`, `b.ne`, self-branch, and `b` to a non-helper/non-runtime symbol (none count — the `bl` policy, mirrored); a tail `b` into another function's `.cold` chunk (cold, never hot) vs the function's own split chunk (control flow); `JMP name(SB)` vs `n(PC)`/`(Rn)` in go objdump; and a `b` past `G_M` labels vs an opaque raw-address tail in JitDisasm.

**Before/after on real clang output.** A `-O2` fixture where the entry tail-branches (`b _rt_probe_helper`) into a noinline helper carrying one runtime call in its loop:

```
before (main):        _rt_probe_write_loop verdict full      (transitive hot 0)
after (this branch):  _rt_probe_write_loop verdict partial:1 (transitive hot 1)
```

**Suite:** `make test` green, `go vet` clean, `bench/tools/inline-gate.sh selftest` green. No benchmark was run; the leg gates in CI will show whether any measured binary carries tail-branch calls the budgets never saw.

**Adjacent blind spots seen, not fixed here:** (1) indirect tail branches (`br xN`) are uncounted — indistinguishable from switch jump tables without more analysis, so counting them would miscount in the false-partial direction; (2) a tail edge out of an *unrolled* timed loop would lower `perop_for`'s unroll witness to 1 and overcount — the refusing direction, never a false full, and today's timed loops end in returns, not tail calls.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
