### PR TITLE
schema#82 cs: compressed floats adopt the precomputed entry point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           SERIALIZE_C_TAG: v1.4.0
           SERIALIZE_GO_TAG: v1.11.0
           SERIALIZE_RS_TAG: v2.1.2
-          SERIALIZE_CS_TAG: v1.4.0
+          SERIALIZE_CS_TAG: v1.5.0
           SERIALIZE_JS_TAG: v1.1.0
         run: |
           cd ..

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -340,7 +340,7 @@ namespace Realworld
             }
             {
                 float compressedValue = value.F004Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 2000.0f, 0.1f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 20000u, 15, 2000.0f, 0.0f))
                 {
                     return false;
                 }
@@ -487,7 +487,7 @@ namespace Realworld
             }
             {
                 float compressedValue = value.F027Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, -2.0f, 2.0f, 0.25f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 16u, 5, 4.0f, -2.0f))
                 {
                     return false;
                 }
@@ -712,7 +712,7 @@ namespace Realworld
             }
             {
                 float compressedValue = value.F061Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, -90.0f, 90.0f, 0.5f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 360u, 9, 180.0f, -90.0f))
                 {
                     return false;
                 }
@@ -748,7 +748,7 @@ namespace Realworld
             }
             {
                 float compressedValue = value.F065Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 30.0f, 0.5f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 60u, 6, 30.0f, 0.0f))
                 {
                     return false;
                 }
@@ -759,14 +759,14 @@ namespace Realworld
             }
             {
                 float compressedValue = value.F067Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, -100.0f, 100.0f, 0.25f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 800u, 10, 200.0f, -100.0f))
                 {
                     return false;
                 }
             }
             {
                 float compressedValue = value.F068Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 2000.0f, 1.0f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 2000u, 11, 2000.0f, 0.0f))
                 {
                     return false;
                 }
@@ -788,14 +788,14 @@ namespace Realworld
             }
             {
                 float compressedValue = value.F071Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 10.0f, 0.02f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 500u, 9, 10.0f, 0.0f))
                 {
                     return false;
                 }
             }
             {
                 float compressedValue = value.F072Cf32;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 100.0f, 0.01f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 10000u, 14, 100.0f, 0.0f))
                 {
                     return false;
                 }
@@ -998,7 +998,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F004Cf32, 0.0f, 2000.0f, 0.1f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F004Cf32, 20000u, 15, 2000.0f, 0.0f))
             {
                 return false;
             }
@@ -1129,7 +1129,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F027Cf32, -2.0f, 2.0f, 0.25f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F027Cf32, 16u, 5, 4.0f, -2.0f))
             {
                 return false;
             }
@@ -1329,7 +1329,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F061Cf32, -90.0f, 90.0f, 0.5f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F061Cf32, 360u, 9, 180.0f, -90.0f))
             {
                 return false;
             }
@@ -1357,7 +1357,7 @@ namespace Realworld
                 }
                 value.F064Uint = (ushort)rangeValue;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F065Cf32, 0.0f, 30.0f, 0.5f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F065Cf32, 60u, 6, 30.0f, 0.0f))
             {
                 return false;
             }
@@ -1365,11 +1365,11 @@ namespace Realworld
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F067Cf32, -100.0f, 100.0f, 0.25f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F067Cf32, 800u, 10, 200.0f, -100.0f))
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F068Cf32, 0.0f, 2000.0f, 1.0f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F068Cf32, 2000u, 11, 2000.0f, 0.0f))
             {
                 return false;
             }
@@ -1385,11 +1385,11 @@ namespace Realworld
                 }
                 value.F070Uint = (byte)rangeValue;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F071Cf32, 0.0f, 10.0f, 0.02f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F071Cf32, 500u, 9, 10.0f, 0.0f))
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.F072Cf32, 0.0f, 100.0f, 0.01f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.F072Cf32, 10000u, 14, 100.0f, 0.0f))
             {
                 return false;
             }

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -434,7 +434,7 @@ namespace Example
             }
             {
                 float compressedValue = value.Orientation;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, -180.0f, 180.0f, 0.01f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 36000u, 16, 360.0f, -180.0f))
                 {
                     return false;
                 }
