### PR TITLE
inline-verdict: a bench row names its generated unit — real_packet gets a verdict in all five compiled languages (issue #104)

### DIFF
--- a/bench/inline-budget.txt
+++ b/bench/inline-budget.txt
@@ -13,6 +13,20 @@
 # Accepted deliberately (issue #25): the gate also fires on compiler-version
 # changes, and telling a regression from a new compiler apart is manual.
 #
+# The real_packet rows were added 2026-08-21 by issue #104, which taught
+# inline-verdict.sh's map to name a row's generated UNIT: real_packet is the
+# only row of the RealWorld corpus unit, so until that fix it had no map entry
+# in ANY language and carried inline=unknown everywhere — §5.3 rule 7 refused
+# every ratio it appeared in, which is why the Studio pass on PR #84 had to
+# drop four of its rows as un-ratioable. The numbers below are the FIRST
+# honest measurement of these ten legs, not a target: pinned where the
+# instrument found them, on an M-series MacBook Air against the CI-pinned
+# runtime tags. They are the densest per-op numbers in the ledger (~93
+# individually serialized fields per message) and several of them are
+# genuinely large — go's 97 hot calls per op on both paths, C#'s 80 on read.
+# Whether any of them SHOULD be smaller is a separate question from whether
+# the gate can see them, and this ledger only answers the second.
+#
 # Seeded 2026-08-15 from the current-era, zero-unknown studio passes:
 #   O3 + default rows: results/2026-08-15-arm64-studio-postlane-O3-pass.csv (schema 695fde3)
 #   O2 rows:           results/2026-08-15-arm64-studio-O2-pass.csv          (schema c19cdb3)
@@ -42,6 +56,8 @@ cpp probearray write O3 0
 cpp probearray read O3 0
 cpp testdata write O3 2
 cpp testdata read O3 0
+cpp real_packet write O3 2
+cpp real_packet read O3 0
 cpp message_batch write O3 2
 cpp message_batch read O3 0
 cpp bench_packet write O3 1
@@ -76,6 +92,8 @@ c probearray write O3 0
 c probearray read O3 0
 c testdata write O3 1
 c testdata read O3 0
+c real_packet write O3 0
+c real_packet read O3 0
 c message_batch write O3 0
 c message_batch read O3 0
 c bench_packet write O3 0
@@ -110,6 +128,8 @@ rust probearray write O3 0
 rust probearray read O3 0
 rust testdata write O3 3
 rust testdata read O3 2
+rust real_packet write O3 15
+rust real_packet read O3 14
 # The two rows below moved 1 -> 2 and 1 -> 3 in the same commit that taught
 # count_calls to see tail branches (#86): the extra hot calls were ALWAYS in
 # the binary as tail-called serialize-chain helpers and the old 1 was pinned
@@ -156,6 +176,8 @@ cs probearray write default 3
 cs probearray read default 3
 cs testdata write default 5
 cs testdata read default 5
+cs real_packet write default 1
+cs real_packet read default 80
 cs message_batch write default 2
 cs message_batch read default 14
 cs bench_packet write default 9
@@ -190,6 +212,8 @@ go probearray write default 12
 go probearray read default 12
 go testdata write default 24
 go testdata read default 24
+go real_packet write default 97
+go real_packet read default 97
 go message_batch write default 20
 go message_batch read default 14
 go bench_packet write default 12
@@ -224,6 +248,8 @@ cpp probearray write O2 0
 cpp probearray read O2 0
 cpp testdata write O2 2
 cpp testdata read O2 0
+cpp real_packet write O2 2
+cpp real_packet read O2 0
 cpp message_batch write O2 2
 cpp message_batch read O2 0
 cpp bench_packet write O2 1
@@ -258,6 +284,8 @@ c probearray write O2 0
 c probearray read O2 0
 c testdata write O2 1
 c testdata read O2 0
+c real_packet write O2 0
+c real_packet read O2 0
 c message_batch write O2 1
 c message_batch read O2 0
 c bench_packet write O2 1

--- a/bench/tools/inline-gate.sh
+++ b/bench/tools/inline-gate.sh
@@ -545,7 +545,131 @@ EOF
         fail "budget check: within-budget verdicts must pass"
     fi
 
-    # ---- 12. end-to-end on this host where the toolchain allows: a compiled
+    # ---- 12. the GENERATED UNIT the map resolves against (issue #104) ----
+    # The estate benches two generated units: `example` (examples/*.schema ->
+    # generated/<lang>) and `realworld` (bench/corpus/RealWorld.schema ->
+    # generated/bench/<lang>/..., the unit the real_packet row measures). The
+    # two units' entry points are spelled IDENTICALLY apart from the package /
+    # namespace / crate prefix each port's layout puts in front — so a map that
+    # cannot name a row's unit has two ways to be wrong, and each fixture below
+    # attacks one of them:
+    #
+    #   RESOLUTION — the lookup lands on the OTHER unit's same-named entry
+    #   point and publishes its count as this row's verdict. Every fixture
+    #   plants a decoy of the same name in the other unit, with a different
+    #   count, so a collision cannot pass by accident.
+    #
+    #   COMPLETENESS — the unit is missing from the language's HELPER regex, so
+    #   a call from the row's entry point into that unit's own out-of-line
+    #   helper matches neither the runtime nor the helper set and counts as
+    #   NOTHING. That is not a wrong number, it is a false `full` — the
+    #   direction this machinery exists to refuse. Each fixture routes the
+    #   realworld unit's runtime calls through such a helper.
+    cat > "$ST/unit-go.calls" <<'EOF'
+example.WriteRealPacket:
+0 bl github.com/mas-bandwidth/serialize%2ego.(*WriteStream).writeBits
+0 bl github.com/mas-bandwidth/serialize%2ego.(*WriteStream).writeBits
+0 bl github.com/mas-bandwidth/serialize%2ego.(*WriteStream).writeBits
+0 bl github.com/mas-bandwidth/serialize%2ego.(*WriteStream).writeBits
+0 bl github.com/mas-bandwidth/serialize%2ego.(*WriteStream).writeBits
+bench/realworld.WriteRealPacket:
+0 bl bench/realworld.writeVec3
+bench/realworld.writeVec3:
+0 bl github.com/mas-bandwidth/serialize%2ego.(*WriteStream).writeBits
+0 bl github.com/mas-bandwidth/serialize%2ego.(*WriteStream).writeBits
+EOF
+    GOH="$(unit_helper_re go)"
+    count_calls 'serialize%2ego[.]' "$GOH" '' < "$ST/unit-go.calls" > "$VD/counts.txt"
+    rw="$(count_for "$(unit_go_sym realworld Write RealPacket)")"
+    ex="$(count_for "$(unit_go_sym example Write RealPacket)")"
+    if [ "${rw:-0}" = 2 ] && [ "${ex:-0}" = 5 ]; then
+        ok "go unit fixture: the realworld row resolves to bench/realworld (2, through its own helper) and the example decoy stays 5"
+    else
+        fail "go unit fixture: the realworld row must resolve to bench/realworld.WriteRealPacket and carry its helper's 2 runtime calls, and must NOT pick up the example unit's same-named 5 (got realworld=$rw example=$ex) — a row resolved against the wrong unit publishes another workload's verdict, and a unit missing from the HELPER set publishes a false full"
+    fi
+
+    cat > "$ST/unit-cs.jit" <<'EOF'
+; Assembly listing for method Example.Schema:WriteRealPacket(WriteStream,RealPacket) (FullOpts)
+        bl      CORINFO_HELP_ASSIGN_REF
+        bl      CORINFO_HELP_ASSIGN_REF
+        bl      CORINFO_HELP_ASSIGN_REF
+        bl      CORINFO_HELP_ASSIGN_REF
+        bl      CORINFO_HELP_ASSIGN_REF
+; Assembly listing for method Realworld.Schema:WriteRealPacket(WriteStream,RealPacket) (FullOpts)
+        bl      Realworld.Schema:WriteRealPacketBatch
+; Assembly listing for method Realworld.Schema:WriteRealPacketBatch(WriteBatch,RealPacket) (FullOpts)
+        bl      CORINFO_HELP_ASSIGN_REF
+        bl      CORINFO_HELP_ASSIGN_REF
+EOF
+    cs_translate < "$ST/unit-cs.jit" > "$ST/unit-cs.calls"
+    count_calls '.' "$(unit_helper_re cs)" '' < "$ST/unit-cs.calls" > "$VD/counts.txt"
+    rw="$(count_for "$(unit_cs_sym realworld Write RealPacket)")"
+    ex="$(count_for "$(unit_cs_sym example Write RealPacket)")"
+    if [ "${rw:-0}" = 2 ] && [ "${ex:-0}" = 5 ]; then
+        ok "cs unit fixture: the realworld row resolves to Realworld.Schema (2, through its own Batch helper) and the example decoy stays 5"
+    else
+        fail "cs unit fixture: the realworld row must resolve to Realworld.Schema:WriteRealPacket and count its Batch helper's 2, not the example unit's same-named 5 and not the helper call itself as 1 (got realworld=$rw example=$ex) — with the catch-all C# RTPAT a unit missing from the HELPER set turns a whole helper body into a single counted call"
+    fi
+
+    cat > "$ST/unit-rust.disasm" <<'EOF'
+__ZN7example17write_real_packet17h1111111111111111E:
+0000000100000100	bl	__ZN9serialize11WriteStream10write_bits17h2222222222222222E
+0000000100000104	bl	__ZN9serialize11WriteStream10write_bits17h2222222222222222E
+0000000100000108	bl	__ZN9serialize11WriteStream10write_bits17h2222222222222222E
+000000010000010c	bl	__ZN9serialize11WriteStream10write_bits17h2222222222222222E
+0000000100000110	bl	__ZN9serialize11WriteStream10write_bits17h2222222222222222E
+__ZN15realworldcorpus9realworld17write_real_packet17h3333333333333333E:
+0000000100000200	bl	__ZN15realworldcorpus9realworld10write_vec317h4444444444444444E
+__ZN15realworldcorpus9realworld10write_vec317h4444444444444444E:
+0000000100000300	bl	__ZN9serialize11WriteStream10write_bits17h2222222222222222E
+0000000100000304	bl	__ZN9serialize11WriteStream10write_bits17h2222222222222222E
+EOF
+    rust_translate < "$ST/unit-rust.disasm" > "$ST/unit-rust.calls"
+    RSH="$(unit_helper_re rust)"
+    count_calls '^CRATE_serialize_' "$RSH" '' < "$ST/unit-rust.calls" > "$VD/counts.txt"
+    rw="$(count_for "$(unit_rust_sym realworld write_real_packet)")"
+    ex="$(count_for "$(unit_rust_sym example write_real_packet)")"
+    if [ "${rw:-0}" = 2 ] && [ "${ex:-0}" = 5 ]; then
+        ok "rust unit fixture: the realworldcorpus crate classifies as its own CRATE_ class, resolves to 2 through its helper, and does not alias the example crate's same-named fn (5)"
+    else
+        fail "rust unit fixture: write_real_packet exists in BOTH crates; the realworld row must resolve to the realworldcorpus one and carry its helper's 2, the example row to the example one at 5 (got realworld=$rw example=$ex) — an unclassified crate is 'other', which is neither runtime nor helper, so its calls are dropped and the row reads full"
+    fi
+    if selftest_join "$ST/unit-rust.calls" "$VD/counts.txt" "$RSH"; then
+        ok "join self-test accepts the two-unit rust join"
+    else
+        fail "join self-test rejected the two-unit rust join"
+    fi
+
+    cat > "$ST/unit-cpp.disasm" <<'EOF'
+__ZN9realworld15WriteRealPacketERN9serialize11WriteStreamERKNS_10RealPacketE:
+0000000100000100	bl	__ZN9realworld10write_vec3ERN9serialize11WriteStreamE
+__ZN9realworld10write_vec3ERN9serialize11WriteStreamE:
+0000000100000200	bl	__ZN9serialize11WriteStream10write_bitsEjj
+0000000100000204	bl	__ZN9serialize11WriteStream10write_bitsEjj
+EOF
+    count_calls '^__?ZNK?9serialize' "$(unit_helper_re cpp)" "$COLD_SPLIT" < "$ST/unit-cpp.disasm" > "$VD/counts.txt"
+    n="$(count_for '^__ZN9realworld15WriteRealPacket')"
+    if [ "${n:-0}" = 2 ]; then
+        ok "cpp unit fixture: namespace realworld is generated code, so its helper's 2 runtime calls reach the entry point"
+    else
+        fail "cpp unit fixture: the realworld entry point's 2 runtime calls flow through a realworld helper and must reach it (got $n) — a generated namespace missing from the cpp HELPER regex makes those call sites invisible to the atos attribution and the row publishes a false full"
+    fi
+
+    # a unit the map does not know must REFUSE, not silently answer with some
+    # other unit's spelling: a typo'd unit column is exactly how a row starts
+    # measuring the wrong code, and it must be loud at the first call.
+    bogus=0
+    unit_go_sym   bogusunit Write RealPacket > /dev/null 2>&1 && bogus=$((bogus + 1))
+    unit_cs_sym   bogusunit Write RealPacket > /dev/null 2>&1 && bogus=$((bogus + 1))
+    unit_rust_sym bogusunit write_real_packet > /dev/null 2>&1 && bogus=$((bogus + 1))
+    unit_helper_re bogusfortran > /dev/null 2>&1 && bogus=$((bogus + 1))
+    if [ "$bogus" = 0 ]; then
+        ok "unknown unit/lang fixture: every spelling function refuses rather than answering with another unit's prefix"
+    else
+        fail "unknown unit/lang fixture: $bogus of 4 spelling functions ANSWERED for a unit/language they do not know — a row pointed at an unknown unit would silently be measured against whatever prefix was hardcoded"
+    fi
+
+    # ---- 13. end-to-end on this host where the toolchain allows: a compiled
     # binary with a known noinline callee must count as out of line ----
     if command -v otool > /dev/null 2>&1 && command -v cc > /dev/null 2>&1; then
         cat > "$ST/e2e.c" <<'EOF'

--- a/bench/tools/inline-verdict.sh
+++ b/bench/tools/inline-verdict.sh
@@ -194,6 +194,50 @@ count_calls() {
         }'
 }
 
