### PR TITLE
Table/pack debris out of the compiler sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ generated/c-ludicrous/.stamp: bin/schema $(SCHEMAS128)
 # definition; the goldens come from the generated C++ (test/bench/main.cpp)
 # and every bench runner is §1.5-gated against them. Languages whose module
 # layout cannot hold two packages in one directory put the realworld unit in
-# its own subdirectory (go, cs — per-package TableRuntime) or sibling crate
+# its own subdirectory (go, cs) or sibling crate
 # (rust — one crate root per unit).
 #
 # COMPILE gates: generating a unit proves nothing about it compiling — the cs

--- a/bench/cs/schemabench.csproj
+++ b/bench/cs/schemabench.csproj
@@ -25,10 +25,9 @@
 
   <ItemGroup>
     <Compile Include="../../generated/cs/*.cs" />
-    <!-- the bench-corpus realworld unit (namespace Realworld — its own
-         per-unit TableRuntime, so no basename/type collision with the
-         Example unit above): RealPacket, the §1.7 realistic snapshot the
-         real_packet rows measure -->
+    <!-- the bench-corpus realworld unit (namespace Realworld, so no
+         basename/type collision with the Example unit above): RealPacket,
+         the §1.7 realistic snapshot the real_packet rows measure -->
     <Compile Include="../../generated/bench/cs/realworld/*.cs" />
     <Compile Include="$(SerializeCsRoot)/src/Serialize.cs" />
     <!-- the emulated 128-bit pair (Int128Value/UInt128Value) lives beside

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1,10 +1,9 @@
 // Package compiler is schema's public driver: it turns *.schema paths into a
-// checked unit ([ir.Unit]), hands that unit to a registered generator, and
-// runs the data compiler over a pack manifest. It is the whole compiler as a
-// library — cmd/schema is its first client and imports nothing else from this
-// module except [ir].
+// checked unit ([ir.Unit]) and hands that unit to a registered generator. It
+// is the whole compiler as a library — cmd/schema is its first client and
+// imports nothing else from this module except [ir].
 //
-// The three steps are separate on purpose. [Compiler.Load] does the loud part
+// The two steps are separate on purpose. [Compiler.Load] does the loud part
 // (formatting, parsing, checking, the protocol id) and returns either a unit
 // or the diagnostics; [Compiler.Generate] is pure — a unit in, the emitted
 // file bytes out, nothing written; writing is the caller's, so an embedder can