@@ -530,7 +530,7 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.Orientation, -180.0f, 180.0f, 0.01f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.Orientation, 36000u, 16, 360.0f, -180.0f))
             {
                 return false;
             }
@@ -989,7 +989,7 @@ namespace Example
             }
             {
                 float compressedValue = value.CompressedFloatValue;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 10.0f, 0.01f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
                 {
                     return false;
                 }
@@ -1135,7 +1135,7 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.CompressedFloatValue, 0.0f, 10.0f, 0.01f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.CompressedFloatValue, 1000u, 10, 10.0f, 0.0f))
             {
                 return false;
             }
@@ -1254,14 +1254,14 @@ namespace Example
         {
             {
                 float compressedValue = value.Boundary;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 10.0f, 0.01f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
                 {
                     return false;
                 }
             }
             {
                 float compressedValue = value.Offset;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, -5.0f, 5.0f, 0.001f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 10000u, 14, 10.0f, -5.0f))
                 {
                     return false;
                 }
@@ -1283,11 +1283,11 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadCompressedProbeBatch(ref ReadBatch batch, CompressedProbe value)
         {
-            if (!batch.SerializeCompressedFloat(ref value.Boundary, 0.0f, 10.0f, 0.01f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.Boundary, 1000u, 10, 10.0f, 0.0f))
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.Offset, -5.0f, 5.0f, 0.001f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.Offset, 10000u, 14, 10.0f, -5.0f))
             {
                 return false;
             }

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -560,10 +560,13 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		g.call(ind, fmt.Sprintf("%s.SerializeBool(ref %s)", g.rv(), name), "")
 	case ir.TFloat32:
 		if f.HasFloatRange {
+			steps, wireBits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
+			min32 := float32(f.FMin)
+			delta := float32(f.FMax) - min32
 			// a temp so the wire quantization cannot write back into the input
 			g.sf("%s{\n%s    float compressedValue = %s;\n", ind, ind, name)
-			g.call(ind+"    ", fmt.Sprintf("%s.SerializeCompressedFloat(ref compressedValue, %s, %s, %s)",
-				g.rv(), formatFloat32(f.FMin), formatFloat32(f.FMax), formatFloat32(f.Resolution)), "")
+			g.call(ind+"    ", fmt.Sprintf("%s.SerializeCompressedFloatPrecomputed(ref compressedValue, %du, %d, %s, %s)",
+				g.rv(), steps, wireBits, formatFloat32(float64(delta)), formatFloat32(float64(min32))), "")
 			g.sf("%s}\n", ind)
 			return
 		}
@@ -809,8 +812,11 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 		g.call(ind, fmt.Sprintf("%s.SerializeBool(ref %s)", g.rv(), name), "")
 	case ir.TFloat32:
 		if f.HasFloatRange {
-			g.call(ind, fmt.Sprintf("%s.SerializeCompressedFloat(ref %s, %s, %s, %s)",
-				g.rv(), name, formatFloat32(f.FMin), formatFloat32(f.FMax), formatFloat32(f.Resolution)), "")
+			steps, wireBits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
+			min32 := float32(f.FMin)
+			delta := float32(f.FMax) - min32
+			g.call(ind, fmt.Sprintf("%s.SerializeCompressedFloatPrecomputed(ref %s, %du, %d, %s, %s)",
+				g.rv(), name, steps, wireBits, formatFloat32(float64(delta)), formatFloat32(float64(min32))), "")
 			return
 		}
 		g.call(ind, fmt.Sprintf("%s.SerializeFloat(ref %s)", g.rv(), name), "")

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -434,7 +434,7 @@ namespace Example
             }
             {
                 float compressedValue = value.Orientation;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, -180.0f, 180.0f, 0.01f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 36000u, 16, 360.0f, -180.0f))
                 {
                     return false;
                 }
@@ -530,7 +530,7 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.Orientation, -180.0f, 180.0f, 0.01f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.Orientation, 36000u, 16, 360.0f, -180.0f))
             {
                 return false;
             }