+# ---- generated-unit spelling: HELPER regexes and entry-point patterns ----
+# Library functions (the gate's selftest fixtures attack these, not copies).
+#
+# unit_helper_re <lang>: the HELPER regex count_calls uses to tell GENERATED
+# code from the serialize runtime. Getting it wrong is not a wrong number, it
+# is a DROPPED one — a call target matching neither RTPAT nor HELPER counts as
+# nothing at all, so a row whose runtime calls flow through such a target
+# publishes a false `full`.
+#
+# unit_go_sym / unit_cs_sym / unit_rust_sym: the pattern that finds ONE bench
+# row's generated entry point in that language's symbol table.
+unit_helper_re() {
+    case "$1" in
+    c)    echo '^_?(write|read|quantize|rt_|vary_|bits_)' ;;   # generated helpers (write_vec3 ...) and the hand-written rt/bits ops
+    cpp)  echo '^__?ZNK?7example|_GLOBAL__N_1' ;;              # namespace example (generated) + the anon-namespace rt/bits code
+    go)   echo '^example[.]|^main[.]' ;;
+    rust) echo '^CRATE_(example|benchrust)_' ;;
+    cs)   echo '(Example[.]Schema|Program):' ;;
+    *)    return 1 ;;
+    esac
+}
+
+# go: the objdump symbol for <unit>'s <Cap><camel> generated entry point.
+# cs: the JitDisasm method for the same.
+# rust: the v0 mangling token (<len><name>) for <unit>'s <fn-name>.
+#
+# PRE-#104: every one of these knows exactly ONE generated unit and hardcodes
+# its prefix — the <unit> argument is accepted and IGNORED. That is precisely
+# the defect issue #104 names: the estate benches a second generated unit (the
+# RealWorld corpus the real_packet row measures) whose symbols carry different
+# package/namespace/crate prefixes, and a map that cannot spell them leaves
+# the densest compressed-float workload on inline=unknown. Extracted verbatim
+# from the per-language branches so the gate's fixtures attack the real
+# spelling rather than a copy of it.
+unit_go_sym() {     # <unit> <Cap> <camel>
+    echo "^example[.]${2}${3}\$"
+}
+unit_cs_sym() {     # <unit> <Cap> <camel>
+    echo "^Example[.]Schema:${2}${3}\$"
+}
+unit_rust_sym() {   # <unit> <fn-name>
+    echo "${#2}$2"
+}
+
 # ---- objdump/JitDisasm -> otool-shape translation ----
 # Library functions (the gate's selftest fixtures attack these, not copies):
 # each turns one toolchain's disassembly into the "sym:" / "addr op target"
