### PR TITLE
Bench standard: string + wstring row definitions (measure-first), and the ≤15% bulk batch rebalance

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -127,6 +127,15 @@ the same correction §1.4 already records for the bitpacker, whose inherited
 4096 passes violated the same floor and were rescaled to 24576 for the same
 reason.
 
+The same correction fired a third time on 2026-08-23: the §1.7 batch
+rebalance (issue #64) cut the batch's wire bytes 2.6x, and the smaller
+messages raised its msgs/s enough that all four C/C++ batch legs measured
+80–121 ms at 6,400 passes on the Studio (M3 Ultra, quiet) — under the floor
+again. Passes rescale **6,400 → 25,600** (26,214,400 → 104,857,600 msgs),
+sized against the fastest measured leg (cpp read, 328.5 M msgs/s → 319 ms)
+with margin, identical in all six runners, recorded in the `iters` column
+like both corrections before it.
+
 ### §1.3 Family `rt` — new, and the reason the bespoke harnesses can be retired
 
 The four shapes the bespoke harnesses already measure, transcribed from
@@ -310,7 +319,10 @@ not the serializer.
 So the write/read medians are mostly honest, and the batch columns — the rows the
 C-vs-C++ read campaign was fought over — are three-quarters memcpy by bits. (The
 dispatch-per-message differences those columns exposed were real; but their MB/s is
-inflated by bulk traffic, and by bits they do not resemble a real packet.)
+inflated by bulk traffic, and by bits they do not resemble a real packet.) The
+table above is the audit's record and stays as written; the batch rows were
+rebalanced 2026-08-23 under rule 3's latitude — the enactment block below the
+law carries the before/after.
 
 **The law going forward:**
 
@@ -325,11 +337,141 @@ inflated by bulk traffic, and by bits they do not resemble a real packet.)
    Bulk-heavy rows stay — memcpy throughput is worth tracking — but a table that
    leads with a bulk-dominated row must caption the bulk share, the same way §3's
    captions disclose checks and linkage asymmetries.
