### PR TITLE
schema#82 cpp: compressed floats adopt the precomputed entry point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       #   gh release list --repo mas-bandwidth/<repo> --limit 1
       - name: Check out the serialize runtimes (pinned releases)
         env:
-          SERIALIZE_TAG: v1.10.0
+          SERIALIZE_TAG: v1.12.0
           SERIALIZE_C_TAG: v1.4.0
           SERIALIZE_GO_TAG: v1.11.0
           SERIALIZE_RS_TAG: v2.1.2

--- a/generated/bench/cpp/RealWorldWire.h
+++ b/generated/bench/cpp/RealWorldWire.h
@@ -62,7 +62,7 @@ SCHEMA_WRITE_INLINE bool WriteRealPacket( serialize::WriteStream & stream, const
     write_bits( stream, uint32_t( value.f003_int ) - uint32_t( -835897 ), 21 );
     {
         float compressed_value = value.f004_cf32;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 2000.0f, 0.1f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 20000u, 15, 2000.0f, 0.0f );
     }
     serialize_assert( int32_t( value.f005_uint ) >= int32_t( 0 ) && int32_t( value.f005_uint ) <= int32_t( 7316 ) );
     write_bits( stream, uint32_t( value.f005_uint ), 13 );
@@ -107,7 +107,7 @@ SCHEMA_WRITE_INLINE bool WriteRealPacket( serialize::WriteStream & stream, const
     write_bits( stream, value.f026_bits, 9 );
     {
         float compressed_value = value.f027_cf32;
-        serialize_compressed_float( stream, compressed_value, -2.0f, 2.0f, 0.25f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 16u, 5, 4.0f, -2.0f );
     }
     write_bits( stream, value.f028_bits, 4 );
     write_bits( stream, value.f029_i64, 64 );
@@ -167,7 +167,7 @@ SCHEMA_WRITE_INLINE bool WriteRealPacket( serialize::WriteStream & stream, const
     write_bits( stream, value.f060_bits, 8 );
     {
         float compressed_value = value.f061_cf32;
-        serialize_compressed_float( stream, compressed_value, -90.0f, 90.0f, 0.5f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 360u, 9, 180.0f, -90.0f );
     }
     serialize_assert( int32_t( value.f062_uint ) >= int32_t( 0 ) && int32_t( value.f062_uint ) <= int32_t( 503 ) );
     write_bits( stream, uint32_t( value.f062_uint ), 9 );
@@ -176,7 +176,7 @@ SCHEMA_WRITE_INLINE bool WriteRealPacket( serialize::WriteStream & stream, const
     write_bits( stream, uint32_t( value.f064_uint ), 9 );
     {
         float compressed_value = value.f065_cf32;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 30.0f, 0.5f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 60u, 6, 30.0f, 0.0f );
     }
     {
         uint16_t fixed_value = value.f066_ufixed;
@@ -184,22 +184,22 @@ SCHEMA_WRITE_INLINE bool WriteRealPacket( serialize::WriteStream & stream, const
     }
     {
         float compressed_value = value.f067_cf32;
-        serialize_compressed_float( stream, compressed_value, -100.0f, 100.0f, 0.25f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 800u, 10, 200.0f, -100.0f );
     }
     {
         float compressed_value = value.f068_cf32;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 2000.0f, 1.0f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 2000u, 11, 2000.0f, 0.0f );
     }
     write_bits( stream, value.f069_bits, 11 );
     serialize_assert( int32_t( value.f070_uint ) >= int32_t( 0 ) && int32_t( value.f070_uint ) <= int32_t( 2 ) );
     write_bits( stream, uint32_t( value.f070_uint ), 2 );
     {
         float compressed_value = value.f071_cf32;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 10.0f, 0.02f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 500u, 9, 10.0f, 0.0f );
     }
     {
         float compressed_value = value.f072_cf32;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 100.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 10000u, 14, 100.0f, 0.0f );
     }
     serialize_assert( int32_t( value.f073_int ) >= int32_t( -4 ) && int32_t( value.f073_int ) <= int32_t( 4 ) );
     write_bits( stream, uint32_t( value.f073_int ) - uint32_t( -4 ), 4 );