@@ -245,6 +289,47 @@ cs_translate() {
             if (t ~ /^0x/ || t ~ /^[0-9]/) print "0 blr indirect"
             else print "0 b " t
         }'
+}
+
+# otool -tv of a rust binary -> the otool shape, with every symbol header AND
+# every call target renamed CRATE_<class>_<sym> by its DEFINING crate.
+#
+# v0 mangling puts the defining crate first and the instantiating crate last,
+# and serialize types appear inside the generated units' generics — so
+# classify every name by its EARLIEST crate token, and refuse the naive
+# substring match that would count an example shim mentioning WriteStream as a
+# runtime call. Symbol HEADERS get the identical prefix, because count_calls
+# joins helper-call targets against header names: leave the headers raw and
+# every helper edge looks up a name that was never populated, contributes
+# zero, and each loop whose runtime calls flow through an out-of-line helper
+# publishes a false `full` (selftest_join is the assertion that catches that).
+# A name matching no known crate classifies `other` — and `other` is neither
+# runtime nor helper, so its calls are DROPPED: a generated unit missing from
+# the token list below is a silent false full, not a wrong number.
+rust_translate() {
+    awk '
+        function firstcrate(t,    best, cls, i, n, names, m, ncls) {
+            ncls = split("9serialize 7example 9benchrust 4core 3std 5alloc", names, " ")
+            best = 1000000; cls = "other"
+            for (i = 1; i <= ncls; i++) {
+                n = index(t, names[i])
+                if (n > 0 && n < best) { best = n; m = names[i]; cls = substr(m, 2) }
+            }
+            return cls
+        }
+        /^[^ \t].*:$/ {
+            s = substr($0, 1, length($0) - 1)
+            print "CRATE_" firstcrate(s) "_" s ":"
+            next
+        }
+        $2 == "bl"  { print $1 " bl CRATE_" firstcrate($3) "_" $3; next }
+        $2 == "blr" { print $1 " blr indirect"; next }
+        # tail branches (issue #86): a b to a raw address is intra-function
+        # control flow, dropped here; a b to a symbol gets the same crate
+        # rename as bl targets so count_calls sees one namespace (its own
+        # self/own-chunk guards then apply on the renamed names)
+        $2 == "b" && $3 !~ /^0x/ { print $1 " b CRATE_" firstcrate($3) "_" $3; next }
+    '
 }
 
 # verdict from a transitive HOT count: 0 -> full, N -> partial:N
@@ -469,12 +554,11 @@ c|cpp)
     if [ "$LANG_ARG" = c ]; then
         BIN=build/bench/schema_bench_c
         RT='^_?serialize_'                  # serialize.c entry points
-        HELPER='^_?(write|read|quantize|rt_|vary_|bits_)'  # generated helpers (write_vec3 ...) and the hand-written rt/bits ops
     else
         BIN=build/bench/schema_bench_cpp
         RT='^__?ZNK?9serialize'             # namespace serialize (runtime proper)
