### PR TITLE
The CLI goes quiet by default: success prints nothing, --verbose lists the files

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1434,17 +1434,23 @@ JavaScript's is serialize.js's.
 Go, zero third-party dependencies, one static binary: `schema`.
 
 ```
-schema check      [dir|files...]          // parse + typecheck; exit code for CI
+schema check      [--verbose] [dir|files...]   // parse + typecheck; exit code for CI
 schema generate   [--lang c|cpp|cs|go|js|rust] [--cpp-message union|variant]
-                  [--out <dir>] [dir|files...]
+                  [--out <dir>] [--verbose] [dir|files...]
 schema id         [dir|files...]          // print the protocol id
 schema projection [dir|files...]          // print the wire shape projection (§3.1)
-schema fmt        [dir|files...]          // the canonical formatter, standalone (editors, hooks)
-schema pack       <manifest.json>         // the data compiler: JSON instance files -> a
+schema fmt        [--verbose] [dir|files...]   // the canonical formatter, standalone (editors, hooks)
+schema pack       [--verbose] <manifest.json>  // the data compiler: JSON instance files -> a
                                           // versioned, hashed .bin per the manifest's
                                           // ordered collections (§4.11)
 schema version
 ```
+
+Success is silent. Commands whose printed output is their answer (`id`,
+`projection`, `version`) print it; everything else prints nothing unless
+`--verbose` asks for the per-file report — the files `generate` and `pack`
+wrote, the files the formatter rewrote, `check`'s ok line. Errors and
+diagnostics always reach stderr, and exit codes do not depend on verbosity.
 
 **Every command formats the unit's schema files in place before processing
 them.** One style, no options, no separate binary; a file already in format

--- a/USAGE.md
+++ b/USAGE.md
@@ -57,6 +57,11 @@ Generate:
 schema generate --lang cpp --out generated/cpp .
 ```
 
+Success is silent — the files land in the output directory and nothing is
+printed, so a build wrapping this command stays clean. Add `--verbose` to
+list every file written (`check`, `fmt` and `pack` take the same flag).
+Errors always print, whatever the verbosity.
+
 You get a struct and a pair of wire functions:
 
 ```cpp

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -29,11 +29,17 @@ func main() {
 		os.Exit(2)
 	}
 	// The CLI's load policy: every command formats the unit's files in place
-	// before processing them (schemafmt, SPEC §7.4), announcing the ones it
-	// rewrote.
+	// before processing them (schemafmt, SPEC §7.4). Success is silent —
+	// --verbose announces the files a command rewrote or emitted; errors
+	// always reach stderr.
 	c := compiler.New()
 	c.FormatInPlace = true
