### PR TITLE
bench: real_packet rows for the go, rust and cs runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,14 @@ generated/c-ludicrous/.stamp: bin/schema $(SCHEMAS128)
 # layout cannot hold two packages in one directory put the realworld unit in
 # its own subdirectory (go, cs — per-package TableRuntime) or sibling crate
 # (rust — one crate root per unit).
+#
+# COMPILE gates: generating a unit proves nothing about it compiling — the cs
+# realworld unit shipped uncompilable (SerializeFixed had no 8-bit overload,
+# issue #80's C# leg was its first consumer) while every gate stayed green.
+# The test target builds generated/bench/go and both rust crates directly;
+# C# has no unit-local build file, so `cd bench/cs && dotnet build` is the
+# compile gate for the realworld unit (the runner is its one consumer). The
+# cs Bench unit still has NO compile gate — nothing consumes it.
 generated/bench/cpp/.stamp: bin/schema $(SCHEMAS_BENCH)
 	./bin/schema generate --lang cpp --out generated/bench/cpp bench/corpus/Bench.schema
 	./bin/schema generate --lang cpp --out generated/bench/cpp bench/corpus/RealWorld.schema
@@ -226,6 +234,7 @@ test: build/schema_test build/schema_test_variant build/schema_test_random build
 	cd generated/bench/go && go build ./...
 	cd generated/bench/rust && PATH="$(RUSTUP_BIN):$$PATH" cargo build --quiet
 	cd generated/bench/rust-realworld && PATH="$(RUSTUP_BIN):$$PATH" cargo build --quiet
+	cd bench/cs && dotnet build -c Release --nologo -v quiet
 	cd test/go && go run .
 	cd test/rust && PATH="$(RUSTUP_BIN):$$PATH" cargo run --quiet
 	cd test/cs && dotnet run

--- a/bench/cs/README.md
+++ b/bench/cs/README.md
@@ -13,10 +13,15 @@ surface, §1.5 oracle-gated against `testdata/wire/bench_*.bin`, plus the
 16-width bitpacker workload — timed loops in `[MethodImpl(NoInlining)]`
 methods for the §4.1 JitDisasm verdict.
 
-Wiring: `schemabench.csproj` compiles `../../generated/cs` beside the
-sibling serialize.cs runtime sources, exactly like `test/cs`. `run.sh` runs
-it as `dotnet run -c Release -- --csv` from this directory; the per-path
-warmup run doubles as the JIT warmup.
+Wiring: `schemabench.csproj` compiles `../../generated/cs` and
+`../../generated/bench/cs/realworld` (namespace `Realworld` — the unit the
+`real_packet` row measures, referenced qualified so the two units'
+same-named table types never collide) beside the sibling serialize.cs
+runtime sources, exactly like `test/cs`. `run.sh` runs it as
+`dotnet run -c Release -- --csv` from this directory; the per-path warmup
+run doubles as the JIT warmup. This project is also the realworld unit's
+compile gate in `make test` — its one consumer (the Makefile's bench-corpus
+comment says why).
 
 Escape barriers: a static sink field accumulates observed bytes/counts and
 `GC.KeepAlive` holds decoded objects. Streams are reused via `Reset` (the

--- a/bench/cs/schemabench.csproj
+++ b/bench/cs/schemabench.csproj
@@ -25,6 +25,11 @@
 
   <ItemGroup>
     <Compile Include="../../generated/cs/*.cs" />
+    <!-- the bench-corpus realworld unit (namespace Realworld — its own
+         per-unit TableRuntime, so no basename/type collision with the
+         Example unit above): RealPacket, the §1.7 realistic snapshot the
+         real_packet rows measure -->
+    <Compile Include="../../generated/bench/cs/realworld/*.cs" />
     <Compile Include="$(SerializeCsRoot)/src/Serialize.cs" />
     <!-- the emulated 128-bit pair (Int128Value/UInt128Value) lives beside
          Serialize.cs and Serialize.cs references it on every TFM — the same

--- a/bench/cs/src/Program.cs
+++ b/bench/cs/src/Program.cs
@@ -667,6 +667,83 @@ static partial class Program
         }
     }
 