-        HELPER='^__?ZNK?7example|_GLOBAL__N_1'  # namespace example (generated) + the anon-namespace rt/bits code
     fi
+    HELPER="$(unit_helper_re "$LANG_ARG")" || exit 1
     [ -x "$BIN" ] || { echo "$BIN missing — run the pass first" >&2; exit 1; }
     otool -tv "$BIN" > "$VD/disasm.txt"
     count_calls "$RT" "$HELPER" "$COLD_SPLIT" < "$VD/disasm.txt" > "$VD/counts.txt"
@@ -918,11 +1002,12 @@ go)
 
     # translate objdump into the otool shape count_calls parses
     go_translate < "$VD/objdump.txt" > "$VD/calls.txt"
+    GO_HELPER="$(unit_helper_re go)" || exit 1
     # COLD is empty: gc has no cold attribute, no section split, and no
     # remark that marks a callee cold — §4.2's hot-default applies to every
     # Go call, and the ledger note below says so out loud.
-    count_calls 'serialize%2ego[.]|mas-bandwidth/serialize' '^example[.]|^main[.]' '' < "$VD/calls.txt" > "$VD/counts.txt"
-    selftest_join "$VD/calls.txt" "$VD/counts.txt" '^example[.]|^main[.]' || exit 1
+    count_calls 'serialize%2ego[.]|mas-bandwidth/serialize' "$GO_HELPER" '' < "$VD/calls.txt" > "$VD/counts.txt"
+    selftest_join "$VD/calls.txt" "$VD/counts.txt" "$GO_HELPER" || exit 1
 
     # remarks: go build -a -gcflags=-m=2 — -a is MANDATORY (see header)
     ( cd bench/go && go build $GO_MODFILE_ARG -a -gcflags=all=-m=2 -o /dev/null . 2> "$OLDPWD/$VD/remarks.txt" ) || true
@@ -959,11 +1044,12 @@ go)
     echo "$BENCH_MAP" | while read -r bench snake camel; do
         for path in write read; do
             Cap="$(echo "$path" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
-            n="$(count_for "^example[.]${Cap}${camel}\$")"
+            pat="$(unit_go_sym example "$Cap" "$camel")" || exit 1
+            n="$(count_for "$pat")"
             if [ "$n" -ge 0 ]; then
                 echo "$bench $path $(verdict_of "$n") $n 0" >> "$VD/verdicts.txt"
             else
-                echo "note: go $bench $path: example.${Cap}${camel} not found in objdump — inline stays unknown" >> "$LEDGER"
+                echo "note: go $bench $path: no objdump symbol matching $pat — inline stays unknown" >> "$LEDGER"
             fi
         done
     done
@@ -1001,41 +1087,12 @@ rust)
     [ -n "$RS_CRATE" ] || { echo "SERIALIZE_RS=$SERIALIZE_RS does not exist — cannot scan #[cold]" >&2; exit 1; }
     COLD_RS="$(rust_cold_regex "$RS_CRATE")"
 
-    # v0 mangling puts the DEFINING crate first and the instantiating crate
-    # last, and serialize types appear inside example/benchrust generics —
-    # so classify every call target by its EARLIEST crate token, and refuse
-    # the naive substring match that would count an example shim mentioning
-    # WriteStream as a runtime call. Symbol HEADERS get the identical
-    # CRATE_ prefix, because count_calls joins helper-call targets against
-    # header names: leave the headers raw and every helper edge looks up a
-    # name that was never populated, contributes zero, and each loop whose
-    # runtime calls flow through an out-of-line helper publishes a false
-    # `full` (the selftest_join below is the assertion that catches this).
-    otool -tv "$BIN" | awk '
-        function firstcrate(t,    best, cls, i, n, names, m) {
-            split("9serialize 7example 9benchrust 4core 3std 5alloc", names, " ")
-            best = 1000000; cls = "other"
-            for (i = 1; i <= 6; i++) {
-                n = index(t, names[i])
-                if (n > 0 && n < best) { best = n; m = names[i]; cls = substr(m, 2) }
-            }
-            return cls
-        }
-        /^[^ \t].*:$/ {
-            s = substr($0, 1, length($0) - 1)
-            print "CRATE_" firstcrate(s) "_" s ":"
-            next
-        }
-        $2 == "bl"  { print $1 " bl CRATE_" firstcrate($3) "_" $3; next }
-        $2 == "blr" { print $1 " blr indirect"; next }
-        # tail branches (issue #86): a b to a raw address is intra-function
-        # control flow, dropped here; a b to a symbol gets the same crate
-        # rename as bl targets so count_calls sees one namespace (its own
-        # self/own-chunk guards then apply on the renamed names)
-        $2 == "b" && $3 !~ /^0x/ { print $1 " b CRATE_" firstcrate($3) "_" $3; next }
-    ' > "$VD/disasm.txt"
-    count_calls '^CRATE_serialize_' '^CRATE_(example|benchrust)_' "$COLD_RS" < "$VD/disasm.txt" > "$VD/counts.txt"
-    selftest_join "$VD/disasm.txt" "$VD/counts.txt" '^CRATE_(example|benchrust)_' || exit 1
+    # rust_translate (library, above) renames every symbol header AND call
+    # target by its DEFINING crate, so count_calls sees one namespace.
+    otool -tv "$BIN" | rust_translate > "$VD/disasm.txt"
+    RS_HELPER="$(unit_helper_re rust)" || exit 1
+    count_calls '^CRATE_serialize_' "$RS_HELPER" "$COLD_RS" < "$VD/disasm.txt" > "$VD/counts.txt"
+    selftest_join "$VD/disasm.txt" "$VD/counts.txt" "$RS_HELPER" || exit 1
 
     # remarks: RUSTFLAGS="-Cremark=inline -Cdebuginfo=1" rebuild (fingerprint
     # forces it); runs AFTER the measured binary was disassembled above.
@@ -1071,14 +1128,15 @@ rust)
                 # the Rust binary is what kept both ship_shallow rows unknown
                 name="${path}_ship_data_shallow"
             fi