-3. **Additive only.** Existing rows and mixes are never rebalanced in place — that
-   would silently re-price every cross-era comparison. New realistic rows join
-   under new names with a new `corpus_id`, era-marked like any corpus change.
+3. **Additive only — with Glenn's own latitude for bulk-dominated rows.**
+   Existing rows and mixes are never rebalanced in place — that would silently
+   re-price every cross-era comparison. New realistic rows join under new
+   names with a new `corpus_id`, era-marked like any corpus change.
+   **Amended 2026-08-23 (issue #64), quoting the latitude Glenn granted in
+   the same 2026-08-16 ruling, verbatim:** *"of course, if any of the current
+   test cases are being dominated too much by IO for the string, wstring or
+   bytes types, feel free to update them if you want too."* A row or mix this
+   section's audit names as bulk-dominated MAY therefore be rebalanced in
+   place, under three conditions that keep the re-pricing loud instead of
+   silent: (a) identical constants land in every runner in the same change;
+   (b) the change is era-marked and moves the row's `bytes_per_op`, so §5.3
+   rule 2 already refuses every cross-era ratio mechanically; (c) the
+   rebalance states its bulk share before and after — measured over the
+   actual draws, not estimated from the design weights. Additive stays the
+   default; the latitude reaches exactly the rows the audit names, not every
+   row someone would like to retune.
 4. **Any future corpus addition states its bulk share by bits** in its definition
    comment, so this audit never has to be re-derived from variation code.
+
+**The batch rebalance — enacted 2026-08-23 (issue #64; the RealPacket
+campaign's chunk 7, under rule 3's latitude).** The audit's worst offender
+was the pair of rows the C-vs-C++ read campaign was fought over: the
+4096-message batch at ≈74% bulk by bits. The mix is rebalanced in every
+runner (six today — chunk 7 predates the js runner and said "identical
+constants x5"; the constants are identical x6), one change:
+
+| arm | weight before | weight after | payload draw before | payload draw after |
+|---|---:|---:|---|---|
+| Chat | 25% | 5% | 16–31 chars (avg 23.5) | 8–15 chars (avg 11.5) |
+| Test | 25% | 30% | — | — |
+| Synchronize | 15% | 25% | — | — |
+| Timescale | 15% | 25% | — | — |
+| Heartbeat | 10% | 10% | — | — |
+| Block | 10% | 5% | 64–191 bytes (avg 127.5) | 8–23 bytes (avg 15.5) |
+
+Measured over the actual 4096 LCG draws (seed 12345 — the batch every runner
+builds, so these are the mix's numbers, not the design's): bulk share by
+bits **75.95% → 14.20%**, wire bits per message 206.7 → 80.6, `bytes_per_op`
+25 → 10. The batch now resembles this section's real packet — dominated by
+individual serialize statements, with the bulk paths still present and
+deliberately rare (≈5% short chat strings, ≈5% small blocks) — while staying
+the estate's only steady-state dispatch-surface row. The moved `bytes_per_op`
+is the era mark: the tool refuses every ratio across the rebalance (§5.3
+rule 2), which is exactly the loud re-pricing rule 3 demands. The smaller
+messages raised the row's msgs/s enough to put every measured batch leg
+under §2.1's 200 ms floor at the old pass count, so `BatchPasses` rescaled
+6,400 → 25,600 in the same change — measured first, then rescaled, per
+§1.2's own precedent (the receipt is in §1.2).
+
+### §1.8 The string and wstring rows — defined measure-first (added 2026-08-23, issue #64)
+
+**DECIDED (Glenn, 2026-08-17, verbatim): "You can't improve what you don't
+measure."** Said the morning the estate's first string-body fix (serialize.c
+#26) landed and there was no string row anywhere in the family's benches to
+see it move. Enacted as an ORDERING rule, not a sentiment: a measurement row
+lands BEFORE or WITH the optimization it would measure, never after — and a
+row-landing change carries NO runtime, emitter, or generated-code serialize
+changes, because a row that arrives fused to a fix has measured nothing. The
+rows this section defines are pure instruments; the remaining string and
+wstring work (the wstring/bytes sweep, the C++ WriteBytes candidate, every
+port's equivalents) lands against them, never ahead of them.
+
+**The string row — `bench_string`, family `rt`.** Transcribed from the
+reference implementation's own string row (`serialize/bench.cpp`, landed
+under this issue) the same way §1.3 transcribed the four original shapes:
+
+```
+// joins schema/bench/corpus/Bench.schema when the rows land
+type BenchString {
+    text string(63)   // 6-bit length prefix, align to byte, then the bytes
+} // pinned instance: 24-byte payload -> 6 + 2 pad + 192 = 200 bits = 25 wire bytes
+```
+
+What a conforming row measures: the runtime's string path end to end —
+length dispatch, byte alignment, the bulk body copy, and the read side's
+contract validation (interior-NUL rejection, and UTF-8 well-formedness where
+the runtime checks it). The byte sizes above are the standard's claim; the
+goldens are the authority (§1.3's rule).
+
+- **Bulk share by bits: ≈96% (192 of 200), stated per rule 4 — and that is
+  the point.** This row is a DELIBERATE bulk-path instrument under rule 2:
+  it exists so the string body's copy loop has a number of its own, it never
+  leads a table, it never joins headline corpus medians, and any table that
+  shows it captions the bulk share.
+- The pinned payload is 24 bytes — the §1.7 audit's average chat string —
+  printable ASCII, no interior NUL. **Length is STRUCTURE (§2.7)**: variation
+  mutates payload bytes through the standard LCG at pinned length, every
+  variant buffer is the same wire size, and the runner asserts
+  `bytes_per_op` did not move.
+- Golden: `BenchString` compiles in schema (`string(N)` exists), so the §1.5
+  gate binds unchanged — `testdata/wire/bench_string.bin` produced by the
+  generated C++, independently confirmed by the generated C, every runner
+  byte-compares and round-trips before emitting rows.
+
+**The wstring row — `bench_wstring`, family `rt`, corpus source: this
+document.** schema defers wide strings (SPEC §4.10), so no schema type and
+no generated golden can exist; like §1.4's bitpacker, the shape is specified
+here directly:
+
+```
+buffer   = 64 UTF-16 code units  -> 6-bit length field
+payload  = 24 code units, pinned, BMP only (each code point one unit,
+           so the wire size is deterministic), no surrogates, no NUL
+wire     = 6-bit length, then one unaligned 32-bit group per code unit
+         = 6 + 24 x 32 = 774 bits = 97 bytes
+```
+
+What a conforming row measures: the per-unit group dispatch plus the read
+side's contract validation (group range, surrogate pairing, interior NUL).
+
+- **Bulk share by bits: 0%, stated per rule 4 — the opposite pole from the
+  string row.** The wstring wire is one individual 32-bit dispatch per code
+  unit, not a bulk byte copy, so this row is NOT a bulk instrument and may
+  ride headline tables like any 0%-bulk row.
+- Content varies per iteration through the standard LCG at pinned length,
+  values pinned inside one BMP block so validation cost is uniform across
+  variants. Astral and unpaired-surrogate handling is correctness territory
+  owned by the conformance suites, never exercised by this row.
+- Golden: produced by the C++ reference runtime and byte-confirmed by the
+  serialize.c twin before first check-in — §1.3's two-independent-producers
+  confirmation pattern with the runtimes standing in for the generated code —
+  then every runner byte-compares and round-trips per §1.5's mechanics.
+- **A runtime with no wstring path emits NO row.** An honest null, never an
+  emulation; the row's absence is itself the record that the port lacks the
+  path.
+
+Mechanics both rows share when they land in the schema runners: additive
+under rule 3 (new names, new `corpus_id`, era-marked), iteration counts
+sized at landing per §2.1 (every leg over 200 ms, identical across
+languages, recorded in `iters`), timed loops in noinline symbols with §3.2's
+two call sites, like every other `rt` row. This section is the definition
+only — the schema/bench implementation (corpus type, goldens, six runner
+rows) lands as its own additive change, and the runtime repos' in-repo
+benches carry their own local rows under the same measure-first rule.
 
 ---
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -151,7 +151,7 @@ it. Human-readable tables live beside the CSVs in `bench/results/`.
 | probearray        | probearray            | nested samples, both branch arms, counted arrays  |
 | testdata          | testdata              | the everything message (floats, strings, arrays)  |
 | real_packet       | real_packet           | the §1.7 realistic snapshot (`bench/corpus/RealWorld.schema`): ~93 riding individually serialized small fields of every scalar kind, 204 B, 0% bulk share by bits; pin = the all-defaults instance |
-| message_batch     | (message_stream golden checks the dispatch wire) | 4096 mixed messages + terminator through WriteMessage/ReadMessage, steady-state |
+| message_batch     | (message_stream golden checks the dispatch wire) | 4096 mixed messages + terminator through WriteMessage/ReadMessage, steady-state; mix rebalanced 2026-08-23 to ≤15% bulk by bits (§1.7 rule 3's latitude, issue #64: bulk share 75.95% → 14.20%, bytes/op 25 → 10 — cross-era batch ratios refuse on the moved bytes_per_op, which is the era mark working) |
 
 Family `rt` (hand-written runtime API, oracle-gated per §1.5; iteration
 counts fixed and identical across all six languages) and family `bits`:
@@ -169,6 +169,12 @@ The `rt` timed loops live in noinline symbols (`rt_bench_*_write_loop` /
 the emitted body of the timed loop directly, and every benched op has
 exactly two call sites (§3.2): its untimed oracle/setup helper and its
 timed loop.
+
+Two further `rt` rows — `bench_string` and `bench_wstring` — are DEFINED in
+BENCH-STANDARD §1.8 (measure-first, issue #64) and not yet implemented in
+these runners; the definitions land ahead of any further string/wstring
+optimization, and the rows themselves land as their own additive change
+(corpus type, goldens, runner rows, new corpus_id).
 
 ## Runner contract (how go/rust/cs plug in)
 

--- a/bench/c/bench_main.c
+++ b/bench/c/bench_main.c
@@ -761,7 +761,7 @@ static TestData pin_testdata( void )
    ------------------------------------------------------------------------------------------ */
 
 #define NumBatchMessages 4096
-#define BatchPasses 6400
+#define BatchPasses 25600 /* rescaled 2026-08-23 with the mix rebalance: §2.1's floor wins (§1.2) */
 
 /* the generated C dispatch surface carries no message-level MAX_BYTES (see the
    header comment); BLOCK is the largest arm and the tag adds 3 bits */
@@ -783,14 +783,14 @@ static int build_batch( int * batch_bytes, uint8_t * batch_buffer, int batch_buf
         rng = bench_rng( rng );
         pick = (int) ( ( rng >> 32 ) % 20 );
         memset( m, 0, sizeof( *m ) );
-        if ( pick < 5 )                     /* 25% Chat */
+        if ( pick < 1 )                     /* 5% Chat */
         {
             m->type = MESSAGE_TYPE_CHAT;
-            m->as.chat.text_length = 16 + (int) ( rng & 15 );
+            m->as.chat.text_length = 8 + (int) ( rng & 7 );
             for ( i = 0; i < m->as.chat.text_length; i++ )
                 m->as.chat.text[i] = (char) ( 'a' + ( ( rng >> ( i & 7 ) ) & 15 ) );
         }
-        else if ( pick < 10 )               /* 25% Test */
+        else if ( pick < 7 )                /* 30% Test */
         {
             m->type = MESSAGE_TYPE_TEST;
             m->as.test.test_a = (uint16_t) rng;
@@ -798,27 +798,27 @@ static int build_batch( int * batch_bytes, uint8_t * batch_buffer, int batch_buf
             m->as.test.test_c = (int16_t) ( ( rng >> 25 ) & 511 );
             m->as.test.test_d = (int16_t) ( ( rng >> 34 ) & 511 );
         }
-        else if ( pick < 13 )               /* 15% Synchronize */
+        else if ( pick < 12 )               /* 25% Synchronize */
         {
             m->type = MESSAGE_TYPE_SYNCHRONIZE;
             m->as.synchronize.sync_frame = rng;
             m->as.synchronize.sync_sequence = (uint16_t) ( rng >> 8 );
         }
-        else if ( pick < 16 )               /* 15% Timescale */
+        else if ( pick < 17 )               /* 25% Timescale */
         {
             m->type = MESSAGE_TYPE_TIMESCALE;
             m->as.timescale.scale = (double) ( (uint32_t) rng & 0xFFFF ) / 65536.0;
             m->as.timescale.frame_a = (uint32_t) ( rng >> 16 );
             m->as.timescale.frame_b = (uint32_t) ( rng >> 24 );
         }
-        else if ( pick < 18 )               /* 10% Heartbeat */
+        else if ( pick < 19 )               /* 10% Heartbeat */
         {
             m->type = MESSAGE_TYPE_HEARTBEAT;
         }
-        else                                /* 10% Block */
+        else                                /* 5% Block */
         {
             m->type = MESSAGE_TYPE_BLOCK;
-            m->as.block.data_length = 64 + (int) ( rng & 127 );
+            m->as.block.data_length = 8 + (int) ( rng & 15 );
             for ( i = 0; i < m->as.block.data_length; i++ )
                 m->as.block.data[i] = (uint8_t) ( rng >> ( i & 31 ) );
         }

--- a/bench/cpp/bench_main.cpp
+++ b/bench/cpp/bench_main.cpp
@@ -706,10 +706,13 @@ static void vary_real_packet( realworld::RealPacket & m, uint64_t rng )
 // Message dispatch surface (WriteMessage/ReadMessage) plus the None
 // terminator, mixed types driven by the LCG. Larger than L1/L2 working sets
 // on both bench hosts.
+// Mix rebalanced 2026-08-23 (BENCH-STANDARD §1.7 rule 3's latitude, issue
+// #64): bulk share by bits 75.95% -> 14.20%, bytes/op 25 -> 10, identical
+// constants in every runner; the moved bytes_per_op is the era mark.
 // ------------------------------------------------------------------------------------------
 
 const int NumBatchMessages = 4096;
-const int BatchPasses = 6400;
+const int BatchPasses = 25600;   // rescaled 2026-08-23 with the mix rebalance: §2.1's floor wins (§1.2)
 
 static Message * build_batch( int64_t & batch_bytes, uint8_t * batch_buffer, int batch_buffer_size )
 {
@@ -721,14 +724,14 @@ static Message * build_batch( int64_t & batch_bytes, uint8_t * batch_buffer, int
         rng = bench_rng( rng );
         Message & m = messages[k];
         const int pick = int( ( rng >> 32 ) % 20 );
-        if ( pick < 5 )                     // 25% Chat
+        if ( pick < 1 )                     // 5% Chat
         {
             m.type = MessageType::Chat;
-            m.chat.text_length = 16 + int( rng & 15 );
+            m.chat.text_length = 8 + int( rng & 7 );
             for ( int i = 0; i < m.chat.text_length; i++ )
                 m.chat.text[i] = char( 'a' + ( ( rng >> ( i & 7 ) ) & 15 ) );
         }
-        else if ( pick < 10 )               // 25% Test
+        else if ( pick < 7 )                // 30% Test
         {
             m.type = MessageType::Test;
             m.test.test_a = uint16_t( rng );
@@ -736,27 +739,27 @@ static Message * build_batch( int64_t & batch_bytes, uint8_t * batch_buffer, int
             m.test.test_c = int16_t( ( rng >> 25 ) & 511 );
             m.test.test_d = int16_t( ( rng >> 34 ) & 511 );
         }
-        else if ( pick < 13 )               // 15% Synchronize
+        else if ( pick < 12 )               // 25% Synchronize
         {
             m.type = MessageType::Synchronize;
             m.synchronize.sync_frame = rng;
             m.synchronize.sync_sequence = uint16_t( rng >> 8 );
         }
-        else if ( pick < 16 )               // 15% Timescale
+        else if ( pick < 17 )               // 25% Timescale
         {
             m.type = MessageType::Timescale;
             m.timescale.scale = double( uint32_t( rng ) & 0xFFFF ) / 65536.0;
             m.timescale.frame_a = uint32_t( rng >> 16 );
             m.timescale.frame_b = uint32_t( rng >> 24 );
         }
-        else if ( pick < 18 )               // 10% Heartbeat
+        else if ( pick < 19 )               // 10% Heartbeat
         {
             m.type = MessageType::Heartbeat;
         }
-        else                                // 10% Block
+        else                                // 5% Block
         {
             m.type = MessageType::Block;
-            m.block.data_length = 64 + int( rng & 127 );
+            m.block.data_length = 8 + int( rng & 15 );
             for ( int i = 0; i < m.block.data_length; i++ )
                 m.block.data[i] = uint8_t( rng >> ( i & 31 ) );
         }

--- a/bench/cs/src/Program.cs
+++ b/bench/cs/src/Program.cs
@@ -752,7 +752,7 @@ static partial class Program
     // ------------------------------------------------------------------------------------------
 
     const int NumBatchMessages = 4096;
-    const int BatchPasses = 6400;
+    const int BatchPasses = 25600; // rescaled 2026-08-23 with the mix rebalance: §2.1's floor wins (§1.2)
 
     static Message[] BuildBatch(byte[] batchBuffer, out long batchBytes)
     {
@@ -764,17 +764,17 @@ static partial class Program
         {
             rng = BenchRng(rng);
             int pick = (int)((rng >> 32) % 20);
-            if (pick < 5) // 25% Chat
+            if (pick < 1) // 5% Chat
             {
                 Chat m = new Chat();
-                m.TextLength = 16 + (int)(rng & 15);
+                m.TextLength = 8 + (int)(rng & 7);
                 for (int i = 0; i < m.TextLength; i++)
                 {
                     m.Text[i] = (byte)('a' + (int)((rng >> (i & 7)) & 15));
                 }
                 messages[k] = m;
             }
-            else if (pick < 10) // 25% Test
+            else if (pick < 7) // 30% Test
             {
                 Test m = new Test();
                 m.TestA = (ushort)rng;
@@ -783,14 +783,14 @@ static partial class Program
                 m.TestD = (short)((rng >> 34) & 511);
                 messages[k] = m;
             }
-            else if (pick < 13) // 15% Synchronize
+            else if (pick < 12) // 25% Synchronize
             {
                 Synchronize m = new Synchronize();
                 m.SyncFrame = rng;
                 m.SyncSequence = (ushort)(rng >> 8);
                 messages[k] = m;
             }
-            else if (pick < 16) // 15% Timescale
+            else if (pick < 17) // 25% Timescale
             {
                 Timescale m = new Timescale();
                 m.Scale = ((uint)rng & 0xFFFF) / 65536.0;
@@ -798,14 +798,14 @@ static partial class Program
                 m.FrameB = (uint)(rng >> 24);
                 messages[k] = m;
             }
-            else if (pick < 18) // 10% Heartbeat
+            else if (pick < 19) // 10% Heartbeat
             {
                 messages[k] = new Heartbeat();
             }
-            else // 10% Block
+            else // 5% Block
             {
                 Block m = new Block();
-                m.DataLength = 64 + (int)(rng & 127);
+                m.DataLength = 8 + (int)(rng & 15);
                 for (int i = 0; i < m.DataLength; i++)
                 {
                     m.Data[i] = (byte)(rng >> (i & 31));

--- a/bench/go/main.go
+++ b/bench/go/main.go
@@ -663,7 +663,7 @@ func varyRealPacket(m *realworld.RealPacket, rng uint64) {
 // ------------------------------------------------------------------------------------------
 
 const NumBatchMessages = 4096
-const BatchPasses = 6400
+const BatchPasses = 25600 // rescaled 2026-08-23 with the mix rebalance: §2.1's floor wins (§1.2)
 
 func buildBatch(batchBuffer []byte) ([]example.Message, int64) {
 	messages := make([]example.Message, NumBatchMessages)
@@ -673,36 +673,36 @@ func buildBatch(batchBuffer []byte) ([]example.Message, int64) {
 		rng = benchRng(rng)
 		pick := int((rng >> 32) % 20)
 		switch {
-		case pick < 5: // 25% Chat
+		case pick < 1: // 5% Chat
 			m := &example.Chat{}
-			m.TextLength = 16 + int32(rng&15)
+			m.TextLength = 8 + int32(rng&7)
 			for i := int32(0); i < m.TextLength; i++ {
 				m.Text[i] = byte('a' + ((rng >> (i & 7)) & 15))
 			}
 			messages[k] = m
-		case pick < 10: // 25% Test
+		case pick < 7: // 30% Test
 			m := &example.Test{}
 			m.TestA = uint16(rng)
 			m.TestB = int16((rng >> 16) & 511)
 			m.TestC = int16((rng >> 25) & 511)
 			m.TestD = int16((rng >> 34) & 511)
 			messages[k] = m
-		case pick < 13: // 15% Synchronize
+		case pick < 12: // 25% Synchronize
 			m := &example.Synchronize{}
 			m.SyncFrame = rng
 			m.SyncSequence = uint16(rng >> 8)
 			messages[k] = m
-		case pick < 16: // 15% Timescale
+		case pick < 17: // 25% Timescale
 			m := &example.Timescale{}
 			m.Scale = float64(uint32(rng)&0xFFFF) / 65536.0
 			m.FrameA = uint32(rng >> 16)
 			m.FrameB = uint32(rng >> 24)
 			messages[k] = m
-		case pick < 18: // 10% Heartbeat
+		case pick < 19: // 10% Heartbeat
 			messages[k] = &example.Heartbeat{}
-		default: // 10% Block
+		default: // 5% Block
 			m := &example.Block{}
-			m.DataLength = 64 + int32(rng&127)
+			m.DataLength = 8 + int32(rng&15)
 			for i := int32(0); i < m.DataLength; i++ {
 				m.Data[i] = uint8(rng >> (uint(i) & 31))
 			}

--- a/bench/js/main.mjs
+++ b/bench/js/main.mjs
@@ -961,7 +961,7 @@ function varyRealPacket(m) {
 // --------------------------------------------------------------------------
 
 const NumBatchMessages = 4096;
-const BatchPasses = 6400;
+const BatchPasses = 25600; // rescaled 2026-08-23 with the mix rebalance: §2.1's floor wins (§1.2)
 
 function buildBatch(batchBuffer) {
   const batch = new Array(NumBatchMessages);
@@ -970,42 +970,42 @@ function buildBatch(batchBuffer) {
   for (let k = 0; k < NumBatchMessages; k++) {
     lcgStep();
     const pick = shr64(32) % 20;
-    if (pick < 5) {
-      // 25% Chat
+    if (pick < 1) {
+      // 5% Chat
       const m = new ex.Chat();
-      m.TextLength = 16 + (rng.lo & 15);
+      m.TextLength = 8 + (rng.lo & 7);
       for (let i = 0; i < m.TextLength; i++) {
         m.Text[i] = 97 + ((rng.lo >>> (i & 7)) & 15);
       }
       batch[k] = m;
-    } else if (pick < 10) {
-      // 25% Test
+    } else if (pick < 7) {
+      // 30% Test
       const m = new ex.Test();
       m.TestA = rng.lo & 0xffff;
       m.TestB = shr64(16) & 511;
       m.TestC = shr64(25) & 511;
       m.TestD = shr64(34) & 511;
       batch[k] = m;
-    } else if (pick < 13) {
-      // 15% Synchronize
+    } else if (pick < 12) {
+      // 25% Synchronize
       const m = new ex.Synchronize();
       m.SyncFrame = rngBig();
       m.SyncSequence = shr64(8) & 0xffff;
       batch[k] = m;
-    } else if (pick < 16) {
-      // 15% Timescale
+    } else if (pick < 17) {
+      // 25% Timescale
       const m = new ex.Timescale();
       m.Scale = (rng.lo & 0xffff) / 65536.0;
       m.FrameA = shr64(16);
       m.FrameB = shr64(24);
       batch[k] = m;
-    } else if (pick < 18) {
+    } else if (pick < 19) {
       // 10% Heartbeat
       batch[k] = new ex.Heartbeat();
     } else {
-      // 10% Block
+      // 5% Block
       const m = new ex.Block();
-      m.DataLength = 64 + (rng.lo & 127);
+      m.DataLength = 8 + (rng.lo & 15);
       for (let i = 0; i < m.DataLength; i++) {
         m.Data[i] = shr64(i & 31) & 0xff;
       }

--- a/bench/rust/src/main.rs
+++ b/bench/rust/src/main.rs
@@ -732,7 +732,7 @@ fn vary_real_packet(m: &mut realworld::RealPacket, rng: u64) {
 // ------------------------------------------------------------------------------------------
 
 const NUM_BATCH_MESSAGES: usize = 4096;
-const BATCH_PASSES: usize = 6400;
+const BATCH_PASSES: usize = 25600; // rescaled 2026-08-23 with the mix rebalance: §2.1's floor wins (§1.2)
 
 fn build_batch(ctx: &Ctx, messages: &mut Vec<Message>, batch_buffer: &mut [u8]) -> Option<i64> {
     messages.clear();
@@ -741,42 +741,42 @@ fn build_batch(ctx: &Ctx, messages: &mut Vec<Message>, batch_buffer: &mut [u8]) 
     for _ in 0..NUM_BATCH_MESSAGES {
         rng = bench_rng(rng);
         let pick = ((rng >> 32) % 20) as i32;
-        let m = if pick < 5 {
-            // 25% Chat
+        let m = if pick < 1 {
+            // 5% Chat
             let mut c = Chat::default();
-            c.text_length = 16 + (rng & 15) as i32;
+            c.text_length = 8 + (rng & 7) as i32;
             for i in 0..c.text_length as usize {
                 c.text[i] = b'a' + ((rng >> (i & 7)) & 15) as u8;
             }
             Message::Chat(c)
-        } else if pick < 10 {
-            // 25% Test
+        } else if pick < 7 {
+            // 30% Test
             let mut t = Test::default();
             t.test_a = rng as u16;
             t.test_b = ((rng >> 16) & 511) as i16;
             t.test_c = ((rng >> 25) & 511) as i16;
             t.test_d = ((rng >> 34) & 511) as i16;
             Message::Test(t)
-        } else if pick < 13 {
-            // 15% Synchronize
+        } else if pick < 12 {
+            // 25% Synchronize
             let mut s = Synchronize::default();
             s.sync_frame = rng;
             s.sync_sequence = (rng >> 8) as u16;
             Message::Synchronize(s)
-        } else if pick < 16 {
-            // 15% Timescale
+        } else if pick < 17 {
+            // 25% Timescale
             let mut t = Timescale::default();
             t.scale = ((rng as u32) & 0xFFFF) as f64 / 65536.0;
             t.frame_a = (rng >> 16) as u32;
             t.frame_b = (rng >> 24) as u32;
             Message::Timescale(t)
-        } else if pick < 18 {
+        } else if pick < 19 {
             // 10% Heartbeat
             Message::Heartbeat(Heartbeat::default())
         } else {
-            // 10% Block
+            // 5% Block
             let mut b = Block::default();
-            b.data_length = 64 + (rng & 127) as i32;
+            b.data_length = 8 + (rng & 15) as i32;
             for i in 0..b.data_length as usize {
                 b.data[i] = (rng >> (i & 31)) as u8;
             }


### PR DESCRIPTION
Closes the standard-side half of #64. Two items, one PR, no runtime or emitter change anywhere in the diff — the row definitions are pure instruments by construction.

## 1. BENCH-STANDARD §1.8 — the string and wstring rows, defined measure-first

Glenn's ruling, 2026-08-17, verbatim: **"You can't improve what you don't measure."** Said the morning serialize.c #26 (the first string-body fix) landed with no string row anywhere in the family's benches to see it move. §1.8 enacts it as an ordering rule: a measurement row lands BEFORE or WITH the optimization it would measure, never after — and a row-landing change carries no runtime, emitter, or generated-code serialize changes, because a row that arrives fused to a fix has measured nothing.

Honest-null check first: no string or wstring row exists in this repo's benches today (confirmed against the row tables and the cfixes-air era finding "no string row and no wstring row in any family bench"), so the definitions go in rather than being skipped.

- **`bench_string`** — family `rt`. `type BenchString { text string(63) }`, pinned 24-byte printable-ASCII payload (the §1.7 audit's average chat string): 6-bit length + 2 pad + 192 payload bits = **25 wire bytes, ≈96% bulk by bits**, stated per §1.7 rule 4. A DELIBERATE bulk instrument under rule 2: never leads a table, never joins headline medians, always captioned. Transcribed from the reference implementation's own string row (serialize/bench.cpp, landed under this same issue) exactly the way §1.3 transcribed the original four rt shapes. Golden: generated C++ produces, generated C confirms — §1.5 unchanged.
- **`bench_wstring`** — family `rt`, corpus source this document (schema defers wstring, SPEC §4.10, so no generated golden can exist — §1.4's pattern). 64-unit buffer → 6-bit length; pinned 24 BMP UTF-16 code units: 6 + 24×32 = **774 bits = 97 wire bytes, 0% bulk** — the wstring wire is one individual 32-bit group dispatch per code unit, the opposite pole from the string row. Golden authority: the C++ reference runtime, byte-confirmed by the serialize.c twin before first check-in. **A runtime with no wstring path emits NO row** — an honest null, never an emulation.

The schema/bench implementation (corpus type, goldens, six runner rows, new corpus_id) lands as its own additive change; this PR is the standard's definitions, ahead of the remaining string/wstring sweep.

## 2. §1.7 rule 3 amended with Glenn's latitude; the batch rebalance enacted (RealPacket campaign chunk 7)

Rule 3 ("additive only") now quotes the latitude Glenn granted in the same 2026-08-16 Auckland ruling, verbatim: *"of course, if any of the current test cases are being dominated too much by IO for the string, wstring or bytes types, feel free to update them if you want too."* — scoped to rows the §1.7 audit names, with three conditions keeping the re-pricing loud: identical constants in every runner in one change, era-marked with a moved `bytes_per_op` (so §5.3 rule 2 refuses every cross-era ratio mechanically), and bulk share stated before/after, measured.

Enacted on the audit's worst offender, the 4096-message batch (≈74% bulk by bits — the rows the C-vs-C++ read campaign was fought over). Identical constants in all six runners (cpp, c, go, rust, cs, js — chunk 7's plan said "identical constants x5"; the js runner joined since):

| arm | weight before | weight after | payload draw before | payload draw after |
|---|---:|---:|---|---|
| Chat | 25% | 5% | 16–31 chars (avg 23.5) | 8–15 chars (avg 11.5) |
| Test | 25% | 30% | — | — |
| Synchronize | 15% | 25% | — | — |
| Timescale | 15% | 25% | — | — |
| Heartbeat | 10% | 10% | — | — |
| Block | 10% | 5% | 64–191 bytes (avg 127.5) | 8–23 bytes (avg 15.5) |

**Measured over the actual 4096 LCG draws (seed 12345 — the batch every runner builds, not the design weights):**

| | before | after |
|---|---:|---:|
| bulk share by bits | **75.95%** (643,112 of 846,735) | **14.20%** (46,856 of 330,065) |
| wire bits / message | 206.7 | 80.6 |
| `bytes_per_op` | 25 | 10 |
| draws: Chat / Test / Sync / Time / HB / Block | 1013 / 1050 / 581 / 608 / 396 / 448 | 210 / 1221 / 1002 / 1007 / 439 / 217 |

The batch now resembles §1.7's real packet — dominated by individual serialize statements, bulk paths still present and deliberately rare — while staying the estate's only steady-state dispatch-surface row.

**Floor consequence, measured then fixed (§1.2's third firing):** the smaller messages raised msgs/s enough that all four C/C++ batch legs ran **80–121 ms** at 6,400 passes on the Studio (M3 Ultra, quiet) — under §2.1's 200 ms floor. `BatchPasses` rescales **6,400 → 25,600** (26,214,400 → 104,857,600 msgs) in the same change, sized against the fastest measured leg (cpp read 328.5 M msgs/s → 319 ms) with margin, recorded in §1.2 beside the two prior firings of the same correction.

## Receipts / verification

- Smoke on the Studio (unpinned `--round 0`, NOT a measurement): cpp and c legs exit 0, every golden gate passes, `corpus_id` unchanged at `7a7c343f1a446f4c` (the goldens don't move — the era mark is the moved `bytes_per_op`, exactly as rule 3 now requires). Post-rescale batch legs: cpp 217.4 w / 329.7 r, c 303.1 w / 329.0 r M msgs/s → 318–482 ms, floor cleared.
- rust: `cargo check` clean. go: `go build` clean. cs / js: the same mechanical mirror edit, not compiled here (no dotnet/node on this bench) — CI's corpus legs cover them.
- Receipts trail: §1.7 landed as PR #49 with the audit (batch ≈74%, chat ≈85%, bench_packet 35%); the latitude and chunk-7 plan are in the 2026-08-16/17 session cairns; PR #61 named "§1.7 batch rebalance of the wider corpus composition" as the campaign's future work — this is that chunk.

Numbers go to #64; no merge without review per the issue's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)