+    // real_packet — BENCH-STANDARD.md §1.7's realistic snapshot, measured
+    // through the GENERATED code (bench/corpus/RealWorld.schema ->
+    // generated/bench/cs/realworld, namespace Realworld — referenced
+    // qualified so the two units' same-named table types never collide).
+    // The pinned instance is the ALL-DEFAULTS instance: new RealPacket()
+    // serialized unmodified (field initializers carry the schema defaults),
+    // 1629 bits = 204 wire bytes, pinned to testdata/wire/real_packet.bin by
+    // test/bench/main.cpp. The four branch gates (f012 true, f043 false,
+    // f050 true, f074 false) are STRUCTURE (§2.7): they keep their schema
+    // defaults here, so the same branch bodies ride every iteration and
+    // bytes/op is constant. The field mappings are bench/cpp/bench_main.cpp's
+    // vary_real_packet exactly — fields under the false gates do not ride
+    // and are not varied; every mapping keeps its field inside its declared
+    // wire range (comments give the bound it stays within).
+    static void VaryRealPacket(Realworld.RealPacket m, ulong rng)
+    {
+        // ranged ints, assorted widths, signed and unsigned
+        m.F001Int = (int)((rng >> 8) & 0xFFFFF) - 0x80000; // +/-2^19 within +/-805495
+        m.F003Int = (int)((rng >> 12) & 0xFFFFF) - 0x80000; // within +/-835897
+        m.F005Uint = (ushort)((rng >> 20) & 0xFFF); // <=4095 within [0, 7316]
+        m.F006Int = (short)((int)((rng >> 26) & 0x7FF) - 1024); // +/-1024 within +/-1513
+        m.F009Int = (sbyte)((int)((rng >> 33) & 31) - 16); // +/-16 within +/-22
+        m.F033Uint = (uint)((rng >> 37) & 0x1FFFF); // <=131071 within [0, 142780]
+        m.F041Int = (sbyte)((int)((rng >> 42) & 63) - 32); // +/-32 within +/-55
+        m.F062Uint = (ushort)((rng >> 47) & 255); // <=255 within [0, 503]
+        m.F088Int = (short)((int)((rng >> 52) & 0x3FF) - 512); // +/-512 within +/-694
+        m.F090Uint = (byte)((rng >> 57) & 127); // <=127 within [0, 214]
+        // bits(N), narrow and wide
+        m.F011Bits = (uint)rng & 0x3FF; // 10 bits
+        m.F023Bits = (uint)(rng >> 5) & 0x1FFFFFF; // 25 bits
+        m.F042Bits = (uint)(rng >> 3) & 0x3FFFFFFF; // 30 bits
+        m.F081Bits = (uint)(rng >> 7) & 0x1FFFFFFF; // 29 bits
+        m.F089Bits = rng & 0xFFFFFFFFFFFFul; // 48 bits
+        m.F093Bits = rng ^ 0x5555555555555555ul; // 64 bits
+        m.F097Bits = (uint)(rng >> 11) & 0xFFF; // 12 bits
+        // bools (NEVER the four branch gates — those are structure, §2.7)
+        m.F037Bool = (rng & 1) != 0;
+        m.F055Bool = (rng & 2) != 0;
+        m.F092Bool = (rng & 4) != 0;
+        // float32 / float64
+        m.F007F32 = (uint)rng & 0xFFFF;
+        m.F020F32 = ((uint)(rng >> 16) & 0xFFFF) * 0.5f;
+        m.F058F32 = ((uint)(rng >> 24) & 0xFFFF) * 0.25f;
+        m.F002F64 = (double)((long)(rng >> 8) & 0xFFFFFF) * 0.5;
+        m.F059F64 = (double)((long)(rng >> 16) & 0xFFFFFF) * 0.25;
+        m.F087F64 = (double)((long)(rng >> 24) & 0xFFFFFF) * 0.125;
+        // compressed floats (in range by construction)
+        m.F004Cf32 = ((uint)rng & 0x3FFF) * 0.1f; // <=1638.3 within [0, 2000]
+        m.F061Cf32 = -90.0f + ((uint)(rng >> 9) & 255) * 0.5f; // within [-90, 90] (max 37.5)
+        m.F067Cf32 = -100.0f + ((uint)(rng >> 18) & 511) * 0.25f; // within [-100, 100] (max 27.75)
+        m.F072Cf32 = ((uint)(rng >> 27) & 8191) * 0.01f; // <=81.91 within [0, 100]
+        // fixed / ufixed (raw storage scaled by 2^F; bounds are whole units)
+        m.F016Fixed = (int)((rng >> 10) & 0x3FFFFFF) - 0x2000000; // +/-2^25 within +/-36*2^20
+        m.F025Fixed = (short)((int)((rng >> 18) & 0x7FFF) - 0x4000); // +/-2^14 within +/-119*2^8
+        m.F095Fixed = (int)((rng >> 22) & 0x7FFFFFF) - 0x4000000; // +/-2^26 within +/-1577*2^16
+        m.F021Ufixed = (uint)(rng >> 30) & 0x3FFFFFF; // <=2^26-1 within 25141*2^12
+        m.F049Ufixed = (ushort)((rng >> 36) & 0x7FFF); // <=32767 within 3*2^14
+        m.F084Ufixed = (byte)((rng >> 44) & 0x7F); // <=127 within 1*2^7
+        // enum / flags (wire-valid by construction)
+        m.F036Enum = (Realworld.PacketMode)((uint)(rng >> 30) & 3); // within wire range [0, 5]
+        m.F083Enum = (Realworld.PacketMode)((uint)(rng >> 34) & 3);
+        m.F091Flags = rng & 31; // 5 wire bits
+        // full-width 64-bit
+        m.F008U64 = rng;
+        m.F029I64 = (long)(rng * 3);
+        m.F063I64 = (long)(rng * 5);
+        // fields riding inside the TAKEN branches (f012 true, f050 true)
+        m.F013F32 = (uint)(rng >> 4) & 0xFFFF;
+        m.F014Uint = (ushort)((rng >> 21) & 511); // <=511 within [0, 775]
+        m.F015Int = (sbyte)((int)((rng >> 40) & 31) - 16); // +/-16 within +/-21
+        m.F017Uint = (ushort)((rng >> 29) & 0xFFF); // <=4095 within [0, 4606]
+        m.F051Bool = (rng & 8) != 0;
+        m.F052Int = (sbyte)((int)((rng >> 38) & 63) - 32); // +/-32 within +/-57
+        m.F053F32 = ((uint)(rng >> 40) & 0xFFFF) * 0.125f;
+        m.F054Int = (sbyte)((int)((rng >> 45) & 63) - 32); // +/-32 within +/-35
+    }
+
     // ------------------------------------------------------------------------------------------
     // the synthetic steady-state batch: NumBatchMessages messages through the
     // Message dispatch surface (WriteMessage/ReadMessage) plus the None
