### PR TITLE
Attributes become the | qualification section; defaults move before the pipe (#126)

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -28,8 +28,8 @@ type ShipCreate {
         flags       ShipFlags                       // 4 flag bits
     }
     team            Team                            // 3 wire values incl. None
-    health          int16 [min = 0, max = MaxHealth]  // MaxHealth = 1000
-    thrust          int8  [min = 0, max = 100]
+    health          int16 | min = 0, max = MaxHealth // MaxHealth = 1000
+    thrust          int8 | min = 0, max = 100
 }
 ```
 
@@ -72,7 +72,7 @@ the writer's own byte count — 219 bits, which is exactly the compiler's
 | **total** | **219 bits = 28 bytes** | |
 
 Nothing is spent identifying a field, because both sides were generated from
-the same schema. `health` is 10 bits because it was declared `[min = 0, max =
+the same schema. `health` is 10 bits because it was declared `| min = 0, max =
 1000]`, not because anyone hand-packed it.
 
 ## What the others are buying

--- a/FAQ.md
+++ b/FAQ.md
@@ -15,7 +15,7 @@ you need, FlatBuffers is the better tool.
 
 What you get for that cost is **size**. FlatBuffers is byte-aligned and carries
 vtables and offsets, because that is what makes in-place access work. schema is
-**bit-packed with no framing at all**: a field declared `[min = 0, max = 1000]`
+**bit-packed with no framing at all**: a field declared `| min = 0, max = 1000`
 occupies 10 bits, an enum with three variants occupies 2, and a branch that is
 not taken occupies nothing. There is no vtable, no offset table, no field
 identifier on the wire — both sides know the layout because the same compiler
@@ -113,7 +113,7 @@ would favour Cap'n Proto's packing far more than it favours schema.
 Honestly: not the idea of generating serializers from a schema. That is old.
 Three things in combination are unusual:
 
-1. **Bit-level bounds as part of the type.** `[min, max]` is not validation
+1. **Bit-level bounds as part of the type.** `| min, max` is not validation
    bolted on — it determines the wire width. Most formats give you a `uint32`
    and store 32 bits.
 2. **Fixed point as a first-class type.** `fixed(48, 16)` — and its unsigned

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ type Vec3 {
 message ShipState {
     ship_type ShipType
     position  Vec3
-    health    int32 [min = 0, max = MaxHealth]
+    health    int32 | min = 0, max = MaxHealth
     at_rest   bool
     if !at_rest {
         velocity Vec3
@@ -65,11 +65,11 @@ would have hand-written, not an interpreter walking a schema at runtime.
 - **One declaration, six languages** — C, C++, C#, Go, Rust and JavaScript,
   bit-identical on the wire, reader and writer generated together so they
   cannot drift.
-- **Bit-packed, not byte-packed** — `[min = 0, max = 1000]` costs 10 bits, not
+- **Bit-packed, not byte-packed** — `| min = 0, max = 1000` costs 10 bits, not
   4 bytes. Bounds are part of the type, and the wire cost follows from them.
 - **Branches that cost nothing** — `if !at_rest { … }` omits whole field groups
   from the wire, back-referencing a bool already sent.
-- **Compressed floats** — `[min, max, resolution]` sends a step index, not a
+- **Compressed floats** — `| min, max, resolution` sends a step index, not a
   float. A 0–1 throttle at 0.01 costs 7 bits.
 - **Fixed point is a type in the language** — `fixed(48, 16)` and its unsigned
   sibling `ufixed(48, 16)` are declared like any other field, and the compiler

--- a/SPEC.md
+++ b/SPEC.md
@@ -129,7 +129,7 @@ string/bytes capacity; float range, resolution and step count; fixed `I` and
 field sitting at its default); branch structure; `const`/`reserved`/`align`
 items; enum max and storage bits; flags wire bits; union variant order,
 count and payload type references (the tag is positional and the payload is
-the wire — §4.8); `[local]` and `[interpolate]` markers.
+the wire — §4.8); `local` and `interpolate` markers.
 
 **Excluded — each has no effect on the bytes:** comments and whitespace; file
 names, file layout and declaration order; enum variant names, union variant
@@ -207,8 +207,11 @@ band) is the application's choice — netcode-style stacks already carry one.
   literals** (decimal, with optional fraction and exponent) appear in float
   constants and as float attribute values (`min`/`max`/`resolution` on
   `float32`).
-- **Punctuation and operators:** `{ } ( ) [ ] , : = ! . .. + - * / %`
-  (maximal munch: `..` wins over `.`). `<=` is not in the language: a count
+- **Punctuation and operators:** `{ } ( ) [ ] , : = ! . .. | + - * / %`
+  (maximal munch: `..` wins over `.`). `|` opens a line's qualification
+  section (§4.2, Attributes) and claims the rest of the line — the newline
+  or a `//` comment terminates it, and no newline suppression applies after
+  `|` or after a `,` inside a qualification. `<=` is not in the language: a count
   bound is a range literal (`[..N]`, `[A..B]`), never a truncated
   comparison, and the retired `[<= N]` spelling is refused with the
   replacement named.
@@ -218,13 +221,21 @@ band) is the application's choice — netcode-style stacks already carry one.
   int32 int64 uint8 uint16 uint32 uint64 int128 uint128` — plus `int` and
   `uint`, reserved so `int` gets a "did you mean int32?" diagnostic instead
   of a parse error. Reserved words cannot be used as names. Attribute keys
-  (`min`, `max`, `resolution`, ...) are contextual — they live only inside
-  `[ ]` and are not reserved.
+  (`min`, `max`, `resolution`, ...) are contextual — they live only right of
+  `|` and are not reserved.
 - **Newlines terminate declarations and fields — there are no semicolons,
   like Go.** The newline is a terminator token, suppressed: immediately after
   `{`, `(`, `[`, `,`, `:`, `=`, `else`, and an infix operator; and
-  immediately before `)`, `]`, `}`. Blank lines are insignificant. `{` sits
-  on the same line as its construct; `} else {` is written on one line — a
+  immediately before `)`, `]`, `}`. **Right of `|`, ALL suppression is
+  off** — from the pipe to the physical end of line, the newline always
+  terminates (that is the no-wrap guarantee of §4.2), and a `/* */` block
+  comment is refused there (its swallowed newline would let the section
+  silently span lines). Blank lines are insignificant. `{` sits
+  on the same line as its construct — EXCEPT a declaration whose line
+  carries a `|` qualification section, whose body brace opens on the next
+  line (§4.2); a declaration without one may also put `{` on the next line,
+  tolerated by the parser and rewritten to the same line by the formatter;
+  `} else {` is written on one line — a
   newline between `}` and `else` is tolerated by the parser and rewritten by
   the formatter. Two consequences make the grammar implementable as written:
   **a closing `}` also terminates the item before it** — in every production
@@ -242,7 +253,10 @@ EBNF (`NL` = the newline terminator; `{X}` repetition; `[X]` option):
 File        = { Declaration } .
 Declaration = Package | Const | Enum | Flags | TypeDecl | Message | Object | Union | Contexts .
 Object      = "object" ident Block NL .
-Flags       = "flags" ident [ Attributes ] VariantList NL .        // "flags" contextual, §4.2
+Flags       = "flags" ident ( VariantList
+            | AttrSection NL VariantList ) NL .                // "flags" contextual, §4.2;
+                                                                   // a qualified declaration's
+                                                                   // body opens on the NEXT line
 Union       = "union" ident UnionBlock NL .                        // "union" contextual, §4.8
 UnionBlock  = "{" { UnionVariant } "}" .
 UnionVariant = ident ident NL .                                    // variant name, then its payload type
@@ -252,16 +266,19 @@ Package     = "package" ident NL .
 Const       = "const" ident [ ConstType ] "=" ConstExpr NL .
 ConstType   = IntType | "float32" | "float64" .
 ConstExpr   = IntExpr | FloatExpr .
-Enum        = "enum" ident [ Attributes ] VariantList NL .
+Enum        = "enum" ident ( VariantList
+            | AttrSection NL VariantList ) NL .
 VariantList = "{" [ ident { "," ident } [ "," ] ] "}" .            // commas; trailing comma OK
-TypeDecl    = ( "type" | "table" ) ident [ Attributes ] Block NL .  // attribute = the type TAG, §4.2;
-                                                            // "table" = a table-wire/reflection
-                                                            // ROOT (§4.11)
+TypeDecl    = ( "type" | "table" ) ident ( Block
+            | AttrSection NL Block ) NL .               // qualifiers = the type TAG and the
+                                                        // cpp_* pair, §4.2; "table" = a
+                                                        // table-wire/reflection ROOT (§4.11)
 Message     = "message" ident Block NL .
 
 Block       = "{" { Item } "}" .
 Item        = Field | ConstField | Reserved | Align | If .
-Field       = ident Type [ Attributes ] [ "=" Default ] NL .
+Field       = ident Type [ "=" Default ] [ AttrSection ] NL .   // the default DEFINES, so it
+                                                                 // precedes the qualification
 Default     = ConstExpr | ident .                    // specified default (see below):
                                                      // ident = true | false | an enum variant
 ConstField  = "const" "(" IntExpr "," IntExpr ")" NL .          // (value, bits)
@@ -286,7 +303,9 @@ IntType     = "int8" | "int16" | "int32" | "int64"
 Bound       = IntExpr | ".." IntExpr | IntExpr ".." IntExpr .       // [N] exact; [..N] = [0..N],
                                                                     // "up to N"; [A..B] = count in [A, B]
 
-Attributes  = "[" Attr { "," Attr } "]" .                        // trailing, optional, per field
+AttrSection = "|" Attr { "," Attr } .                            // runs to END OF LINE: the newline
+                                                                 // or a // comment terminates it —
+                                                                 // nothing follows a qualification
 Attr        = ident "=" ( ConstExpr | ident | string )           // valued:    min = 0, round = up,
                                                                  //            cpp_include = "a.h"
             | ident .                                            // valueless: interpolate, local
@@ -325,7 +344,8 @@ FloatExpr   = float expression over float literals, int literals and const names
   recursively for nested types — in every target (C++ emits default member initializers; the other
   languages get it from their own rules, stated so no target can silently be
   the odd one out). A field may override its zero with `= value` after the
-  attributes: `invulnerable bool [local] = true`. Defaults cover bool
+  type — the default DEFINES the fresh value, so it precedes any `|`
+  qualification: `invulnerable bool = true | local`. Defaults cover bool
   (`true`/`false`), integer and float fields (constant expressions,
   fit-checked like any use site), enum fields (a variant name), the 128-bit
   integers, and `fixed` (§4.6); arrays, strings, bytes, composite and union
@@ -353,18 +373,18 @@ FloatExpr   = float expression over float literals, int literals and const names
   makes a typed constant** — `const MaxBounds uint64 = 12000` — which pins
   the exported type in every target.
 - **Enum max references:** **`E.Max`** in any integer expression names enum
-  `E`'s max — the derived count, or the widened `[max = K]` — the same number
+  `E`'s max — the derived count, or the widened `| max = K` — the same number
   the enum's wire range and storage derive from. The count of wire values is
   `E.Max + 1` by ordinary constant arithmetic; the count of real (non-`None`)
   variants is `E.Max` (see the sentinel-zero convention below). Sizing
-  enum-indexed tables with `E.Max + 1` stays correct under `[max]` headroom,
+  enum-indexed tables with `E.Max + 1` stays correct under `max` headroom,
   where non-variant values are wire-legal. It works on generated sets too
   (`MessageType.Max`, `ObjectType.Max`, a union's `<Union>Type.Max` — §4.8);
   generated sets resolve in constant expressions and nowhere else. **Flags
   have `F.Count`, not `F.Max`** — a flags declaration is a set of
   independent bits, not a range with a top, so max-of-what is exactly the
   confusion `.Max` would invite and the compiler refuses it naming the
-  split. `F.Count` is the DECLARED variant count; under `[max = K]` headroom
+  split. `F.Count` is the DECLARED variant count; under `| max = K` headroom
   the wire width is K while `Count` stays the count — the one case the two
   numbers diverge. `Max` and `Count` after `.` are contextual, like
   attribute keys; the lexer keeps maximal munch, so `..` still wins over
@@ -382,7 +402,7 @@ FloatExpr   = float expression over float literals, int literals and const names
 - **Enum variants** are comma-separated identifiers, trailing comma allowed.
   **Every enum has `None = 0` implicitly — universal, never declared.**
   Declared variants pack tightly from 1; max derives as the count; the
-  `[max = K]` headroom attribute can widen the wire. **Enum storage derives
+  `| max = K` headroom attribute can widen the wire. **Enum storage derives
   from the enum's own max** — the smallest unsigned integer that fits.
 - **Canonical form only.** Enums are always `0 = None`, then `[1, max]`,
   dense. There are no explicit variant values and no sparse enums.
@@ -393,7 +413,7 @@ FloatExpr   = float expression over float literals, int literals and const names
   - **`flags Name { ... }`** — each variant names one bit, assigned densely
     from bit 0 in declaration order, **up to 64**; **storage is `uint64` in
     every target**; no implicit `None` — the empty mask is 0 and needs no
-    name. Wire: **W raw bits, W = variant count** (`[max = K]` widens to K
+    name. Wire: **W raw bits, W = variant count** (`| max = K` widens to K
     bits); every W-bit pattern is legal — a mask field's domain is all
     subsets. **More than 64 variants is a compile error** — one bit per
     variant, and the storage is `uint64`. Each target exports one mask
@@ -414,30 +434,74 @@ FloatExpr   = float expression over float literals, int literals and const names
   order-free; §4.5.)
 - `if` nests freely inside blocks (`switch` is not in v1; §4.4).
 
-### Attributes — per-field, optional, keyed
+### Attributes — the qualification section, after `|`
 
-Ranges and refinements are trailing per-field attributes in `[ ]`:
+A line is **definition, then qualification**: everything that defines the
+value — name, type, specified default — comes first, and the qualifiers
+follow a `|`, running to the end of the line:
 
 ```
-health      int16   [min = 0, max = MaxHealth]
-thrust      int8    [min = 0, max = 100]
-orientation float32 [min = -180.0, max = 180.0, resolution = 0.01]
+health      int16   | min = 0, max = MaxHealth
+thrust      int8    | min = 0, max = 100
+orientation float32 | min = -180.0, max = 180.0, resolution = 0.01
+w           fixed(2, 30) = 1.0 | min = -1, max = 1
 sequence    uint16
 ```
 
-- **Brackets never collide with array bounds, structurally:** an array bound
-  is a **prefix** — `[..MaxObjects]ObjectState`, Go's order — and attributes
-  **trail** the complete type. Position alone disambiguates; no lookahead.
-  Scalar constraints like `min`/`max` apply per element.
-- **Valueless attributes** (the object view markers `[interpolate]` and
-  `[local]`, §4.8) and valued keys sit side by side in one flat list —
-  `[interpolate, min = x, max = y]` — valueless markers first, then valued
+- **The section is terminated by the newline or by a `//` comment** —
+  `other DataHandle | local // simulation-only` carries exactly one
+  qualifier. (An ordinary comment BEFORE any pipe wins by ordinary lexing:
+  in `foo uint8 // c | local` the `|` is comment text and the field carries
+  no qualification.) A `|` with no qualifier before the terminator is a
+  parse error ("empty qualification section — write the qualifiers after |
+  or drop it"), and `|` on a line that admits no qualification — a
+  constant, an `object`/`message`/`union`/`contexts` declaration — is
+  refused with the reason named (`|` is never an operator; the language has
+  no bitwise-or). It cannot wrap: the pipe claims the rest of the line and
+  nothing else can follow it. That **no-exit property is a guarantee**, not
+  an accident — nothing can be appended past the qualifiers, so the
+  definition/qualification partition cannot erode; and the zone right of
+  the pipe is deliberately reserved room ("we can get much more creative in
+  future after `|` ... if we need to" — the design's stated headroom).
+- **The specified default sits BEFORE the pipe** — `= 1.0` defines what a
+  fresh value holds, so it belongs to the definition, not the
+  qualification: `invulnerable bool = true | local`.
+- **Declaration lines take the same section**: a type tag or native-type
+  binding, an enum's or flags' `max` headroom —
+  `type Quat | quat4`, `enum Weapon | max = 15`, `flags Damage | max = 8` —
+  and because the section runs to the end of the line, **a declaration
+  carrying one opens its body brace on the NEXT line**:
+
+  ```
+  type Quat | quat4, cpp_native = quat_t, cpp_include = "core_math.h"
+  {
+      x float64
+      ...
+  }
+
+  enum Weapon | max = 15
+  { Laser, Missile, Railgun }
+  ```
+
+  A declaration with no qualifiers keeps its brace on the declaration line.
+- **Array bounds are not attributes** and are untouched: a bound is a
+  **prefix** — `[..MaxObjects]ObjectState`, Go's order — part of the type's
+  shape. `[` after the complete type (or after its `= default`) opened the
+  RETIRED trailing attribute block; the parser refuses it with the `|`
+  spelling named. Scalar
+  constraints like `min`/`max` apply per element.
+- **Valueless qualifiers** (the object view markers `interpolate` and
+  `local`, §4.8) and valued keys sit side by side in one flat list —
+  `| interpolate, min = x, max = y` — valueless markers first, then valued
   keys; there is no nested argument syntax.
 - **The line between positional and attribute:** a *size* that defines the
   type's shape stays positional — `bits(64)`, `string(64)`, `bytes(N)`,
   `fixed(I, F)`, array bounds. A *constraint or refinement* of a named type
-  is an attribute. The enum's `[max = 15]` is the same syntax; it is one
-  general mechanism.
+  is a qualifier. The enum's `| max = 15` is the same syntax; it is one
+  general mechanism. The glyph is deliberately the language's own — a DSL
+  owns its spelling, and familiarity to other languages' readers is not a
+  design constraint where clarity is better served ("let's be bold and do
+  our own shit! It's a DSL anyway").
 - **The vocabulary is typed and closed per compiler version — an unknown
   attribute is a compile error**, never a silently ignored string. The
   vocabulary: integers take `min`/`max` (both together or neither); `float32`
@@ -446,7 +510,7 @@ sequence    uint16
   §4.3); enum declarations take `max`; type declarations take a tag and the
   `cpp_native`/`cpp_include` pair (below); `object` bodies additionally admit
   the view markers `interpolate` and `local`, `context = <name>` (legal only
-  beside `[local]` — Contexts, below), and the view-encoding keys `quantize`
+  beside `local` — Contexts, below), and the view-encoding keys `quantize`
   and `round` (§4.8).
 
 ### Type tags — types are the user's; meaning is claimed later
@@ -456,13 +520,15 @@ built-in quat, no privileged class list. A user declares a type and may
 **tag** it:
 
 ```
-type Vec3 [vec3] {
+type Vec3 | vec3
+{
     x float64
     y float64
     z float64
 }
 
-type Quat [quat4] {
+type Quat | quat4
+{
     x float64
     y float64
     z float64
@@ -483,7 +549,7 @@ type Quat [quat4] {
   (interpolation, prediction, normalization, render mapping). Claiming is an
   ordinary compiler-version event, and the protocol id never moves for it:
   tags are excluded from the wire shape projection (§3.1). The claiming pass
-  defines its own shape validation for claimed tags (e.g. `[quat4]` requiring
+  defines its own shape validation for claimed tags (e.g. `| quat4` requiring
   four float components) and its own policy toward unclaimed strangers.
 - The architecture: types on one side; a layer that defines the needed
   actions for those types on the other. v1 ships the types; each schema
@@ -496,7 +562,8 @@ behavior — and a hand-written math type **derives** from it, adding operators
 and methods without touching layout:
 
 ```
-type Vector3 [vec3, cpp_native = Vector3, cpp_include = "core_vector.h"] { ... }
+type Vector3 | vec3, cpp_native = Vector3, cpp_include = "core_vector.h"
+{ ... }
 ```
 
 ```cpp
@@ -549,10 +616,10 @@ contexts { client, server }
 - **`contexts { ... }`** — one comma-separated list per unit (the same
   `VariantList` form as enums; `contexts` is contextual at file scope, like
   `flags`). Context names are user-chosen; lowercase by convention.
-- **Per-`[local]` field, an optional `context = <name>` attribute:**
-  `predicted_explode bool [local, context = client]`. An unscoped field
+- **Per-`local` field, an optional `context = <name>` attribute:**
+  `predicted_explode bool | local, context = client`. An unscoped field
   defaults to `context = all` (every context); `all` is reserved and cannot
-  be declared. **`context` is legal only beside `[local]`** — a wire field
+  be declared. **`context` is legal only beside `local`** — a wire field
   with a context is a compile error, because the wire must be identical on
   every side. The `context` key's legal values are closed *by the unit's own
   `contexts` declaration*, not by the compiler.
@@ -597,7 +664,7 @@ extent as a member named `Max` in the target's own convention: `E::Max`
 (C++), `E.Max` (C#), `EMax` (Go), `E::MAX` (Rust), `E.Max` (JS), `E_MAX`
 (C). Its value is the enum's max — the same number `E.Max` names in schema
 expressions (§4.2): the highest wire-legal value, which under the
-sentinel-zero convention is the count of real variants when no `[max]`
+sentinel-zero convention is the count of real variants when no `max`
 headroom widens it. Application code states ranges and asserts directly
 against it (`ShipType`'s wire range is `[0, ShipType.Max]`, its real
 variants `[1, ShipType.Max]`) instead of exporting a hand-declared count
@@ -636,17 +703,17 @@ classic twin, which is the wire oracle for the stated model.
 |---|---|---|
 | `f bits(N)` | N raw bits, N in [1,64] | `serialize_bits` ([1,64]; >32 = low 32 bits first, then the high remainder) |
 | `f intN` / `f uintN` (bare, N ∈ 8/16/32/64) | N raw bits (two's complement for signed) | `serialize_uint8/16/32/64`; signed raw is the same bits, cast |
-| `f intN [min = A, max = B]` / `f uintN [min = A, max = B]` | minimal bits for the range, value − A; read rejects out-of-range; **the range must fit the declared storage** | `serialize_int` (≤32-bit int ranges) / `serialize_int64` / width-computed `serialize_bits` for full-unsigned ranges |
+| `f intN | min = A, max = B` / `f uintN | min = A, max = B` | minimal bits for the range, value − A; read rejects out-of-range; **the range must fit the declared storage** | `serialize_int` (≤32-bit int ranges) / `serialize_int64` / width-computed `serialize_bits` for full-unsigned ranges |
 | `f uint128` (bare only) | 128 raw bits — the low 64-bit half first, then the high half; representation-independent (native `__int128` and the emulated two-lane pair produce identical bytes) | `serialize_uint128` |
-| `f int128 [min = A, max = B]` (range required) | value − A in `bits_required128(A, B)` bits, 32-bit groups from the bottom; read rejects an offset above B − A — reject, never clamp; **where the range fits 64 bits or fewer the bytes are identical to `serialize_int64` over the same bounds.** Bare `int128` and ranged `uint128` are compile errors — serialize's own surface, mirrored exactly (uint→raw, int→ranged) | `serialize_int128` |
-| `f fixed(I, F) [min = A, max = B]` (range required; **signed**) | Q I.F, the sign bit counting toward I; storage is a signed integer of exactly I+F bits (I+F ∈ 8/16/32/64/128, I ≥ 1, F ≥ 0); bounds are compile-time WHOLE UNITS fitting the Q format and int64; wire = raw − (A << F) in bitlen(B − A) + F bits, 32-bit groups from the bottom — **except A == B, which costs ZERO bits (not F): the reader materializes raw = A << F from the range alone (§4.6)**; read rejects above the raw range; round trip is EXACT (no quantization step), and with F = 0 the operation IS a ranged integer | `serialize_fixed` |
-| `f ufixed(I, F) [min = A, max = B]` (range required; **unsigned**) | UQ I.F: no sign bit, whole-unit domain [0, 2^I); storage is an UNSIGNED integer of exactly I+F bits (I+F ∈ 8/16/32/64/128, I ≥ 1, F ≥ 0); bounds are compile-time WHOLE UNITS fitting the unsigned domain and int64 (so I ≥ 63 clamps to int64's ceiling); the wire law is fixed's own — raw − (A << F) in bitlen(B − A) + F bits, A == B costs ZERO bits, read rejects above the raw range, round trip EXACT. The raw values of wide formats legitimately fill uint64's HIGH HALF (above 2^63): every route through a signed-typed runtime API is a bit-exact cast or zero-extension, never sign extension, and the corpus pins that byte-for-byte | `serialize_fixed` (unsigned storage — the codec is storage-generic) |
+| `f int128 | min = A, max = B` (range required) | value − A in `bits_required128(A, B)` bits, 32-bit groups from the bottom; read rejects an offset above B − A — reject, never clamp; **where the range fits 64 bits or fewer the bytes are identical to `serialize_int64` over the same bounds.** Bare `int128` and ranged `uint128` are compile errors — serialize's own surface, mirrored exactly (uint→raw, int→ranged) | `serialize_int128` |
+| `f fixed(I, F) | min = A, max = B` (range required; **signed**) | Q I.F, the sign bit counting toward I; storage is a signed integer of exactly I+F bits (I+F ∈ 8/16/32/64/128, I ≥ 1, F ≥ 0); bounds are compile-time WHOLE UNITS fitting the Q format and int64; wire = raw − (A << F) in bitlen(B − A) + F bits, 32-bit groups from the bottom — **except A == B, which costs ZERO bits (not F): the reader materializes raw = A << F from the range alone (§4.6)**; read rejects above the raw range; round trip is EXACT (no quantization step), and with F = 0 the operation IS a ranged integer | `serialize_fixed` |
+| `f ufixed(I, F) | min = A, max = B` (range required; **unsigned**) | UQ I.F: no sign bit, whole-unit domain [0, 2^I); storage is an UNSIGNED integer of exactly I+F bits (I+F ∈ 8/16/32/64/128, I ≥ 1, F ≥ 0); bounds are compile-time WHOLE UNITS fitting the unsigned domain and int64 (so I ≥ 63 clamps to int64's ceiling); the wire law is fixed's own — raw − (A << F) in bitlen(B − A) + F bits, A == B costs ZERO bits, read rejects above the raw range, round trip EXACT. The raw values of wide formats legitimately fill uint64's HIGH HALF (above 2^63): every route through a signed-typed runtime API is a bit-exact cast or zero-extension, never sign extension, and the corpus pins that byte-for-byte | `serialize_fixed` (unsigned storage — the codec is storage-generic) |
 | `f bool` | 1 bit | `serialize_bool` |
 | `f float32` | 32 raw IEEE-754 bits | `serialize_float` |
 | `f float64` | 64 raw bits (low dword first) | `serialize_double` |
-| `f float32 [min = A, max = B, resolution = R]` | quantized to ceil((B−A)/R) steps — the actual step is (B−A)/ceil((B−A)/R), ≤ R; read rejects values above the step count | `serialize_compressed_float` (exact formulas incl. the ceil, +0.5f rounding and clamp); storage stays `float32` — the attributes describe the wire |
+| `f float32 | min = A, max = B, resolution = R` | quantized to ceil((B−A)/R) steps — the actual step is (B−A)/ceil((B−A)/R), ≤ R; read rejects values above the step count | `serialize_compressed_float` (exact formulas incl. the ceil, +0.5f rounding and clamp); storage stays `float32` — the attributes describe the wire |
 | `f Weapon` (an enum) | minimal bits for [0, max]; read rejects above max | `serialize_int` over [0, max] |
-| `f Damage` (a `flags` declaration, §4.2) | W raw bits, W = variant count (or [max]); every pattern legal; storage `uint64` in every target | `serialize_bits` |
+| `f Damage` (a `flags` declaration, §4.2) | W raw bits, W = variant count (or the widened max); every pattern legal; storage `uint64` in every target | `serialize_bits` |
 | `f Inner` (a type) | Inner's fields, in place | `serialize_object` |
 | `f Shape` (a `union`, §4.8) | tag in minimal bits for [0, variant count] (0 = None, no payload), then the selected variant's payload only; read rejects a tag above the count | `serialize_int` over [0, count] + `serialize_object` on the selected arm |
 | `const(Value, Bits)` | the constant; read **rejects** any other value | `serialize_bits` + compare |
@@ -734,12 +801,12 @@ All compile errors with positions:
   as language rules, so generated code cannot fail to compile):
   `fixed(I, F)` requires I ≥ 1 (the sign bit counts toward I), F ≥ 0, and
   I + F equal to a storage width — 8, 16, 32, 64 or 128; a `fixed` field
-  requires `[min = A, max = B]` in whole units, A ≤ B, both fitting the Q
+  requires `| min = A, max = B` in whole units, A ≤ B, both fitting the Q
   format's whole-unit domain [−2^(I−1), 2^(I−1) − 1] AND int64 (where the
   runtime's compile-time bound parameters live). `ufixed(I, F)` carries the
   same shape rules with the unsigned domain — I ≥ 1 still, bounds in
   [0, 2^I − 1] clamped to int64's ceiling — and its diagnostics name the
-  `ufixed` spelling. `int128` requires `[min = A, max = B]` (bare `int128` is
+  `ufixed` spelling. `int128` requires `| min = A, max = B` (bare `int128` is
   a compile error — serialize has no raw signed 128-bit operation); `uint128`
   refuses `min`/`max` (ranged 128-bit is `int128`). Specified defaults cover
   `int128`/`uint128` (fit-checked like any integer) and `fixed`: a fixed
@@ -749,7 +816,7 @@ All compile errors with positions:
   legal in Q2.30, `0.1` is a compile error naming the constraint. Storage
   initializes to the raw scaled integer.
 - **A range that does not fit its declared storage:**
-  `int8 [min = 0, max = 1000]` is a compile error — the range determines the
+  `int8 | min = 0, max = 1000` is a compile error — the range determines the
   wire, the type name determines the storage, and a legal wire value the
   storage truncates would be silent corruption that passes read validation.
 - **Attribute discipline:** an unknown attribute key, a key repeated, an
@@ -757,7 +824,7 @@ All compile errors with positions:
   versa), and `resolution` without both bounds are compile errors, each
   naming the field and the legal vocabulary for its type. One scoped
   exception: in the composite quantization form
-  `[interpolate, quantize = K, max = B]` (§4.8 rule 2), `max` is the quantize
+  `| interpolate, quantize = K, max = B` (§4.8 rule 2), `max` is the quantize
   bound and appears WITHOUT `min` by design — `min` is forbidden there, the
   domain being symmetric [-B, +B].
 - **Non-finite compressed-float parameters are rejected:** each of
@@ -797,7 +864,7 @@ All compile errors with positions:
   per-declaration generated symbols (`Write*`/`Read*`/`New*`,
   `*MaxBits`/`*MaxBytes`, companion length/count names, the dispatch
   surface). Diagnostics name the generated artifact that claims the name.
-- Enum `[max = K]` below the variant count.
+- Enum `| max = K` below the variant count.
 - **Duplicate field names anywhere in one type — including across branch
   sides.** One name, one field, declared once. (schema owns the type, and
   unique names keep the flattened generated output unambiguous.)
@@ -956,10 +1023,10 @@ is uniform across every generated discriminant.
 The view structs exist **in generated code only**; the schema holds one
 definition per object. The markers:
 
-- **`[interpolate]`** — visual state, sent to the client for interpolation.
+- **`interpolate`** — visual state, sent to the client for interpolation.
 - **deep** — the default: an unmarked field is full-state only, sent for
   client-side prediction.
-- **`[local]`** — simulation-only state that reaches no wire: lives in
+- **`local`** — simulation-only state that reaches no wire: lives in
   `ShipState`, absent from every network struct.
 
 What one definition generates per object, per target (shapes per language,
@@ -968,9 +1035,9 @@ behavior identical — the message-set rule):
 | artifact | contents |
 |---|---|
 | `ShipState` | every field — the simulation struct |
-| `ShipData_Deep` + serialize | every non-`[local]` field, deep encodings |
-| `ShipData_Shallow` + serialize | the `[interpolate]` fields, **quantized wire encodings** from the field's attributes |
-| `ShipData_Interpolate` | the same `[interpolate]` fields in continuous storage (see rule 5 for the projected-field exception) |
+| `ShipData_Deep` + serialize | every non-`local` field, deep encodings |
+| `ShipData_Shallow` + serialize | the `interpolate` fields, **quantized wire encodings** from the field's attributes |
+| `ShipData_Interpolate` | the same `interpolate` fields in continuous storage (see rule 5 for the projected-field exception) |
 | `Quantize` / `Unquantize` | the mapping pair between Interpolate and Shallow |
 
 **View-encoding semantics.** Inside an `object` body the attribute vocabulary
@@ -978,9 +1045,9 @@ widens: `interpolate` and `local` (valueless) and `quantize` / `round`
 (valued) join the set. View-encoding attributes describe the SHALLOW wire
 only; the deep wire always uses the bare storage type's encoding.
 
-1. **`[interpolate]` alone** — the shallow wire is the deep encoding,
+1. **`interpolate` alone** — the shallow wire is the deep encoding,
    unchanged.
-2. **Composite quantization** — `[interpolate, quantize = K, max = B]` on a
+2. **Composite quantization** — `| interpolate, quantize = K, max = B` on a
    field whose type is a composite of float components applies
    component-wise: the shallow wire per component is a ranged int
    `[−B·K, +B·K]`; write maps `c → floor(c·K + 0.5)`, clamped to the range;
@@ -989,14 +1056,14 @@ only; the deep wire always uses the bare storage type's encoding.
    smallest-three; the delta pass owns cleverer encodings.
 
    **Fixed components dissolve quantization.** When an object's
-   `[interpolate]` fields are all already wire-domain — fixed-component
+   `interpolate` fields are all already wire-domain — fixed-component
    composites (a `fixed(I, F)` component IS its own quantization: storage and
    wire share one integer domain, ranged by the component's declared bounds),
    plain integers, or int-composite types — the `QuantizeX`/`UnquantizeX`
    pair would be a pure member copy, and the backends do NOT emit it:
    Interpolate and Shallow are the same values.
 
-2b. **Fixed-composite shallow narrowing.** `[interpolate, quantize = K]` on a
+2b. **Fixed-composite shallow narrowing.** `| interpolate, quantize = K` on a
    composite whose components are ALL `fixed(I, F)` scalars narrows the
    shallow wire instead of dissolving: deep values keep full precision;
    shallow (non-simulating) values are quantized down to K, the kept
@@ -1004,7 +1071,7 @@ only; the deep wire always uses the bare storage type's encoding.
    of two with log2(K) ≤ F (the shallow wire cannot be finer than the
    storage; K = 2^F keeps everything and the pair degenerates to copies). No
    `max` here: each component's shallow wire range is its own whole-unit
-   `[min, max]` scaled by K — bounds every fixed component already declares
+   `| min, max` scaled by K — bounds every fixed component already declares
    (§4.3) — and its shallow storage is the smallest signed integer holding
    that range. The `Quantize`/`Unquantize` pair returns, as pure integer
    arithmetic with no floating point anywhere: quantize is round-to-nearest
@@ -1019,7 +1086,7 @@ only; the deep wire always uses the bare storage type's encoding.
    components: a wide ufixed raw legitimately fills uint64's high half,
    where these int64 shifts are wrong — the unsigned door needs its own
    arithmetic before it opens, and the diagnostic says so. Un-narrowed
-   `[interpolate]` composites of ufixed components dissolve fine, because
+   `interpolate` composites of ufixed components dissolve fine, because
    dissolving just delegates to the component encodings. The deep wire is
    untouched: full precision, the component's own ranged fixed encoding. The
    two forms compose field-by-field in one object.
@@ -1036,14 +1103,14 @@ only; the deep wire always uses the bare storage type's encoding.
 3. **No special composite cases in v1 — tags are inert (§4.2, Type tags).**
    Rules 2 and 2b are the whole of composite quantization: every composite
    quantizes per-component — a float rotation field states its bound like
-   anything else (`rotation Quat [interpolate, quantize = RotationUnits,
-   max = 1]`; unit quaternions are always unit length, so the bound is 1,
+   anything else (`rotation Quat | interpolate, quantize = RotationUnits,
+   max = 1`; unit quaternions are always unit length, so the bound is 1,
    written rather than implied). Rotation-specific actions (renormalize on
    unquantize, shortest-arc interpolation) belong to the future pass that
-   claims `[quat4]` — v1 generates the structural mapping only, and the
+   claims `| quat4` — v1 generates the structural mapping only, and the
    application keeps its hand-written rotation actions meanwhile.
 4. **Ranged-int projection** — on `float32`/`float64`,
-   `[interpolate, min = A, max = B, resolution = R]` reuses §4.3's
+   `| interpolate, min = A, max = B, resolution = R` reuses §4.3's
    compressed-float triple: min/max name the **CONTINUOUS domain**, the
    shallow wire is the int `[0, (B−A)/R]`, write maps `v → round((v−A)/R)`
    clamped, unproject maps `q → A + q·R`. The optional
@@ -1225,11 +1292,11 @@ type Vec {
 }
 
 type ObjectState {
-    id       int32 [min = 0, max = MaxObjects - 1]
+    id       int32 | min = 0, max = MaxObjects - 1
     position Vec
     active   bool
     if active {
-        orientation float32 [min = -180.0, max = 180.0, resolution = 0.01]
+        orientation float32 | min = -180.0, max = 180.0, resolution = 0.01
     }
 }
 
@@ -1428,7 +1495,7 @@ Per `type`, per target:
    buffer is fixed at its declared capacity with a used length/count beside
    it — no Go slices as storage, no Rust `Vec`, no growing containers.
 
-   Enums are integer-backed named types in every target because `[max = ...]`
+   Enums are integer-backed named types in every target because `| max = ...`
    headroom makes non-variant values wire-legal; a native Rust `enum` cannot
    hold them — C#'s `enum E : uint` can, natively, which is why it needs no
    newtype.
@@ -1611,8 +1678,8 @@ Go, zero third-party dependencies, one static binary: `schema`.
 schema check      [--verbose] [dir|files...]   // parse + typecheck; exit code for CI
 schema generate   [--lang c|cpp|cs|go|js|rust] [--cpp-message union|variant]
                   [--out <dir>] [--verbose] [dir|files...]
-schema id         [dir|files...]          // print the protocol id
-schema projection [dir|files...]          // print the wire shape projection (§3.1)
+schema id | dir|files... // print the protocol id
+schema projection | dir|files... // print the wire shape projection (§3.1)
 schema fmt        [--verbose] [dir|files...]   // the canonical formatter, standalone (editors, hooks)
 schema pack       [--verbose] <manifest.json>  // the data compiler: JSON instance files -> a
                                           // versioned, hashed .bin per the manifest's
@@ -1741,17 +1808,34 @@ consumer and run by every `schema` command over the unit before processing.
 Rules:
 
 1. **Indent: 4 spaces** per block level, never tabs. `{` on the construct's
-   line; `} else {` on one line. One field or declaration per line.
+   line — except a declaration whose line carries a `|` qualification
+   section, whose body brace opens on the next line (§4.2); `} else {` on
+   one line. One field or declaration per line.
 2. **Alignment groups**: within a contiguous run of fields — broken by blank
-   lines and by comment lines — pad names to align the type column and types
-   to align the `[` attribute column. The same rule aligns `=` in const runs.
-   Single space minimum between columns.
-3. **Attributes**: `[min = 0, max = MaxHealth]` — spaces around `=`,
-   comma-space between entries, no padding inside the brackets. Valueless
-   markers first, then valued keys.
+   lines and by comment lines — pad names to align the type column, and pad
+   past the longest DEFINITION (the type plus any `= default`) to align the
+   `|` qualification column. The same rule aligns `=` in const runs. Single
+   space minimum between columns.
+3. **Qualifications**: `| min = 0, max = MaxHealth` — a space each side of
+   `|`, spaces around `=`, comma-space between entries. Valueless markers
+   first, then valued keys. A trailing `//` comment survives after the
+   section.
+3b. **Migration is a one-shot mode, not the formatter's default**:
+   `schema fmt -migrate` additionally accepts the two RETIRED spellings —
+   the trailing `[ ... ]` attribute block (with its default after the
+   attributes) and the `[<= N]` bound — and re-emits the file in the
+   CURRENT canonical form: qualifiers moved right of `|`, the default moved
+   before the pipe, a qualified declaration's body brace moved to the next
+   line, then the ordinary rules above. An attribute block wrapped across
+   lines (the old grammar allowed it) is refused with "unwrap the attribute
+   block first" — a wrapped block can carry interior comments that have no
+   home right of a pipe. Plain `schema fmt` refuses retired spellings
+   exactly as the compiler does.
 4. **Expressions**: single spaces around binary operators.
-5. **Enums**: one line while they fit; the wrap trigger is decided at the
-   first multi-line instance (no line-length limit exists yet).
+5. **Enums**: the variant list is one line while it fits (a qualified enum
+   is two lines by grammar — the list is the measured unit); the wrap
+   trigger is decided at the first multi-line instance (no line-length
+   limit exists yet).
 6. **switch/case** (reserved for `switch`'s return): `case` at the same
    indent as its `switch`; a single-item case body inline after the label,
    bodies column-aligned across the cases of one switch; multi-item bodies on
@@ -1808,7 +1892,7 @@ Every row to date is settled, deferred with its design banked, or discarded.
    `string`/`bytes`; C# and Rust compose the wire from primitives; the
    interior-null check is generated-code validation in every target.
 2. ~~Storage-type overrides~~ — settled by the integer family: storage is
-   declared by the type name (`thrust int8 [min = 0, max = 100]`); no
+   declared by the type name (`thrust int8 | min = 0, max = 100`); no
    override mechanism exists.
 3. ~~Wide strings and relative integers~~ — deferred: §4.10. Wide strings
    have no usage anywhere in the surveyed tree; every `int_relative` use site
@@ -1820,7 +1904,7 @@ Every row to date is settled, deferred with its design banked, or discarded.
 7. ~~Const expressions over enum counts~~ — settled: `E.Max` (§4.2);
    `const NumTeams = Team.Max + 1`. `len(Team)` was declined: it has three
    plausible meanings, and every one sizes enum-indexed tables wrong under
-   `[max]` headroom — the max is the true primitive.
+   `max` headroom — the max is the true primitive.
 8. ~~Platform-conditional constants~~ — settled: constants are
    platform-uniform (§4.2); platform-varying tuning stays in application
    code.

--- a/USAGE.md
+++ b/USAGE.md
@@ -48,7 +48,7 @@ type Vector3 {
 message ShipCreate {
     ship_type ShipType
     position  Vector3
-    health    int32 [min = 0, max = MaxHealth]
+    health    int32 | min = 0, max = MaxHealth
 }
 ```
 
@@ -115,7 +115,8 @@ enum class ShipType : uint8_t { None = 0, Fighter = 1, Corvette = 2, Bomber = 3,
 ```
 
 On the wire it costs `bitsRequired(variant count)` — 2 bits here, for four
-values. Declaring `enum E [max = 15] { ... }` reserves headroom so you can
+values. Declaring `enum E | max = 15` (its variant list on the next line) reserves
+headroom so you can
 add variants later without moving the field width.
 
 The `Max` member is the enum's **extent** — the same number `E.Max` names in
@@ -238,7 +239,7 @@ evolution-tolerant encoding for data that outlives builds. See
 
 An object declares state that is replicated in more than one form — a full
 state, a deep wire, a lightweight shallow wire, and an interpolation view.
-Fields carry `[interpolate]` and `[local]` markers to say which views they
+Fields carry `interpolate` and `local` markers to say which views they
 belong to. This is the delta/snapshot machinery; if you are not writing a
 replication layer you will not need it.
 
@@ -254,7 +255,7 @@ width on the wire unless you give a range.
 ### Ranged integers
 
 ```
-health int32 [min = 0, max = MaxHealth]
+health int32 | min = 0, max = MaxHealth
 ```
 
 The range is **part of the type**, and the wire cost follows from it. This
@@ -289,7 +290,7 @@ One bit.
 ### Compressed floats
 
 ```
-throttle float32 [min = 0, max = 1, resolution = 0.01]
+throttle float32 | min = 0, max = 1, resolution = 0.01
 ```
 
 A float quantized onto a grid: the wire carries the step index, not the
@@ -299,7 +300,7 @@ float. 101 steps here, so 7 bits instead of 32. Add `round = up` / `down` /
 ### fixed(I, F)
 
 ```
-position fixed(48, 16) [min = -30000, max = 30000]
+position fixed(48, 16) | min = -30000, max = 30000
 ```
 
 Signed fixed point: `I` integer bits (the sign bit counts), `F` fractional
@@ -318,7 +319,7 @@ one integer domain, so there is no separate quantize step to keep in sync.
 ### ufixed(I, F)
 
 ```
-distance ufixed(48, 16) [min = 0, max = 60000]
+distance ufixed(48, 16) | min = 0, max = 60000
 ```
 
 The unsigned sibling: no sign bit, whole-unit domain `[0, 2^I)`, same `F`
@@ -408,8 +409,8 @@ previous packet through a branch that was not taken this time.
 ## Defaults
 
 ```
-health int32 [min = 0, max = 1000] = 100
-w      fixed(2, 30) [min = -1, max = 1] = 1.0
+health int32 = 100 | min = 0, max = 1000
+w      fixed(2, 30) = 1.0 | min = -1, max = 1
 ```
 
 Everything zero-initializes unless a default says otherwise. Defaults are
@@ -487,8 +488,9 @@ end of the buffer.
 
 One precision worth having: an enum read is bounded by the enum's declared
 **max**, not by its variant count. For a plain `enum E { A, B, C }` those are
-the same thing and a non-variant cannot survive a read. But `enum E [max = 15]
-{ A, B }` deliberately reserves headroom so variants can be added later without
+the same thing and a non-variant cannot survive a read. But `enum E | max = 15`
+(variants `{ A, B }` on the next line) deliberately reserves headroom so
+variants can be added later without
 moving the field width — and a read of that enum accepts anything in `[0, 15]`.
 That is the point of the headroom, but it means a value you have not defined
 yet can arrive, and your `switch` should have a default. The same VALIDATION rules hold in all six languages, because
@@ -514,7 +516,7 @@ backend uses `serialize_assert`. Go has no assert idiom, so it returns
 one. The rule is that a language should verify correctness the way that
 language verifies correctness — not that every target behaves identically here.
 
-So writing `health = 2000` into a field declared `[min = 0, max = 1000]`
+So writing `health = 2000` into a field declared `| min = 0, max = 1000`
 asserts in a C++ debug build, silently writes the truncated low bits in a C++
 release build, and returns an error in the other three.
 
@@ -676,7 +678,7 @@ output can say `MaxObjects - 1` where the resolved field alone could only
 say `9999`:
 
 ```go
-// object_id int32 [min = 0, max = MaxObjects - 1]
+// object_id int32 | min = 0, max = MaxObjects - 1
 f := handle.Fields[0]
 ir.RenderExpr(f.IntMaxExpr)                        // "MaxObjects - 1" — schema spelling, for comments
 ir.RenderExprIdent(f.IntMaxExpr, nil)              // "MaxObjects - 1" — a target that keeps the name
@@ -716,7 +718,7 @@ that first carries it; everything under `internal/` is not
 
 **C++** — header-only generated output, targeting
 [serialize](https://github.com/mas-bandwidth/serialize). A type can map to
-your own math type with `[cpp_native = Vector3, cpp_include = "vec.h"]`, so
+your own math type with `| cpp_native = Vector3, cpp_include = "vec.h"`, so
 simulation code does math directly on generated storage.
 
 **C#** — C# 9 / netstandard2.1-clean, so it runs on Unity-class runtimes.

--- a/WIRES.md
+++ b/WIRES.md
@@ -40,7 +40,7 @@ message ShipCreate {
 
 table ShipConfig {
     ship_type ShipType
-    health    int32 [min = 0, max = 1000] = 100
+    health    int32 = 100 | min = 0, max = 1000
     name      string(32)
 }
 ```

--- a/bench/corpus/Bench.schema
+++ b/bench/corpus/Bench.schema
@@ -9,9 +9,9 @@ package bench
 // The stream packet. Transcribed from serialize/bench.cpp:141-182 —
 // 12 operations in that exact order. 392 bits = 49 wire bytes.
 type BenchPacket {
-    a      int32          [min = -100, max = 100] //  8 bits
-    b      int32          [min = 0, max = 65535] // 16
-    c      int32          [min = -1000000, max = 1000000] // 21
+    a      int32          | min = -100, max = 100 //  8 bits
+    b      int32          | min = 0, max = 65535 // 16
+    c      int32          | min = -1000000, max = 1000000 // 21
     bits7  bits(7) //  7
     bits13 bits(13) // 13
     bits23 bits(23) // 23
@@ -26,16 +26,16 @@ type BenchPacket {
 
 // serialize/bench.cpp:391-403. 110 bits = 14 wire bytes.
 type BenchInts {
-    f0 int32 [min = -100, max = 100] //  8
-    f1 int32 [min = 0, max = 65535] // 16
-    f2 int32 [min = -1000000, max = 1000000] // 21
-    f3 int32 [min = 0, max = 3] //  2
-    f4 int32 [min = -15, max = 15] //  5
-    f5 int32 [min = 0, max = 1000] // 10
-    f6 int32 [min = -2048, max = 2047] // 12
-    f7 int32 [min = 0, max = 255] //  8
-    f8 int32 [min = -600000, max = 600000] // 21
-    f9 int32 [min = 0, max = 100] //  7
+    f0 int32 | min = -100, max = 100 //  8
+    f1 int32 | min = 0, max = 65535 // 16
+    f2 int32 | min = -1000000, max = 1000000 // 21
+    f3 int32 | min = 0, max = 3 //  2
+    f4 int32 | min = -15, max = 15 //  5
+    f5 int32 | min = 0, max = 1000 // 10
+    f6 int32 | min = -2048, max = 2047 // 12
+    f7 int32 | min = 0, max = 255 //  8
+    f8 int32 | min = -600000, max = 600000 // 21
+    f9 int32 | min = 0, max = 100 //  7
 } // = 110 bits, 14 bytes
 
 // serialize/bench.cpp:449-457. 156 bits = 20 wire bytes.
@@ -54,15 +54,15 @@ type BenchBits {
 
 // serialize/bench.cpp:517-528. 168 bits = 21 wire bytes.
 type BenchMixed {
-    sequence  int32          [min = 0, max = 65535] // 16
+    sequence  int32          | min = 0, max = 65535 // 16
     ack_bits  bits(32) // 32
     entity_id bits(12) // 12
-    pos_x     int32          [min = -16384, max = 16383] // 15
-    pos_y     int32          [min = -16384, max = 16383] // 15
-    pos_z     int32          [min = -16384, max = 16383] // 15
+    pos_x     int32          | min = -16384, max = 16383 // 15
+    pos_y     int32          | min = -16384, max = 16383 // 15
+    pos_z     int32          | min = -16384, max = 16383 // 15
     yaw       bits(9) //  9
     moving    bool //  1
     firing    bool //  1
     timestamp bits(48) // 48
-    weapon    int32          [min = 0, max = 15] //  4
+    weapon    int32          | min = 0, max = 15 //  4
 } // = 168 bits, 21 bytes

--- a/bench/corpus/RealWorld.schema
+++ b/bench/corpus/RealWorld.schema
@@ -32,109 +32,109 @@ enum PacketMode { Idle, Active, Combat, Docked, Warping }
 flags PacketFlags { Shielded, Cloaked, Overheated, LowPower, Jamming }
 
 type RealPacket {
-    f001_int  int32               [min = -805495, max = 805495] // 21 bits
+    f001_int  int32                                                                                | min = -805495, max = 805495 // 21 bits
     f002_f64  float64 // 64 bits
-    f003_int  int32               [min = -835897, max = 835897] // 21 bits
-    f004_cf32 float32             [min = 0.0, max = 2000.0, resolution = 0.1] // 15 bits
-    f005_uint uint16              [min = 0, max = 7316] // 13 bits
-    f006_int  int16               [min = -1513, max = 1513] // 12 bits
+    f003_int  int32                                                                                | min = -835897, max = 835897 // 21 bits
+    f004_cf32 float32                                                                              | min = 0.0, max = 2000.0, resolution = 0.1 // 15 bits
+    f005_uint uint16                                                                               | min = 0, max = 7316 // 13 bits
+    f006_int  int16                                                                                | min = -1513, max = 1513 // 12 bits
     f007_f32  float32 // 32 bits
     f008_u64  uint64 // 64 bits
-    f009_int  int8                [min = -22, max = 22] // 6 bits
+    f009_int  int8                                                                                 | min = -22, max = 22 // 6 bits
     f010_f32  float32 // 32 bits
     f011_bits bits(10) // 10 bits
-    f012_bool bool                = true // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
+    f012_bool bool = true // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
     if f012_bool {
         f013_f32   float32 // 32 bits
-        f014_uint  uint16             [min = 0, max = 775] // 10 bits
-        f015_int   int8               [min = -21, max = 21] // 6 bits
-        f016_fixed fixed(12, 20)      [min = -36, max = 36] // 27 bits
-        f017_uint  uint16             [min = 0, max = 4606] // 13 bits
+        f014_uint  uint16             | min = 0, max = 775 // 10 bits
+        f015_int   int8               | min = -21, max = 21 // 6 bits
+        f016_fixed fixed(12, 20)      | min = -36, max = 36 // 27 bits
+        f017_uint  uint16             | min = 0, max = 4606 // 13 bits
     }
-    f018_int    int16                [min = -834, max = 834] // 11 bits
+    f018_int    int16                                                                                 | min = -834, max = 834 // 11 bits
     f019_f64    float64 // 64 bits
     f020_f32    float32 // 32 bits
-    f021_ufixed ufixed(20, 12)       [min = 0, max = 25141] // 27 bits
+    f021_ufixed ufixed(20, 12)                                                                        | min = 0, max = 25141 // 27 bits
     f022_f32    float32 // 32 bits
     f023_bits   bits(25) // 25 bits
     f024_f32    float32 // 32 bits
-    f025_fixed  fixed(8, 8)          [min = -119, max = 119] // 16 bits
+    f025_fixed  fixed(8, 8)                                                                           | min = -119, max = 119 // 16 bits
     f026_bits   bits(9) // 9 bits
-    f027_cf32   float32              [min = -2.0, max = 2.0, resolution = 0.25] // 5 bits
+    f027_cf32   float32                                                                               | min = -2.0, max = 2.0, resolution = 0.25 // 5 bits
     f028_bits   bits(4) // 4 bits
     f029_i64    int64 // 64 bits
     f030_f32    float32 // 32 bits
     f031_bits   bits(1) // 1 bit
-    f032_int    int8                 [min = -3, max = 3] // 3 bits
-    f033_uint   uint32               [min = 0, max = 142780] // 18 bits
-    f034_uint   uint16               [min = 0, max = 14149] // 14 bits
+    f032_int    int8                                                                                  | min = -3, max = 3 // 3 bits
+    f033_uint   uint32                                                                                | min = 0, max = 142780 // 18 bits
+    f034_uint   uint16                                                                                | min = 0, max = 14149 // 14 bits
     f035_bits   bits(9) // 9 bits
     f036_enum   PacketMode // 3 bits
     f037_bool   bool // 1 bit
     f038_bool   bool // 1 bit
     f039_bits   bits(19) // 19 bits
-    f040_fixed  fixed(4, 12)         [min = -5, max = 5] // 16 bits
-    f041_int    int8                 [min = -55, max = 55] // 7 bits
+    f040_fixed  fixed(4, 12)                                                                          | min = -5, max = 5 // 16 bits
+    f041_int    int8                                                                                  | min = -55, max = 55 // 7 bits
     f042_bits   bits(30) // 30 bits
-    f043_bool   bool                 = false // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
+    f043_bool   bool = false // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
     if f043_bool {
         f044_f32  float32 // 32 bits (does not ride: gate false)
         f045_bits bits(12) // 12 bits (does not ride: gate false)
-        f046_uint uint32                                          [min = 0, max = 76063] // 17 bits (does not ride: gate false)
-        f047_int  int32                                           [min = -430976, max = 430976] // 20 bits (does not ride: gate false)
+        f046_uint uint32                                          | min = 0, max = 76063 // 17 bits (does not ride: gate false)
+        f047_int  int32                                           | min = -430976, max = 430976 // 20 bits (does not ride: gate false)
     }
     f048_f64    float64 // 64 bits
-    f049_ufixed ufixed(2, 14)      [min = 0, max = 3] // 16 bits
-    f050_bool   bool               = true // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
+    f049_ufixed ufixed(2, 14)                                                                        | min = 0, max = 3 // 16 bits
+    f050_bool   bool = true // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
     if f050_bool {
         f051_bool bool // 1 bit
-        f052_int  int8               [min = -57, max = 57] // 7 bits
+        f052_int  int8               | min = -57, max = 57 // 7 bits
         f053_f32  float32 // 32 bits
-        f054_int  int8               [min = -35, max = 35] // 7 bits
+        f054_int  int8               | min = -35, max = 35 // 7 bits
     }
     f055_bool   bool // 1 bit
-    f056_int    int8                [min = -13, max = 13] // 5 bits
-    f057_int    int8                [min = -15, max = 15] // 5 bits
+    f056_int    int8                                                                                  | min = -13, max = 13 // 5 bits
+    f057_int    int8                                                                                  | min = -15, max = 15 // 5 bits
     f058_f32    float32 // 32 bits
     f059_f64    float64 // 64 bits
     f060_bits   bits(8) // 8 bits
-    f061_cf32   float32             [min = -90.0, max = 90.0, resolution = 0.5] // 9 bits
-    f062_uint   uint16              [min = 0, max = 503] // 9 bits
+    f061_cf32   float32                                                                               | min = -90.0, max = 90.0, resolution = 0.5 // 9 bits
+    f062_uint   uint16                                                                                | min = 0, max = 503 // 9 bits
     f063_i64    int64 // 64 bits
-    f064_uint   uint16              [min = 0, max = 299] // 9 bits
-    f065_cf32   float32             [min = 0.0, max = 30.0, resolution = 0.5] // 6 bits
-    f066_ufixed ufixed(2, 14)       [min = 0, max = 2] // 16 bits
-    f067_cf32   float32             [min = -100.0, max = 100.0, resolution = 0.25] // 10 bits
-    f068_cf32   float32             [min = 0.0, max = 2000.0, resolution = 1.0] // 11 bits
+    f064_uint   uint16                                                                                | min = 0, max = 299 // 9 bits
+    f065_cf32   float32                                                                               | min = 0.0, max = 30.0, resolution = 0.5 // 6 bits
+    f066_ufixed ufixed(2, 14)                                                                         | min = 0, max = 2 // 16 bits
+    f067_cf32   float32                                                                               | min = -100.0, max = 100.0, resolution = 0.25 // 10 bits
+    f068_cf32   float32                                                                               | min = 0.0, max = 2000.0, resolution = 1.0 // 11 bits
     f069_bits   bits(11) // 11 bits
-    f070_uint   uint8               [min = 0, max = 2] // 2 bits
-    f071_cf32   float32             [min = 0.0, max = 10.0, resolution = 0.02] // 9 bits
-    f072_cf32   float32             [min = 0.0, max = 100.0, resolution = 0.01] // 14 bits
-    f073_int    int8                [min = -4, max = 4] // 4 bits
-    f074_bool   bool                = false // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
+    f070_uint   uint8                                                                                 | min = 0, max = 2 // 2 bits
+    f071_cf32   float32                                                                               | min = 0.0, max = 10.0, resolution = 0.02 // 9 bits
+    f072_cf32   float32                                                                               | min = 0.0, max = 100.0, resolution = 0.01 // 14 bits
+    f073_int    int8                                                                                  | min = -4, max = 4 // 4 bits
+    f074_bool   bool = false // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
     if f074_bool {
         f075_u64  uint64 // 64 bits (does not ride: gate false)
-        f076_int  int16                                         [min = -26218, max = 26218] // 16 bits (does not ride: gate false)
-        f077_int  int8                                          [min = -17, max = 17] // 6 bits (does not ride: gate false)
+        f076_int  int16                                         | min = -26218, max = 26218 // 16 bits (does not ride: gate false)
+        f077_int  int8                                          | min = -17, max = 17 // 6 bits (does not ride: gate false)
         f078_bits bits(9) // 9 bits (does not ride: gate false)
-        f079_uint uint8                                         [min = 0, max = 17] // 5 bits (does not ride: gate false)
+        f079_uint uint8                                         | min = 0, max = 17 // 5 bits (does not ride: gate false)
     }
     f080_bool   bool // 1 bit
     f081_bits   bits(29) // 29 bits
     f082_bits   bits(25) // 25 bits
     f083_enum   PacketMode // 3 bits
-    f084_ufixed ufixed(1, 7)          [min = 0, max = 1] // 8 bits
+    f084_ufixed ufixed(1, 7)          | min = 0, max = 1 // 8 bits
     f085_bits   bits(21) // 21 bits
-    f086_uint   uint16                [min = 0, max = 399] // 9 bits
+    f086_uint   uint16                | min = 0, max = 399 // 9 bits
     f087_f64    float64 // 64 bits
-    f088_int    int16                 [min = -694, max = 694] // 11 bits
+    f088_int    int16                 | min = -694, max = 694 // 11 bits
     f089_bits   bits(48) // 48 bits
-    f090_uint   uint8                 [min = 0, max = 214] // 8 bits
+    f090_uint   uint8                 | min = 0, max = 214 // 8 bits
     f091_flags  PacketFlags // 5 bits
     f092_bool   bool // 1 bit
     f093_bits   bits(64) // 64 bits
     f094_bool   bool // 1 bit
-    f095_fixed  fixed(16, 16)         [min = -1577, max = 1577] // 28 bits
+    f095_fixed  fixed(16, 16)         | min = -1577, max = 1577 // 28 bits
     f096_bits   bits(18) // 18 bits
     f097_bits   bits(12) // 12 bits
 }

--- a/bench/tools/realpacket-gen/main.go
+++ b/bench/tools/realpacket-gen/main.go
@@ -92,7 +92,7 @@ func genRangedInt(r *lcg) field {
 			st = "int16"
 		}
 		bits := ir.BitsRequired(big.NewInt(-h), big.NewInt(h))
-		return field{"int", fmt.Sprintf("%s [min = %d, max = %d]", st, -h, h), bits}
+		return field{"int", fmt.Sprintf("%s | min = %d, max = %d", st, -h, h), bits}
 	}
 	// unsigned range [0, m] with bitlen(m) == w
 	lo := int64(1) << uint(w-1)
@@ -106,7 +106,7 @@ func genRangedInt(r *lcg) field {
 		st = "uint16"
 	}
 	bits := ir.BitsRequired(big.NewInt(0), big.NewInt(m))
-	return field{"uint", fmt.Sprintf("%s [min = 0, max = %d]", st, m), bits}
+	return field{"uint", fmt.Sprintf("%s | min = 0, max = %d", st, m), bits}
 }
 
 func genBits(r *lcg) field {
@@ -140,7 +140,7 @@ func genCompressed(r *lcg) field {
 		if bits < 4 || bits > 20 {
 			continue // keep the field small, per the design; redraw deterministically
 		}
-		return field{"cf32", fmt.Sprintf("float32 [min = %s, max = %s, resolution = %s]",
+		return field{"cf32", fmt.Sprintf("float32 | min = %s, max = %s, resolution = %s",
 			flit(min), flit(max), flit(res)), bits}
 	}
 }
@@ -167,7 +167,7 @@ func genFixed(r *lcg, unsigned bool) field {
 			}
 			m := int64(r.between(1, int(capv)))
 			bits := ir.BitsRequired(big.NewInt(0), big.NewInt(m)) + int64(F)
-			return field{"ufixed", fmt.Sprintf("ufixed(%d, %d) [min = 0, max = %d]", I, F, m), bits}
+			return field{"ufixed", fmt.Sprintf("ufixed(%d, %d) | min = 0, max = %d", I, F, m), bits}
 		}
 		if I < 2 {
 			continue // signed whole-unit domain needs I >= 2 for a symmetric range
@@ -181,7 +181,7 @@ func genFixed(r *lcg, unsigned bool) field {
 		}
 		h := int64(r.between(1, int(capv)))
 		bits := ir.BitsRequired(big.NewInt(-h), big.NewInt(h)) + int64(F)
-		return field{"fixed", fmt.Sprintf("fixed(%d, %d) [min = %d, max = %d]", I, F, -h, h), bits}
+		return field{"fixed", fmt.Sprintf("fixed(%d, %d) | min = %d, max = %d", I, F, -h, h), bits}
 	}
 }
 

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -70,13 +70,19 @@ func main() {
 		// processing, so this exists for editors and pre-commit hooks
 		fs := flag.NewFlagSet("fmt", flag.ExitOnError)
 		fs.BoolVar(&verbose, "verbose", false, "list the files rewritten")
+		migrate := fs.Bool("migrate", false, "one-shot migration: additionally accept the retired spellings ([ ... ] attribute blocks, [<= N] bounds) and rewrite them to the current grammar (SPEC §7.4)")
 		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
 		paths, err := compiler.GatherPaths(fs.Args())
 		if err != nil {
 			fail(err)
 		}
 		for _, p := range paths {
-			_, rewrote, err := compiler.FormatFile(p)
+			var rewrote bool
+			if *migrate {
+				_, rewrote, err = compiler.MigrateFile(p)
+			} else {
+				_, rewrote, err = compiler.FormatFile(p)
+			}
 			if err != nil {
 				fail(err)
 			}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -219,6 +219,30 @@ func FormatFile(path string) (canonical []byte, rewrote bool, err error) {
 	return out, true, nil
 }
 
+// MigrateFile is the ONE-SHOT migration mode (SPEC §7.4 rule 3b): it
+// additionally accepts the retired spellings — the trailing [ ... ]
+// attribute block (default after the attributes) and the [<= N] bound —
+// rewrites them into the current grammar, formats, and writes the file back
+// when the bytes change. Plain formatting refuses retired spellings exactly
+// as the compiler does.
+func MigrateFile(path string) (canonical []byte, rewrote bool, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false, err
+	}
+	out, err := format.Migrate(path, data)
+	if err != nil {
+		return nil, false, err
+	}
+	if string(out) == string(data) {
+		return out, false, nil
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
 // Version reports which build of the compiler is running: the linker stamp if
 // the build carried one, otherwise the module version or a VCS revision.
 // Never empty. Deliberately absent from generated output — generated code

--- a/examples/Messages.schema
+++ b/examples/Messages.schema
@@ -19,9 +19,9 @@ message Heartbeat {
 
 message Test {
     test_a uint16
-    test_b int16  [min = 0, max = 1000]
-    test_c int16  [min = 0, max = 1000]
-    test_d int16  [min = 0, max = 1000]
+    test_b int16  | min = 0, max = 1000
+    test_c int16  | min = 0, max = 1000
+    test_d int16  | min = 0, max = 1000
 }
 
 message Block {

--- a/examples/Objects.schema
+++ b/examples/Objects.schema
@@ -27,21 +27,21 @@ object Ship {
     // ---- visual state, [interpolate]: sent for client interpolation, rides
     // the quantized shallow wire into ShipData_Interpolate ----
 
-    ship_type ShipType [interpolate]
+    ship_type ShipType | interpolate
 
-    position        Vec3 [interpolate, quantize = PositionUnits, max = MaxWorldMeters]
-    rotation        Quat [interpolate, quantize = RotationUnits, max = 1]
-    linear_velocity Vec3 [interpolate, quantize = VelocityUnits, max = MaxSpeedMeters]
+    position        Vec3 | interpolate, quantize = PositionUnits, max = MaxWorldMeters
+    rotation        Quat | interpolate, quantize = RotationUnits, max = 1
+    linear_velocity Vec3 | interpolate, quantize = VelocityUnits, max = MaxSpeedMeters
 
-    flags ShipFlags [interpolate]
-    team  Team      [interpolate]
+    flags ShipFlags | interpolate
+    team  Team      | interpolate
 
     // float in deep; ranged-int projection on the shallow wire (SPEC §4.8 rule 4).
     // health rounds UP so any living fractional health quantizes alive — the
     // hand-written ceil is load-bearing. thrust's continuous domain is [0, 1];
     // resolution 0.01 gives the wire int [0, 100], identical bits to today.
-    health float32 [interpolate, min = 0, max = MaxHealth, resolution = 1, round = up]
-    thrust float32 [interpolate, min = 0, max = 1, resolution = 0.01]
+    health float32 | interpolate, min = 0, max = MaxHealth, resolution = 1, round = up
+    thrust float32 | interpolate, min = 0, max = 1, resolution = 0.01
 
     // ---- full state: deep only (the default — no marker) ----
 
@@ -65,29 +65,29 @@ object Ship {
     aim_current  float32
     aim_velocity float32
 
-    laser_index   int8 [min = 0, max = ShipMaxLasers - 1]
-    missile_index int8 [min = 0, max = ShipMaxMissiles - 1]
+    laser_index   int8 | min = 0, max = ShipMaxLasers - 1
+    missile_index int8 | min = 0, max = ShipMaxMissiles - 1
 
     target          Handle
     lock_start_time float64
 
     // ---- simulation-only: no wire at all ----
 
-    invulnerable bool [local]
+    invulnerable bool | local
 
     // the wrapper class's sim-local state, folded in so the generated state is
     // the FULL working ship state (surveyed from the hand-written Ship class
     // 2026-08-05): previous position, and the per-collider armor table. Engine
     // runtime handles (the physics body id) stay in engine code — they are
     // process-local resources, not state the schema owns.
-    previous_position Vec3                       [local]
-    num_colliders     int32                      [local]
-    collider_armor    [MaxCollidersPerShip]int32 [local]
+    previous_position Vec3                       | local
+    num_colliders     int32                      | local
+    collider_armor    [MaxCollidersPerShip]int32 | local
 
     // context-scoped local state (SPEC §4.2, Contexts): exists only in the
     // client's generated type (ClientShipState) — the declared replacement for
     // the hand-written #if GAME_CLIENT
-    predicted_explode bool [local, context = client]
+    predicted_explode bool | local, context = client
 }
 
 object Missile {
@@ -97,25 +97,25 @@ object Missile {
     // [1,MAX] on create but [0,MAX] on delta — drift; as a plain enum the
     // generated wire is [0,MAX] on both paths (enum_index is cut, SPEC §9 q11).
 
-    missile_type MissileType [interpolate]
+    missile_type MissileType | interpolate
 
-    position        Vec3 [interpolate, quantize = PositionUnits, max = MaxWorldMeters]
-    rotation        Quat [interpolate, quantize = RotationUnits, max = 1]
-    linear_velocity Vec3 [interpolate, quantize = VelocityUnits, max = MaxSpeedMeters]
+    position        Vec3 | interpolate, quantize = PositionUnits, max = MaxWorldMeters
+    rotation        Quat | interpolate, quantize = RotationUnits, max = 1
+    linear_velocity Vec3 | interpolate, quantize = VelocityUnits, max = MaxSpeedMeters
 
-    team Team [interpolate]
+    team Team | interpolate
 
     // real field is an anonymous uint64 — bits unnamed in hand code; named bits
     // move to a flags declaration when they are identified
-    flags uint64 [interpolate]
+    flags uint64 | interpolate
 
     // ---- simulation-only ----
 
-    angular_velocity Vec3   [local]
-    target           Handle [local]
+    angular_velocity Vec3   | local
+    target           Handle | local
 
     // server-only sim state — exists only in ServerMissileState (SPEC §4.2)
-    timer float64 [local, context = server]
+    timer float64 | local, context = server
 }
 
 object DynamicProp {
@@ -124,18 +124,18 @@ object DynamicProp {
     // that form returns (SPEC §9 q11); a plain enum spends the None value
     // meanwhile.
 
-    prop_type PropType [interpolate]
+    prop_type PropType | interpolate
 
-    position        Vec3 [interpolate, quantize = PositionUnits, max = MaxWorldMeters]
-    rotation        Quat [interpolate, quantize = RotationUnits, max = 1]
-    linear_velocity Vec3 [interpolate, quantize = VelocityUnits, max = MaxSpeedMeters]
+    position        Vec3 | interpolate, quantize = PositionUnits, max = MaxWorldMeters
+    rotation        Quat | interpolate, quantize = RotationUnits, max = 1
+    linear_velocity Vec3 | interpolate, quantize = VelocityUnits, max = MaxSpeedMeters
 
-    flags uint64 [interpolate]
-    team  Team   [interpolate]
+    flags uint64 | interpolate
+    team  Team   | interpolate
 
     // ---- simulation-only ----
 
-    angular_velocity Vec3 [local]
+    angular_velocity Vec3 | local
 }
 
 object Turret {
@@ -147,17 +147,17 @@ object Turret {
     // deep view is full-state per the model — the stub is unfinished hand code,
     // not a design to reproduce.
 
-    parent       Handle [interpolate]
-    turret_index int32  [interpolate, min = 0, max = MaxTurretsPerShip - 1]
+    parent       Handle | interpolate
+    turret_index int32  | interpolate, min = 0, max = MaxTurretsPerShip - 1
 
-    rotation Quat [interpolate, quantize = RotationUnits, max = 1]
+    rotation Quat | interpolate, quantize = RotationUnits, max = 1
 
-    flags uint64 [interpolate]
+    flags uint64 | interpolate
 
     // ---- simulation-only ----
 
     // real TurretState carries team with zero wire presence — [local] here,
     // unlike Ship where team is [interpolate]. Same name, different wire
     // treatment, per object: the marker is per-field, so this is free.
-    team Team [local]
+    team Team | local
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,9 +31,9 @@ hard requirement, just a personal preference"*; order-free cross-file resolution
 | `Contexts.schema` | the build contexts | `contexts { client, server }` — user-declared sides, per-context generated types |
 | `Constants.schema` | every `const` | composition (`const C = A * B`), `Team.Max` enum references, order-free cross-file refs |
 | `Enums.schema` | the enum family | both forms, comma-separated variants: `enum` (with-None) and `flags` (uint64, bit-per-variant) |
-| `Types.schema` | every `type` | tagged user types (`Vec3 [vec3]`, `Quat [quat4]` — tags inert in v1, claimed by the delta pass), quantized-int types, prefix arrays `[..N]T`, bool-gated `if` with a `flags` field, and `RigidBody` — the serialize README's own example, schema-specified: the velocity group rides only when `!at_rest`, and §5's zero-on-untaken-branch rule is the hand-written `else if ( Stream::IsReading )` zeroing made contract |
+| `Types.schema` | every `type` | tagged user types (`Vec3 | vec3`, `Quat | quat4` — tags inert in v1, claimed by the delta pass), quantized-int types, prefix arrays `[..N]T`, bool-gated `if` with a `flags` field, and `RigidBody` — the serialize README's own example, schema-specified: the velocity group rides only when `!at_rest`, and §5's zero-on-untaken-branch rule is the hand-written `else if ( Stream::IsReading )` zeroing made contract |
 | `Messages.schema` | every `message` | the implicit `MessageType` set, sorted-by-name tags, empty message, unified `string(N)`/`bytes(N)` (fixed buffers, used-length wire) |
-| `Objects.schema` | all four `object`s | the view markers (`[interpolate]`/`[local]`, deep by default), explicit-bound composite `quantize`, ranged-int projection with `round = up`, `[local, context = ...]` scoped fields, per-field wire treatment divergences between objects — and the FULL working ship state: the wrapper class's sim-local fields (previous position, collider armor table) folded in, so the generated per-context state structs could serve as the simulation struct outright |
+| `Objects.schema` | all four `object`s | the view markers (`interpolate`/`local`, deep by default), explicit-bound composite `quantize`, ranged-int projection with `round = up`, `| local, context = ...` scoped fields, per-field wire treatment divergences between objects — and the FULL working ship state: the wrapper class's sim-local fields (previous position, collider armor table) folded in, so the generated per-context state structs could serve as the simulation struct outright |
 
 *Coming when their design passes open: `Config.schema` and `Assets.schema` (SPEC, "The
 horizon" — the flatbuffers replacement), and the delta pass (out of v1 scope by decision).*
@@ -45,7 +45,7 @@ horizon" — the flatbuffers replacement), and the delta pass (out of v1 scope b
    recorded at SPEC §9 q11. Kind fields are plain enums spending one unused wire value —
    the honest v1 cost, back to this finding's original state.
 2. **Quantized ints are the real float idiom** — *(outcome, 2026-08-05: the
-   `compressed_float` keyword dissolved into `float32 [min, max, resolution]`; the
+   `compressed_float` keyword dissolved into `float32 | min, max, resolution`; the
    ranged-int projection in object views carries the same triple plus `round`.)*
 3. **Sentinel-terminated collections** — **deferred into the delta pass by decision**
    (three terminator idioms measured in the real packets; inseparable from budget-driven
@@ -58,5 +58,5 @@ we will hit that once we lay the foundation of types/objects."*): delta-against-
 with prediction expressions, `int_relative` ascending-id streams, mid-stream packet
 splitting, sentinel-terminated streams. The table layer: `Config.schema`/`Assets.schema`
 and the derived type enums. *(Side-conditional fields, once an omission note here, are
-now first-class: `Contexts.schema` + `[local, context = ...]` — both former omission
+now first-class: `Contexts.schema` + `| local, context = ...` — both former omission
 sites are declared fields in `Objects.schema`.)*

--- a/examples/Types.schema
+++ b/examples/Types.schema
@@ -13,7 +13,8 @@ package example
 // declares Vec3 storage as ::VecMath — a hand math type deriving from the
 // generated basis struct (same layout, plus operators) — and every header
 // referencing it includes the mapped header. Other targets ignore the pair.
-type Vec3 [vec3, cpp_native = VecMath, cpp_include = "vec_math.h"] {
+type Vec3 | vec3, cpp_native = VecMath, cpp_include = "vec_math.h"
+{
     x float64
     y float64
     z float64
@@ -22,7 +23,8 @@ type Vec3 [vec3, cpp_native = VecMath, cpp_include = "vec_math.h"] {
 // Unit rotation quaternion — always unit length (rotations are). The tag is
 // what the delta pass will claim for renormalize + shortest-arc actions; in v1
 // this is a plain 4-float type and the hand-written rotation actions remain.
-type Quat [quat4] {
+type Quat | quat4
+{
     x float64
     y float64
     z float64
@@ -32,7 +34,7 @@ type Quat [quat4] {
 // A handle to another object: id + generation sequence.
 // object_id 0 doubles as the null sentinel (the surveyed NULL_OBJECT convention).
 type Handle {
-    object_id       int32 [min = 0, max = MaxObjects - 1]
+    object_id       int32 | min = 0, max = MaxObjects - 1
     object_sequence uint8
 }
 
@@ -40,22 +42,22 @@ type Handle {
 // (Object views express the same thing with [interpolate, quantize = ...]; both
 // belong in the corpus while both idioms exist in real code.)
 type QuantizedPosition {
-    x int32 [min = -MaxPositionUnits, max = MaxPositionUnits]
-    y int32 [min = -MaxPositionUnits, max = MaxPositionUnits]
-    z int32 [min = -MaxPositionUnits, max = MaxPositionUnits]
+    x int32 | min = -MaxPositionUnits, max = MaxPositionUnits
+    y int32 | min = -MaxPositionUnits, max = MaxPositionUnits
+    z int32 | min = -MaxPositionUnits, max = MaxPositionUnits
 }
 
 type QuantizedVelocity {
-    x int32 [min = -MaxVelocityUnits, max = MaxVelocityUnits]
-    y int32 [min = -MaxVelocityUnits, max = MaxVelocityUnits]
-    z int32 [min = -MaxVelocityUnits, max = MaxVelocityUnits]
+    x int32 | min = -MaxVelocityUnits, max = MaxVelocityUnits
+    y int32 | min = -MaxVelocityUnits, max = MaxVelocityUnits
+    z int32 | min = -MaxVelocityUnits, max = MaxVelocityUnits
 }
 
 type QuantizedRotation {
-    x int16 [min = -RotationUnits, max = RotationUnits]
-    y int16 [min = -RotationUnits, max = RotationUnits]
-    z int16 [min = -RotationUnits, max = RotationUnits]
-    w int16 [min = -RotationUnits, max = RotationUnits]
+    x int16 | min = -RotationUnits, max = RotationUnits
+    y int16 | min = -RotationUnits, max = RotationUnits
+    z int16 | min = -RotationUnits, max = RotationUnits
+    w int16 | min = -RotationUnits, max = RotationUnits
 }
 
 // ---- the back-reference worked example (SPEC §4.4, §4.5, §5) ----
@@ -126,8 +128,8 @@ type ShipCreate {
     }
 
     team   Team
-    health int16 [min = 0, max = MaxHealth]
-    thrust int8  [min = 0, max = 100]
+    health int16 | min = 0, max = MaxHealth
+    thrust int8  | min = 0, max = 100
 
     // an empty enum: the degenerate [0, 0] wire range, ZERO BITS. It rides
     // here to keep the no-variant path in the cross-language corpus rather
@@ -146,8 +148,8 @@ type ShipCreate {
 // doubled-minus parenthesization changes no wire bit and no folded value —
 // only these goldens go red.
 type ExpressionProbe {
-    hardpoint_index int32 [min = 0, max = (ShipMaxLasers + ShipMaxMissiles) - 1]
-    spin_rate       int32 [min = --RotationUnits, max = RotationUnits * 2]
+    hardpoint_index int32 | min = 0, max = (ShipMaxLasers + ShipMaxMissiles) - 1
+    spin_rate       int32 | min = --RotationUnits, max = RotationUnits * 2
 }
 
 // ---- issue #95: the integer extremes, pinned end-to-end ----
@@ -170,16 +172,16 @@ const FloorLimit          = -9223372036854775808
 const CeilingCount uint64 = 18446744073709551615
 
 type ExtremeProbe {
-    floor_bound     int64  [min = -9223372036854775808, max = 100]
-    doubled_floor   int64  [min = --FloorLimit, max = 100]
-    ceiling_range   uint64 [min = 1, max = 18446744073709551615]
-    floor_default   int64  = -9223372036854775808
+    floor_bound     int64                         | min = -9223372036854775808, max = 100
+    doubled_floor   int64                         | min = --FloorLimit, max = 100
+    ceiling_range   uint64                        | min = 1, max = 18446744073709551615
+    floor_default   int64 = -9223372036854775808
     ceiling_default uint64 = 18446744073709551615
 }
 
 table ExtremeRow {
-    clamped_floor   int64  [min = -9223372036854775808, max = 100]
-    clamped_ceiling uint64 [min = 1, max = 18446744073709551614]
-    floor_def       int64  = -9223372036854775808
+    clamped_floor   int64                         | min = -9223372036854775808, max = 100
+    clamped_ceiling uint64                        | min = 1, max = 18446744073709551614
+    floor_def       int64 = -9223372036854775808
     ceiling_def     uint64 = 18446744073709551615
 }

--- a/examples/Wire.schema
+++ b/examples/Wire.schema
@@ -15,10 +15,12 @@ const SpinRate         = 1.5
 
 // enum headroom: the wire range is [0, 15] whatever the variant count, and
 // non-variant values are wire-legal (SPEC §4.2, §6.1)
-enum Weapon [max = 15] { Laser, Missile, Railgun }
+enum Weapon | max = 15
+{ Laser, Missile, Railgun }
 
 // flags widening: 8 wire bits with three named so far (SPEC §4.2)
-flags ProbeFlags [max = 8] { Armed, Cloaked, Damaged }
+flags ProbeFlags | max = 8
+{ Armed, Cloaked, Damaged }
 
 // the storage-less wire constructs (SPEC §4.3): a magic byte the read
 // REJECTS if wrong, reserved bits held at zero, and an alignment point
@@ -37,8 +39,8 @@ type ProbeBits {
     small    bits(9)
     boundary bits(33)
     wide     bits(64)
-    sensor   uint32   [min = 0, max = 4294967295]
-    nonce    uint64   [min = 0, max = 18446744073709551615]
+    sensor   uint32   | min = 0, max = 4294967295
+    nonce    uint64   | min = 0, max = 18446744073709551615
 }
 
 // a compressed float on a plain type's wire (SPEC §4.3 — the object-view
@@ -46,8 +48,8 @@ type ProbeBits {
 // nested branch, bare int32/int64, and a range-counted array whose count
 // can never be zero
 type ProbeSample {
-    active      bool    = true
-    orientation float32 [min = -HalfTurn, max = HalfTurn, resolution = 0.01]
+    active      bool = true
+    orientation float32     | min = -HalfTurn, max = HalfTurn, resolution = 0.01
     raw_delta   int32
     big_delta   int64
     if active {
@@ -70,7 +72,7 @@ type ProbeRing {
 }
 
 type ProbeSlab {
-    width  uint8 [min = 0, max = 100]
+    width  uint8 | min = 0, max = 100
     height uint8
 }
 
@@ -91,7 +93,7 @@ type ProbeCollider {
 // specified defaults past bool (SPEC §4.2): a negative integer and an enum
 // variant — zero init everywhere else
 type ProbeConfig {
-    retries   int32  = -1
+    retries   int32 = -1
     preferred Weapon = Railgun
 }
 
@@ -120,9 +122,9 @@ type ProbeReport {
 // two constructs are v1-deferred by decision and absent — int_relative
 // (§4.10, the delta pass) and wstring.
 table TestData {
-    a int32 [min = -100, max = 100]
-    b int32 [min = -100, max = 100]
-    c int32 [min = -100, max = 150]
+    a int32 | min = -100, max = 100
+    b int32 | min = -100, max = 100
+    c int32 | min = -100, max = 150
 
     d bits(8)
     e bits(8)
@@ -130,10 +132,10 @@ table TestData {
 
     g bool
 
-    items [..16]int32 [min = 0, max = 255]
+    items [..16]int32 | min = 0, max = 255
 
     float_value            float32
-    compressed_float_value float32 [min = 0, max = 10, resolution = 0.01]
+    compressed_float_value float32 | min = 0, max = 10, resolution = 0.01
     double_value           float64
 
     int8_value  int8
@@ -145,7 +147,7 @@ table TestData {
     uint64_value uint64
 
     int64_full  int64
-    int64_range int64 [min = -1000000000000, max = 1000000000000]
+    int64_range int64 | min = -1000000000000, max = 1000000000000
 
     align
     fixed_bytes [17]uint8
@@ -166,6 +168,6 @@ table TestData {
 //                        full-range float32 sweep found no fused divergence
 //                        on this shape — measured, not assumed)
 type CompressedProbe {
-    boundary float32 [min = 0, max = 10, resolution = 0.01]
-    offset   float32 [min = -5, max = 5, resolution = 0.001]
+    boundary float32 | min = 0, max = 10, resolution = 0.01
+    offset   float32 | min = -5, max = 5, resolution = 0.001
 }

--- a/examples128/Ludicrous.schema
+++ b/examples128/Ludicrous.schema
@@ -20,11 +20,11 @@ enum DriveMode { Cruise, Warp, Ludicrous }
 // two groups), Q32.0 (a fixed with no fraction IS a ranged integer —
 // STANDARD.md), and a fixed array (per-element encoding)
 type FixedProbe {
-    angle    fixed(16, 16)    [min = -180, max = 180]
-    position fixed(48, 16)    [min = -MaxWorldUnits, max = MaxWorldUnits]
-    reach    fixed(112, 16)   [min = -1000000, max = 1000000]
-    ticks    fixed(32, 0)     [min = 0, max = 1000000]
-    samples  [2]fixed(16, 16) [min = -8, max = 8]
+    angle    fixed(16, 16)    | min = -180, max = 180
+    position fixed(48, 16)    | min = -MaxWorldUnits, max = MaxWorldUnits
+    reach    fixed(112, 16)   | min = -1000000, max = 1000000
+    ticks    fixed(32, 0)     | min = 0, max = 1000000
+    samples  [2]fixed(16, 16) | min = -8, max = 8
 }
 
 // The unsigned sibling — ufixed(I, F), DECIDED (Glenn, 2026-08-15: "ufixed
@@ -37,12 +37,12 @@ type FixedProbe {
 // byte-compare. locked is the degenerate ufixed shape (zero bits, F = 16
 // would show), riding in front of the tail byte like DegenerateProbe's.
 type UnsignedProbe {
-    angle   ufixed(16, 16)    [min = 0, max = 360]
-    span    ufixed(48, 16)    [min = 0, max = 281474976710655]
-    reach   ufixed(112, 16)   [min = 0, max = 2000000]
-    ticks   ufixed(32, 0)     [min = 0, max = 1000000]
-    samples [2]ufixed(16, 16) [min = 0, max = 16]
-    locked  ufixed(16, 16)    [min = 3, max = 3]
+    angle   ufixed(16, 16)    | min = 0, max = 360
+    span    ufixed(48, 16)    | min = 0, max = 281474976710655
+    reach   ufixed(112, 16)   | min = 0, max = 2000000
+    ticks   ufixed(32, 0)     | min = 0, max = 1000000
+    samples [2]ufixed(16, 16) | min = 0, max = 16
+    locked  ufixed(16, 16)    | min = 3, max = 3
     tail    uint8
 }
 
@@ -54,9 +54,9 @@ type UnsignedProbe {
 // composed unsigned halves (no 128-bit literal exists)
 type WideProbe {
     entity_id uint128
-    energy    int128  [min = -5000000000, max = 5000000000]
-    flux      int128  [min = -1267650600228229401496703205376, max = 1267650600228229401496703205376]
-    bias      int128  [min = -1000, max = 1000] = -250
+    energy    int128                         | min = -5000000000, max = 5000000000
+    flux      int128                         | min = -1267650600228229401496703205376, max = 1267650600228229401496703205376
+    bias      int128 = -250                  | min = -1000, max = 1000
     seed      uint128 = 36893488147419103232
 }
 
@@ -82,9 +82,9 @@ message LudicrousState {
 // fails the byte-compare. locked_fixed is the fraction_bits shape
 // (F = 16 would appear); locked_wide is the 64/128 boundary shape.
 type DegenerateProbe {
-    locked_fixed fixed(16, 16) [min = -3, max = -3]
-    locked_int   int32         [min = 7, max = 7]
-    locked_wide  int128        [min = -12345678901234, max = -12345678901234]
+    locked_fixed fixed(16, 16) | min = -3, max = -3
+    locked_int   int32         | min = 7, max = 7
+    locked_wide  int128        | min = -12345678901234, max = -12345678901234
     tail         uint8
 }
 
@@ -93,26 +93,28 @@ type DegenerateProbe {
 // wire-domain scalar, so NO Quantize/Unquantize pair is emitted — the
 // Interpolate and Shallow views hold the same values, and the wire is the
 // ranged fixed encoding from the component bounds.
-type FixedVec [vec3] {
-    x fixed(48, 16) [min = -100000, max = 100000]
-    y fixed(48, 16) [min = -100000, max = 100000]
-    z fixed(48, 16) [min = -100000, max = 100000]
+type FixedVec | vec3
+{
+    x fixed(48, 16) | min = -100000, max = 100000
+    y fixed(48, 16) | min = -100000, max = 100000
+    z fixed(48, 16) | min = -100000, max = 100000
 }
 
-type FixedQuat [quat4] {
-    x fixed(2, 30) [min = -1, max = 1]
-    y fixed(2, 30) [min = -1, max = 1]
-    z fixed(2, 30) [min = -1, max = 1]
+type FixedQuat | quat4
+{
+    x fixed(2, 30) | min = -1, max = 1
+    y fixed(2, 30) | min = -1, max = 1
+    z fixed(2, 30) | min = -1, max = 1
     // the identity rest state — THE case that reopened fixed defaults
     // (SPEC §4.3): whole units, exactly representable (1.0 * 2^30)
-    w fixed(2, 30) [min = -1, max = 1] = 1.0
+    w fixed(2, 30) = 1.0 | min = -1, max = 1
 }
 
 object Body {
-    position FixedVec  [interpolate]
-    rotation FixedQuat [interpolate]
-    velocity FixedVec  [interpolate]
-    spin     float64   [local]
+    position FixedVec  | interpolate
+    rotation FixedQuat | interpolate
+    velocity FixedVec  | interpolate
+    spin     float64   | local
 }
 
 // The narrowed shallow — §4.8 rule 2b: [interpolate, quantize = K] on a
@@ -124,7 +126,7 @@ object Body {
 // [min, max] scaled by K. velocity stays full precision beside them — the
 // two forms compose in one object.
 object NarrowBody {
-    position FixedVec  [interpolate, quantize = 256]
-    rotation FixedQuat [interpolate, quantize = 1024]
-    velocity FixedVec  [interpolate]
+    position FixedVec  | interpolate, quantize = 256
+    rotation FixedQuat | interpolate, quantize = 1024
+    velocity FixedVec  | interpolate
 }

--- a/generated/bench/c/RealWorld.h
+++ b/generated/bench/c/RealWorld.h
@@ -30,7 +30,7 @@ extern "C" {
 
 /* enum PacketMode — None = 0 implicit, variants dense from 1, wire range [0, 5]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t PacketMode;
 #define PACKET_MODE_NONE 0

--- a/generated/bench/cpp/BenchTable.h
+++ b/generated/bench/cpp/BenchTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/bench/cpp/RealWorldTable.h
+++ b/generated/bench/cpp/RealWorldTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/bench/cs/TableRuntime.cs
+++ b/generated/bench/cs/TableRuntime.cs
@@ -53,7 +53,7 @@ namespace Bench
         public bool Counted;                 // a Count/Length companion exists (counted arrays, strings, bytes)
         public int ArrayBound;               // array capacity / string max length; 0 for plain scalars
         public TableTypeInfo Table;          // nested table's descriptor, or null
-        public bool HasRange;                // a declared [min, max] (int or float)
+        public bool HasRange;                // a declared | min, max (int or float)
         public double RangeMin;              // NOTE: int64 ranges beyond 2^53 lose precision here
         public double RangeMax;
         public long EnumMax;                 // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -15,7 +15,7 @@ namespace Realworld
 {
 
     // PacketMode — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum PacketMode : byte
     {

--- a/generated/bench/cs/realworld/TableRuntime.cs
+++ b/generated/bench/cs/realworld/TableRuntime.cs
@@ -53,7 +53,7 @@ namespace Realworld
         public bool Counted;                 // a Count/Length companion exists (counted arrays, strings, bytes)
         public int ArrayBound;               // array capacity / string max length; 0 for plain scalars
         public TableTypeInfo Table;          // nested table's descriptor, or null
-        public bool HasRange;                // a declared [min, max] (int or float)
+        public bool HasRange;                // a declared | min, max (int or float)
         public double RangeMin;              // NOTE: int64 ranges beyond 2^53 lose precision here
         public double RangeMax;
         public long EnumMax;                 // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/bench/go/TableRuntime.go
+++ b/generated/bench/go/TableRuntime.go
@@ -39,7 +39,7 @@ type TableFieldInfo struct {
 	Counted    bool           // a Count/Length int32 companion exists (counted arrays, strings, bytes)
 	ArrayBound int32          // array capacity / string max length; 0 for plain scalars
 	Table      *TableTypeInfo // nested table's descriptor, or nil
-	HasRange   bool           // a declared [min, max] (int or float)
+	HasRange   bool           // a declared | min, max (int or float)
 	RangeMin   float64        // NOTE: int64 ranges beyond 2^53 lose precision here
 	RangeMax   float64
 	EnumMax    int64               // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/bench/go/realworld/TableRuntime.go
+++ b/generated/bench/go/realworld/TableRuntime.go
@@ -39,7 +39,7 @@ type TableFieldInfo struct {
 	Counted    bool           // a Count/Length int32 companion exists (counted arrays, strings, bytes)
 	ArrayBound int32          // array capacity / string max length; 0 for plain scalars
 	Table      *TableTypeInfo // nested table's descriptor, or nil
-	HasRange   bool           // a declared [min, max] (int or float)
+	HasRange   bool           // a declared | min, max (int or float)
 	RangeMin   float64        // NOTE: int64 ranges beyond 2^53 lose precision here
 	RangeMax   float64
 	EnumMax    int64               // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/bench/js/realworld/RealWorld.js
+++ b/generated/bench/js/realworld/RealWorld.js
@@ -27,7 +27,7 @@ export const ProtocolId = 0x8f7228a19854fbb2n;
 
 // PacketMode — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const PacketMode = Object.freeze({
   None: 0,
   Idle: 1,

--- a/generated/bench/rust-realworld/src/realworld.rs
+++ b/generated/bench/rust-realworld/src/realworld.rs
@@ -32,7 +32,7 @@ impl From<core::convert::Infallible> for Error {
 pub type Result<T = ()> = core::result::Result<T, Error>;
 
 // PacketMode — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct PacketMode(pub u8);

--- a/generated/c-ludicrous/Ludicrous.h
+++ b/generated/c-ludicrous/Ludicrous.h
@@ -32,7 +32,7 @@ extern "C" {
 
 /* enum DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t DriveMode;
 #define DRIVE_MODE_NONE 0
@@ -204,7 +204,7 @@ typedef struct BodyState {
     double spin;
 } BodyState;
 
-/* BodyData_Deep — every non-[local] field, deep encodings: full state for
+/* BodyData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct BodyData_Deep {
     FixedVec position;
@@ -212,7 +212,7 @@ typedef struct BodyData_Deep {
     FixedVec velocity;
 } BodyData_Deep;
 
-/* BodyData_Shallow — the [interpolate] fields on the quantized wire */
+/* BodyData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct BodyData_Shallow {
     FixedVec position;
     FixedQuat rotation;
@@ -226,7 +226,7 @@ typedef struct BodyData_Interpolate {
     FixedVec velocity;
 } BodyData_Interpolate;
 
-/* QuantizeBody/UnquantizeBody are not emitted: every [interpolate] field
+/* QuantizeBody/UnquantizeBody are not emitted: every | interpolate field
    is already wire-domain (fixed components are their own quantization,
    SPEC §4.8) — Interpolate and Shallow are the same values. */
 
@@ -240,7 +240,7 @@ typedef struct NarrowBodyState {
     FixedVec velocity;
 } NarrowBodyState;
 
-/* NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+/* NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct NarrowBodyData_Deep {
     FixedVec position;
@@ -248,7 +248,7 @@ typedef struct NarrowBodyData_Deep {
     FixedVec velocity;
 } NarrowBodyData_Deep;
 
-/* NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire */
+/* NarrowBodyData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct NarrowBodyData_Shallow {
     /* position: FixedVec narrowed — 8 fractional bits kept (SPEC §4.8 rule 2b) */
     int32_t position_x; /* [-25600000, 25600000] */

--- a/generated/c/Contexts.h
+++ b/generated/c/Contexts.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /* contexts declared for this unit: client, server (SPEC §4.2).
    Contexts generate no standalone artifacts — where an object carries
-   context-scoped [local] fields, its State struct is generated once per
+   context-scoped | local fields, its State struct is generated once per
    context (ClientShipState, ServerShipState, ...), each holding the `all`
    fields plus its own context's. No preprocessor in any target. */
 

--- a/generated/c/Enums.h
+++ b/generated/c/Enums.h
@@ -26,7 +26,7 @@ extern "C" {
 
 /* enum Team — None = 0 implicit, variants dense from 1, wire range [0, 2]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t Team;
 #define TEAM_NONE 0
@@ -62,7 +62,7 @@ static SCHEMA_UNUSED const char * enum_name_team_dyn( uint64_t value )
 
 /* enum ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t ShipType;
 #define SHIP_TYPE_NONE 0
@@ -107,7 +107,7 @@ static SCHEMA_UNUSED const char * enum_name_ship_type_dyn( uint64_t value )
 
 /* enum MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t MissileType;
 #define MISSILE_TYPE_NONE 0
@@ -146,7 +146,7 @@ static SCHEMA_UNUSED const char * enum_name_missile_type_dyn( uint64_t value )
 
 /* enum PropType — None = 0 implicit, variants dense from 1, wire range [0, 6]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t PropType;
 #define PROP_TYPE_NONE 0
@@ -194,7 +194,7 @@ static SCHEMA_UNUSED const char * enum_name_prop_type_dyn( uint64_t value )
 
 /* enum Pending — None = 0 implicit, variants dense from 1, wire range [0, 0]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t Pending;
 #define PENDING_NONE 0

--- a/generated/c/Objects.h
+++ b/generated/c/Objects.h
@@ -30,7 +30,7 @@ extern "C" {
 /* ---- object Ship — one definition, a generated family per target (SPEC §4.8) ---- */
 
 /* ClientShipState — the full simulation struct for the client context: every `all`
-   field plus the fields scoped [local, context = client] */
+   field plus the fields scoped | local, context = client */
 typedef struct ClientShipState {
     ShipType ship_type;
     Vec3 position;
@@ -65,7 +65,7 @@ typedef struct ClientShipState {
 } ClientShipState;
 
 /* ServerShipState — the full simulation struct for the server context: every `all`
-   field plus the fields scoped [local, context = server] */
+   field plus the fields scoped | local, context = server */
 typedef struct ServerShipState {
     ShipType ship_type;
     Vec3 position;
@@ -98,7 +98,7 @@ typedef struct ServerShipState {
     int32_t collider_armor[MAX_COLLIDERS_PER_SHIP];
 } ServerShipState;
 
-/* ShipData_Deep — every non-[local] field, deep encodings: full state for
+/* ShipData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct ShipData_Deep {
     ShipType ship_type;
@@ -128,7 +128,7 @@ typedef struct ShipData_Deep {
     double lock_start_time;
 } ShipData_Deep;
 
-/* ShipData_Shallow — the [interpolate] fields on the quantized wire */
+/* ShipData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct ShipData_Shallow {
     ShipType ship_type;
     /* position: Vec3 quantized — per-component int in [-8388608, 8388608] */
@@ -336,7 +336,7 @@ static SCHEMA_UNUSED void unquantize_ship( const ShipData_Shallow * input, ShipD
 /* ---- object Missile — one definition, a generated family per target (SPEC §4.8) ---- */
 
 /* ClientMissileState — the full simulation struct for the client context: every `all`
-   field plus the fields scoped [local, context = client] */
+   field plus the fields scoped | local, context = client */
 typedef struct ClientMissileState {
     MissileType missile_type;
     Vec3 position;
@@ -349,7 +349,7 @@ typedef struct ClientMissileState {
 } ClientMissileState;
 
 /* ServerMissileState — the full simulation struct for the server context: every `all`
-   field plus the fields scoped [local, context = server] */
+   field plus the fields scoped | local, context = server */
 typedef struct ServerMissileState {
     MissileType missile_type;
     Vec3 position;
@@ -362,7 +362,7 @@ typedef struct ServerMissileState {
     double timer;
 } ServerMissileState;
 
-/* MissileData_Deep — every non-[local] field, deep encodings: full state for
+/* MissileData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct MissileData_Deep {
     MissileType missile_type;
@@ -373,7 +373,7 @@ typedef struct MissileData_Deep {
     uint64_t flags;
 } MissileData_Deep;
 
-/* MissileData_Shallow — the [interpolate] fields on the quantized wire */
+/* MissileData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct MissileData_Shallow {
     MissileType missile_type;
     /* position: Vec3 quantized — per-component int in [-8388608, 8388608] */
@@ -583,7 +583,7 @@ typedef struct DynamicPropState {
     Vec3 angular_velocity;
 } DynamicPropState;
 
-/* DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+/* DynamicPropData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct DynamicPropData_Deep {
     PropType prop_type;
@@ -594,7 +594,7 @@ typedef struct DynamicPropData_Deep {
     Team team;
 } DynamicPropData_Deep;
 
-/* DynamicPropData_Shallow — the [interpolate] fields on the quantized wire */
+/* DynamicPropData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct DynamicPropData_Shallow {
     PropType prop_type;
     /* position: Vec3 quantized — per-component int in [-8388608, 8388608] */
@@ -802,7 +802,7 @@ typedef struct TurretState {
     Team team;
 } TurretState;
 
-/* TurretData_Deep — every non-[local] field, deep encodings: full state for
+/* TurretData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct TurretData_Deep {
     Handle parent;
@@ -811,7 +811,7 @@ typedef struct TurretData_Deep {
     uint64_t flags;
 } TurretData_Deep;
 
-/* TurretData_Shallow — the [interpolate] fields on the quantized wire */
+/* TurretData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct TurretData_Shallow {
     Handle parent;
     int32_t turret_index;

--- a/generated/c/TableRuntime.h
+++ b/generated/c/TableRuntime.h
@@ -51,7 +51,7 @@ typedef struct table_field_info_t
     int counted;              /* a count/length companion exists */
     int64_t array_bound;      /* array capacity / string max length; 0 for scalars */
     const struct table_type_info_t * table;  /* nested table's descriptor, or NULL */
-    int has_range;            /* a declared [min, max] */
+    int has_range;            /* a declared | min, max */
     double range_min;         /* NOTE: int64 ranges beyond 2^53 lose precision here */
     double range_max;
     int64_t enum_max;         /* enums: highest valid wire value; else -1 */

--- a/generated/c/Wire.h
+++ b/generated/c/Wire.h
@@ -31,7 +31,7 @@ extern "C" {
 
 /* enum Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t Weapon;
 #define WEAPON_NONE 0

--- a/generated/cpp/ConstantsTable.h
+++ b/generated/cpp/ConstantsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/Contexts.h
+++ b/generated/cpp/Contexts.h
@@ -12,7 +12,7 @@ namespace example {
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State struct is generated once per
+// context-scoped | local fields, its State struct is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's. No preprocessor in any target.
 

--- a/generated/cpp/ContextsTable.h
+++ b/generated/cpp/ContextsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/EnumsTable.h
+++ b/generated/cpp/EnumsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/MessagesTable.h
+++ b/generated/cpp/MessagesTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/Objects.h
+++ b/generated/cpp/Objects.h
@@ -31,7 +31,7 @@ enum class ObjectType : uint8_t {
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 struct ClientShipState {
     ShipType ship_type = ShipType::None;
     ::VecMath position;
@@ -58,15 +58,15 @@ struct ClientShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; // [local] — no wire
-    ::VecMath previous_position; // [local] — no wire
-    int32_t num_colliders = 0; // [local] — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; // [local] — no wire
-    bool predicted_explode = false; // [local, context = client]
+    bool invulnerable = false; //  | local — no wire
+    ::VecMath previous_position; //  | local — no wire
+    int32_t num_colliders = 0; //  | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
+    bool predicted_explode = false; //  | local, context = client
 };
 
 // ServerShipState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 struct ServerShipState {
     ShipType ship_type = ShipType::None;
     ::VecMath position;
@@ -93,13 +93,13 @@ struct ServerShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; // [local] — no wire
-    ::VecMath previous_position; // [local] — no wire
-    int32_t num_colliders = 0; // [local] — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; // [local] — no wire
+    bool invulnerable = false; //  | local — no wire
+    ::VecMath previous_position; //  | local — no wire
+    int32_t num_colliders = 0; //  | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
 };
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct ShipData_Deep {
     ShipType ship_type = ShipType::None;
@@ -129,7 +129,7 @@ struct ShipData_Deep {
     double lock_start_time = 0.0;
 };
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct ShipData_Shallow {
     ShipType ship_type = ShipType::None;
@@ -343,7 +343,7 @@ inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // rounded up to the 8-b
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 struct ClientMissileState {
     MissileType missile_type = MissileType::None;
     ::VecMath position;
@@ -351,12 +351,12 @@ struct ClientMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; // [local] — no wire
-    Handle target; // [local] — no wire
+    ::VecMath angular_velocity; //  | local — no wire
+    Handle target; //  | local — no wire
 };
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 struct ServerMissileState {
     MissileType missile_type = MissileType::None;
     ::VecMath position;
@@ -364,12 +364,12 @@ struct ServerMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; // [local] — no wire
-    Handle target; // [local] — no wire
-    double timer = 0.0; // [local, context = server]
+    ::VecMath angular_velocity; //  | local — no wire
+    Handle target; //  | local — no wire
+    double timer = 0.0; //  | local, context = server
 };
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct MissileData_Deep {
     MissileType missile_type = MissileType::None;
@@ -380,7 +380,7 @@ struct MissileData_Deep {
     uint64_t flags = 0;
 };
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct MissileData_Shallow {
     MissileType missile_type = MissileType::None;
@@ -593,10 +593,10 @@ struct DynamicPropState {
     ::VecMath linear_velocity;
     uint64_t flags = 0;
     Team team = Team::None;
-    ::VecMath angular_velocity; // [local] — no wire
+    ::VecMath angular_velocity; //  | local — no wire
 };
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct DynamicPropData_Deep {
     PropType prop_type = PropType::None;
@@ -607,7 +607,7 @@ struct DynamicPropData_Deep {
     Team team = Team::None;
 };
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct DynamicPropData_Shallow {
     PropType prop_type = PropType::None;
@@ -818,10 +818,10 @@ struct TurretState {
     int32_t turret_index = 0; // wire [0, 255]
     Quat rotation;
     uint64_t flags = 0;
-    Team team = Team::None; // [local] — no wire
+    Team team = Team::None; //  | local — no wire
 };
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct TurretData_Deep {
     Handle parent;
@@ -830,7 +830,7 @@ struct TurretData_Deep {
     uint64_t flags = 0;
 };
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct TurretData_Shallow {
     Handle parent;

--- a/generated/cpp/ObjectsTable.h
+++ b/generated/cpp/ObjectsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/RenderTable.h
+++ b/generated/cpp/RenderTable.h
@@ -54,7 +54,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/TypesTable.h
+++ b/generated/cpp/TypesTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/WireTable.h
+++ b/generated/cpp/WireTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cpp/ludicrous/Ludicrous.h
+++ b/generated/cpp/ludicrous/Ludicrous.h
@@ -150,10 +150,10 @@ struct BodyState {
     FixedVec position;
     FixedQuat rotation;
     FixedVec velocity;
-    double spin = 0.0; // [local] — no wire
+    double spin = 0.0; //  | local — no wire
 };
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct BodyData_Deep {
     FixedVec position;
@@ -161,7 +161,7 @@ struct BodyData_Deep {
     FixedVec velocity;
 };
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct BodyData_Shallow {
     FixedVec position;
@@ -178,7 +178,7 @@ struct BodyData_Interpolate {
     FixedVec velocity;
 };
 
-// QuantizeBody/UnquantizeBody are not emitted: every [interpolate] field
+// QuantizeBody/UnquantizeBody are not emitted: every | interpolate field
 // is already wire-domain (fixed components are their own quantization,
 // SPEC §4.8) — Interpolate and Shallow are the same values.
 
@@ -197,7 +197,7 @@ struct NarrowBodyState {
     FixedVec velocity;
 };
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct NarrowBodyData_Deep {
     FixedVec position;
@@ -205,16 +205,16 @@ struct NarrowBodyData_Deep {
     FixedVec velocity;
 };
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct NarrowBodyData_Shallow {
     // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     int32_t position_x = 0; // in [-25600000, 25600000]
     int32_t position_y = 0; // in [-25600000, 25600000]
     int32_t position_z = 0; // in [-25600000, 25600000]
     // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     int16_t rotation_x = 0; // in [-1024, 1024]
     int16_t rotation_y = 0; // in [-1024, 1024]
     int16_t rotation_z = 0; // in [-1024, 1024]

--- a/generated/cpp/ludicrous/LudicrousTable.h
+++ b/generated/cpp/ludicrous/LudicrousTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/generated/cs-ludicrous/Ludicrous.cs
+++ b/generated/cs-ludicrous/Ludicrous.cs
@@ -41,7 +41,7 @@ namespace Ludicrous
     }
 
     // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum DriveMode : byte
     {
@@ -137,10 +137,10 @@ namespace Ludicrous
         public FixedVec Position = new FixedVec();
         public FixedQuat Rotation = new FixedQuat();
         public FixedVec Velocity = new FixedVec();
-        public double Spin; // [local] — no wire
+        public double Spin; //  | local — no wire
     }
 
-    // BodyData_Deep — every non-[local] field, deep encodings: full state for
+    // BodyData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class BodyData_Deep
     {
@@ -149,7 +149,7 @@ namespace Ludicrous
         public FixedVec Velocity = new FixedVec();
     }
 
-    // BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+    // BodyData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class BodyData_Shallow
     {
@@ -178,7 +178,7 @@ namespace Ludicrous
         public FixedVec Velocity = new FixedVec();
     }
 
-    // NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+    // NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class NarrowBodyData_Deep
     {
@@ -187,17 +187,17 @@ namespace Ludicrous
         public FixedVec Velocity = new FixedVec();
     }
 
-    // NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+    // NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class NarrowBodyData_Shallow
     {
         // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-        // quantized units; bounds are the component's whole-unit [min, max] scaled
+        // quantized units; bounds are the component's whole-unit | min, max scaled
         public int PositionX; // in [-25600000, 25600000]
         public int PositionY; // in [-25600000, 25600000]
         public int PositionZ; // in [-25600000, 25600000]
         // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-        // quantized units; bounds are the component's whole-unit [min, max] scaled
+        // quantized units; bounds are the component's whole-unit | min, max scaled
         public short RotationX; // in [-1024, 1024]
         public short RotationY; // in [-1024, 1024]
         public short RotationZ; // in [-1024, 1024]

--- a/generated/cs-ludicrous/TableRuntime.cs
+++ b/generated/cs-ludicrous/TableRuntime.cs
@@ -53,7 +53,7 @@ namespace Ludicrous
         public bool Counted;                 // a Count/Length companion exists (counted arrays, strings, bytes)
         public int ArrayBound;               // array capacity / string max length; 0 for plain scalars
         public TableTypeInfo Table;          // nested table's descriptor, or null
-        public bool HasRange;                // a declared [min, max] (int or float)
+        public bool HasRange;                // a declared | min, max (int or float)
         public double RangeMin;              // NOTE: int64 ranges beyond 2^53 lose precision here
         public double RangeMax;
         public long EnumMax;                 // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/cs/Contexts.cs
+++ b/generated/cs/Contexts.cs
@@ -6,7 +6,7 @@ namespace Example
 
     // contexts declared for this unit: client, server (SPEC §4.2).
     // Contexts generate no standalone artifacts — where an object carries
-    // context-scoped [local] fields, its State class is generated once per
+    // context-scoped | local fields, its State class is generated once per
     // context (ClientShipState, ServerShipState, ...), each holding the `all`
     // fields plus its own context's. No preprocessor symbols in this target.
 

--- a/generated/cs/Enums.cs
+++ b/generated/cs/Enums.cs
@@ -5,7 +5,7 @@ namespace Example
 {
 
     // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum Team : byte
     {
@@ -16,7 +16,7 @@ namespace Example
     }
 
     // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum ShipType : byte
     {
@@ -30,7 +30,7 @@ namespace Example
     }
 
     // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum MissileType : byte
     {
@@ -42,7 +42,7 @@ namespace Example
     }
 
     // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum PropType : byte
     {
@@ -57,7 +57,7 @@ namespace Example
     }
 
     // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum Pending : byte
     {

--- a/generated/cs/Objects.cs
+++ b/generated/cs/Objects.cs
@@ -29,7 +29,7 @@ namespace Example
     // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
     // ClientShipState — the full simulation class for the client context: every `all`
-    // field plus the fields scoped [local, context = client]
+    // field plus the fields scoped | local, context = client
     public sealed class ClientShipState
     {
         public ShipType ShipType;
@@ -57,15 +57,15 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; // [local] — no wire
-        public Vec3 PreviousPosition = new Vec3(); // [local] — no wire
-        public int NumColliders; // [local] — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // [local] — no wire
-        public bool PredictedExplode; // [local, context = client]
+        public bool Invulnerable; //  | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
+        public int NumColliders; //  | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
+        public bool PredictedExplode; //  | local, context = client
     }
 
     // ServerShipState — the full simulation class for the server context: every `all`
-    // field plus the fields scoped [local, context = server]
+    // field plus the fields scoped | local, context = server
     public sealed class ServerShipState
     {
         public ShipType ShipType;
@@ -93,13 +93,13 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; // [local] — no wire
-        public Vec3 PreviousPosition = new Vec3(); // [local] — no wire
-        public int NumColliders; // [local] — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // [local] — no wire
+        public bool Invulnerable; //  | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
+        public int NumColliders; //  | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
     }
 
-    // ShipData_Deep — every non-[local] field, deep encodings: full state for
+    // ShipData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class ShipData_Deep
     {
@@ -130,7 +130,7 @@ namespace Example
         public double LockStartTime;
     }
 
-    // ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+    // ShipData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class ShipData_Shallow
     {
@@ -172,7 +172,7 @@ namespace Example
     // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
     // ClientMissileState — the full simulation class for the client context: every `all`
-    // field plus the fields scoped [local, context = client]
+    // field plus the fields scoped | local, context = client
     public sealed class ClientMissileState
     {
         public MissileType MissileType;
@@ -181,12 +181,12 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); // [local] — no wire
-        public Handle Target = new Handle(); // [local] — no wire
+        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
+        public Handle Target = new Handle(); //  | local — no wire
     }
 
     // ServerMissileState — the full simulation class for the server context: every `all`
-    // field plus the fields scoped [local, context = server]
+    // field plus the fields scoped | local, context = server
     public sealed class ServerMissileState
     {
         public MissileType MissileType;
@@ -195,12 +195,12 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); // [local] — no wire
-        public Handle Target = new Handle(); // [local] — no wire
-        public double Timer; // [local, context = server]
+        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
+        public Handle Target = new Handle(); //  | local — no wire
+        public double Timer; //  | local, context = server
     }
 
-    // MissileData_Deep — every non-[local] field, deep encodings: full state for
+    // MissileData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class MissileData_Deep
     {
@@ -212,7 +212,7 @@ namespace Example
         public ulong Flags;
     }
 
-    // MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+    // MissileData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class MissileData_Shallow
     {
@@ -258,10 +258,10 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public ulong Flags;
         public Team Team;
-        public Vec3 AngularVelocity = new Vec3(); // [local] — no wire
+        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
     }
 
-    // DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+    // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class DynamicPropData_Deep
     {
@@ -273,7 +273,7 @@ namespace Example
         public Team Team;
     }
 
-    // DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+    // DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class DynamicPropData_Shallow
     {
@@ -317,10 +317,10 @@ namespace Example
         public int TurretIndex; // wire [0, 255]
         public Quat Rotation = new Quat();
         public ulong Flags;
-        public Team Team; // [local] — no wire
+        public Team Team; //  | local — no wire
     }
 
-    // TurretData_Deep — every non-[local] field, deep encodings: full state for
+    // TurretData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class TurretData_Deep
     {
@@ -330,7 +330,7 @@ namespace Example
         public ulong Flags;
     }
 
-    // TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+    // TurretData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class TurretData_Shallow
     {

--- a/generated/cs/TableRuntime.cs
+++ b/generated/cs/TableRuntime.cs
@@ -53,7 +53,7 @@ namespace Example
         public bool Counted;                 // a Count/Length companion exists (counted arrays, strings, bytes)
         public int ArrayBound;               // array capacity / string max length; 0 for plain scalars
         public TableTypeInfo Table;          // nested table's descriptor, or null
-        public bool HasRange;                // a declared [min, max] (int or float)
+        public bool HasRange;                // a declared | min, max (int or float)
         public double RangeMin;              // NOTE: int64 ranges beyond 2^53 lose precision here
         public double RangeMax;
         public long EnumMax;                 // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -16,7 +16,7 @@ namespace Example
 {
 
     // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum Weapon : byte
     {

--- a/generated/go-ludicrous/Ludicrous.go
+++ b/generated/go-ludicrous/Ludicrous.go
@@ -486,10 +486,10 @@ type BodyState struct {
 	Position FixedVec
 	Rotation FixedQuat
 	Velocity FixedVec
-	Spin     float64 // [local] — no wire
+	Spin     float64 //  | local — no wire
 }
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type BodyData_Deep struct {
 	Position FixedVec
@@ -497,7 +497,7 @@ type BodyData_Deep struct {
 	Velocity FixedVec
 }
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type BodyData_Shallow struct {
 	Position FixedVec
@@ -581,7 +581,7 @@ type NarrowBodyState struct {
 	Velocity FixedVec
 }
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type NarrowBodyData_Deep struct {
 	Position FixedVec
@@ -589,16 +589,16 @@ type NarrowBodyData_Deep struct {
 	Velocity FixedVec
 }
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type NarrowBodyData_Shallow struct {
 	// position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-	// quantized units; bounds are the component's whole-unit [min, max] scaled
+	// quantized units; bounds are the component's whole-unit | min, max scaled
 	PositionX int32 // in [-25600000, 25600000]
 	PositionY int32 // in [-25600000, 25600000]
 	PositionZ int32 // in [-25600000, 25600000]
 	// rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-	// quantized units; bounds are the component's whole-unit [min, max] scaled
+	// quantized units; bounds are the component's whole-unit | min, max scaled
 	RotationX int16 // in [-1024, 1024]
 	RotationY int16 // in [-1024, 1024]
 	RotationZ int16 // in [-1024, 1024]

--- a/generated/go-ludicrous/TableRuntime.go
+++ b/generated/go-ludicrous/TableRuntime.go
@@ -39,7 +39,7 @@ type TableFieldInfo struct {
 	Counted    bool           // a Count/Length int32 companion exists (counted arrays, strings, bytes)
 	ArrayBound int32          // array capacity / string max length; 0 for plain scalars
 	Table      *TableTypeInfo // nested table's descriptor, or nil
-	HasRange   bool           // a declared [min, max] (int or float)
+	HasRange   bool           // a declared | min, max (int or float)
 	RangeMin   float64        // NOTE: int64 ranges beyond 2^53 lose precision here
 	RangeMax   float64
 	EnumMax    int64               // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/go/Contexts.go
+++ b/generated/go/Contexts.go
@@ -5,6 +5,6 @@ package example
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State struct is generated once per
+// context-scoped | local fields, its State struct is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's. No build tags in this target.

--- a/generated/go/Objects.go
+++ b/generated/go/Objects.go
@@ -24,7 +24,7 @@ const (
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 type ClientShipState struct {
 	ShipType            ShipType
 	Position            Vec3
@@ -51,15 +51,15 @@ type ClientShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       // [local] — no wire
-	PreviousPosition    Vec3                       // [local] — no wire
-	NumColliders        int32                      // [local] — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 // [local] — no wire
-	PredictedExplode    bool                       // [local, context = client]
+	Invulnerable        bool                       //  | local — no wire
+	PreviousPosition    Vec3                       //  | local — no wire
+	NumColliders        int32                      //  | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
+	PredictedExplode    bool                       //  | local, context = client
 }
 
 // ServerShipState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 type ServerShipState struct {
 	ShipType            ShipType
 	Position            Vec3
@@ -86,13 +86,13 @@ type ServerShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       // [local] — no wire
-	PreviousPosition    Vec3                       // [local] — no wire
-	NumColliders        int32                      // [local] — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 // [local] — no wire
+	Invulnerable        bool                       //  | local — no wire
+	PreviousPosition    Vec3                       //  | local — no wire
+	NumColliders        int32                      //  | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
 }
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type ShipData_Deep struct {
 	ShipType            ShipType
@@ -122,7 +122,7 @@ type ShipData_Deep struct {
 	LockStartTime       float64
 }
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type ShipData_Shallow struct {
 	ShipType ShipType
@@ -640,7 +640,7 @@ func UnquantizeShip(input *ShipData_Shallow, output *ShipData_Interpolate) {
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 type ClientMissileState struct {
 	MissileType     MissileType
 	Position        Vec3
@@ -648,12 +648,12 @@ type ClientMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3   // [local] — no wire
-	Target          Handle // [local] — no wire
+	AngularVelocity Vec3   //  | local — no wire
+	Target          Handle //  | local — no wire
 }
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 type ServerMissileState struct {
 	MissileType     MissileType
 	Position        Vec3
@@ -661,12 +661,12 @@ type ServerMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3    // [local] — no wire
-	Target          Handle  // [local] — no wire
-	Timer           float64 // [local, context = server]
+	AngularVelocity Vec3    //  | local — no wire
+	Target          Handle  //  | local — no wire
+	Timer           float64 //  | local, context = server
 }
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type MissileData_Deep struct {
 	MissileType    MissileType
@@ -677,7 +677,7 @@ type MissileData_Deep struct {
 	Flags          uint64
 }
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type MissileData_Shallow struct {
 	MissileType MissileType
@@ -1064,10 +1064,10 @@ type DynamicPropState struct {
 	LinearVelocity  Vec3
 	Flags           uint64
 	Team            Team
-	AngularVelocity Vec3 // [local] — no wire
+	AngularVelocity Vec3 //  | local — no wire
 }
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type DynamicPropData_Deep struct {
 	PropType       PropType
@@ -1078,7 +1078,7 @@ type DynamicPropData_Deep struct {
 	Team           Team
 }
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type DynamicPropData_Shallow struct {
 	PropType PropType
@@ -1463,10 +1463,10 @@ type TurretState struct {
 	TurretIndex int32 // wire [0, 255]
 	Rotation    Quat
 	Flags       uint64
-	Team        Team // [local] — no wire
+	Team        Team //  | local — no wire
 }
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type TurretData_Deep struct {
 	Parent      Handle
@@ -1475,7 +1475,7 @@ type TurretData_Deep struct {
 	Flags       uint64
 }
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type TurretData_Shallow struct {
 	Parent      Handle

--- a/generated/go/TableRuntime.go
+++ b/generated/go/TableRuntime.go
@@ -39,7 +39,7 @@ type TableFieldInfo struct {
 	Counted    bool           // a Count/Length int32 companion exists (counted arrays, strings, bytes)
 	ArrayBound int32          // array capacity / string max length; 0 for plain scalars
 	Table      *TableTypeInfo // nested table's descriptor, or nil
-	HasRange   bool           // a declared [min, max] (int or float)
+	HasRange   bool           // a declared | min, max (int or float)
 	RangeMin   float64        // NOTE: int64 ranges beyond 2^53 lose precision here
 	RangeMax   float64
 	EnumMax    int64               // enums: highest valid wire value (None = 0 always valid); else -1

--- a/generated/js-ludicrous/Ludicrous.js
+++ b/generated/js-ludicrous/Ludicrous.js
@@ -44,7 +44,7 @@ export const MaxWorldUnits = 30000;
 
 // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const DriveMode = Object.freeze({
   None: 0,
   Cruise: 1,
@@ -611,11 +611,11 @@ export class BodyState {
     this.Position = new FixedVec();
     this.Rotation = new FixedQuat();
     this.Velocity = new FixedVec();
-    this.Spin = 0; // [local] — no wire
+    this.Spin = 0; //  | local — no wire
   }
 }
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class BodyData_Deep {
   constructor() {
@@ -625,7 +625,7 @@ export class BodyData_Deep {
   }
 }
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class BodyData_Shallow {
   constructor() {
@@ -715,7 +715,7 @@ export class NarrowBodyState {
   }
 }
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class NarrowBodyData_Deep {
   constructor() {
@@ -725,17 +725,17 @@ export class NarrowBodyData_Deep {
   }
 }
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class NarrowBodyData_Shallow {
   constructor() {
     // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     this.PositionX = 0; // in [-25600000, 25600000]
     this.PositionY = 0; // in [-25600000, 25600000]
     this.PositionZ = 0; // in [-25600000, 25600000]
     // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     this.RotationX = 0; // in [-1024, 1024]
     this.RotationY = 0; // in [-1024, 1024]
     this.RotationZ = 0; // in [-1024, 1024]

--- a/generated/js/Contexts.js
+++ b/generated/js/Contexts.js
@@ -14,7 +14,7 @@
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State class is generated once per
+// context-scoped | local fields, its State class is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's.
 

--- a/generated/js/Enums.js
+++ b/generated/js/Enums.js
@@ -14,7 +14,7 @@
 
 // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const Team = Object.freeze({
   None: 0,
   Red: 1,
@@ -39,7 +39,7 @@ export function EnumNameTeam(value) {
 
 // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const ShipType = Object.freeze({
   None: 0,
   Fighter: 1,
@@ -73,7 +73,7 @@ export function EnumNameShipType(value) {
 
 // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const MissileType = Object.freeze({
   None: 0,
   Heatseeker: 1,
@@ -101,7 +101,7 @@ export function EnumNameMissileType(value) {
 
 // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const PropType = Object.freeze({
   None: 0,
   Asteroid: 1,
@@ -138,7 +138,7 @@ export function EnumNamePropType(value) {
 
 // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const Pending = Object.freeze({
   None: 0,
   Max: 0, // the exported extent (SPEC §4.2)

--- a/generated/js/Objects.js
+++ b/generated/js/Objects.js
@@ -37,7 +37,7 @@ export const ObjectType = Object.freeze({
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation class for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 export class ClientShipState {
   constructor() {
     this.ShipType = ShipType.None;
@@ -65,16 +65,16 @@ export class ClientShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; // [local] — no wire
-    this.PreviousPosition = new Vec3(); // [local] — no wire
-    this.NumColliders = 0; // [local] — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // [local] — no wire
-    this.PredictedExplode = false; // [local, context = client]
+    this.Invulnerable = false; //  | local — no wire
+    this.PreviousPosition = new Vec3(); //  | local — no wire
+    this.NumColliders = 0; //  | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
+    this.PredictedExplode = false; //  | local, context = client
   }
 }
 
 // ServerShipState — the full simulation class for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 export class ServerShipState {
   constructor() {
     this.ShipType = ShipType.None;
@@ -102,14 +102,14 @@ export class ServerShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; // [local] — no wire
-    this.PreviousPosition = new Vec3(); // [local] — no wire
-    this.NumColliders = 0; // [local] — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // [local] — no wire
+    this.Invulnerable = false; //  | local — no wire
+    this.PreviousPosition = new Vec3(); //  | local — no wire
+    this.NumColliders = 0; //  | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
   }
 }
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class ShipData_Deep {
   constructor() {
@@ -141,7 +141,7 @@ export class ShipData_Deep {
   }
 }
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class ShipData_Shallow {
   constructor() {
@@ -708,7 +708,7 @@ export function UnquantizeShip(input, output) {
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation class for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 export class ClientMissileState {
   constructor() {
     this.MissileType = MissileType.None;
@@ -717,13 +717,13 @@ export class ClientMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); // [local] — no wire
-    this.Target = new Handle(); // [local] — no wire
+    this.AngularVelocity = new Vec3(); //  | local — no wire
+    this.Target = new Handle(); //  | local — no wire
   }
 }
 
 // ServerMissileState — the full simulation class for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 export class ServerMissileState {
   constructor() {
     this.MissileType = MissileType.None;
@@ -732,13 +732,13 @@ export class ServerMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); // [local] — no wire
-    this.Target = new Handle(); // [local] — no wire
-    this.Timer = 0; // [local, context = server]
+    this.AngularVelocity = new Vec3(); //  | local — no wire
+    this.Target = new Handle(); //  | local — no wire
+    this.Timer = 0; //  | local, context = server
   }
 }
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class MissileData_Deep {
   constructor() {
@@ -751,7 +751,7 @@ export class MissileData_Deep {
   }
 }
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class MissileData_Shallow {
   constructor() {
@@ -1134,11 +1134,11 @@ export class DynamicPropState {
     this.LinearVelocity = new Vec3();
     this.Flags = 0n;
     this.Team = Team.None;
-    this.AngularVelocity = new Vec3(); // [local] — no wire
+    this.AngularVelocity = new Vec3(); //  | local — no wire
   }
 }
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class DynamicPropData_Deep {
   constructor() {
@@ -1151,7 +1151,7 @@ export class DynamicPropData_Deep {
   }
 }
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class DynamicPropData_Shallow {
   constructor() {
@@ -1532,11 +1532,11 @@ export class TurretState {
     this.TurretIndex = 0; // wire [0, 255]
     this.Rotation = new Quat();
     this.Flags = 0n;
-    this.Team = Team.None; // [local] — no wire
+    this.Team = Team.None; //  | local — no wire
   }
 }
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class TurretData_Deep {
   constructor() {
@@ -1547,7 +1547,7 @@ export class TurretData_Deep {
   }
 }
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class TurretData_Shallow {
   constructor() {

--- a/generated/js/Wire.js
+++ b/generated/js/Wire.js
@@ -33,7 +33,7 @@ export const SpinRate = 1.5;
 
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const Weapon = Object.freeze({
   None: 0,
   Laser: 1,

--- a/generated/rust-ludicrous/src/ludicrous.rs
+++ b/generated/rust-ludicrous/src/ludicrous.rs
@@ -57,7 +57,7 @@ impl ObjectType {
 pub const MAX_WORLD_UNITS: i64 = 30000;
 
 // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct DriveMode(pub u8);
@@ -668,7 +668,7 @@ pub struct BodyState {
     pub position: FixedVec,
     pub rotation: FixedQuat,
     pub velocity: FixedVec,
-    pub spin: f64, // [local] — no wire
+    pub spin: f64, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -683,7 +683,7 @@ impl Default for BodyState {
     }
 }
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -704,7 +704,7 @@ impl Default for BodyData_Deep {
     }
 }
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -806,7 +806,7 @@ impl Default for NarrowBodyState {
     }
 }
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -827,18 +827,18 @@ impl Default for NarrowBodyData_Deep {
     }
 }
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct NarrowBodyData_Shallow {
     // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     pub position_x: i32, // in [-25600000, 25600000]
     pub position_y: i32, // in [-25600000, 25600000]
     pub position_z: i32, // in [-25600000, 25600000]
     // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     pub rotation_x: i16, // in [-1024, 1024]
     pub rotation_y: i16, // in [-1024, 1024]
     pub rotation_z: i16, // in [-1024, 1024]

--- a/generated/rust/src/contexts.rs
+++ b/generated/rust/src/contexts.rs
@@ -3,7 +3,7 @@
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State struct is generated once per
+// context-scoped | local fields, its State struct is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's. No cfg gates in this target.
 

--- a/generated/rust/src/enums.rs
+++ b/generated/rust/src/enums.rs
@@ -2,7 +2,7 @@
 // package example — protocol id 0x9cdffa5a3048f991
 
 // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Team(pub u8);
@@ -31,7 +31,7 @@ pub fn enum_name_team_dyn(value: u64) -> &'static str {
 }
 
 // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct ShipType(pub u8);
@@ -66,7 +66,7 @@ pub fn enum_name_ship_type_dyn(value: u64) -> &'static str {
 }
 
 // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct MissileType(pub u8);
@@ -97,7 +97,7 @@ pub fn enum_name_missile_type_dyn(value: u64) -> &'static str {
 }
 
 // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct PropType(pub u8);
@@ -134,7 +134,7 @@ pub fn enum_name_prop_type_dyn(value: u64) -> &'static str {
 }
 
 // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Pending(pub u8);

--- a/generated/rust/src/objects.rs
+++ b/generated/rust/src/objects.rs
@@ -21,7 +21,7 @@ impl ObjectType {
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ClientShipState {
     pub ship_type: ShipType,
@@ -49,11 +49,11 @@ pub struct ClientShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, // [local] — no wire
-    pub previous_position: Vec3, // [local] — no wire
-    pub num_colliders: i32, // [local] — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // [local] — no wire
-    pub predicted_explode: bool, // [local, context = client]
+    pub invulnerable: bool, //  | local — no wire
+    pub previous_position: Vec3, //  | local — no wire
+    pub num_colliders: i32, //  | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
+    pub predicted_explode: bool, //  | local, context = client
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -95,7 +95,7 @@ impl Default for ClientShipState {
 }
 
 // ServerShipState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ServerShipState {
     pub ship_type: ShipType,
@@ -123,10 +123,10 @@ pub struct ServerShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, // [local] — no wire
-    pub previous_position: Vec3, // [local] — no wire
-    pub num_colliders: i32, // [local] — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // [local] — no wire
+    pub invulnerable: bool, //  | local — no wire
+    pub previous_position: Vec3, //  | local — no wire
+    pub num_colliders: i32, //  | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -166,7 +166,7 @@ impl Default for ServerShipState {
     }
 }
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -231,7 +231,7 @@ impl Default for ShipData_Deep {
     }
 }
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -749,7 +749,7 @@ pub fn unquantize_ship(input: &ShipData_Shallow, output: &mut ShipData_Interpola
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ClientMissileState {
     pub missile_type: MissileType,
@@ -758,8 +758,8 @@ pub struct ClientMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, // [local] — no wire
-    pub target: Handle, // [local] — no wire
+    pub angular_velocity: Vec3, //  | local — no wire
+    pub target: Handle, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -779,7 +779,7 @@ impl Default for ClientMissileState {
 }
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ServerMissileState {
     pub missile_type: MissileType,
@@ -788,9 +788,9 @@ pub struct ServerMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, // [local] — no wire
-    pub target: Handle, // [local] — no wire
-    pub timer: f64, // [local, context = server]
+    pub angular_velocity: Vec3, //  | local — no wire
+    pub target: Handle, //  | local — no wire
+    pub timer: f64, //  | local, context = server
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -810,7 +810,7 @@ impl Default for ServerMissileState {
     }
 }
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -837,7 +837,7 @@ impl Default for MissileData_Deep {
     }
 }
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1218,7 +1218,7 @@ pub struct DynamicPropState {
     pub linear_velocity: Vec3,
     pub flags: u64,
     pub team: Team,
-    pub angular_velocity: Vec3, // [local] — no wire
+    pub angular_velocity: Vec3, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1236,7 +1236,7 @@ impl Default for DynamicPropState {
     }
 }
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1263,7 +1263,7 @@ impl Default for DynamicPropData_Deep {
     }
 }
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1642,7 +1642,7 @@ pub struct TurretState {
     pub turret_index: i32, // wire [0, 255]
     pub rotation: Quat,
     pub flags: u64,
-    pub team: Team, // [local] — no wire
+    pub team: Team, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1658,7 +1658,7 @@ impl Default for TurretState {
     }
 }
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1681,7 +1681,7 @@ impl Default for TurretData_Deep {
     }
 }
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/generated/rust/src/table_runtime.rs
+++ b/generated/rust/src/table_runtime.rs
@@ -44,7 +44,7 @@ pub struct TableFieldInfo {
     pub array_bound: i64,
     /// nested table's descriptor
     pub table: Option<&'static TableTypeInfo>,
-    /// a declared [min, max] (int or float)
+    /// a declared | min, max (int or float)
     pub has_range: bool,
     /// NOTE: i64 ranges beyond 2^53 lose precision here
     pub range_min: f64,

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -13,7 +13,7 @@ pub const TICK_RATE: f32 = 60.0;
 pub const SPIN_RATE: f64 = 1.5;
 
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Weapon(pub u8);

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -44,12 +44,12 @@ type checker struct {
 	unions   map[string]*ir.Union
 	ctxDecl  *ast.ContextsDecl
 
-	// enums currently being resolved — the cycle guard for [max = E.Max]
+	// enums currently being resolved — the cycle guard for | max = E.Max
 	// chains (resolveEnum memoizes only on completion, so recursion needs
 	// its own in-progress set, exactly as constants have one)
 	resolvingEnum map[string]bool
 
-	// enums whose [max = ...] failed to resolve — their Max fell back to the
+	// enums whose | max = ... failed to resolve — their Max fell back to the
 	// variant count, which is NOT what the author wrote, so .Max references
 	// to them must fail rather than propagate a fabricated bound
 	failedEnum map[string]bool
@@ -534,7 +534,7 @@ func (c *checker) bigIntFloat(v *big.Int, pos ast.Pos) (float64, bool) {
 }
 
 // valuedAttr lists the field attributes that MUST carry `= value`. The bare
-// markers ([interpolate], [local], and the context words) are absent by
+// markers ( | interpolate, | local, and the context words) are absent by
 // design. Adding a valued attribute means adding it here, or a bare spelling
 // of it reaches expression evaluation as a nil and panics.
 var valuedAttr = map[string]bool{
@@ -586,7 +586,7 @@ func (c *checker) enumMax(e *ast.MaxExpr) (*big.Int, bool) {
 }
 
 // flagsCount resolves F.Count (SPEC §4.2): the DECLARED variant count of a
-// flags declaration — not the wire width, which a [max = K] widening can
+// flags declaration — not the wire width, which a | max = K widening can
 // raise above it.
 func (c *checker) flagsCount(e *ast.MaxExpr) (*big.Int, bool) {
 	d, ok := c.astDecls[e.Enum]
@@ -656,7 +656,7 @@ func (c *checker) resolveEnum(d *ast.EnumDecl) *ir.Enum {
 		return en
 	}
 	// In-progress guard, the twin of resolveConst's state machine. An
-	// enum's [max = Other.Max] resolves Other, which can lead back here —
+	// enum's | max = Other.Max resolves Other, which can lead back here —
 	// and the memo below is only written at the END, so without this the
 	// recursion never terminates. It reached the Go runtime as a raw
 	// "fatal error: stack overflow" with no diagnostic and no source
@@ -691,7 +691,7 @@ func (c *checker) resolveEnum(d *ast.EnumDecl) *ir.Enum {
 	}
 	// An enum with no variants is LEGAL: it holds only the implicit None = 0,
 	// so its wire range is the degenerate [0, 0] and it costs zero bits. That
-	// is the same rule a [min = K, max = K] field follows, and every runtime
+	// is the same rule a | min = K, max = K field follows, and every runtime
 	// supports it — a degenerate range is defined by STANDARD.md and the five
 	// serialize ports agree on it.
 	//
@@ -702,7 +702,7 @@ func (c *checker) resolveEnum(d *ast.EnumDecl) *ir.Enum {
 	max := int64(len(variants))
 	for _, a := range d.Attrs {
 		if a.Key != "max" {
-			c.errf(a.Pos, "unknown attribute %q on an enum — enums take [max = K] only (SPEC §4.6)", a.Key)
+			c.errf(a.Pos, "unknown attribute %q on an enum — enums take | max = K only (SPEC §4.6)", a.Key)
 			continue
 		}
 		if a.Value == nil {
@@ -722,12 +722,12 @@ func (c *checker) resolveEnum(d *ast.EnumDecl) *ir.Enum {
 			continue
 		}
 		if !v.IsInt64() || v.Int64() < max {
-			c.errf(a.Pos, "enum %s [max = %s] is below its variant count %d (SPEC §4.6)", d.Name, v, max)
+			c.errf(a.Pos, "enum %s | max = %s is below its variant count %d (SPEC §4.6)", d.Name, v, max)
 			continue
 		}
 		if v.Int64() > math.MaxInt32 {
 			// the enum wire rides the 32-bit ranged call in every target
-			c.errf(a.Pos, "enum %s [max = %s] exceeds the 32-bit tag wire's ceiling %d (SPEC §4.6)", d.Name, v, int64(math.MaxInt32))
+			c.errf(a.Pos, "enum %s | max = %s exceeds the 32-bit tag wire's ceiling %d (SPEC §4.6)", d.Name, v, int64(math.MaxInt32))
 			continue
 		}
 		max = v.Int64()
@@ -760,7 +760,7 @@ func (c *checker) resolveFlags(d *ast.FlagsDecl) *ir.Flags {
 	bits := len(variants)
 	for _, a := range d.Attrs {
 		if a.Key != "max" {
-			c.errf(a.Pos, "unknown attribute %q on flags — flags take [max = K] only", a.Key)
+			c.errf(a.Pos, "unknown attribute %q on flags — flags take | max = K only", a.Key)
 			continue
 		}
 		if a.Value == nil {
@@ -772,7 +772,7 @@ func (c *checker) resolveFlags(d *ast.FlagsDecl) *ir.Flags {
 			continue
 		}
 		if !v.IsInt64() || v.Int64() < int64(bits) || v.Int64() > 64 {
-			c.errf(a.Pos, "flags %s [max = %s] must be in [%d, 64]", d.Name, v, bits)
+			c.errf(a.Pos, "flags %s | max = %s must be in [%d, 64]", d.Name, v, bits)
 			continue
 		}
 		bits = int(v.Int64())
@@ -1196,7 +1196,7 @@ func (c *checker) resolveField(kind declKind, owner string, f *ast.Field) *ir.Fi
 	// the fixed and 128-bit families mirror serialize's own surface exactly
 	// (SPEC §4.3, runtime-first): fixed(I, F) and int128 are RANGED — the
 	// bounds are part of the wire format — and uint128 is the raw field.
-	// [local] fields reach no wire, so they carry no bounds (resolveAttrs
+	// | local fields reach no wire, so they carry no bounds (resolveAttrs
 	// already rejects encoding attributes there); a field whose declared
 	// bounds failed above was already diagnosed, so the requirement error
 	// fires only when no bounds were attempted at all.
@@ -1207,12 +1207,12 @@ func (c *checker) resolveField(kind declKind, owner string, f *ast.Field) *ir.Fi
 		}
 	}
 	if !out.Local && !attempted && out.Type.Kind == ir.TFixed && !out.HasIntRange {
-		c.errf(f.Pos, "field %s: %s(%d, %d) requires [min = A, max = B] — the whole-unit bounds are part of the wire format, exactly like a ranged integer's (SPEC §4.3)",
+		c.errf(f.Pos, "field %s: %s(%d, %d) requires | min = A, max = B — the whole-unit bounds are part of the wire format, exactly like a ranged integer's (SPEC §4.3)",
 			f.Name, fixedSpelling(out.Type.Signed), out.Type.IntBits, out.Type.FracBits)
 		return nil
 	}
 	if !out.Local && !attempted && out.Type.Kind == ir.TInt && out.Type.Width == 128 && out.Type.Signed && !out.HasIntRange {
-		c.errf(f.Pos, "field %s: int128 requires [min = A, max = B] — serialize_int128 is the only ranged 128-bit operation; a raw 128-bit field is uint128 (SPEC §4.3)",
+		c.errf(f.Pos, "field %s: int128 requires | min = A, max = B — serialize_int128 is the only ranged 128-bit operation; a raw 128-bit field is uint128 (SPEC §4.3)",
 			f.Name)
 		return nil
 	}
@@ -1280,7 +1280,7 @@ func (c *checker) resolveDefault(f *ast.Field, out *ir.Field) {
 	case ir.TFixed:
 		// the door reopened 2026-08-12: the quaternion identity (w = 1.0) is
 		// the real case. A fixed default is declared in WHOLE UNITS — the same
-		// domain as the [min, max] bounds — and must scale EXACTLY: v * 2^F an
+		// domain as the | min, max bounds — and must scale EXACTLY: v * 2^F an
 		// integer, so no rounding rule is ever involved in a default.
 		v, ok := c.evalFloat(f.Default)
 		if !ok {
@@ -1343,8 +1343,8 @@ func (c *checker) resolveAttrs(kind declKind, owner string, f *ast.Field, out *i
 			c.errf(a.Pos, "attribute %s repeated (SPEC §4.6)", a.Key)
 			continue
 		}
-		// A valued attribute written bare — `[min, max]` for
-		// `[min = 0, max = 10]` — used to reach evalInt with a nil
+		// A valued attribute written bare — ` | min, max` for
+		// ` | min = 0, max = 10` — used to reach evalInt with a nil
 		// expression and panic the compiler. Reject it here, once, for every
 		// valued attribute, rather than nil-checking at each use: a typo in a
 		// schema must produce a diagnostic, never a stack trace.
@@ -1399,9 +1399,9 @@ func (c *checker) resolveAttrs(kind declKind, owner string, f *ast.Field, out *i
 	}
 	if a, ok := byKey["context"]; ok {
 		if kind != objectD {
-			c.errf(a.Pos, "context scopes a [local] object field (SPEC §4.2, Contexts)")
+			c.errf(a.Pos, "context scopes a | local object field (SPEC §4.2, Contexts)")
 		} else if !out.Local {
-			c.errf(a.Pos, "context is legal only beside [local] — a wire field must be identical on every side (SPEC §4.2)")
+			c.errf(a.Pos, "context is legal only beside | local — a wire field must be identical on every side (SPEC §4.2)")
 		} else if w, ok := wordValue(a); ok {
 			switch {
 			case w == "all":
@@ -1420,22 +1420,22 @@ func (c *checker) resolveAttrs(kind declKind, owner string, f *ast.Field, out *i
 	}
 
 	if out.Local && out.Interpolate {
-		c.errf(f.Pos, "field %s is [local, interpolate] — a local field reaches no wire and cannot be in the interpolate view (SPEC §4.8)", f.Name)
+		c.errf(f.Pos, "field %s is | local, interpolate — a local field reaches no wire and cannot be in the interpolate view (SPEC §4.8)", f.Name)
 	}
 
 	hasMin, hasMax := byKey["min"] != nil, byKey["max"] != nil
 	hasRes, hasQuant, hasRound := byKey["resolution"] != nil, byKey["quantize"] != nil, byKey["round"] != nil
 
 	if out.Local && (hasMin || hasMax || hasRes || hasQuant || hasRound) {
-		c.errf(f.Pos, "field %s is [local] — it reaches no wire, so encoding attributes are not valid on it", f.Name)
+		c.errf(f.Pos, "field %s is | local — it reaches no wire, so encoding attributes are not valid on it", f.Name)
 		return
 	}
 
-	// composite quantization (SPEC §4.8 rules 2/2b): [interpolate, quantize = K, ...]
+	// composite quantization (SPEC §4.8 rules 2/2b): | interpolate, quantize = K, ...
 	if hasQuant {
 		a := byKey["quantize"]
 		if kind != objectD || !out.Interpolate {
-			c.errf(a.Pos, "quantize belongs to the [interpolate] view-encoding rules of an object body (SPEC §4.8)")
+			c.errf(a.Pos, "quantize belongs to the | interpolate view-encoding rules of an object body (SPEC §4.8)")
 			return
 		}
 		// classification and validation DEFER until every body is resolved —
@@ -1461,7 +1461,7 @@ func (c *checker) resolveAttrs(kind declKind, owner string, f *ast.Field, out *i
 			return
 		}
 		if out.Type.Kind == ir.TFloat64 && (kind != objectD || !out.Interpolate) {
-			c.errf(f.Pos, "field %s: the compressed float is float32 (SPEC §4.3) — float64 takes the triple only as an [interpolate] object-view projection (SPEC §4.8 rule 4)", f.Name)
+			c.errf(f.Pos, "field %s: the compressed float is float32 (SPEC §4.3) — float64 takes the triple only as an | interpolate object-view projection (SPEC §4.8 rule 4)", f.Name)
 			return
 		}
 		if !hasMin || !hasMax || !hasRes {
@@ -1485,8 +1485,8 @@ func (c *checker) resolveAttrs(kind declKind, owner string, f *ast.Field, out *i
 		// carry the write asserts; the compiler's half is refusing the
 		// declaration). Both levels matter: non-finite at float64, and finite
 		// at float64 but infinite at FLOAT32, where every runtime evaluates
-		// the triple — before this check [min = -1e39, max = 1e39,
-		// resolution = 1e30] compiled, and the C++ emitter printed -Inf.0f,
+		// the triple — before this check | min = -1e39, max = 1e39,
+		// resolution = 1e30 compiled, and the C++ emitter printed -Inf.0f,
 		// a token no C++ compiler accepts (SPEC §4.6, the non-finite rule).
 		for _, p := range [3]struct {
 			key string
@@ -1606,7 +1606,7 @@ func (c *checker) resolveAttrs(kind declKind, owner string, f *ast.Field, out *i
 // checkCompositeQuantize is the deferred half of the composite-quantize rule
 // (SPEC §4.8 rules 2 and 2b): it runs after EVERY body is resolved, so the
 // referenced composite's component list is complete regardless of which file
-// declared it (§3.1 file order). resolveAttrs verified [interpolate]-on-object
+// declared it (§3.1 file order). resolveAttrs verified | interpolate-on-object
 // and scheduled this; everything that reads component fields lives here.
 func (c *checker) checkCompositeQuantize(f *ast.Field, out *ir.Field, byKey map[string]*ast.Attr, hasMin, hasMax, hasRes bool) {
 	a := byKey["quantize"]
@@ -1624,29 +1624,29 @@ func (c *checker) checkCompositeQuantize(f *ast.Field, out *ir.Field, byKey map[
 	}
 	if allFixed {
 		// fixed-composite shallow narrowing (SPEC §4.8 rule 2b):
-		// [interpolate, quantize = K] — the shallow wire keeps log2(K)
+		// | interpolate, quantize = K — the shallow wire keeps log2(K)
 		// fractional bits of the component format (K quantized units per
 		// whole unit, a power of two no finer than the storage's 2^F).
 		// Quantize is a round-to-nearest arithmetic shift, Unquantize a left
 		// shift; no max here — the shallow bound derives from each
-		// component's own whole-unit [min, max], which every component must
+		// component's own whole-unit | min, max, which every component must
 		// therefore declare.
 		//
 		// SIGNED components only in this landing: rule 2b's generated
 		// narrowing runs through int64 shifts, and a ufixed raw may occupy
 		// the u64 high half where those shifts are wrong — the unsigned door
 		// needs its own arithmetic before it opens (SPEC §4.8 rule 2b;
-		// plain [interpolate] ufixed composites dissolve fine, because
+		// plain | interpolate ufixed composites dissolve fine, because
 		// dissolving just delegates to the component encodings).
 		for _, cf := range st.Fields {
 			if !cf.Type.Signed {
-				c.errf(a.Pos, "fixed-composite shallow narrowing is signed fixed(I, F) only — %s.%s is ufixed(%d, %d); an un-narrowed [interpolate] composite of ufixed components is fine (SPEC §4.8 rule 2b)",
+				c.errf(a.Pos, "fixed-composite shallow narrowing is signed fixed(I, F) only — %s.%s is ufixed(%d, %d); an un-narrowed | interpolate composite of ufixed components is fine (SPEC §4.8 rule 2b)",
 					st.Name, cf.Name, cf.Type.IntBits, cf.Type.FracBits)
 				return
 			}
 		}
 		if hasMax || hasMin || hasRes {
-			c.errf(a.Pos, "fixed-composite quantization is [interpolate, quantize = K] alone — the bound comes from the components' own [min, max], not the field (SPEC §4.8 rule 2b)")
+			c.errf(a.Pos, "fixed-composite quantization is | interpolate, quantize = K alone — the bound comes from the components' own | min, max, not the field (SPEC §4.8 rule 2b)")
 			return
 		}
 		k, ok := c.evalInt(a.Value)
@@ -1673,7 +1673,7 @@ func (c *checker) checkCompositeQuantize(f *ast.Field, out *ir.Field, byKey map[
 				return
 			}
 			if !cf.HasIntRange {
-				c.errf(a.Pos, "fixed-composite quantization derives its wire bound from the components — %s.%s must declare whole-unit [min, max] (SPEC §4.8 rule 2b)", st.Name, cf.Name)
+				c.errf(a.Pos, "fixed-composite quantization derives its wire bound from the components — %s.%s must declare whole-unit | min, max (SPEC §4.8 rule 2b)", st.Name, cf.Name)
 				return
 			}
 		}
@@ -1691,7 +1691,7 @@ func (c *checker) checkCompositeQuantize(f *ast.Field, out *ir.Field, byKey map[
 		}
 	}
 	if !hasMax || hasMin || hasRes {
-		c.errf(a.Pos, "composite quantization is [interpolate, quantize = K, max = B] — max required, min and resolution not valid here (SPEC §4.8 rule 2)")
+		c.errf(a.Pos, "composite quantization is | interpolate, quantize = K, max = B — max required, min and resolution not valid here (SPEC §4.8 rule 2)")
 		return
 	}
 	k, ok := c.evalInt(a.Value)

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -77,7 +77,7 @@ func TestDiagnostics(t *testing.T) {
 
 		// ---- ranges and storage ----
 		{name: "range does not fit storage", want: "does not fit its declared storage",
-			src: "package t\ntype T { h int8 [min = 0, max = 1000] }\n"},
+			src: "package t\ntype T { h int8 | min = 0, max = 1000 }\n"},
 		{name: "implicit const past int64 (FuzzGeneratedCompiles 0c59b1fd)", want: "does not fit int64, the default constant storage",
 			src: "package t\nconst A = 20000000000000000000\n"},
 		{name: "implicit const past int64, uint64 range (constexpr narrowing repro)", want: "does not fit int64, the default constant storage",
@@ -85,17 +85,17 @@ func TestDiagnostics(t *testing.T) {
 		{name: "implicit const below int64 min", want: "does not fit int64, the default constant storage",
 			src: "package t\nconst A = -9223372036854775809\n"},
 		{name: "min without max", want: "min without max",
-			src: "package t\ntype T { h int16 [min = 0] }\n"},
+			src: "package t\ntype T { h int16 | min = 0 }\n"},
 		{name: "inverted range", want: "inverted range",
-			src: "package t\ntype T { h int16 [min = 6, max = 5] }\n"},
+			src: "package t\ntype T { h int16 | min = 6, max = 5 }\n"},
 		{name: "unknown attribute", want: "unknown attribute",
-			src: "package t\ntype T { h int16 [flavor = 3] }\n"},
+			src: "package t\ntype T { h int16 | flavor = 3 }\n"},
 		{name: "resolution on an integer", want: "resolution applies to float",
-			src: "package t\ntype T { h int16 [min = 0, max = 10, resolution = 1] }\n"},
+			src: "package t\ntype T { h int16 | min = 0, max = 10, resolution = 1 }\n"},
 		{name: "range on an enum field", want: "derives its range",
-			src: "package t\nenum E { A }\ntype T { e E [min = 0, max = 1] }\n"},
+			src: "package t\nenum E { A }\ntype T { e E | min = 0, max = 1 }\n"},
 		{name: "float64 compressed in a plain type", want: "compressed float is float32",
-			src: "package t\ntype T { v float64 [min = 0, max = 1, resolution = 0.1] }\n"},
+			src: "package t\ntype T { v float64 | min = 0, max = 1, resolution = 0.1 }\n"},
 
 		// ---- widths and bounds ----
 		{name: "bits zero", want: "outside [1, 64]",
@@ -112,6 +112,23 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\ntype T { a [0]uint8 }\n"},
 		{name: "count range backwards", want: "0 <= Min < N",
 			src: "package t\ntype T { a [5..3]uint8 }\n"},
+		// ---- the qualification section (SPEC §4.2) ----
+		{name: "the retired field attribute block names its replacement", want: "qualifiers follow | to the end of the line",
+			src: "package t\ntype T { h int16 " + "[min = 0, max = 5] }\n"},
+		{name: "the retired declaration attribute block names its replacement", want: "the body opens on the next line",
+			src: "package t\nenum E " + "[max = 5] { A }\n"},
+		{name: "empty qualification section", want: "empty qualification section",
+			src: "package t\ntype T { h int16 | }\n"},
+		{name: "a constant takes no qualification", want: "| is never an operator",
+			src: "package t\nconst X = 1 | 2\n"},
+		{name: "a message declaration takes no qualification", want: "message declaration takes no qualification",
+			src: "package t\nmessage M | x { }\n"},
+		{name: "an object declaration takes no qualification", want: "object declaration takes no qualification",
+			src: "package t\nobject O | x { f uint8 }\n"},
+		{name: "a union declaration takes no qualification", want: "union declaration takes no qualification",
+			src: "package t\nunion U | x { }\n"},
+		{name: "a block comment cannot sit right of |", want: "cannot sit right of |",
+			src: "package t\ntype T { h int16 | min = 0, /* c */ max = 5 }\n"},
 		{name: "the retired <= bound names its replacement", want: "spell it [..N], the range literal",
 			src: "package t\ntype T { a [" + "<= 4]uint8 }\n"}, // spliced so the migration sweep never respells this fixture
 		{name: "bound above int32", want: "counts live in int32",
@@ -123,17 +140,17 @@ func TestDiagnostics(t *testing.T) {
 
 		// ---- fixed point and the 128-bit family (SPEC §4.3, §4.6) ----
 		{name: "fixed I+F is not a storage width", want: "must equal a storage width",
-			src: "package t\ntype T { x fixed(16, 15) [min = 0, max = 1] }\n"},
+			src: "package t\ntype T { x fixed(16, 15) | min = 0, max = 1 }\n"},
 		{name: "fixed with zero integer bits", want: "at least one integer bit",
-			src: "package t\ntype T { x fixed(0, 32) [min = 0, max = 1] }\n"},
+			src: "package t\ntype T { x fixed(0, 32) | min = 0, max = 1 }\n"},
 		{name: "fixed with negative fractional bits", want: "cannot be negative",
-			src: "package t\ntype T { x fixed(24, -8) [min = 0, max = 1] }\n"},
-		{name: "fixed without bounds", want: "requires [min = A, max = B]",
+			src: "package t\ntype T { x fixed(24, -8) | min = 0, max = 1 }\n"},
+		{name: "fixed without bounds", want: "requires | min = A, max = B",
 			src: "package t\ntype T { x fixed(48, 16) }\n"},
 		{name: "fixed bounds outside the Q format", want: "do not fit fixed(8, 8)",
-			src: "package t\ntype T { x fixed(8, 8) [min = -300, max = 300] }\n"},
+			src: "package t\ntype T { x fixed(8, 8) | min = -300, max = 300 }\n"},
 		{name: "fixed with resolution", want: "resolution applies to float",
-			src: "package t\ntype T { x fixed(16, 16) [min = 0, max = 1, resolution = 0.1] }\n"},
+			src: "package t\ntype T { x fixed(16, 16) | min = 0, max = 1, resolution = 0.1 }\n"},
 		// fixed defaults are LEGAL since 2026-08-12 (whole units, exact) — the
 		// old rejection case lives on as the good corner below; what stays
 		// illegal is inexactness and range violation (cases at the bottom).
@@ -141,32 +158,32 @@ func TestDiagnostics(t *testing.T) {
 		// is fine" — §9 q17 closed). Same shape rules, unsigned domain, and
 		// the diagnostics name the ufixed spelling. ----
 		{name: "ufixed bounds below zero", want: "do not fit ufixed(16, 16)",
-			src: "package t\ntype T { x ufixed(16, 16) [min = -1, max = 5] }\n"},
+			src: "package t\ntype T { x ufixed(16, 16) | min = -1, max = 5 }\n"},
 		{name: "ufixed with zero integer bits", want: "at least one integer bit",
-			src: "package t\ntype T { x ufixed(0, 32) [min = 0, max = 1] }\n"},
+			src: "package t\ntype T { x ufixed(0, 32) | min = 0, max = 1 }\n"},
 		{name: "ufixed I+F is not a storage width", want: "must equal a storage width",
-			src: "package t\ntype T { x ufixed(16, 15) [min = 0, max = 1] }\n"},
-		{name: "ufixed without bounds", want: "ufixed(48, 16) requires [min = A, max = B]",
+			src: "package t\ntype T { x ufixed(16, 15) | min = 0, max = 1 }\n"},
+		{name: "ufixed without bounds", want: "ufixed(48, 16) requires | min = A, max = B",
 			src: "package t\ntype T { x ufixed(48, 16) }\n"},
 		{name: "ufixed bounds above the unsigned domain", want: "do not fit ufixed(8, 8)",
-			src: "package t\ntype T { x ufixed(8, 8) [min = 0, max = 300] }\n"},
+			src: "package t\ntype T { x ufixed(8, 8) | min = 0, max = 300 }\n"},
 		{name: "ufixed(64, 0) bounds clamp at int64's ceiling", want: "do not fit ufixed(64, 0)",
-			src: "package t\ntype T { x ufixed(64, 0) [min = 0, max = 18446744073709551615] }\n"},
+			src: "package t\ntype T { x ufixed(64, 0) | min = 0, max = 18446744073709551615 }\n"},
 		{name: "ufixed default below its unsigned range", want: "outside its range",
-			src: "package t\ntype T { x ufixed(16, 16) [min = 0, max = 5] = -1.0 }\n"},
+			src: "package t\ntype T { x ufixed(16, 16) = -1.0 | min = 0, max = 5 }\n"},
 		{name: "ufixed in a table closure", want: "ufixed(I, F) has no table-wire kind",
-			src: "package t\ntable T { x ufixed(16, 16) [min = 0, max = 5] }\n"},
+			src: "package t\ntable T { x ufixed(16, 16) | min = 0, max = 5 }\n"},
 		{name: "ufixed components do not narrow (rule 2b is signed-only)", want: "signed fixed(I, F) only",
-			src: "package t\ntype V { x ufixed(16, 16) [min = 0, max = 5]\n y ufixed(16, 16) [min = 0, max = 5] }\nobject O { p V [interpolate, quantize = 256] \n b bool }\n"},
+			src: "package t\ntype V { x ufixed(16, 16) | min = 0, max = 5\n y ufixed(16, 16) | min = 0, max = 5 }\nobject O { p V | interpolate, quantize = 256 \n b bool }\n"},
 		{name: "ufixed with resolution", want: "resolution applies to float",
-			src: "package t\ntype T { x ufixed(16, 16) [min = 0, max = 1, resolution = 0.1] }\n"},
+			src: "package t\ntype T { x ufixed(16, 16) | min = 0, max = 1, resolution = 0.1 }\n"},
 
 		{name: "bare int128", want: "int128 requires",
 			src: "package t\ntype T { x int128 }\n"},
 		{name: "uint128 with a range", want: "not valid on uint128",
-			src: "package t\ntype T { x uint128 [min = 0, max = 5] }\n"},
+			src: "package t\ntype T { x uint128 | min = 0, max = 5 }\n"},
 		{name: "int128 range above its storage", want: "does not fit its declared storage int128",
-			src: "package t\ntype T { x int128 [min = 0, max = 340282366920938463463374607431768211456] }\n"},
+			src: "package t\ntype T { x int128 | min = 0, max = 340282366920938463463374607431768211456 }\n"},
 
 		// ---- enums, flags, contexts ----
 		{name: "variant named None", want: "None",
@@ -176,7 +193,7 @@ func TestDiagnostics(t *testing.T) {
 		{name: "a decl collides with an enum's generated Max extent (Go)", want: "generated Max extent",
 			src: "package t\nenum Team { Red }\nconst TeamMax = 3\n"},
 		{name: "enum max below variant count", want: "below its variant count",
-			src: "package t\nenum E [max = 2] { A, B, C }\n"},
+			src: "package t\nenum E | max = 2\n{ A, B, C }\n"},
 		{name: "Max reference to a non-enum", want: "is not an enum",
 			src: "package t\ntype V { x uint8 }\nconst N = V.Max + 1\n"},
 		{name: "Max reference to a flags declaration", want: "has no .Max",
@@ -209,7 +226,7 @@ func TestDiagnostics(t *testing.T) {
 		{name: "union composition cycle", want: "type composition cycle",
 			src: "package t\nunion U {\n    b Box\n}\ntype Box { u U }\n"},
 		{name: "union field in an object body", want: "not reachable from an object body in v1",
-			src: "package t\nobject O { u U [interpolate] \n x uint8 }\nunion U { }\n"},
+			src: "package t\nobject O { u U | interpolate \n x uint8 }\nunion U { }\n"},
 		{name: "an object reaching a union transitively", want: "reaches a union, and an object body may not",
 			src: "package t\nobject O { w Wrap \n x uint8 }\ntype Wrap { u U }\nunion U { }\n"},
 		{name: "a union on a table-closure path", want: "may not sit on a table-closure path in v1",
@@ -218,10 +235,10 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\nmessage Msg { }\nunion Message { }\n"},
 		{name: "a decl colliding with a union's generated tag enum", want: "generated tag enum",
 			src: "package t\nunion U { }\ntype UType { x uint8 }\n"},
-		{name: "context without local", want: "legal only beside [local]",
-			src: "package t\ncontexts { client }\nobject O { a bool [context = client] \n b uint8 }\n"},
+		{name: "context without local", want: "legal only beside | local",
+			src: "package t\ncontexts { client }\nobject O { a bool | context = client \n b uint8 }\n"},
 		{name: "undeclared context", want: "not declared",
-			src: "package t\ncontexts { client }\nobject O { a bool [local, context = server] \n b uint8 }\n"},
+			src: "package t\ncontexts { client }\nobject O { a bool | local, context = server \n b uint8 }\n"},
 		{name: "context all is reserved", want: "reserved",
 			src: "package t\ncontexts { all, client }\n"},
 
@@ -232,64 +249,64 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\nobject O { }\n"},
 		{name: "object as a field type", want: "not a field type",
 			src: "package t\nobject O { a bool }\ntype T { o O }\n"},
-		{name: "quantize without interpolate", want: "quantize belongs to the [interpolate]",
-			src: "package t\ntype V { x float64 }\nobject O { p V [quantize = 10, max = 1] \n b bool }\n"},
+		{name: "quantize without interpolate", want: "quantize belongs to the | interpolate",
+			src: "package t\ntype V { x float64 }\nobject O { p V | quantize = 10, max = 1 \n b bool }\n"},
 		{name: "quantize on a non-composite", want: "component-wise",
-			src: "package t\nobject O { p uint32 [interpolate, quantize = 10, max = 1] \n b bool }\n"},
+			src: "package t\nobject O { p uint32 | interpolate, quantize = 10, max = 1 \n b bool }\n"},
 		{name: "fixed-composite quantize scale must be a power of two", want: "positive power of two",
-			src: "package t\ntype V { x fixed(16, 16) [min = -8, max = 8] }\nobject O { p V [interpolate, quantize = 100] \n b bool }\n"},
+			src: "package t\ntype V { x fixed(16, 16) | min = -8, max = 8 }\nobject O { p V | interpolate, quantize = 100 \n b bool }\n"},
 		{name: "fixed-composite quantize cannot exceed the storage's fraction", want: "cannot be finer than the storage",
-			src: "package t\ntype V { x fixed(8, 8) [min = -8, max = 8] }\nobject O { p V [interpolate, quantize = 512] \n b bool }\n"},
+			src: "package t\ntype V { x fixed(8, 8) | min = -8, max = 8 }\nobject O { p V | interpolate, quantize = 512 \n b bool }\n"},
 		{name: "fixed-composite quantize takes no max", want: "the bound comes from the components",
-			src: "package t\ntype V { x fixed(16, 16) [min = -8, max = 8] }\nobject O { p V [interpolate, quantize = 256, max = 8] \n b bool }\n"},
+			src: "package t\ntype V { x fixed(16, 16) | min = -8, max = 8 }\nobject O { p V | interpolate, quantize = 256, max = 8 \n b bool }\n"},
 		// an unbounded fixed component is already illegal by §4.3 (bounds are
 		// part of the wire format) — the narrowing rule never sees one alone;
 		// this documents the error the author gets, and that the composite
 		// rule survives the multi-error pass beside it
-		{name: "fixed-composite quantize under an unbounded component", want: "requires [min = A, max = B]",
-			src: "package t\ntype V { x fixed(16, 16) }\nobject O { p V [interpolate, quantize = 256] \n b bool }\n"},
+		{name: "fixed-composite quantize under an unbounded component", want: "requires | min = A, max = B",
+			src: "package t\ntype V { x fixed(16, 16) }\nobject O { p V | interpolate, quantize = 256 \n b bool }\n"},
 		{name: "fixed-composite quantize is 64-bit at most", want: "wider than 64 bits",
-			src: "package t\ntype V { x fixed(112, 16) [min = -8, max = 8] }\nobject O { p V [interpolate, quantize = 256] \n b bool }\n"},
+			src: "package t\ntype V { x fixed(112, 16) | min = -8, max = 8 }\nobject O { p V | interpolate, quantize = 256 \n b bool }\n"},
 		{name: "mixed float/fixed composite falls to the float rule", want: "every component of V to be a float scalar",
-			src: "package t\ntype V { x fixed(16, 16) [min = -8, max = 8]\n y float64 }\nobject O { p V [interpolate, quantize = 256, max = 8] \n b bool }\n"},
+			src: "package t\ntype V { x fixed(16, 16) | min = -8, max = 8\n y float64 }\nobject O { p V | interpolate, quantize = 256, max = 8 \n b bool }\n"},
 		// the deferred pass also CLOSES a latent hole: with the composite in
 		// a later-sorting file, the inline rule used to validate components
 		// against an empty shell — vacuously passing anything
 		{name: "non-float non-fixed component rejected across file order", want: "every component of V to be a float scalar",
 			srcs: map[string]string{
-				"A_Objects.schema": "package t\nobject O { p V [interpolate, quantize = 10, max = 1] \n b bool }\n",
+				"A_Objects.schema": "package t\nobject O { p V | interpolate, quantize = 10, max = 1 \n b bool }\n",
 				"Z_Types.schema":   "package t\ntype V { x float64\n s string(8) }\n"},
 		},
 
 		// ---- namespace, names, claims ----
 		// valued attributes written bare. FOUND BY THE FUZZER (internal/fuzz)
-		// in 3 seconds: `[min, max]` reached expression evaluation as a nil
+		// in 3 seconds: ` | min, max` reached expression evaluation as a nil
 		// and panicked the compiler with a stack trace instead of pointing at
 		// the typo. One case per valued attribute — the guard is a table, and
 		// a table with an untested entry is a table that will lose one.
 		{name: "min written without a value", want: "requires a value",
-			src: "package t\ntype T { n int32 [min, max = 10] }\n"},
+			src: "package t\ntype T { n int32 | min, max = 10 }\n"},
 		{name: "max written without a value", want: "requires a value",
-			src: "package t\ntype T { n int32 [min = 0, max] }\n"},
+			src: "package t\ntype T { n int32 | min = 0, max }\n"},
 		{name: "resolution written without a value", want: "requires a value",
-			src: "package t\ntype T { x float32 [min = 0, max = 1, resolution] }\n"},
+			src: "package t\ntype T { x float32 | min = 0, max = 1, resolution }\n"},
 		{name: "quantize written without a value", want: "requires a value",
-			src: "package t\ntype V { x float64 }\nobject O { p V [interpolate, quantize, max = 1] \n b bool }\n"},
+			src: "package t\ntype V { x float64 }\nobject O { p V | interpolate, quantize, max = 1 \n b bool }\n"},
 		{name: "round written without a value", want: "requires a value",
-			src: "package t\nobject O { x float32 [interpolate, min = 0, max = 1, resolution = 0.1, round] \n b bool }\n"},
+			src: "package t\nobject O { x float32 | interpolate, min = 0, max = 1, resolution = 0.1, round \n b bool }\n"},
 
 		// cycle guards: every resolver that can re-enter itself must REJECT,
 		// not recurse. Before the enum guard these crashed the compiler with
 		// a raw "fatal error: stack overflow" — no diagnostic, no position.
-		{name: "enum [max = E.Max] self-cycle", want: "reference cycle",
-			src: "package t\nenum Alpha [max = Alpha.Max] { One }\n"},
-		{name: "enum [max = E.Max] mutual cycle across files", want: "reference cycle",
+		{name: "enum | max = E.Max self-cycle", want: "reference cycle",
+			src: "package t\nenum Alpha | max = Alpha.Max\n{ One }\n"},
+		{name: "enum | max = E.Max mutual cycle across files", want: "reference cycle",
 			srcs: map[string]string{
-				"A_e.schema": "package t\nenum Alpha [max = Zed.Max] { One, Two }\n",
-				"Z_e.schema": "package t\nenum Zed [max = Alpha.Max] { Three }\n"},
+				"A_e.schema": "package t\nenum Alpha | max = Zed.Max\n{ One, Two }\n",
+				"Z_e.schema": "package t\nenum Zed | max = Alpha.Max\n{ Three }\n"},
 		},
-		{name: "enum [max = E.Max] three-enum cycle", want: "reference cycle",
-			src: "package t\nenum A [max = B.Max] { One }\nenum B [max = C.Max] { Two }\nenum C [max = A.Max] { Three }\n"},
+		{name: "enum | max = E.Max three-enum cycle", want: "reference cycle",
+			src: "package t\nenum A | max = B.Max\n{ One }\nenum B | max = C.Max\n{ Two }\nenum C | max = A.Max\n{ Three }\n"},
 		{name: "constant self-cycle", want: "reference cycle",
 			src: "package t\nconst A = A + 1\n"},
 		{name: "constant mutual cycle", want: "reference cycle",
@@ -326,11 +343,11 @@ func TestDiagnostics(t *testing.T) {
 		{name: "field export equals its declaring type's name (C# CS0542)", want: "enclosing type",
 			src: "package t\nmessage Timescale { timescale float64 }\n"},
 		{name: "object field export equals a generated family class name", want: "enclosing class",
-			src: "package t\nobject Ship { ship_state uint8 [interpolate, min = 0, max = 3] }\n"},
+			src: "package t\nobject Ship { ship_state uint8 | interpolate, min = 0, max = 3 }\n"},
 		{name: "float triple degenerate at float32", want: "degenerate at float32",
-			src: "package t\ntype T { x float32 [min = 1.0, max = 1.00000001, resolution = 0.000000001] }\n"},
+			src: "package t\ntype T { x float32 | min = 1.0, max = 1.00000001, resolution = 0.000000001 }\n"},
 		{name: "resolution collapses to zero at float32", want: "collapses to zero at float32",
-			src: "package t\ntype T { x float32 [min = 0.0, max = 1.0, resolution = 1e-46] }\n"},
+			src: "package t\ntype T { x float32 | min = 0.0, max = 1.0, resolution = 1e-46 }\n"},
 
 		// ---- package names that cannot compile (the 2026-08-16 ruling on the
 		// compile fuzzer's `package exit` specimen — Glenn, verbatim: "Refuse
@@ -369,33 +386,33 @@ func TestDiagnostics(t *testing.T) {
 		// range is a parse error; constant arithmetic is overflow-guarded).
 		// NaN has no spelling at all — its arm is TestNonFiniteTripleNaN. ----
 		{name: "compressed float min -Inf at float32", want: "min = -1e+39 overflows float32",
-			src: "package t\ntype T { x float32 [min = -1e39, max = 1e39, resolution = 1e30] }\n"},
+			src: "package t\ntype T { x float32 | min = -1e39, max = 1e39, resolution = 1e30 }\n"},
 		{name: "compressed float min +Inf at float32", want: "min = 1e+39 overflows float32",
-			src: "package t\ntype T { x float32 [min = 1e39, max = 2e39, resolution = 1e30] }\n"},
+			src: "package t\ntype T { x float32 | min = 1e39, max = 2e39, resolution = 1e30 }\n"},
 		{name: "compressed float max +Inf at float32", want: "max = 1e+39 overflows float32",
-			src: "package t\ntype T { x float32 [min = 0.0, max = 1e39, resolution = 1e30] }\n"},
+			src: "package t\ntype T { x float32 | min = 0.0, max = 1e39, resolution = 1e30 }\n"},
 		// (a -Inf max cannot be its own diagnostic: min < max puts min below
 		// it, so the min arm always fires first — the parameter is still
 		// covered, by ordering rather than by a separate message)
 		{name: "compressed float resolution +Inf at float32", want: "resolution = 1e+39 overflows float32",
-			src: "package t\ntype T { x float32 [min = 0.0, max = 1.0, resolution = 1e39] }\n"},
+			src: "package t\ntype T { x float32 | min = 0.0, max = 1.0, resolution = 1e39 }\n"},
 		{name: "compressed float min +Inf at float64, integer literal", want: "does not fit float64",
-			src: "package t\ntype T { x float32 [min = 1" + strings.Repeat("0", 400) + ", max = 1.0, resolution = 0.1] }\n"},
+			src: "package t\ntype T { x float32 | min = 1" + strings.Repeat("0", 400) + ", max = 1.0, resolution = 0.1 }\n"},
 		{name: "compressed float min -Inf at float64, negated integer literal", want: "does not fit float64",
-			src: "package t\ntype T { x float32 [min = -1" + strings.Repeat("0", 400) + ", max = 1.0, resolution = 0.1] }\n"},
+			src: "package t\ntype T { x float32 | min = -1" + strings.Repeat("0", 400) + ", max = 1.0, resolution = 0.1 }\n"},
 		// The through-a-const vehicle is refused EARLIER since the #22 guard
 		// landed: an implicitly-typed const past int64 fails at its own
 		// declaration, so the float64-finiteness arm can no longer be reached
 		// through a const — the schema is refused either way, and the float64
 		// arm keeps its coverage via the integer-literal cases beside this one.
 		{name: "compressed float max +Inf at float64, through a const", want: "does not fit int64, the default constant storage",
-			src: "package t\nconst Big = 1" + strings.Repeat("0", 400) + "\ntype T { x float32 [min = 0.0, max = Big, resolution = 0.1] }\n"},
+			src: "package t\nconst Big = 1" + strings.Repeat("0", 400) + "\ntype T { x float32 | min = 0.0, max = Big, resolution = 0.1 }\n"},
 		{name: "compressed float resolution +Inf at float64, integer literal", want: "does not fit float64",
-			src: "package t\ntype T { x float32 [min = 0.0, max = 1.0, resolution = 1" + strings.Repeat("0", 400) + "] }\n"},
+			src: "package t\ntype T { x float32 | min = 0.0, max = 1.0, resolution = 1" + strings.Repeat("0", 400) + " }\n"},
 		{name: "interpolate float64 triple infinite at float32 — rule 4 shares the path", want: "overflows float32, where every runtime evaluates the triple",
-			src: "package t\nobject O { x float64 [interpolate, min = -1e39, max = 1e39, resolution = 1e30]\n b bool }\n"},
+			src: "package t\nobject O { x float64 | interpolate, min = -1e39, max = 1e39, resolution = 1e30\n b bool }\n"},
 		{name: "enum max above the 32-bit tag wire", want: "32-bit tag wire",
-			src: "package t\nenum E [max = 2147483648] { A }\ntype T { e E }\n"},
+			src: "package t\nenum E | max = 2147483648\n{ A }\ntype T { e E }\n"},
 		{name: "message field would shadow the C# Type dispatch property", want: "Type dispatch property",
 			src: "package t\nmessage M { type_ uint8 }\n"},
 		{name: "a message named Type cannot carry its own C# dispatch property", want: "Type dispatch property",
@@ -409,9 +426,9 @@ func TestDiagnostics(t *testing.T) {
 		{name: "two consts whose Rust constant spellings collide", want: "both generate the symbol AB_MAX",
 			src: "package t\nconst ABMax = 1\nconst AbMax = 2\n"},
 		{name: "quantize scale beyond float64 exactness", want: "not exactly representable in float64",
-			src: "package t\ntype V {\n    x float32\n    y float32\n}\nobject O { p V [interpolate, quantize = 9007199254740993, max = 1] }\n"},
+			src: "package t\ntype V {\n    x float32\n    y float32\n}\nobject O { p V | interpolate, quantize = 9007199254740993, max = 1 }\n"},
 		{name: "a type collides with an object view's flat wire function (Rust/C)", want: "both generate the symbol write_ship_data_shallow",
-			src: "package t\nobject Ship { x uint8 [interpolate, min = 0, max = 3] }\ntype ShipDataShallow { y uint8 }\n"},
+			src: "package t\nobject Ship { x uint8 | interpolate, min = 0, max = 3 }\ntype ShipDataShallow { y uint8 }\n"},
 		{name: "a const collides with an enum's C variant #define", want: "variant constants (C form)",
 			src: "package t\nenum DriveMode { Ludicrous }\nconst DriveModeLudicrous = 1\ntype T { m DriveMode }\n"},
 		{name: "two enums whose C debug-name functions collide", want: "both generate the symbol enum_name_ab_mode",
@@ -424,7 +441,7 @@ func TestDiagnostics(t *testing.T) {
 
 		// ---- defaults ----
 		{name: "default out of range", want: "outside its range",
-			src: "package t\ntype T { h int16 [min = 0, max = 10] = 99 }\n"},
+			src: "package t\ntype T { h int16 = 99 | min = 0, max = 10 }\n"},
 		{name: "default on an array", want: "array takes no specified default",
 			src: "package t\ntype T { a [4]uint8 = 1 }\n"},
 		{name: "enum default is not a variant", want: "names a variant",
@@ -434,15 +451,15 @@ func TestDiagnostics(t *testing.T) {
 
 		// ---- native type mapping (SPEC §4.2) ----
 		{name: "cpp_native without cpp_include", want: "cpp_native and cpp_include go together",
-			src: "package t\ntype V [cpp_native = VMath] { x float64 }\n"},
+			src: "package t\ntype V | cpp_native = VMath { x float64 }\n"},
 		{name: "cpp_include without cpp_native", want: "cpp_native and cpp_include go together",
-			src: "package t\ntype V [cpp_include = \"v.h\"] { x float64 }\n"},
+			src: "package t\ntype V | cpp_include = \"v.h\" { x float64 }\n"},
 		{name: "cpp_native takes an identifier", want: "cpp_native takes an identifier",
-			src: "package t\ntype V [cpp_native = \"VMath\", cpp_include = \"v.h\"] { x float64 }\n"},
+			src: "package t\ntype V | cpp_native = \"VMath\", cpp_include = \"v.h\" { x float64 }\n"},
 		{name: "cpp_include takes a string", want: "cpp_include takes a quoted header path",
-			src: "package t\ntype V [cpp_native = VMath, cpp_include = vh] { x float64 }\n"},
+			src: "package t\ntype V | cpp_native = VMath, cpp_include = vh { x float64 }\n"},
 		{name: "a valued type attr that is not a binding is still rejected", want: "bare identifier",
-			src: "package t\ntype V [vec3 = 4] { x float64 }\n"},
+			src: "package t\ntype V | vec3 = 4 { x float64 }\n"},
 	}
 
 	for _, tc := range cases {
@@ -476,35 +493,39 @@ func TestGoodCornersStillCompile(t *testing.T) {
 		{name: "nested if with cond in the same branch",
 			src: "package t\ntype T {\n    a bool\n    if a {\n        b bool\n        if b { x uint8 }\n    }\n}\n"},
 		{name: "fixed default in whole units, exactly representable (the reopened door)",
-			src: "package t\ntype Q { w fixed(2, 30) [min = -1, max = 1] = 1.0 \n x fixed(16, 16) [min = 0, max = 100] = 0.5 \n y fixed(48, 16) [min = -10, max = 10] = 3 }\n"},
+			src: "package t\ntype Q { w fixed(2, 30) = 1.0 | min = -1, max = 1\n x fixed(16, 16) = 0.5 | min = 0, max = 100\n y fixed(48, 16) = 3 | min = -10, max = 10 }\n"},
 		{name: "field named flags at block scope",
 			src: "package t\nflags F { A }\ntype T { flags F }\n"},
 		{name: "64 flags variants fill uint64 storage exactly",
 			src: "package t\nflags F { " + strings.Replace(flags65, ", V64", "", 1) + " }\n"},
 		{name: "F.Count in a constant expression",
 			src: "package t\nflags F { A, B }\nconst N = F.Count\n"},
+		{name: "a // comment terminates the qualification section",
+			src: "package t\ntype T { h int16 | min = 0, max = 5 // the section ends here\n}\n"},
+		{name: "a qualified declaration's body opens on the next line",
+			src: "package t\nenum E | max = 5\n{ A, B }\ntype Q | tagged\n{\n    e E\n}\n"},
 		{name: "message as a field type",
 			src: "package t\nmessage M { x uint8 }\ntype T { m M }\n"},
 		{name: "empty type and empty message",
 			src: "package t\ntype T { }\nmessage M { }\n"},
 		{name: "full-range uint64",
-			src: "package t\ntype T { n uint64 [min = 0, max = 18446744073709551615] }\n"},
+			src: "package t\ntype T { n uint64 | min = 0, max = 18446744073709551615 }\n"},
 		{name: "fixed at every storage width, F = 0, and the sign-bit-only corner",
-			src: "package t\ntype T {\n    a fixed(8, 8) [min = -100, max = 100]\n    b fixed(16, 16) [min = -180, max = 180]\n    c fixed(32, 0) [min = 0, max = 1000000]\n    d fixed(48, 16) [min = -30000, max = 30000]\n    e fixed(112, 16) [min = -1000000, max = 1000000]\n    f fixed(1, 63) [min = -1, max = 0]\n}\n"},
+			src: "package t\ntype T {\n    a fixed(8, 8) | min = -100, max = 100\n    b fixed(16, 16) | min = -180, max = 180\n    c fixed(32, 0) | min = 0, max = 1000000\n    d fixed(48, 16) | min = -30000, max = 30000\n    e fixed(112, 16) | min = -1000000, max = 1000000\n    f fixed(1, 63) | min = -1, max = 0\n}\n"},
 		{name: "ufixed at every storage width, the full unsigned domains, and the one-bit corner",
-			src: "package t\ntype T {\n    a ufixed(8, 8) [min = 0, max = 255]\n    b ufixed(16, 16) [min = 0, max = 360]\n    c ufixed(32, 0) [min = 0, max = 4294967295]\n    d ufixed(48, 16) [min = 0, max = 281474976710655]\n    e ufixed(112, 16) [min = 0, max = 2000000]\n    f ufixed(1, 63) [min = 0, max = 1]\n    g ufixed(16, 16) [min = 3, max = 3]\n}\n"},
+			src: "package t\ntype T {\n    a ufixed(8, 8) | min = 0, max = 255\n    b ufixed(16, 16) | min = 0, max = 360\n    c ufixed(32, 0) | min = 0, max = 4294967295\n    d ufixed(48, 16) | min = 0, max = 281474976710655\n    e ufixed(112, 16) | min = 0, max = 2000000\n    f ufixed(1, 63) | min = 0, max = 1\n    g ufixed(16, 16) | min = 3, max = 3\n}\n"},
 		{name: "ufixed default in whole units, exactly representable",
-			src: "package t\ntype T { x ufixed(2, 30) [min = 0, max = 1] = 1.0 \n y ufixed(16, 16) [min = 0, max = 100] = 0.5 }\n"},
+			src: "package t\ntype T { x ufixed(2, 30) = 1.0 | min = 0, max = 1\n y ufixed(16, 16) = 0.5 | min = 0, max = 100 }\n"},
 		{name: "un-narrowed ufixed composite dissolves (rule 2, sign-agnostic delegation)",
-			src: "package t\ntype V { x ufixed(48, 16) [min = 0, max = 100]\n y ufixed(48, 16) [min = 0, max = 100] }\nobject O { p V [interpolate] \n b bool }\n"},
+			src: "package t\ntype V { x ufixed(48, 16) | min = 0, max = 100\n y ufixed(48, 16) | min = 0, max = 100 }\nobject O { p V | interpolate \n b bool }\n"},
 		{name: "int128 with a range only 128 bits can hold, and raw uint128",
-			src: "package t\ntype T {\n    flux int128 [min = -1267650600228229401496703205376, max = 1267650600228229401496703205376]\n    id   uint128\n}\n"},
+			src: "package t\ntype T {\n    flux int128 | min = -1267650600228229401496703205376, max = 1267650600228229401496703205376\n    id   uint128\n}\n"},
 		{name: "128-bit defaults inside their range",
-			src: "package t\ntype T {\n    a int128 [min = -10, max = 10] = -5\n    b uint128 = 7\n}\n"},
-		{name: "a [local] fixed object field carries no bounds (it reaches no wire)",
-			src: "package t\nobject O {\n    cache fixed(16, 16) [local]\n    size  uint8 [interpolate, min = 0, max = 100]\n}\n"},
+			src: "package t\ntype T {\n    a int128 = -5 | min = -10, max = 10\n    b uint128 = 7\n}\n"},
+		{name: "a | local fixed object field carries no bounds (it reaches no wire)",
+			src: "package t\nobject O {\n    cache fixed(16, 16) | local\n    size  uint8 | interpolate, min = 0, max = 100\n}\n"},
 		{name: "headroom enum with non-variant wire values",
-			src: "package t\nenum E [max = 15] { A, B }\ntype T { e E }\n"},
+			src: "package t\nenum E | max = 15\n{ A, B }\ntype T { e E }\n"},
 		{name: "field named message_type on a plain type (only messages claim the method)",
 			src: "package t\ntype T { message_type uint8 }\n"},
 		{name: "a type named WriteFoo with no type Foo anywhere",
@@ -535,12 +556,12 @@ func TestGoodCornersStillCompile(t *testing.T) {
 		// component list (the deferred pass; found the day rule 2b landed)
 		{name: "fixed-composite quantize with the composite in a later-sorting file",
 			srcs: map[string]string{
-				"A_Objects.schema": "package t\nobject O { rotation Q [interpolate, quantize = 1024] \n b bool }\n",
-				"Z_Types.schema":   "package t\ntype Q { x fixed(2, 30) [min = -1, max = 1]\n y fixed(2, 30) [min = -1, max = 1]\n z fixed(2, 30) [min = -1, max = 1]\n w fixed(2, 30) [min = -1, max = 1] = 1.0 }\n"},
+				"A_Objects.schema": "package t\nobject O { rotation Q | interpolate, quantize = 1024 \n b bool }\n",
+				"Z_Types.schema":   "package t\ntype Q { x fixed(2, 30) | min = -1, max = 1\n y fixed(2, 30) | min = -1, max = 1\n z fixed(2, 30) | min = -1, max = 1\n w fixed(2, 30) = 1.0 | min = -1, max = 1 }\n"},
 		},
 		{name: "float-composite quantize with the composite in a later-sorting file",
 			srcs: map[string]string{
-				"A_Objects.schema": "package t\nobject O { p V [interpolate, quantize = 10, max = 1] \n b bool }\n",
+				"A_Objects.schema": "package t\nobject O { p V | interpolate, quantize = 10, max = 1 \n b bool }\n",
 				"Z_Types.schema":   "package t\ntype V { x float64\n y float64 }\n"},
 		},
 	}
@@ -564,7 +585,7 @@ func TestGoodCornersStillCompile(t *testing.T) {
 // exercised the only way a NaN can exist in the checker's input: planted
 // directly in the AST. Defense in depth, proven rather than assumed.
 func TestNonFiniteTripleNaN(t *testing.T) {
-	src := "package t\ntype T { x float32 [min = 0.5, max = 1.0, resolution = 0.25] }\n"
+	src := "package t\ntype T { x float32 | min = 0.5, max = 1.0, resolution = 0.25 }\n"
 	f, perrs := parser.Parse("T.schema", []byte(src))
 	if len(perrs) > 0 {
 		t.Fatal(perrs[0])

--- a/internal/check/projection_test.go
+++ b/internal/check/projection_test.go
@@ -47,7 +47,7 @@ type Vec3 {
 message State {
     team     Team
     position Vec3
-    health   int32 [min = 0, max = MaxHealth]
+    health   int32 | min = 0, max = MaxHealth
     at_rest  bool
     if !at_rest {
         velocity Vec3
@@ -90,7 +90,7 @@ func TestIdIsStableUnderFloatConstAnnotation(t *testing.T) {
 const Half float64 = 180.0
 
 type Sample {
-    orientation float32 [min = -Half, max = Half, resolution = 0.01]
+    orientation float32 | min = -Half, max = Half, resolution = 0.01
 }
 `
 	bare := strings.Replace(annotated, "const Half float64 = 180.0", "const Half = 180.0", 1)
@@ -118,7 +118,7 @@ func TestIdMovesUnderWireEdits(t *testing.T) {
 			"    team     Team\n    position Vec3", "    position Vec3\n    team     Team", 1)},
 		{"a new enum variant (the tag range widens)",
 			strings.Replace(baseSchema, "{ Red, Blue }", "{ Red, Blue, Green }", 1)},
-		{"a field added", strings.Replace(baseSchema, "    at_rest  bool", "    shield   int32 [min = 0, max = 100]\n    at_rest  bool", 1)},
+		{"a field added", strings.Replace(baseSchema, "    at_rest  bool", "    shield   int32 | min = 0, max = 100\n    at_rest  bool", 1)},
 		{"a branch inverted", strings.Replace(baseSchema, "if !at_rest {", "if at_rest {", 1)},
 		{"a type widened", strings.Replace(baseSchema, "    x float64", "    x float32", 1)},
 		{"the package renamed", strings.Replace(baseSchema, "package probe", "package other", 1)},
@@ -202,7 +202,7 @@ message Pong {
 }
 
 object Rock {
-    size uint8 [interpolate, min = 0, max = 100]
+    size uint8 | interpolate, min = 0, max = 100
 }
 
 type Arm {
@@ -229,7 +229,7 @@ const Arms     = HeldType.Max
 	}
 }
 
-// F.Count is the DECLARED variant count (SPEC §4.2) — under [max = K]
+// F.Count is the DECLARED variant count (SPEC §4.2) — under | max = K
 // headroom it diverges from the wire width, and Count stays the count.
 func TestFlagsCountValue(t *testing.T) {
 	u := build(t, `package probe
@@ -240,7 +240,8 @@ flags Plain {
     C,
 }
 
-flags Wide [max = 8] {
+flags Wide | max = 8
+{
     A,
     B,
     C,
@@ -259,7 +260,7 @@ const WideN  = Wide.Count
 		}
 	}
 	if u.Flags["Wide"].WireBits != 8 {
-		t.Errorf("Wide.WireBits = %d, want 8 — the [max = 8] widening is the WIRE width, distinct from Count", u.Flags["Wide"].WireBits)
+		t.Errorf("Wide.WireBits = %d, want 8 — the | max = 8 widening is the WIRE width, distinct from Count", u.Flags["Wide"].WireBits)
 	}
 }
 

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -27,7 +27,7 @@
 //
 //   - Enums are a fixed-width typedef plus #define constants, NOT a C enum. A C
 //     enum's underlying type is implementation-defined, which would break the
-//     storage-width contract in §6.1 — and headroom from [max = K] makes
+//     storage-width contract in §6.1 — and headroom from | max = K makes
 //     non-variant values wire-legal, which a C enum cannot represent honestly
 //     anyway. Same reasoning as the Rust newtype.
 package c
@@ -254,7 +254,7 @@ func (g *gen) emitDataHeader(carriesProtocolId bool) {
 		case *ir.ContextsMarker:
 			g.pf("/* contexts declared for this unit: %s (SPEC §4.2).\n", strings.Join(decl.Names, ", "))
 			g.pf("   Contexts generate no standalone artifacts — where an object carries\n")
-			g.pf("   context-scoped [local] fields, its State struct is generated once per\n")
+			g.pf("   context-scoped | local fields, its State struct is generated once per\n")
 			g.pf("   context (ClientShipState, ServerShipState, ...), each holding the `all`\n")
 			g.pf("   fields plus its own context's. No preprocessor in any target. */\n\n")
 		default:
@@ -316,7 +316,7 @@ func formatFloat32(v float32) string {
 func (g *gen) emitEnum(d *ir.Enum) {
 	g.pf("\n/* enum %s — None = 0 implicit, variants dense from 1, wire range [0, %d]\n", d.Name, d.Max)
 	g.pf("   (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying\n")
-	g.pf("   type is implementation-defined, and [max = K] headroom makes non-variant\n")
+	g.pf("   type is implementation-defined, and | max = K headroom makes non-variant\n")
 	g.pf("   values wire-legal, which a C enum cannot hold honestly. */\n")
 	g.pf("typedef %s %s;\n", cUint(d.StorageBits), d.Name)
 	g.pf("#define %s_NONE 0\n", screaming(d.Name))

--- a/internal/codegen/c/c_test.go
+++ b/internal/codegen/c/c_test.go
@@ -64,7 +64,7 @@ type UnmarkedOffBoundary {
 
 type UnmarkedRanged {
     align
-    data [4]uint8 [min = 0, max = 255]
+    data [4]uint8 | min = 0, max = 255
 }
 
 type UnmarkedCounted {

--- a/internal/codegen/c/expr_test.go
+++ b/internal/codegen/c/expr_test.go
@@ -27,12 +27,12 @@ enum Team { Red, Blue }
 const NumTeams = Team.Max
 
 type Probe {
-    object_id int32  [min = 0, max = MaxObjects - 1]
-    doubled   int32  [min = --MaxUnits, max = MaxUnits * 2]
-    hexed     int32  [min = 0, max = 0x10]
-    overflow  int64  [min = 0, max = 2000000000 * 3]
-    wide_ok   int64  [min = -Wide, max = Wide]
-    team_size uint8  [min = 0, max = Team.Max]
+    object_id int32  | min = 0, max = MaxObjects - 1
+    doubled   int32  | min = --MaxUnits, max = MaxUnits * 2
+    hexed     int32  | min = 0, max = 0x10
+    overflow  int64  | min = 0, max = 2000000000 * 3
+    wide_ok   int64  | min = -Wide, max = Wide
+    team_size uint8  | min = 0, max = Team.Max
     counted   [..MaxObjects]uint8
     name      string(MaxUnits)
 }
@@ -181,17 +181,17 @@ const FloorLimit = -9223372036854775808
 const CeilingCount uint64 = 18446744073709551615
 
 type ExtremeProbe {
-    floor_bound int64 [min = -9223372036854775808, max = 100]
-    ceiling_range uint64 [min = 1, max = 18446744073709551615]
+    floor_bound int64 | min = -9223372036854775808, max = 100
+    ceiling_range uint64 | min = 1, max = 18446744073709551615
     floor_default int64 = -9223372036854775808
     ceiling_default uint64 = 18446744073709551615
-    doubled_floor int64 [min = --FloorLimit, max = 100]
-    deep_floor fixed(128, 0) [min = -9223372036854775808, max = 0]
+    doubled_floor int64 | min = --FloorLimit, max = 100
+    deep_floor fixed(128, 0) | min = -9223372036854775808, max = 0
 }
 
 table ExtremeRow {
-    clamped_floor int64 [min = -9223372036854775808, max = 100]
-    clamped_ceiling uint64 [min = 1, max = 18446744073709551614]
+    clamped_floor int64 | min = -9223372036854775808, max = 100
+    clamped_ceiling uint64 | min = 1, max = 18446744073709551614
     floor_def int64 = -9223372036854775808
     ceiling_def uint64 = 18446744073709551615
 }

--- a/internal/codegen/c/objects.go
+++ b/internal/codegen/c/objects.go
@@ -3,9 +3,9 @@ package c
 // Objects (SPEC §4.8): one declaration, a generated family per target.
 //
 // An object produces a State struct (the full simulation type, generated once
-// per context where the object carries [local, context = ...] fields), plus
-// three views: Data_Deep (every non-[local] field, declared encodings),
-// Data_Shallow (the [interpolate] fields on the quantized wire) and
+// per context where the object carries | local, context = ... fields), plus
+// three views: Data_Deep (every non- | local field, declared encodings),
+// Data_Shallow (the | interpolate fields on the quantized wire) and
 // Data_Interpolate (the same fields in their interpolation domain). The
 // Quantize/Unquantize pair moves between the last two.
 
@@ -34,8 +34,8 @@ func hasContextFields(d *ir.Object) bool {
 	return false
 }
 
-// splitObjectFields separates the deep view (every non-[local] field) from the
-// interpolate view (the [interpolate] fields).
+// splitObjectFields separates the deep view (every non- | local field) from the
+// interpolate view (the | interpolate fields).
 func splitObjectFields(d *ir.Object) (deep, interp []*ir.Field) {
 	for _, f := range d.Fields {
 		if !f.Local {
@@ -70,7 +70,7 @@ func (g *gen) emitObject(d *ir.Object) {
 			}
 			name := capitalize(ctx) + d.Name + "State"
 			g.pf("/* %s — the full simulation struct for the %s context: every `all`\n", name, ctx)
-			g.pf("   field plus the fields scoped [local, context = %s] */\n", ctx)
+			g.pf("   field plus the fields scoped | local, context = %s */\n", ctx)
 			g.emitViewStruct(name, fields, storageDeep)
 		}
 	} else {
@@ -80,11 +80,11 @@ func (g *gen) emitObject(d *ir.Object) {
 
 	deep, interp := splitObjectFields(d)
 
-	g.pf("/* %sData_Deep — every non-[local] field, deep encodings: full state for\n", d.Name)
+	g.pf("/* %sData_Deep — every non- | local field, deep encodings: full state for\n", d.Name)
 	g.pf("   client-side prediction */\n")
 	g.emitViewStruct(d.Name+"Data_Deep", deep, storageDeep)
 
-	g.pf("/* %sData_Shallow — the [interpolate] fields on the quantized wire */\n", d.Name)
+	g.pf("/* %sData_Shallow — the | interpolate fields on the quantized wire */\n", d.Name)
 	g.emitViewStruct(d.Name+"Data_Shallow", interp, storageShallow)
 
 	g.pf("/* %sData_Interpolate — the same fields in their interpolation domain */\n", d.Name)
@@ -113,7 +113,7 @@ func (g *gen) emitViewField(f *ir.Field, v view) {
 	if v == storageShallow && f.HasQuantize && f.FixedShallow {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		g.pf("    /* %s: %s narrowed — %d fractional bits kept (SPEC §4.8 rule 2b) */\n", f.Name, f.Type.Name, f.QuantShift)
@@ -128,7 +128,7 @@ func (g *gen) emitViewField(f *ir.Field, v view) {
 	if v == storageShallow && f.HasQuantize {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		lo, hi := quantBounds(f)
@@ -285,7 +285,7 @@ func (g *gen) emitShallowWriteField(f *ir.Field, ind string) {
 	if f.HasQuantize && f.FixedShallow {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		for _, comp := range st.Fields {
@@ -315,7 +315,7 @@ func (g *gen) emitShallowWriteField(f *ir.Field, ind string) {
 	if f.HasQuantize {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		lo, hi := quantBounds(f)
@@ -344,7 +344,7 @@ func (g *gen) emitShallowReadField(f *ir.Field, ind string) {
 	if f.HasQuantize && f.FixedShallow {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		for _, comp := range st.Fields {
@@ -378,7 +378,7 @@ func (g *gen) emitShallowReadField(f *ir.Field, ind string) {
 	if f.HasQuantize {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		lo, hi := quantBounds(f)
@@ -440,11 +440,11 @@ func (g *gen) emitDeepReadField(f *ir.Field, ind string) {
 
 func (g *gen) emitQuantizePair(d *ir.Object) {
 	if !ir.ObjectNeedsQuantize(d) {
-		// every [interpolate] field rides the wire domain verbatim — fixed
+		// every | interpolate field rides the wire domain verbatim — fixed
 		// components are their own quantization (SPEC §4.8) — so the pair
 		// would be a pure member copy and is NOT emitted. The same rule,
 		// the same words, as the other four backends.
-		g.pf("/* Quantize%s/Unquantize%s are not emitted: every [interpolate] field\n", d.Name, d.Name)
+		g.pf("/* Quantize%s/Unquantize%s are not emitted: every | interpolate field\n", d.Name, d.Name)
 		g.pf("   is already wire-domain (fixed components are their own quantization,\n")
 		g.pf("   SPEC §4.8) — Interpolate and Shallow are the same values. */\n\n")
 		return
@@ -489,7 +489,7 @@ func (g *gen) emitQuantizeField(f *ir.Field) {
 	if f.FixedShallow {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		for _, comp := range st.Fields {
@@ -516,7 +516,7 @@ func (g *gen) emitQuantizeField(f *ir.Field) {
 	}
 	st, ok := f.Type.Ref.(*ir.Struct)
 	if !ok {
-		g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+		g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 		return
 	}
 	bound := f.QuantBound
@@ -549,7 +549,7 @@ func (g *gen) emitUnquantizeField(f *ir.Field) {
 	if f.FixedShallow {
 		st, ok := f.Type.Ref.(*ir.Struct)
 		if !ok {
-			g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+			g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 			return
 		}
 		for _, comp := range st.Fields {
@@ -566,7 +566,7 @@ func (g *gen) emitUnquantizeField(f *ir.Field) {
 	}
 	st, ok := f.Type.Ref.(*ir.Struct)
 	if !ok {
-		g.unsupported("field %s is [quantize]d but does not reference a composite type", f.Name)
+		g.unsupported("field %s is | quantized but does not reference a composite type", f.Name)
 		return
 	}
 	for _, comp := range st.Fields {

--- a/internal/codegen/c/table.go
+++ b/internal/codegen/c/table.go
@@ -913,7 +913,7 @@ typedef struct table_field_info_t
     int counted;              /* a count/length companion exists */
     int64_t array_bound;      /* array capacity / string max length; 0 for scalars */
     const struct table_type_info_t * table;  /* nested table's descriptor, or NULL */
-    int has_range;            /* a declared [min, max] */
+    int has_range;            /* a declared | min, max */
     double range_min;         /* NOTE: int64 ranges beyond 2^53 lose precision here */
     double range_max;
     int64_t enum_max;         /* enums: highest valid wire value; else -1 */

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -312,7 +312,7 @@ func (g *gen) emitDataFile(carriesProtocolId bool) {
 		case *ir.ContextsMarker:
 			g.pf("// contexts declared for this unit: %s (SPEC §4.2).\n", strings.Join(d.Names, ", "))
 			g.pf("// Contexts generate no standalone artifacts — where an object carries\n")
-			g.pf("// context-scoped [local] fields, its State struct is generated once per\n")
+			g.pf("// context-scoped | local fields, its State struct is generated once per\n")
 			g.pf("// context (ClientShipState, ServerShipState, ...), each holding the `all`\n")
 			g.pf("// fields plus its own context's. No preprocessor in any target.\n\n")
 		case *ir.Struct:
@@ -553,7 +553,7 @@ func (g *gen) emitObject(d *ir.Object) {
 				}
 			}
 			g.pf("// %s%sState — the full simulation struct for the %s context: every `all`\n", capitalize(ctx), d.Name, ctx)
-			g.pf("// field plus the fields scoped [local, context = %s]\n", ctx)
+			g.pf("// field plus the fields scoped | local, context = %s\n", ctx)
 			g.pf("struct %s%sState {\n", capitalize(ctx), d.Name)
 			g.emitFields(fields, storageDeep)
 			g.pf("};\n\n")
@@ -575,13 +575,13 @@ func (g *gen) emitObject(d *ir.Object) {
 		}
 	}
 
-	g.pf("// %sData_Deep — every non-[local] field, deep encodings: full state for\n", d.Name)
+	g.pf("// %sData_Deep — every non- | local field, deep encodings: full state for\n", d.Name)
 	g.pf("// client-side prediction\n")
 	g.pf("struct %sData_Deep {\n", d.Name)
 	g.emitFields(deep, storageDeep)
 	g.pf("};\n\n")
 
-	g.pf("// %sData_Shallow — the [interpolate] fields on the quantized wire: the\n", d.Name)
+	g.pf("// %sData_Shallow — the | interpolate fields on the quantized wire: the\n", d.Name)
 	g.pf("// implementation detail on the way to interpolation on the client\n")
 	g.pf("struct %sData_Shallow {\n", d.Name)
 	g.emitFields(interp, storageShallow)
@@ -626,7 +626,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		if f.FixedShallow {
 			g.pf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
 				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
-			g.pf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
+			g.pf("    // quantized units; bounds are the component's whole-unit | min, max scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, _, typ := fixedShallowComp(f, comp)
 				g.pf("    %s %s_%s = 0; // in [%s, %s]\n", typ, f.Name, comp.Name, lo, hi)
@@ -760,9 +760,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf("[local, context = %s]", f.Context))
+			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
 		} else {
-			parts = append(parts, "[local] — no wire")
+			parts = append(parts, " | local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/cpp/expr_test.go
+++ b/internal/codegen/cpp/expr_test.go
@@ -23,16 +23,16 @@ const FloorLimit = -9223372036854775808
 const CeilingCount uint64 = 18446744073709551615
 
 type ExtremeProbe {
-    floor_bound int64 [min = -9223372036854775808, max = 100]
-    ceiling_range uint64 [min = 1, max = 18446744073709551615]
+    floor_bound int64 | min = -9223372036854775808, max = 100
+    ceiling_range uint64 | min = 1, max = 18446744073709551615
     floor_default int64 = -9223372036854775808
     ceiling_default uint64 = 18446744073709551615
-    doubled_floor int64 [min = --FloorLimit, max = 100]
+    doubled_floor int64 | min = --FloorLimit, max = 100
 }
 
 table ExtremeRow {
-    clamped_floor int64 [min = -9223372036854775808, max = 100]
-    clamped_ceiling uint64 [min = 1, max = 18446744073709551614]
+    clamped_floor int64 | min = -9223372036854775808, max = 100
+    clamped_ceiling uint64 | min = 1, max = 18446744073709551614
     floor_def int64 = -9223372036854775808
     ceiling_def uint64 = 18446744073709551615
 }

--- a/internal/codegen/cpp/objects.go
+++ b/internal/codegen/cpp/objects.go
@@ -62,7 +62,7 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 	}
 
 	// ---- Deep: every non-local field, deep encodings — the view-encoding
-	// attributes describe the SHALLOW wire only, so an [interpolate] float
+	// attributes describe the SHALLOW wire only, so an | interpolate float
 	// triple serializes as a bare float here (SPEC §4.8)
 	deepName := d.Name + "Data_Deep"
 	g.pf("SCHEMA_WRITE_INLINE bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", deepName, deepName)
@@ -80,7 +80,7 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 	g.voidIfEmpty(mark, "stream", "value")
 	g.pf("    return true;\n}\n\n")
 
-	// ---- Shallow: the [interpolate] fields on the quantized wire
+	// ---- Shallow: the | interpolate fields on the quantized wire
 	shName := d.Name + "Data_Shallow"
 	g.pf("SCHEMA_WRITE_INLINE bool Write%s( serialize::WriteStream & stream, const %s & value )\n{\n", shName, shName)
 	mark = g.body.Len()
@@ -107,10 +107,10 @@ func (g *gen) emitObjectWire(d *ir.Object) {
 // without the wire header's serialize.h.
 func (g *gen) emitObjectQuantize(d *ir.Object) {
 	if !ir.ObjectNeedsQuantize(d) {
-		// every [interpolate] field rides the wire domain verbatim — fixed
+		// every | interpolate field rides the wire domain verbatim — fixed
 		// components are their own quantization (SPEC §4.8) — so the pair
 		// would be a pure member copy and is NOT emitted.
-		g.pf("// Quantize%s/Unquantize%s are not emitted: every [interpolate] field\n", d.Name, d.Name)
+		g.pf("// Quantize%s/Unquantize%s are not emitted: every | interpolate field\n", d.Name, d.Name)
 		g.pf("// is already wire-domain (fixed components are their own quantization,\n")
 		g.pf("// SPEC §4.8) — Interpolate and Shallow are the same values.\n\n")
 		return

--- a/internal/codegen/cpp/table.go
+++ b/internal/codegen/cpp/table.go
@@ -189,7 +189,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -10,7 +10,7 @@
 // via ir.GoExportName — the SAME PascalCase mapping as the Go target, so the
 // checker's existing collision detection covers C# members without a second
 // registry. Integer families name their storage directly (sbyte..ulong),
-// enums are native C# enums with explicit unsigned backing ([max = ...]
+// enums are native C# enums with explicit unsigned backing ( | max = ...
 // headroom values are representable natively — C# enums are open over their
 // backing type, so no newtype is needed), flags-typed fields are plain ulong
 // with flat mask constants on Schema (the Go spelling exactly, so the
@@ -248,7 +248,7 @@ func (g *gen) emitFile(carriesProtocolId bool) {
 		case *ir.ContextsMarker:
 			g.tf("// contexts declared for this unit: %s (SPEC §4.2).\n", strings.Join(d.Names, ", "))
 			g.tf("// Contexts generate no standalone artifacts — where an object carries\n")
-			g.tf("// context-scoped [local] fields, its State class is generated once per\n")
+			g.tf("// context-scoped | local fields, its State class is generated once per\n")
 			g.tf("// context (ClientShipState, ServerShipState, ...), each holding the `all`\n")
 			g.tf("// fields plus its own context's. No preprocessor symbols in this target.\n\n")
 		case *ir.Struct:
@@ -336,7 +336,7 @@ func (g *gen) foldComment(e ast.Expr) string {
 
 func (g *gen) emitEnum(d *ir.Enum) {
 	g.tf("// %s — None = 0 implicit, variants dense from 1, wire range [0, %d] (SPEC §4.2);\n", d.Name, d.Max)
-	g.tf("// a native enum with unsigned backing — [max = ...] headroom values are\n")
+	g.tf("// a native enum with unsigned backing — | max = ... headroom values are\n")
 	g.tf("// representable because C# enums are open over their backing type (SPEC §6.1)\n")
 	g.tf("public enum %s : %s\n{\n", d.Name, csUint(d.StorageBits))
 	g.tf("    None = 0,\n")
@@ -457,7 +457,7 @@ func (g *gen) emitObject(d *ir.Object) {
 			}
 			name := capitalize(ctx) + d.Name + "State"
 			g.tf("// %s — the full simulation class for the %s context: every `all`\n", name, ctx)
-			g.tf("// field plus the fields scoped [local, context = %s]\n", ctx)
+			g.tf("// field plus the fields scoped | local, context = %s\n", ctx)
 			g.emitViewClass(name, fields, storageDeep)
 		}
 	} else {
@@ -467,11 +467,11 @@ func (g *gen) emitObject(d *ir.Object) {
 
 	deep, interp := splitObjectFields(d)
 
-	g.tf("// %sData_Deep — every non-[local] field, deep encodings: full state for\n", d.Name)
+	g.tf("// %sData_Deep — every non- | local field, deep encodings: full state for\n", d.Name)
 	g.tf("// client-side prediction\n")
 	g.emitViewClass(d.Name+"Data_Deep", deep, storageDeep)
 
-	g.tf("// %sData_Shallow — the [interpolate] fields on the quantized wire: the\n", d.Name)
+	g.tf("// %sData_Shallow — the | interpolate fields on the quantized wire: the\n", d.Name)
 	g.tf("// implementation detail on the way to interpolation on the client\n")
 	g.emitViewClass(d.Name+"Data_Shallow", interp, storageShallow)
 
@@ -543,7 +543,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		if f.FixedShallow {
 			g.tf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
 				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
-			g.tf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
+			g.tf("    // quantized units; bounds are the component's whole-unit | min, max scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, typ, _ := fixedShallowComp(f, comp)
 				g.tf("    public %s %s; // in [%s, %s]\n", typ, g.m(ir.GoExportName(f.Name)+ir.GoExportName(comp.Name)), lo, hi)
@@ -637,9 +637,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf("[local, context = %s]", f.Context))
+			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
 		} else {
-			parts = append(parts, "[local] — no wire")
+			parts = append(parts, " | local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -399,7 +399,7 @@ func storageBounds(t ir.FieldType) (*big.Int, *big.Int) {
 	return big.NewInt(0), new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), w), big.NewInt(1))
 }
 
-// emitWriteFoldedRange writes the integer expression expr, in [min, max], as
+// emitWriteFoldedRange writes the integer expression expr, in | min, max, as
 // offset-from-min in a generation-time bit count. lo/hi are the rendered
 // bound expressions (typed so they compare against expr legally); wide picks
 // the 64-bit call family; guardLo/guardHi say whether each half of the range

--- a/internal/codegen/csharp/objects.go
+++ b/internal/codegen/csharp/objects.go
@@ -66,7 +66,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 	// (SPEC §4.8's artifact table — the hand-written Quantize(), generated).
 	// Top-level members of the view classes never need the CS0542 escape
 	// (view class names carry an underscore ir.GoExportName cannot produce).
-	// NOT emitted when every [interpolate] field is already wire-domain —
+	// NOT emitted when every | interpolate field is already wire-domain —
 	// fixed components are their own quantization (SPEC §4.8).
 	if ir.ObjectNeedsQuantize(d) {
 		inName := d.Name + "Data_Interpolate"

--- a/internal/codegen/csharp/table.go
+++ b/internal/codegen/csharp/table.go
@@ -896,7 +896,7 @@ func (g *tableGen) emitTableSetField(f *ir.Field) {
 	g.pf("        }\n")
 }
 
-// emitTableSetClamp clamps n to [min, max]; an empty min means the low side
+// emitTableSetClamp clamps n to | min, max; an empty min means the low side
 // cannot underflow (unsigned with a non-positive declared min).
 func (g *tableGen) emitTableSetClamp(ind, min, max, note string) {
 	if min != "" {
@@ -975,7 +975,7 @@ public struct TableFieldInfo
     public bool Counted;                 // a Count/Length companion exists (counted arrays, strings, bytes)
     public int ArrayBound;               // array capacity / string max length; 0 for plain scalars
     public TableTypeInfo Table;          // nested table's descriptor, or null
-    public bool HasRange;                // a declared [min, max] (int or float)
+    public bool HasRange;                // a declared | min, max (int or float)
     public double RangeMin;              // NOTE: int64 ranges beyond 2^53 lose precision here
     public double RangeMax;
     public long EnumMax;                 // enums: highest valid wire value (None = 0 always valid); else -1

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -174,7 +174,7 @@ func (g *gen) emitFile(carriesProtocolId bool) {
 		case *ir.ContextsMarker:
 			g.pf("// contexts declared for this unit: %s (SPEC §4.2).\n", strings.Join(d.Names, ", "))
 			g.pf("// Contexts generate no standalone artifacts — where an object carries\n")
-			g.pf("// context-scoped [local] fields, its State struct is generated once per\n")
+			g.pf("// context-scoped | local fields, its State struct is generated once per\n")
 			g.pf("// context (ClientShipState, ServerShipState, ...), each holding the `all`\n")
 			g.pf("// fields plus its own context's. No build tags in this target.\n\n")
 		case *ir.Struct:
@@ -449,7 +449,7 @@ func (g *gen) emitObject(d *ir.Object) {
 				}
 			}
 			g.pf("// %s%sState — the full simulation struct for the %s context: every `all`\n", capitalize(ctx), d.Name, ctx)
-			g.pf("// field plus the fields scoped [local, context = %s]\n", ctx)
+			g.pf("// field plus the fields scoped | local, context = %s\n", ctx)
 			g.pf("type %s%sState struct {\n", capitalize(ctx), d.Name)
 			g.emitFields(fields, storageDeep)
 			g.pf("}\n\n")
@@ -463,13 +463,13 @@ func (g *gen) emitObject(d *ir.Object) {
 
 	deep, interp := splitObjectFields(d)
 
-	g.pf("// %sData_Deep — every non-[local] field, deep encodings: full state for\n", d.Name)
+	g.pf("// %sData_Deep — every non- | local field, deep encodings: full state for\n", d.Name)
 	g.pf("// client-side prediction\n")
 	g.pf("type %sData_Deep struct {\n", d.Name)
 	g.emitFields(deep, storageDeep)
 	g.pf("}\n\n")
 
-	g.pf("// %sData_Shallow — the [interpolate] fields on the quantized wire: the\n", d.Name)
+	g.pf("// %sData_Shallow — the | interpolate fields on the quantized wire: the\n", d.Name)
 	g.pf("// implementation detail on the way to interpolation on the client\n")
 	g.pf("type %sData_Shallow struct {\n", d.Name)
 	g.emitFields(interp, storageShallow)
@@ -527,7 +527,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		if f.FixedShallow {
 			g.pf("\t// %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
 				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
-			g.pf("\t// quantized units; bounds are the component's whole-unit [min, max] scaled\n")
+			g.pf("\t// quantized units; bounds are the component's whole-unit | min, max scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, _, typ, _ := fixedShallowComp(f, comp)
 				g.pf("\t%s%s %s // in [%s, %s]\n", name, ir.GoExportName(comp.Name), typ, lo, hi)
@@ -607,9 +607,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf("[local, context = %s]", f.Context))
+			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
 		} else {
-			parts = append(parts, "[local] — no wire")
+			parts = append(parts, " | local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -21,8 +21,8 @@ import (
 func multiFileUnit(t *testing.T) *ir.Unit {
 	t.Helper()
 	sources := map[string]string{
-		"MessagesA.schema": "package t\nmessage Ping { x uint8 }\nobject Rock { size uint8 [interpolate, min = 0, max = 100] }\n",
-		"MessagesB.schema": "package t\nmessage Pong { y uint8 }\nobject Tree { size uint8 [interpolate, min = 0, max = 100] }\n",
+		"MessagesA.schema": "package t\nmessage Ping { x uint8 }\nobject Rock { size uint8 | interpolate, min = 0, max = 100 }\n",
+		"MessagesB.schema": "package t\nmessage Pong { y uint8 }\nobject Tree { size uint8 | interpolate, min = 0, max = 100 }\n",
 	}
 	var files []check.SourceFile
 	for name, src := range sources {
@@ -90,11 +90,11 @@ func TestBareFloatConstExportsTypedFloat64(t *testing.T) {
 // E.Max's generated twin instead of a hand-declared count constant.
 func TestEnumExtentEmitted(t *testing.T) {
 	src := "package t\n\n" +
-		"enum Weapon [max = 15] { Laser, Missile }\n\n" +
+		"enum Weapon | max = 15\n{ Laser, Missile }\n\n" +
 		"message Ping { w Weapon }\n\n" +
 		"message Pong { y uint8 }\n\n" +
-		"object Rock { size uint8 [interpolate, min = 0, max = 100] }\n\n" +
-		"object Tree { size uint8 [interpolate, min = 0, max = 100] }\n"
+		"object Rock { size uint8 | interpolate, min = 0, max = 100 }\n\n" +
+		"object Tree { size uint8 | interpolate, min = 0, max = 100 }\n"
 	f, perrs := parser.Parse("Extent.schema", []byte(src))
 	if len(perrs) > 0 {
 		t.Fatalf("parse: %v", perrs[0])
@@ -271,7 +271,7 @@ func TestUnionSurfaceEmitted(t *testing.T) {
 
 // Flags export their declared variant count as Count (SPEC §4.2 — one name,
 // not Max: the variants are independent bits, not a range with a top), and
-// the wire spends EXACTLY Count bits when no [max = K] widens it (schema
+// the wire spends EXACTLY Count bits when no | max = K widens it (schema
 // issue #129's verification): a 4-variant flags field serializes in 4 bits
 // in every target, write and read alike.
 func TestFlagsCountAndWireBits(t *testing.T) {

--- a/internal/codegen/golang/objects.go
+++ b/internal/codegen/golang/objects.go
@@ -51,7 +51,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 
 	// ---- Quantize / Unquantize: the Interpolate <-> Shallow mapping pair
 	// (SPEC §4.8's artifact table — the hand-written Quantize(), generated).
-	// NOT emitted when every [interpolate] field is already wire-domain —
+	// NOT emitted when every | interpolate field is already wire-domain —
 	// fixed components are their own quantization (SPEC §4.8).
 	if ir.ObjectNeedsQuantize(d) {
 		inName := d.Name + "Data_Interpolate"

--- a/internal/codegen/golang/table.go
+++ b/internal/codegen/golang/table.go
@@ -958,7 +958,7 @@ func (g *tableGen) emitTableSetNumeric(matchType, normType string) {
 	g.pf("\t\tdefault:\n\t\t\treturn false\n\t\t}\n")
 }
 
-// emitTableSetClamp clamps n to [min, max]; an empty min means the low side
+// emitTableSetClamp clamps n to | min, max; an empty min means the low side
 // cannot underflow (unsigned with a non-positive declared min).
 func (g *tableGen) emitTableSetClamp(min, max, note string) {
 	if min != "" {
@@ -1020,7 +1020,7 @@ type TableFieldInfo struct {
 	Counted    bool                // a Count/Length int32 companion exists (counted arrays, strings, bytes)
 	ArrayBound int32               // array capacity / string max length; 0 for plain scalars
 	Table      *TableTypeInfo      // nested table's descriptor, or nil
-	HasRange   bool                // a declared [min, max] (int or float)
+	HasRange   bool                // a declared | min, max (int or float)
 	RangeMin   float64             // NOTE: int64 ranges beyond 2^53 lose precision here
 	RangeMax   float64
 	EnumMax    int64               // enums: highest valid wire value (None = 0 always valid); else -1

--- a/internal/codegen/js/flat.go
+++ b/internal/codegen/js/flat.go
@@ -1499,7 +1499,7 @@ func (g *fgen) emitReadInt(f *ir.Field, name, ind string) {
 // emitReadRangedBig decodes a BigInt-domain ranged integer (int64 family
 // and full-range unsigned): offset read wide, headroom rejected unless the
 // range fills the width, min added in the value domain (exact — decoded
-// values are in [min, max]).
+// values are in | min, max).
 func (g *fgen) emitReadRangedBig(f *ir.Field, name string, bits int64, ind string) {
 	diff := new(big.Int).Sub(f.IntMax, f.IntMin)
 	full := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))

--- a/internal/codegen/js/functions.go
+++ b/internal/codegen/js/functions.go
@@ -340,7 +340,7 @@ func intRangePath(min, max *big.Int) string {
 }
 
 // emitWriteFoldedNum writes the Number-domain integer expression expr, in
-// [min, max], as offset-from-min in a generation-time bit count. JS Number
+// | min, max, as offset-from-min in a generation-time bit count. JS Number
 // storage is untyped, so the guard is never vacuous and also refuses
 // non-integers (checkInt) — the runtime checked write's own shape, folded,
 // riding in both modes. The offset subtraction is exact: the int64-family
@@ -763,7 +763,7 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 					g.pf("%s%s = %s.value;\n", ind, name, scratch)
 				} else {
 					// uint32 storage whose range escapes int32: the decoded
-					// value is inside [min, max], so the narrowing is exact
+					// value is inside | min, max, so the narrowing is exact
 					g.pf("%s%s = Number(%s.value);\n", ind, name, scratch)
 				}
 			default:

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -258,7 +258,7 @@ func (g *gen) emitFile(carriesProtocolId bool) {
 		case *ir.ContextsMarker:
 			g.pf("// contexts declared for this unit: %s (SPEC §4.2).\n", strings.Join(d.Names, ", "))
 			g.pf("// Contexts generate no standalone artifacts — where an object carries\n")
-			g.pf("// context-scoped [local] fields, its State class is generated once per\n")
+			g.pf("// context-scoped | local fields, its State class is generated once per\n")
 			g.pf("// context (ClientShipState, ServerShipState, ...), each holding the `all`\n")
 			g.pf("// fields plus its own context's.\n\n")
 		case *ir.Struct:
@@ -345,7 +345,7 @@ func (g *gen) foldComment(e ast.Expr) string {
 func (g *gen) emitEnum(d *ir.Enum) {
 	g.pf("// %s — None = 0 implicit, variants dense from 1, wire range [0, %d] (SPEC §4.2);\n", d.Name, d.Max)
 	g.pf("// a frozen object of Number values — the JS translation of the family's\n")
-	g.pf("// integer-backed enums; [max = ...] headroom values are plain Numbers\n")
+	g.pf("// integer-backed enums; | max = ... headroom values are plain Numbers\n")
 	g.pf("export const %s = Object.freeze({\n", d.Name)
 	g.pf("  None: 0,\n")
 	for i, v := range d.Variants {
@@ -577,9 +577,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf("[local, context = %s]", f.Context))
+			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
 		} else {
-			parts = append(parts, "[local] — no wire")
+			parts = append(parts, " | local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/js/objects.go
+++ b/internal/codegen/js/objects.go
@@ -1,5 +1,5 @@
 // Object-view emission (SPEC §4.8, §6.1 item 7): the State classes (one per
-// context where context-scoped [local] fields exist), the Deep and Shallow
+// context where context-scoped | local fields exist), the Deep and Shallow
 // wire classes' split Write/Read pairs, the Interpolate class, and the
 // Quantize/Unquantize mapping between Interpolate and Shallow —
 // floor(c*K + 0.5) per component in double math for float composites,
@@ -46,7 +46,7 @@ func (g *gen) emitObject(d *ir.Object) {
 			}
 			name := capitalize(ctx) + d.Name + "State"
 			g.pf("// %s — the full simulation class for the %s context: every `all`\n", name, ctx)
-			g.pf("// field plus the fields scoped [local, context = %s]\n", ctx)
+			g.pf("// field plus the fields scoped | local, context = %s\n", ctx)
 			g.emitViewClass(name, fields, storageDeep)
 		}
 	} else {
@@ -56,11 +56,11 @@ func (g *gen) emitObject(d *ir.Object) {
 
 	deep, interp := splitObjectFields(d)
 
-	g.pf("// %sData_Deep — every non-[local] field, deep encodings: full state for\n", d.Name)
+	g.pf("// %sData_Deep — every non- | local field, deep encodings: full state for\n", d.Name)
 	g.pf("// client-side prediction\n")
 	g.emitViewClass(d.Name+"Data_Deep", deep, storageDeep)
 
-	g.pf("// %sData_Shallow — the [interpolate] fields on the quantized wire: the\n", d.Name)
+	g.pf("// %sData_Shallow — the | interpolate fields on the quantized wire: the\n", d.Name)
 	g.pf("// implementation detail on the way to interpolation on the client\n")
 	g.emitViewClass(d.Name+"Data_Shallow", interp, storageShallow)
 
@@ -123,7 +123,7 @@ func (g *gen) emitViewStorageField(f *ir.Field, v view) {
 		if f.FixedShallow {
 			g.pf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
 				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
-			g.pf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
+			g.pf("    // quantized units; bounds are the component's whole-unit | min, max scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, width := fixedShallowComp(f, comp)
 				g.pf("    this.%s%s = %s; // in [%s, %s]\n",
@@ -205,7 +205,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 
 	// ---- Quantize / Unquantize: the Interpolate <-> Shallow mapping pair
 	// (SPEC §4.8's artifact table — the hand-written Quantize(), generated).
-	// NOT emitted when every [interpolate] field is already wire-domain —
+	// NOT emitted when every | interpolate field is already wire-domain —
 	// fixed components are their own quantization (SPEC §4.8).
 	if ir.ObjectNeedsQuantize(d) {
 		inName := d.Name + "Data_Interpolate"

--- a/internal/codegen/rust/objects.go
+++ b/internal/codegen/rust/objects.go
@@ -59,7 +59,7 @@ func (g *gen) emitObjectFunctions(d *ir.Object) {
 
 	// ---- quantize / unquantize: the Interpolate <-> Shallow mapping pair
 	// (SPEC §4.8's artifact table — the hand-written Quantize(), generated).
-	// NOT emitted when every [interpolate] field is already wire-domain —
+	// NOT emitted when every | interpolate field is already wire-domain —
 	// fixed components are their own quantization (SPEC §4.8).
 	if ir.ObjectNeedsQuantize(d) {
 		inName := d.Name + "Data_Interpolate"

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -238,7 +238,7 @@ func (g *gen) emitFile(carriesProtocolId bool) {
 		case *ir.ContextsMarker:
 			g.pf("// contexts declared for this unit: %s (SPEC §4.2).\n", strings.Join(d.Names, ", "))
 			g.pf("// Contexts generate no standalone artifacts — where an object carries\n")
-			g.pf("// context-scoped [local] fields, its State struct is generated once per\n")
+			g.pf("// context-scoped | local fields, its State struct is generated once per\n")
 			g.pf("// context (ClientShipState, ServerShipState, ...), each holding the `all`\n")
 			g.pf("// fields plus its own context's. No cfg gates in this target.\n\n")
 		case *ir.Struct:
@@ -345,7 +345,7 @@ func (g *gen) emitUnion(d *ir.Union) {
 
 func (g *gen) emitEnum(d *ir.Enum) {
 	g.pf("// %s — None = 0 implicit, variants dense from 1, wire range [0, %d] (SPEC §4.2);\n", d.Name, d.Max)
-	g.pf("// a newtype because [max = ...] headroom makes non-variant values wire-legal\n")
+	g.pf("// a newtype because | max = ... headroom makes non-variant values wire-legal\n")
 	g.allowNonCamel(d.Name)
 	g.pf("#[repr(transparent)]\n#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]\n")
 	g.pf("pub struct %s(pub %s);\n\n", d.Name, rustUint(d.StorageBits))
@@ -593,7 +593,7 @@ func (g *gen) emitObject(d *ir.Object) {
 			}
 			stateName := capitalize(ctx) + d.Name + "State"
 			g.pf("// %s — the full simulation struct for the %s context: every `all`\n", stateName, ctx)
-			g.pf("// field plus the fields scoped [local, context = %s]\n", ctx)
+			g.pf("// field plus the fields scoped | local, context = %s\n", ctx)
 			g.allowNonCamel(stateName)
 			g.pf("#[derive(Clone, Copy, PartialEq, Debug)]\n")
 			g.pf("pub struct %s {\n", stateName)
@@ -613,7 +613,7 @@ func (g *gen) emitObject(d *ir.Object) {
 
 	deep, interp := splitObjectFields(d)
 
-	g.pf("// %sData_Deep — every non-[local] field, deep encodings: full state for\n", d.Name)
+	g.pf("// %sData_Deep — every non- | local field, deep encodings: full state for\n", d.Name)
 	g.pf("// client-side prediction\n")
 	g.allowNonCamel(d.Name + "Data_Deep")
 	g.pf("#[derive(Clone, Copy, PartialEq, Debug)]\n")
@@ -622,7 +622,7 @@ func (g *gen) emitObject(d *ir.Object) {
 	g.pf("}\n\n")
 	g.emitDefaultImpl(d.Name+"Data_Deep", deep, storageDeep)
 
-	g.pf("// %sData_Shallow — the [interpolate] fields on the quantized wire: the\n", d.Name)
+	g.pf("// %sData_Shallow — the | interpolate fields on the quantized wire: the\n", d.Name)
 	g.pf("// implementation detail on the way to interpolation on the client\n")
 	g.allowNonCamel(d.Name + "Data_Shallow")
 	g.pf("#[derive(Clone, Copy, PartialEq, Debug)]\n")
@@ -685,7 +685,7 @@ func (g *gen) emitField(f *ir.Field, v view) {
 		if f.FixedShallow {
 			g.pf("    // %s: %s narrowed to %d fractional bits (quantize = %s) — per-component\n",
 				f.Name, f.Type.Name, f.QuantShift, ir.RenderExpr(f.QuantScaleExpr))
-			g.pf("    // quantized units; bounds are the component's whole-unit [min, max] scaled\n")
+			g.pf("    // quantized units; bounds are the component's whole-unit | min, max scaled\n")
 			for _, comp := range st.Fields {
 				lo, hi, _, _, typ, _ := fixedShallowComp(f, comp)
 				g.pf("    pub %s_%s: %s, // in [%s, %s]\n", f.Name, comp.Name, typ, lo, hi)
@@ -764,9 +764,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf("[local, context = %s]", f.Context))
+			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
 		} else {
-			parts = append(parts, "[local] — no wire")
+			parts = append(parts, " | local — no wire")
 		}
 	}
 	if len(parts) == 0 {
@@ -1000,7 +1000,7 @@ func fixedShallowComp(f, cf *ir.Field) (lo, hi *big.Int, bits int64, wide bool, 
 	return
 }
 
-// signedStorageBounds is the [min, max] domain of an iN storage type.
+// signedStorageBounds is the | min, max domain of an iN storage type.
 func signedStorageBounds(width int) (lo, hi *big.Int) {
 	lo = new(big.Int).Neg(new(big.Int).Lsh(big.NewInt(1), uint(width-1)))
 	hi = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(width-1)), big.NewInt(1))

--- a/internal/codegen/rust/rust_test.go
+++ b/internal/codegen/rust/rust_test.go
@@ -50,9 +50,9 @@ const FloorLimit = -9223372036854775808
 const RotationUnits = 3000
 
 type ExtremeProbe {
-    floor_bound   int64 [min = -9223372036854775808, max = 100]
-    doubled_floor int64 [min = --FloorLimit, max = 100]
-    spin_rate     int32 [min = --RotationUnits, max = RotationUnits * 2]
+    floor_bound   int64 | min = -9223372036854775808, max = 100
+    doubled_floor int64 | min = --FloorLimit, max = 100
+    spin_rate     int32 | min = --RotationUnits, max = RotationUnits * 2
     floor_default int64 = -9223372036854775808
 }
 `

--- a/internal/codegen/rust/table.go
+++ b/internal/codegen/rust/table.go
@@ -567,7 +567,7 @@ func (g *tableGen) emitClampInt(f *ir.Field, kind int, src, lvalue, ind string) 
 	if f.Type.Kind == ir.TNamed {
 		if e, isEnum := f.Type.Ref.(*ir.Enum); isEnum {
 			// Enum.Max is the top WIRE value — the variant count, or the
-			// [max = K] widening. Values above it are not wire-legal, so they
+			// | max = K widening. Values above it are not wire-legal, so they
 			// clamp to None (0) and count, matching the other three backends.
 			g.pf("%slet mut v = %s;\n", ind, src)
 			g.pf("%sif v as u64 > %d { v = 0; report.clamped += 1; }\n", ind, e.Max)
@@ -682,7 +682,7 @@ pub struct TableFieldInfo {
     pub array_bound: i64,
     /// nested table's descriptor
     pub table: Option<&'static TableTypeInfo>,
-    /// a declared [min, max] (int or float)
+    /// a declared | min, max (int or float)
     pub has_range: bool,
     /// NOTE: i64 ranges beyond 2^53 lose precision here
     pub range_min: f64,

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -178,56 +178,16 @@ func dropTrailingCommaOneLine(tokens []scanner.Token) []scanner.Token {
 	return tokens
 }
 
-// reorderAttrs rewrites every [ ... ] attribute list on the line with
-// valueless markers first, then valued keys, both in stable order — except
-// array bounds, which are not attribute lists (they FOLLOW no expression
-// context that has keys; a bound never contains a comma at the top level in
-// v1, so any bracket group containing `=` or lone identifiers only is safe
-// to normalize, and groups that are bounds pass through unchanged).
+// reorderAttrs rewrites a line's | qualification section with valueless
+// markers first, then valued keys, both in stable order (SPEC §7.4 rule 3).
+// The section runs from the first top-level | to the end of the line, so
+// there is at most one and nothing can follow it.
 func reorderAttrs(tokens []scanner.Token) []scanner.Token {
-	out := make([]scanner.Token, 0, len(tokens))
-	i := 0
-	for i < len(tokens) {
-		t := tokens[i]
-		if t.Kind != scanner.LBrack || !isAttrOpen(tokens, i) {
-			out = append(out, t)
-			i++
+	for i, t := range tokens {
+		if t.Kind != scanner.Pipe {
 			continue
 		}
-		// collect the bracket group
-		j := i + 1
-		depth := 1
-		for j < len(tokens) && depth > 0 {
-			switch tokens[j].Kind {
-			case scanner.LBrack:
-				depth++
-			case scanner.RBrack:
-				depth--
-			}
-			j++
-		}
-		if depth != 0 {
-			// The bracket group does not close on this line. reorderAttrs runs
-			// per LINE, and the scanner deliberately suppresses the newline
-			// after `[` and `,` so that attribute lists MAY wrap (SPEC §4.1) —
-			// so this is ordinary valid source, not malformed input:
-			//
-			//     a int32 [
-			//         min = 0,
-			//         max = 10
-			//     ]
-			//
-			// Reordering needs the whole group, and we do not have it. Emit the
-			// rest of the line untouched. Previously this fell through to
-			// tokens[i+1 : j-1] with j == i+1 and panicked the process — from
-			// `check`, `generate`, `id`, `fmt` and `pack` alike, since they all
-			// format before parsing.
-			out = append(out, tokens[i:]...)
-			return out
-		}
-
-		group := tokens[i+1 : j-1] // inside the brackets
-		entries := splitTop(group, scanner.Comma)
+		entries := splitTop(tokens[i+1:], scanner.Comma)
 		var valueless, valued [][]scanner.Token
 		for _, e := range entries {
 			if containsKind(e, scanner.Assign) {
@@ -236,7 +196,7 @@ func reorderAttrs(tokens []scanner.Token) []scanner.Token {
 				valueless = append(valueless, e)
 			}
 		}
-		out = append(out, tokens[i]) // [
+		out := append([]scanner.Token{}, tokens[:i+1]...)
 		first := true
 		for _, e := range append(valueless, valued...) {
 			if !first {
@@ -245,10 +205,9 @@ func reorderAttrs(tokens []scanner.Token) []scanner.Token {
 			first = false
 			out = append(out, e...)
 		}
-		out = append(out, tokens[j-1]) // ]
-		i = j
+		return out
 	}
-	return out
+	return tokens
 }
 
 // isAttrOpen reports whether the [ at index i opens an ATTRIBUTE list rather
@@ -491,12 +450,12 @@ func splitField(s string) (name, typ, tail string, ok bool) {
 	if rest == "" || strings.HasPrefix(rest, "//") {
 		return "", "", "", false
 	}
-	// the type runs to the first ` [` (attributes) or ` =` (default)
+	// the DEFINITION (type plus any `= default`) runs to the first ` |` —
+	// the qualification column is padded past the longest definition in the
+	// run (SPEC §7.4 rule 2)
 	typ = rest
 	tail = ""
-	if k := strings.Index(rest, " ["); k >= 0 {
-		typ, tail = rest[:k], strings.TrimLeft(rest[k:], " ")
-	} else if k := strings.Index(rest, " ="); k >= 0 {
+	if k := strings.Index(rest, " |"); k >= 0 {
 		typ, tail = rest[:k], strings.TrimLeft(rest[k:], " ")
 	}
 	if strings.HasSuffix(typ, "{") {

--- a/internal/format/migrate.go
+++ b/internal/format/migrate.go
@@ -72,7 +72,7 @@ func Migrate(path string, src []byte) ([]byte, error) {
 		tokens := l.tokens
 
 		// [<= N] -> [..N] (the #125 respell)
-		for i := 0; i < len(tokens); i++ {
+		for i := range tokens {
 			if tokens[i].Kind == scanner.LessEq && i > 0 && tokens[i-1].Kind == scanner.LBrack {
 				tokens[i] = scanner.Token{Kind: scanner.DotDot, Text: "..", Pos: tokens[i].Pos}
 			}

--- a/internal/format/migrate.go
+++ b/internal/format/migrate.go
@@ -1,0 +1,142 @@
+// The one-shot migration mode (SPEC §7.4 rule 3b): `schema fmt -migrate`
+// accepts the RETIRED spellings and re-emits the file in the current
+// canonical form — the trailing [ ... ] attribute block becomes a |
+// qualification section, the specified default moves before the pipe, a
+// qualified declaration's body brace moves to the next line, and the
+// [<= N] bound respells as [..N]. Plain fmt refuses retired spellings
+// exactly as the compiler does; this mode exists so downstream schemas
+// respell mechanically, once.
+package format
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/internal/scanner"
+)
+
+// Migrate rewrites retired spellings in src into the current grammar, then
+// formats the result (Format's own safety net — re-parse, fingerprint,
+// idempotence — runs over the migrated text).
+func Migrate(path string, src []byte) ([]byte, error) {
+	raw, errs := scanner.ScanRaw(path, src)
+	if len(errs) > 0 {
+		return nil, errs[0]
+	}
+
+	// assemble physical lines, the render pass's own move
+	type mline struct {
+		tokens  []scanner.Token
+		comment string
+	}
+	var lines []mline
+	cur := mline{}
+	flush := func() {
+		lines = append(lines, cur)
+		cur = mline{}
+	}
+	for _, t := range raw {
+		switch t.Kind {
+		case scanner.Newline:
+			flush()
+		case scanner.EOF:
+			if len(cur.tokens) > 0 || cur.comment != "" {
+				flush()
+			}
+		case scanner.Comment:
+			cur.comment = strings.TrimRight(t.Text, " \t")
+		default:
+			cur.tokens = append(cur.tokens, t)
+		}
+	}
+
+	var out []string
+	emit := func(tokens []scanner.Token, comment string) {
+		var b strings.Builder
+		for i, t := range tokens {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(t.Text)
+		}
+		if comment != "" {
+			if b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			b.WriteString(comment)
+		}
+		out = append(out, b.String())
+	}
+
+	for _, l := range lines {
+		tokens := l.tokens
+
+		// [<= N] -> [..N] (the #125 respell)
+		for i := 0; i < len(tokens); i++ {
+			if tokens[i].Kind == scanner.LessEq && i > 0 && tokens[i-1].Kind == scanner.LBrack {
+				tokens[i] = scanner.Token{Kind: scanner.DotDot, Text: "..", Pos: tokens[i].Pos}
+			}
+		}
+
+		// find a trailing attribute block on this line
+		attrAt := -1
+		for i, t := range tokens {
+			if t.Kind == scanner.LBrack && isAttrOpen(tokens, i) {
+				attrAt = i
+				break
+			}
+		}
+		if attrAt < 0 {
+			emit(tokens, l.comment)
+			continue
+		}
+		// the group must close on this line: a wrapped block can carry
+		// interior comments that have no home right of a pipe (SPEC §7.4)
+		depth := 0
+		closeAt := -1
+		for j := attrAt; j < len(tokens); j++ {
+			switch tokens[j].Kind {
+			case scanner.LBrack:
+				depth++
+			case scanner.RBrack:
+				depth--
+				if depth == 0 {
+					closeAt = j
+				}
+			}
+			if closeAt >= 0 {
+				break
+			}
+		}
+		if closeAt < 0 {
+			return nil, fmt.Errorf("%s: the attribute block wraps across lines — unwrap the attribute block first, then migrate (SPEC §7.4)", tokens[attrAt].Pos)
+		}
+
+		head := tokens[:attrAt]
+		inner := tokens[attrAt+1 : closeAt]
+		rest := tokens[closeAt+1:]
+
+		pipe := scanner.Token{Kind: scanner.Pipe, Text: "|"}
+		switch {
+		case len(rest) == 0:
+			// a field line: definition | qualifiers
+			line := append(append([]scanner.Token{}, head...), pipe)
+			emit(append(line, inner...), l.comment)
+		case rest[0].Kind == scanner.Assign:
+			// the old default-after-attributes order: the default moves
+			// BEFORE the pipe — it defines the fresh value (SPEC §4.2)
+			line := append(append([]scanner.Token{}, head...), rest...)
+			line = append(line, pipe)
+			emit(append(line, inner...), l.comment)
+		default:
+			// a declaration line: the section claims the line, and the body
+			// (brace or variant list) opens on the next line (SPEC §4.2)
+			line := append(append([]scanner.Token{}, head...), pipe)
+			emit(append(line, inner...), l.comment)
+			emit(rest, "")
+		}
+	}
+
+	migrated := []byte(strings.Join(out, "\n") + "\n")
+	return Format(path, migrated)
+}

--- a/internal/format/migrate_test.go
+++ b/internal/format/migrate_test.go
@@ -1,0 +1,61 @@
+// The one-shot migration mode's own pin (SPEC §7.4 rule 3b): retired
+// spellings in, current canonical form out — the default moved before the
+// pipe, a qualified declaration's brace moved down, [<= N] respelled — and
+// the wrapped-block refusal.
+package format
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMigrateRewritesRetiredSpellings(t *testing.T) {
+	old := "package t\n" +
+		"\n" +
+		"enum Weapon [max = 15] { Laser, Missile }\n" +
+		"\n" +
+		"type T {\n" +
+		"    health int16 [min = 0, max = 100]\n" +
+		"    invulnerable bool [local] = true\n" +
+		"    w fixed(2, 30) [min = -1, max = 1] = 1.0\n" +
+		"    other uint8 [min = 0, max = 5] // trailing note\n" +
+		"    arr [<= 4]uint8\n" +
+		"}\n"
+	want := "package t\n" +
+		"\n" +
+		"enum Weapon | max = 15\n" +
+		"{ Laser, Missile }\n" +
+		"\n" +
+		"type T {\n" +
+		"    health       int16              | min = 0, max = 100\n" +
+		"    invulnerable bool = true        | local\n" +
+		"    w            fixed(2, 30) = 1.0 | min = -1, max = 1\n" +
+		"    other        uint8              | min = 0, max = 5 // trailing note\n" +
+		"    arr          [..4]uint8\n" +
+		"}\n"
+	got, err := Migrate("Old.schema", []byte(old))
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("migrate output diverges from the canonical form\n---- got ----\n%s---- want ----\n%s", got, want)
+	}
+
+	// idempotent over its own output, and plain Format agrees with it
+	again, err := Migrate("Old.schema", got)
+	if err != nil || string(again) != string(got) {
+		t.Errorf("migrate is not idempotent (err %v)", err)
+	}
+	plain, err := Format("Old.schema", got)
+	if err != nil || string(plain) != string(got) {
+		t.Errorf("plain fmt disagrees with migrated output (err %v)", err)
+	}
+}
+
+func TestMigrateRefusesWrappedAttributeBlock(t *testing.T) {
+	old := "package t\n\ntype T {\n    h int16 [\n        min = 0,\n        max = 100\n    ]\n}\n"
+	_, err := Migrate("Old.schema", []byte(old))
+	if err == nil || !strings.Contains(err.Error(), "unwrap the attribute block first") {
+		t.Errorf("a wrapped attribute block must be refused with the unwrap instruction, got %v", err)
+	}
+}

--- a/internal/fuzz/fuzz_test.go
+++ b/internal/fuzz/fuzz_test.go
@@ -133,21 +133,21 @@ func seedFromCorpus(f *testing.F, add func(string)) {
 var handSeeds = []string{
 	"package t\n",
 	"package t\nconst A = A + 1\n",
-	"package t\nenum E [max = E.Max] { One }\n",
+	"package t\nenum E | max = E.Max\n{ One }\n",
 	"package t\ntype A { b B }\ntype B { a A }\n",
-	"package t\ntype T { x fixed(48, 16) [min = -100, max = 100] }\n",
-	"package t\ntype T { x ufixed(48, 16) [min = 0, max = 281474976710655] }\n",
-	"package t\ntype T { x ufixed(16, 16) [min = -1, max = 100] }\n",
-	"package t\ntype T { x ufixed(64, 0) [min = 0, max = 18446744073709551615] }\n",
-	"package t\ntype T { n int32 [min = 0, max = 4294967295] }\n",
+	"package t\ntype T { x fixed(48, 16) | min = -100, max = 100 }\n",
+	"package t\ntype T { x ufixed(48, 16) | min = 0, max = 281474976710655 }\n",
+	"package t\ntype T { x ufixed(16, 16) | min = -1, max = 100 }\n",
+	"package t\ntype T { x ufixed(64, 0) | min = 0, max = 18446744073709551615 }\n",
+	"package t\ntype T { n int32 | min = 0, max = 4294967295 }\n",
 	"package t\ntype T { s string(0) }\n",
 	"package t\ntype T { xs [0]uint8 }\n",
-	"package t\ntype T { x float32 [min = 0, max = 1, resolution = 0] }\n",
-	"package t\nobject O { p V [interpolate, quantize = 0, max = 1] \n b bool }\ntype V { x float64 }\n",
+	"package t\ntype T { x float32 | min = 0, max = 1, resolution = 0 }\n",
+	"package t\nobject O { p V | interpolate, quantize = 0, max = 1 \n b bool }\ntype V { x float64 }\n",
 	"package t\ntype T {\n    c bool\n    if c { x uint8 } else { x uint8 }\n}\n",
-	"package t\ntype T { x uint64 [min = 0, max = 18446744073709551615] }\n",
-	"package t\ntype T { x int128 [min = -1267650600228229401496703205376, max = 1267650600228229401496703205376] }\n",
-	"package t\nenum E [max = 2147483648] { A }\n",
+	"package t\ntype T { x uint64 | min = 0, max = 18446744073709551615 }\n",
+	"package t\ntype T { x int128 | min = -1267650600228229401496703205376, max = 1267650600228229401496703205376 }\n",
+	"package t\nenum E | max = 2147483648\n{ A }\n",
 	"package t\ntype T { x bits(0) }\n",
 	"package t\ntype T { x bits(65) }\n",
 	// issue #95: the integer extremes. INT64_MIN has no direct literal in C
@@ -155,9 +155,9 @@ var handSeeds = []string{
 	// applies) and an above-INT64_MAX value has no signed rung to land on —
 	// both must reach the compiler in their guarded spellings, the doubled
 	// minus AT the extreme folding rather than rendering symbolically.
-	"package t\nconst F = -9223372036854775808\ntype T { x int64 [min = --F, max = 100] = -9223372036854775808 }\n",
-	"package t\nconst H uint64 = 18446744073709551615\ntype T { x uint64 [min = 1, max = 18446744073709551615] }\n",
-	"package t\ntable R {\n    x int64 [min = -9223372036854775808, max = 100] = -9223372036854775808\n    y uint64 [min = 1, max = 18446744073709551614]\n}\n",
+	"package t\nconst F = -9223372036854775808\ntype T { x int64 = -9223372036854775808 | min = --F, max = 100 }\n",
+	"package t\nconst H uint64 = 18446744073709551615\ntype T { x uint64 | min = 1, max = 18446744073709551615 }\n",
+	"package t\ntable R {\n    x int64 = -9223372036854775808 | min = -9223372036854775808, max = 100\n    y uint64 | min = 1, max = 18446744073709551614\n}\n",
 	// issue #100: a uint64 DEFAULT above INT64_MAX — the member-initializer
 	// path must suffix it ull like every other fold of the value (an
 	// unsuffixed decimal deduces unsigned, -Wimplicitly-unsigned-literal
@@ -184,11 +184,11 @@ func FuzzPipeline(f *testing.F) {
 // corpus — single-file for every fixed-point case — is exactly why they
 // survived so long.
 func FuzzPipelineTwoFiles(f *testing.F) {
-	f.Add("package t\nconst Lim = 100\n", "package t\ntype T { hp int32 [min = 0, max = Lim] }\n")
-	f.Add("package t\ntype T { hp int32 [min = 0, max = Lim] }\n", "package t\nconst Lim = 100\n")
-	f.Add("package t\nenum A [max = Z.Max] { One }\n", "package t\nenum Z [max = A.Max] { Two }\n")
-	f.Add("package t\nobject O { p V [interpolate, quantize = 1024] \n b bool }\n",
-		"package t\ntype V { x fixed(2, 30) [min = -1, max = 1] }\n")
+	f.Add("package t\nconst Lim = 100\n", "package t\ntype T { hp int32 | min = 0, max = Lim }\n")
+	f.Add("package t\ntype T { hp int32 | min = 0, max = Lim }\n", "package t\nconst Lim = 100\n")
+	f.Add("package t\nenum A | max = Z.Max\n{ One }\n", "package t\nenum Z | max = A.Max\n{ Two }\n")
+	f.Add("package t\nobject O { p V | interpolate, quantize = 1024 \n b bool }\n",
+		"package t\ntype V { x fixed(2, 30) | min = -1, max = 1 }\n")
 	f.Add("package t\ntype A { b B }\n", "package t\ntype B { a A }\n")
 	f.Fuzz(func(t *testing.T, a, b string) {
 		// A_ and Z_ so the pair straddles the §3.1 name sort in both

--- a/internal/fuzz/pack_fuzz_test.go
+++ b/internal/fuzz/pack_fuzz_test.go
@@ -34,15 +34,15 @@ type Inner {
 }
 
 table Cfg {
-    a     int32   [min = -1000, max = 1000] = 5
+    a     int32   = 5 | min = -1000, max = 1000
     b     float32                           = 1.5
-    big   uint64  [min = 0, max = 18446744073709551615]
+    big   uint64  | min = 0, max = 18446744073709551615
     mode  Mode                              = Beta
     caps  Caps
     name  string(32)
     blob  bytes(64)
     inner Inner
-    items [..8]int32 [min = 0, max = 255]
+    items [..8]int32 | min = 0, max = 255
     on    bool = true
 }
 `

--- a/internal/fuzz/property_test.go
+++ b/internal/fuzz/property_test.go
@@ -174,7 +174,7 @@ func TestFormatIsIdempotent(t *testing.T) {
 // source the formatter accepts must be a fixed point after one pass — and it
 // must mean the same thing. Idempotence alone is a trap: a formatter that
 // silently DROPPED an attribute (the exact class of the 9468155 crash, a
-// `[min = 0]` on a wrapped attribute list) is perfectly idempotent while
+// ` | min = 0` on a wrapped attribute list) is perfectly idempotent while
 // changing the wire of every field it touched. The protocol id is the low 64
 // bits of SHA-256 over the wire-shape projection, so "same id" is precisely
 // "same wire": for any source that checks, format() must preserve it.
@@ -222,8 +222,8 @@ func TestDiagnosticOrderIsDeterministic(t *testing.T) {
 	// error and the ordering is observable
 	const src = `package t
 
-type Aaa { x fixed(16, 16) [min = -100, max = 100] }
-type Bbb { y int128 [min = -10, max = 10] }
+type Aaa { x fixed(16, 16) | min = -100, max = 100 }
+type Bbb { y int128 | min = -10, max = 10 }
 type Ccc { z bits(96) }
 
 table Root {

--- a/internal/pack/encode.go
+++ b/internal/pack/encode.go
@@ -301,13 +301,13 @@ func (e *Encoder) encodeScalar(w *bitWriter, f *ir.Field, val any, fpath string)
 
 	case ir.TFixed:
 		if !f.HasIntRange {
-			// only a [local] field reaches no wire, and no [local] field is
+			// only a | local field reaches no wire, and no | local field is
 			// ever encoded — so this is a compiler bug, not a data error
 			spelling := "fixed"
 			if !f.Type.Signed {
 				spelling = "ufixed"
 			}
-			return fmt.Errorf("%s: %s(%d, %d) carries no [min, max] — the whole-unit bounds are part of the wire format (SPEC §4.3)",
+			return fmt.Errorf("%s: %s(%d, %d) carries no | min, max — the whole-unit bounds are part of the wire format (SPEC §4.3)",
 				fpath, spelling, f.Type.IntBits, f.Type.FracBits)
 		}
 		raw, err := e.fixedRaw(f, val, fpath)
@@ -413,7 +413,7 @@ func (e *Encoder) boundInt(v, min, max *big.Int, fpath string) (*big.Int, error)
 // fixedRaw resolves a fixed(I, F) field's JSON value to its RAW scaled
 // integer — the value the wire carries an offset of.
 //
-// A JSON value is in WHOLE UNITS, the same domain as the field's [min, max]
+// A JSON value is in WHOLE UNITS, the same domain as the field's | min, max
 // and its specified default (SPEC §4.6: "declared in WHOLE UNITS ... so no
 // raw/units confusion is possible"). Units × 2^F is rounded to nearest, half
 // away from zero — the ONE fixed-point rounding rule (SPEC §4.8, decided

--- a/internal/pack/table_test.go
+++ b/internal/pack/table_test.go
@@ -48,12 +48,12 @@ type Inner {
 }
 
 table Cfg {
-    a     int32   [min = 0, max = 1000] = 5
+    a     int32   = 5 | min = 0, max = 1000
     b     float32                       = 1.5
     mode  Mode                          = Beta
     name  string(32)
     inner Inner
-    items [..8]int32 [min = 0, max = 255]
+    items [..8]int32 | min = 0, max = 255
 }
 `
 
@@ -73,7 +73,7 @@ table Cfg {
     mode  Mode    = Beta
     name  string(32)
     inner Inner
-    items [..8]int32 [min = 0, max = 255]
+    items [..8]int32 | min = 0, max = 255
 }
 `
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -165,6 +165,10 @@ func (p *parser) parseDecl() {
 		}
 		p.expect(scanner.Assign, "=")
 		d.Expr = p.parseExpr()
+		if p.kind() == scanner.Pipe {
+			p.errf(p.tok().Pos, "a constant takes no qualification, and | is never an operator — the language has no bitwise-or (SPEC §4.2)")
+			p.skipToTerminator()
+		}
 		p.expectTerminator("constant declaration")
 		p.file.Decls = append(p.file.Decls, d)
 
@@ -172,9 +176,7 @@ func (p *parser) parseDecl() {
 		p.advance()
 		name := p.expect(scanner.Ident, "enum name")
 		d := &ast.EnumDecl{Name: name.Text, Pos: t.Pos}
-		if p.kind() == scanner.LBrack {
-			d.Attrs = p.parseAttrs()
-		}
+		d.Attrs = p.declQualifiers("enum")
 		d.Variants = p.parseVariantList("enum")
 		p.expectTerminator("enum declaration")
 		p.file.Decls = append(p.file.Decls, d)
@@ -183,9 +185,7 @@ func (p *parser) parseDecl() {
 		p.advance()
 		name := p.expect(scanner.Ident, "type name")
 		d := &ast.TypeDecl{Name: name.Text, Pos: t.Pos}
-		if p.kind() == scanner.LBrack {
-			d.Attrs = p.parseAttrs()
-		}
+		d.Attrs = p.declQualifiers("type")
 		d.Body = p.parseBlock()
 		p.expectTerminator("type declaration")
 		p.file.Decls = append(p.file.Decls, d)
@@ -196,9 +196,7 @@ func (p *parser) parseDecl() {
 		p.advance()
 		name := p.expect(scanner.Ident, "table name")
 		d := &ast.TypeDecl{Name: name.Text, Pos: t.Pos, IsTable: true}
-		if p.kind() == scanner.LBrack {
-			d.Attrs = p.parseAttrs()
-		}
+		d.Attrs = p.declQualifiers("table")
 		d.Body = p.parseBlock()
 		p.expectTerminator("table declaration")
 		p.file.Decls = append(p.file.Decls, d)
@@ -207,6 +205,10 @@ func (p *parser) parseDecl() {
 		p.advance()
 		name := p.expect(scanner.Ident, "message name")
 		d := &ast.MessageDecl{Name: name.Text, Pos: t.Pos}
+		if p.kind() == scanner.Pipe {
+			p.errf(p.tok().Pos, "a message declaration takes no qualification (SPEC §4.2)")
+			p.skipToTerminator()
+		}
 		d.Body = p.parseBlock()
 		p.expectTerminator("message declaration")
 		p.file.Decls = append(p.file.Decls, d)
@@ -215,6 +217,10 @@ func (p *parser) parseDecl() {
 		p.advance()
 		name := p.expect(scanner.Ident, "object name")
 		d := &ast.ObjectDecl{Name: name.Text, Pos: t.Pos}
+		if p.kind() == scanner.Pipe {
+			p.errf(p.tok().Pos, "an object declaration takes no qualification (SPEC §4.2)")
+			p.skipToTerminator()
+		}
 		d.Body = p.parseBlock()
 		p.expectTerminator("object declaration")
 		p.file.Decls = append(p.file.Decls, d)
@@ -234,9 +240,7 @@ func (p *parser) parseDecl() {
 			p.advance()
 			name := p.expect(scanner.Ident, "flags name")
 			d := &ast.FlagsDecl{Name: name.Text, Pos: t.Pos}
-			if p.kind() == scanner.LBrack {
-				d.Attrs = p.parseAttrs()
-			}
+			d.Attrs = p.declQualifiers("flags")
 			d.Variants = p.parseVariantList("flags")
 			p.expectTerminator("flags declaration")
 			p.file.Decls = append(p.file.Decls, d)
@@ -250,6 +254,10 @@ func (p *parser) parseDecl() {
 			p.advance()
 			name := p.expect(scanner.Ident, "union name")
 			d := &ast.UnionDecl{Name: name.Text, Pos: t.Pos}
+			if p.kind() == scanner.Pipe {
+				p.errf(p.tok().Pos, "a union declaration takes no qualification (SPEC §4.2)")
+				p.skipToTerminator()
+			}
 			d.Variants = p.parseUnionBody()
 			p.expectTerminator("union declaration")
 			p.file.Decls = append(p.file.Decls, d)
@@ -437,15 +445,26 @@ func (p *parser) parseItem() ast.Item {
 			f.Array = p.parseArrayBound()
 		}
 		f.Type = p.parseScalar()
-		if p.kind() == scanner.LBrack {
-			f.Attrs = p.parseAttrs()
-		}
 		if p.kind() == scanner.Assign {
-			// optional specified default: `invulnerable bool [local] = true`
-			// (Glenn, 2026-08-05: zero initialization everywhere, "unless we
-			// allow some specified default, eg. ... = true")
+			// optional specified default: `invulnerable bool = true | local`
+			// — the default DEFINES the fresh value, so it precedes the
+			// qualification (SPEC §4.2)
 			p.advance()
 			f.Default = p.parseExpr()
+		}
+		if p.kind() == scanner.LBrack {
+			// the RETIRED trailing attribute block (SPEC §4.2) — refuse with
+			// the replacement named, then parse the group so the rest of the
+			// file's diagnostics still land
+			p.errf(p.tok().Pos, "the [ ... ] attribute block is retired — qualifiers follow | to the end of the line (SPEC §4.2)")
+			f.Attrs = p.parseBracketAttrs()
+			if p.kind() == scanner.Assign { // the old default-after-attrs order
+				p.advance()
+				f.Default = p.parseExpr()
+			}
+		}
+		if p.kind() == scanner.Pipe {
+			f.Attrs = p.parsePipeAttrs()
 		}
 		p.expectTerminator("field")
 		return f
@@ -549,7 +568,55 @@ func (p *parser) parseScalar() ast.ScalarType {
 	}
 }
 
-func (p *parser) parseAttrs() []ast.Attr {
+// declQualifiers parses a declaration line's optional qualification: the |
+// section (which runs to end of line, so the caller's body opens on the NEXT
+// line — the newline is consumed here), or the RETIRED [ ... ] block,
+// refused by name but parsed so diagnosis continues (SPEC §4.2).
+func (p *parser) declQualifiers(what string) []ast.Attr {
+	switch p.kind() {
+	case scanner.LBrack:
+		p.errf(p.tok().Pos, "the [ ... ] attribute block is retired — a %s's qualifiers follow | to the end of the line, and the body opens on the next line (SPEC §4.2)", what)
+		return p.parseBracketAttrs()
+	case scanner.Pipe:
+		attrs := p.parsePipeAttrs()
+		if p.kind() == scanner.Newline {
+			p.advance() // the section claimed the line; the body opens below
+		}
+		return attrs
+	}
+	return nil
+}
+
+// parsePipeAttrs parses a | qualification section: comma-separated
+// attributes running to the end of the line (SPEC §4.2). The terminator is
+// left for the caller. An empty section is a parse error.
+func (p *parser) parsePipeAttrs() []ast.Attr {
+	var attrs []ast.Attr
+	pipe := p.expect(scanner.Pipe, "|")
+	for p.kind() == scanner.Ident {
+		key := p.advance()
+		a := ast.Attr{Key: key.Text, Pos: key.Pos}
+		if p.kind() == scanner.Assign {
+			p.advance()
+			a.Value = p.parseExpr() // a bare word value (round = up) parses as an IdentExpr
+		}
+		attrs = append(attrs, a)
+		if p.kind() == scanner.Comma {
+			p.advance()
+			continue
+		}
+		break
+	}
+	if len(attrs) == 0 {
+		p.errf(pipe.Pos, "empty qualification section — write the qualifiers after | or drop it (SPEC §4.2)")
+	}
+	return attrs
+}
+
+// parseBracketAttrs parses the RETIRED [ ... ] attribute block — kept so the
+// named refusal can recover and keep diagnosing the rest of the file, and so
+// `schema fmt -migrate` can rewrite old sources (SPEC §7.4).
+func (p *parser) parseBracketAttrs() []ast.Attr {
 	var attrs []ast.Attr
 	p.expect(scanner.LBrack, "[")
 	for p.kind() != scanner.RBrack && p.kind() != scanner.EOF {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -34,7 +34,8 @@ const (
 	Not    // !
 	Dot    // .
 	DotDot // ..
-	LessEq // <=
+	LessEq // <= — retired spelling; scanned so the parser can refuse it by name (SPEC §4.3)
+	Pipe   // | — opens a line's qualification section (SPEC §4.2)
 	Plus
 	Minus
 	Star
@@ -160,6 +161,7 @@ type state struct {
 	col          int
 	errs         []error
 	keepComments bool // raw-scan mode: comments become tokens
+	pipeLine     bool // right of | on the current line: no wrapping there (SPEC §4.1)
 }
 
 func (s *state) pos() Pos { return Pos{s.file, s.line, s.col} }
@@ -243,8 +245,15 @@ func (s *state) next() Token {
 				if s.keepComments {
 					return Token{Comment, string(s.src[start:s.off]), p}
 				}
+				if s.pipeLine {
+					// the qualification section runs to the PHYSICAL end of
+					// line; a block comment could swallow that newline and
+					// let the section silently span lines (SPEC §4.1)
+					s.errf(p, "a /* */ comment cannot sit right of | — the qualification section runs to the end of the line; use a trailing // comment (SPEC §4.1)")
+				}
 				if s.line > startLine {
 					// a block comment spanning lines acts as a newline (Go's rule)
+					s.pipeLine = false
 					return Token{Newline, "\n", p}
 				}
 				continue
@@ -261,6 +270,7 @@ func (s *state) next() Token {
 		switch {
 		case c == '\n':
 			s.advance()
+			s.pipeLine = false
 			return Token{Newline, "\n", p}
 
 		case isIdentStart(c):
@@ -323,6 +333,9 @@ func (s *state) next() Token {
 				return Token{Slash, "/", p}
 			case '%':
 				return Token{Percent, "%", p}
+			case '|':
+				s.pipeLine = true
+				return Token{Pipe, "|", p}
 			case '.':
 				if s.peek() == '.' {
 					s.advance()
@@ -419,15 +432,20 @@ func filter(raw []Token) []Token {
 	suppressBefore := map[Kind]bool{RParen: true, RBrack: true, RBrace: true}
 
 	var out []Token
+	sincePipe := false // right of |, ALL suppression is off (SPEC §4.1)
 	for _, t := range raw {
+		if t.Kind == Pipe {
+			sincePipe = true
+		}
 		if t.Kind == Newline {
 			if len(out) == 0 {
 				continue // leading newlines
 			}
 			last := out[len(out)-1].Kind
-			if last == Newline || suppressAfter[last] {
+			if last == Newline || (suppressAfter[last] && !sincePipe) {
 				continue
 			}
+			sincePipe = false
 			out = append(out, t)
 			continue
 		}

--- a/ir/align_test.go
+++ b/ir/align_test.go
@@ -54,7 +54,7 @@ type MarkedWholeBytesBetween {
 
 type UnmarkedRanged {
     align
-    data [4]uint8 [min = 0, max = 255]
+    data [4]uint8 | min = 0, max = 255
 }
 
 type UnmarkedCounted {

--- a/ir/expr_test.go
+++ b/ir/expr_test.go
@@ -34,12 +34,12 @@ const NumTeams = Team.Max
 const TeamsPlus = Team.Max + 1
 
 type Bounds {
-    object_id int32 [min = 0, max = MaxObjects - 1]
-    delta     int32 [min = -MaxUnits, max = MaxUnits]
-    hexed     int32 [min = 0, max = 0x10]
+    object_id int32 | min = 0, max = MaxObjects - 1
+    delta     int32 | min = -MaxUnits, max = MaxUnits
+    hexed     int32 | min = 0, max = 0x10
     counted   [..MaxObjects]uint8
     name      string(MaxUnits)
-    retries   int32 [min = 0, max = MaxObjects] = HalfObjects
+    retries   int32 = HalfObjects | min = 0, max = MaxObjects
 }
 `
 

--- a/ir/filedeps_test.go
+++ b/ir/filedeps_test.go
@@ -47,17 +47,17 @@ func TestFileDepsCoversEverySymbolicExpression(t *testing.T) {
 		name string
 		use  string
 	}{
-		{"int range min/max", "package t\ntype T { hp int32 [min = -Lim, max = Lim] }\n"},
-		{"fixed range min/max", "package t\ntype T { p fixed(48, 16) [min = -Lim, max = Lim] }\n"},
+		{"int range min/max", "package t\ntype T { hp int32 | min = -Lim, max = Lim }\n"},
+		{"fixed range min/max", "package t\ntype T { p fixed(48, 16) | min = -Lim, max = Lim }\n"},
 		{"array bound", "package t\ntype T { xs [Lim]uint8 }\n"},
 		{"counted array bound", "package t\ntype T { xs [..Lim]uint8 }\n"},
 		{"string size", "package t\ntype T { s string(Lim) }\n"},
 		{"bytes size", "package t\ntype T { b bytes(Lim) }\n"},
-		{"specified default", "package t\ntype T { n int32 [min = 0, max = 1000] = Lim }\n"},
-		{"composite quantize scale and max", "package t\ntype V { x float64\n y float64 }\nobject O {\n    p V [interpolate, quantize = Lim, max = 1]\n    b bool\n}\n"},
+		{"specified default", "package t\ntype T { n int32 = Lim | min = 0, max = 1000 }\n"},
+		{"composite quantize scale and max", "package t\ntype V { x float64\n y float64 }\nobject O {\n    p V | interpolate, quantize = Lim, max = 1\n    b bool\n}\n"},
 		// the bound inside a nested expression, not at the top of the tree
-		{"range bound in a binary expression", "package t\ntype T { hp int32 [min = 0, max = Lim * 2 + 1] }\n"},
-		{"range bound under a unary minus", "package t\ntype T { hp int32 [min = -Lim, max = 0] }\n"},
+		{"range bound in a binary expression", "package t\ntype T { hp int32 | min = 0, max = Lim * 2 + 1 }\n"},
+		{"range bound under a unary minus", "package t\ntype T { hp int32 | min = -Lim, max = 0 }\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestFileDepsCoversEverySymbolicExpression(t *testing.T) {
 // the wrong file.
 func TestFileDepsRangeBoundDrivesMessageOwner(t *testing.T) {
 	u := loadFiles(t, map[string]string{
-		"Aaa.schema": "package t\nmessage Ma { hp int32 [min = 0, max = Limit] }\n",
+		"Aaa.schema": "package t\nmessage Ma { hp int32 | min = 0, max = Limit }\n",
 		"Bbb.schema": "package t\nconst Limit = 100\nmessage Mb { x uint8 }\n",
 	})
 	deps := ir.FileDeps(u)

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -63,14 +63,14 @@ type Const struct {
 type Enum struct {
 	Name        string
 	Variants    []string // implicit None = 0 is not listed; variants pack from 1
-	Max         int64    // top wire value: variant count, or the [max = K] widening
+	Max         int64    // top wire value: variant count, or the | max = K widening
 	StorageBits int      // 8 / 16 / 32 / 64 — smallest unsigned fitting Max
 }
 
 type Flags struct {
 	Name     string
 	Variants []string // bit i is variant i
-	WireBits int      // variant count, or the [max = K] widening
+	WireBits int      // variant count, or the | max = K widening
 }
 
 // ContextsMarker records the contexts declaration in its declaring file so the
@@ -381,7 +381,7 @@ func FixedShallowBounds(f *Field, cf *Field) (lo, hi *big.Int) {
 }
 
 // ObjectNeedsQuantize reports whether an object's Quantize/Unquantize pair
-// does any work: true when some [interpolate] field quantizes a composite
+// does any work: true when some | interpolate field quantizes a composite
 // (HasQuantize) or projects a float (HasFloatRange). When false the pair
 // would be a pure member copy — fixed-point components are their own
 // quantization (SPEC §4.8) — and the backends do not emit it at all.

--- a/ir/projection.go
+++ b/ir/projection.go
@@ -25,7 +25,7 @@ package ir
 //                            protocols; conservative, and can only add ids
 //   message ordinals         the MessageType tag is the message's index
 //   object ordinals          the ObjectType tag likewise
-//   contexts                 a context scopes [local] fields out of a view
+//   contexts                 a context scopes | local fields out of a view
 //   every type's fields      order IS the wire order
 //   field names              the TABLE wire's field identity is
 //                            fold16(fnv1a32(name)) — a rename moves data
@@ -214,7 +214,7 @@ func projectField(b *strings.Builder, f *Field, ind string) {
 			f.QuantScale, f.QuantBound, f.FixedShallow, f.QuantShift)
 	}
 	// view membership changes which fields appear in which generated view,
-	// and a [local] field is off the deep wire entirely
+	// and a | local field is off the deep wire entirely
 	if f.Local {
 		b.WriteString(" local")
 	}

--- a/testdata/golden/c/Contexts.h
+++ b/testdata/golden/c/Contexts.h
@@ -25,7 +25,7 @@ extern "C" {
 
 /* contexts declared for this unit: client, server (SPEC §4.2).
    Contexts generate no standalone artifacts — where an object carries
-   context-scoped [local] fields, its State struct is generated once per
+   context-scoped | local fields, its State struct is generated once per
    context (ClientShipState, ServerShipState, ...), each holding the `all`
    fields plus its own context's. No preprocessor in any target. */
 

--- a/testdata/golden/c/Enums.h
+++ b/testdata/golden/c/Enums.h
@@ -26,7 +26,7 @@ extern "C" {
 
 /* enum Team — None = 0 implicit, variants dense from 1, wire range [0, 2]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t Team;
 #define TEAM_NONE 0
@@ -62,7 +62,7 @@ static SCHEMA_UNUSED const char * enum_name_team_dyn( uint64_t value )
 
 /* enum ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t ShipType;
 #define SHIP_TYPE_NONE 0
@@ -107,7 +107,7 @@ static SCHEMA_UNUSED const char * enum_name_ship_type_dyn( uint64_t value )
 
 /* enum MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t MissileType;
 #define MISSILE_TYPE_NONE 0
@@ -146,7 +146,7 @@ static SCHEMA_UNUSED const char * enum_name_missile_type_dyn( uint64_t value )
 
 /* enum PropType — None = 0 implicit, variants dense from 1, wire range [0, 6]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t PropType;
 #define PROP_TYPE_NONE 0
@@ -194,7 +194,7 @@ static SCHEMA_UNUSED const char * enum_name_prop_type_dyn( uint64_t value )
 
 /* enum Pending — None = 0 implicit, variants dense from 1, wire range [0, 0]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t Pending;
 #define PENDING_NONE 0

--- a/testdata/golden/c/Objects.h
+++ b/testdata/golden/c/Objects.h
@@ -30,7 +30,7 @@ extern "C" {
 /* ---- object Ship — one definition, a generated family per target (SPEC §4.8) ---- */
 
 /* ClientShipState — the full simulation struct for the client context: every `all`
-   field plus the fields scoped [local, context = client] */
+   field plus the fields scoped | local, context = client */
 typedef struct ClientShipState {
     ShipType ship_type;
     Vec3 position;
@@ -65,7 +65,7 @@ typedef struct ClientShipState {
 } ClientShipState;
 
 /* ServerShipState — the full simulation struct for the server context: every `all`
-   field plus the fields scoped [local, context = server] */
+   field plus the fields scoped | local, context = server */
 typedef struct ServerShipState {
     ShipType ship_type;
     Vec3 position;
@@ -98,7 +98,7 @@ typedef struct ServerShipState {
     int32_t collider_armor[MAX_COLLIDERS_PER_SHIP];
 } ServerShipState;
 
-/* ShipData_Deep — every non-[local] field, deep encodings: full state for
+/* ShipData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct ShipData_Deep {
     ShipType ship_type;
@@ -128,7 +128,7 @@ typedef struct ShipData_Deep {
     double lock_start_time;
 } ShipData_Deep;
 
-/* ShipData_Shallow — the [interpolate] fields on the quantized wire */
+/* ShipData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct ShipData_Shallow {
     ShipType ship_type;
     /* position: Vec3 quantized — per-component int in [-8388608, 8388608] */
@@ -336,7 +336,7 @@ static SCHEMA_UNUSED void unquantize_ship( const ShipData_Shallow * input, ShipD
 /* ---- object Missile — one definition, a generated family per target (SPEC §4.8) ---- */
 
 /* ClientMissileState — the full simulation struct for the client context: every `all`
-   field plus the fields scoped [local, context = client] */
+   field plus the fields scoped | local, context = client */
 typedef struct ClientMissileState {
     MissileType missile_type;
     Vec3 position;
@@ -349,7 +349,7 @@ typedef struct ClientMissileState {
 } ClientMissileState;
 
 /* ServerMissileState — the full simulation struct for the server context: every `all`
-   field plus the fields scoped [local, context = server] */
+   field plus the fields scoped | local, context = server */
 typedef struct ServerMissileState {
     MissileType missile_type;
     Vec3 position;
@@ -362,7 +362,7 @@ typedef struct ServerMissileState {
     double timer;
 } ServerMissileState;
 
-/* MissileData_Deep — every non-[local] field, deep encodings: full state for
+/* MissileData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct MissileData_Deep {
     MissileType missile_type;
@@ -373,7 +373,7 @@ typedef struct MissileData_Deep {
     uint64_t flags;
 } MissileData_Deep;
 
-/* MissileData_Shallow — the [interpolate] fields on the quantized wire */
+/* MissileData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct MissileData_Shallow {
     MissileType missile_type;
     /* position: Vec3 quantized — per-component int in [-8388608, 8388608] */
@@ -583,7 +583,7 @@ typedef struct DynamicPropState {
     Vec3 angular_velocity;
 } DynamicPropState;
 
-/* DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+/* DynamicPropData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct DynamicPropData_Deep {
     PropType prop_type;
@@ -594,7 +594,7 @@ typedef struct DynamicPropData_Deep {
     Team team;
 } DynamicPropData_Deep;
 
-/* DynamicPropData_Shallow — the [interpolate] fields on the quantized wire */
+/* DynamicPropData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct DynamicPropData_Shallow {
     PropType prop_type;
     /* position: Vec3 quantized — per-component int in [-8388608, 8388608] */
@@ -802,7 +802,7 @@ typedef struct TurretState {
     Team team;
 } TurretState;
 
-/* TurretData_Deep — every non-[local] field, deep encodings: full state for
+/* TurretData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct TurretData_Deep {
     Handle parent;
@@ -811,7 +811,7 @@ typedef struct TurretData_Deep {
     uint64_t flags;
 } TurretData_Deep;
 
-/* TurretData_Shallow — the [interpolate] fields on the quantized wire */
+/* TurretData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct TurretData_Shallow {
     Handle parent;
     int32_t turret_index;

--- a/testdata/golden/c/TableRuntime.h
+++ b/testdata/golden/c/TableRuntime.h
@@ -51,7 +51,7 @@ typedef struct table_field_info_t
     int counted;              /* a count/length companion exists */
     int64_t array_bound;      /* array capacity / string max length; 0 for scalars */
     const struct table_type_info_t * table;  /* nested table's descriptor, or NULL */
-    int has_range;            /* a declared [min, max] */
+    int has_range;            /* a declared | min, max */
     double range_min;         /* NOTE: int64 ranges beyond 2^53 lose precision here */
     double range_max;
     int64_t enum_max;         /* enums: highest valid wire value; else -1 */

--- a/testdata/golden/c/Wire.h
+++ b/testdata/golden/c/Wire.h
@@ -31,7 +31,7 @@ extern "C" {
 
 /* enum Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t Weapon;
 #define WEAPON_NONE 0

--- a/testdata/golden/cs/Contexts.cs
+++ b/testdata/golden/cs/Contexts.cs
@@ -6,7 +6,7 @@ namespace Example
 
     // contexts declared for this unit: client, server (SPEC §4.2).
     // Contexts generate no standalone artifacts — where an object carries
-    // context-scoped [local] fields, its State class is generated once per
+    // context-scoped | local fields, its State class is generated once per
     // context (ClientShipState, ServerShipState, ...), each holding the `all`
     // fields plus its own context's. No preprocessor symbols in this target.
 

--- a/testdata/golden/cs/Enums.cs
+++ b/testdata/golden/cs/Enums.cs
@@ -5,7 +5,7 @@ namespace Example
 {
 
     // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum Team : byte
     {
@@ -16,7 +16,7 @@ namespace Example
     }
 
     // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum ShipType : byte
     {
@@ -30,7 +30,7 @@ namespace Example
     }
 
     // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum MissileType : byte
     {
@@ -42,7 +42,7 @@ namespace Example
     }
 
     // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum PropType : byte
     {
@@ -57,7 +57,7 @@ namespace Example
     }
 
     // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum Pending : byte
     {

--- a/testdata/golden/cs/Objects.cs
+++ b/testdata/golden/cs/Objects.cs
@@ -29,7 +29,7 @@ namespace Example
     // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
     // ClientShipState — the full simulation class for the client context: every `all`
-    // field plus the fields scoped [local, context = client]
+    // field plus the fields scoped | local, context = client
     public sealed class ClientShipState
     {
         public ShipType ShipType;
@@ -57,15 +57,15 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; // [local] — no wire
-        public Vec3 PreviousPosition = new Vec3(); // [local] — no wire
-        public int NumColliders; // [local] — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // [local] — no wire
-        public bool PredictedExplode; // [local, context = client]
+        public bool Invulnerable; //  | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
+        public int NumColliders; //  | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
+        public bool PredictedExplode; //  | local, context = client
     }
 
     // ServerShipState — the full simulation class for the server context: every `all`
-    // field plus the fields scoped [local, context = server]
+    // field plus the fields scoped | local, context = server
     public sealed class ServerShipState
     {
         public ShipType ShipType;
@@ -93,13 +93,13 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; // [local] — no wire
-        public Vec3 PreviousPosition = new Vec3(); // [local] — no wire
-        public int NumColliders; // [local] — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // [local] — no wire
+        public bool Invulnerable; //  | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
+        public int NumColliders; //  | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
     }
 
-    // ShipData_Deep — every non-[local] field, deep encodings: full state for
+    // ShipData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class ShipData_Deep
     {
@@ -130,7 +130,7 @@ namespace Example
         public double LockStartTime;
     }
 
-    // ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+    // ShipData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class ShipData_Shallow
     {
@@ -172,7 +172,7 @@ namespace Example
     // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
     // ClientMissileState — the full simulation class for the client context: every `all`
-    // field plus the fields scoped [local, context = client]
+    // field plus the fields scoped | local, context = client
     public sealed class ClientMissileState
     {
         public MissileType MissileType;
@@ -181,12 +181,12 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); // [local] — no wire
-        public Handle Target = new Handle(); // [local] — no wire
+        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
+        public Handle Target = new Handle(); //  | local — no wire
     }
 
     // ServerMissileState — the full simulation class for the server context: every `all`
-    // field plus the fields scoped [local, context = server]
+    // field plus the fields scoped | local, context = server
     public sealed class ServerMissileState
     {
         public MissileType MissileType;
@@ -195,12 +195,12 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); // [local] — no wire
-        public Handle Target = new Handle(); // [local] — no wire
-        public double Timer; // [local, context = server]
+        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
+        public Handle Target = new Handle(); //  | local — no wire
+        public double Timer; //  | local, context = server
     }
 
-    // MissileData_Deep — every non-[local] field, deep encodings: full state for
+    // MissileData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class MissileData_Deep
     {
@@ -212,7 +212,7 @@ namespace Example
         public ulong Flags;
     }
 
-    // MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+    // MissileData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class MissileData_Shallow
     {
@@ -258,10 +258,10 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public ulong Flags;
         public Team Team;
-        public Vec3 AngularVelocity = new Vec3(); // [local] — no wire
+        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
     }
 
-    // DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+    // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class DynamicPropData_Deep
     {
@@ -273,7 +273,7 @@ namespace Example
         public Team Team;
     }
 
-    // DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+    // DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class DynamicPropData_Shallow
     {
@@ -317,10 +317,10 @@ namespace Example
         public int TurretIndex; // wire [0, 255]
         public Quat Rotation = new Quat();
         public ulong Flags;
-        public Team Team; // [local] — no wire
+        public Team Team; //  | local — no wire
     }
 
-    // TurretData_Deep — every non-[local] field, deep encodings: full state for
+    // TurretData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class TurretData_Deep
     {
@@ -330,7 +330,7 @@ namespace Example
         public ulong Flags;
     }
 
-    // TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+    // TurretData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class TurretData_Shallow
     {

--- a/testdata/golden/cs/TableRuntime.cs
+++ b/testdata/golden/cs/TableRuntime.cs
@@ -53,7 +53,7 @@ namespace Example
         public bool Counted;                 // a Count/Length companion exists (counted arrays, strings, bytes)
         public int ArrayBound;               // array capacity / string max length; 0 for plain scalars
         public TableTypeInfo Table;          // nested table's descriptor, or null
-        public bool HasRange;                // a declared [min, max] (int or float)
+        public bool HasRange;                // a declared | min, max (int or float)
         public double RangeMin;              // NOTE: int64 ranges beyond 2^53 lose precision here
         public double RangeMax;
         public long EnumMax;                 // enums: highest valid wire value (None = 0 always valid); else -1

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -16,7 +16,7 @@ namespace Example
 {
 
     // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum Weapon : byte
     {

--- a/testdata/golden/go/Contexts.go
+++ b/testdata/golden/go/Contexts.go
@@ -5,6 +5,6 @@ package example
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State struct is generated once per
+// context-scoped | local fields, its State struct is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's. No build tags in this target.

--- a/testdata/golden/go/Objects.go
+++ b/testdata/golden/go/Objects.go
@@ -24,7 +24,7 @@ const (
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 type ClientShipState struct {
 	ShipType            ShipType
 	Position            Vec3
@@ -51,15 +51,15 @@ type ClientShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       // [local] — no wire
-	PreviousPosition    Vec3                       // [local] — no wire
-	NumColliders        int32                      // [local] — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 // [local] — no wire
-	PredictedExplode    bool                       // [local, context = client]
+	Invulnerable        bool                       //  | local — no wire
+	PreviousPosition    Vec3                       //  | local — no wire
+	NumColliders        int32                      //  | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
+	PredictedExplode    bool                       //  | local, context = client
 }
 
 // ServerShipState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 type ServerShipState struct {
 	ShipType            ShipType
 	Position            Vec3
@@ -86,13 +86,13 @@ type ServerShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       // [local] — no wire
-	PreviousPosition    Vec3                       // [local] — no wire
-	NumColliders        int32                      // [local] — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 // [local] — no wire
+	Invulnerable        bool                       //  | local — no wire
+	PreviousPosition    Vec3                       //  | local — no wire
+	NumColliders        int32                      //  | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
 }
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type ShipData_Deep struct {
 	ShipType            ShipType
@@ -122,7 +122,7 @@ type ShipData_Deep struct {
 	LockStartTime       float64
 }
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type ShipData_Shallow struct {
 	ShipType ShipType
@@ -640,7 +640,7 @@ func UnquantizeShip(input *ShipData_Shallow, output *ShipData_Interpolate) {
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 type ClientMissileState struct {
 	MissileType     MissileType
 	Position        Vec3
@@ -648,12 +648,12 @@ type ClientMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3   // [local] — no wire
-	Target          Handle // [local] — no wire
+	AngularVelocity Vec3   //  | local — no wire
+	Target          Handle //  | local — no wire
 }
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 type ServerMissileState struct {
 	MissileType     MissileType
 	Position        Vec3
@@ -661,12 +661,12 @@ type ServerMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3    // [local] — no wire
-	Target          Handle  // [local] — no wire
-	Timer           float64 // [local, context = server]
+	AngularVelocity Vec3    //  | local — no wire
+	Target          Handle  //  | local — no wire
+	Timer           float64 //  | local, context = server
 }
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type MissileData_Deep struct {
 	MissileType    MissileType
@@ -677,7 +677,7 @@ type MissileData_Deep struct {
 	Flags          uint64
 }
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type MissileData_Shallow struct {
 	MissileType MissileType
@@ -1064,10 +1064,10 @@ type DynamicPropState struct {
 	LinearVelocity  Vec3
 	Flags           uint64
 	Team            Team
-	AngularVelocity Vec3 // [local] — no wire
+	AngularVelocity Vec3 //  | local — no wire
 }
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type DynamicPropData_Deep struct {
 	PropType       PropType
@@ -1078,7 +1078,7 @@ type DynamicPropData_Deep struct {
 	Team           Team
 }
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type DynamicPropData_Shallow struct {
 	PropType PropType
@@ -1463,10 +1463,10 @@ type TurretState struct {
 	TurretIndex int32 // wire [0, 255]
 	Rotation    Quat
 	Flags       uint64
-	Team        Team // [local] — no wire
+	Team        Team //  | local — no wire
 }
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type TurretData_Deep struct {
 	Parent      Handle
@@ -1475,7 +1475,7 @@ type TurretData_Deep struct {
 	Flags       uint64
 }
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type TurretData_Shallow struct {
 	Parent      Handle

--- a/testdata/golden/go/TableRuntime.go
+++ b/testdata/golden/go/TableRuntime.go
@@ -39,7 +39,7 @@ type TableFieldInfo struct {
 	Counted    bool           // a Count/Length int32 companion exists (counted arrays, strings, bytes)
 	ArrayBound int32          // array capacity / string max length; 0 for plain scalars
 	Table      *TableTypeInfo // nested table's descriptor, or nil
-	HasRange   bool           // a declared [min, max] (int or float)
+	HasRange   bool           // a declared | min, max (int or float)
 	RangeMin   float64        // NOTE: int64 ranges beyond 2^53 lose precision here
 	RangeMax   float64
 	EnumMax    int64               // enums: highest valid wire value (None = 0 always valid); else -1

--- a/testdata/golden/js/Contexts.js
+++ b/testdata/golden/js/Contexts.js
@@ -14,7 +14,7 @@
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State class is generated once per
+// context-scoped | local fields, its State class is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's.
 

--- a/testdata/golden/js/Enums.js
+++ b/testdata/golden/js/Enums.js
@@ -14,7 +14,7 @@
 
 // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const Team = Object.freeze({
   None: 0,
   Red: 1,
@@ -39,7 +39,7 @@ export function EnumNameTeam(value) {
 
 // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const ShipType = Object.freeze({
   None: 0,
   Fighter: 1,
@@ -73,7 +73,7 @@ export function EnumNameShipType(value) {
 
 // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const MissileType = Object.freeze({
   None: 0,
   Heatseeker: 1,
@@ -101,7 +101,7 @@ export function EnumNameMissileType(value) {
 
 // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const PropType = Object.freeze({
   None: 0,
   Asteroid: 1,
@@ -138,7 +138,7 @@ export function EnumNamePropType(value) {
 
 // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const Pending = Object.freeze({
   None: 0,
   Max: 0, // the exported extent (SPEC §4.2)

--- a/testdata/golden/js/Objects.js
+++ b/testdata/golden/js/Objects.js
@@ -37,7 +37,7 @@ export const ObjectType = Object.freeze({
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation class for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 export class ClientShipState {
   constructor() {
     this.ShipType = ShipType.None;
@@ -65,16 +65,16 @@ export class ClientShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; // [local] — no wire
-    this.PreviousPosition = new Vec3(); // [local] — no wire
-    this.NumColliders = 0; // [local] — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // [local] — no wire
-    this.PredictedExplode = false; // [local, context = client]
+    this.Invulnerable = false; //  | local — no wire
+    this.PreviousPosition = new Vec3(); //  | local — no wire
+    this.NumColliders = 0; //  | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
+    this.PredictedExplode = false; //  | local, context = client
   }
 }
 
 // ServerShipState — the full simulation class for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 export class ServerShipState {
   constructor() {
     this.ShipType = ShipType.None;
@@ -102,14 +102,14 @@ export class ServerShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; // [local] — no wire
-    this.PreviousPosition = new Vec3(); // [local] — no wire
-    this.NumColliders = 0; // [local] — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // [local] — no wire
+    this.Invulnerable = false; //  | local — no wire
+    this.PreviousPosition = new Vec3(); //  | local — no wire
+    this.NumColliders = 0; //  | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
   }
 }
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class ShipData_Deep {
   constructor() {
@@ -141,7 +141,7 @@ export class ShipData_Deep {
   }
 }
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class ShipData_Shallow {
   constructor() {
@@ -708,7 +708,7 @@ export function UnquantizeShip(input, output) {
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation class for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 export class ClientMissileState {
   constructor() {
     this.MissileType = MissileType.None;
@@ -717,13 +717,13 @@ export class ClientMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); // [local] — no wire
-    this.Target = new Handle(); // [local] — no wire
+    this.AngularVelocity = new Vec3(); //  | local — no wire
+    this.Target = new Handle(); //  | local — no wire
   }
 }
 
 // ServerMissileState — the full simulation class for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 export class ServerMissileState {
   constructor() {
     this.MissileType = MissileType.None;
@@ -732,13 +732,13 @@ export class ServerMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); // [local] — no wire
-    this.Target = new Handle(); // [local] — no wire
-    this.Timer = 0; // [local, context = server]
+    this.AngularVelocity = new Vec3(); //  | local — no wire
+    this.Target = new Handle(); //  | local — no wire
+    this.Timer = 0; //  | local, context = server
   }
 }
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class MissileData_Deep {
   constructor() {
@@ -751,7 +751,7 @@ export class MissileData_Deep {
   }
 }
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class MissileData_Shallow {
   constructor() {
@@ -1134,11 +1134,11 @@ export class DynamicPropState {
     this.LinearVelocity = new Vec3();
     this.Flags = 0n;
     this.Team = Team.None;
-    this.AngularVelocity = new Vec3(); // [local] — no wire
+    this.AngularVelocity = new Vec3(); //  | local — no wire
   }
 }
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class DynamicPropData_Deep {
   constructor() {
@@ -1151,7 +1151,7 @@ export class DynamicPropData_Deep {
   }
 }
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class DynamicPropData_Shallow {
   constructor() {
@@ -1532,11 +1532,11 @@ export class TurretState {
     this.TurretIndex = 0; // wire [0, 255]
     this.Rotation = new Quat();
     this.Flags = 0n;
-    this.Team = Team.None; // [local] — no wire
+    this.Team = Team.None; //  | local — no wire
   }
 }
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class TurretData_Deep {
   constructor() {
@@ -1547,7 +1547,7 @@ export class TurretData_Deep {
   }
 }
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class TurretData_Shallow {
   constructor() {

--- a/testdata/golden/js/Wire.js
+++ b/testdata/golden/js/Wire.js
@@ -33,7 +33,7 @@ export const SpinRate = 1.5;
 
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const Weapon = Object.freeze({
   None: 0,
   Laser: 1,

--- a/testdata/golden/ludicrous/c/Ludicrous.h
+++ b/testdata/golden/ludicrous/c/Ludicrous.h
@@ -32,7 +32,7 @@ extern "C" {
 
 /* enum DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3]
    (SPEC §4.2). A fixed-width typedef rather than a C enum: an enum's underlying
-   type is implementation-defined, and [max = K] headroom makes non-variant
+   type is implementation-defined, and | max = K headroom makes non-variant
    values wire-legal, which a C enum cannot hold honestly. */
 typedef uint8_t DriveMode;
 #define DRIVE_MODE_NONE 0
@@ -204,7 +204,7 @@ typedef struct BodyState {
     double spin;
 } BodyState;
 
-/* BodyData_Deep — every non-[local] field, deep encodings: full state for
+/* BodyData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct BodyData_Deep {
     FixedVec position;
@@ -212,7 +212,7 @@ typedef struct BodyData_Deep {
     FixedVec velocity;
 } BodyData_Deep;
 
-/* BodyData_Shallow — the [interpolate] fields on the quantized wire */
+/* BodyData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct BodyData_Shallow {
     FixedVec position;
     FixedQuat rotation;
@@ -226,7 +226,7 @@ typedef struct BodyData_Interpolate {
     FixedVec velocity;
 } BodyData_Interpolate;
 
-/* QuantizeBody/UnquantizeBody are not emitted: every [interpolate] field
+/* QuantizeBody/UnquantizeBody are not emitted: every | interpolate field
    is already wire-domain (fixed components are their own quantization,
    SPEC §4.8) — Interpolate and Shallow are the same values. */
 
@@ -240,7 +240,7 @@ typedef struct NarrowBodyState {
     FixedVec velocity;
 } NarrowBodyState;
 
-/* NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+/* NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
    client-side prediction */
 typedef struct NarrowBodyData_Deep {
     FixedVec position;
@@ -248,7 +248,7 @@ typedef struct NarrowBodyData_Deep {
     FixedVec velocity;
 } NarrowBodyData_Deep;
 
-/* NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire */
+/* NarrowBodyData_Shallow — the | interpolate fields on the quantized wire */
 typedef struct NarrowBodyData_Shallow {
     /* position: FixedVec narrowed — 8 fractional bits kept (SPEC §4.8 rule 2b) */
     int32_t position_x; /* [-25600000, 25600000] */

--- a/testdata/golden/ludicrous/cs/Ludicrous.cs
+++ b/testdata/golden/ludicrous/cs/Ludicrous.cs
@@ -41,7 +41,7 @@ namespace Ludicrous
     }
 
     // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-    // a native enum with unsigned backing — [max = ...] headroom values are
+    // a native enum with unsigned backing — | max = ... headroom values are
     // representable because C# enums are open over their backing type (SPEC §6.1)
     public enum DriveMode : byte
     {
@@ -137,10 +137,10 @@ namespace Ludicrous
         public FixedVec Position = new FixedVec();
         public FixedQuat Rotation = new FixedQuat();
         public FixedVec Velocity = new FixedVec();
-        public double Spin; // [local] — no wire
+        public double Spin; //  | local — no wire
     }
 
-    // BodyData_Deep — every non-[local] field, deep encodings: full state for
+    // BodyData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class BodyData_Deep
     {
@@ -149,7 +149,7 @@ namespace Ludicrous
         public FixedVec Velocity = new FixedVec();
     }
 
-    // BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+    // BodyData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class BodyData_Shallow
     {
@@ -178,7 +178,7 @@ namespace Ludicrous
         public FixedVec Velocity = new FixedVec();
     }
 
-    // NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+    // NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
     // client-side prediction
     public sealed class NarrowBodyData_Deep
     {
@@ -187,17 +187,17 @@ namespace Ludicrous
         public FixedVec Velocity = new FixedVec();
     }
 
-    // NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+    // NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
     // implementation detail on the way to interpolation on the client
     public sealed class NarrowBodyData_Shallow
     {
         // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-        // quantized units; bounds are the component's whole-unit [min, max] scaled
+        // quantized units; bounds are the component's whole-unit | min, max scaled
         public int PositionX; // in [-25600000, 25600000]
         public int PositionY; // in [-25600000, 25600000]
         public int PositionZ; // in [-25600000, 25600000]
         // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-        // quantized units; bounds are the component's whole-unit [min, max] scaled
+        // quantized units; bounds are the component's whole-unit | min, max scaled
         public short RotationX; // in [-1024, 1024]
         public short RotationY; // in [-1024, 1024]
         public short RotationZ; // in [-1024, 1024]

--- a/testdata/golden/ludicrous/cs/TableRuntime.cs
+++ b/testdata/golden/ludicrous/cs/TableRuntime.cs
@@ -53,7 +53,7 @@ namespace Ludicrous
         public bool Counted;                 // a Count/Length companion exists (counted arrays, strings, bytes)
         public int ArrayBound;               // array capacity / string max length; 0 for plain scalars
         public TableTypeInfo Table;          // nested table's descriptor, or null
-        public bool HasRange;                // a declared [min, max] (int or float)
+        public bool HasRange;                // a declared | min, max (int or float)
         public double RangeMin;              // NOTE: int64 ranges beyond 2^53 lose precision here
         public double RangeMax;
         public long EnumMax;                 // enums: highest valid wire value (None = 0 always valid); else -1

--- a/testdata/golden/ludicrous/go/Ludicrous.go
+++ b/testdata/golden/ludicrous/go/Ludicrous.go
@@ -486,10 +486,10 @@ type BodyState struct {
 	Position FixedVec
 	Rotation FixedQuat
 	Velocity FixedVec
-	Spin     float64 // [local] — no wire
+	Spin     float64 //  | local — no wire
 }
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type BodyData_Deep struct {
 	Position FixedVec
@@ -497,7 +497,7 @@ type BodyData_Deep struct {
 	Velocity FixedVec
 }
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type BodyData_Shallow struct {
 	Position FixedVec
@@ -581,7 +581,7 @@ type NarrowBodyState struct {
 	Velocity FixedVec
 }
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 type NarrowBodyData_Deep struct {
 	Position FixedVec
@@ -589,16 +589,16 @@ type NarrowBodyData_Deep struct {
 	Velocity FixedVec
 }
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 type NarrowBodyData_Shallow struct {
 	// position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-	// quantized units; bounds are the component's whole-unit [min, max] scaled
+	// quantized units; bounds are the component's whole-unit | min, max scaled
 	PositionX int32 // in [-25600000, 25600000]
 	PositionY int32 // in [-25600000, 25600000]
 	PositionZ int32 // in [-25600000, 25600000]
 	// rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-	// quantized units; bounds are the component's whole-unit [min, max] scaled
+	// quantized units; bounds are the component's whole-unit | min, max scaled
 	RotationX int16 // in [-1024, 1024]
 	RotationY int16 // in [-1024, 1024]
 	RotationZ int16 // in [-1024, 1024]

--- a/testdata/golden/ludicrous/go/TableRuntime.go
+++ b/testdata/golden/ludicrous/go/TableRuntime.go
@@ -39,7 +39,7 @@ type TableFieldInfo struct {
 	Counted    bool           // a Count/Length int32 companion exists (counted arrays, strings, bytes)
 	ArrayBound int32          // array capacity / string max length; 0 for plain scalars
 	Table      *TableTypeInfo // nested table's descriptor, or nil
-	HasRange   bool           // a declared [min, max] (int or float)
+	HasRange   bool           // a declared | min, max (int or float)
 	RangeMin   float64        // NOTE: int64 ranges beyond 2^53 lose precision here
 	RangeMax   float64
 	EnumMax    int64               // enums: highest valid wire value (None = 0 always valid); else -1

--- a/testdata/golden/ludicrous/js/Ludicrous.js
+++ b/testdata/golden/ludicrous/js/Ludicrous.js
@@ -44,7 +44,7 @@ export const MaxWorldUnits = 30000;
 
 // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's
-// integer-backed enums; [max = ...] headroom values are plain Numbers
+// integer-backed enums; | max = ... headroom values are plain Numbers
 export const DriveMode = Object.freeze({
   None: 0,
   Cruise: 1,
@@ -611,11 +611,11 @@ export class BodyState {
     this.Position = new FixedVec();
     this.Rotation = new FixedQuat();
     this.Velocity = new FixedVec();
-    this.Spin = 0; // [local] — no wire
+    this.Spin = 0; //  | local — no wire
   }
 }
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class BodyData_Deep {
   constructor() {
@@ -625,7 +625,7 @@ export class BodyData_Deep {
   }
 }
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class BodyData_Shallow {
   constructor() {
@@ -715,7 +715,7 @@ export class NarrowBodyState {
   }
 }
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 export class NarrowBodyData_Deep {
   constructor() {
@@ -725,17 +725,17 @@ export class NarrowBodyData_Deep {
   }
 }
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 export class NarrowBodyData_Shallow {
   constructor() {
     // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     this.PositionX = 0; // in [-25600000, 25600000]
     this.PositionY = 0; // in [-25600000, 25600000]
     this.PositionZ = 0; // in [-25600000, 25600000]
     // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     this.RotationX = 0; // in [-1024, 1024]
     this.RotationY = 0; // in [-1024, 1024]
     this.RotationZ = 0; // in [-1024, 1024]

--- a/testdata/golden/ludicrous/rust/ludicrous.rs
+++ b/testdata/golden/ludicrous/rust/ludicrous.rs
@@ -57,7 +57,7 @@ impl ObjectType {
 pub const MAX_WORLD_UNITS: i64 = 30000;
 
 // DriveMode — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct DriveMode(pub u8);
@@ -668,7 +668,7 @@ pub struct BodyState {
     pub position: FixedVec,
     pub rotation: FixedQuat,
     pub velocity: FixedVec,
-    pub spin: f64, // [local] — no wire
+    pub spin: f64, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -683,7 +683,7 @@ impl Default for BodyState {
     }
 }
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -704,7 +704,7 @@ impl Default for BodyData_Deep {
     }
 }
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -806,7 +806,7 @@ impl Default for NarrowBodyState {
     }
 }
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -827,18 +827,18 @@ impl Default for NarrowBodyData_Deep {
     }
 }
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct NarrowBodyData_Shallow {
     // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     pub position_x: i32, // in [-25600000, 25600000]
     pub position_y: i32, // in [-25600000, 25600000]
     pub position_z: i32, // in [-25600000, 25600000]
     // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     pub rotation_x: i16, // in [-1024, 1024]
     pub rotation_y: i16, // in [-1024, 1024]
     pub rotation_z: i16, // in [-1024, 1024]

--- a/testdata/golden/ludicrous/union/Ludicrous.h
+++ b/testdata/golden/ludicrous/union/Ludicrous.h
@@ -150,10 +150,10 @@ struct BodyState {
     FixedVec position;
     FixedQuat rotation;
     FixedVec velocity;
-    double spin = 0.0; // [local] — no wire
+    double spin = 0.0; //  | local — no wire
 };
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct BodyData_Deep {
     FixedVec position;
@@ -161,7 +161,7 @@ struct BodyData_Deep {
     FixedVec velocity;
 };
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct BodyData_Shallow {
     FixedVec position;
@@ -178,7 +178,7 @@ struct BodyData_Interpolate {
     FixedVec velocity;
 };
 
-// QuantizeBody/UnquantizeBody are not emitted: every [interpolate] field
+// QuantizeBody/UnquantizeBody are not emitted: every | interpolate field
 // is already wire-domain (fixed components are their own quantization,
 // SPEC §4.8) — Interpolate and Shallow are the same values.
 
@@ -197,7 +197,7 @@ struct NarrowBodyState {
     FixedVec velocity;
 };
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct NarrowBodyData_Deep {
     FixedVec position;
@@ -205,16 +205,16 @@ struct NarrowBodyData_Deep {
     FixedVec velocity;
 };
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct NarrowBodyData_Shallow {
     // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     int32_t position_x = 0; // in [-25600000, 25600000]
     int32_t position_y = 0; // in [-25600000, 25600000]
     int32_t position_z = 0; // in [-25600000, 25600000]
     // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     int16_t rotation_x = 0; // in [-1024, 1024]
     int16_t rotation_y = 0; // in [-1024, 1024]
     int16_t rotation_z = 0; // in [-1024, 1024]

--- a/testdata/golden/ludicrous/union/LudicrousTable.h
+++ b/testdata/golden/ludicrous/union/LudicrousTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/ludicrous/variant/Ludicrous.h
+++ b/testdata/golden/ludicrous/variant/Ludicrous.h
@@ -151,10 +151,10 @@ struct BodyState {
     FixedVec position;
     FixedQuat rotation;
     FixedVec velocity;
-    double spin = 0.0; // [local] — no wire
+    double spin = 0.0; //  | local — no wire
 };
 
-// BodyData_Deep — every non-[local] field, deep encodings: full state for
+// BodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct BodyData_Deep {
     FixedVec position;
@@ -162,7 +162,7 @@ struct BodyData_Deep {
     FixedVec velocity;
 };
 
-// BodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// BodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct BodyData_Shallow {
     FixedVec position;
@@ -179,7 +179,7 @@ struct BodyData_Interpolate {
     FixedVec velocity;
 };
 
-// QuantizeBody/UnquantizeBody are not emitted: every [interpolate] field
+// QuantizeBody/UnquantizeBody are not emitted: every | interpolate field
 // is already wire-domain (fixed components are their own quantization,
 // SPEC §4.8) — Interpolate and Shallow are the same values.
 
@@ -198,7 +198,7 @@ struct NarrowBodyState {
     FixedVec velocity;
 };
 
-// NarrowBodyData_Deep — every non-[local] field, deep encodings: full state for
+// NarrowBodyData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct NarrowBodyData_Deep {
     FixedVec position;
@@ -206,16 +206,16 @@ struct NarrowBodyData_Deep {
     FixedVec velocity;
 };
 
-// NarrowBodyData_Shallow — the [interpolate] fields on the quantized wire: the
+// NarrowBodyData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct NarrowBodyData_Shallow {
     // position: FixedVec narrowed to 8 fractional bits (quantize = 256) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     int32_t position_x = 0; // in [-25600000, 25600000]
     int32_t position_y = 0; // in [-25600000, 25600000]
     int32_t position_z = 0; // in [-25600000, 25600000]
     // rotation: FixedQuat narrowed to 10 fractional bits (quantize = 1024) — per-component
-    // quantized units; bounds are the component's whole-unit [min, max] scaled
+    // quantized units; bounds are the component's whole-unit | min, max scaled
     int16_t rotation_x = 0; // in [-1024, 1024]
     int16_t rotation_y = 0; // in [-1024, 1024]
     int16_t rotation_z = 0; // in [-1024, 1024]

--- a/testdata/golden/ludicrous/variant/LudicrousTable.h
+++ b/testdata/golden/ludicrous/variant/LudicrousTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/rust/contexts.rs
+++ b/testdata/golden/rust/contexts.rs
@@ -3,7 +3,7 @@
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State struct is generated once per
+// context-scoped | local fields, its State struct is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's. No cfg gates in this target.
 

--- a/testdata/golden/rust/enums.rs
+++ b/testdata/golden/rust/enums.rs
@@ -2,7 +2,7 @@
 // package example — protocol id 0x9cdffa5a3048f991
 
 // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Team(pub u8);
@@ -31,7 +31,7 @@ pub fn enum_name_team_dyn(value: u64) -> &'static str {
 }
 
 // ShipType — None = 0 implicit, variants dense from 1, wire range [0, 5] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct ShipType(pub u8);
@@ -66,7 +66,7 @@ pub fn enum_name_ship_type_dyn(value: u64) -> &'static str {
 }
 
 // MissileType — None = 0 implicit, variants dense from 1, wire range [0, 3] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct MissileType(pub u8);
@@ -97,7 +97,7 @@ pub fn enum_name_missile_type_dyn(value: u64) -> &'static str {
 }
 
 // PropType — None = 0 implicit, variants dense from 1, wire range [0, 6] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct PropType(pub u8);
@@ -134,7 +134,7 @@ pub fn enum_name_prop_type_dyn(value: u64) -> &'static str {
 }
 
 // Pending — None = 0 implicit, variants dense from 1, wire range [0, 0] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Pending(pub u8);

--- a/testdata/golden/rust/objects.rs
+++ b/testdata/golden/rust/objects.rs
@@ -21,7 +21,7 @@ impl ObjectType {
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ClientShipState {
     pub ship_type: ShipType,
@@ -49,11 +49,11 @@ pub struct ClientShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, // [local] — no wire
-    pub previous_position: Vec3, // [local] — no wire
-    pub num_colliders: i32, // [local] — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // [local] — no wire
-    pub predicted_explode: bool, // [local, context = client]
+    pub invulnerable: bool, //  | local — no wire
+    pub previous_position: Vec3, //  | local — no wire
+    pub num_colliders: i32, //  | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
+    pub predicted_explode: bool, //  | local, context = client
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -95,7 +95,7 @@ impl Default for ClientShipState {
 }
 
 // ServerShipState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ServerShipState {
     pub ship_type: ShipType,
@@ -123,10 +123,10 @@ pub struct ServerShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, // [local] — no wire
-    pub previous_position: Vec3, // [local] — no wire
-    pub num_colliders: i32, // [local] — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // [local] — no wire
+    pub invulnerable: bool, //  | local — no wire
+    pub previous_position: Vec3, //  | local — no wire
+    pub num_colliders: i32, //  | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -166,7 +166,7 @@ impl Default for ServerShipState {
     }
 }
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -231,7 +231,7 @@ impl Default for ShipData_Deep {
     }
 }
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -749,7 +749,7 @@ pub fn unquantize_ship(input: &ShipData_Shallow, output: &mut ShipData_Interpola
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ClientMissileState {
     pub missile_type: MissileType,
@@ -758,8 +758,8 @@ pub struct ClientMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, // [local] — no wire
-    pub target: Handle, // [local] — no wire
+    pub angular_velocity: Vec3, //  | local — no wire
+    pub target: Handle, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -779,7 +779,7 @@ impl Default for ClientMissileState {
 }
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct ServerMissileState {
     pub missile_type: MissileType,
@@ -788,9 +788,9 @@ pub struct ServerMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, // [local] — no wire
-    pub target: Handle, // [local] — no wire
-    pub timer: f64, // [local, context = server]
+    pub angular_velocity: Vec3, //  | local — no wire
+    pub target: Handle, //  | local — no wire
+    pub timer: f64, //  | local, context = server
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -810,7 +810,7 @@ impl Default for ServerMissileState {
     }
 }
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -837,7 +837,7 @@ impl Default for MissileData_Deep {
     }
 }
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1218,7 +1218,7 @@ pub struct DynamicPropState {
     pub linear_velocity: Vec3,
     pub flags: u64,
     pub team: Team,
-    pub angular_velocity: Vec3, // [local] — no wire
+    pub angular_velocity: Vec3, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1236,7 +1236,7 @@ impl Default for DynamicPropState {
     }
 }
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1263,7 +1263,7 @@ impl Default for DynamicPropData_Deep {
     }
 }
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1642,7 +1642,7 @@ pub struct TurretState {
     pub turret_index: i32, // wire [0, 255]
     pub rotation: Quat,
     pub flags: u64,
-    pub team: Team, // [local] — no wire
+    pub team: Team, //  | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1658,7 +1658,7 @@ impl Default for TurretState {
     }
 }
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -1681,7 +1681,7 @@ impl Default for TurretData_Deep {
     }
 }
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 #[allow(non_camel_case_types)] // the name is fixed across targets (SPEC §4.8)
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/testdata/golden/rust/table_runtime.rs
+++ b/testdata/golden/rust/table_runtime.rs
@@ -44,7 +44,7 @@ pub struct TableFieldInfo {
     pub array_bound: i64,
     /// nested table's descriptor
     pub table: Option<&'static TableTypeInfo>,
-    /// a declared [min, max] (int or float)
+    /// a declared | min, max (int or float)
     pub has_range: bool,
     /// NOTE: i64 ranges beyond 2^53 lose precision here
     pub range_min: f64,

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -13,7 +13,7 @@ pub const TICK_RATE: f32 = 60.0;
 pub const SPIN_RATE: f64 = 1.5;
 
 // Weapon — None = 0 implicit, variants dense from 1, wire range [0, 15] (SPEC §4.2);
-// a newtype because [max = ...] headroom makes non-variant values wire-legal
+// a newtype because | max = ... headroom makes non-variant values wire-legal
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub struct Weapon(pub u8);

--- a/testdata/golden/union/ConstantsTable.h
+++ b/testdata/golden/union/ConstantsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/union/Contexts.h
+++ b/testdata/golden/union/Contexts.h
@@ -12,7 +12,7 @@ namespace example {
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State struct is generated once per
+// context-scoped | local fields, its State struct is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's. No preprocessor in any target.
 

--- a/testdata/golden/union/ContextsTable.h
+++ b/testdata/golden/union/ContextsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/union/EnumsTable.h
+++ b/testdata/golden/union/EnumsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/union/MessagesTable.h
+++ b/testdata/golden/union/MessagesTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/union/Objects.h
+++ b/testdata/golden/union/Objects.h
@@ -31,7 +31,7 @@ enum class ObjectType : uint8_t {
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 struct ClientShipState {
     ShipType ship_type = ShipType::None;
     ::VecMath position;
@@ -58,15 +58,15 @@ struct ClientShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; // [local] — no wire
-    ::VecMath previous_position; // [local] — no wire
-    int32_t num_colliders = 0; // [local] — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; // [local] — no wire
-    bool predicted_explode = false; // [local, context = client]
+    bool invulnerable = false; //  | local — no wire
+    ::VecMath previous_position; //  | local — no wire
+    int32_t num_colliders = 0; //  | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
+    bool predicted_explode = false; //  | local, context = client
 };
 
 // ServerShipState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 struct ServerShipState {
     ShipType ship_type = ShipType::None;
     ::VecMath position;
@@ -93,13 +93,13 @@ struct ServerShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; // [local] — no wire
-    ::VecMath previous_position; // [local] — no wire
-    int32_t num_colliders = 0; // [local] — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; // [local] — no wire
+    bool invulnerable = false; //  | local — no wire
+    ::VecMath previous_position; //  | local — no wire
+    int32_t num_colliders = 0; //  | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
 };
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct ShipData_Deep {
     ShipType ship_type = ShipType::None;
@@ -129,7 +129,7 @@ struct ShipData_Deep {
     double lock_start_time = 0.0;
 };
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct ShipData_Shallow {
     ShipType ship_type = ShipType::None;
@@ -343,7 +343,7 @@ inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // rounded up to the 8-b
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 struct ClientMissileState {
     MissileType missile_type = MissileType::None;
     ::VecMath position;
@@ -351,12 +351,12 @@ struct ClientMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; // [local] — no wire
-    Handle target; // [local] — no wire
+    ::VecMath angular_velocity; //  | local — no wire
+    Handle target; //  | local — no wire
 };
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 struct ServerMissileState {
     MissileType missile_type = MissileType::None;
     ::VecMath position;
@@ -364,12 +364,12 @@ struct ServerMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; // [local] — no wire
-    Handle target; // [local] — no wire
-    double timer = 0.0; // [local, context = server]
+    ::VecMath angular_velocity; //  | local — no wire
+    Handle target; //  | local — no wire
+    double timer = 0.0; //  | local, context = server
 };
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct MissileData_Deep {
     MissileType missile_type = MissileType::None;
@@ -380,7 +380,7 @@ struct MissileData_Deep {
     uint64_t flags = 0;
 };
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct MissileData_Shallow {
     MissileType missile_type = MissileType::None;
@@ -593,10 +593,10 @@ struct DynamicPropState {
     ::VecMath linear_velocity;
     uint64_t flags = 0;
     Team team = Team::None;
-    ::VecMath angular_velocity; // [local] — no wire
+    ::VecMath angular_velocity; //  | local — no wire
 };
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct DynamicPropData_Deep {
     PropType prop_type = PropType::None;
@@ -607,7 +607,7 @@ struct DynamicPropData_Deep {
     Team team = Team::None;
 };
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct DynamicPropData_Shallow {
     PropType prop_type = PropType::None;
@@ -818,10 +818,10 @@ struct TurretState {
     int32_t turret_index = 0; // wire [0, 255]
     Quat rotation;
     uint64_t flags = 0;
-    Team team = Team::None; // [local] — no wire
+    Team team = Team::None; //  | local — no wire
 };
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct TurretData_Deep {
     Handle parent;
@@ -830,7 +830,7 @@ struct TurretData_Deep {
     uint64_t flags = 0;
 };
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct TurretData_Shallow {
     Handle parent;

--- a/testdata/golden/union/ObjectsTable.h
+++ b/testdata/golden/union/ObjectsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/union/RenderTable.h
+++ b/testdata/golden/union/RenderTable.h
@@ -54,7 +54,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/union/TypesTable.h
+++ b/testdata/golden/union/TypesTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/union/WireTable.h
+++ b/testdata/golden/union/WireTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/ConstantsTable.h
+++ b/testdata/golden/variant/ConstantsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/Contexts.h
+++ b/testdata/golden/variant/Contexts.h
@@ -12,7 +12,7 @@ namespace example {
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries
-// context-scoped [local] fields, its State struct is generated once per
+// context-scoped | local fields, its State struct is generated once per
 // context (ClientShipState, ServerShipState, ...), each holding the `all`
 // fields plus its own context's. No preprocessor in any target.
 

--- a/testdata/golden/variant/ContextsTable.h
+++ b/testdata/golden/variant/ContextsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/EnumsTable.h
+++ b/testdata/golden/variant/EnumsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/MessagesTable.h
+++ b/testdata/golden/variant/MessagesTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/Objects.h
+++ b/testdata/golden/variant/Objects.h
@@ -31,7 +31,7 @@ enum class ObjectType : uint8_t {
 // ---- object Ship — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientShipState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 struct ClientShipState {
     ShipType ship_type = ShipType::None;
     ::VecMath position;
@@ -58,15 +58,15 @@ struct ClientShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; // [local] — no wire
-    ::VecMath previous_position; // [local] — no wire
-    int32_t num_colliders = 0; // [local] — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; // [local] — no wire
-    bool predicted_explode = false; // [local, context = client]
+    bool invulnerable = false; //  | local — no wire
+    ::VecMath previous_position; //  | local — no wire
+    int32_t num_colliders = 0; //  | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
+    bool predicted_explode = false; //  | local, context = client
 };
 
 // ServerShipState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 struct ServerShipState {
     ShipType ship_type = ShipType::None;
     ::VecMath position;
@@ -93,13 +93,13 @@ struct ServerShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; // [local] — no wire
-    ::VecMath previous_position; // [local] — no wire
-    int32_t num_colliders = 0; // [local] — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; // [local] — no wire
+    bool invulnerable = false; //  | local — no wire
+    ::VecMath previous_position; //  | local — no wire
+    int32_t num_colliders = 0; //  | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
 };
 
-// ShipData_Deep — every non-[local] field, deep encodings: full state for
+// ShipData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct ShipData_Deep {
     ShipType ship_type = ShipType::None;
@@ -129,7 +129,7 @@ struct ShipData_Deep {
     double lock_start_time = 0.0;
 };
 
-// ShipData_Shallow — the [interpolate] fields on the quantized wire: the
+// ShipData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct ShipData_Shallow {
     ShipType ship_type = ShipType::None;
@@ -343,7 +343,7 @@ inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // rounded up to the 8-b
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
 // ClientMissileState — the full simulation struct for the client context: every `all`
-// field plus the fields scoped [local, context = client]
+// field plus the fields scoped | local, context = client
 struct ClientMissileState {
     MissileType missile_type = MissileType::None;
     ::VecMath position;
@@ -351,12 +351,12 @@ struct ClientMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; // [local] — no wire
-    Handle target; // [local] — no wire
+    ::VecMath angular_velocity; //  | local — no wire
+    Handle target; //  | local — no wire
 };
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
-// field plus the fields scoped [local, context = server]
+// field plus the fields scoped | local, context = server
 struct ServerMissileState {
     MissileType missile_type = MissileType::None;
     ::VecMath position;
@@ -364,12 +364,12 @@ struct ServerMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; // [local] — no wire
-    Handle target; // [local] — no wire
-    double timer = 0.0; // [local, context = server]
+    ::VecMath angular_velocity; //  | local — no wire
+    Handle target; //  | local — no wire
+    double timer = 0.0; //  | local, context = server
 };
 
-// MissileData_Deep — every non-[local] field, deep encodings: full state for
+// MissileData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct MissileData_Deep {
     MissileType missile_type = MissileType::None;
@@ -380,7 +380,7 @@ struct MissileData_Deep {
     uint64_t flags = 0;
 };
 
-// MissileData_Shallow — the [interpolate] fields on the quantized wire: the
+// MissileData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct MissileData_Shallow {
     MissileType missile_type = MissileType::None;
@@ -593,10 +593,10 @@ struct DynamicPropState {
     ::VecMath linear_velocity;
     uint64_t flags = 0;
     Team team = Team::None;
-    ::VecMath angular_velocity; // [local] — no wire
+    ::VecMath angular_velocity; //  | local — no wire
 };
 
-// DynamicPropData_Deep — every non-[local] field, deep encodings: full state for
+// DynamicPropData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct DynamicPropData_Deep {
     PropType prop_type = PropType::None;
@@ -607,7 +607,7 @@ struct DynamicPropData_Deep {
     Team team = Team::None;
 };
 
-// DynamicPropData_Shallow — the [interpolate] fields on the quantized wire: the
+// DynamicPropData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct DynamicPropData_Shallow {
     PropType prop_type = PropType::None;
@@ -818,10 +818,10 @@ struct TurretState {
     int32_t turret_index = 0; // wire [0, 255]
     Quat rotation;
     uint64_t flags = 0;
-    Team team = Team::None; // [local] — no wire
+    Team team = Team::None; //  | local — no wire
 };
 
-// TurretData_Deep — every non-[local] field, deep encodings: full state for
+// TurretData_Deep — every non- | local field, deep encodings: full state for
 // client-side prediction
 struct TurretData_Deep {
     Handle parent;
@@ -830,7 +830,7 @@ struct TurretData_Deep {
     uint64_t flags = 0;
 };
 
-// TurretData_Shallow — the [interpolate] fields on the quantized wire: the
+// TurretData_Shallow — the | interpolate fields on the quantized wire: the
 // implementation detail on the way to interpolation on the client
 struct TurretData_Shallow {
     Handle parent;

--- a/testdata/golden/variant/ObjectsTable.h
+++ b/testdata/golden/variant/ObjectsTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/RenderTable.h
+++ b/testdata/golden/variant/RenderTable.h
@@ -54,7 +54,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/TypesTable.h
+++ b/testdata/golden/variant/TypesTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1

--- a/testdata/golden/variant/WireTable.h
+++ b/testdata/golden/variant/WireTable.h
@@ -53,7 +53,7 @@ struct TableFieldInfo
     uint32_t elem_size;     // sizeof the member (element size for arrays)
     uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
     const TableTypeInfo * table; // nested table's descriptor, or NULL
-    bool has_range;         // a declared [min, max] (int or float)
+    bool has_range;         // a declared | min, max (int or float)
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1


### PR DESCRIPTION
Closes #126. Full description in the commit message (e768d93): definition-then-qualification with | running to end of line, default before the pipe, declaration qualifiers with next-line brace, no-exit guarantee (all newline suppression off right of |), named refusals for the retired [ ... ] block / empty sections / | on non-qualifiable lines / block comments right of the pipe, and the shipped one-shot 'schema fmt -migrate' mode covering both retired spellings. SPEC-first with a cold adversarial read (15 findings folded in; 2 blockers fixed). Spelling only: wire goldens and protocol id unchanged (0x9cdffa5a3048f991); ProjectionVersion not bumped. Full make gauntlet and lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)