### PR TITLE
Flags export Count — the declared variant count, never Max (#121 follow-on)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -299,7 +299,7 @@ If          = "if" [ "!" ] ident Block [ "else" Block ] NL .
                                                                  // as variants first)
 
 IntExpr     = integer expression over literals, const names, and enum max
-              references ( ident "." "Max" ):
+              references ( ident "." "Max" | ident "." "Count" ):
               "+" "-" "*" "/" "%", unary "-", parentheses.
 FloatExpr   = float expression over float literals, int literals and const names:
               "+" "-" "*" "/", unary "-", parentheses — float64 arithmetic, no "%".
@@ -355,8 +355,16 @@ FloatExpr   = float expression over float literals, int literals and const names
   variants is `E.Max` (see the sentinel-zero convention below). Sizing
   enum-indexed tables with `E.Max + 1` stays correct under `[max]` headroom,
   where non-variant values are wire-legal. It works on generated sets too
-  (`MessageType.Max`). `Max` after `.` is contextual, like attribute keys;
-  the lexer keeps maximal munch, so `..` still wins over `.`.
+  (`MessageType.Max`, `ObjectType.Max`, a union's `<Union>Type.Max` — §4.8);
+  generated sets resolve in constant expressions and nowhere else. **Flags
+  have `F.Count`, not `F.Max`** — a flags declaration is a set of
+  independent bits, not a range with a top, so max-of-what is exactly the
+  confusion `.Max` would invite and the compiler refuses it naming the
+  split. `F.Count` is the DECLARED variant count; under `[max = K]` headroom
+  the wire width is K while `Count` stays the count — the one case the two
+  numbers diverge. `Max` and `Count` after `.` are contextual, like
+  attribute keys; the lexer keeps maximal munch, so `..` still wins over
+  `.`.
 - **Constants are platform-uniform.** A schema has no platform conditionals.
   One schema is one protocol id on every platform; a platform-conditional
   constant reaching any range, bound or width would let two builds carry the
@@ -383,8 +391,13 @@ FloatExpr   = float expression over float literals, int literals and const names
     every target**; no implicit `None` — the empty mask is 0 and needs no
     name. Wire: **W raw bits, W = variant count** (`[max = K]` widens to K
     bits); every W-bit pattern is legal — a mask field's domain is all
-    subsets. Each target exports one mask constant per variant (`1 << bit`),
-    because mask tests are how flag state is consumed. **`flags` is a
+    subsets. **More than 64 variants is a compile error** — one bit per
+    variant, and the storage is `uint64`. Each target exports one mask
+    constant per variant (`1 << bit`),
+    because mask tests are how flag state is consumed, **plus the `Count`
+    constant** — the declared variant count, spelled per target beside the
+    enum extents (`CapsCount` in C++/C#/Go/JS, `CAPS_COUNT` in C and Rust).
+    **`flags` is a
     contextual keyword, not reserved** — it introduces a declaration at file
     scope only, so a *field* named `flags` stays fully legal; declarations at
     file scope otherwise begin with reserved words, so one token of lookahead

--- a/USAGE.md
+++ b/USAGE.md
@@ -135,14 +135,21 @@ flags Capabilities { Cloak, Shield, Warp }
 ```
 
 One bit per variant, consumed as a mask. Storage is `uint64` in every
-language; the wire is exactly as many bits as there are variants:
+language (more than 64 variants is a compile error); the wire is exactly as
+many bits as there are variants:
 
 ```cpp
 using Capabilities = uint64_t;
 inline constexpr Capabilities Capabilities_Cloak  = 1ull << 0;
 inline constexpr Capabilities Capabilities_Shield = 1ull << 1;
 inline constexpr Capabilities Capabilities_Warp   = 1ull << 2;
+inline constexpr int64_t CapabilitiesCount = 3;
 ```
+
+The declared variant count is exported as `Count` and usable in schema
+expressions as `Capabilities.Count`. Flags have no `.Max` — the variants are
+independent bits, not a range with a top; the compiler refuses `.Max` on a
+flags type and names `.Count` instead.
 
 ### type
 

--- a/generated/bench/c/RealWorld.h
+++ b/generated/bench/c/RealWorld.h
@@ -81,6 +81,7 @@ typedef uint64_t PacketFlags;
 #define PACKET_FLAGS_OVERHEATED (1ULL << 2)
 #define PACKET_FLAGS_LOW_POWER (1ULL << 3)
 #define PACKET_FLAGS_JAMMING (1ULL << 4)
+#define PACKET_FLAGS_COUNT 5 /* the declared variant count (SPEC §4.2) */
 
 
 /* type RealPacket */

--- a/generated/bench/cpp/RealWorld.h
+++ b/generated/bench/cpp/RealWorld.h
@@ -48,6 +48,7 @@ inline constexpr PacketFlags PacketFlags_Cloaked = 1ull << 1;
 inline constexpr PacketFlags PacketFlags_Overheated = 1ull << 2;
 inline constexpr PacketFlags PacketFlags_LowPower = 1ull << 3;
 inline constexpr PacketFlags PacketFlags_Jamming = 1ull << 4;
+inline constexpr int64_t PacketFlagsCount = 5; // the declared variant count (SPEC §4.2)
 
 // type RealPacket
 struct RealPacket {

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -186,6 +186,7 @@ namespace Realworld
         public const ulong PacketFlagsOverheated = 1ul << 2;
         public const ulong PacketFlagsLowPower = 1ul << 3;
         public const ulong PacketFlagsJamming = 1ul << 4;
+        public const long PacketFlagsCount = 5; // the declared variant count (SPEC §4.2)
 
         // RealPacketMaxBits is the longest wire path; align pads at worst case (SPEC §6.1).
         // RealPacketMaxBytes is rounded up to the 8-byte write-buffer granularity.

--- a/generated/bench/go/realworld/RealWorld.go
+++ b/generated/bench/go/realworld/RealWorld.go
@@ -62,6 +62,9 @@ const (
 	PacketFlagsJamming    PacketFlags = 1 << 4
 )
 
+// PacketFlagsCount is the declared variant count (SPEC §4.2).
+const PacketFlagsCount = 5
+
 // type RealPacket
 type RealPacket struct {
 	F001Int  int32 // wire [-805495, 805495]

--- a/generated/bench/js/realworld/RealWorld.js
+++ b/generated/bench/js/realworld/RealWorld.js
@@ -68,6 +68,7 @@ export const PacketFlagsCloaked = 1n << 1n;
 export const PacketFlagsOverheated = 1n << 2n;
 export const PacketFlagsLowPower = 1n << 3n;
 export const PacketFlagsJamming = 1n << 4n;
+export const PacketFlagsCount = 5; // the declared variant count (SPEC §4.2)
 
 // type RealPacket
 export class RealPacket {

--- a/generated/bench/rust-realworld/src/realworld.rs
+++ b/generated/bench/rust-realworld/src/realworld.rs
@@ -75,6 +75,7 @@ pub const PACKET_FLAGS_CLOAKED: PacketFlags = 1 << 1;
 pub const PACKET_FLAGS_OVERHEATED: PacketFlags = 1 << 2;
 pub const PACKET_FLAGS_LOW_POWER: PacketFlags = 1 << 3;
 pub const PACKET_FLAGS_JAMMING: PacketFlags = 1 << 4;
+pub const PACKET_FLAGS_COUNT: i64 = 5; // the declared variant count (SPEC §4.2)
 
 // type RealPacket
 #[repr(C)]

--- a/generated/c/Enums.h
+++ b/generated/c/Enums.h
@@ -229,6 +229,7 @@ typedef uint64_t ShipFlags;
 #define SHIP_FLAGS_BOOSTING (1ULL << 1)
 #define SHIP_FLAGS_BRAKING (1ULL << 2)
 #define SHIP_FLAGS_AIMING (1ULL << 3)
+#define SHIP_FLAGS_COUNT 4 /* the declared variant count (SPEC §4.2) */
 
 #ifdef __cplusplus
 }

--- a/generated/c/Wire.h
+++ b/generated/c/Wire.h
@@ -74,6 +74,7 @@ typedef uint64_t ProbeFlags;
 #define PROBE_FLAGS_ARMED (1ULL << 0)
 #define PROBE_FLAGS_CLOAKED (1ULL << 1)
 #define PROBE_FLAGS_DAMAGED (1ULL << 2)
+#define PROBE_FLAGS_COUNT 3 /* the declared variant count (SPEC §4.2) */
 
 
 /* type ProbeHeader */

--- a/generated/cpp/Enums.h
+++ b/generated/cpp/Enums.h
@@ -129,5 +129,6 @@ inline constexpr ShipFlags ShipFlags_FiringLaser = 1ull << 0;
 inline constexpr ShipFlags ShipFlags_Boosting = 1ull << 1;
 inline constexpr ShipFlags ShipFlags_Braking = 1ull << 2;
 inline constexpr ShipFlags ShipFlags_Aiming = 1ull << 3;
+inline constexpr int64_t ShipFlagsCount = 4; // the declared variant count (SPEC §4.2)
 
 } // namespace example

--- a/generated/cpp/Wire.h
+++ b/generated/cpp/Wire.h
@@ -44,6 +44,7 @@ using ProbeFlags = uint64_t;
 inline constexpr ProbeFlags ProbeFlags_Armed = 1ull << 0;
 inline constexpr ProbeFlags ProbeFlags_Cloaked = 1ull << 1;
 inline constexpr ProbeFlags ProbeFlags_Damaged = 1ull << 2;
+inline constexpr int64_t ProbeFlagsCount = 3; // the declared variant count (SPEC §4.2)
 
 // type ProbeHeader
 struct ProbeHeader {

--- a/generated/cs/Enums.cs
+++ b/generated/cs/Enums.cs
@@ -174,6 +174,7 @@ namespace Example
         public const ulong ShipFlagsBoosting = 1ul << 1;
         public const ulong ShipFlagsBraking = 1ul << 2;
         public const ulong ShipFlagsAiming = 1ul << 3;
+        public const long ShipFlagsCount = 4; // the declared variant count (SPEC §4.2)
     }
 
 }

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -223,6 +223,7 @@ namespace Example
         public const ulong ProbeFlagsArmed = 1ul << 0;
         public const ulong ProbeFlagsCloaked = 1ul << 1;
         public const ulong ProbeFlagsDamaged = 1ul << 2;
+        public const long ProbeFlagsCount = 3; // the declared variant count (SPEC §4.2)
 
         // ProbeHeaderMaxBits is the longest wire path; align pads at worst case (SPEC §6.1).
         // ProbeHeaderMaxBytes is rounded up to the 8-byte write-buffer granularity.

--- a/generated/go/Enums.go
+++ b/generated/go/Enums.go
@@ -151,3 +151,6 @@ const (
 	ShipFlagsBraking     ShipFlags = 1 << 2
 	ShipFlagsAiming      ShipFlags = 1 << 3
 )
+
+// ShipFlagsCount is the declared variant count (SPEC §4.2).
+const ShipFlagsCount = 4

--- a/generated/go/Wire.go
+++ b/generated/go/Wire.go
@@ -52,6 +52,9 @@ const (
 	ProbeFlagsDamaged ProbeFlags = 1 << 2
 )
 
+// ProbeFlagsCount is the declared variant count (SPEC §4.2).
+const ProbeFlagsCount = 3
+
 // type ProbeHeader
 type ProbeHeader struct {
 	Version uint32

--- a/generated/js/Enums.js
+++ b/generated/js/Enums.js
@@ -163,4 +163,5 @@ export const ShipFlagsFiringLaser = 1n << 0n;
 export const ShipFlagsBoosting = 1n << 1n;
 export const ShipFlagsBraking = 1n << 2n;
 export const ShipFlagsAiming = 1n << 3n;
+export const ShipFlagsCount = 4; // the declared variant count (SPEC §4.2)
 

--- a/generated/js/Wire.js
+++ b/generated/js/Wire.js
@@ -66,6 +66,7 @@ export function EnumNameWeapon(value) {
 export const ProbeFlagsArmed = 1n << 0n;
 export const ProbeFlagsCloaked = 1n << 1n;
 export const ProbeFlagsDamaged = 1n << 2n;
+export const ProbeFlagsCount = 3; // the declared variant count (SPEC §4.2)
 
 // type ProbeHeader
 export class ProbeHeader {

--- a/generated/rust/src/enums.rs
+++ b/generated/rust/src/enums.rs
@@ -166,4 +166,5 @@ pub const SHIP_FLAGS_FIRING_LASER: ShipFlags = 1 << 0;
 pub const SHIP_FLAGS_BOOSTING: ShipFlags = 1 << 1;
 pub const SHIP_FLAGS_BRAKING: ShipFlags = 1 << 2;
 pub const SHIP_FLAGS_AIMING: ShipFlags = 1 << 3;
+pub const SHIP_FLAGS_COUNT: i64 = 4; // the declared variant count (SPEC §4.2)
 

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -50,6 +50,7 @@ pub type ProbeFlags = u64;
 pub const PROBE_FLAGS_ARMED: ProbeFlags = 1 << 0;
 pub const PROBE_FLAGS_CLOAKED: ProbeFlags = 1 << 1;
 pub const PROBE_FLAGS_DAMAGED: ProbeFlags = 1 << 2;
+pub const PROBE_FLAGS_COUNT: i64 = 3; // the declared variant count (SPEC §4.2)
 
 // type ProbeHeader
 #[repr(C)]

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -228,10 +228,12 @@ type StringLit struct {
 	Value string // without the quotes
 }
 
-// MaxExpr is an enum max reference: E.Max (SPEC §4.2).
+// MaxExpr is a set-extent reference: E.Max on an enum or generated set, and
+// F.Count on a flags declaration (SPEC §4.2). Sel is "Max" or "Count".
 type MaxExpr struct {
 	Pos  Pos
 	Enum string
+	Sel  string
 }
 
 type UnaryExpr struct {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -546,6 +546,9 @@ var valuedAttr = map[string]bool{
 }
 
 func (c *checker) enumMax(e *ast.MaxExpr) (*big.Int, bool) {
+	if e.Sel == "Count" {
+		return c.flagsCount(e)
+	}
 	d, ok := c.astDecls[e.Enum]
 	if !ok {
 		// generated sets work in constant expressions too (SPEC §4.2, §4.8):
@@ -556,6 +559,12 @@ func (c *checker) enumMax(e *ast.MaxExpr) (*big.Int, bool) {
 			return big.NewInt(max), true
 		}
 		c.errf(e.Pos, "undefined enum %s in %s.Max", e.Enum, e.Enum)
+		return nil, false
+	}
+	if _, isFlags := d.(*ast.FlagsDecl); isFlags {
+		// max-of-what is the exact confusion a flags .Max would invite: the
+		// variants are independent bits, not an ordered range with a top
+		c.errf(e.Pos, "flags %s has no .Max — a flags declaration is a set of independent bits, not a range with a top; %s.Count names the declared variant count (SPEC §4.2)", e.Enum, e.Enum)
 		return nil, false
 	}
 	ed, ok := d.(*ast.EnumDecl)
@@ -574,6 +583,27 @@ func (c *checker) enumMax(e *ast.MaxExpr) (*big.Int, bool) {
 		return nil, false
 	}
 	return big.NewInt(en.Max), true
+}
+
+// flagsCount resolves F.Count (SPEC §4.2): the DECLARED variant count of a
+// flags declaration — not the wire width, which a [max = K] widening can
+// raise above it.
+func (c *checker) flagsCount(e *ast.MaxExpr) (*big.Int, bool) {
+	d, ok := c.astDecls[e.Enum]
+	if !ok {
+		c.errf(e.Pos, "undefined flags %s in %s.Count", e.Enum, e.Enum)
+		return nil, false
+	}
+	fd, ok := d.(*ast.FlagsDecl)
+	if !ok {
+		c.errf(e.Pos, "%s is not a flags declaration — .Count names a flags declaration's variant count; an enum's extent is %s.Max (SPEC §4.2)", e.Enum, e.Enum)
+		return nil, false
+	}
+	fl := c.resolveFlags(fd)
+	if fl == nil {
+		return nil, false
+	}
+	return big.NewInt(int64(len(fl.Variants))), true
 }
 
 // generatedSetMax resolves E.Max over the GENERATED tag sets (SPEC §4.2,
@@ -2353,6 +2383,8 @@ func (c *checker) checkClaimedNames() {
 			}
 			addRust("enum_name_"+ir.RustSnake(name+"Type"), fmt.Sprintf("union %s's generated tag debug-name function (C form)", name), d.Pos)
 		case *ast.FlagsDecl:
+			add(name+"Count", fmt.Sprintf("flags %s's generated Count constant", name), d.Pos)
+			addRust(ir.RustConstName(name+"Count"), fmt.Sprintf("flags %s's generated Count constant (Rust/C form)", name), d.Pos, name+"Count")
 			for _, v := range d.Variants {
 				add(name+v.Text, fmt.Sprintf("flags %s's generated mask constant (Go form)", name), v.Pos)
 				add(name+"_"+v.Text, fmt.Sprintf("flags %s's generated mask constant (C++ form)", name), v.Pos)

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -6,6 +6,7 @@
 package check
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -33,6 +34,15 @@ func runUnit(t *testing.T, sources map[string]string) []error {
 	_, errs := Unit(files)
 	return errs
 }
+
+// flags65 spells 65 comma-separated variant names — one past uint64 storage.
+var flags65 = func() string {
+	names := make([]string, 65)
+	for i := range names {
+		names[i] = fmt.Sprintf("V%d", i)
+	}
+	return strings.Join(names, ", ")
+}()
 
 func TestDiagnostics(t *testing.T) {
 	cases := []struct {
@@ -167,6 +177,14 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\nenum E [max = 2] { A, B, C }\n"},
 		{name: "Max reference to a non-enum", want: "is not an enum",
 			src: "package t\ntype V { x uint8 }\nconst N = V.Max + 1\n"},
+		{name: "Max reference to a flags declaration", want: "has no .Max",
+			src: "package t\nflags F { A, B }\nconst N = F.Max\n"},
+		{name: "Count reference to an enum", want: "is not a flags declaration",
+			src: "package t\nenum E { A }\nconst N = E.Count\n"},
+		{name: "Count reference undefined", want: "undefined flags",
+			src: "package t\nconst N = F.Count\n"},
+		{name: "65 flags variants overflow uint64 storage", want: "one bit per variant, up to 64",
+			src: "package t\nflags F { " + flags65 + " }\n"},
 		// ---- unions (SPEC §4.8) ----
 		{name: "union variant named none (exported spelling)", want: "every union has None = 0 implicitly",
 			src: "package t\nunion U {\n    none Box\n}\ntype Box { x uint8 }\n"},
@@ -459,6 +477,10 @@ func TestGoodCornersStillCompile(t *testing.T) {
 			src: "package t\ntype Q { w fixed(2, 30) [min = -1, max = 1] = 1.0 \n x fixed(16, 16) [min = 0, max = 100] = 0.5 \n y fixed(48, 16) [min = -10, max = 10] = 3 }\n"},
 		{name: "field named flags at block scope",
 			src: "package t\nflags F { A }\ntype T { flags F }\n"},
+		{name: "64 flags variants fill uint64 storage exactly",
+			src: "package t\nflags F { " + strings.Replace(flags65, ", V64", "", 1) + " }\n"},
+		{name: "F.Count in a constant expression",
+			src: "package t\nflags F { A, B }\nconst N = F.Count\n"},
 		{name: "message as a field type",
 			src: "package t\nmessage M { x uint8 }\ntype T { m M }\n"},
 		{name: "empty type and empty message",

--- a/internal/check/projection_test.go
+++ b/internal/check/projection_test.go
@@ -229,6 +229,40 @@ const Arms     = HeldType.Max
 	}
 }
 
+// F.Count is the DECLARED variant count (SPEC §4.2) — under [max = K]
+// headroom it diverges from the wire width, and Count stays the count.
+func TestFlagsCountValue(t *testing.T) {
+	u := build(t, `package probe
+
+flags Plain {
+    A,
+    B,
+    C,
+}
+
+flags Wide [max = 8] {
+    A,
+    B,
+    C,
+}
+
+const PlainN = Plain.Count
+const WideN  = Wide.Count
+`)
+	for _, tc := range []struct {
+		name string
+		want int64
+	}{{"PlainN", 3}, {"WideN", 3}} {
+		c := u.Consts[tc.name]
+		if c == nil || c.Int == nil || c.Int.Int64() != tc.want {
+			t.Errorf("const %s: want %d, got %v — Count is the declared count, never the widened wire width", tc.name, tc.want, c)
+		}
+	}
+	if u.Flags["Wide"].WireBits != 8 {
+		t.Errorf("Wide.WireBits = %d, want 8 — the [max = 8] widening is the WIRE width, distinct from Count", u.Flags["Wide"].WireBits)
+	}
+}
+
 // The projection is a reviewable artifact, so it has to be deterministic:
 // same unit, same text, every time and in any map iteration order.
 func TestProjectionIsDeterministic(t *testing.T) {

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -357,6 +357,7 @@ func (g *gen) emitFlags(d *ir.Flags) {
 	for i, v := range d.Variants {
 		g.pf("#define %s_%s (1ULL << %d)\n", screaming(d.Name), screaming(v), i)
 	}
+	g.pf("#define %s_COUNT %d /* the declared variant count (SPEC §4.2) */\n", screaming(d.Name), len(d.Variants))
 	g.pf("\n")
 }
 

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -510,6 +510,7 @@ func (g *gen) emitFlags(d *ir.Flags) {
 	for i, v := range d.Variants {
 		g.pf("inline constexpr %s %s_%s = 1ull << %d;\n", d.Name, d.Name, v, i)
 	}
+	g.pf("inline constexpr int64_t %sCount = %d; // the declared variant count (SPEC §4.2)\n", d.Name, len(d.Variants))
 	g.pf("\n")
 }
 

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -366,6 +366,7 @@ func (g *gen) emitFlags(d *ir.Flags) {
 	for i, v := range d.Variants {
 		g.sf("public const ulong %s%s = 1ul << %d;\n", d.Name, v, i)
 	}
+	g.sf("public const long %sCount = %d; // the declared variant count (SPEC §4.2)\n", d.Name, len(d.Variants))
 	g.sf("\n")
 }
 

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -294,6 +294,8 @@ func (g *gen) emitFlags(d *ir.Flags) {
 		g.pf("\t%s%s %s = 1 << %d\n", d.Name, v, d.Name, i)
 	}
 	g.pf(")\n\n")
+	g.pf("// %sCount is the declared variant count (SPEC §4.2).\n", d.Name)
+	g.pf("const %sCount = %d\n\n", d.Name, len(d.Variants))
 }
 
 func (g *gen) emitStruct(d *ir.Struct) {

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -269,6 +269,87 @@ func TestUnionSurfaceEmitted(t *testing.T) {
 	}
 }
 
+// Flags export their declared variant count as Count (SPEC §4.2 — one name,
+// not Max: the variants are independent bits, not a range with a top), and
+// the wire spends EXACTLY Count bits when no [max = K] widens it (schema
+// issue #129's verification): a 4-variant flags field serializes in 4 bits
+// in every target, write and read alike.
+func TestFlagsCountAndWireBits(t *testing.T) {
+	src := "package t\n\n" +
+		"flags Caps { A, B, C, D }\n\n" +
+		"type Holder { caps Caps }\n"
+	f, perrs := parser.Parse("Flags.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "Flags.schema", Name: "Flags.schema", Base: "Flags",
+		Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	if got := ir.MaxBitsStruct(u.Structs["Holder"]); got != 4 {
+		t.Fatalf("MaxBits(Holder) = %d, want 4 — a 4-variant flags spends exactly Count bits", got)
+	}
+
+	type expectation struct {
+		needle string
+		count  int
+	}
+	type target struct {
+		name    string
+		files   map[string][]byte
+		genErr  error
+		expects []expectation
+	}
+	var targets []target
+	addTarget := func(name string, files map[string][]byte, err error, expects ...expectation) {
+		targets = append(targets, target{name, files, err, expects})
+	}
+
+	goFiles, goErr := Generate(u)
+	addTarget("Go", goFiles, goErr,
+		expectation{"const CapsCount = 4", 1},
+		expectation{"stream.SerializeBits(&flagsValue, 4)", 2}) // write + read
+	rustFiles, rustErr := rust.Generate(u)
+	addTarget("Rust", rustFiles, rustErr,
+		expectation{"pub const CAPS_COUNT: i64 = 4;", 1},
+		expectation{"stream.serialize_bits(&mut flags_value, 4)?;", 2})
+	csFiles, csErr := csharp.Generate(u)
+	addTarget("C#", csFiles, csErr,
+		expectation{"public const long CapsCount = 4;", 1},
+		expectation{"SerializeBits(ref flagsValue, 4)", 2})
+	jsFiles, jsErr := js.Generate(u)
+	addTarget("JS", jsFiles, jsErr,
+		expectation{"export const CapsCount = 4;", 1},
+		expectation{"stream.serializeBits(NUMBER_SCRATCH, 4)", 2})
+	cFiles, cErr := cgen.Generate(u)
+	addTarget("C", cFiles, cErr,
+		expectation{"#define CAPS_COUNT 4", 1},
+		expectation{"serialize_write_bits( stream, (serialize_uint32_t) value->caps, 4 )", 1},
+		expectation{"serialize_read_bits( stream, &flags_value, 4 )", 1})
+	for _, mode := range []string{"union", "variant"} {
+		cppFiles, cppErr := cpp.Generate(u, cpp.Options{MessageRepr: mode})
+		addTarget("C++ ("+mode+")", cppFiles, cppErr,
+			expectation{"inline constexpr int64_t CapsCount = 4;", 1},
+			expectation{"write_bits( stream, value.caps, 4 );", 1},
+			expectation{"read_bits( stream, value.caps, 4 );", 1})
+	}
+
+	for _, tgt := range targets {
+		if tgt.genErr != nil {
+			t.Errorf("%s: generate: %v", tgt.name, tgt.genErr)
+			continue
+		}
+		for _, e := range tgt.expects {
+			if got := countAcross(tgt.files, e.needle); got != e.count {
+				t.Errorf("%s: %q emitted %d times, want %d — flags spend exactly Count wire bits and export Count (SPEC §4.2)", tgt.name, e.needle, got, e.count)
+			}
+		}
+	}
+}
+
 func TestDispatchSurfaceEmittedOnce(t *testing.T) {
 	u := multiFileUnit(t)
 

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -372,6 +372,7 @@ func (g *gen) emitFlags(d *ir.Flags) {
 	for i, v := range d.Variants {
 		g.pf("export const %s%s = 1n << %dn;\n", d.Name, v, i)
 	}
+	g.pf("export const %sCount = %d; // the declared variant count (SPEC §4.2)\n", d.Name, len(d.Variants))
 	g.pf("\n")
 }
 

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -386,6 +386,7 @@ func (g *gen) emitFlags(d *ir.Flags) {
 	for i, v := range d.Variants {
 		g.pf("pub const %s_%s: %s = 1 << %d;\n", ir.RustConstName(d.Name), ir.RustConstName(v), d.Name, i)
 	}
+	g.pf("pub const %s: i64 = %d; // the declared variant count (SPEC §4.2)\n", ir.RustConstName(d.Name+"Count"), len(d.Variants))
 	g.pf("\n")
 }
 

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -680,7 +680,7 @@ func fpExpr(e ast.Expr) string {
 	case *ast.StringLit:
 		return `"` + e.Value + `"`
 	case *ast.MaxExpr:
-		return e.Enum + ".Max"
+		return e.Enum + "." + e.Sel
 	case *ast.UnaryExpr:
 		return "(- " + fpExpr(e.X) + ")"
 	case *ast.BinaryExpr:

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -617,14 +617,14 @@ func (p *parser) parsePrimary() ast.Expr {
 		return &ast.StringLit{Pos: t.Pos, Value: strings.Trim(t.Text, `"`)}
 	case scanner.Ident:
 		p.advance()
-		// E.Max — Max is contextual after '.' (SPEC §4.2)
+		// E.Max / F.Count — contextual after '.' (SPEC §4.2)
 		if p.kind() == scanner.Dot {
 			dot := p.advance()
-			m := p.expect(scanner.Ident, `"Max"`)
-			if m.Text != "Max" {
-				p.errf(dot.Pos, "only .Max is legal after an enum name (found .%s)", m.Text)
+			m := p.expect(scanner.Ident, `"Max" or "Count"`)
+			if m.Text != "Max" && m.Text != "Count" {
+				p.errf(dot.Pos, "only .Max (enums and generated sets) and .Count (flags) are legal after a name (found .%s)", m.Text)
 			}
-			return &ast.MaxExpr{Pos: t.Pos, Enum: t.Text}
+			return &ast.MaxExpr{Pos: t.Pos, Enum: t.Text, Sel: m.Text}
 		}
 		return &ast.IdentExpr{Pos: t.Pos, Name: t.Text}
 	case scanner.LParen:

--- a/ir/expr.go
+++ b/ir/expr.go
@@ -26,7 +26,7 @@ func RenderExpr(e Expr) string {
 	case *ast.IdentExpr:
 		return e.Name
 	case *ast.MaxExpr:
-		return e.Enum + ".Max"
+		return e.Enum + "." + e.Sel
 	case *ast.UnaryExpr:
 		return "-" + RenderExpr(e.X)
 	case *ast.BinaryExpr:

--- a/testdata/golden/c/Enums.h
+++ b/testdata/golden/c/Enums.h
@@ -229,6 +229,7 @@ typedef uint64_t ShipFlags;
 #define SHIP_FLAGS_BOOSTING (1ULL << 1)
 #define SHIP_FLAGS_BRAKING (1ULL << 2)
 #define SHIP_FLAGS_AIMING (1ULL << 3)
+#define SHIP_FLAGS_COUNT 4 /* the declared variant count (SPEC §4.2) */
 
 #ifdef __cplusplus
 }

--- a/testdata/golden/c/Wire.h
+++ b/testdata/golden/c/Wire.h
@@ -74,6 +74,7 @@ typedef uint64_t ProbeFlags;
 #define PROBE_FLAGS_ARMED (1ULL << 0)
 #define PROBE_FLAGS_CLOAKED (1ULL << 1)
 #define PROBE_FLAGS_DAMAGED (1ULL << 2)
+#define PROBE_FLAGS_COUNT 3 /* the declared variant count (SPEC §4.2) */
 
 
 /* type ProbeHeader */

--- a/testdata/golden/cs/Enums.cs
+++ b/testdata/golden/cs/Enums.cs
@@ -174,6 +174,7 @@ namespace Example
         public const ulong ShipFlagsBoosting = 1ul << 1;
         public const ulong ShipFlagsBraking = 1ul << 2;
         public const ulong ShipFlagsAiming = 1ul << 3;
+        public const long ShipFlagsCount = 4; // the declared variant count (SPEC §4.2)
     }
 
 }

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -223,6 +223,7 @@ namespace Example
         public const ulong ProbeFlagsArmed = 1ul << 0;
         public const ulong ProbeFlagsCloaked = 1ul << 1;
         public const ulong ProbeFlagsDamaged = 1ul << 2;
+        public const long ProbeFlagsCount = 3; // the declared variant count (SPEC §4.2)
 
         // ProbeHeaderMaxBits is the longest wire path; align pads at worst case (SPEC §6.1).
         // ProbeHeaderMaxBytes is rounded up to the 8-byte write-buffer granularity.

--- a/testdata/golden/go/Enums.go
+++ b/testdata/golden/go/Enums.go
@@ -151,3 +151,6 @@ const (
 	ShipFlagsBraking     ShipFlags = 1 << 2
 	ShipFlagsAiming      ShipFlags = 1 << 3
 )
+
+// ShipFlagsCount is the declared variant count (SPEC §4.2).
+const ShipFlagsCount = 4

--- a/testdata/golden/go/Wire.go
+++ b/testdata/golden/go/Wire.go
@@ -52,6 +52,9 @@ const (
 	ProbeFlagsDamaged ProbeFlags = 1 << 2
 )
 
+// ProbeFlagsCount is the declared variant count (SPEC §4.2).
+const ProbeFlagsCount = 3
+
 // type ProbeHeader
 type ProbeHeader struct {
 	Version uint32

--- a/testdata/golden/js/Enums.js
+++ b/testdata/golden/js/Enums.js
@@ -163,4 +163,5 @@ export const ShipFlagsFiringLaser = 1n << 0n;
 export const ShipFlagsBoosting = 1n << 1n;
 export const ShipFlagsBraking = 1n << 2n;
 export const ShipFlagsAiming = 1n << 3n;
+export const ShipFlagsCount = 4; // the declared variant count (SPEC §4.2)
 

--- a/testdata/golden/js/Wire.js
+++ b/testdata/golden/js/Wire.js
@@ -66,6 +66,7 @@ export function EnumNameWeapon(value) {
 export const ProbeFlagsArmed = 1n << 0n;
 export const ProbeFlagsCloaked = 1n << 1n;
 export const ProbeFlagsDamaged = 1n << 2n;
+export const ProbeFlagsCount = 3; // the declared variant count (SPEC §4.2)
 
 // type ProbeHeader
 export class ProbeHeader {

--- a/testdata/golden/rust/enums.rs
+++ b/testdata/golden/rust/enums.rs
@@ -166,4 +166,5 @@ pub const SHIP_FLAGS_FIRING_LASER: ShipFlags = 1 << 0;
 pub const SHIP_FLAGS_BOOSTING: ShipFlags = 1 << 1;
 pub const SHIP_FLAGS_BRAKING: ShipFlags = 1 << 2;
 pub const SHIP_FLAGS_AIMING: ShipFlags = 1 << 3;
+pub const SHIP_FLAGS_COUNT: i64 = 4; // the declared variant count (SPEC §4.2)
 

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -50,6 +50,7 @@ pub type ProbeFlags = u64;
 pub const PROBE_FLAGS_ARMED: ProbeFlags = 1 << 0;
 pub const PROBE_FLAGS_CLOAKED: ProbeFlags = 1 << 1;
 pub const PROBE_FLAGS_DAMAGED: ProbeFlags = 1 << 2;
+pub const PROBE_FLAGS_COUNT: i64 = 3; // the declared variant count (SPEC §4.2)
 
 // type ProbeHeader
 #[repr(C)]

--- a/testdata/golden/union/Enums.h
+++ b/testdata/golden/union/Enums.h
@@ -129,5 +129,6 @@ inline constexpr ShipFlags ShipFlags_FiringLaser = 1ull << 0;
 inline constexpr ShipFlags ShipFlags_Boosting = 1ull << 1;
 inline constexpr ShipFlags ShipFlags_Braking = 1ull << 2;
 inline constexpr ShipFlags ShipFlags_Aiming = 1ull << 3;
+inline constexpr int64_t ShipFlagsCount = 4; // the declared variant count (SPEC §4.2)
 
 } // namespace example

--- a/testdata/golden/union/Wire.h
+++ b/testdata/golden/union/Wire.h
@@ -44,6 +44,7 @@ using ProbeFlags = uint64_t;
 inline constexpr ProbeFlags ProbeFlags_Armed = 1ull << 0;
 inline constexpr ProbeFlags ProbeFlags_Cloaked = 1ull << 1;
 inline constexpr ProbeFlags ProbeFlags_Damaged = 1ull << 2;
+inline constexpr int64_t ProbeFlagsCount = 3; // the declared variant count (SPEC §4.2)
 
 // type ProbeHeader
 struct ProbeHeader {

--- a/testdata/golden/variant/Enums.h
+++ b/testdata/golden/variant/Enums.h
@@ -129,5 +129,6 @@ inline constexpr ShipFlags ShipFlags_FiringLaser = 1ull << 0;
 inline constexpr ShipFlags ShipFlags_Boosting = 1ull << 1;
 inline constexpr ShipFlags ShipFlags_Braking = 1ull << 2;
 inline constexpr ShipFlags ShipFlags_Aiming = 1ull << 3;
+inline constexpr int64_t ShipFlagsCount = 4; // the declared variant count (SPEC §4.2)
 
 } // namespace example

--- a/testdata/golden/variant/Wire.h
+++ b/testdata/golden/variant/Wire.h
@@ -44,6 +44,7 @@ using ProbeFlags = uint64_t;
 inline constexpr ProbeFlags ProbeFlags_Armed = 1ull << 0;
 inline constexpr ProbeFlags ProbeFlags_Cloaked = 1ull << 1;
 inline constexpr ProbeFlags ProbeFlags_Damaged = 1ull << 2;
+inline constexpr int64_t ProbeFlagsCount = 3; // the declared variant count (SPEC §4.2)
 
 // type ProbeHeader
 struct ProbeHeader {


### PR DESCRIPTION
Glenn's ruling on the flags half of the extent work, folded with schema#129's verification:

- **`F.Count`** — one name ("Count and Bits is the same. Use Count."): the DECLARED variant count, resolvable in schema constant expressions like `E.Max`, and emitted into every target's generated surface beside the enum extents (`CapsCount` in C++/C#/Go/JS, `CAPS_COUNT` in C and Rust). Claimed-name coverage included.
- **`F.Max` on a flags type is refused** with the diagnostic naming the split: a flags declaration is a set of independent bits, not a range with a top — max-of-what is exactly the confusion `.Max` would invite; the message points to `.Count`.
- **The divergence case is stated and pinned**: under `[max = K]` headroom the WIRE width is K while `Count` stays the declared count (`TestFlagsCountValue`: Count = 3 with WireBits = 8).
- **More than 64 variants is a compile error** — already in the checker (storage is uint64); now tested at 64 (accepted) and 65 (refused).
- **schema#129 verified per target**: a 4-variant flags spends exactly 4 wire bits, write and read alike, pinned by `TestFlagsCountAndWireBits` across Go, Rust, C#, JS, C and both C++ modes, with the MaxBits fold asserted at the IR.

Implementation note: `E.Max`/`F.Count` share one AST node (`MaxExpr` gains a `Sel`), so every expression walker treats both as fold-to-literal; only evaluation and rendering read the selector. Goldens gain only the Count symbols (18 insertions, zero deletions); protocol id unchanged at 0x9cdffa5a3048f991. Full make gauntlet + golangci-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)