-            n="$(count_for "${#name}${name}")"
-            cold="$(cold_for "${#name}${name}")"
+            pat="$(unit_rust_sym example "$name")" || exit 1
+            n="$(count_for "$pat")"
+            cold="$(cold_for "$pat")"
             if [ "$n" -ge 0 ]; then
                 echo "$bench $path $(verdict_of "$n") $n $cold" >> "$VD/verdicts.txt"
             elif [ "$(count_total)" -eq 0 ]; then
                 echo "$bench $path full 0 0" >> "$VD/verdicts.txt"
             else
-                echo "note: rust $bench $path: no ${name} symbol and runtime calls exist elsewhere — inline stays unknown" >> "$LEDGER"
+                echo "note: rust $bench $path: no symbol matching $pat and runtime calls exist elsewhere — inline stays unknown" >> "$LEDGER"
             fi
         done
     done
@@ -1119,10 +1177,11 @@ cs)
     # per §4.1 the C# count is bl AND blr in the method body; blr targets
     # are opaque, so they are counted rather than silently dropped)
     cs_translate < "$JIT" > "$VD/calls.txt"
+    CS_HELPER="$(unit_helper_re cs)" || exit 1
     # COLD is empty: JitDisasm names no cold blocks or targets on this
     # surface — §4.2's hot-default applies to every C# call, said out loud
     # in the section header below.
-    count_calls '.' '(Example[.]Schema|Program):' '' < "$VD/calls.txt" > "$VD/counts.txt"
+    count_calls '.' "$CS_HELPER" '' < "$VD/calls.txt" > "$VD/counts.txt"
     # ('.' after the helper carve-out: every non-helper bl counts — Serialize.*
     # methods, JIT helpers, BCL — plus blr via the indirect column, folded in
     # below, because §4.1 counts them all for C#. selftest_join is not run
@@ -1149,11 +1208,12 @@ cs)
     echo "$BENCH_MAP" | while read -r bench snake camel; do
         for path in write read; do
             Cap="$(echo "$path" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
-            n="$(count_for "^Example[.]Schema:${Cap}${camel}\$")"
+            pat="$(unit_cs_sym example "$Cap" "$camel")" || exit 1
+            n="$(count_for "$pat")"
             if [ "$n" -ge 0 ]; then
                 echo "$bench $path $(verdict_of "$n") $n 0" >> "$VD/verdicts.txt"
             else
-                echo "note: cs $bench $path: Example.Schema:${Cap}${camel} not in the JitDisasm output — inline stays unknown" >> "$LEDGER"
+                echo "note: cs $bench $path: no JitDisasm method matching $pat — inline stays unknown" >> "$LEDGER"
             fi
         done
     done

--- a/bench/tools/inline-verdict.sh
+++ b/bench/tools/inline-verdict.sh
@@ -93,19 +93,33 @@ if [ -z "${INLINE_VERDICT_LIB:-}" ]; then
     esac
 fi
 
-# bench -> generated per-op entry stems: <snake for c/rust> <Camel for cpp/go/cs>
-BENCH_MAP='rigidbody_moving rigid_body RigidBody
-rigidbody_at_rest rigid_body RigidBody
-chat chat Chat
-test test Test
-inputpacket input_packet InputPacket
-shipcreate ship_create ShipCreate
-ship_shallow ship_shallow ShipData_Shallow
-probe_header probe_header ProbeHeader
-probebits probe_bits ProbeBits
-probearray probe_array ProbeArray
-testdata test_data TestData
-message_batch message Message'
+# bench -> generated per-op entry stems, and the generated UNIT they live in:
+#   <bench> <snake for c/rust> <Camel for cpp/go/cs> <unit>
+#
+# The unit column is issue #104. This estate benches TWO generated units and
+# the map used to assume one: `example` (examples/*.schema -> generated/<lang>)
+# carries every row below but the last, and `realworld`
+# (bench/corpus/RealWorld.schema -> generated/bench/<lang>/...) carries
+# real_packet, §1.7's realistic snapshot and the densest compressed-float
+# workload in the suite. The two units' entry points are spelled identically
+# apart from the package / namespace / crate prefix each port's layout puts in
+# front, so a row that cannot name its unit is resolved against whichever
+# unit's spelling was hardcoded — which for real_packet meant no verdict at
+# all, inline=unknown, and §5.3 rule 7 refusing every ratio it appears in.
+# UNIT_MAP below is where each unit's per-language spelling lives.
+BENCH_MAP='rigidbody_moving rigid_body RigidBody example
+rigidbody_at_rest rigid_body RigidBody example
+chat chat Chat example
+test test Test example
+inputpacket input_packet InputPacket example
+shipcreate ship_create ShipCreate example
+ship_shallow ship_shallow ShipData_Shallow example
+probe_header probe_header ProbeHeader example
+probebits probe_bits ProbeBits example
+probearray probe_array ProbeArray example
+testdata test_data TestData example
+message_batch message Message example
+real_packet real_packet RealPacket realworld'
 
 # families rt and bits: bench -> the runner's noinline timed-loop symbol stems
 # (<snake>_write_loop/_read_loop for c/cpp/rust; main.<lowerCamel>WriteLoop for
