### PR TITLE
Bare float consts infer float64 in every target (#120)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -335,7 +335,12 @@ FloatExpr   = float expression over float literals, int literals and const names
   arithmetic, fit-checked at each use) or float (float64 arithmetic; `+ - *
   /` and parentheses, no `%`) — and converts wherever that kind fits: integer
   constants in any range, bound, width, case label or float position; float
-  constants in float attribute values and float contexts. An **explicit type
+  constants in float attribute values and float contexts. The kind follows
+  Go's literal rule: a literal containing a decimal point or an exponent is a
+  float literal, so a bare `const` whose expression contains a float literal
+  or references a float constant **infers `float64`** — `const Rate = 1.5`
+  exports in every target exactly as `const Rate float64 = 1.5` would; a bare
+  integer expression infers `int64` storage as before. An **explicit type
   makes a typed constant** — `const MaxBounds uint64 = 12000` — which pins
   the exported type in every target.
 - **Enum max references:** **`E.Max`** in any integer expression names enum

--- a/USAGE.md
+++ b/USAGE.md
@@ -87,15 +87,17 @@ Run the same command with `--lang cs`, `--lang go`, `--lang js` or
 
 ```
 const MaxHealth = 1000
-const Pi float64 = 3.14159265359
+const TickInterval = 1.5
+const Pi float32 = 3.14159265359
 ```
 
 Constants are exported into every generated language, so the bound you
 declared is the bound your code compares against — no second copy to drift.
 They may reference each other in any order, across files.
 
-An untyped constant takes the type its use needs. Name a type explicitly
-when you care.
+An untyped constant infers its type from its expression, Go's rule: a
+literal with a decimal point or exponent makes it `float64`, a bare integer
+makes it `int64`. Name a type explicitly when you want a different one.
 
 ### enum
 

--- a/examples/Wire.schema
+++ b/examples/Wire.schema
@@ -6,10 +6,12 @@
 package example
 
 // typed constants pin their exported type in every target (SPEC §4.2);
-// float constants exist since the integer-only note was retired
+// a bare const with a float literal infers float64 — Go's rule: a decimal
+// point or exponent in the literal makes it float
 const ProbeId uint64   = 0xDEADBEEFCAFE
 const HalfTurn float64 = 180.0
 const TickRate float32 = 60.0
+const SpinRate         = 1.5
 
 // enum headroom: the wire range is [0, 15] whatever the variant count, and
 // non-variant values are wire-legal (SPEC §4.2, §6.1)