@@ -989,7 +989,7 @@ namespace Example
             }
             {
                 float compressedValue = value.CompressedFloatValue;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 10.0f, 0.01f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
                 {
                     return false;
                 }
@@ -1135,7 +1135,7 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.CompressedFloatValue, 0.0f, 10.0f, 0.01f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.CompressedFloatValue, 1000u, 10, 10.0f, 0.0f))
             {
                 return false;
             }
@@ -1254,14 +1254,14 @@ namespace Example
         {
             {
                 float compressedValue = value.Boundary;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, 0.0f, 10.0f, 0.01f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
                 {
                     return false;
                 }
             }
             {
                 float compressedValue = value.Offset;
-                if (!batch.SerializeCompressedFloat(ref compressedValue, -5.0f, 5.0f, 0.001f))
+                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 10000u, 14, 10.0f, -5.0f))
                 {
                     return false;
                 }
@@ -1283,11 +1283,11 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadCompressedProbeBatch(ref ReadBatch batch, CompressedProbe value)
         {
-            if (!batch.SerializeCompressedFloat(ref value.Boundary, 0.0f, 10.0f, 0.01f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.Boundary, 1000u, 10, 10.0f, 0.0f))
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloat(ref value.Offset, -5.0f, 5.0f, 0.001f))
+            if (!batch.SerializeCompressedFloatPrecomputed(ref value.Offset, 10000u, 14, 10.0f, -5.0f))
             {
                 return false;
             }


### PR DESCRIPTION
The emitter half of #82 for the cs backend. Both compressed-float call sites switch from `SerializeCompressedFloat(ref v, min, max, resolution)` to `SerializeCompressedFloatPrecomputed(ref v, maxIntegerValue, bits, delta, min)`, with the four literals computed at generation time by `ir.CompressedFloatParams` — the same helper `internal/pack`, the JS flat backend, the Go fold (#79) and the cpp adoption (#114) already emit from, and exactly the four scalars the adoption spec in the #82 thread names. CI's serialize.cs pin moves v1.4.0 → v1.5.0 (the entry point shipped in 1.5.0 on all five stream/batch surfaces; the #109 clamp and #20 decode guard sit on serialize.cs main past 1.5.0, unreleased, wire-identical for every corpus declaration — all step counts far below 2^23).

## The JIT verdict, answered on the generated path

The #82 thread's serialize.cs-side measurement said: at a literal inlined call site RyuJIT constant-folds the whole derivation and the two spellings tie. Reconfirmed here — the FullOpts bodies of the generated units carry **zero `frintp`/`clz` in either spelling**, and the two inlined real_packet quantizes fold their constants identically.

What that measurement could not see, and this one does: **on the generated batch path the call does not always inline, and there the spellings are not equivalent.** `DOTNET_JitDisasmSummary` on the bench, both builds:

| | derive-per-call (base) | precomputed (adopted) |
|---|---|---|
| `WriteBatch` callee | IL 35, 448 B code | IL 22, 360 B code |
| `ReadBatch` callee | IL 55, 484 B code | IL 42, 392 B code |

The derive spelling drags `CompressedFloatParams` (IL 64) into every inline attempt; the precomputed spelling deletes the derivation. At tier 1 under dynamic PGO that IL difference crosses the inline threshold on the testdata read path: `ReadTestData` goes 8104 B / 11 out-of-line calls (base) → 5800 B / 9 (adopted). And a non-inlined call taking the batch by ref **address-exposes the batch and enregistration dies** — this repo's own measured doctrine — so the un-inlined derive call taxed every field of the message. In the FullOpts real_packet write body, 6 of the 8 compressed-float sites are out-of-line calls in both builds: base pays the derivation (fdiv + ceiling + BitsRequired) inside the callee per call, adopted's callee starts at the quantize.

## Differential (the #79 gate)