@@ -197,45 +211,82 @@ count_calls() {
 # ---- generated-unit spelling: HELPER regexes and entry-point patterns ----
 # Library functions (the gate's selftest fixtures attack these, not copies).
 #
-# unit_helper_re <lang>: the HELPER regex count_calls uses to tell GENERATED
-# code from the serialize runtime. Getting it wrong is not a wrong number, it
-# is a DROPPED one — a call target matching neither RTPAT nor HELPER counts as
-# nothing at all, so a row whose runtime calls flow through such a target
-# publishes a false `full`.
+# UNIT_MAP: one line per generated unit BENCH_MAP rows can name, giving that
+# unit's per-language symbol spelling:
 #
-# unit_go_sym / unit_cs_sym / unit_rust_sym: the pattern that finds ONE bench
-# row's generated entry point in that language's symbol table.
+#   <unit> <go objdump prefix> <cs JitDisasm prefix> <rust crate> <cpp token>
+#
+# go's prefix is the Go IMPORT PATH, not the package name — objdump spells the
+# realworld unit `bench/realworld.WriteRealPacket` (module `bench`, package
+# `realworld`), which is why a `^realworld[.]` guess would find nothing. The
+# rust column is the crate whose name rust_translate stamps onto every symbol
+# header and call target; the cpp column is the namespace's Itanium mangling
+# token (<len><name>). C is absent by construction: both units' generated
+# entry points land in one flat C namespace in one translation unit, so a
+# collision there would be a compile error rather than a mis-resolution, and
+# the c branch attributes rows by atos inline stack anyway.
+UNIT_MAP='example example Example.Schema example 7example
+realworld bench/realworld Realworld.Schema realworldcorpus 9realworld'
+
+# one field of one unit's row; REFUSES (nonzero, no output) on a unit the map
+# does not know — a typo'd unit column must be loud at the first call, never
+# answered with whatever prefix happened to be hardcoded
+unit_field() {      # <unit> <column>
+    echo "$UNIT_MAP" | awk -v u="$1" -v n="$2" '$1 == u { print $n; found = 1; exit } END { exit !found }'
+}
+
+# dots are literal in these prefixes; [.] means the same thing in every awk
+# dialect, unlike \. (the COLD_SPLIT comment below has the long version)
+re_quote_dots() { echo "$1" | sed 's/[.]/[.]/g'; }
+
+# one regex alternation over EVERY unit's <column>, each wrapped
+# <prefix>...<suffix>, dots quoted. Built from UNIT_MAP rather than written
+# out, so adding a unit cannot leave a language's helper set behind.
+unit_alt() {        # <column> <prefix> <suffix>
+    echo "$UNIT_MAP" | awk -v n="$1" -v pre="$2" -v suf="$3" '
+        { v = $n; gsub(/\./, "[.]", v); printf "%s%s%s%s", (NR > 1 ? "|" : ""), pre, v, suf }
+        END { print "" }'
+}
+
+# unit_helper_re <lang>: the HELPER regex count_calls uses to tell GENERATED
+# code from the serialize runtime. EVERY generated unit must appear. A unit
+# left out is not a wrong number, it is a DROPPED one — a call target matching
+# neither RTPAT nor HELPER counts as nothing at all, so a row whose runtime
+# calls flow through that unit's own out-of-line helper publishes a false
+# `full`. (For cs, where RTPAT is the catch-all `.` per §4.1, the failure is
+# milder but still wrong: the helper call counts 1 instead of the helper body's
+# own per-op total.) The trailing literals are the code that is NOT a
+# generated unit but is still not the runtime: the runner's own noinline timed
+# loops and the anon-namespace rt/bits ops.
 unit_helper_re() {
     case "$1" in
-    c)    echo '^_?(write|read|quantize|rt_|vary_|bits_)' ;;   # generated helpers (write_vec3 ...) and the hand-written rt/bits ops
-    cpp)  echo '^__?ZNK?7example|_GLOBAL__N_1' ;;              # namespace example (generated) + the anon-namespace rt/bits code
-    go)   echo '^example[.]|^main[.]' ;;
-    rust) echo '^CRATE_(example|benchrust)_' ;;
-    cs)   echo '(Example[.]Schema|Program):' ;;
+    c)    echo '^_?(write|read|quantize|rt_|vary_|bits_)' ;;   # generated helpers (write_vec3 ...) and the hand-written rt/bits ops — one flat C namespace for both units
+    cpp)  echo "$(unit_alt 5 '^__?ZNK?' '')|_GLOBAL__N_1" ;;
+    go)   echo "$(unit_alt 2 '^' '[.]')|^main[.]" ;;
+    rust) echo "^CRATE_($(unit_alt 4 '' '')|benchrust)_" ;;
+    cs)   echo "($(unit_alt 3 '' '')|Program):" ;;
     *)    return 1 ;;
     esac
 }
 
 # go: the objdump symbol for <unit>'s <Cap><camel> generated entry point.
 # cs: the JitDisasm method for the same.
-# rust: the v0 mangling token (<len><name>) for <unit>'s <fn-name>.
-#
-# PRE-#104: every one of these knows exactly ONE generated unit and hardcodes
-# its prefix — the <unit> argument is accepted and IGNORED. That is precisely
-# the defect issue #104 names: the estate benches a second generated unit (the
-# RealWorld corpus the real_packet row measures) whose symbols carry different
-# package/namespace/crate prefixes, and a map that cannot spell them leaves
-# the densest compressed-float workload on inline=unknown. Extracted verbatim
-# from the per-language branches so the gate's fixtures attack the real
-# spelling rather than a copy of it.
+# rust: <unit>'s <fn-name>, ANCHORED to the crate rust_translate classified it
+#   into. The anchor is load-bearing twice over: the two units are separate
+#   crates carrying identically named entry points, and the bare v0 token
+#   would also alias a core::ops::FnOnce shim that embeds the same name.
+# Each refuses on a unit UNIT_MAP does not carry.
 unit_go_sym() {     # <unit> <Cap> <camel>
-    echo "^example[.]${2}${3}\$"
+    local p; p="$(unit_field "$1" 2)" || return 1
+    echo "^$(re_quote_dots "$p")[.]${2}${3}\$"
 }
 unit_cs_sym() {     # <unit> <Cap> <camel>
-    echo "^Example[.]Schema:${2}${3}\$"
+    local p; p="$(unit_field "$1" 3)" || return 1
+    echo "^$(re_quote_dots "$p"):${2}${3}\$"
 }
 unit_rust_sym() {   # <unit> <fn-name>
-    echo "${#2}$2"
+    local c; c="$(unit_field "$1" 4)" || return 1
+    echo "^CRATE_${c}_.*${#2}$2"
 }
 
 # ---- objdump/JitDisasm -> otool-shape translation ----
@@ -307,13 +358,21 @@ cs_translate() {
 # runtime nor helper, so its calls are DROPPED: a generated unit missing from
 # the token list below is a silent false full, not a wrong number.
 rust_translate() {
-    awk '
+    # the generated units' crate tokens come from UNIT_MAP (<len><name>, v0's
+    # spelling) so a new unit cannot be left classified `other` — issue #104:
+    # realworldcorpus was, and every call from write_real_packet into its own
+    # helpers would have been dropped on the floor.
+    awk -v UNITS="$(echo "$UNIT_MAP" | awk '{ printf "%s%d%s", (NR > 1 ? " " : ""), length($4), $4 }')" '
         function firstcrate(t,    best, cls, i, n, names, m, ncls) {
-            ncls = split("9serialize 7example 9benchrust 4core 3std 5alloc", names, " ")
+            ncls = split("9serialize " UNITS " 9benchrust 4core 3std 5alloc", names, " ")
             best = 1000000; cls = "other"
             for (i = 1; i <= ncls; i++) {
                 n = index(t, names[i])
-                if (n > 0 && n < best) { best = n; m = names[i]; cls = substr(m, 2) }
+                # strip the WHOLE <len> prefix, not one character:
+                # realworldcorpus mangles 15realworldcorpus and a substr(m, 2)
+                # would classify it `5realworldcorpus`, a class no HELPER
+                # regex names — so every call into the unit would be dropped
+                if (n > 0 && n < best) { best = n; m = names[i]; cls = m; sub(/^[0-9]+/, "", cls) }
             }
             return cls
         }
@@ -679,6 +738,10 @@ c|cpp)
                 bmap["ship_shallow"] = "ship_shallow"; bmap["probe_header"] = "probe_header"
                 bmap["probebits"] = "probebits"; bmap["probearray"] = "probearray"
                 bmap["testdata"] = "testdata"
+                # the realworld unit (issue #104): BM_SUFFIX real_packet, so
+                # the frame name is bench_message_real_packet like every row
+                # above — C puts both generated units in one flat namespace
+                bmap["real_packet"] = "real_packet"
                 g = 0
             }
             function flush_group(    i, f, bench, path, L, sfx, t) {
@@ -764,7 +827,7 @@ c|cpp)
             sed 's/^/attr /' "$VD/attribution.txt"
         } >> "$LEDGER"
 