@@ -252,7 +252,7 @@ SCHEMA_READ_INLINE bool ReadRealPacket( serialize::ReadStream & stream, RealPack
     read_int( stream, value.f001_int, -805495, 805495 );
     read_double( stream, value.f002_f64 );
     read_int( stream, value.f003_int, -835897, 835897 );
-    serialize_compressed_float( stream, value.f004_cf32, 0.0f, 2000.0f, 0.1f );
+    serialize_compressed_float_precomputed( stream, value.f004_cf32, 20000u, 15, 2000.0f, 0.0f );
     {
         int32_t range_value = 0;
         read_int( stream, range_value, 0, 7316 );
@@ -314,7 +314,7 @@ SCHEMA_READ_INLINE bool ReadRealPacket( serialize::ReadStream & stream, RealPack
     read_float( stream, value.f024_f32 );
     read_fixed( stream, value.f025_fixed, 8, 8, -119, 119 );
     read_bits( stream, value.f026_bits, 9 );
-    serialize_compressed_float( stream, value.f027_cf32, -2.0f, 2.0f, 0.25f );
+    serialize_compressed_float_precomputed( stream, value.f027_cf32, 16u, 5, 4.0f, -2.0f );
     read_bits( stream, value.f028_bits, 4 );
     {
         uint64_t raw_value = 0;
@@ -404,7 +404,7 @@ SCHEMA_READ_INLINE bool ReadRealPacket( serialize::ReadStream & stream, RealPack
     read_float( stream, value.f058_f32 );
     read_double( stream, value.f059_f64 );
     read_bits( stream, value.f060_bits, 8 );
-    serialize_compressed_float( stream, value.f061_cf32, -90.0f, 90.0f, 0.5f );
+    serialize_compressed_float_precomputed( stream, value.f061_cf32, 360u, 9, 180.0f, -90.0f );
     {
         int32_t range_value = 0;
         read_int( stream, range_value, 0, 503 );
@@ -420,18 +420,18 @@ SCHEMA_READ_INLINE bool ReadRealPacket( serialize::ReadStream & stream, RealPack
         read_int( stream, range_value, 0, 299 );
         value.f064_uint = uint16_t( range_value );
     }
-    serialize_compressed_float( stream, value.f065_cf32, 0.0f, 30.0f, 0.5f );
+    serialize_compressed_float_precomputed( stream, value.f065_cf32, 60u, 6, 30.0f, 0.0f );
     read_fixed( stream, value.f066_ufixed, 2, 14, 0, 2 );
-    serialize_compressed_float( stream, value.f067_cf32, -100.0f, 100.0f, 0.25f );
-    serialize_compressed_float( stream, value.f068_cf32, 0.0f, 2000.0f, 1.0f );
+    serialize_compressed_float_precomputed( stream, value.f067_cf32, 800u, 10, 200.0f, -100.0f );
+    serialize_compressed_float_precomputed( stream, value.f068_cf32, 2000u, 11, 2000.0f, 0.0f );
     read_bits( stream, value.f069_bits, 11 );
     {
         int32_t range_value = 0;
         read_int( stream, range_value, 0, 2 );
         value.f070_uint = uint8_t( range_value );
     }
-    serialize_compressed_float( stream, value.f071_cf32, 0.0f, 10.0f, 0.02f );
-    serialize_compressed_float( stream, value.f072_cf32, 0.0f, 100.0f, 0.01f );
+    serialize_compressed_float_precomputed( stream, value.f071_cf32, 500u, 9, 10.0f, 0.0f );
+    serialize_compressed_float_precomputed( stream, value.f072_cf32, 10000u, 14, 100.0f, 0.0f );
     {
         int32_t range_value = 0;
         read_int( stream, range_value, -4, 4 );

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -229,7 +229,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
     write_bool( stream, value.active );
     {
         float compressed_value = value.orientation;
-        serialize_compressed_float( stream, compressed_value, -180.0f, 180.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 36000u, 16, 360.0f, -180.0f );
     }
     write_bits( stream, uint32_t( value.raw_delta ), 32 );
     write_bits( stream, value.big_delta, 64 );
@@ -259,7 +259,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
 SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
 {
     read_bool( stream, value.active );
-    serialize_compressed_float( stream, value.orientation, -180.0f, 180.0f, 0.01f );
+    serialize_compressed_float_precomputed( stream, value.orientation, 36000u, 16, 360.0f, -180.0f );
     {
         uint32_t raw_value = 0;
         read_bits( stream, raw_value, 32 );
@@ -417,7 +417,7 @@ SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const T
     write_float( stream, value.float_value );
     {
         float compressed_value = value.compressed_float_value;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 10.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 1000u, 10, 10.0f, 0.0f );
     }
     write_double( stream, value.double_value );
     write_bits( stream, uint8_t( value.int8_value ), 8 );
@@ -457,7 +457,7 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
         read_int( stream, value.items[i], 0, 255 );
     }
     read_float( stream, value.float_value );
-    serialize_compressed_float( stream, value.compressed_float_value, 0.0f, 10.0f, 0.01f );
+    serialize_compressed_float_precomputed( stream, value.compressed_float_value, 1000u, 10, 10.0f, 0.0f );
     read_double( stream, value.double_value );
     {
         uint32_t raw_value = 0;
@@ -503,19 +503,19 @@ SCHEMA_WRITE_INLINE bool WriteCompressedProbe( serialize::WriteStream & stream, 
 {
     {
         float compressed_value = value.boundary;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 10.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 1000u, 10, 10.0f, 0.0f );
     }
     {
         float compressed_value = value.offset;
-        serialize_compressed_float( stream, compressed_value, -5.0f, 5.0f, 0.001f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 10000u, 14, 10.0f, -5.0f );
     }
     return true;
 }
 
 SCHEMA_READ_INLINE bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
 {
-    serialize_compressed_float( stream, value.boundary, 0.0f, 10.0f, 0.01f );
-    serialize_compressed_float( stream, value.offset, -5.0f, 5.0f, 0.001f );
+    serialize_compressed_float_precomputed( stream, value.boundary, 1000u, 10, 10.0f, 0.0f );
+    serialize_compressed_float_precomputed( stream, value.offset, 10000u, 14, 10.0f, -5.0f );
     return true;
 }
 

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -419,9 +419,12 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		g.pf("%swrite_bool( stream, %s );\n", ind, name)
 	case ir.TFloat32:
 		if f.HasFloatRange {
+			steps, wireBits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
+			min32 := float32(f.FMin)
+			delta := float32(f.FMax) - min32
 			g.pf("%s{\n%s    float compressed_value = %s;\n", ind, ind, name)
-			g.pf("%s    serialize_compressed_float( stream, compressed_value, %s, %s, %s );\n",
-				ind, formatFloat(f.FMin, true), formatFloat(f.FMax, true), formatFloat(f.Resolution, true))
+			g.pf("%s    serialize_compressed_float_precomputed( stream, compressed_value, %du, %d, %s, %s );\n",
+				ind, steps, wireBits, formatFloat(float64(delta), true), formatFloat(float64(min32), true))
 			g.pf("%s}\n", ind)
 			return
 		}
@@ -580,8 +583,11 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 		g.pf("%sread_bool( stream, %s );\n", ind, name)
 	case ir.TFloat32:
 		if f.HasFloatRange {
-			g.pf("%sserialize_compressed_float( stream, %s, %s, %s, %s );\n",
-				ind, name, formatFloat(f.FMin, true), formatFloat(f.FMax, true), formatFloat(f.Resolution, true))
+			steps, wireBits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
+			min32 := float32(f.FMin)
+			delta := float32(f.FMax) - min32
+			g.pf("%sserialize_compressed_float_precomputed( stream, %s, %du, %d, %s, %s );\n",
+				ind, name, steps, wireBits, formatFloat(float64(delta), true), formatFloat(float64(min32), true))
 			return
 		}
 		g.pf("%sread_float( stream, %s );\n", ind, name)

--- a/testdata/golden/union/WireWire.h
+++ b/testdata/golden/union/WireWire.h
@@ -229,7 +229,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
     write_bool( stream, value.active );
     {
         float compressed_value = value.orientation;
-        serialize_compressed_float( stream, compressed_value, -180.0f, 180.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 36000u, 16, 360.0f, -180.0f );
     }
     write_bits( stream, uint32_t( value.raw_delta ), 32 );
     write_bits( stream, value.big_delta, 64 );
@@ -259,7 +259,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
 SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
 {
     read_bool( stream, value.active );
-    serialize_compressed_float( stream, value.orientation, -180.0f, 180.0f, 0.01f );
+    serialize_compressed_float_precomputed( stream, value.orientation, 36000u, 16, 360.0f, -180.0f );
     {
         uint32_t raw_value = 0;
         read_bits( stream, raw_value, 32 );
@@ -417,7 +417,7 @@ SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const T
     write_float( stream, value.float_value );
     {
         float compressed_value = value.compressed_float_value;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 10.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 1000u, 10, 10.0f, 0.0f );
     }
     write_double( stream, value.double_value );
     write_bits( stream, uint8_t( value.int8_value ), 8 );
@@ -457,7 +457,7 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
         read_int( stream, value.items[i], 0, 255 );
     }
     read_float( stream, value.float_value );
-    serialize_compressed_float( stream, value.compressed_float_value, 0.0f, 10.0f, 0.01f );
+    serialize_compressed_float_precomputed( stream, value.compressed_float_value, 1000u, 10, 10.0f, 0.0f );
     read_double( stream, value.double_value );
     {
         uint32_t raw_value = 0;
@@ -503,19 +503,19 @@ SCHEMA_WRITE_INLINE bool WriteCompressedProbe( serialize::WriteStream & stream, 
 {
     {
         float compressed_value = value.boundary;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 10.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 1000u, 10, 10.0f, 0.0f );
     }
     {
         float compressed_value = value.offset;
-        serialize_compressed_float( stream, compressed_value, -5.0f, 5.0f, 0.001f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 10000u, 14, 10.0f, -5.0f );
     }
     return true;
 }
 
 SCHEMA_READ_INLINE bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
 {
-    serialize_compressed_float( stream, value.boundary, 0.0f, 10.0f, 0.01f );
-    serialize_compressed_float( stream, value.offset, -5.0f, 5.0f, 0.001f );
+    serialize_compressed_float_precomputed( stream, value.boundary, 1000u, 10, 10.0f, 0.0f );
+    serialize_compressed_float_precomputed( stream, value.offset, 10000u, 14, 10.0f, -5.0f );
     return true;
 }
 

--- a/testdata/golden/variant/WireWire.h
+++ b/testdata/golden/variant/WireWire.h
@@ -229,7 +229,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
     write_bool( stream, value.active );
     {
         float compressed_value = value.orientation;
-        serialize_compressed_float( stream, compressed_value, -180.0f, 180.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 36000u, 16, 360.0f, -180.0f );
     }
     write_bits( stream, uint32_t( value.raw_delta ), 32 );
     write_bits( stream, value.big_delta, 64 );
@@ -259,7 +259,7 @@ SCHEMA_WRITE_INLINE bool WriteProbeSample( serialize::WriteStream & stream, cons
 SCHEMA_READ_INLINE bool ReadProbeSample( serialize::ReadStream & stream, ProbeSample & value )
 {
     read_bool( stream, value.active );
-    serialize_compressed_float( stream, value.orientation, -180.0f, 180.0f, 0.01f );
+    serialize_compressed_float_precomputed( stream, value.orientation, 36000u, 16, 360.0f, -180.0f );
     {
         uint32_t raw_value = 0;
         read_bits( stream, raw_value, 32 );
@@ -417,7 +417,7 @@ SCHEMA_WRITE_INLINE bool WriteTestData( serialize::WriteStream & stream, const T
     write_float( stream, value.float_value );
     {
         float compressed_value = value.compressed_float_value;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 10.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 1000u, 10, 10.0f, 0.0f );
     }
     write_double( stream, value.double_value );
     write_bits( stream, uint8_t( value.int8_value ), 8 );
@@ -457,7 +457,7 @@ SCHEMA_READ_INLINE bool ReadTestData( serialize::ReadStream & stream, TestData &
         read_int( stream, value.items[i], 0, 255 );
     }
     read_float( stream, value.float_value );
-    serialize_compressed_float( stream, value.compressed_float_value, 0.0f, 10.0f, 0.01f );
+    serialize_compressed_float_precomputed( stream, value.compressed_float_value, 1000u, 10, 10.0f, 0.0f );
     read_double( stream, value.double_value );
     {
         uint32_t raw_value = 0;
@@ -503,19 +503,19 @@ SCHEMA_WRITE_INLINE bool WriteCompressedProbe( serialize::WriteStream & stream, 
 {
     {
         float compressed_value = value.boundary;
-        serialize_compressed_float( stream, compressed_value, 0.0f, 10.0f, 0.01f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 1000u, 10, 10.0f, 0.0f );
     }
     {
         float compressed_value = value.offset;
-        serialize_compressed_float( stream, compressed_value, -5.0f, 5.0f, 0.001f );
+        serialize_compressed_float_precomputed( stream, compressed_value, 10000u, 14, 10.0f, -5.0f );
     }
     return true;
 }
 
 SCHEMA_READ_INLINE bool ReadCompressedProbe( serialize::ReadStream & stream, CompressedProbe & value )
 {
-    serialize_compressed_float( stream, value.boundary, 0.0f, 10.0f, 0.01f );
-    serialize_compressed_float( stream, value.offset, -5.0f, 5.0f, 0.001f );
+    serialize_compressed_float_precomputed( stream, value.boundary, 1000u, 10, 10.0f, 0.0f );
+    serialize_compressed_float_precomputed( stream, value.offset, 10000u, 14, 10.0f, -5.0f );
     return true;
 }
 


### PR DESCRIPTION
The emitter half of #82 for the cpp backend. Both compressed-float call sites switch from `serialize_compressed_float( stream, value, min, max, res )` to `serialize_compressed_float_precomputed( stream, value, max_integer_value, bits, delta, min )`, with the four literals computed at generation time by `ir.CompressedFloatParams` — the same helper `internal/pack` and the Go fold (#79) already emit from, and exactly the four scalars the adoption spec in the #82 thread names. CI's serialize pin moves v1.10.0 → v1.12.0 (the entry point shipped in 1.11.0; 1.12.0 adds the #109 clamp, wire-identical for every corpus declaration — all step counts sit far below 2^23).

## Why this is not just one-audited-home

The folds-to-zero premise for C++ is true on the reads and on `probearray` — and false on the dense write path, which the ledger already recorded (`cpp real_packet write O3 partial:2`). Disassembly of the bench binary shows clang keeping `serialize_compressed_float_internal<WriteStream>` out of line in `bench_message<RealPacket>` (14 `bl` sites), so each compressed-float write pays the divide, the clamp, the ceil and the `bits_required` per call at runtime. The precomputed callee drops the derivation; the call sites pass immediates. `bench_message<RealPacket>` is the only timed body whose machine code changes — every other message compiles both spellings to identical code.

## Differential (the #79 gate)

- `testdata/wire` untouched; `schema_test`, `schema_test_random` (2000 round-trip iterations), `schema_test_ludicrous`, `schema_test_bench` (real_packet 204 B pin) and `schema_test_variant` all green against the baseline-pinned goldens — the full corpus, byte-identical.
- A dedicated #79-shape differential drives BOTH generated spellings — literals extracted mechanically from the baseline and variant generated trees, paired per call site — over the 11 distinct declarations behind all 24 sites: params pin against `serialize_compressed_float_params`, measured bits, wire bytes, decoded float32 bit patterns, dense sweeps with overshoot, bounds ±8 ulps, specials (NaN, ±Inf, subnormals, ±FLT_MAX), quantum midpoints with ulp neighbours, 200k random bit patterns per declaration, and the exhaustive read side through the full width including headroom. **13,556,238 checks, 0 failures**, at `-ffp-contract=off`, `-ffp-contract=on` (the discriminating mode per the #82 C++ leg) and default `-O3`.
- Falsified before trusted: a one-ulp `delta` perturbation goes red (223,507 failures, first at the family's one-ulp decode class `0x41200000` vs `0x41200002`); `bits+1` goes red (404,056 failures, and the params pin names it directly).

## Bench (bench/README.md + BENCH-STANDARD.md)

M-series MacBook, run.sh's exact Release flags (`-O3 -DNDEBUG -DSERIALIZE_RELEASE -ffp-contract=off`, serialize v1.12.0), 6 interleaved A/B rounds, each the runner's own 1 warmup + 7 measured runs; §2.2 headline = best, median beside it. Full table in the round CSVs; the compressed-float-carrying rows:

| row | base best | adopted best | Δ best | base med | adopted med | Δ med |
|---|---|---|---|---|---|---|
| **real_packet write** | 25.13M | **27.27M** | **+8.5%** | 24.36M | **26.76M** | **+9.9%** |
| real_packet read | 34.65M | 34.63M | −0.1% | 34.02M | 33.29M | −2.2% |
| probearray write | 96.14M | 95.74M | −0.4% | 92.57M | 94.18M | +1.7% |
| probearray read | 184.98M | 184.91M | −0.0% | 179.22M | 178.20M | −0.6% |
| testdata write | 55.85M | 54.75M | −2.0% | 53.93M | 53.23M | −1.3% |
| testdata read | 90.18M | 87.96M | −2.5% | 86.79M | 84.70M | −2.4% |
| message_batch write | 192.88M | 193.79M | +0.5% | 187.59M | 189.25M | +0.9% |
| message_batch read | 195.62M | 194.87M | −0.4% | 190.40M | 185.74M | −2.4% |

28 control (non-compressed-float) rows: median Δ −0.13%, spread −2.4%..+1.8% — the testdata/message_batch wobbles sit inside that band, and their machine code is provably unchanged. `real_packet` write improved **+7.8%..+9.9% in every individual round**. Honest caveats: shared desktop box, no pinning (macOS), and rounds 2–5 overlapped another agent's C-leg bench pass on the same machine — round 1, which predates the contention, shows +9.0%.

Gates run locally: the five cpp legs above, `go test ./...` (goldens re-pinned deliberately: only the cpp source goldens move — `generated/cpp`, `generated/bench/cpp`, `testdata/golden/{union,variant}/WireWire.h`). Wire bytes and protocol id unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)