### PR TITLE
Every generated enum surface exports its extent as Max (#121)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -569,6 +569,20 @@ construction, so a fresh struct starts in the null state without any code
 saying so. This is a convention over the corpus and generated-code usage, not
 a language rule — the language does not enforce entry 0's meaning.
 
+**The extent is exported.** Every generated enum surface — each declared
+enum and the generated `MessageType`/`ObjectType` tag enums — carries its
+extent as a member named `Max` in the target's own convention: `E::Max`
+(C++), `E.Max` (C#), `EMax` (Go), `E::MAX` (Rust), `E.Max` (JS), `E_MAX`
+(C). Its value is the enum's max — the same number `E.Max` names in schema
+expressions (§4.2): the highest wire-legal value, which under the
+sentinel-zero convention is the count of real variants when no `[max]`
+headroom widens it. Application code states ranges and asserts directly
+against it (`ShipType`'s wire range is `[0, ShipType.Max]`, its real
+variants `[1, ShipType.Max]`) instead of exporting a hand-declared count
+constant that re-derives it. `Max` is therefore a reserved variant name —
+declaring a variant named `Max` is refused at check time, exactly as `None`
+is.
+
 ### 4.3 Field types and their wire encodings
 
 **The wire model — normative:**

--- a/USAGE.md
+++ b/USAGE.md
@@ -110,12 +110,22 @@ zero-initialized enum field is therefore the null, in band, and you never
 need a separate has-flag beside it:
 
 ```cpp
-enum class ShipType : uint8_t { None = 0, Fighter = 1, Corvette = 2, Bomber = 3 };
+enum class ShipType : uint8_t { None = 0, Fighter = 1, Corvette = 2, Bomber = 3, Max = 3 };
 ```
 
 On the wire it costs `bitsRequired(variant count)` — 2 bits here, for four
 values. Declaring `enum E [max = 15] { ... }` reserves headroom so you can
 add variants later without moving the field width.
+
+The `Max` member is the enum's **extent** — the same number `E.Max` names in
+schema expressions: the highest wire-legal value, and (headroom aside) the
+count of real variants under the sentinel-zero convention. Every target
+spells it its own way — `ShipType::Max` (C++), `ShipType.Max` (C#),
+`ShipTypeMax` (Go), `ShipType::MAX` (Rust), `ShipType.Max` (JS),
+`SHIP_TYPE_MAX` (C) — and the generated `MessageType`/`ObjectType` tag enums
+carry it too, so ranges and asserts reference the enum directly instead of a
+hand-declared count constant. `Max` is consequently reserved as a variant
+name, like `None`.
 
 ### flags
 

--- a/generated/bench/cpp/RealWorld.h
+++ b/generated/bench/cpp/RealWorld.h
@@ -22,6 +22,7 @@ enum class PacketMode : uint8_t {
     Combat = 3,
     Docked = 4,
     Warping = 5,
+    Max = 5, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any PacketMode value, out-of-set included

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -25,6 +25,7 @@ namespace Realworld
         Combat = 3,
         Docked = 4,
         Warping = 5,
+        Max = 5, // the exported extent (SPEC §4.2)
     }
 
     // type RealPacket

--- a/generated/bench/go/realworld/RealWorld.go
+++ b/generated/bench/go/realworld/RealWorld.go
@@ -27,6 +27,7 @@ const (
 	PacketModeCombat  PacketMode = 3
 	PacketModeDocked  PacketMode = 4
 	PacketModeWarping PacketMode = 5
+	PacketModeMax     PacketMode = 5 // the exported extent (SPEC §4.2)
 )
 
 // EnumNamePacketMode: debug/log/tooling name for any PacketMode wire value —

--- a/generated/bench/js/realworld/RealWorld.js
+++ b/generated/bench/js/realworld/RealWorld.js
@@ -35,6 +35,7 @@ export const PacketMode = Object.freeze({
   Combat: 3,
   Docked: 4,
   Warping: 5,
+  Max: 5, // the exported extent (SPEC §4.2)
 });
 
 // EnumNamePacketMode: debug/log/tooling name for any PacketMode wire value —

--- a/generated/bench/rust-realworld/src/realworld.rs
+++ b/generated/bench/rust-realworld/src/realworld.rs
@@ -44,6 +44,7 @@ impl PacketMode {
     pub const COMBAT: PacketMode = PacketMode(3);
     pub const DOCKED: PacketMode = PacketMode(4);
     pub const WARPING: PacketMode = PacketMode(5);
+    pub const MAX: PacketMode = PacketMode(5); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `PacketMode` value, out-of-set included.

--- a/generated/cpp/Enums.h
+++ b/generated/cpp/Enums.h
@@ -15,6 +15,7 @@ enum class Team : uint8_t {
     None = 0,
     Red = 1,
     Blue = 2,
+    Max = 2, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Team value, out-of-set included
@@ -37,6 +38,7 @@ enum class ShipType : uint8_t {
     Bomber = 3,
     Destroyer = 4,
     Carrier = 5,
+    Max = 5, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any ShipType value, out-of-set included
@@ -60,6 +62,7 @@ enum class MissileType : uint8_t {
     Heatseeker = 1,
     Torpedo = 2,
     Nuke = 3,
+    Max = 3, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any MissileType value, out-of-set included
@@ -84,6 +87,7 @@ enum class PropType : uint8_t {
     Sphere = 4,
     BlackHole = 5,
     DysonPanel = 6,
+    Max = 6, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any PropType value, out-of-set included
@@ -105,6 +109,7 @@ inline const char * EnumName( PropType value )
 // enum Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2)
 enum class Pending : uint8_t {
     None = 0,
+    Max = 0, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Pending value, out-of-set included

--- a/generated/cpp/Messages.h
+++ b/generated/cpp/Messages.h
@@ -21,6 +21,7 @@ enum class MessageType : uint8_t {
     Synchronize = 4,
     Test = 5,
     Timescale = 6,
+    Max = 6, // the exported extent (SPEC §4.2)
 };
 
 // message Heartbeat

--- a/generated/cpp/Objects.h
+++ b/generated/cpp/Objects.h
@@ -25,6 +25,7 @@ enum class ObjectType : uint8_t {
     Missile = 2,
     Ship = 3,
     Turret = 4,
+    Max = 4, // the exported extent (SPEC §4.2)
 };
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/generated/cpp/Wire.h
+++ b/generated/cpp/Wire.h
@@ -22,6 +22,7 @@ enum class Weapon : uint8_t {
     Laser = 1,
     Missile = 2,
     Railgun = 3,
+    Max = 15, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Weapon value, out-of-set included

--- a/generated/cpp/ludicrous/Ludicrous.h
+++ b/generated/cpp/ludicrous/Ludicrous.h
@@ -20,6 +20,7 @@ inline constexpr uint64_t ProtocolId = 0xa925c86b46058512ull;
 enum class MessageType : uint8_t {
     None = 0,
     LudicrousState = 1,
+    Max = 1, // the exported extent (SPEC §4.2)
 };
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -27,6 +28,7 @@ enum class ObjectType : uint8_t {
     None = 0,
     Body = 1,
     NarrowBody = 2,
+    Max = 2, // the exported extent (SPEC §4.2)
 };
 
 inline constexpr int64_t MaxWorldUnits = 30000;
@@ -36,6 +38,7 @@ enum class DriveMode : uint8_t {
     Cruise = 1,
     Warp = 2,
     Ludicrous = 3,
+    Max = 3, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any DriveMode value, out-of-set included

--- a/generated/cs-ludicrous/Ludicrous.cs
+++ b/generated/cs-ludicrous/Ludicrous.cs
@@ -20,6 +20,7 @@ namespace Ludicrous
     {
         None = 0,
         LudicrousState = 1,
+        Max = 1, // the exported extent (SPEC §4.2)
     }
 
     // Message is the dispatch surface: the abstract base every generated message
@@ -36,6 +37,7 @@ namespace Ludicrous
         None = 0,
         Body = 1,
         NarrowBody = 2,
+        Max = 2, // the exported extent (SPEC §4.2)
     }
 
     // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
@@ -47,6 +49,7 @@ namespace Ludicrous
         Cruise = 1,
         Warp = 2,
         Ludicrous = 3,
+        Max = 3, // the exported extent (SPEC §4.2)
     }
 
     // type FixedProbe

--- a/generated/cs/Enums.cs
+++ b/generated/cs/Enums.cs
@@ -12,6 +12,7 @@ namespace Example
         None = 0,
         Red = 1,
         Blue = 2,
+        Max = 2, // the exported extent (SPEC §4.2)
     }
 
     // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
@@ -25,6 +26,7 @@ namespace Example
         Bomber = 3,
         Destroyer = 4,
         Carrier = 5,
+        Max = 5, // the exported extent (SPEC §4.2)
     }
 
     // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
@@ -36,6 +38,7 @@ namespace Example
         Heatseeker = 1,
         Torpedo = 2,
         Nuke = 3,
+        Max = 3, // the exported extent (SPEC §4.2)
     }
 
     // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
@@ -50,6 +53,7 @@ namespace Example
         Sphere = 4,
         BlackHole = 5,
         DysonPanel = 6,
+        Max = 6, // the exported extent (SPEC §4.2)
     }
 
     // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
@@ -58,6 +62,7 @@ namespace Example
     public enum Pending : byte
     {
         None = 0,
+        Max = 0, // the exported extent (SPEC §4.2)
     }
 
     // Schema carries every generated function and constant of the unit — C# has

--- a/generated/cs/Messages.cs
+++ b/generated/cs/Messages.cs
@@ -25,6 +25,7 @@ namespace Example
         Synchronize = 4,
         Test = 5,
         Timescale = 6,
+        Max = 6, // the exported extent (SPEC §4.2)
     }
 
     // Message is the dispatch surface: the abstract base every generated message

--- a/generated/cs/Objects.cs
+++ b/generated/cs/Objects.cs
@@ -23,6 +23,7 @@ namespace Example
         Missile = 2,
         Ship = 3,
         Turret = 4,
+        Max = 4, // the exported extent (SPEC §4.2)
     }
 
     // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -24,6 +24,7 @@ namespace Example
         Laser = 1,
         Missile = 2,
         Railgun = 3,
+        Max = 15, // the exported extent (SPEC §4.2)
     }
 
     // type ProbeHeader

--- a/generated/go-ludicrous/Ludicrous.go
+++ b/generated/go-ludicrous/Ludicrous.go
@@ -23,6 +23,7 @@ type MessageType uint8
 const (
 	MessageTypeNone           MessageType = 0
 	MessageTypeLudicrousState MessageType = 1
+	MessageTypeMax            MessageType = 1 // the exported extent (SPEC §4.2)
 )
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -32,6 +33,7 @@ const (
 	ObjectTypeNone       ObjectType = 0
 	ObjectTypeBody       ObjectType = 1
 	ObjectTypeNarrowBody ObjectType = 2
+	ObjectTypeMax        ObjectType = 2 // the exported extent (SPEC §4.2)
 )
 
 const MaxWorldUnits = 30000
@@ -44,6 +46,7 @@ const (
 	DriveModeCruise    DriveMode = 1
 	DriveModeWarp      DriveMode = 2
 	DriveModeLudicrous DriveMode = 3
+	DriveModeMax       DriveMode = 3 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameDriveMode: debug/log/tooling name for any DriveMode wire value —

--- a/generated/go/Enums.go
+++ b/generated/go/Enums.go
@@ -10,6 +10,7 @@ const (
 	TeamNone Team = 0
 	TeamRed  Team = 1
 	TeamBlue Team = 2
+	TeamMax  Team = 2 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameTeam: debug/log/tooling name for any Team wire value —
@@ -36,6 +37,7 @@ const (
 	ShipTypeBomber    ShipType = 3
 	ShipTypeDestroyer ShipType = 4
 	ShipTypeCarrier   ShipType = 5
+	ShipTypeMax       ShipType = 5 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameShipType: debug/log/tooling name for any ShipType wire value —
@@ -66,6 +68,7 @@ const (
 	MissileTypeHeatseeker MissileType = 1
 	MissileTypeTorpedo    MissileType = 2
 	MissileTypeNuke       MissileType = 3
+	MissileTypeMax        MissileType = 3 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameMissileType: debug/log/tooling name for any MissileType wire value —
@@ -95,6 +98,7 @@ const (
 	PropTypeSphere     PropType = 4
 	PropTypeBlackHole  PropType = 5
 	PropTypeDysonPanel PropType = 6
+	PropTypeMax        PropType = 6 // the exported extent (SPEC §4.2)
 )
 
 // EnumNamePropType: debug/log/tooling name for any PropType wire value —
@@ -124,6 +128,7 @@ type Pending uint8
 
 const (
 	PendingNone Pending = 0
+	PendingMax  Pending = 0 // the exported extent (SPEC §4.2)
 )
 
 // EnumNamePending: debug/log/tooling name for any Pending wire value —

--- a/generated/go/Messages.go
+++ b/generated/go/Messages.go
@@ -18,6 +18,7 @@ const (
 	MessageTypeSynchronize MessageType = 4
 	MessageTypeTest        MessageType = 5
 	MessageTypeTimescale   MessageType = 6
+	MessageTypeMax         MessageType = 6 // the exported extent (SPEC §4.2)
 )
 
 // message Heartbeat

--- a/generated/go/Objects.go
+++ b/generated/go/Objects.go
@@ -18,6 +18,7 @@ const (
 	ObjectTypeMissile     ObjectType = 2
 	ObjectTypeShip        ObjectType = 3
 	ObjectTypeTurret      ObjectType = 4
+	ObjectTypeMax         ObjectType = 4 // the exported extent (SPEC §4.2)
 )
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/generated/go/Wire.go
+++ b/generated/go/Wire.go
@@ -23,6 +23,7 @@ const (
 	WeaponLaser   Weapon = 1
 	WeaponMissile Weapon = 2
 	WeaponRailgun Weapon = 3
+	WeaponMax     Weapon = 15 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —

--- a/generated/js-ludicrous/Ludicrous.js
+++ b/generated/js-ludicrous/Ludicrous.js
@@ -29,6 +29,7 @@ export const ProtocolId = 0xa925c86b46058512n;
 export const MessageType = Object.freeze({
   None: 0,
   LudicrousState: 1,
+  Max: 1, // the exported extent (SPEC §4.2)
 });
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -36,6 +37,7 @@ export const ObjectType = Object.freeze({
   None: 0,
   Body: 1,
   NarrowBody: 2,
+  Max: 2, // the exported extent (SPEC §4.2)
 });
 
 export const MaxWorldUnits = 30000;
@@ -48,6 +50,7 @@ export const DriveMode = Object.freeze({
   Cruise: 1,
   Warp: 2,
   Ludicrous: 3,
+  Max: 3, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameDriveMode: debug/log/tooling name for any DriveMode wire value —

--- a/generated/js/Enums.js
+++ b/generated/js/Enums.js
@@ -19,6 +19,7 @@ export const Team = Object.freeze({
   None: 0,
   Red: 1,
   Blue: 2,
+  Max: 2, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameTeam: debug/log/tooling name for any Team wire value —
@@ -46,6 +47,7 @@ export const ShipType = Object.freeze({
   Bomber: 3,
   Destroyer: 4,
   Carrier: 5,
+  Max: 5, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameShipType: debug/log/tooling name for any ShipType wire value —
@@ -77,6 +79,7 @@ export const MissileType = Object.freeze({
   Heatseeker: 1,
   Torpedo: 2,
   Nuke: 3,
+  Max: 3, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameMissileType: debug/log/tooling name for any MissileType wire value —
@@ -107,6 +110,7 @@ export const PropType = Object.freeze({
   Sphere: 4,
   BlackHole: 5,
   DysonPanel: 6,
+  Max: 6, // the exported extent (SPEC §4.2)
 });
 
 // EnumNamePropType: debug/log/tooling name for any PropType wire value —
@@ -137,6 +141,7 @@ export function EnumNamePropType(value) {
 // integer-backed enums; [max = ...] headroom values are plain Numbers
 export const Pending = Object.freeze({
   None: 0,
+  Max: 0, // the exported extent (SPEC §4.2)
 });
 
 // EnumNamePending: debug/log/tooling name for any Pending wire value —

--- a/generated/js/Messages.js
+++ b/generated/js/Messages.js
@@ -31,6 +31,7 @@ export const MessageType = Object.freeze({
   Synchronize: 4,
   Test: 5,
   Timescale: 6,
+  Max: 6, // the exported extent (SPEC §4.2)
 });
 
 // message Heartbeat

--- a/generated/js/Objects.js
+++ b/generated/js/Objects.js
@@ -31,6 +31,7 @@ export const ObjectType = Object.freeze({
   Missile: 2,
   Ship: 3,
   Turret: 4,
+  Max: 4, // the exported extent (SPEC §4.2)
 });
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/generated/js/Wire.js
+++ b/generated/js/Wire.js
@@ -39,6 +39,7 @@ export const Weapon = Object.freeze({
   Laser: 1,
   Missile: 2,
   Railgun: 3,
+  Max: 15, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —

--- a/generated/rust-ludicrous/src/ludicrous.rs
+++ b/generated/rust-ludicrous/src/ludicrous.rs
@@ -39,6 +39,7 @@ pub struct MessageType(pub u8);
 impl MessageType {
     pub const NONE: MessageType = MessageType(0);
     pub const LUDICROUS_STATE: MessageType = MessageType(1);
+    pub const MAX: MessageType = MessageType(1); // the exported extent (SPEC §4.2)
 }
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -50,6 +51,7 @@ impl ObjectType {
     pub const NONE: ObjectType = ObjectType(0);
     pub const BODY: ObjectType = ObjectType(1);
     pub const NARROW_BODY: ObjectType = ObjectType(2);
+    pub const MAX: ObjectType = ObjectType(2); // the exported extent (SPEC §4.2)
 }
 
 pub const MAX_WORLD_UNITS: i64 = 30000;
@@ -65,6 +67,7 @@ impl DriveMode {
     pub const CRUISE: DriveMode = DriveMode(1);
     pub const WARP: DriveMode = DriveMode(2);
     pub const LUDICROUS: DriveMode = DriveMode(3);
+    pub const MAX: DriveMode = DriveMode(3); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `DriveMode` value, out-of-set included.

--- a/generated/rust/src/enums.rs
+++ b/generated/rust/src/enums.rs
@@ -11,6 +11,7 @@ impl Team {
     pub const NONE: Team = Team(0);
     pub const RED: Team = Team(1);
     pub const BLUE: Team = Team(2);
+    pub const MAX: Team = Team(2); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `Team` value, out-of-set included.
@@ -42,6 +43,7 @@ impl ShipType {
     pub const BOMBER: ShipType = ShipType(3);
     pub const DESTROYER: ShipType = ShipType(4);
     pub const CARRIER: ShipType = ShipType(5);
+    pub const MAX: ShipType = ShipType(5); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `ShipType` value, out-of-set included.
@@ -74,6 +76,7 @@ impl MissileType {
     pub const HEATSEEKER: MissileType = MissileType(1);
     pub const TORPEDO: MissileType = MissileType(2);
     pub const NUKE: MissileType = MissileType(3);
+    pub const MAX: MissileType = MissileType(3); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `MissileType` value, out-of-set included.
@@ -107,6 +110,7 @@ impl PropType {
     pub const SPHERE: PropType = PropType(4);
     pub const BLACK_HOLE: PropType = PropType(5);
     pub const DYSON_PANEL: PropType = PropType(6);
+    pub const MAX: PropType = PropType(6); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `PropType` value, out-of-set included.
@@ -137,6 +141,7 @@ pub struct Pending(pub u8);
 
 impl Pending {
     pub const NONE: Pending = Pending(0);
+    pub const MAX: Pending = Pending(0); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `Pending` value, out-of-set included.

--- a/generated/rust/src/messages.rs
+++ b/generated/rust/src/messages.rs
@@ -17,6 +17,7 @@ impl MessageType {
     pub const SYNCHRONIZE: MessageType = MessageType(4);
     pub const TEST: MessageType = MessageType(5);
     pub const TIMESCALE: MessageType = MessageType(6);
+    pub const MAX: MessageType = MessageType(6); // the exported extent (SPEC §4.2)
 }
 
 // message Heartbeat

--- a/generated/rust/src/objects.rs
+++ b/generated/rust/src/objects.rs
@@ -15,6 +15,7 @@ impl ObjectType {
     pub const MISSILE: ObjectType = ObjectType(2);
     pub const SHIP: ObjectType = ObjectType(3);
     pub const TURRET: ObjectType = ObjectType(4);
+    pub const MAX: ObjectType = ObjectType(4); // the exported extent (SPEC §4.2)
 }
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -23,6 +23,7 @@ impl Weapon {
     pub const LASER: Weapon = Weapon(1);
     pub const MISSILE: Weapon = Weapon(2);
     pub const RAILGUN: Weapon = Weapon(3);
+    pub const MAX: Weapon = Weapon(15); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `Weapon` value, out-of-set included.

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -607,6 +607,10 @@ func (c *checker) resolveEnum(d *ast.EnumDecl) *ir.Enum {
 			c.errf(v.Pos, "variant None is a compile error — every enum has None = 0 implicitly (SPEC §4.2)")
 			continue
 		}
+		if v.Text == "Max" {
+			c.errf(v.Pos, "variant Max is a compile error — every generated enum carries its extent as the member Max, the same number E.Max names (SPEC §4.2)")
+			continue
+		}
 		if seen[v.Text] {
 			c.errf(v.Pos, "duplicate variant %s", v.Text)
 			continue
@@ -2040,17 +2044,17 @@ func (c *checker) checkClaimedNames() {
 	add("Result", "the unit's generated Result alias (Rust form)", unitPos)
 	hasMessages := countMessages(c.astDecls) > 0
 	if hasMessages {
-		for _, gen := range []string{"MessageType", "MessageTypeNone", "Message", "MessageStorage",
+		for _, gen := range []string{"MessageType", "MessageTypeNone", "MessageTypeMax", "Message", "MessageStorage",
 			"WriteMessage", "ReadMessage", "WriteMessageType", "ReadMessageType", "MessageMaxBits", "MessageMaxBytes"} {
 			add(gen, "the generated message dispatch surface", unitPos)
 		}
 		for _, gen := range []string{"write_message", "read_message", "write_message_type",
-			"read_message_type", "MESSAGE_MAX_BITS", "MESSAGE_MAX_BYTES"} {
+			"read_message_type", "MESSAGE_TYPE_MAX", "MESSAGE_MAX_BITS", "MESSAGE_MAX_BYTES"} {
 			add(gen, "the generated message dispatch surface (Rust/C form)", unitPos)
 		}
 	}
 	if len(c.objects) > 0 {
-		for _, gen := range []string{"ObjectType", "ObjectTypeNone", "WriteObjectType", "ReadObjectType"} {
+		for _, gen := range []string{"ObjectType", "ObjectTypeNone", "ObjectTypeMax", "WriteObjectType", "ReadObjectType"} {
 			add(gen, "the generated object tag surface", unitPos)
 		}
 		for _, gen := range []string{"write_object_type", "read_object_type"} {
@@ -2087,7 +2091,8 @@ func (c *checker) checkClaimedNames() {
 			// SCREAMING_SNAKE spellings need only be unique WITHIN the enum —
 			// including against the implicit NONE
 			add(name+"None", fmt.Sprintf("enum %s's generated None constant", name), d.Pos)
-			assoc := map[string]string{"NONE": "the implicit None variant"}
+			add(name+"Max", fmt.Sprintf("enum %s's generated Max extent (Go form)", name), d.Pos)
+			assoc := map[string]string{"NONE": "the implicit None variant", "MAX": "the generated Max extent"}
 			for _, v := range d.Variants {
 				add(name+v.Text, fmt.Sprintf("enum %s's generated variant constant", name), v.Pos)
 				rv := ir.RustConstName(v.Text)

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -159,6 +159,10 @@ func TestDiagnostics(t *testing.T) {
 		// ---- enums, flags, contexts ----
 		{name: "variant named None", want: "None",
 			src: "package t\nenum E { None, A }\n"},
+		{name: "variant named Max", want: "carries its extent as the member Max",
+			src: "package t\nenum E { A, Max }\n"},
+		{name: "a decl collides with an enum's generated Max extent (Go)", want: "generated Max extent",
+			src: "package t\nenum Team { Red }\nconst TeamMax = 3\n"},
 		{name: "enum max below variant count", want: "below its variant count",
 			src: "package t\nenum E [max = 2] { A, B, C }\n"},
 		{name: "Max reference to a non-enum", want: "is not an enum",

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -393,6 +393,7 @@ func (g *gen) emitTagEnum(name string, members []string, comment string) {
 	for i, m := range members {
 		g.pf("    %s = %d,\n", m, i+1)
 	}
+	g.pf("    Max = %d, // the exported extent (SPEC §4.2)\n", len(members))
 	g.pf("};\n\n")
 }
 
@@ -430,6 +431,7 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	for i, v := range d.Variants {
 		g.pf("    %s = %d,\n", v, i+1)
 	}
+	g.pf("    Max = %d, // the exported extent (SPEC §4.2)\n", d.Max)
 	g.pf("};\n\n")
 	g.pf("// EnumName: debug/log name for any %s value, out-of-set included\n", d.Name)
 	g.pf("inline const char * EnumName( %s value )\n{\n", d.Name)

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -277,6 +277,7 @@ func (g *gen) emitTagEnum(name string, members []string, comment string) {
 	for i, m := range members {
 		g.tf("    %s = %d,\n", m, i+1)
 	}
+	g.tf("    Max = %d, // the exported extent (SPEC §4.2)\n", len(members))
 	g.tf("}\n\n")
 }
 
@@ -315,6 +316,7 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	for i, v := range d.Variants {
 		g.tf("    %s = %d,\n", v, i+1)
 	}
+	g.tf("    Max = %d, // the exported extent (SPEC §4.2)\n", d.Max)
 	g.tf("}\n\n")
 	// the ulong parameter (not the enum type) keeps out-of-set values exact:
 	// a cast through a narrower backing would truncate 256 -> 0 -> "None"

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -203,6 +203,7 @@ func (g *gen) emitTagEnum(name string, members []string, comment string) {
 	for i, m := range members {
 		g.pf("\t%s%s %s = %d\n", name, m, name, i+1)
 	}
+	g.pf("\t%sMax %s = %d // the exported extent (SPEC §4.2)\n", name, name, len(members))
 	g.pf(")\n\n")
 }
 
@@ -242,6 +243,7 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	for i, v := range d.Variants {
 		g.pf("\t%s%s %s = %d\n", d.Name, v, d.Name, i+1)
 	}
+	g.pf("\t%sMax %s = %d // the exported extent (SPEC §4.2)\n", d.Name, d.Name, d.Max)
 	g.pf(")\n\n")
 	// the uint64 parameter (not the enum type) keeps out-of-set values exact:
 	// a narrower named type would truncate 256 -> 0 -> "None" for an 8-bit enum

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	"github.com/mas-bandwidth/schema/internal/check"
+	cgen "github.com/mas-bandwidth/schema/internal/codegen/c"
 	"github.com/mas-bandwidth/schema/internal/codegen/cpp"
 	"github.com/mas-bandwidth/schema/internal/codegen/csharp"
+	"github.com/mas-bandwidth/schema/internal/codegen/js"
 	"github.com/mas-bandwidth/schema/internal/codegen/rust"
 	"github.com/mas-bandwidth/schema/internal/parser"
 	"github.com/mas-bandwidth/schema/ir"
@@ -77,6 +79,91 @@ func TestBareFloatConstExportsTypedFloat64(t *testing.T) {
 	} {
 		if got := countAcross(files, want); got != 1 {
 			t.Errorf("Go: %q emitted %d times — a bare float const must export the same typed float64 the annotation spells", want, got)
+		}
+	}
+}
+
+// Every generated enum surface carries its extent as the member Max (SPEC
+// §4.2 — the exported-extent rule, issue #121): declared enums (headroom
+// included) and the generated MessageType/ObjectType tag enums alike, in
+// each target's own convention. Call sites then state ranges against
+// E.Max's generated twin instead of a hand-declared count constant.
+func TestEnumExtentEmitted(t *testing.T) {
+	src := "package t\n\n" +
+		"enum Weapon [max = 15] { Laser, Missile }\n\n" +
+		"message Ping { w Weapon }\n\n" +
+		"message Pong { y uint8 }\n\n" +
+		"object Rock { size uint8 [interpolate, min = 0, max = 100] }\n\n" +
+		"object Tree { size uint8 [interpolate, min = 0, max = 100] }\n"
+	f, perrs := parser.Parse("Extent.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "Extent.schema", Name: "Extent.schema", Base: "Extent",
+		Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+
+	type expectation struct {
+		needle string
+		count  int
+	}
+	type target struct {
+		name    string
+		files   map[string][]byte
+		genErr  error
+		expects []expectation
+	}
+	var targets []target
+	addTarget := func(name string, files map[string][]byte, err error, expects ...expectation) {
+		targets = append(targets, target{name, files, err, expects})
+	}
+
+	goFiles, goErr := Generate(u)
+	// go/format aligns const blocks, so the symbol and its value are asserted
+	// as separate needles rather than one whitespace-sensitive line
+	addTarget("Go", goFiles, goErr,
+		expectation{"WeaponMax", 1},
+		expectation{"MessageTypeMax", 1},
+		expectation{"ObjectTypeMax", 1},
+		expectation{"= 15 // the exported extent (SPEC §4.2)", 1},
+		expectation{"= 2 // the exported extent (SPEC §4.2)", 2})
+	rustFiles, rustErr := rust.Generate(u)
+	addTarget("Rust", rustFiles, rustErr,
+		expectation{"pub const MAX: Weapon = Weapon(15);", 1},
+		expectation{"pub const MAX: MessageType = MessageType(2);", 1},
+		expectation{"pub const MAX: ObjectType = ObjectType(2);", 1})
+	csFiles, csErr := csharp.Generate(u)
+	addTarget("C#", csFiles, csErr,
+		expectation{"Max = 15,", 1}, // Weapon
+		expectation{"Max = 2,", 2})  // MessageType + ObjectType
+	jsFiles, jsErr := js.Generate(u)
+	addTarget("JS", jsFiles, jsErr,
+		expectation{"Max: 15,", 1},
+		expectation{"Max: 2,", 2})
+	cFiles, cErr := cgen.Generate(u)
+	addTarget("C", cFiles, cErr,
+		expectation{"#define WEAPON_MAX 15", 1},
+		expectation{"#define MESSAGE_TYPE_MAX 2", 1})
+	for _, mode := range []string{"union", "variant"} {
+		cppFiles, cppErr := cpp.Generate(u, cpp.Options{MessageRepr: mode})
+		addTarget("C++ ("+mode+")", cppFiles, cppErr,
+			expectation{"Max = 15,", 1},
+			expectation{"Max = 2,", 2})
+	}
+
+	for _, tgt := range targets {
+		if tgt.genErr != nil {
+			t.Errorf("%s: generate: %v", tgt.name, tgt.genErr)
+			continue
+		}
+		for _, e := range tgt.expects {
+			if got := countAcross(tgt.files, e.needle); got != e.count {
+				t.Errorf("%s: %q emitted %d times, want %d — the enum extent must ride every generated enum surface", tgt.name, e.needle, got, e.count)
+			}
 		}
 	}
 }

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -290,6 +290,7 @@ func (g *gen) emitTagEnum(name string, members []string, comment string) {
 	for i, m := range members {
 		g.pf("  %s: %d,\n", m, i+1)
 	}
+	g.pf("  Max: %d, // the exported extent (SPEC §4.2)\n", len(members))
 	g.pf("});\n\n")
 }
 
@@ -347,6 +348,7 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	for i, v := range d.Variants {
 		g.pf("  %s: %d,\n", v, i+1)
 	}
+	g.pf("  Max: %d, // the exported extent (SPEC §4.2)\n", d.Max)
 	g.pf("});\n\n")
 	g.pf("// EnumName%s: debug/log/tooling name for any %s wire value —\n", d.Name, d.Name)
 	g.pf("// out-of-set values (wire-legal up to the declared max) name as \"???\"\n")

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -273,6 +273,7 @@ func (g *gen) emitTagEnum(name string, members []string, comment string) {
 	for i, m := range members {
 		g.pf("    pub const %s: %s = %s(%d);\n", ir.RustConstName(m), name, name, i+1)
 	}
+	g.pf("    pub const MAX: %s = %s(%d); // the exported extent (SPEC §4.2)\n", name, name, len(members))
 	g.pf("}\n\n")
 }
 
@@ -326,6 +327,7 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	for i, v := range d.Variants {
 		g.pf("    pub const %s: %s = %s(%d);\n", ir.RustConstName(v), d.Name, d.Name, i+1)
 	}
+	g.pf("    pub const MAX: %s = %s(%d); // the exported extent (SPEC §4.2)\n", d.Name, d.Name, d.Max)
 	g.pf("}\n\n")
 
 	// Debug/log name for any value, out-of-set included — the counterpart of

--- a/testdata/golden/cs/Enums.cs
+++ b/testdata/golden/cs/Enums.cs
@@ -12,6 +12,7 @@ namespace Example
         None = 0,
         Red = 1,
         Blue = 2,
+        Max = 2, // the exported extent (SPEC §4.2)
     }
 
     // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
@@ -25,6 +26,7 @@ namespace Example
         Bomber = 3,
         Destroyer = 4,
         Carrier = 5,
+        Max = 5, // the exported extent (SPEC §4.2)
     }
 
     // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
@@ -36,6 +38,7 @@ namespace Example
         Heatseeker = 1,
         Torpedo = 2,
         Nuke = 3,
+        Max = 3, // the exported extent (SPEC §4.2)
     }
 
     // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
@@ -50,6 +53,7 @@ namespace Example
         Sphere = 4,
         BlackHole = 5,
         DysonPanel = 6,
+        Max = 6, // the exported extent (SPEC §4.2)
     }
 
     // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
@@ -58,6 +62,7 @@ namespace Example
     public enum Pending : byte
     {
         None = 0,
+        Max = 0, // the exported extent (SPEC §4.2)
     }
 
     // Schema carries every generated function and constant of the unit — C# has

--- a/testdata/golden/cs/Messages.cs
+++ b/testdata/golden/cs/Messages.cs
@@ -25,6 +25,7 @@ namespace Example
         Synchronize = 4,
         Test = 5,
         Timescale = 6,
+        Max = 6, // the exported extent (SPEC §4.2)
     }
 
     // Message is the dispatch surface: the abstract base every generated message

--- a/testdata/golden/cs/Objects.cs
+++ b/testdata/golden/cs/Objects.cs
@@ -23,6 +23,7 @@ namespace Example
         Missile = 2,
         Ship = 3,
         Turret = 4,
+        Max = 4, // the exported extent (SPEC §4.2)
     }
 
     // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -24,6 +24,7 @@ namespace Example
         Laser = 1,
         Missile = 2,
         Railgun = 3,
+        Max = 15, // the exported extent (SPEC §4.2)
     }
 
     // type ProbeHeader

--- a/testdata/golden/go/Enums.go
+++ b/testdata/golden/go/Enums.go
@@ -10,6 +10,7 @@ const (
 	TeamNone Team = 0
 	TeamRed  Team = 1
 	TeamBlue Team = 2
+	TeamMax  Team = 2 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameTeam: debug/log/tooling name for any Team wire value —
@@ -36,6 +37,7 @@ const (
 	ShipTypeBomber    ShipType = 3
 	ShipTypeDestroyer ShipType = 4
 	ShipTypeCarrier   ShipType = 5
+	ShipTypeMax       ShipType = 5 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameShipType: debug/log/tooling name for any ShipType wire value —
@@ -66,6 +68,7 @@ const (
 	MissileTypeHeatseeker MissileType = 1
 	MissileTypeTorpedo    MissileType = 2
 	MissileTypeNuke       MissileType = 3
+	MissileTypeMax        MissileType = 3 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameMissileType: debug/log/tooling name for any MissileType wire value —
@@ -95,6 +98,7 @@ const (
 	PropTypeSphere     PropType = 4
 	PropTypeBlackHole  PropType = 5
 	PropTypeDysonPanel PropType = 6
+	PropTypeMax        PropType = 6 // the exported extent (SPEC §4.2)
 )
 
 // EnumNamePropType: debug/log/tooling name for any PropType wire value —
@@ -124,6 +128,7 @@ type Pending uint8
 
 const (
 	PendingNone Pending = 0
+	PendingMax  Pending = 0 // the exported extent (SPEC §4.2)
 )
 
 // EnumNamePending: debug/log/tooling name for any Pending wire value —

--- a/testdata/golden/go/Messages.go
+++ b/testdata/golden/go/Messages.go
@@ -18,6 +18,7 @@ const (
 	MessageTypeSynchronize MessageType = 4
 	MessageTypeTest        MessageType = 5
 	MessageTypeTimescale   MessageType = 6
+	MessageTypeMax         MessageType = 6 // the exported extent (SPEC §4.2)
 )
 
 // message Heartbeat

--- a/testdata/golden/go/Objects.go
+++ b/testdata/golden/go/Objects.go
@@ -18,6 +18,7 @@ const (
 	ObjectTypeMissile     ObjectType = 2
 	ObjectTypeShip        ObjectType = 3
 	ObjectTypeTurret      ObjectType = 4
+	ObjectTypeMax         ObjectType = 4 // the exported extent (SPEC §4.2)
 )
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/testdata/golden/go/Wire.go
+++ b/testdata/golden/go/Wire.go
@@ -23,6 +23,7 @@ const (
 	WeaponLaser   Weapon = 1
 	WeaponMissile Weapon = 2
 	WeaponRailgun Weapon = 3
+	WeaponMax     Weapon = 15 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —

--- a/testdata/golden/js/Enums.js
+++ b/testdata/golden/js/Enums.js
@@ -19,6 +19,7 @@ export const Team = Object.freeze({
   None: 0,
   Red: 1,
   Blue: 2,
+  Max: 2, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameTeam: debug/log/tooling name for any Team wire value —
@@ -46,6 +47,7 @@ export const ShipType = Object.freeze({
   Bomber: 3,
   Destroyer: 4,
   Carrier: 5,
+  Max: 5, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameShipType: debug/log/tooling name for any ShipType wire value —
@@ -77,6 +79,7 @@ export const MissileType = Object.freeze({
   Heatseeker: 1,
   Torpedo: 2,
   Nuke: 3,
+  Max: 3, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameMissileType: debug/log/tooling name for any MissileType wire value —
@@ -107,6 +110,7 @@ export const PropType = Object.freeze({
   Sphere: 4,
   BlackHole: 5,
   DysonPanel: 6,
+  Max: 6, // the exported extent (SPEC §4.2)
 });
 
 // EnumNamePropType: debug/log/tooling name for any PropType wire value —
@@ -137,6 +141,7 @@ export function EnumNamePropType(value) {
 // integer-backed enums; [max = ...] headroom values are plain Numbers
 export const Pending = Object.freeze({
   None: 0,
+  Max: 0, // the exported extent (SPEC §4.2)
 });
 
 // EnumNamePending: debug/log/tooling name for any Pending wire value —

--- a/testdata/golden/js/Messages.js
+++ b/testdata/golden/js/Messages.js
@@ -31,6 +31,7 @@ export const MessageType = Object.freeze({
   Synchronize: 4,
   Test: 5,
   Timescale: 6,
+  Max: 6, // the exported extent (SPEC §4.2)
 });
 
 // message Heartbeat

--- a/testdata/golden/js/Objects.js
+++ b/testdata/golden/js/Objects.js
@@ -31,6 +31,7 @@ export const ObjectType = Object.freeze({
   Missile: 2,
   Ship: 3,
   Turret: 4,
+  Max: 4, // the exported extent (SPEC §4.2)
 });
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/testdata/golden/js/Wire.js
+++ b/testdata/golden/js/Wire.js
@@ -39,6 +39,7 @@ export const Weapon = Object.freeze({
   Laser: 1,
   Missile: 2,
   Railgun: 3,
+  Max: 15, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameWeapon: debug/log/tooling name for any Weapon wire value —

--- a/testdata/golden/ludicrous/cs/Ludicrous.cs
+++ b/testdata/golden/ludicrous/cs/Ludicrous.cs
@@ -20,6 +20,7 @@ namespace Ludicrous
     {
         None = 0,
         LudicrousState = 1,
+        Max = 1, // the exported extent (SPEC §4.2)
     }
 
     // Message is the dispatch surface: the abstract base every generated message
@@ -36,6 +37,7 @@ namespace Ludicrous
         None = 0,
         Body = 1,
         NarrowBody = 2,
+        Max = 2, // the exported extent (SPEC §4.2)
     }
 
     // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
@@ -47,6 +49,7 @@ namespace Ludicrous
         Cruise = 1,
         Warp = 2,
         Ludicrous = 3,
+        Max = 3, // the exported extent (SPEC §4.2)
     }
 
     // type FixedProbe

--- a/testdata/golden/ludicrous/go/Ludicrous.go
+++ b/testdata/golden/ludicrous/go/Ludicrous.go
@@ -23,6 +23,7 @@ type MessageType uint8
 const (
 	MessageTypeNone           MessageType = 0
 	MessageTypeLudicrousState MessageType = 1
+	MessageTypeMax            MessageType = 1 // the exported extent (SPEC §4.2)
 )
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -32,6 +33,7 @@ const (
 	ObjectTypeNone       ObjectType = 0
 	ObjectTypeBody       ObjectType = 1
 	ObjectTypeNarrowBody ObjectType = 2
+	ObjectTypeMax        ObjectType = 2 // the exported extent (SPEC §4.2)
 )
 
 const MaxWorldUnits = 30000
@@ -44,6 +46,7 @@ const (
 	DriveModeCruise    DriveMode = 1
 	DriveModeWarp      DriveMode = 2
 	DriveModeLudicrous DriveMode = 3
+	DriveModeMax       DriveMode = 3 // the exported extent (SPEC §4.2)
 )
 
 // EnumNameDriveMode: debug/log/tooling name for any DriveMode wire value —

--- a/testdata/golden/ludicrous/js/Ludicrous.js
+++ b/testdata/golden/ludicrous/js/Ludicrous.js
@@ -29,6 +29,7 @@ export const ProtocolId = 0xa925c86b46058512n;
 export const MessageType = Object.freeze({
   None: 0,
   LudicrousState: 1,
+  Max: 1, // the exported extent (SPEC §4.2)
 });
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -36,6 +37,7 @@ export const ObjectType = Object.freeze({
   None: 0,
   Body: 1,
   NarrowBody: 2,
+  Max: 2, // the exported extent (SPEC §4.2)
 });
 
 export const MaxWorldUnits = 30000;
@@ -48,6 +50,7 @@ export const DriveMode = Object.freeze({
   Cruise: 1,
   Warp: 2,
   Ludicrous: 3,
+  Max: 3, // the exported extent (SPEC §4.2)
 });
 
 // EnumNameDriveMode: debug/log/tooling name for any DriveMode wire value —

--- a/testdata/golden/ludicrous/rust/ludicrous.rs
+++ b/testdata/golden/ludicrous/rust/ludicrous.rs
@@ -39,6 +39,7 @@ pub struct MessageType(pub u8);
 impl MessageType {
     pub const NONE: MessageType = MessageType(0);
     pub const LUDICROUS_STATE: MessageType = MessageType(1);
+    pub const MAX: MessageType = MessageType(1); // the exported extent (SPEC §4.2)
 }
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -50,6 +51,7 @@ impl ObjectType {
     pub const NONE: ObjectType = ObjectType(0);
     pub const BODY: ObjectType = ObjectType(1);
     pub const NARROW_BODY: ObjectType = ObjectType(2);
+    pub const MAX: ObjectType = ObjectType(2); // the exported extent (SPEC §4.2)
 }
 
 pub const MAX_WORLD_UNITS: i64 = 30000;
@@ -65,6 +67,7 @@ impl DriveMode {
     pub const CRUISE: DriveMode = DriveMode(1);
     pub const WARP: DriveMode = DriveMode(2);
     pub const LUDICROUS: DriveMode = DriveMode(3);
+    pub const MAX: DriveMode = DriveMode(3); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `DriveMode` value, out-of-set included.

--- a/testdata/golden/ludicrous/union/Ludicrous.h
+++ b/testdata/golden/ludicrous/union/Ludicrous.h
@@ -20,6 +20,7 @@ inline constexpr uint64_t ProtocolId = 0xa925c86b46058512ull;
 enum class MessageType : uint8_t {
     None = 0,
     LudicrousState = 1,
+    Max = 1, // the exported extent (SPEC §4.2)
 };
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -27,6 +28,7 @@ enum class ObjectType : uint8_t {
     None = 0,
     Body = 1,
     NarrowBody = 2,
+    Max = 2, // the exported extent (SPEC §4.2)
 };
 
 inline constexpr int64_t MaxWorldUnits = 30000;
@@ -36,6 +38,7 @@ enum class DriveMode : uint8_t {
     Cruise = 1,
     Warp = 2,
     Ludicrous = 3,
+    Max = 3, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any DriveMode value, out-of-set included

--- a/testdata/golden/ludicrous/variant/Ludicrous.h
+++ b/testdata/golden/ludicrous/variant/Ludicrous.h
@@ -21,6 +21,7 @@ inline constexpr uint64_t ProtocolId = 0xa925c86b46058512ull;
 enum class MessageType : uint8_t {
     None = 0,
     LudicrousState = 1,
+    Max = 1, // the exported extent (SPEC §4.2)
 };
 
 // ObjectType: the object set, extracted by the compiler — None = 0, then each object sorted by name (SPEC §4.8)
@@ -28,6 +29,7 @@ enum class ObjectType : uint8_t {
     None = 0,
     Body = 1,
     NarrowBody = 2,
+    Max = 2, // the exported extent (SPEC §4.2)
 };
 
 inline constexpr int64_t MaxWorldUnits = 30000;
@@ -37,6 +39,7 @@ enum class DriveMode : uint8_t {
     Cruise = 1,
     Warp = 2,
     Ludicrous = 3,
+    Max = 3, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any DriveMode value, out-of-set included

--- a/testdata/golden/rust/enums.rs
+++ b/testdata/golden/rust/enums.rs
@@ -11,6 +11,7 @@ impl Team {
     pub const NONE: Team = Team(0);
     pub const RED: Team = Team(1);
     pub const BLUE: Team = Team(2);
+    pub const MAX: Team = Team(2); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `Team` value, out-of-set included.
@@ -42,6 +43,7 @@ impl ShipType {
     pub const BOMBER: ShipType = ShipType(3);
     pub const DESTROYER: ShipType = ShipType(4);
     pub const CARRIER: ShipType = ShipType(5);
+    pub const MAX: ShipType = ShipType(5); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `ShipType` value, out-of-set included.
@@ -74,6 +76,7 @@ impl MissileType {
     pub const HEATSEEKER: MissileType = MissileType(1);
     pub const TORPEDO: MissileType = MissileType(2);
     pub const NUKE: MissileType = MissileType(3);
+    pub const MAX: MissileType = MissileType(3); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `MissileType` value, out-of-set included.
@@ -107,6 +110,7 @@ impl PropType {
     pub const SPHERE: PropType = PropType(4);
     pub const BLACK_HOLE: PropType = PropType(5);
     pub const DYSON_PANEL: PropType = PropType(6);
+    pub const MAX: PropType = PropType(6); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `PropType` value, out-of-set included.
@@ -137,6 +141,7 @@ pub struct Pending(pub u8);
 
 impl Pending {
     pub const NONE: Pending = Pending(0);
+    pub const MAX: Pending = Pending(0); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `Pending` value, out-of-set included.

--- a/testdata/golden/rust/messages.rs
+++ b/testdata/golden/rust/messages.rs
@@ -17,6 +17,7 @@ impl MessageType {
     pub const SYNCHRONIZE: MessageType = MessageType(4);
     pub const TEST: MessageType = MessageType(5);
     pub const TIMESCALE: MessageType = MessageType(6);
+    pub const MAX: MessageType = MessageType(6); // the exported extent (SPEC §4.2)
 }
 
 // message Heartbeat

--- a/testdata/golden/rust/objects.rs
+++ b/testdata/golden/rust/objects.rs
@@ -15,6 +15,7 @@ impl ObjectType {
     pub const MISSILE: ObjectType = ObjectType(2);
     pub const SHIP: ObjectType = ObjectType(3);
     pub const TURRET: ObjectType = ObjectType(4);
+    pub const MAX: ObjectType = ObjectType(4); // the exported extent (SPEC §4.2)
 }
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -23,6 +23,7 @@ impl Weapon {
     pub const LASER: Weapon = Weapon(1);
     pub const MISSILE: Weapon = Weapon(2);
     pub const RAILGUN: Weapon = Weapon(3);
+    pub const MAX: Weapon = Weapon(15); // the exported extent (SPEC §4.2)
 }
 
 /// Debug/log name for any `Weapon` value, out-of-set included.

--- a/testdata/golden/union/Enums.h
+++ b/testdata/golden/union/Enums.h
@@ -15,6 +15,7 @@ enum class Team : uint8_t {
     None = 0,
     Red = 1,
     Blue = 2,
+    Max = 2, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Team value, out-of-set included
@@ -37,6 +38,7 @@ enum class ShipType : uint8_t {
     Bomber = 3,
     Destroyer = 4,
     Carrier = 5,
+    Max = 5, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any ShipType value, out-of-set included
@@ -60,6 +62,7 @@ enum class MissileType : uint8_t {
     Heatseeker = 1,
     Torpedo = 2,
     Nuke = 3,
+    Max = 3, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any MissileType value, out-of-set included
@@ -84,6 +87,7 @@ enum class PropType : uint8_t {
     Sphere = 4,
     BlackHole = 5,
     DysonPanel = 6,
+    Max = 6, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any PropType value, out-of-set included
@@ -105,6 +109,7 @@ inline const char * EnumName( PropType value )
 // enum Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2)
 enum class Pending : uint8_t {
     None = 0,
+    Max = 0, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Pending value, out-of-set included

--- a/testdata/golden/union/Messages.h
+++ b/testdata/golden/union/Messages.h
@@ -21,6 +21,7 @@ enum class MessageType : uint8_t {
     Synchronize = 4,
     Test = 5,
     Timescale = 6,
+    Max = 6, // the exported extent (SPEC §4.2)
 };
 
 // message Heartbeat

--- a/testdata/golden/union/Objects.h
+++ b/testdata/golden/union/Objects.h
@@ -25,6 +25,7 @@ enum class ObjectType : uint8_t {
     Missile = 2,
     Ship = 3,
     Turret = 4,
+    Max = 4, // the exported extent (SPEC §4.2)
 };
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/testdata/golden/union/Wire.h
+++ b/testdata/golden/union/Wire.h
@@ -22,6 +22,7 @@ enum class Weapon : uint8_t {
     Laser = 1,
     Missile = 2,
     Railgun = 3,
+    Max = 15, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Weapon value, out-of-set included

--- a/testdata/golden/variant/Enums.h
+++ b/testdata/golden/variant/Enums.h
@@ -15,6 +15,7 @@ enum class Team : uint8_t {
     None = 0,
     Red = 1,
     Blue = 2,
+    Max = 2, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Team value, out-of-set included
@@ -37,6 +38,7 @@ enum class ShipType : uint8_t {
     Bomber = 3,
     Destroyer = 4,
     Carrier = 5,
+    Max = 5, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any ShipType value, out-of-set included
@@ -60,6 +62,7 @@ enum class MissileType : uint8_t {
     Heatseeker = 1,
     Torpedo = 2,
     Nuke = 3,
+    Max = 3, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any MissileType value, out-of-set included
@@ -84,6 +87,7 @@ enum class PropType : uint8_t {
     Sphere = 4,
     BlackHole = 5,
     DysonPanel = 6,
+    Max = 6, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any PropType value, out-of-set included
@@ -105,6 +109,7 @@ inline const char * EnumName( PropType value )
 // enum Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2)
 enum class Pending : uint8_t {
     None = 0,
+    Max = 0, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Pending value, out-of-set included

--- a/testdata/golden/variant/Messages.h
+++ b/testdata/golden/variant/Messages.h
@@ -22,6 +22,7 @@ enum class MessageType : uint8_t {
     Synchronize = 4,
     Test = 5,
     Timescale = 6,
+    Max = 6, // the exported extent (SPEC §4.2)
 };
 
 // message Heartbeat

--- a/testdata/golden/variant/Objects.h
+++ b/testdata/golden/variant/Objects.h
@@ -25,6 +25,7 @@ enum class ObjectType : uint8_t {
     Missile = 2,
     Ship = 3,
     Turret = 4,
+    Max = 4, // the exported extent (SPEC §4.2)
 };
 
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----

--- a/testdata/golden/variant/Wire.h
+++ b/testdata/golden/variant/Wire.h
@@ -22,6 +22,7 @@ enum class Weapon : uint8_t {
     Laser = 1,
     Missile = 2,
     Railgun = 3,
+    Max = 15, // the exported extent (SPEC §4.2)
 };
 
 // EnumName: debug/log name for any Weapon value, out-of-set included


### PR DESCRIPTION
Closes #121.

SPEC §4.2 gains the exported-extent rule (in the constants-and-enums-are-exported section): every generated enum surface — declared enums, headroom included, and the generated MessageType/ObjectType tag enums — carries its extent as a member named Max in the target's own convention: `E::Max` (C++), `E.Max` (C#), `EMax` (Go), `E::MAX` (Rust), `E.Max` (JS), `E_MAX` (C — already emitted before this change, now the documented rule). The value is the enum's max, the same number `E.Max` names in schema expressions, so call sites state `[1, ShipType.Max]` directly and the hand-declared `Num*` re-derivations retire downstream.

Decisions taken and documented:
- `Max` is a reserved variant name, refused at check time with its own diagnostic ("variant Max is a compile error — every generated enum carries its extent as the member Max, the same number E.Max names"), exactly parallel to `None`. It was previously refused only by accident, through the C-form `E_MAX` symbol collision with a confusing self-referential message.
- The claimed-name registry gains the new flat symbols: `EMax` per enum (Go form), `MessageTypeMax`/`ObjectTypeMax`, and `MESSAGE_TYPE_MAX` — the last was emitted by the C backend but never claimed (same latent class as issue #23).

Receipts:
- Red-first: `TestEnumExtentEmitted` (internal/codegen/golang) pinned all seven emission surfaces (Go, Rust, C#, JS, C, C++ union+variant) before the implementation — 14 failures, then green.
- Wire and id untouched: goldens re-derived gain only the new symbols (66 insertions, zero deletions, every added line the Max member); `testdata/golden/id.txt` unchanged at 0x40230069cc791fab. The projection already includes enum max, and no max value moved.
- Diagnostics tests: variant named Max; a const named `TeamMax` colliding with the generated extent.
- USAGE.md enum section teaches the extent and its per-target spellings.

Full `make` gauntlet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)