-        echo "$BENCH_MAP" | while read -r bench snake camel; do
+        echo "$BENCH_MAP" | while read -r bench snake camel unit; do
             for path in write read; do
                 set -- $(awk -v b="$bench" -v p="$path" '$1 == "N" && $2 == b && $3 == p { print $4, $5; f = 1; exit } END { if (!f) print 0, 0 }' "$VD/attribution.txt")
                 echo "$bench $path $(verdict_of "$1") $1 $2" >> "$VD/verdicts.txt"
@@ -870,6 +933,7 @@ c|cpp)
                 tmap["ShipCreate"] = "shipcreate"; tmap["ShipData_Shallow"] = "ship_shallow"
                 tmap["ProbeHeader"] = "probe_header"; tmap["ProbeBits"] = "probebits"
                 tmap["ProbeArray"] = "probearray"; tmap["TestData"] = "testdata"
+                tmap["RealPacket"] = "real_packet"      # the realworld unit (issue #104)
                 g = 0
             }
             function flush_group(    i, f, bench, path, L, contrib, t, tn) {
@@ -899,9 +963,14 @@ c|cpp)
                             }
                         }
                         if (bench == "") {
-                            # "bench_message<" is 14 chars, "example::" is 9
-                            if (match(f, /bench_message<example::[A-Za-z_]+/)) {
-                                tn = substr(f, RSTART + 23, RLENGTH - 23)
+                            # the template argument names the type, whichever
+                            # generated NAMESPACE it lives in (issue #104:
+                            # example:: and realworld:: both appear here, and
+                            # a fixed character offset past "example::" would
+                            # simply miss the second one)
+                            if (match(f, /bench_message<[A-Za-z_]+::[A-Za-z_]+/)) {
+                                tn = substr(f, RSTART, RLENGTH)
+                                sub(/^bench_message<[A-Za-z_]+::/, "", tn)
                                 if (tn in tmap) bench = tmap[tn]
                                 if (bench == "rigidbody_moving" && f ~ /\$_/) bench = "rigidbody_at_rest"
                             }
@@ -963,7 +1032,7 @@ c|cpp)
             sed 's/^/attr /' "$VD/attribution.txt"
         } >> "$LEDGER"
 
-        echo "$BENCH_MAP" | while read -r bench snake camel; do
+        echo "$BENCH_MAP" | while read -r bench snake camel unit; do
             for path in write read; do
                 set -- $(awk -v b="$bench" -v p="$path" '$1 == "N" && $2 == b && $3 == p { print $4, $5; f = 1; exit } END { if (!f) print 0, 0 }' "$VD/attribution.txt")
                 echo "$bench $path $(verdict_of "$1") $1 $2" >> "$VD/verdicts.txt"
@@ -1041,10 +1110,10 @@ go)
     } >> "$LEDGER"
 
     : > "$VD/verdicts.txt"
-    echo "$BENCH_MAP" | while read -r bench snake camel; do
+    echo "$BENCH_MAP" | while read -r bench snake camel unit; do
         for path in write read; do
             Cap="$(echo "$path" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
-            pat="$(unit_go_sym example "$Cap" "$camel")" || exit 1
+            pat="$(unit_go_sym "$unit" "$Cap" "$camel")" || { echo "inline-verdict: $LANG_ARG $bench $path: BENCH_MAP names generated unit '$unit', which UNIT_MAP does not carry — refusing rather than guessing a prefix" >&2; exit 1; }
             n="$(count_for "$pat")"
             if [ "$n" -ge 0 ]; then
                 echo "$bench $path $(verdict_of "$n") $n 0" >> "$VD/verdicts.txt"
@@ -1115,7 +1184,7 @@ rust)
     } >> "$LEDGER"
 
     : > "$VD/verdicts.txt"
-    echo "$BENCH_MAP" | while read -r bench snake camel; do
+    echo "$BENCH_MAP" | while read -r bench snake camel unit; do
         for path in write read; do
             name="${path}_${snake}"
             if [ "$bench" = message_batch ] && [ "$path" = read ]; then
@@ -1128,7 +1197,7 @@ rust)
                 # the Rust binary is what kept both ship_shallow rows unknown
                 name="${path}_ship_data_shallow"
             fi
-            pat="$(unit_rust_sym example "$name")" || exit 1
+            pat="$(unit_rust_sym "$unit" "$name")" || { echo "inline-verdict: $LANG_ARG $bench $path: BENCH_MAP names generated unit '$unit', which UNIT_MAP does not carry — refusing rather than guessing a prefix" >&2; exit 1; }
             n="$(count_for "$pat")"
             cold="$(cold_for "$pat")"
             if [ "$n" -ge 0 ]; then
@@ -1166,9 +1235,14 @@ cs)
     # §4.1: release runtime, tiering off, disasm of the generated dispatch
     # surface to a file. One quick --round pass JITs every method at FullOpts.
     JIT="$VD/jit.txt"
+    # the disasm filter names EVERY generated unit (built from UNIT_MAP) plus
+    # the runner: a unit missing here has no methods in the listing at all, so
+    # its rows find nothing and go unknown — the safe direction, but still a
+    # hole, and issue #104's real_packet row fell straight through it.
+    CS_JIT_FILTER="$(echo "$UNIT_MAP" | awk '{ printf "%s:* ", $3 }')Program:*"
     ( cd bench/cs && \
       DOTNET_TieredCompilation=0 \
-      DOTNET_JitDisasm='Example.Schema:* Program:*' \
+      DOTNET_JitDisasm="$CS_JIT_FILTER" \
       DOTNET_JitStdOutFile="$OLDPWD/$JIT" \
       dotnet run -c Release --no-build -- --round 0 > /dev/null 2>&1 ) || true
     [ -s "$JIT" ] || { echo "JitDisasm produced nothing — is the Release build present?" >&2; exit 1; }
@@ -1205,10 +1279,10 @@ cs)
     } >> "$LEDGER"
 
     : > "$VD/verdicts.txt"
-    echo "$BENCH_MAP" | while read -r bench snake camel; do
+    echo "$BENCH_MAP" | while read -r bench snake camel unit; do
         for path in write read; do
             Cap="$(echo "$path" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