@@ -989,6 +1066,13 @@ static partial class Program
         BenchMessage("probebits", "probebits", 128000000, PinProbeBits(), WriteProbeBits, ReadProbeBits, VaryProbeBits);
         BenchMessage("probearray", "probearray", 20000000, PinProbeArray(), WriteProbeArray, ReadProbeArray, VaryProbeArray);
         BenchMessage("testdata", "testdata", 8000000, PinTestData(), WriteTestData, ReadTestData, VaryTestData);
+
+        // real_packet (§1.7): the realistic snapshot — ~93 riding individually
+        // serialized small fields, 204 wire bytes, 0% bulk share by bits. The
+        // pin is the ALL-DEFAULTS instance (new RealPacket() — the C++
+        // RealPacket{}), golden-gated like every row above. Iteration count
+        // sized in the C++ reference (§2.1).
+        BenchMessage("real_packet", "real_packet", 8000000, new Realworld.RealPacket(), Realworld.Schema.WriteRealPacket, Realworld.Schema.ReadRealPacket, VaryRealPacket);
 
         BenchBatch();
 

--- a/bench/go/README.md
+++ b/bench/go/README.md
@@ -14,10 +14,11 @@ bitpacker workload — timed loops in `//go:noinline` symbols for the §4.1
 verdict.
 
 Wiring: `go.mod` (module `benchgo`) replaces `example` →
-`../../generated/go` and `github.com/mas-bandwidth/serialize.go` → the
-sibling port checkout, exactly like `test/go`. `run.sh` runs it as
-`go run . --csv` from this directory (optimized by default — Go has no
-debug/release split).
+`../../generated/go`, `bench` → `../../generated/bench/go` (the realworld
+unit the `real_packet` row measures), and
+`github.com/mas-bandwidth/serialize.go` → the sibling port checkout,
+exactly like `test/go`. `run.sh` runs it as `go run . --csv` from this
+directory (optimized by default — Go has no debug/release split).
 
 Escape barriers: a package-level sink accumulator plus `runtime.KeepAlive`
 on decoded values. Streams are reused via `Reset` (the runtime's documented

--- a/bench/go/go.mod
+++ b/bench/go/go.mod
@@ -3,9 +3,12 @@ module benchgo
 go 1.23
 
 require (
+	bench v0.0.0
 	example v0.0.0
 	github.com/mas-bandwidth/serialize.go v0.0.0
 )
+
+replace bench => ../../generated/bench/go
 
 replace example => ../../generated/go
 

--- a/bench/go/main.go
+++ b/bench/go/main.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"time"
 
+	"bench/realworld"
 	"example"
 
 	"github.com/mas-bandwidth/serialize.go"
@@ -582,6 +583,79 @@ func varyTestData(m *example.TestData, rng uint64) {
 	}
 }
 
