### PR TITLE
The TU-boundary attribution is history: era-scope four docs

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -74,9 +74,13 @@ each measured. C now leads C++ on batch read.
 Two honest caveats on the comparison. The machine changed (M2 → M3 Ultra), so the two tables
 are not a controlled before/after — the C read movement is far outside machine variance and
 the mechanism is confirmed by inline verdicts, but the exact figures are not subtraction. And
-the C row's remaining gap is packaging: `serialize.c` is a compiled translation unit, not a
-header, so every runtime call crosses a boundary the header-only C++ runtime does not have,
-and no leg here is built with LTO because none of the other four are.
+the C row's remaining gap was packaging *in this table's era*: `serialize.c` was then a
+compiled translation unit, so every runtime call crossed a boundary the header-only C++
+runtime does not have, and no leg here is built with LTO because none of the other four are.
+(That era ended 2026-08-17: serialize.c #25 made the C runtime header-only too, and every
+pass since records `linkage=hdr` for both legs — see BENCH-STANDARD §3.1's amendment and
+issue #66. The figures in this table predate the change and are correct for what they
+measured.)
 
 ## Reading the table honestly
 

--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -548,6 +548,12 @@ You cannot give C and C++ the same linkage — `serialize.h` is a header and
 compiled TU, `hdr+tu`). That difference is the largest single term in the C
 row and it is a property of the runtimes, not the languages. So it is recorded, and
 §5.3 makes the tool refuse to divide across it without an explicit flag.
+(Amended 2026-08-22, issue #66: serialize.c #25 ended this on 2026-08-17 —
+the C runtime is header-only and both legs now record `linkage=hdr`, which
+§5.3 compares freely. The paragraph above is kept as the rule's reason and
+governs any port whose packaging still differs; for C-vs-C++ specifically it
+is history, and present-tense TU attributions in any doc dated after
+2026-08-17 are wrong.)
 
 > **Every pass MUST additionally emit a labelled external-linkage diagnostic leg for
 > C++ and C**, so the size of the linkage term is a published number rather than a

--- a/bench/README.md
+++ b/bench/README.md
@@ -96,14 +96,15 @@ Every results file records the exact compiler and flags in its preamble.
 C flags: `-std=c99 -Wall -Wextra -Werror -O3 -DNDEBUG`, with
 `$SERIALIZE_C/serialize.c` compiled in and **no `-flto`** — every leg is
 measured in its language's ordinary release configuration (the Rust leg is
-`cargo run --release`, no LTO either). Read the C row knowing what it
-includes: **serialize.c is a compiled translation unit, not a header**, so
-every runtime call in the C leg crosses a TU boundary that the header-only C++
-runtime does not have. That is a property of the runtime's packaging, not of
-the generated code, and it is the largest single term in the C row. An
-`-flto` build recovers part of it — median 1.11x, up to 2.25x on the paths made
-of many small runtime calls and ~1.05x on the double-heavy ones, measured as a
-labelled leg in `bench/results/2026-08-14-c-lto-diagnostic-arm64-macbook.csv`.
+`cargo run --release`, no LTO either). Read the C row knowing its
+history: **both legs are header-only (`linkage=hdr`) since serialize.c #25, 2026-08-17** —
+the runners and the certified space CSV record it per row. Before that date serialize.c was
+a compiled translation unit, every runtime call crossed a TU boundary the C++ runtime did
+not have, and that boundary was the largest single term in the C row; results from that era
+carry the old attribution and stay correct for what they measured. The `-flto` diagnostic
+from the TU era — median 1.11x, up to 2.25x on the many-small-call paths, recorded in
+`bench/results/2026-08-14-c-lto-diagnostic-arm64-macbook.csv` — is likewise historical: with
+both legs header-only there is no TU boundary for LTO to recover (issue #66).
 That is how a config divergence gets reported here: label the leg, record the
 flag, keep it beside the default pass — the way the `DOTNET_TieredCompilation=0`
 diagnostic did.

--- a/bench/results/2026-08-18-certified-space-1.md
+++ b/bench/results/2026-08-18-certified-space-1.md
@@ -109,7 +109,10 @@ driver, never the runner. Window: controls 114.16 → 113.98 M msg/s, **delta
 3. **No certified row contradicts the quick tier beyond noise.** Window 2's
    72 rows sit 72/72 inside the quick-era band envelope (realworld-space,
    realworld2-space, pr29 quick-check). The rt-family C++ ~2x leads
-   (bench_packet/ints/mixed — the attributed TU-call-boundary-era class) and
+   (bench_packet/ints/mixed — the attributed TU-call-boundary-era class
+   [label era-scoped 2026-08-22, issue #66: both legs linkage=hdr since
+   serialize.c #25, so the literal TU boundary is gone; the leads reproduce
+   and their attribution is the timing era's, pending re-attribution]) and
    the C ~2x leads on probearray/testdata reads (the #29 lane-inline wins,
    C++ mirror candidate still on the board) all reproduce.
 


### PR DESCRIPTION
Docs only. serialize.c #25 made the C runtime header-only on 2026-08-17, and both bench legs have recorded linkage=hdr since — but four documents kept attributing the C row's gap to a TU call boundary in present tense. This era-scopes all four: the current truth where a reader arrives today, the old attribution kept as dated history where it was true, and the certified table's class label annotated in place because its leads reproduce while their attribution belongs to the timing era. The 2026-08-14 results file is deliberately untouched; it predates the change. Closes #66, where the receipts live.