--- a/generated/c/Wire.h
+++ b/generated/c/Wire.h
@@ -27,6 +27,7 @@ extern "C" {
 #define PROBE_ID (0xDEADBEEFCAFE)
 #define HALF_TURN 180.0
 #define TICK_RATE 60.0
+#define SPIN_RATE 1.5
 
 /* enum Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying

--- a/generated/cpp/Wire.h
+++ b/generated/cpp/Wire.h
@@ -15,6 +15,7 @@ namespace example {
 inline constexpr uint64_t ProbeId = 0xDEADBEEFCAFE;
 inline constexpr double HalfTurn = 180.0;
 inline constexpr float TickRate = 60.0f;
+inline constexpr double SpinRate = 1.5;
 // enum Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2)
 enum class Weapon : uint8_t {
     None = 0,

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -144,6 +144,8 @@ namespace Example
 
         public const float TickRate = 60.0f;
 
+        public const double SpinRate = 1.5;
+
         // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —
         // out-of-set values (wire-legal up to the declared max) name as "???"
         public static string EnumNameWeapon(ulong value)

--- a/generated/go/Wire.go
+++ b/generated/go/Wire.go
@@ -13,6 +13,8 @@ const HalfTurn float64 = 180.0
 
 const TickRate float32 = 60.0
 
+const SpinRate float64 = 1.5
+
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2)
 type Weapon uint8
 

--- a/generated/js/Wire.js
+++ b/generated/js/Wire.js
@@ -29,6 +29,8 @@ export const HalfTurn = 180.0;
 
 export const TickRate = 60.0;
 
+export const SpinRate = 1.5;
+
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
 // integer-backed enums; [max = ...] headroom values are plain Numbers

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -10,6 +10,8 @@ pub const HALF_TURN: f64 = 180.0;
 
 pub const TICK_RATE: f32 = 60.0;
 
+pub const SPIN_RATE: f64 = 1.5;
+
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
 // a newtype because [max = ...] headroom makes non-variant values wire-legal
 #[repr(transparent)]

--- a/internal/check/projection_test.go
+++ b/internal/check/projection_test.go
@@ -80,6 +80,27 @@ func TestIdIsStableUnderNonWireEdits(t *testing.T) {
 	}
 }
 
+// Float const inference is id-neutral (SPEC §4.2, issue #120): a bare float
+// const infers float64, so dropping the annotation resolves to the same
+// value reaching the same wire facts — the id must not move in either
+// direction, whether the const feeds an attribute or sits unused.
+func TestIdIsStableUnderFloatConstAnnotation(t *testing.T) {
+	const annotated = `package probe
+
+const Half float64 = 180.0
+
+type Sample {
+    orientation float32 [min = -Half, max = Half, resolution = 0.01]
+}
+`
+	bare := strings.Replace(annotated, "const Half float64 = 180.0", "const Half = 180.0", 1)
+	a := build(t, annotated).ProtocolId
+	b := build(t, bare).ProtocolId
+	if a != b {
+		t.Errorf("removing a float const's annotation moved the protocol id (0x%016x -> 0x%016x); the inferred type is the annotated type and no wire byte changed", a, b)
+	}
+}
+
 // The other direction, and the one that must never regress: an edit that DOES
 // move bytes must move the id. A missed case here is two incompatible builds
 // claiming compatibility.

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -206,16 +206,20 @@ func (g *gen) emitTagEnum(name string, members []string, comment string) {
 	g.pf(")\n\n")
 }
 
-// emitConst emits a bare schema const as an UNTYPED Go constant — usable as an
-// array length, a wire argument, anything — and an explicitly-typed schema
-// const as a typed one (the declared type pins the exported type, SPEC §4.2).
+// emitConst emits a bare INTEGER schema const as an UNTYPED Go constant —
+// usable as an array length, a wire argument, anything — and an
+// explicitly-typed schema const as a typed one (the declared type pins the
+// exported type, SPEC §4.2). A FLOAT const is always typed: a bare float
+// const infers float64 (SPEC §4.2, Go's literal rule), and the export must
+// be the same surface the explicit annotation spells — every other target
+// already pins the type either way (issue #120).
 func (g *gen) emitConst(d *ir.Const) {
 	typ := ""
 	if d.Explicit {
 		typ = " " + d.Storage
 	}
 	if d.IsFloat {
-		g.pf("const %s%s = %s%s\n\n", d.Name, typ, formatFloat(d.Float), g.foldComment(d.Expr))
+		g.pf("const %s %s = %s%s\n\n", d.Name, d.Storage, formatFloat(d.Float), g.foldComment(d.Expr))
 		return
 	}
 	g.pf("const %s%s = %s%s\n\n", d.Name, typ, g.renderInt(d.Expr, d.Int), g.foldComment(d.Expr))

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -48,6 +48,39 @@ func countAcross(files map[string][]byte, needle string) int {
 	return n
 }
 
+// A bare float const infers float64 (SPEC §4.2, Go's literal rule): the Go
+// target must export it exactly as the explicit annotation would — a TYPED
+// float64 constant, the same surface every other target already emits
+// (issue #120). An untyped Go constant is a different exported type: it
+// converts where float64 does not, so consumer code written against one
+// form breaks against the other.
+func TestBareFloatConstExportsTypedFloat64(t *testing.T) {
+	src := "package t\n\nconst Bare      = 1.5\nconst Annotated float64 = 1.5\n"
+	f, perrs := parser.Parse("Consts.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "Consts.schema", Name: "Consts.schema", Base: "Consts",
+		Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"const Bare float64 = 1.5",
+		"const Annotated float64 = 1.5",
+	} {
+		if got := countAcross(files, want); got != 1 {
+			t.Errorf("Go: %q emitted %d times — a bare float const must export the same typed float64 the annotation spells", want, got)
+		}
+	}
+}
+
 func TestDispatchSurfaceEmittedOnce(t *testing.T) {
 	u := multiFileUnit(t)
 

--- a/testdata/golden/c/Wire.h
+++ b/testdata/golden/c/Wire.h
@@ -27,6 +27,7 @@ extern "C" {
 #define PROBE_ID (0xDEADBEEFCAFE)
 #define HALF_TURN 180.0
 #define TICK_RATE 60.0
+#define SPIN_RATE 1.5
 
 /* enum Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -144,6 +144,8 @@ namespace Example
 
         public const float TickRate = 60.0f;
 
+        public const double SpinRate = 1.5;
+
         // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —
         // out-of-set values (wire-legal up to the declared max) name as "???"
         public static string EnumNameWeapon(ulong value)

--- a/testdata/golden/go/Wire.go
+++ b/testdata/golden/go/Wire.go
@@ -13,6 +13,8 @@ const HalfTurn float64 = 180.0
 
 const TickRate float32 = 60.0
 
+const SpinRate float64 = 1.5
+
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2)
 type Weapon uint8
 

--- a/testdata/golden/js/Wire.js
+++ b/testdata/golden/js/Wire.js
@@ -29,6 +29,8 @@ export const HalfTurn = 180.0;
 
 export const TickRate = 60.0;
 
+export const SpinRate = 1.5;
+
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
 // integer-backed enums; [max = ...] headroom values are plain Numbers

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -10,6 +10,8 @@ pub const HALF_TURN: f64 = 180.0;
 
 pub const TICK_RATE: f32 = 60.0;
 
+pub const SPIN_RATE: f64 = 1.5;
+
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
 // a newtype because [max = ...] headroom makes non-variant values wire-legal
 #[repr(transparent)]

--- a/testdata/golden/union/Wire.h
+++ b/testdata/golden/union/Wire.h
@@ -15,6 +15,7 @@ namespace example {
 inline constexpr uint64_t ProbeId = 0xDEADBEEFCAFE;
 inline constexpr double HalfTurn = 180.0;
 inline constexpr float TickRate = 60.0f;
+inline constexpr double SpinRate = 1.5;
 // enum Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2)
 enum class Weapon : uint8_t {
     None = 0,

--- a/testdata/golden/variant/Wire.h
+++ b/testdata/golden/variant/Wire.h
@@ -15,6 +15,7 @@ namespace example {
 inline constexpr uint64_t ProbeId = 0xDEADBEEFCAFE;
 inline constexpr double HalfTurn = 180.0;
 inline constexpr float TickRate = 60.0f;
+inline constexpr double SpinRate = 1.5;
 // enum Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2)
 enum class Weapon : uint8_t {
     None = 0,


### PR DESCRIPTION
Closes #120.

Go's rule, now stated in SPEC §4.2's typed-constant passage: a literal containing a decimal point or an exponent makes the constant float64; bare integer literals keep inferring int64 (unchanged); an explicit annotation still pins any type.

The checker already classified kinds this way — the one divergent surface was the Go backend, which exported a bare float const as an UNTYPED Go constant while C, C++, C#, Rust and JS all pinned the inferred type. `const X = 1.5` and `const X float64 = 1.5` now generate identical output in all six targets (verified by diff before the fix for five, and by the new red-first test for Go).

- Red-first: `TestBareFloatConstExportsTypedFloat64` (internal/codegen/golang) failed against the untyped emission, green after.
- Id-neutrality: `TestIdIsStableUnderFloatConstAnnotation` (internal/check) pins that dropping a float const's annotation moves no protocol id, with the const feeding a live attribute bound.
- Corpus: `examples/Wire.schema` gains the bare form (`SpinRate = 1.5`) so every emitter codepath runs it under `make`; goldens gain only the new symbol; `testdata/golden/id.txt` unchanged (0x40230069cc791fab before and after).
- USAGE.md const section teaches the inference rule by example.

Full `make` gauntlet green: all six backends, twelve binaries, wire byte-compares, diagnostics suite, golden pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)