### PR TITLE
The house brace style is Allman (#127)

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -18,13 +18,15 @@ velocity, some flags, a team, health and thrust. It is the corpus's
 `ShipCreate` from [`examples/Types.schema`](examples/Types.schema), unchanged.
 
 ```
-type ShipCreate {
+type ShipCreate
+{
     ship_type       ShipType                        // 6 wire values incl. None
     position        QuantizedPosition               // 3 x int32, each ±8388608
     rotation        QuantizedRotation               // 4 x int16, each ±1024
     linear_velocity QuantizedVelocity               // 3 x int32, each ±2097152
     has_flags       bool
-    if has_flags {
+    if has_flags
+    {
         flags       ShipFlags                       // 4 flag bits
     }
     team            Team                            // 3 wire values incl. None

--- a/README.md
+++ b/README.md
@@ -12,18 +12,21 @@ const MaxHealth = 1000
 
 enum ShipType { Fighter, Corvette, Bomber }
 
-type Vec3 {
+type Vec3
+{
     x float64
     y float64
     z float64
 }
 
-message ShipState {
+message ShipState
+{
     ship_type ShipType
     position  Vec3
     health    int32 | min = 0, max = MaxHealth
     at_rest   bool
-    if !at_rest {
+    if !at_rest
+    {
         velocity Vec3
     }
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -230,14 +230,15 @@ band) is the application's choice — netcode-style stacks already carry one.
   off** — from the pipe to the physical end of line, the newline always
   terminates (that is the no-wrap guarantee of §4.2), and a `/* */` block
   comment is refused there (its swallowed newline would let the section
-  silently span lines). Blank lines are insignificant. `{` sits
-  on the same line as its construct — EXCEPT a declaration whose line
-  carries a `|` qualification section, whose body brace opens on the next
-  line (§4.2); a declaration without one may also put `{` on the next line,
-  tolerated by the parser and rewritten to the same line by the formatter;
-  `} else {` is written on one line — a
-  newline between `}` and `else` is tolerated by the parser and rewritten by
-  the formatter. Two consequences make the grammar implementable as written:
+  silently span lines). Blank lines are insignificant. **The house
+  brace style is Allman**: a multi-line block's opening `{` stands on its
+  own line, and `else` stands alone between its braces. A one-line
+  `{ ... }` group — an inline enum list, a one-line type body — closes on
+  its own line and stays whole. The parser reads BOTH placements (a
+  line-oriented grammar treats a lone `{` line as the block opener); the
+  formatter normalizes to Allman as the one canonical output. This is the
+  language's own style, not a borrowed one ("we stop looking like a dialect
+  of golang — we're not"). Two consequences make the grammar implementable as written:
   **a closing `}` also terminates the item before it** — in every production
   below, a trailing `NL` is satisfied by an actual newline or by the
   immediately following `}` — and **end-of-file synthesizes a terminator**,
@@ -247,7 +248,10 @@ band) is the application's choice — netcode-style stacks already carry one.
 
 ### 4.2 Grammar
 
-EBNF (`NL` = the newline terminator; `{X}` repetition; `[X]` option):
+EBNF (`NL` = the newline terminator; `{X}` repetition; `[X]` option). The
+productions elide one tolerance stated in §4.1: a newline is accepted before
+any `Block`, `UnionBlock` or `VariantList` opener — Allman is the canonical
+placement and the formatter normalizes to it:
 
 ```
 File        = { Declaration } .
@@ -469,8 +473,9 @@ sequence    uint16
 - **Declaration lines take the same section**: a type tag or native-type
   binding, an enum's or flags' `max` headroom —
   `type Quat | quat4`, `enum Weapon | max = 15`, `flags Damage | max = 8` —
-  and because the section runs to the end of the line, **a declaration
-  carrying one opens its body brace on the NEXT line**:
+  and the body brace opens on the next line — with a qualification section
+  that is forced (the section runs to the end of the line), and everywhere
+  else it is the Allman house style (§4.1):
 
   ```
   type Quat | quat4, cpp_native = quat_t, cpp_include = "core_math.h"
@@ -483,7 +488,9 @@ sequence    uint16
   { Laser, Missile, Railgun }
   ```
 
-  A declaration with no qualifiers keeps its brace on the declaration line.
+  A one-line body (`{ Laser, Missile }`, `type Box { x uint8 }`) stays
+  whole on its line — braces around a group that closes on the same line
+  are a list, not a block.
 - **Array bounds are not attributes** and are untouched: a bound is a
   **prefix** — `[..MaxObjects]ObjectState`, Go's order — part of the type's
   shape. `[` after the complete type (or after its `= default`) opened the
@@ -749,10 +756,12 @@ back-reference. The branch itself costs no wire bits; the referenced field
 was already paid for.
 
 ```
-type Body {
+type Body
+{
     position Vec
     at_rest  bool
-    if !at_rest {
+    if !at_rest
+    {
         velocity         Vec
         angular_velocity Vec
     }
@@ -944,15 +953,18 @@ Each message is its own declaration; the discriminant enum, the wire tag and
 the dispatch are the compiler's job, not the author's.
 
 ```
-message Ping {
+message Ping
+{
     sequence uint16
 }
 
-message Chat {
+message Chat
+{
     text string(MaxChatLength)
 }
 
-message Heartbeat {
+message Heartbeat
+{
     // empty body — presence is the payload
 }
 ```
@@ -1155,7 +1167,8 @@ absent arm and makes illegal states representable — zero payloads, or
 several at once.
 
 ```
-union ColliderShape {
+union ColliderShape
+{
     box     BoxCollider
     sphere  SphereCollider
     capsule CapsuleCollider
@@ -1285,34 +1298,41 @@ package protocol
 const MaxObjects    = 1024
 const MaxChatLength = 256
 
-type Vec {
+type Vec
+{
     x float32
     y float32
     z float32
 }
 
-type ObjectState {
+type ObjectState
+{
     id       int32 | min = 0, max = MaxObjects - 1
     position Vec
     active   bool
-    if active {
+    if active
+    {
         orientation float32 | min = -180.0, max = 180.0, resolution = 0.01
     }
 }
 
-message Ping {
+message Ping
+{
     sequence uint16
 }
 
-message Pong {
+message Pong
+{
     sequence uint16
 }
 
-message Chat {
+message Chat
+{
     text string(MaxChatLength)
 }
 
-message Snapshot {
+message Snapshot
+{
     base_sequence uint16
     objects       [..MaxObjects]ObjectState
 }
@@ -1807,10 +1827,10 @@ gofmt's philosophy: one style, no options. Built as the parser's first
 consumer and run by every `schema` command over the unit before processing.
 Rules:
 
-1. **Indent: 4 spaces** per block level, never tabs. `{` on the construct's
-   line — except a declaration whose line carries a `|` qualification
-   section, whose body brace opens on the next line (§4.2); `} else {` on
-   one line. One field or declaration per line.
+1. **Indent: 4 spaces** per block level, never tabs. **Braces are Allman**
+   (§4.1): a multi-line block's `{` on its own line at the construct's
+   depth, `else` alone between its braces; a one-line `{ ... }` group stays
+   whole. One field or declaration per line.
 2. **Alignment groups**: within a contiguous run of fields — broken by blank
    lines and by comment lines — pad names to align the type column, and pad
    past the longest DEFINITION (the type plus any `= default`) to align the

--- a/USAGE.md
+++ b/USAGE.md
@@ -39,13 +39,15 @@ const MaxHealth = 1000
 
 enum ShipType { Fighter, Corvette, Bomber }
 
-type Vector3 {
+type Vector3
+{
     x float64
     y float64
     z float64
 }
 
-message ShipCreate {
+message ShipCreate
+{
     ship_type ShipType
     position  Vector3
     health    int32 | min = 0, max = MaxHealth
@@ -157,7 +159,8 @@ flags type and names `.Count` instead.
 A plain struct. Composes into messages, tables and other types:
 
 ```
-type Vector3 {
+type Vector3
+{
     x float64
     y float64
     z float64
@@ -170,14 +173,16 @@ A first-class one-of: at most one of a named set of payloads, discriminated
 by a generated tag.
 
 ```
-union ColliderShape {
+union ColliderShape
+{
     box     BoxCollider
     sphere  SphereCollider
     capsule CapsuleCollider
     hull    HullCollider
 }
 
-type Collider {
+type Collider
+{
     armor uint8
     shape ColliderShape
 }
@@ -378,9 +383,11 @@ if ( !WriteVector3( stream, value.position ) )
 ## Branches: if / else
 
 ```
-message ShipCreate {
+message ShipCreate
+{
     at_rest bool
-    if !at_rest {
+    if !at_rest
+    {
         velocity Vector3
     }
 }

--- a/WIRES.md
+++ b/WIRES.md
@@ -27,18 +27,21 @@ package example
 
 enum ShipType { Fighter, Corvette, Bomber }
 
-type Vector3 {
+type Vector3
+{
     x float64
     y float64
     z float64
 }
 
-message ShipCreate {
+message ShipCreate
+{
     ship_type ShipType
     position  Vector3
 }
 
-table ShipConfig {
+table ShipConfig
+{
     ship_type ShipType
     health    int32 = 100 | min = 0, max = 1000
     name      string(32)

--- a/bench/corpus/Bench.schema
+++ b/bench/corpus/Bench.schema
@@ -8,7 +8,8 @@ package bench
 
 // The stream packet. Transcribed from serialize/bench.cpp:141-182 —
 // 12 operations in that exact order. 392 bits = 49 wire bytes.
-type BenchPacket {
+type BenchPacket
+{
     a      int32          | min = -100, max = 100 //  8 bits
     b      int32          | min = 0, max = 65535 // 16
     c      int32          | min = -1000000, max = 1000000 // 21
@@ -25,7 +26,8 @@ type BenchPacket {
 } // = 392 bits, 49 bytes
 
 // serialize/bench.cpp:391-403. 110 bits = 14 wire bytes.
-type BenchInts {
+type BenchInts
+{
     f0 int32 | min = -100, max = 100 //  8
     f1 int32 | min = 0, max = 65535 // 16
     f2 int32 | min = -1000000, max = 1000000 // 21
@@ -41,7 +43,8 @@ type BenchInts {
 // serialize/bench.cpp:449-457. 156 bits = 20 wire bytes.
 // (One field per line: the grammar requires a newline after every field, so
 // §1.3's four-per-line shorthand is transcribed line-per-field here.)
-type BenchBits {
+type BenchBits
+{
     b7  bits(7)
     b13 bits(13)
     b23 bits(23)
@@ -53,7 +56,8 @@ type BenchBits {
 } // = 156 bits, 20 bytes
 
 // serialize/bench.cpp:517-528. 168 bits = 21 wire bytes.
-type BenchMixed {
+type BenchMixed
+{
     sequence  int32          | min = 0, max = 65535 // 16
     ack_bits  bits(32) // 32
     entity_id bits(12) // 12

--- a/bench/corpus/RealWorld.schema
+++ b/bench/corpus/RealWorld.schema
@@ -31,7 +31,8 @@ enum PacketMode { Idle, Active, Combat, Docked, Warping }
 // The one small flags the packet's flags fields reference: 5 named bits.
 flags PacketFlags { Shielded, Cloaked, Overheated, LowPower, Jamming }
 
-type RealPacket {
+type RealPacket
+{
     f001_int  int32                                                                                | min = -805495, max = 805495 // 21 bits
     f002_f64  float64 // 64 bits
     f003_int  int32                                                                                | min = -835897, max = 835897 // 21 bits
@@ -44,7 +45,8 @@ type RealPacket {
     f010_f32  float32 // 32 bits
     f011_bits bits(10) // 10 bits
     f012_bool bool = true // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
-    if f012_bool {
+    if f012_bool
+    {
         f013_f32   float32 // 32 bits
         f014_uint  uint16             | min = 0, max = 775 // 10 bits
         f015_int   int8               | min = -21, max = 21 // 6 bits
@@ -77,7 +79,8 @@ type RealPacket {
     f041_int    int8                                                                                  | min = -55, max = 55 // 7 bits
     f042_bits   bits(30) // 30 bits
     f043_bool   bool = false // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
-    if f043_bool {
+    if f043_bool
+    {
         f044_f32  float32 // 32 bits (does not ride: gate false)
         f045_bits bits(12) // 12 bits (does not ride: gate false)
         f046_uint uint32                                          | min = 0, max = 76063 // 17 bits (does not ride: gate false)
@@ -86,7 +89,8 @@ type RealPacket {
     f048_f64    float64 // 64 bits
     f049_ufixed ufixed(2, 14)                                                                        | min = 0, max = 3 // 16 bits
     f050_bool   bool = true // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
-    if f050_bool {
+    if f050_bool
+    {
         f051_bool bool // 1 bit
         f052_int  int8               | min = -57, max = 57 // 7 bits
         f053_f32  float32 // 32 bits
@@ -112,7 +116,8 @@ type RealPacket {
     f072_cf32   float32                                                                               | min = 0.0, max = 100.0, resolution = 0.01 // 14 bits
     f073_int    int8                                                                                  | min = -4, max = 4 // 4 bits
     f074_bool   bool = false // 1 bit — branch gate: STRUCTURE (§2.7), held fixed during variation
-    if f074_bool {
+    if f074_bool
+    {
         f075_u64  uint64 // 64 bits (does not ride: gate false)
         f076_int  int16                                         | min = -26218, max = 26218 // 16 bits (does not ride: gate false)
         f077_int  int8                                          | min = -17, max = 17 // 6 bits (does not ride: gate false)

--- a/examples/Messages.schema
+++ b/examples/Messages.schema
@@ -13,24 +13,28 @@ package example
 // cross-file, order-free (SPEC §4.2). A duplicate declaration here was a real
 // §4.6 compile error — caught 2026-08-05 by the corpus standing check.
 
-message Heartbeat {
+message Heartbeat
+{
     // empty body — presence of the message is the payload
 }
 
-message Test {
+message Test
+{
     test_a uint16
     test_b int16  | min = 0, max = 1000
     test_c int16  | min = 0, max = 1000
     test_d int16  | min = 0, max = 1000
 }
 
-message Block {
+message Block
+{
     // wire: length in [0, MaxBlockSize], align, then the used bytes — same
     // shape as string(N); pre-allocated fixed buffer + used length (SPEC §4.7)
     data bytes(MaxBlockSize)
 }
 
-message Chat {
+message Chat
+{
     // wire: length in [0, MaxChatLength], align, then the used bytes —
     // well-formed UTF-8 by contract (writer-trusted, debug-asserted; decided
     // 2026-08-15), interior 0x00 rejected on read; N is the max length, and
@@ -38,12 +42,14 @@ message Chat {
     text string(MaxChatLength)
 }
 
-message Synchronize {
+message Synchronize
+{
     sync_frame    uint64
     sync_sequence uint16
 }
 
-message Timescale {
+message Timescale
+{
     scale   float64
     frame_a uint32
     frame_b uint32

--- a/examples/Objects.schema
+++ b/examples/Objects.schema
@@ -23,7 +23,8 @@
 
 package example
 
-object Ship {
+object Ship
+{
     // ---- visual state, [interpolate]: sent for client interpolation, rides
     // the quantized shallow wire into ShipData_Interpolate ----
 
@@ -90,7 +91,8 @@ object Ship {
     predicted_explode bool | local, context = client
 }
 
-object Missile {
+object Missile
+{
     // The hand-written Missile has NO deep structs (shallow/interpolate only);
     // v1 generates the full family regardless — the unused deep view costs
     // nothing and the model stays uniform. Hand-code writes missile_type
@@ -118,7 +120,8 @@ object Missile {
     timer float64 | local, context = server
 }
 
-object DynamicProp {
+object DynamicProp
+{
     // Also shallow/interpolate-only in hand code; prop_type's hand wire is
     // [1, MAX] on both paths — the cleanest future enum_index customer when
     // that form returns (SPEC §9 q11); a plain enum spends the None value
@@ -138,7 +141,8 @@ object DynamicProp {
     angular_velocity Vec3 | local
 }
 
-object Turret {
+object Turret
+{
     // The turret rides its parent ship: the parent Handle and turret_index are
     // on every wire path, in the interpolate set (discrete fields; their action
     // when the claiming pass arrives is snap).

--- a/examples/Render.schema
+++ b/examples/Render.schema
@@ -16,7 +16,8 @@ package example
 
 const RenderBlockMaxSprites = 64
 
-table RenderSprite {
+table RenderSprite
+{
     sort_key    uint64
     mesh_id     uint32
     material_id uint32
@@ -24,7 +25,8 @@ table RenderSprite {
     team        Team
 }
 
-table RenderBlock {
+table RenderBlock
+{
     worker_index      uint32
     sprite_count_hint uint32
     sprites           [..RenderBlockMaxSprites]RenderSprite

--- a/examples/Types.schema
+++ b/examples/Types.schema
@@ -33,7 +33,8 @@ type Quat | quat4
 
 // A handle to another object: id + generation sequence.
 // object_id 0 doubles as the null sentinel (the surveyed NULL_OBJECT convention).
-type Handle {
+type Handle
+{
     object_id       int32 | min = 0, max = MaxObjects - 1
     object_sequence uint8
 }
@@ -41,19 +42,22 @@ type Handle {
 // Hand-quantized vectors and rotation — the pre-object-views idiom ShipCreate uses below.
 // (Object views express the same thing with [interpolate, quantize = ...]; both
 // belong in the corpus while both idioms exist in real code.)
-type QuantizedPosition {
+type QuantizedPosition
+{
     x int32 | min = -MaxPositionUnits, max = MaxPositionUnits
     y int32 | min = -MaxPositionUnits, max = MaxPositionUnits
     z int32 | min = -MaxPositionUnits, max = MaxPositionUnits
 }
 
-type QuantizedVelocity {
+type QuantizedVelocity
+{
     x int32 | min = -MaxVelocityUnits, max = MaxVelocityUnits
     y int32 | min = -MaxVelocityUnits, max = MaxVelocityUnits
     z int32 | min = -MaxVelocityUnits, max = MaxVelocityUnits
 }
 
-type QuantizedRotation {
+type QuantizedRotation
+{
     x int16 | min = -RotationUnits, max = RotationUnits
     y int16 | min = -RotationUnits, max = RotationUnits
     z int16 | min = -RotationUnits, max = RotationUnits
@@ -70,11 +74,13 @@ type QuantizedRotation {
 // zero-on-untaken-branch rule, the language's contract rather than a
 // convention the caller remembers. The branch costs no wire bits beyond the
 // bool already paid for (back-referencing, SPEC §4.5).
-table RigidBody {
+table RigidBody
+{
     position    Vec3
     orientation Quat
     at_rest     bool
-    if !at_rest {
+    if !at_rest
+    {
         linear_velocity  Vec3
         angular_velocity Vec3
     }
@@ -82,7 +88,8 @@ table RigidBody {
 
 // ---- input ----
 
-type Input {
+type Input
+{
     stick_x  float32
     stick_y  float32
     throttle float32
@@ -99,7 +106,8 @@ type Input {
     ping     bool
 }
 
-type InputPacket {
+type InputPacket
+{
     synchronize_sequence uint16
     current_frame        uint64
     start_frame          uint64
@@ -110,7 +118,8 @@ type InputPacket {
 
 // ---- the create idiom (pre-object-views) ----
 
-type ShipCreate {
+type ShipCreate
+{
     // ship_type is a plain enum: wire [0, ShipType.Max], None wire-legal. The
     // hand-written create path writes [1, MAX] — that index form (enum_index)
     // was designed and cut for now (SPEC §9 q11); one unused wire value is the
@@ -123,7 +132,8 @@ type ShipCreate {
 
     // the flags gate idiom: one bool saves the flag bits in the common all-zero case
     has_flags bool
-    if has_flags {
+    if has_flags
+    {
         flags ShipFlags
     }
 
@@ -147,7 +157,8 @@ type ShipCreate {
 // themselves refuse a paren regression: dropping the author's parens or the
 // doubled-minus parenthesization changes no wire bit and no folded value —
 // only these goldens go red.
-type ExpressionProbe {
+type ExpressionProbe
+{
     hardpoint_index int32 | min = 0, max = (ShipMaxLasers + ShipMaxMissiles) - 1
     spin_rate       int32 | min = --RotationUnits, max = RotationUnits * 2
 }
@@ -171,7 +182,8 @@ type ExpressionProbe {
 const FloorLimit          = -9223372036854775808
 const CeilingCount uint64 = 18446744073709551615
 
-type ExtremeProbe {
+type ExtremeProbe
+{
     floor_bound     int64                         | min = -9223372036854775808, max = 100
     doubled_floor   int64                         | min = --FloorLimit, max = 100
     ceiling_range   uint64                        | min = 1, max = 18446744073709551615
@@ -179,7 +191,8 @@ type ExtremeProbe {
     ceiling_default uint64 = 18446744073709551615
 }
 
-table ExtremeRow {
+table ExtremeRow
+{
     clamped_floor   int64                         | min = -9223372036854775808, max = 100
     clamped_ceiling uint64                        | min = 1, max = 18446744073709551614
     floor_def       int64 = -9223372036854775808

--- a/examples/Wire.schema
+++ b/examples/Wire.schema
@@ -24,7 +24,8 @@ flags ProbeFlags | max = 8
 
 // the storage-less wire constructs (SPEC §4.3): a magic byte the read
 // REJECTS if wrong, reserved bits held at zero, and an alignment point
-type ProbeHeader {
+type ProbeHeader
+{
     const(0xAB, 8)
     version     bits(3)
     reserved(5)
@@ -35,7 +36,8 @@ type ProbeHeader {
 // bits at the interesting widths — 9, the 33-bit low-first boundary, 64 —
 // and the ranged-integer emission paths past int32: a full-range uint32
 // (the int64 call family) and a full-range uint64 (raw offset bits)
-type ProbeBits {
+type ProbeBits
+{
     small    bits(9)
     boundary bits(33)
     wide     bits(64)
@@ -47,18 +49,23 @@ type ProbeBits {
 // projection is a different codepath), a specified default, if/else with a
 // nested branch, bare int32/int64, and a range-counted array whose count
 // can never be zero
-type ProbeSample {
+type ProbeSample
+{
     active      bool = true
     orientation float32     | min = -HalfTurn, max = HalfTurn, resolution = 0.01
     raw_delta   int32
     big_delta   int64
-    if active {
+    if active
+    {
         weapon     Weapon
         has_target bool
-        if has_target {
+        if has_target
+        {
             target_id uint16
         }
-    } else {
+    }
+    else
+    {
         idle_ticks uint32
     }
     samples [1..8]uint16
@@ -67,23 +74,27 @@ type ProbeSample {
 // first-class one-of (SPEC §4.8): the tag rides in minimal bits for
 // [0, variant count], then the selected arm only; None = 0 is the in-band
 // empty union and a read rejects a tag above the count
-type ProbeRing {
+type ProbeRing
+{
     radius uint16
 }
 
-type ProbeSlab {
+type ProbeSlab
+{
     width  uint8 | min = 0, max = 100
     height uint8
 }
 
-union ProbeShape {
+union ProbeShape
+{
     ring ProbeRing
     slab ProbeSlab
 }
 
 // a union as a field, an empty (None) union field, and a counted array of
 // unions — every composition form the language admits
-type ProbeCollider {
+type ProbeCollider
+{
     armor  uint8
     shape  ProbeShape
     backup ProbeShape
@@ -92,7 +103,8 @@ type ProbeCollider {
 
 // specified defaults past bool (SPEC §4.2): a negative integer and an enum
 // variant — zero init everywhere else
-type ProbeConfig {
+type ProbeConfig
+{
     retries   int32 = -1
     preferred Weapon = Railgun
 }
@@ -100,14 +112,16 @@ type ProbeConfig {
 // a type composing DEFAULTED types — through a fixed array and a plain
 // member: New*/construction must install the inner defaults transitively in
 // every target (zero init reaches only fields with no specified default)
-table ProbeArray {
+table ProbeArray
+{
     samples [2]ProbeSample
     config  ProbeConfig
 }
 
 // a message used as an ordinary field type — a message IS an ordinary type
 // (SPEC §4.8)
-type ProbeReport {
+type ProbeReport
+{
     header ProbeHeader
     flags  ProbeFlags
     echo   Test
@@ -121,7 +135,8 @@ type ProbeReport {
 // explicit align (the exact-N bytes form died in the §4.7 unification); and
 // two constructs are v1-deferred by decision and absent — int_relative
 // (§4.10, the delta pass) and wstring.
-table TestData {
+table TestData
+{
     a int32 | min = -100, max = 100
     b int32 | min = -100, max = 100
     c int32 | min = -100, max = 150
@@ -167,7 +182,8 @@ table TestData {
 //                        on write and the + min reconstruction on read; a
 //                        full-range float32 sweep found no fused divergence
 //                        on this shape — measured, not assumed)
-type CompressedProbe {
+type CompressedProbe
+{
     boundary float32 | min = 0, max = 10, resolution = 0.01
     offset   float32 | min = -5, max = 5, resolution = 0.001
 }

--- a/examples128/Ludicrous.schema
+++ b/examples128/Ludicrous.schema
@@ -19,7 +19,8 @@ enum DriveMode { Cruise, Warp, Ludicrous }
 // Q48.16 (32-bit wire, the single-group boundary), Q112.16 (the wide path,
 // two groups), Q32.0 (a fixed with no fraction IS a ranged integer —
 // STANDARD.md), and a fixed array (per-element encoding)
-type FixedProbe {
+type FixedProbe
+{
     angle    fixed(16, 16)    | min = -180, max = 180
     position fixed(48, 16)    | min = -MaxWorldUnits, max = MaxWorldUnits
     reach    fixed(112, 16)   | min = -1000000, max = 1000000
@@ -36,7 +37,8 @@ type FixedProbe {
 // them — the C entry routing and the Go bit-casts are proven by the
 // byte-compare. locked is the degenerate ufixed shape (zero bits, F = 16
 // would show), riding in front of the tail byte like DegenerateProbe's.
-type UnsignedProbe {
+type UnsignedProbe
+{
     angle   ufixed(16, 16)    | min = 0, max = 360
     span    ufixed(48, 16)    | min = 0, max = 281474976710655
     reach   ufixed(112, 16)   | min = 0, max = 2000000
@@ -52,7 +54,8 @@ type UnsignedProbe {
 // (serialize's own ±2^100 band: 102 wire bits, four groups), and specified
 // defaults on both kinds — including one beyond int64, which C++ renders as
 // composed unsigned halves (no 128-bit literal exists)
-type WideProbe {
+type WideProbe
+{
     entity_id uint128
     energy    int128                         | min = -5000000000, max = 5000000000
     flux      int128                         | min = -1267650600228229401496703205376, max = 1267650600228229401496703205376
@@ -62,13 +65,15 @@ type WideProbe {
 
 // composition, a counted array of the raw field, and branch zeroing over a
 // 128-bit field (SPEC §5: the untaken side reads back as zero)
-message LudicrousState {
+message LudicrousState
+{
     mode       DriveMode
     probe      FixedProbe
     wide       WideProbe
     keys       [..4]uint128
     has_target bool
-    if has_target {
+    if has_target
+    {
         target_id uint128
     }
 }
@@ -81,7 +86,8 @@ message LudicrousState {
 // byte: a port that emits ANY bits for one of them shifts the tail and
 // fails the byte-compare. locked_fixed is the fraction_bits shape
 // (F = 16 would appear); locked_wide is the 64/128 boundary shape.
-type DegenerateProbe {
+type DegenerateProbe
+{
     locked_fixed fixed(16, 16) | min = -3, max = -3
     locked_int   int32         | min = 7, max = 7
     locked_wide  int128        | min = -12345678901234, max = -12345678901234
@@ -110,7 +116,8 @@ type FixedQuat | quat4
     w fixed(2, 30) = 1.0 | min = -1, max = 1
 }
 
-object Body {
+object Body
+{
     position FixedVec  | interpolate
     rotation FixedQuat | interpolate
     velocity FixedVec  | interpolate
@@ -125,7 +132,8 @@ object Body {
 // The per-component shallow bound is the component's own whole-unit
 // [min, max] scaled by K. velocity stays full precision beside them — the
 // two forms compose in one object.
-object NarrowBody {
+object NarrowBody
+{
     position FixedVec  | interpolate, quantize = 256
     rotation FixedQuat | interpolate, quantize = 1024
     velocity FixedVec  | interpolate

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -504,6 +504,8 @@ func TestGoodCornersStillCompile(t *testing.T) {
 			src: "package t\ntype T { h int16 | min = 0, max = 5 // the section ends here\n}\n"},
 		{name: "a qualified declaration's body opens on the next line",
 			src: "package t\nenum E | max = 5\n{ A, B }\ntype Q | tagged\n{\n    e E\n}\n"},
+		{name: "both brace placements parse (Allman canonical, same-line tolerated)",
+			src: "package t\ntype A {\n    x uint8\n}\ntype B\n{\n    a bool\n    if a {\n        y uint8\n    }\n    if !a\n    {\n        z uint8\n    }\n}\n"},
 		{name: "message as a field type",
 			src: "package t\nmessage M { x uint8 }\ntype T { m M }\n"},
 		{name: "empty type and empty message",

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -89,6 +89,30 @@ func render(path string, src []byte) ([]byte, error) {
 		}
 	}
 
+	// Allman normalization (SPEC §4.1, §7.4 rule 1): a MULTI-LINE block's
+	// opening brace moves to its own line, and `else` stands alone between
+	// its braces. One-line { ... } groups — an inline enum list, a one-line
+	// type body — close on their own line and stay whole. Both placements
+	// parse; this is the one canonical output.
+	var normalized []line
+	for _, l := range lines {
+		work := l
+		// a closing } followed by more tokens (`} else {`) splits after the }
+		for len(work.tokens) > 1 && work.tokens[0].Kind == scanner.RBrace {
+			normalized = append(normalized, line{tokens: work.tokens[:1]})
+			work = line{tokens: work.tokens[1:], comment: work.comment}
+		}
+		// a line ENDING in { opens a multi-line block: the brace stands alone
+		// (a group that closes on the same line ends in }, not {, and passes
+		// through untouched)
+		if n := len(work.tokens); n > 1 && work.tokens[n-1].Kind == scanner.LBrace {
+			normalized = append(normalized, line{tokens: work.tokens[:n-1], comment: work.comment})
+			work = line{tokens: work.tokens[n-1:]}
+		}
+		normalized = append(normalized, work)
+	}
+	lines = normalized
+
 	// render each line at its depth, collapsing blank runs and dropping
 	// blanks at the file start, after an opener and before a closer
 	var rendered []string

--- a/internal/format/migrate_test.go
+++ b/internal/format/migrate_test.go
@@ -26,7 +26,8 @@ func TestMigrateRewritesRetiredSpellings(t *testing.T) {
 		"enum Weapon | max = 15\n" +
 		"{ Laser, Missile }\n" +
 		"\n" +
-		"type T {\n" +
+		"type T\n" +
+		"{\n" +
 		"    health       int16              | min = 0, max = 100\n" +
 		"    invulnerable bool = true        | local\n" +
 		"    w            fixed(2, 30) = 1.0 | min = -1, max = 1\n" +

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -285,6 +285,7 @@ func (p *parser) constType() (string, bool) {
 
 func (p *parser) parseVariantList(what string) []ast.Name {
 	var names []ast.Name
+	p.skipNewlineBeforeBrace()
 	p.expect(scanner.LBrace, "{")
 	for p.kind() != scanner.RBrace && p.kind() != scanner.EOF {
 		t := p.expect(scanner.Ident, what+" variant name")
@@ -308,6 +309,7 @@ func (p *parser) parseVariantList(what string) []ast.Name {
 // it does not describe a wire refinement.
 func (p *parser) parseUnionBody() []ast.UnionVariant {
 	var variants []ast.UnionVariant
+	p.skipNewlineBeforeBrace()
 	p.expect(scanner.LBrace, "{")
 	for {
 		switch p.kind() {
@@ -360,8 +362,18 @@ func (p *parser) parseUnionBody() []ast.UnionVariant {
 	}
 }
 
+// skipNewlineBeforeBrace tolerates the opening brace on its own line —
+// Allman is the house style (SPEC §4.1); the formatter normalizes, the
+// parser reads both placements.
+func (p *parser) skipNewlineBeforeBrace() {
+	if p.kind() == scanner.Newline && p.peek().Kind == scanner.LBrace {
+		p.advance()
+	}
+}
+
 func (p *parser) parseBlock() *ast.Block {
 	b := &ast.Block{}
+	p.skipNewlineBeforeBrace()
 	p.expect(scanner.LBrace, "{")
 	for {
 		switch p.kind() {


### PR DESCRIPTION
Closes #127.

A multi-line block's opening brace stands on its own line, and else stands alone between its braces; a one-line { ... } group — an inline enum list, a one-line type body — closes on its own line and stays whole (braces around a group that closes on the same line are a list, not a block). The parser reads BOTH placements — a line-oriented grammar treats a lone { line as the block opener — and fmt normalizes to Allman as the one canonical output. This resolves #126's declaration line completely: the pipe section takes the whole line, the brace takes its own. 'This way we stop looking like a dialect of golang (we're not).'

Braces are pure syntax, proven at the strongest level: after reformatting the corpus, ZERO files under testdata moved — generated sources, wire pins, table pins and the protocol id (0x9cdffa5a3048f991) are byte-identical. Both placements are pinned as a good corner in the diagnostics suite (same-line, Allman, and both if-forms in one unit); the one-shot migrate mode emits Allman in the same pass as #126; SPEC §4.1/§7.4 state the style with the one-line-group rule, the EBNF carries the tolerance note, and every SPEC/doc example is respelled. Full make gauntlet, lint and the modernize leg green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)