+// real_packet — BENCH-STANDARD.md §1.7's realistic snapshot, measured through
+// the GENERATED code (bench/corpus/RealWorld.schema ->
+// generated/bench/go/realworld). The pinned instance is the ALL-DEFAULTS
+// instance: realworld.NewRealPacket() serialized unmodified, 1629 bits = 204
+// wire bytes, pinned to testdata/wire/real_packet.bin by test/bench/main.cpp.
+// The four branch gates (f012 true, f043 false, f050 true, f074 false) are
+// STRUCTURE (§2.7): they keep their schema defaults here, so the same branch
+// bodies ride every iteration and bytes/op is constant. The field mappings
+// are bench/cpp/bench_main.cpp's vary_real_packet exactly — fields under the
+// false gates do not ride and are not varied; every mapping keeps its field
+// inside its declared wire range (comments give the bound it stays within).
+func varyRealPacket(m *realworld.RealPacket, rng uint64) {
+	// ranged ints, assorted widths, signed and unsigned
+	m.F001Int = int32((rng>>8)&0xFFFFF) - 0x80000    // +/-2^19 within +/-805495
+	m.F003Int = int32((rng>>12)&0xFFFFF) - 0x80000   // within +/-835897
+	m.F005Uint = uint16((rng >> 20) & 0xFFF)         // <=4095 within [0, 7316]
+	m.F006Int = int16(int32((rng>>26)&0x7FF) - 1024) // +/-1024 within +/-1513
+	m.F009Int = int8(int32((rng>>33)&31) - 16)       // +/-16 within +/-22
+	m.F033Uint = uint32((rng >> 37) & 0x1FFFF)       // <=131071 within [0, 142780]
+	m.F041Int = int8(int32((rng>>42)&63) - 32)       // +/-32 within +/-55
+	m.F062Uint = uint16((rng >> 47) & 255)           // <=255 within [0, 503]
+	m.F088Int = int16(int32((rng>>52)&0x3FF) - 512)  // +/-512 within +/-694
+	m.F090Uint = uint8((rng >> 57) & 127)            // <=127 within [0, 214]
+	// bits(N), narrow and wide
+	m.F011Bits = uint32(rng) & 0x3FF         // 10 bits
+	m.F023Bits = uint32(rng>>5) & 0x1FFFFFF  // 25 bits
+	m.F042Bits = uint32(rng>>3) & 0x3FFFFFFF // 30 bits
+	m.F081Bits = uint32(rng>>7) & 0x1FFFFFFF // 29 bits
+	m.F089Bits = rng & 0xFFFFFFFFFFFF        // 48 bits
+	m.F093Bits = rng ^ 0x5555555555555555    // 64 bits
+	m.F097Bits = uint32(rng>>11) & 0xFFF     // 12 bits
+	// bools (NEVER the four branch gates — those are structure, §2.7)
+	m.F037Bool = (rng & 1) != 0
+	m.F055Bool = (rng & 2) != 0
+	m.F092Bool = (rng & 4) != 0
+	// float32 / float64
+	m.F007F32 = float32(uint32(rng) & 0xFFFF)
+	m.F020F32 = float32(uint32(rng>>16)&0xFFFF) * 0.5
+	m.F058F32 = float32(uint32(rng>>24)&0xFFFF) * 0.25
+	m.F002F64 = float64(int64(rng>>8)&0xFFFFFF) * 0.5
+	m.F059F64 = float64(int64(rng>>16)&0xFFFFFF) * 0.25
+	m.F087F64 = float64(int64(rng>>24)&0xFFFFFF) * 0.125
+	// compressed floats (in range by construction)
+	m.F004Cf32 = float32(uint32(rng)&0x3FFF) * 0.1          // <=1638.3 within [0, 2000]
+	m.F061Cf32 = -90.0 + float32(uint32(rng>>9)&255)*0.5    // within [-90, 90] (max 37.5)
+	m.F067Cf32 = -100.0 + float32(uint32(rng>>18)&511)*0.25 // within [-100, 100] (max 27.75)
+	m.F072Cf32 = float32(uint32(rng>>27)&8191) * 0.01       // <=81.91 within [0, 100]
+	// fixed / ufixed (raw storage scaled by 2^F; bounds are whole units)
+	m.F016Fixed = int32((rng>>10)&0x3FFFFFF) - 0x2000000  // +/-2^25 within +/-36*2^20
+	m.F025Fixed = int16(int32((rng>>18)&0x7FFF) - 0x4000) // +/-2^14 within +/-119*2^8
+	m.F095Fixed = int32((rng>>22)&0x7FFFFFF) - 0x4000000  // +/-2^26 within +/-1577*2^16
+	m.F021Ufixed = uint32(rng>>30) & 0x3FFFFFF            // <=2^26-1 within 25141*2^12
+	m.F049Ufixed = uint16((rng >> 36) & 0x7FFF)           // <=32767 within 3*2^14
+	m.F084Ufixed = uint8((rng >> 44) & 0x7F)              // <=127 within 1*2^7
+	// enum / flags (wire-valid by construction)
+	m.F036Enum = realworld.PacketMode(uint32(rng>>30) & 3) // within wire range [0, 5]
+	m.F083Enum = realworld.PacketMode(uint32(rng>>34) & 3)
+	m.F091Flags = realworld.PacketFlags(rng & 31) // 5 wire bits
+	// full-width 64-bit
+	m.F008U64 = rng
+	m.F029I64 = int64(rng * 3)
+	m.F063I64 = int64(rng * 5)
+	// fields riding inside the TAKEN branches (f012 true, f050 true)
+	m.F013F32 = float32(uint32(rng>>4) & 0xFFFF)
+	m.F014Uint = uint16((rng >> 21) & 511)     // <=511 within [0, 775]
+	m.F015Int = int8(int32((rng>>40)&31) - 16) // +/-16 within +/-21
+	m.F017Uint = uint16((rng >> 29) & 0xFFF)   // <=4095 within [0, 4606]
+	m.F051Bool = (rng & 8) != 0
+	m.F052Int = int8(int32((rng>>38)&63) - 32) // +/-32 within +/-57
+	m.F053F32 = float32(uint32(rng>>40)&0xFFFF) * 0.125
+	m.F054Int = int8(int32((rng>>45)&63) - 32) // +/-32 within +/-35
+}
+
 // ------------------------------------------------------------------------------------------
 // the synthetic steady-state batch: NumBatchMessages messages through the
 // Message dispatch surface (WriteMessage/ReadMessage) plus the None
