### PR TITLE
PR conformance runs on ubuntu only — the platform #133 budgeted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,15 @@ jobs:
   # the C++-pinned goldens — that cross-language bit identity is the property
   # this project exists to provide, and CI is where it gets proven on
   # hardware we do not own. It runs on every trigger, PRs included, because
-  # it is cheap (31-45s measured): the fast leg trims nothing from it.
+  # it is cheap (31-45s measured): the fast leg trims nothing from the
+  # corpus.
+  #
+  # PRs run it on ubuntu ONLY (the one platform #133 budgeted): the shared
+  # macOS pool is 5 runners wide and a certification run's gate fan-out
+  # saturates it, so a PR macOS job pushed during those minutes queues behind
+  # it and blows the 2-minute law (measured: 1:34 of queueing, 3:00 wall,
+  # run 32830268855). The ubuntu pool is 20 wide. macOS conformance still
+  # proves every main commit, minutes later, in this same job.
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -68,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest"]') }}
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The follow-up measurement to #135, which merged while this commit was still on its branch. The gate split held the 2-minute law only until a certification run and a PR run overlapped: the shared macOS pool is 5 runners wide, a certification's gate fan-out saturates it, and a PR's macOS test job pushed during those minutes queued 1:34 behind the gates for a 3:00 wall (run 32830268855). That is the contention #133's own budget already answered — it prescribed one platform for the PR leg.

So the PR trigger now runs conformance on ubuntu only, where the pool is 20 wide and a certification run cannot starve it. Nothing else changes: certification (push to main, nightly, dispatch) keeps the macOS conformance job, so every main commit is still proven on both OSes minutes after merge, and the full corpus still runs on every PR — 31 to 45 seconds, all six languages, goldens, staleness, fuzz seeds.

Measured on the #135 branch before its merge: PR wall 1:45 with both OSes uncontended, 3:00 contended; ubuntu test job alone is stable at 1:17 to 1:21. This PR's own checks are the after-number. First post-split main certification: 6:43 green (run 32830593585) against 9:20 to 10:35 before the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