- `testdata/wire` untouched; `test/cs` and `test/cs-ludicrous` byte-compare green; the bench runner's golden gate passes with the **identical corpus_id (`7a7c343f1a446f4c`)** on both trees — the full corpus, byte-identical.
- A #79-shape differential drives BOTH spellings — literals extracted mechanically from the baseline and adopted generated trees, paired per call site — over the 11 distinct declarations behind all 24 generated call sites, on the stream AND batch surfaces, write/read/measure: params pin against `SerializeUtil.CompressedFloatParams` (bit-exact on delta and min), `BitsProcessed`, wire bytes, decoded float32 bit patterns, dense sweeps with overshoot, quantum midpoints ± 1 ulp, bounds ± 8 ulps, zeros/subnormals/±MaxValue, specials (NaN, ±Inf — Release, where the debug intake's non-finite assert permits them), 200k seeded-LCG bit patterns per declaration, and the exhaustive read side through the full width including headroom. **27,637,739 checks Release / 27,552,439 Debug (asserts live), 0 failures** — and the same 27,637,739 / 0 rebuilt against a **v1.5.0 checkout** of the runtime (the pin this PR sets).
- Falsified before trusted: one-ulp `delta` goes red (**3,225,883 failures**, params pin naming it, first value divergence in the family's one-ulp decode class); `bits+1` goes red (**6,575,947 failures**, params pin naming it, carried by the `BitsProcessed` and measure compares — on a single-field buffer the wire bytes alone are blind to the trailing zero bit, the gap the #82 thread's C# adversarial pass documented).

## Bench (bench/README.md + BENCH-STANDARD.md)

M3 Ultra, macOS, dotnet 10.0.400, runner defaults per run.sh (workstation GC, default tiering), serialize.cs main `17e9255`; 8 clean interleaved A/B rounds (§2.4 `--round K`, order alternating per round), each side one warmup + one measured run per round; §2.2 headline = best, median beside. Two earlier rounds were discarded whole for overlapping a JitDisasm pass on the same box (the §2 contamination rule). Compressed-float-carrying gen rows:

| row | base best | adopted best | Δ best | base med | adopted med | Δ med |
|---|---|---|---|---|---|---|
| **testdata read** | 17.30M | **26.04M** | **+50.5%** | 16.47M | **25.36M** | **+54.0%** |
| real_packet write | 4.32M | 4.51M | +4.4% | 4.15M | 4.18M | +0.9% |
| probearray read | 53.66M | 56.56M | +5.4% | 51.88M | 52.66M | +1.5% |
| probearray write | 53.61M | 54.74M | +2.1% | 52.57M | 52.58M | +0.0% |
| testdata write | 20.87M | 20.03M | −4.0% | 20.16M | 19.02M | −5.7% |
| real_packet read | 4.39M | 4.38M | −0.2% | 4.18M | 4.10M | −1.9% |
| message_batch write | 156.73M | 154.48M | −1.4% | 147.24M | 145.18M | −1.4% |
| message_batch read | 68.43M | 68.40M | −0.0% | 64.76M | 63.94M | −1.3% |

testdata read improved **+44..+58% in every individual round**, and is the row the tier-1 disasm above attributes. Reported against the change, not hidden: **testdata write −4.0% best / −5.7% median** and real_packet read −1.9% median. Both sit inside the same sitting's unchanged-code control band — the rt/bits rows, whose machine code is identical in both builds, moved **−2.7..+7.3% median** — and the FullOpts testdata write bodies differ only in register allocation, so per the house rule these are filed as unattributed movement rather than claimed either way. Banked-prediction honesty: the small write-side win was predicted; the +54% read was **not** (banked ceiling +10%) — a wrong-magnitude refutation in the favorable direction, reported as such.

Even read as a strict tie outside testdata read, the adoption stands on the issue's stated why: one audited home for the quantization arithmetic, and the tie rule prefers the Pre call.

Gates run locally: `test/cs`, `test/cs-ludicrous`, bench runner golden gate both trees, `go test ./...` (cs source goldens re-pinned deliberately — only `generated/cs/Wire.cs`, `generated/bench/cs/realworld/RealWorld.cs`, `testdata/golden/cs/Wire.cs` move), `go vet`/`gofmt` on the emitter, and the adopted trees compile against the v1.5.0 pin (`-property:SerializeCsRoot`). Wire bytes and protocol id unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