@@ -836,6 +910,13 @@ func main() {
 	benchMessage("probebits", "probebits", 128000000, pinProbeBits(), example.WriteProbeBits, example.ReadProbeBits, varyProbeBits)
 	benchMessage("probearray", "probearray", 20000000, pinProbeArray(), example.WriteProbeArray, example.ReadProbeArray, varyProbeArray)
 	benchMessage("testdata", "testdata", 8000000, pinTestData(), example.WriteTestData, example.ReadTestData, varyTestData)
+
+	// real_packet (§1.7): the realistic snapshot — ~93 riding individually
+	// serialized small fields, 204 wire bytes, 0% bulk share by bits. The pin
+	// is the ALL-DEFAULTS instance (NewRealPacket — the C++ RealPacket{}),
+	// golden-gated like every row above. Iteration count sized in the C++
+	// reference (§2.1).
+	benchMessage("real_packet", "real_packet", 8000000, realworld.NewRealPacket(), realworld.WriteRealPacket, realworld.ReadRealPacket, varyRealPacket)
 
 	benchBatch()
 

--- a/bench/rust/Cargo.toml
+++ b/bench/rust/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 
 [dependencies]
 example = { path = "../../generated/rust" }
+realworldcorpus = { path = "../../generated/bench/rust-realworld" }
 serialize = { path = "../../../serialize.rs" }

--- a/bench/rust/README.md
+++ b/bench/rust/README.md
@@ -13,10 +13,11 @@ oracle-gated against `testdata/wire/bench_*.bin`, plus the 16-width
 bitpacker workload — timed loops in `#[inline(never)]` symbols for the
 §4.1 verdict.
 
-Wiring: `Cargo.toml` path-depends on `../../generated/rust` and the sibling
-serialize.rs checkout, exactly like `test/rust`. `run.sh` runs it as
-`cargo run --release -- --csv` from this directory (default release
-profile: opt-level 3, no LTO).
+Wiring: `Cargo.toml` path-depends on `../../generated/rust`,
+`../../generated/bench/rust-realworld` (the realworld crate the
+`real_packet` row measures), and the sibling serialize.rs checkout, exactly
+like `test/rust`. `run.sh` runs it as `cargo run --release -- --csv` from
+this directory (default release profile: opt-level 3, no LTO).
 
 The default profile is a measured choice, not an omission: six
 `[profile.release]` variants (thin/fat LTO x codegen-units, paired

--- a/bench/rust/src/main.rs
+++ b/bench/rust/src/main.rs
@@ -25,6 +25,7 @@ use std::hint::black_box;
 use std::time::Instant;
 
 use example::*;
+use realworldcorpus as realworld;
 use serialize::{ReadStream, Stream, WriteStream};
 
 mod rt;
@@ -202,7 +203,10 @@ impl Ctx {
 // the per-message benchmark driver
 // ------------------------------------------------------------------------------------------
 
-fn bench_message<T, W, R, V>(
+// EW/ER: each generated unit carries its own Error type (example and
+// realworldcorpus alike expose Result<T = ()> over their own enum); the
+// driver only ever asks is_err(), so it is generic over both.
+fn bench_message<T, W, R, V, EW, ER>(
     ctx: &Ctx,
     name: &str,
     golden: Option<&str>,
@@ -213,8 +217,8 @@ fn bench_message<T, W, R, V>(
     mut vary_fn: V,
 ) where
     T: Copy + Default,
-    W: Fn(&mut WriteStream<'_>, &T) -> example::Result,
-    R: Fn(&mut ReadStream<'_>, &mut T) -> example::Result,
+    W: Fn(&mut WriteStream<'_>, &T) -> core::result::Result<(), EW>,
+    R: Fn(&mut ReadStream<'_>, &mut T) -> core::result::Result<(), ER>,
     V: FnMut(&mut T, u64),
 {
     let mut buffer = vec![0u8; BUFFER_SIZE];
@@ -647,6 +651,80 @@ fn vary_testdata(m: &mut TestData, rng: u64) {
     }
 }
 
+// real_packet — BENCH-STANDARD.md §1.7's realistic snapshot, measured through
+// the GENERATED code (bench/corpus/RealWorld.schema ->
+// generated/bench/rust-realworld). The pinned instance is the ALL-DEFAULTS
+// instance: realworld::RealPacket::new() serialized unmodified, 1629 bits =
+// 204 wire bytes, pinned to testdata/wire/real_packet.bin by
+// test/bench/main.cpp. The four branch gates (f012 true, f043 false, f050
+// true, f074 false) are STRUCTURE (§2.7): they keep their schema defaults
+// here, so the same branch bodies ride every iteration and bytes/op is
+// constant. The field mappings are bench/cpp/bench_main.cpp's
+// vary_real_packet exactly — fields under the false gates do not ride and
+// are not varied; every mapping keeps its field inside its declared wire
+// range (comments give the bound it stays within).
+fn vary_real_packet(m: &mut realworld::RealPacket, rng: u64) {
+    // ranged ints, assorted widths, signed and unsigned
+    m.f001_int = (((rng >> 8) & 0xFFFFF) as i32) - 0x80000; // +/-2^19 within +/-805495
+    m.f003_int = (((rng >> 12) & 0xFFFFF) as i32) - 0x80000; // within +/-835897
+    m.f005_uint = ((rng >> 20) & 0xFFF) as u16; // <=4095 within [0, 7316]
+    m.f006_int = ((((rng >> 26) & 0x7FF) as i32) - 1024) as i16; // +/-1024 within +/-1513
+    m.f009_int = ((((rng >> 33) & 31) as i32) - 16) as i8; // +/-16 within +/-22
+    m.f033_uint = ((rng >> 37) & 0x1FFFF) as u32; // <=131071 within [0, 142780]
+    m.f041_int = ((((rng >> 42) & 63) as i32) - 32) as i8; // +/-32 within +/-55
+    m.f062_uint = ((rng >> 47) & 255) as u16; // <=255 within [0, 503]
+    m.f088_int = ((((rng >> 52) & 0x3FF) as i32) - 512) as i16; // +/-512 within +/-694
+    m.f090_uint = ((rng >> 57) & 127) as u8; // <=127 within [0, 214]
+    // bits(N), narrow and wide
+    m.f011_bits = (rng as u32) & 0x3FF; // 10 bits
+    m.f023_bits = ((rng >> 5) as u32) & 0x1FFFFFF; // 25 bits
+    m.f042_bits = ((rng >> 3) as u32) & 0x3FFFFFFF; // 30 bits
+    m.f081_bits = ((rng >> 7) as u32) & 0x1FFFFFFF; // 29 bits
+    m.f089_bits = rng & 0xFFFF_FFFF_FFFF; // 48 bits
+    m.f093_bits = rng ^ 0x5555555555555555; // 64 bits
+    m.f097_bits = ((rng >> 11) as u32) & 0xFFF; // 12 bits
+    // bools (NEVER the four branch gates — those are structure, §2.7)
+    m.f037_bool = (rng & 1) != 0;
+    m.f055_bool = (rng & 2) != 0;
+    m.f092_bool = (rng & 4) != 0;
+    // float32 / float64
+    m.f007_f32 = ((rng as u32) & 0xFFFF) as f32;
+    m.f020_f32 = (((rng >> 16) as u32) & 0xFFFF) as f32 * 0.5;
+    m.f058_f32 = (((rng >> 24) as u32) & 0xFFFF) as f32 * 0.25;
+    m.f002_f64 = (((rng >> 8) as i64) & 0xFFFFFF) as f64 * 0.5;
+    m.f059_f64 = (((rng >> 16) as i64) & 0xFFFFFF) as f64 * 0.25;
+    m.f087_f64 = (((rng >> 24) as i64) & 0xFFFFFF) as f64 * 0.125;
+    // compressed floats (in range by construction)
+    m.f004_cf32 = ((rng as u32) & 0x3FFF) as f32 * 0.1; // <=1638.3 within [0, 2000]
+    m.f061_cf32 = -90.0 + (((rng >> 9) as u32) & 255) as f32 * 0.5; // within [-90, 90] (max 37.5)
+    m.f067_cf32 = -100.0 + (((rng >> 18) as u32) & 511) as f32 * 0.25; // within [-100, 100] (max 27.75)
+    m.f072_cf32 = (((rng >> 27) as u32) & 8191) as f32 * 0.01; // <=81.91 within [0, 100]
+    // fixed / ufixed (raw storage scaled by 2^F; bounds are whole units)
+    m.f016_fixed = (((rng >> 10) & 0x3FFFFFF) as i32) - 0x2000000; // +/-2^25 within +/-36*2^20
+    m.f025_fixed = ((((rng >> 18) & 0x7FFF) as i32) - 0x4000) as i16; // +/-2^14 within +/-119*2^8
+    m.f095_fixed = (((rng >> 22) & 0x7FFFFFF) as i32) - 0x4000000; // +/-2^26 within +/-1577*2^16
+    m.f021_ufixed = ((rng >> 30) as u32) & 0x3FFFFFF; // <=2^26-1 within 25141*2^12
+    m.f049_ufixed = ((rng >> 36) & 0x7FFF) as u16; // <=32767 within 3*2^14
+    m.f084_ufixed = ((rng >> 44) & 0x7F) as u8; // <=127 within 1*2^7
+    // enum / flags (wire-valid by construction)
+    m.f036_enum = realworld::PacketMode((((rng >> 30) as u32) & 3) as u8); // within wire range [0, 5]
+    m.f083_enum = realworld::PacketMode((((rng >> 34) as u32) & 3) as u8);
+    m.f091_flags = rng & 31; // 5 wire bits
+    // full-width 64-bit
+    m.f008_u64 = rng;
+    m.f029_i64 = rng.wrapping_mul(3) as i64;
+    m.f063_i64 = rng.wrapping_mul(5) as i64;
+    // fields riding inside the TAKEN branches (f012 true, f050 true)
+    m.f013_f32 = (((rng >> 4) as u32) & 0xFFFF) as f32;
+    m.f014_uint = ((rng >> 21) & 511) as u16; // <=511 within [0, 775]
+    m.f015_int = ((((rng >> 40) & 31) as i32) - 16) as i8; // +/-16 within +/-21
+    m.f017_uint = ((rng >> 29) & 0xFFF) as u16; // <=4095 within [0, 4606]
+    m.f051_bool = (rng & 8) != 0;
+    m.f052_int = ((((rng >> 38) & 63) as i32) - 32) as i8; // +/-32 within +/-57
+    m.f053_f32 = (((rng >> 40) as u32) & 0xFFFF) as f32 * 0.125;
+    m.f054_int = ((((rng >> 45) & 63) as i32) - 32) as i8; // +/-32 within +/-35
+}
+
 // ------------------------------------------------------------------------------------------
 // the synthetic steady-state batch: NUM_BATCH_MESSAGES messages through the
 // Message dispatch surface (write_message/read_message) plus the None
@@ -1002,6 +1080,13 @@ fn main() {
     bench_message(&ctx, "probebits", Some("probebits"), 128000000, pin_probebits(), write_probe_bits, read_probe_bits, vary_probebits);
     bench_message(&ctx, "probearray", Some("probearray"), 20000000, pin_probearray(), write_probe_array, read_probe_array, vary_probearray);
     bench_message(&ctx, "testdata", Some("testdata"), 8000000, pin_testdata(), write_test_data, read_test_data, vary_testdata);
+
+    // real_packet (§1.7): the realistic snapshot — ~93 riding individually
+    // serialized small fields, 204 wire bytes, 0% bulk share by bits. The pin
+    // is the ALL-DEFAULTS instance (RealPacket::new() — the C++ RealPacket{}),
+    // golden-gated like every row above. Iteration count sized in the C++
+    // reference (§2.1).
+    bench_message(&ctx, "real_packet", Some("real_packet"), 8000000, realworld::RealPacket::new(), realworld::write_real_packet, realworld::read_real_packet, vary_real_packet);
 
     bench_batch(&ctx);
 

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -882,9 +882,12 @@ namespace Realworld
                     return false;
                 }
             }
-            if (!batch.SerializeFixed(ref value.F084Ufixed, 1, 7, 0, 1))
             {
-                return false;
+                ushort fixedValue = value.F084Ufixed;
+                if (!batch.SerializeFixed(ref fixedValue, 1, 7, 0, 1))
+                {
+                    return false;
+                }
             }
             if (!batch.SerializeBits(ref value.F085Bits, 21))
             {
@@ -1465,9 +1468,13 @@ namespace Realworld
                 }
                 value.F083Enum = (PacketMode)enumValue;
             }
-            if (!batch.SerializeFixed(ref value.F084Ufixed, 1, 7, 0, 1))
             {
-                return false;
+                ushort fixedValue = 0;
+                if (!batch.SerializeFixed(ref fixedValue, 1, 7, 0, 1))
+                {
+                    return false;
+                }
+                value.F084Ufixed = (byte)fixedValue;
             }
             if (!batch.SerializeBits(ref value.F085Bits, 21))
             {

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -484,6 +484,16 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		// the Q format and whole-unit bounds are compile-time constants of the
 		// call site, exactly like a ranged integer's bounds (STANDARD.md, fixed)
 		lo, hi := g.rangeArgs(f, "long")
+		if f.Type.Width == 8 {
+			// 8-bit storage sits below serialize.cs's narrowest SerializeFixed
+			// overload (short/ushort): widen through a temp — lossless, the
+			// raw value fits I+F = 8 bits by construction (the golang
+			// emitter's narrower-than-the-library pattern, mirrored)
+			g.sf("%s{\n%s    %s fixedValue = %s;\n", ind, ind, csFixed8Temp(f), name)
+			g.call(ind+"    ", fmt.Sprintf("%s.SerializeFixed(ref fixedValue, %d, %d, %s, %s)", g.rv(), f.Type.IntBits, f.Type.FracBits, lo, hi), "")
+			g.sf("%s}\n", ind)
+			return
+		}
 		g.call(ind, fmt.Sprintf("%s.SerializeFixed(ref %s, %d, %d, %s, %s)", g.rv(), name, f.Type.IntBits, f.Type.FracBits, lo, hi), "")
 	case ir.TInt:
 		if f.Type.Width == 128 {
@@ -650,6 +660,17 @@ func fmt32Cast(f *ir.Field, name string) string {
 	return name // byte/ushort widen implicitly
 }
 
+// csFixed8Temp is the temp type an 8-bit fixed field widens through:
+// serialize.cs's narrowest SerializeFixed overload pair is short/ushort
+// (sbyte/byte have none), so the emitter carries the raw value across the
+// call in the matching 16-bit type. sbyte/byte widen into it implicitly.
+func csFixed8Temp(f *ir.Field) string {
+	if f.Type.Signed {
+		return "short"
+	}
+	return "ushort"
+}
+
 func (g *gen) emitReadField(f *ir.Field, ind string) {
 	base := g.fieldBase(f)
 	name := "value." + base
@@ -702,6 +723,16 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 		// validates the raw offset against the raw bounds and rejects — never
 		// clamps — returning false on a hostile stream
 		lo, hi := g.rangeArgs(f, "long")
+		if f.Type.Width == 8 {
+			// 8-bit storage sits below serialize.cs's narrowest SerializeFixed
+			// overload (short/ushort): read through a temp and narrow on the
+			// member assignment — lossless, a decoded raw value is inside the
+			// raw bounds or the read already failed
+			g.sf("%s{\n%s    %s fixedValue = 0;\n", ind, ind, csFixed8Temp(f))
+			g.call(ind+"    ", fmt.Sprintf("%s.SerializeFixed(ref fixedValue, %d, %d, %s, %s)", g.rv(), f.Type.IntBits, f.Type.FracBits, lo, hi), "")
+			g.sf("%s    %s = (%s)fixedValue;\n%s}\n", ind, name, g.csFieldType(f.Type), ind)
+			return
+		}
 		g.call(ind, fmt.Sprintf("%s.SerializeFixed(ref %s, %d, %d, %s, %s)", g.rv(), name, f.Type.IntBits, f.Type.FracBits, lo, hi), "")
 	case ir.TInt:
 		if f.Type.Width == 128 {


### PR DESCRIPTION
Closes #80, closes #65.

The §1.7 compressed-float-dense workload (`real_packet`: ~93 riding individually serialized small fields, 7 compressed floats, 204 wire bytes, 0% bulk share) was measured only by the cpp, c and js runners — unmeasured on exactly the backends where compressed-float cost matters most, and blocking #28's C# measure-first question.

## What each runner gained

- **go** (`bench/go`): `varyRealPacket` (the C++ reference's `vary_real_packet` mappings exactly) + the `benchMessage` row at the reference's 8M iterations. Plumbing: `go.mod` gains `bench => ../../generated/bench/go` so the runner imports the generated `realworld` package — the same replace pattern the `example` unit rides.
- **rust** (`bench/rust`): `vary_real_packet` + the row. Plumbing: `Cargo.toml` gains the `realworldcorpus` path dep (the sibling crate the Makefile already generates); the generic driver's write/read bounds go generic over the unit error type, since `example` and `realworldcorpus` each carry their own `Result` and the driver only asks `is_err()`.
- **cs** (`bench/cs`): `VaryRealPacket` + the row. Plumbing: `schemabench.csproj` compiles `generated/bench/cs/realworld` (namespace `Realworld`, referenced qualified — the two units carry same-named table types).

Smoke rows (one `--round 0` on the Air): all three emit `real_packet,write|read,8000000,204,...` with 0-alloc notes.

## The byte-check design

The cross-language contract is the pinned wire golden, and the check lives in the row's setup, not beside it: each runner writes the ALL-DEFAULTS `RealPacket` (`NewRealPacket()` / `RealPacket::new()` / `new RealPacket()` — the C++ `RealPacket{}`) and byte-compares the result against `testdata/wire/real_packet.bin` **before any number is produced**. A mismatch fails the run, and §1.5 means a failing run emits NO rows. Then the round-trip (write → read → re-write → memcmp) and the 64 variant buffers' constant-bytes/op proof run, as for every gen row. The golden also feeds `corpus_id`, so corpus drift is visible in the row itself.

**Falsified:** with one byte of `real_packet.bin` flipped, the go runner printed `WIRE GOLDEN MISMATCH: real_packet`, emitted zero CSV rows, and exited 1 (and the stamped corpus_id changed). Restored; clean run green.

Side effect worth naming: the go/rust/cs legs now load the same golden set as c/cpp/js, so all six runners stamp **one corpus_id** (`7a7c343f1a446f4c` on this tree) and `relative.go`'s §5.3 corpus_id rule no longer refuses their cross-language ratios — previously go/rust/cs stamped a different id than the reference legs.

## Found on the way: the cs realworld unit did not compile

First consumer's privilege: `generated/bench/cs/realworld` shipped uncompilable — `f084_ufixed ufixed(1, 7)` has 8-bit storage and serialize.cs's narrowest `SerializeFixed` overload pair is `short`/`ushort` (no `sbyte`/`byte`). No gate ever compiled the generated cs bench units, so it sat broken while everything stayed green. Fixed in the C# emitter (first commit): 8-bit fixed storage widens through a `short`/`ushort` temp on write and narrows on the member assignment on read — the golang emitter's narrower-than-the-library pattern, mirrored; wire bits unchanged (the pinned golden proves it). `make test` gains `cd bench/cs && dotnet build` as the realworld unit's compile gate. The cs **Bench** unit remains compile-ungated (nothing consumes it) — noted in the Makefile comment.

## Verification

- `make test` green (full suite, all six languages, generated tree regenerated in place with only the deliberate `RealWorld.cs` diff).
- `gofmt` / `go vet` / `go mod tidy -diff` clean.
- `bench/tools/inline-gate.sh leg go|rust|cs` all PASS locally (real_packet rows carry `inline=unknown` like the existing c/cpp real_packet rows — the verdict maps have no real_packet entry in any language; pre-existing, not widened here).

**Air-numbers caveat:** every number in this PR came from a MacBook Air smoke run whose only purpose was proving the rows execute and refuse correctly. They are not bench results; do not quote them. The real pass belongs on a bench surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)