-            pat="$(unit_cs_sym example "$Cap" "$camel")" || exit 1
+            pat="$(unit_cs_sym "$unit" "$Cap" "$camel")" || { echo "inline-verdict: $LANG_ARG $bench $path: BENCH_MAP names generated unit '$unit', which UNIT_MAP does not carry — refusing rather than guessing a prefix" >&2; exit 1; }
             n="$(count_for "$pat")"
             if [ "$n" -ge 0 ]; then
                 echo "$bench $path $(verdict_of "$n") $n 0" >> "$VD/verdicts.txt"


### PR DESCRIPTION
Closes #104

`real_packet` had no entry in `inline-verdict.sh`'s `BENCH_MAP` in any language, so the densest compressed-float workload in the suite has always carried `inline=unknown` — un-ratioable under BENCH-STANDARD §5.3 rule 7, which is why the Studio pass on PR #84 had to drop four of its rows.

## The map keys on the unit now

`BENCH_MAP` gains a fourth column naming the generated **unit** a row's entry points live in, and `UNIT_MAP` is the single place each unit's per-language spelling lives:

| unit | go objdump | cs JitDisasm | rust crate | cpp token |
|---|---|---|---|---|
| `example` | `example` | `Example.Schema` | `example` | `7example` |
| `realworld` | `bench/realworld` | `Realworld.Schema` | `realworldcorpus` | `9realworld` |

Three consumers read that table, so a unit cannot be half-added: `unit_go_sym` / `unit_cs_sym` / `unit_rust_sym` build the anchored entry-point pattern (and **refuse** on a unit the table does not carry); `unit_helper_re` builds each language's HELPER regex as an alternation over *every* unit; `rust_translate` takes its crate tokens from the same place.

Two of those matter more than they look. go's prefix is the **import path** — objdump spells it `bench/realworld.WriteRealPacket`, so a `^realworld[.]` guess finds nothing. And a unit missing from HELPER is not a wrong number but a **dropped** one: a call target matching neither RTPAT nor HELPER counts as *nothing*, so the whole realworld namespace was invisible and any row whose runtime calls flowed through it would have published a false `full`.

## Red first

The fixtures went in as their own commit (cd364dd) with the spelling extracted verbatim and the `<unit>` argument accepted-and-ignored — the pre-#104 truth. Each language gets a real_packet-shaped entry point in the realworld unit whose runtime calls flow through that unit's own helper, plus a **same-named decoy in the example unit** with a different count. Against the unfixed map, 5 of 5 new specimens FAIL:

```
go:   realworld=5 example=5 (want 2/5) — resolved to the example decoy
cs:   realworld=5 example=5 (want 2/5) — same collision
rust: realworld=5 example=5 (want 2/5) — the bare v0 token aliases both
      crates, and realworldcorpus classifies `other`, so its helper is dropped
cpp:  0 (want 2) — namespace realworld is in no HELPER set: a false full
unknown unit — 3 of 4 spelling functions ANSWER for a unit they do not know
```

After the fix (a4f15df): **27/27 green.**

## Before / after verdicts

Go, in full (`bench/tools/inline-gate.sh leg go`):

```
before:  go,real_packet,write,...,default,unknown
         go,real_packet,read, ...,default,unknown
         inline-gate PASS: go default: 34 legs within budget, 0 unguarded

after:   go,real_packet,write,...,default,partial:97
         go,real_packet,read, ...,default,partial:97
         inline-gate PASS: go default: 36 legs within budget, 0 unguarded
```

All five languages, hot counts per op:

| lang | write | read | what the hot calls are |
|---|---|---|---|
| c | 0 (`full`) | 0 (`full`) | both paths fully inlined, O3 and O2 alike |
| cpp | 2 | 0 (`full`) | `serialize::serialize_compressed_float_internal<WriteStream>`, still out of line |
| rust | 15 | 14 | read also carries 210 **cold** calls beside the verdict |
| cs | 1 | 80 | the 1 is §4.1's C# rule counting one opaque call to a `WriteRealPacketBatch` the JIT did not inline; on read that helper *is* inlined and its 80 show |
| go | 97 | 97 | ~93 riding fields, one runtime call each — the largest per-op counts in the ledger |

These are the findings, not defects fixed here: whether any of those counts *should* be smaller is a separate question from whether the gate can see them, and only the second is closed.

## Byte-stability

Every language leg was run twice, once on the pristine scripts and once on the fixed ones, and the verdict files diffed:

```
GO   VERDICTS BYTE-IDENTICAL apart from the new real_packet rows
CPP  VERDICTS BYTE-IDENTICAL apart from the new real_packet rows
C    VERDICTS BYTE-IDENTICAL apart from the new real_packet rows
RUST VERDICTS BYTE-IDENTICAL apart from the new real_packet rows
CS   VERDICTS BYTE-IDENTICAL apart from the new real_packet rows
```

No other row's verdict moved. The ledger gains ten rows (five languages × two paths at O3/default, plus c and cpp at O2), pinned where the instrument found them.

## Air-local caveat

**Everything above was measured on an M-series MacBook Air, not on a certified surface.** The numbers are *structural* facts — call instructions counted in emitted code — and no timing claim is made from this machine; the throughput columns in the CSVs above came from `--round 0` verdict rounds whose timings are explicitly advisory and never published. The runtime siblings were the CI-pinned tags (serialize v1.10.0, .c v1.4.0, .go v1.11.0, .rs v2.1.2, .cs v1.4.0), but the compiler, JIT and rustc versions are this host's. The ledger fires on compiler-version and host differences by design (issue #25); if the CI runner disagrees with one of the ten new rows, that is exactly the manual call those headers exist for.

Two pre-existing "under budget" notes on this host (`cpp testdata write 0 vs 2`, `cpp message_batch write 0 vs 2`, and the c/cs equivalents) reproduce **identically on the pristine tree** — they are this Air disagreeing with the 2026-08-15 Studio seed, not anything this PR did, and they are left alone.

## Verification

- `bench/tools/inline-gate.sh selftest` — 27/27 green (5 red before the fix)
- `leg go` / `leg cpp` / `leg c` / `leg rust` / `leg cs` — all PASS, 36 legs within budget, 0 unguarded
- `BENCH_OPT_LEVEL=O2 leg cpp` / `leg c` — both PASS, 36 legs, 0 unguarded
- `make test` — green, generated tree clean
- `go vet ./...` — clean

## Adjacent, seen and not fixed

- The rust `count_for` lookup takes the *first* matching symbol out of an awk hash-ordered file. Anchoring on the CRATE_ class removed the specific alias this issue was about (`core::ops::FnOnce::call_once` shims that embed a generated fn's name), but a multi-match is still resolved by hash order rather than refused.
- The c/cpp attribution defaults a bench/path with no attributed call site to `0` → `full`. That is right when the chain really inlined, and indistinguishable from an attribution that never saw the row. c's `real_packet read` reaches `full` down that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