-	c.OnFormat = func(path string) { fmt.Printf("formatted %s\n", path) }
+	verbose := false // set by each subcommand's --verbose flag before any file is loaded
+	c.OnFormat = func(path string) {
+		if verbose {
+			fmt.Printf("formatted %s\n", path)
+		}
+	}
 
 	switch os.Args[1] {
 	// Accept every spelling a newcomer will try. `--version` costs nothing to
@@ -43,8 +49,13 @@ func main() {
 	case "help", "--help", "-help", "-h":
 		usage()
 	case "check":
-		unit := loadUnit(c, os.Args[2:])
-		fmt.Printf("ok: package %s, protocol id 0x%016x\n", unit.Package, unit.ProtocolId)
+		fs := flag.NewFlagSet("check", flag.ExitOnError)
+		fs.BoolVar(&verbose, "verbose", false, "report the package and protocol id on success")
+		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
+		unit := loadUnit(c, fs.Args())
+		if verbose {
+			fmt.Printf("ok: package %s, protocol id 0x%016x\n", unit.Package, unit.ProtocolId)
+		}
 	case "id":
 		unit := loadUnit(c, os.Args[2:])
 		fmt.Printf("0x%016x\n", unit.ProtocolId)
@@ -57,7 +68,10 @@ func main() {
 	case "fmt":
 		// standalone formatting; check/generate/id already format before
 		// processing, so this exists for editors and pre-commit hooks
-		paths, err := compiler.GatherPaths(os.Args[2:])
+		fs := flag.NewFlagSet("fmt", flag.ExitOnError)
+		fs.BoolVar(&verbose, "verbose", false, "list the files rewritten")
+		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
+		paths, err := compiler.GatherPaths(fs.Args())
 		if err != nil {
 			fail(err)
 		}
@@ -66,7 +80,7 @@ func main() {
 			if err != nil {
 				fail(err)
 			}
-			if rewrote {
+			if rewrote && verbose {
 				fmt.Printf("formatted %s\n", p)
 			}
 		}
@@ -75,6 +89,7 @@ func main() {
 		lang := fs.String("lang", "cpp", "target language (c, cpp, cs, go, js, rust)")
 		out := fs.String("out", "generated", "output directory")
 		cppMessage := fs.String("cpp-message", "union", "C++ message representation: union (default) or variant")
+		fs.BoolVar(&verbose, "verbose", false, "list the files emitted")
 		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
 		unit := loadUnit(c, fs.Args())
 		files, err := c.Generate(unit, *lang, compiler.Options{"cpp-message": *cppMessage})
@@ -94,13 +109,18 @@ func main() {
 			if err := os.WriteFile(path, files[n], 0o644); err != nil {
 				fatalf("%v", err)
 			}
-			fmt.Printf("wrote %s\n", path)
+			if verbose {
+				fmt.Printf("wrote %s\n", path)
+			}
 		}
 	case "pack":
-		if len(os.Args) != 3 {
-			fatalf("usage: schema pack <manifest.json>")
+		fs := flag.NewFlagSet("pack", flag.ExitOnError)
+		fs.BoolVar(&verbose, "verbose", false, "report each artifact written")
+		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
+		if fs.NArg() != 1 {
+			fatalf("usage: schema pack [--verbose] <manifest.json>")
 		}
-		unit, outputs, err := c.Pack(os.Args[2])
+		unit, outputs, err := c.Pack(fs.Arg(0))
 		if err != nil {
 			fail(err)
 		}
@@ -108,8 +128,10 @@ func main() {
 			if err := os.WriteFile(o.File, o.Bytes, 0o644); err != nil {
 				fatalf("%v", err)
 			}
-			fmt.Printf("wrote %s (%d bytes, protocol id 0x%016x, content hash 0x%016x)\n",
-				o.File, len(o.Bytes), unit.ProtocolId, o.ContentHash)
+			if verbose {
+				fmt.Printf("wrote %s (%d bytes, protocol id 0x%016x, content hash 0x%016x)\n",
+					o.File, len(o.Bytes), unit.ProtocolId, o.ContentHash)
+			}
 		}
 	default:
 		usage()
@@ -119,16 +141,17 @@ func main() {
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `usage:
-  schema check      [dir|files...]
-  schema generate   [--lang c|cpp|cs|go|js|rust] [--cpp-message union|variant] [--out generated] [dir|files...]
+  schema check      [--verbose] [dir|files...]
+  schema generate   [--lang c|cpp|cs|go|js|rust] [--cpp-message union|variant] [--out generated] [--verbose] [dir|files...]
   schema id         [dir|files...]
   schema projection [dir|files...]
-  schema fmt        [dir|files...]
-  schema pack       <manifest.json>
+  schema fmt        [--verbose] [dir|files...]
+  schema pack       [--verbose] <manifest.json>
   schema version
 
 Every command formats the unit's schema files in place before processing them
 (schemafmt — one style, no options); a file already in format is not touched.
+Success is silent: --verbose lists the files a command wrote or reformatted.
 pack is the data compiler: JSON instance files -> a versioned, hashed .bin,
 per the manifest's ordered collections (the table layer's transition form).
 `)

--- a/internal/publicapi/publicapi_test.go
+++ b/internal/publicapi/publicapi_test.go
@@ -120,14 +120,19 @@ func TestExternalModuleBuildsTheCLI(t *testing.T) {
 	goBuild(t, clientDir, external)
 
 	// the reporting commands: identical text, including the protocol id and
-	// the projection the id hashes.
+	// the projection the id hashes. check is silent on success (its answer is
+	// the exit code); --verbose restores its ok line, so both shapes run.
 	for _, corpus := range []string{corpusDir, corpus128Dir} {
-		for _, verb := range []string{"check", "id", "projection"} {
-			want := run(t, inRepo, verb, corpus)
-			got := run(t, external, verb, corpus)
+		for _, verb := range [][]string{{"check"}, {"check", "--verbose"}, {"id"}, {"projection"}} {
+			args := append(append([]string{}, verb...), corpus)
+			want := run(t, inRepo, args...)
+			got := run(t, external, args...)
 			if got != want {
-				t.Errorf("%s %s diverged\n in-repo: %q\nexternal: %q", verb, corpus, want, got)
+				t.Errorf("%s %s diverged\n in-repo: %q\nexternal: %q", strings.Join(verb, " "), corpus, want, got)
 			}
+		}
+		if out := run(t, inRepo, "check", corpus); out != "" {
+			t.Errorf("check %s: success is silent by default, printed %q", corpus, out)
 		}
 	}
 
@@ -165,13 +170,31 @@ func TestExternalModuleBuildsTheCLI(t *testing.T) {
 	for _, c := range cases {
 		wantDir := filepath.Join(work, "want", c.name)
 		gotDir := filepath.Join(work, "got", c.name)
-		run(t, inRepo, generateArgs(c, wantDir)...)
-		run(t, external, generateArgs(c, gotDir)...)
+		if out := run(t, inRepo, generateArgs(c, wantDir)...); out != "" {
+			t.Errorf("%s: generate is silent on success by default, printed %q", c.name, out)
+		}
+		if out := run(t, external, generateArgs(c, gotDir)...); out != "" {
+			t.Errorf("%s: generate is silent on success by default (external build), printed %q", c.name, out)
+		}
 		compareTrees(t, c.name, wantDir, gotDir)
 	}
 
+	// --verbose restores the per-file report, identically on both sides (the
+	// output directories differ per run, so they are normalized out).
+	wantVDir := filepath.Join(work, "want-verbose")
+	gotVDir := filepath.Join(work, "got-verbose")
+	wantV := strings.ReplaceAll(run(t, inRepo, "generate", "--lang", "cpp", "--out", wantVDir, "--verbose", corpusDir), wantVDir, "<out>")
+	gotV := strings.ReplaceAll(run(t, external, "generate", "--lang", "cpp", "--out", gotVDir, "--verbose", corpusDir), gotVDir, "<out>")
+	if gotV != wantV {
+		t.Errorf("generate --verbose diverged\n in-repo: %q\nexternal: %q", wantV, gotV)
+	}
+	if !strings.Contains(wantV, "wrote ") {
+		t.Errorf("generate --verbose did not list the emitted files: %q", wantV)
+	}
+
 	// the data compiler: same manifest, same instance, same container bytes —
-	// down to the content hash the two builds print.
+	// down to the content hash the two builds print under --verbose (the
+	// default is silent, checked below).
 	wantBin, wantLine := runPack(t, inRepo, filepath.Join(work, "pack-want"), root)
 	gotBin, gotLine := runPack(t, external, filepath.Join(work, "pack-got"), root)
 	if !bytes.Equal(wantBin, gotBin) {
@@ -221,7 +244,10 @@ func runPack(t *testing.T, bin, dir, root string) ([]byte, string) {
 	if err := os.WriteFile(filepath.Join(dir, "probe.json"), []byte(packInstance), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	report := strings.ReplaceAll(run(t, bin, "pack", manifest), dir, "<dir>")
+	if out := run(t, bin, "pack", manifest); out != "" {
+		t.Errorf("pack: success is silent by default, printed %q", out)
+	}
+	report := strings.ReplaceAll(run(t, bin, "pack", "--verbose", manifest), dir, "<dir>")
 	data, err := os.ReadFile(filepath.Join(dir, "probes.bin"))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Success is silent across the CLI: `generate` and `pack` no longer print a line per file written, the in-place formatter no longer announces the files it rewrote, and `check` no longer prints its ok line. A new `--verbose` flag on `check`, `generate`, `fmt` and `pack` restores the per-file report. Commands whose printed output is their answer (`id`, `projection`, `version`) are unchanged, errors and diagnostics still reach stderr, and exit codes do not depend on verbosity.

The compiler library API is untouched — this is CLI policy, held where CLI policy lives (`cmd/schema`). The publicapi gate pins the new shape: default `generate`, `pack` and `check` runs must print nothing, and `--verbose` must produce the identical per-file report from both sides of the module boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)