@@ -33,8 +32,8 @@ import (
 // with the six built-in generators registered.
 //
 // Register and the two policy fields configure a Compiler; do that before use
-// and from one goroutine. Once configured it is read-only, and Load, Generate
-// and Pack may run concurrently — with the caveat that FormatInPlace writes to
+// and from one goroutine. Once configured it is read-only, and Load and
+// Generate may run concurrently — with the caveat that FormatInPlace writes to
 // the input tree, so concurrent loads must not name the same files.
 type Compiler struct {
 	// FormatInPlace canonicalizes every schema file on disk before parsing it

--- a/examples/Render.schema
+++ b/examples/Render.schema
@@ -1,5 +1,5 @@
-// Render.schema — the parallel scatter/gather worked example. Table types
-// are trivially copyable and standard-layout by enforced construction, so
+// Render.schema — the parallel scatter/gather worked example. Generated
+// types are trivially copyable and standard-layout by enforced construction, so
 // N workers can build instances INDEPENDENTLY — into their own memory, or
 // scattered directly into disjoint sections of one shared blob — and the
 // gather is concatenation or offset arithmetic, never a serial builder.

--- a/internal/codegen/c/fields.go
+++ b/internal/codegen/c/fields.go
@@ -60,8 +60,8 @@ func (g *gen) emitWriteScalar(f *ir.Field, expr, ind string) {
 			// The runtime's precomputed entry point (issue #82): the step
 			// count, wire width and float32 range width depend only on the
 			// declaration, so ir.CompressedFloatParams derives them ONCE at
-			// generation time — the same derivation internal/pack and the
-			// Go fold (#79) emit from — and the quantization arithmetic
+			// generation time — the same derivation the Go fold (#79)
+			// emits from — and the quantization arithmetic
 			// keeps its one audited home in serialize.h.
 			steps, wireBits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
 			min32 := float32(f.FMin)

--- a/internal/codegen/c/objects.go
+++ b/internal/codegen/c/objects.go
@@ -500,9 +500,7 @@ func (g *gen) emitQuantizeField(f *ir.Field) {
 				continue
 			}
 			// round-to-nearest narrowing shift — arithmetic on int64, ties
-			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8,
-			// decided 2026-08-15; the data compiler's ratRoundHalfAway is the
-			// same rule). Negative raws mirror through negation so the tie
+			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8). Negative raws mirror through negation so the tie
 			// leaves zero in both signs. In-bounds raws cannot overflow the
 			// add or the negation (checker-enforced bounds leave 2^(F-1) of
 			// headroom past any legal raw)

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -67,10 +67,8 @@ func Generate(u *ir.Unit, opts Options) (map[string][]byte, error) {
 		bases[f.Base] = true
 	}
 	for _, f := range u.Files {
-		for _, suffix := range []string{"Wire", "Table"} {
-			if bases[f.Base+suffix] {
-				return nil, fmt.Errorf("schema files %s and %s%s collide — the C++ emitter writes %s%s.h as %s's %s header; rename one file (SPEC §6.1)", f.Base, f.Base, suffix, f.Base, suffix, f.Base, strings.ToLower(suffix))
-			}
+		if bases[f.Base+"Wire"] {
+			return nil, fmt.Errorf("schema files %s and %sWire collide — the C++ emitter writes %sWire.h as %s's wire header; rename one file (SPEC §6.1)", f.Base, f.Base, f.Base, f.Base)
 		}
 	}
 	out := map[string][]byte{}

--- a/internal/codegen/cpp/objects.go
+++ b/internal/codegen/cpp/objects.go
@@ -276,9 +276,7 @@ func (g *gen) emitQuantizeField(f *ir.Field, ind string) {
 				continue
 			}
 			// round-to-nearest narrowing shift — arithmetic on int64, ties
-			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8,
-			// decided 2026-08-15; the data compiler's ratRoundHalfAway is the
-			// same rule). Negative raws mirror through negation so the tie
+			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8). Negative raws mirror through negation so the tie
 			// leaves zero in both signs. In-bounds raws cannot overflow the
 			// add or the negation (checker-enforced bounds leave 2^(F-1) of
 			// headroom past any legal raw)

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -61,15 +61,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	batched, needCore := batchPlan(u)
-	bases := map[string]bool{}
-	for _, f := range u.Files {
-		bases[f.Base] = true
-	}
-	for _, f := range u.Files {
-		if bases[f.Base+"Table"] {
-			return nil, fmt.Errorf("schema files %s and %sTable collide — the C# emitter writes %sTable.cs as %s's table codec; rename one file", f.Base, f.Base, f.Base, f.Base)
-		}
-	}
 	for _, f := range u.Files {
 		g := &gen{unit: u, file: f, msgOwner: msgOwner, objOwner: objOwner, batched: batched, needCore: needCore}
 		g.emitFile(f.Base == home)

--- a/internal/codegen/csharp/objects.go
+++ b/internal/codegen/csharp/objects.go
@@ -221,9 +221,7 @@ func (g *gen) emitQuantizeField(f *ir.Field, ind string) {
 				continue
 			}
 			// round-to-nearest narrowing shift — arithmetic on long, ties
-			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8,
-			// decided 2026-08-15; the data compiler's ratRoundHalfAway is the
-			// same rule). Negative raws mirror through negation so the tie
+			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8). Negative raws mirror through negation so the tie
 			// leaves zero in both signs. In-bounds raws cannot overflow the
 			// add or the negation (checker-enforced bounds leave 2^(F-1) of
 			// headroom past any legal raw)

--- a/internal/codegen/golang/functions.go
+++ b/internal/codegen/golang/functions.go
@@ -327,7 +327,7 @@ func (g *gen) emitWriteRangedFold64(expr, lo, hi string, bits int64, loZero bool
 // here instead of on every field of every message.
 //
 // The float32() around the product is LOAD BEARING, exactly as it is in the
-// runtime and in internal/pack: STANDARD.md pins this arithmetic to float32 with
+// runtime: STANDARD.md pins this arithmetic to float32 with
 // TWO roundings, and Go permits fusing a multiply into an add unless a
 // conversion forces the intermediate rounding. arm64 takes that permission, so a
 // fused line writes different bytes for 0.005 over [0, 10] at resolution 0.01.

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -41,15 +41,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	home := protocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
-	bases := map[string]bool{}
-	for _, f := range u.Files {
-		bases[f.Base] = true
-	}
-	for _, f := range u.Files {
-		if bases[f.Base+"Table"] {
-			return nil, fmt.Errorf("schema files %s and %sTable collide — the Go emitter writes %sTable.go as %s's table codec; rename one file", f.Base, f.Base, f.Base, f.Base)
-		}
-	}
 	for _, f := range u.Files {
 		g := &gen{unit: u, file: f, msgOwner: msgOwner, objOwner: objOwner}
 		g.emitFile(f.Base == home)

--- a/internal/codegen/golang/objects.go
+++ b/internal/codegen/golang/objects.go
@@ -220,9 +220,7 @@ func (g *gen) emitQuantizeField(f *ir.Field, ind string) {
 				continue
 			}
 			// round-to-nearest narrowing shift — arithmetic on int64, ties
-			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8,
-			// decided 2026-08-15; the data compiler's ratRoundHalfAway is the
-			// same rule). Negative raws mirror through negation so the tie
+			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8). Negative raws mirror through negation so the tie
 			// leaves zero in both signs. In-bounds raws cannot overflow the
 			// add or the negation (checker-enforced bounds leave 2^(F-1) of
 			// headroom past any legal raw)

--- a/internal/codegen/js/flat.go
+++ b/internal/codegen/js/flat.go
@@ -9,7 +9,7 @@
 // reference surface and the CI oracle this tier is held byte-identical to.
 //
 // Per schema file Base.schema, BaseFlat.js is emitted beside Base.js
-// whenever the file declares types, messages or tables (their dense wire) or
+// whenever the file declares types or messages or
 // carries the message dispatch surface. Per struct Name:
 //
 //	Write<Name>Flat(value, view)          -> bytes written | -1 (checked refusal)
@@ -94,7 +94,7 @@ type fgen struct {
 }
 
 // flatFileHasSurface reports whether a file gets a Flat module: any file
-// declaring structs (types, messages, tables' dense wire), or the message
+// declaring structs (types, messages), or the message
 // owner file (the dispatch surface).
 func flatFileHasSurface(u *ir.Unit, f *ir.File, msgOwner string) bool {
 	for _, d := range f.Decls {

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -73,9 +73,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		bases[f.Base] = true
 	}
 	for _, f := range u.Files {
-		if bases[f.Base+"Table"] {
-			return nil, fmt.Errorf("schema files %s and %sTable collide — the JS emitter writes %sTable.js as %s's table codec; rename one file", f.Base, f.Base, f.Base, f.Base)
-		}
 		if bases[f.Base+"Flat"] {
 			return nil, fmt.Errorf("schema files %s and %sFlat collide — the JS emitter writes %sFlat.js as %s's flat-tier codec; rename one file", f.Base, f.Base, f.Base, f.Base)
 		}

--- a/internal/codegen/js/objects.go
+++ b/internal/codegen/js/objects.go
@@ -393,7 +393,7 @@ func (g *gen) emitQuantizeField(f *ir.Field, ind string) {
 				continue
 			}
 			// round-to-nearest narrowing shift — ties AWAY FROM ZERO: the one
-			// fixed-point rounding rule (SPEC §4.8, decided 2026-08-15).
+			// fixed-point rounding rule (SPEC §4.8).
 			// Negative raws mirror through negation so the tie leaves zero in
 			// both signs. In-bounds raws cannot overflow the add (checker-
 			// enforced bounds leave 2^(F-1) of headroom past any legal raw).

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -639,7 +639,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 // precomputed compressed-float entry point (issue #82): the family contract's
 // four scalars in the family order — max_integer_value, bits, delta, min, with
 // min last. The values are ir.CompressedFloatParams' generation-time fold, the
-// same derivation internal/pack, the JS flat backend, the Go fold (#79) and
+// same derivation the JS flat backend, the Go fold (#79) and
 // the cpp backend (#114) already consume, and the same arithmetic
 // serialize.rs's serialize_compressed_float_params performs per call — so the
 // entry points are wire-identical by construction, and the runtime's debug

--- a/internal/codegen/rust/objects.go
+++ b/internal/codegen/rust/objects.go
@@ -240,9 +240,7 @@ func (g *gen) emitQuantizeField(f *ir.Field, ind string) {
 				continue
 			}
 			// round-to-nearest narrowing shift — arithmetic on i64, ties
-			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8,
-			// decided 2026-08-15; the data compiler's ratRoundHalfAway is the
-			// same rule). Negative raws mirror through negation so the tie
+			// AWAY FROM ZERO: the one fixed-point rounding rule (SPEC §4.8). Negative raws mirror through negation so the tie
 			// leaves zero in both signs. In-bounds raws cannot overflow the
 			// add or the negation (checker-enforced bounds leave 2^(F-1) of
 			// headroom past any legal raw)

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -388,7 +388,7 @@ func (g *gen) emitStruct(d *ir.Struct) {
 	// Copy alone only says the bytes can be duplicated within one build;
 	// Rust's default representation may reorder fields and is not stable
 	// across builds, so memcpy to a file, an mmap or another process — the
-	// things WIRES.md promises of table storage — would be honoured by
+	// things WIRES.md promises of generated storage — would be honoured by
 	// accident until the day they were not. It also makes the layout match
 	// the C++ struct field for field, which is what "the same data type in
 	// five languages" ought to mean.

--- a/internal/fuzz/oracle_test.go
+++ b/internal/fuzz/oracle_test.go
@@ -19,7 +19,7 @@
 //     the check is exact-duplicate DEFINITION LINES within one file — two
 //     byte-identical `inline bool WriteShip(...)` openers in one translation
 //     unit are a redefinition whatever the bodies say. Pure forward
-//     declarations (`struct TableTypeInfo;`) may repeat and are excluded.
+//     declarations (`struct ShipData;`) may repeat and are excluded.
 package fuzz_test
 
 import (
@@ -148,9 +148,8 @@ var cFamilyDefLine = regexp.MustCompile(`^(static |inline |constexpr |struct |cl
 
 // csTypeDefLine matches C# type declarations (indented inside the namespace).
 // Member and method lines are excluded on purpose: identical member text in
-// two classes is legal and common — and so are repeated `partial class`
-// openers, which this emitter really does put twice in one file
-// (generated/cs/TypesTable.cs), so `partial` is excluded too.
+// two classes is legal and common, and repeated `partial class` openers are
+// legal C# an emitter may legitimately produce, so `partial` is excluded too.
 var csTypeDefLine = regexp.MustCompile(`^(public |internal |static )*(sealed |static )*(class|struct|enum|interface) `)
 
 // pure forward declarations may legally repeat.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -258,7 +258,7 @@ func (p *parser) parseDecl() {
 			p.expectTerminator("union declaration")
 			p.file.Decls = append(p.file.Decls, d)
 		default:
-			p.errf(t.Pos, "unexpected %q at file scope (declarations begin with package, const, enum, flags, type, table, message, object, union or contexts)", t.Text)
+			p.errf(t.Pos, "unexpected %q at file scope (declarations begin with package, const, enum, flags, type, message, object, union or contexts)", t.Text)
 			p.skipDecl()
 		}
 

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -79,7 +79,7 @@ type ContextsMarker struct {
 	Names []string
 }
 
-// Struct is a `type`, `table` or `message` declaration.
+// Struct is a `type` or `message` declaration.
 // Union is a first-class one-of type (SPEC §4.8): the implicit None row at
 // tag 0, then each variant in DECLARED order, dense from 1. The tag encodes
 // in minimal bits for [0, Max]; the wire then carries the selected variant's

--- a/ir/projection.go
+++ b/ir/projection.go
@@ -27,8 +27,8 @@ package ir
 //   object ordinals          the ObjectType tag likewise
 //   contexts                 a context scopes | local fields out of a view
 //   every type's fields      order IS the wire order
-//   field names              the TABLE wire's field identity is
-//                            fold16(fnv1a32(name)) — a rename moves data
+//   field names              FROZEN input (see projectField) — a rename
+//                            moves the id
 //   type kind/width/sign     the bit width and the encoding
 //   declared bounds          the width follows from the range
 //   array kind and bounds    the count field's width, and the element count
@@ -36,7 +36,7 @@ package ir
 //   float range + resolution the quantized step count
 //   fixed I and F            the Q format and the raw bounds
 //   quantize scale/bound     the shallow view's per-component width
-//   specified defaults       the TABLE wire elides a field at its default
+//   specified defaults       FROZEN input (see projectField)
 //   branch structure         a guard removes fields from the wire
 //   const/reserved/align     literal bits, zero bits, and padding
 //   enum max, storage bits   the tag's wire range
@@ -183,9 +183,11 @@ func projectItems(b *strings.Builder, items []Item, ind string) {
 }
 
 func projectField(b *strings.Builder, f *Field, ind string) {
-	// the NAME rides: the table wire's field identity is its name hash, so a
-	// rename is a wire-breaking change even though the message wire is
-	// unmoved
+	// the NAME rides as a FROZEN token: it projected for the retired table
+	// wire (field identity was its name hash), and keeping it keeps every
+	// existing id stable — so a rename moves the id even though the message
+	// wire is unmoved. Dropping it is a ProjectionVersion bump, taken
+	// deliberately or not at all.
 	fmt.Fprintf(b, "%sfield %s kind=%d", ind, f.Name, int(f.Type.Kind))
 
 	if f.Type.Kind == TNamed {
@@ -228,8 +230,9 @@ func projectField(b *strings.Builder, f *Field, ind string) {
 	if f.Context != "" {
 		fmt.Fprintf(b, " context=%s", f.Context)
 	}
-	// the TABLE wire elides a field sitting at its default, so the default is
-	// part of the bytes
+	// the default rides as a FROZEN token (the retired table wire elided a
+	// field sitting at its default); it stays part of the bytes to keep
+	// existing ids stable
 	if f.HasDefault {
 		switch {
 		case f.DefVariant != "":


### PR DESCRIPTION
Pre-v1.0.0 review, subtraction pass 1 of several: what the table layer's removal (#139) left behind in the compiler sources.

- Dead `*Table` filename-collision refusals in the Go, JS and C# emitters and the `Table` suffix in C++'s — no emitter writes a `FooTable.*` file anymore, and the check could spuriously refuse a legal unit containing `Foo.schema` + `FooTable.schema`. The live `Wire`/`Flat`/`serialize` collision checks stay.
- `compiler` package doc no longer describes the removed Pack step ("three steps", "Load, Generate and Pack may run concurrently").
- Comments no longer point at deleted `internal/pack` / `ratRoundHalfAway`.
- `ir/projection.go` comments now state the present truth: field names and defaults are FROZEN projection tokens kept for id stability, not a live table wire.
- Parser file-scope diagnostic no longer lists `table` as a valid declaration opener (the by-name refusal and its pinned test are untouched).
- `Makefile`/`schemabench.csproj`/`examples/Render.schema` stale TableRuntime / "Table types" wording.

No generated output changes; protocol ids verified unchanged (0xbc05d83a8135cdb9 / 0xa925c86b46058512); `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)