### PR TITLE
Generated output reads like an expert wrote it

### DIFF
--- a/generated/bench/c/Bench.h
+++ b/generated/bench/c/Bench.h
@@ -8,16 +8,6 @@
 #define SCHEMA_BENCH_BENCH_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -63,7 +53,7 @@ typedef struct BenchInts {
 } BenchInts;
 
 #define BENCH_INTS_MAX_BITS 110   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define BENCH_INTS_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define BENCH_INTS_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type BenchBits */
@@ -79,7 +69,7 @@ typedef struct BenchBits {
 } BenchBits;
 
 #define BENCH_BITS_MAX_BITS 156   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define BENCH_BITS_MAX_BYTES 24  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define BENCH_BITS_MAX_BYTES 24  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type BenchMixed */
@@ -98,7 +88,7 @@ typedef struct BenchMixed {
 } BenchMixed;
 
 #define BENCH_MIXED_MAX_BITS 168   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define BENCH_MIXED_MAX_BYTES 24  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define BENCH_MIXED_MAX_BYTES 24  /* 8-byte write granularity; read slack per the contract above */
 
 #ifdef __cplusplus
 }

--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -8,7 +8,6 @@
 #define SCHEMA_BENCH_BENCHWIRE_H
 
 #include "Bench.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
 
 #ifndef SCHEMA_UNUSED
@@ -22,6 +21,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -45,8 +50,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes BenchPacket. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes BenchPacket. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_packet( serialize_write_stream_t * stream, const BenchPacket * value )
 {
     if ( (serialize_int64_t) value->a < -100 || (serialize_int64_t) value->a > 100 )
@@ -116,8 +120,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_packet( serialize_wri
     return 1;
 }
 
-/* Reads BenchPacket. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads BenchPacket. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_packet( serialize_read_stream_t * stream, BenchPacket * value )
 {
     {
@@ -221,8 +224,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_packet( serialize_read_
     return 1;
 }
 
-/* Writes BenchInts. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes BenchInts. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_ints( serialize_write_stream_t * stream, const BenchInts * value )
 {
     if ( (serialize_int64_t) value->f0 < -100 || (serialize_int64_t) value->f0 > 100 )
@@ -308,8 +310,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_ints( serialize_write
     return 1;
 }
 
-/* Reads BenchInts. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads BenchInts. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_stream_t * stream, BenchInts * value )
 {
     {
@@ -455,8 +456,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_ints( serialize_read_st
     return 1;
 }
 
-/* Writes BenchBits. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes BenchBits. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_bits( serialize_write_stream_t * stream, const BenchBits * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->b7, 7 ) )
@@ -501,8 +501,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_bits( serialize_write
     return 1;
 }
 
-/* Reads BenchBits. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads BenchBits. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_bits( serialize_read_stream_t * stream, BenchBits * value )
 {
     {
@@ -577,8 +576,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_bits( serialize_read_st
     return 1;
 }
 
-/* Writes BenchMixed. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes BenchMixed. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_write_stream_t * stream, const BenchMixed * value )
 {
     if ( (serialize_int64_t) value->sequence < 0 || (serialize_int64_t) value->sequence > 65535 )
@@ -655,8 +653,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
     return 1;
 }
 
-/* Reads BenchMixed. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads BenchMixed. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_mixed( serialize_read_stream_t * stream, BenchMixed * value )
 {
     {

--- a/generated/bench/c/RealWorld.h
+++ b/generated/bench/c/RealWorld.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED
 #if defined(__GNUC__) || defined(__clang__)
@@ -47,27 +46,11 @@ static SCHEMA_UNUSED const char * enum_name_packet_mode( PacketMode value )
     switch ( value )
     {
         case PACKET_MODE_NONE: return "None";
-        case 1: return "Idle";
-        case 2: return "Active";
-        case 3: return "Combat";
-        case 4: return "Docked";
-        case 5: return "Warping";
-        default: return "???";
-    }
-}
-
-/* As enum_name_packet_mode, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_packet_mode_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Idle";
-        case 2: return "Active";
-        case 3: return "Combat";
-        case 4: return "Docked";
-        case 5: return "Warping";
+        case PACKET_MODE_IDLE: return "Idle";
+        case PACKET_MODE_ACTIVE: return "Active";
+        case PACKET_MODE_COMBAT: return "Combat";
+        case PACKET_MODE_DOCKED: return "Docked";
+        case PACKET_MODE_WARPING: return "Warping";
         default: return "???";
     }
 }

--- a/generated/bench/c/RealWorldWire.h
+++ b/generated/bench/c/RealWorldWire.h
@@ -8,7 +8,6 @@
 #define SCHEMA_REALWORLD_REAL_WORLDWIRE_H
 
 #include "RealWorld.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
 
 #ifndef SCHEMA_UNUSED
@@ -22,6 +21,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -45,8 +50,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes RealPacket. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes RealPacket. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_write_stream_t * stream, const RealPacket * value )
 {
     if ( (serialize_int64_t) value->f001_int < -805495 || (serialize_int64_t) value->f001_int > 805495 )
@@ -614,8 +618,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     return 1;
 }
 
-/* Reads RealPacket. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads RealPacket. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_real_packet( serialize_read_stream_t * stream, RealPacket * value )
 {
     {

--- a/generated/bench/cpp/Bench.h
+++ b/generated/bench/cpp/Bench.h
@@ -48,7 +48,7 @@ struct BenchInts {
 };
 
 inline constexpr int64_t BenchIntsMaxBits = 110; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t BenchIntsMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BenchIntsMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type BenchBits
 struct BenchBits {
@@ -63,7 +63,7 @@ struct BenchBits {
 };
 
 inline constexpr int64_t BenchBitsMaxBits = 156; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t BenchBitsMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BenchBitsMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 // type BenchMixed
 struct BenchMixed {
@@ -81,6 +81,6 @@ struct BenchMixed {
 };
 
 inline constexpr int64_t BenchMixedMaxBits = 168; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t BenchMixedMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BenchMixedMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 } // namespace bench

--- a/generated/bench/cs/Bench.cs
+++ b/generated/bench/cs/Bench.cs
@@ -4,12 +4,11 @@
 // AGPL-3.0, its output is not.
 // package bench — protocol id 0x694f261d887abaa5
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an interior null)
+// returns false WITHOUT latching; stream failures latch on stream.Error —
+// the runtime's own sticky latch. Callers get bool always; Error tells the
+// two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -93,8 +92,7 @@ namespace Bench
         public const long BenchPacketMaxBits = 392;
         public const long BenchPacketMaxBytes = 56;
 
-        // ZeroBenchPacket resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroBenchPacket(BenchPacket value)
         {
             value.A = 0;
@@ -111,25 +109,21 @@ namespace Bench
             Array.Clear(value.Blob, 0, 17);
         }
 
-        // WriteBenchPacket/ReadBenchPacket run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBenchPacket(WriteStream stream, BenchPacket value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBenchPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBenchPacketBatch(ref WriteBatch batch, BenchPacket value)
         {
-            if (value.A < -100 || value.A > 100) // out-of-contract writes are refused, not wrapped
+            if (value.A < -100 || value.A > 100)
             {
                 return false;
             }
@@ -140,7 +134,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.B < 0 || value.B > 65535) // out-of-contract writes are refused, not wrapped
+            if (value.B < 0 || value.B > 65535)
             {
                 return false;
             }
@@ -151,7 +145,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.C < -1000000 || value.C > 1000000) // out-of-contract writes are refused, not wrapped
+            if (value.C < -1000000 || value.C > 1000000)
             {
                 return false;
             }
@@ -209,13 +203,11 @@ namespace Bench
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBenchPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBenchPacketBatch(ref ReadBatch batch, BenchPacket value)
         {
@@ -279,8 +271,7 @@ namespace Bench
         public const long BenchIntsMaxBits = 110;
         public const long BenchIntsMaxBytes = 16;
 
-        // ZeroBenchInts resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroBenchInts(BenchInts value)
         {
             value.F0 = 0;
@@ -295,25 +286,21 @@ namespace Bench
             value.F9 = 0;
         }
 
-        // WriteBenchInts/ReadBenchInts run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBenchInts(WriteStream stream, BenchInts value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBenchIntsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBenchIntsBatch(ref WriteBatch batch, BenchInts value)
         {
-            if (value.F0 < -100 || value.F0 > 100) // out-of-contract writes are refused, not wrapped
+            if (value.F0 < -100 || value.F0 > 100)
             {
                 return false;
             }
@@ -324,7 +311,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F1 < 0 || value.F1 > 65535) // out-of-contract writes are refused, not wrapped
+            if (value.F1 < 0 || value.F1 > 65535)
             {
                 return false;
             }
@@ -335,7 +322,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F2 < -1000000 || value.F2 > 1000000) // out-of-contract writes are refused, not wrapped
+            if (value.F2 < -1000000 || value.F2 > 1000000)
             {
                 return false;
             }
@@ -346,7 +333,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F3 < 0 || value.F3 > 3) // out-of-contract writes are refused, not wrapped
+            if (value.F3 < 0 || value.F3 > 3)
             {
                 return false;
             }
@@ -357,7 +344,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F4 < -15 || value.F4 > 15) // out-of-contract writes are refused, not wrapped
+            if (value.F4 < -15 || value.F4 > 15)
             {
                 return false;
             }
@@ -368,7 +355,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F5 < 0 || value.F5 > 1000) // out-of-contract writes are refused, not wrapped
+            if (value.F5 < 0 || value.F5 > 1000)
             {
                 return false;
             }
@@ -379,7 +366,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F6 < -2048 || value.F6 > 2047) // out-of-contract writes are refused, not wrapped
+            if (value.F6 < -2048 || value.F6 > 2047)
             {
                 return false;
             }
@@ -390,7 +377,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F7 < 0 || value.F7 > 255) // out-of-contract writes are refused, not wrapped
+            if (value.F7 < 0 || value.F7 > 255)
             {
                 return false;
             }
@@ -401,7 +388,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F8 < -600000 || value.F8 > 600000) // out-of-contract writes are refused, not wrapped
+            if (value.F8 < -600000 || value.F8 > 600000)
             {
                 return false;
             }
@@ -412,7 +399,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.F9 < 0 || value.F9 > 100) // out-of-contract writes are refused, not wrapped
+            if (value.F9 < 0 || value.F9 > 100)
             {
                 return false;
             }
@@ -430,13 +417,11 @@ namespace Bench
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBenchIntsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBenchIntsBatch(ref ReadBatch batch, BenchInts value)
         {
@@ -488,8 +473,7 @@ namespace Bench
         public const long BenchBitsMaxBits = 156;
         public const long BenchBitsMaxBytes = 24;
 
-        // ZeroBenchBits resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroBenchBits(BenchBits value)
         {
             value.B7 = 0;
@@ -502,21 +486,17 @@ namespace Bench
             value.B48 = 0;
         }
 
-        // WriteBenchBits/ReadBenchBits run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBenchBits(WriteStream stream, BenchBits value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBenchBitsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBenchBitsBatch(ref WriteBatch batch, BenchBits value)
         {
@@ -559,13 +539,11 @@ namespace Bench
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBenchBitsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBenchBitsBatch(ref ReadBatch batch, BenchBits value)
         {
@@ -609,8 +587,7 @@ namespace Bench
         public const long BenchMixedMaxBits = 168;
         public const long BenchMixedMaxBytes = 24;
 
-        // ZeroBenchMixed resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroBenchMixed(BenchMixed value)
         {
             value.Sequence = 0;
@@ -626,25 +603,21 @@ namespace Bench
             value.Weapon = 0;
         }
 
-        // WriteBenchMixed/ReadBenchMixed run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBenchMixed(WriteStream stream, BenchMixed value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBenchMixedBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBenchMixedBatch(ref WriteBatch batch, BenchMixed value)
         {
-            if (value.Sequence < 0 || value.Sequence > 65535) // out-of-contract writes are refused, not wrapped
+            if (value.Sequence < 0 || value.Sequence > 65535)
             {
                 return false;
             }
@@ -663,7 +636,7 @@ namespace Bench
             {
                 return false;
             }
-            if (value.PosX < -16384 || value.PosX > 16383) // out-of-contract writes are refused, not wrapped
+            if (value.PosX < -16384 || value.PosX > 16383)
             {
                 return false;
             }
@@ -674,7 +647,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.PosY < -16384 || value.PosY > 16383) // out-of-contract writes are refused, not wrapped
+            if (value.PosY < -16384 || value.PosY > 16383)
             {
                 return false;
             }
@@ -685,7 +658,7 @@ namespace Bench
                     return false;
                 }
             }
-            if (value.PosZ < -16384 || value.PosZ > 16383) // out-of-contract writes are refused, not wrapped
+            if (value.PosZ < -16384 || value.PosZ > 16383)
             {
                 return false;
             }
@@ -712,7 +685,7 @@ namespace Bench
             {
                 return false;
             }
-            if (value.Weapon < 0 || value.Weapon > 15) // out-of-contract writes are refused, not wrapped
+            if (value.Weapon < 0 || value.Weapon > 15)
             {
                 return false;
             }
@@ -730,13 +703,11 @@ namespace Bench
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBenchMixedBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBenchMixedBatch(ref ReadBatch batch, BenchMixed value)
         {

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -4,12 +4,11 @@
 // AGPL-3.0, its output is not.
 // package realworld — protocol id 0x8f7228a19854fbb2
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an interior null)
+// returns false WITHOUT latching; stream failures latch on stream.Error —
+// the runtime's own sticky latch. Callers get bool always; Error tells the
+// two apart.
 
 using System.Runtime.CompilerServices;
 using Serialize;
@@ -45,7 +44,7 @@ namespace Realworld
         public sbyte F009Int; // wire [-22, 22]
         public float F010F32;
         public uint F011Bits;
-        public bool F012Bool = true; // = true at construction; Zero* gives the §5 zero form
+        public bool F012Bool = true; // specified default at construction; Zero* gives the §5 zero form
 
         // if f012_bool — wire branch; storage holds both sides, a read zeroes the
         // untaken side (SPEC §5)
@@ -80,7 +79,7 @@ namespace Realworld
         public short F040Fixed; // wire [-5, 5]
         public sbyte F041Int; // wire [-55, 55]
         public uint F042Bits;
-        public bool F043Bool = false; // = false at construction; Zero* gives the §5 zero form
+        public bool F043Bool = false; // specified default at construction; Zero* gives the §5 zero form
 
         // if f043_bool — wire branch; storage holds both sides, a read zeroes the
         // untaken side (SPEC §5)
@@ -91,7 +90,7 @@ namespace Realworld
 
         public double F048F64;
         public ushort F049Ufixed; // wire [0, 3]
-        public bool F050Bool = true; // = true at construction; Zero* gives the §5 zero form
+        public bool F050Bool = true; // specified default at construction; Zero* gives the §5 zero form
 
         // if f050_bool — wire branch; storage holds both sides, a read zeroes the
         // untaken side (SPEC §5)
@@ -119,7 +118,7 @@ namespace Realworld
         public float F071Cf32; // compressed float [0.0, 10.0] @ 0.02
         public float F072Cf32; // compressed float [0.0, 100.0] @ 0.01
         public sbyte F073Int; // wire [-4, 4]
-        public bool F074Bool = false; // = false at construction; Zero* gives the §5 zero form
+        public bool F074Bool = false; // specified default at construction; Zero* gives the §5 zero form
 
         // if f074_bool — wire branch; storage holds both sides, a read zeroes the
         // untaken side (SPEC §5)
@@ -196,8 +195,7 @@ namespace Realworld
         public const long RealPacketMaxBits = 1810;
         public const long RealPacketMaxBytes = 232;
 
-        // ZeroRealPacket resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroRealPacket(RealPacket value)
         {
             value.F001Int = 0;
@@ -299,25 +297,21 @@ namespace Realworld
             value.F097Bits = 0;
         }
 
-        // WriteRealPacket/ReadRealPacket run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRealPacket(WriteStream stream, RealPacket value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteRealPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRealPacketBatch(ref WriteBatch batch, RealPacket value)
         {
-            if (value.F001Int < -805495 || value.F001Int > 805495) // out-of-contract writes are refused, not wrapped
+            if (value.F001Int < -805495 || value.F001Int > 805495)
             {
                 return false;
             }
@@ -332,7 +326,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F003Int < -835897 || value.F003Int > 835897) // out-of-contract writes are refused, not wrapped
+            if (value.F003Int < -835897 || value.F003Int > 835897)
             {
                 return false;
             }
@@ -350,7 +344,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F005Uint > 7316) // out-of-contract writes are refused, not wrapped
+            if (value.F005Uint > 7316)
             {
                 return false;
             }
@@ -361,7 +355,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F006Int < -1513 || value.F006Int > 1513) // out-of-contract writes are refused, not wrapped
+            if (value.F006Int < -1513 || value.F006Int > 1513)
             {
                 return false;
             }
@@ -380,7 +374,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F009Int < -22 || value.F009Int > 22) // out-of-contract writes are refused, not wrapped
+            if (value.F009Int < -22 || value.F009Int > 22)
             {
                 return false;
             }
@@ -409,7 +403,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F014Uint > 775) // out-of-contract writes are refused, not wrapped
+                if (value.F014Uint > 775)
                 {
                     return false;
                 }
@@ -420,7 +414,7 @@ namespace Realworld
                         return false;
                     }
                 }
-                if (value.F015Int < -21 || value.F015Int > 21) // out-of-contract writes are refused, not wrapped
+                if (value.F015Int < -21 || value.F015Int > 21)
                 {
                     return false;
                 }
@@ -435,7 +429,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F017Uint > 4606) // out-of-contract writes are refused, not wrapped
+                if (value.F017Uint > 4606)
                 {
                     return false;
                 }
@@ -447,7 +441,7 @@ namespace Realworld
                     }
                 }
             }
-            if (value.F018Int < -834 || value.F018Int > 834) // out-of-contract writes are refused, not wrapped
+            if (value.F018Int < -834 || value.F018Int > 834)
             {
                 return false;
             }
@@ -516,7 +510,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F032Int < -3 || value.F032Int > 3) // out-of-contract writes are refused, not wrapped
+            if (value.F032Int < -3 || value.F032Int > 3)
             {
                 return false;
             }
@@ -527,7 +521,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F033Uint > 142780) // out-of-contract writes are refused, not wrapped
+            if (value.F033Uint > 142780)
             {
                 return false;
             }
@@ -538,7 +532,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F034Uint > 14149) // out-of-contract writes are refused, not wrapped
+            if (value.F034Uint > 14149)
             {
                 return false;
             }
@@ -580,7 +574,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F041Int < -55 || value.F041Int > 55) // out-of-contract writes are refused, not wrapped
+            if (value.F041Int < -55 || value.F041Int > 55)
             {
                 return false;
             }
@@ -609,7 +603,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F046Uint > 76063) // out-of-contract writes are refused, not wrapped
+                if (value.F046Uint > 76063)
                 {
                     return false;
                 }
@@ -620,7 +614,7 @@ namespace Realworld
                         return false;
                     }
                 }
-                if (value.F047Int < -430976 || value.F047Int > 430976) // out-of-contract writes are refused, not wrapped
+                if (value.F047Int < -430976 || value.F047Int > 430976)
                 {
                     return false;
                 }
@@ -650,7 +644,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F052Int < -57 || value.F052Int > 57) // out-of-contract writes are refused, not wrapped
+                if (value.F052Int < -57 || value.F052Int > 57)
                 {
                     return false;
                 }
@@ -665,7 +659,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F054Int < -35 || value.F054Int > 35) // out-of-contract writes are refused, not wrapped
+                if (value.F054Int < -35 || value.F054Int > 35)
                 {
                     return false;
                 }
@@ -681,7 +675,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F056Int < -13 || value.F056Int > 13) // out-of-contract writes are refused, not wrapped
+            if (value.F056Int < -13 || value.F056Int > 13)
             {
                 return false;
             }
@@ -692,7 +686,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F057Int < -15 || value.F057Int > 15) // out-of-contract writes are refused, not wrapped
+            if (value.F057Int < -15 || value.F057Int > 15)
             {
                 return false;
             }
@@ -722,7 +716,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F062Uint > 503) // out-of-contract writes are refused, not wrapped
+            if (value.F062Uint > 503)
             {
                 return false;
             }
@@ -740,7 +734,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F064Uint > 299) // out-of-contract writes are refused, not wrapped
+            if (value.F064Uint > 299)
             {
                 return false;
             }
@@ -780,7 +774,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F070Uint > 2) // out-of-contract writes are refused, not wrapped
+            if (value.F070Uint > 2)
             {
                 return false;
             }
@@ -805,7 +799,7 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F073Int < -4 || value.F073Int > 4) // out-of-contract writes are refused, not wrapped
+            if (value.F073Int < -4 || value.F073Int > 4)
             {
                 return false;
             }
@@ -826,7 +820,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F076Int < -26218 || value.F076Int > 26218) // out-of-contract writes are refused, not wrapped
+                if (value.F076Int < -26218 || value.F076Int > 26218)
                 {
                     return false;
                 }
@@ -837,7 +831,7 @@ namespace Realworld
                         return false;
                     }
                 }
-                if (value.F077Int < -17 || value.F077Int > 17) // out-of-contract writes are refused, not wrapped
+                if (value.F077Int < -17 || value.F077Int > 17)
                 {
                     return false;
                 }
@@ -852,7 +846,7 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F079Uint > 17) // out-of-contract writes are refused, not wrapped
+                if (value.F079Uint > 17)
                 {
                     return false;
                 }
@@ -898,7 +892,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F086Uint > 399) // out-of-contract writes are refused, not wrapped
+            if (value.F086Uint > 399)
             {
                 return false;
             }
@@ -913,7 +907,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F088Int < -694 || value.F088Int > 694) // out-of-contract writes are refused, not wrapped
+            if (value.F088Int < -694 || value.F088Int > 694)
             {
                 return false;
             }
@@ -928,7 +922,7 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F090Uint > 214) // out-of-contract writes are refused, not wrapped
+            if (value.F090Uint > 214)
             {
                 return false;
             }
@@ -981,13 +975,11 @@ namespace Realworld
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadRealPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRealPacketBatch(ref ReadBatch batch, RealPacket value)
         {

--- a/generated/bench/go/Bench.go
+++ b/generated/bench/go/Bench.go
@@ -42,21 +42,21 @@ const BenchPacketMaxBits = 392
 const BenchPacketMaxBytes = 56
 
 func WriteBenchPacket(stream *serialize.WriteStream, value *BenchPacket) error {
-	if value.A < -100 || value.A > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.A < -100 || value.A > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.A - (-100))
 		stream.SerializeBits(&offsetValue, 8)
 	}
-	if value.B < 0 || value.B > 65535 { // the runtime range refusal, folded (SPEC §5)
+	if value.B < 0 || value.B > 65535 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.B)
 		stream.SerializeBits(&offsetValue, 16)
 	}
-	if value.C < -1000000 || value.C > 1000000 { // the runtime range refusal, folded (SPEC §5)
+	if value.C < -1000000 || value.C > 1000000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -113,70 +113,70 @@ const BenchIntsMaxBits = 110
 const BenchIntsMaxBytes = 16
 
 func WriteBenchInts(stream *serialize.WriteStream, value *BenchInts) error {
-	if value.F0 < -100 || value.F0 > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.F0 < -100 || value.F0 > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F0 - (-100))
 		stream.SerializeBits(&offsetValue, 8)
 	}
-	if value.F1 < 0 || value.F1 > 65535 { // the runtime range refusal, folded (SPEC §5)
+	if value.F1 < 0 || value.F1 > 65535 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F1)
 		stream.SerializeBits(&offsetValue, 16)
 	}
-	if value.F2 < -1000000 || value.F2 > 1000000 { // the runtime range refusal, folded (SPEC §5)
+	if value.F2 < -1000000 || value.F2 > 1000000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F2 - (-1000000))
 		stream.SerializeBits(&offsetValue, 21)
 	}
-	if value.F3 < 0 || value.F3 > 3 { // the runtime range refusal, folded (SPEC §5)
+	if value.F3 < 0 || value.F3 > 3 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F3)
 		stream.SerializeBits(&offsetValue, 2)
 	}
-	if value.F4 < -15 || value.F4 > 15 { // the runtime range refusal, folded (SPEC §5)
+	if value.F4 < -15 || value.F4 > 15 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F4 - (-15))
 		stream.SerializeBits(&offsetValue, 5)
 	}
-	if value.F5 < 0 || value.F5 > 1000 { // the runtime range refusal, folded (SPEC §5)
+	if value.F5 < 0 || value.F5 > 1000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F5)
 		stream.SerializeBits(&offsetValue, 10)
 	}
-	if value.F6 < -2048 || value.F6 > 2047 { // the runtime range refusal, folded (SPEC §5)
+	if value.F6 < -2048 || value.F6 > 2047 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F6 - (-2048))
 		stream.SerializeBits(&offsetValue, 12)
 	}
-	if value.F7 < 0 || value.F7 > 255 { // the runtime range refusal, folded (SPEC §5)
+	if value.F7 < 0 || value.F7 > 255 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F7)
 		stream.SerializeBits(&offsetValue, 8)
 	}
-	if value.F8 < -600000 || value.F8 > 600000 { // the runtime range refusal, folded (SPEC §5)
+	if value.F8 < -600000 || value.F8 > 600000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.F8 - (-600000))
 		stream.SerializeBits(&offsetValue, 21)
 	}
-	if value.F9 < 0 || value.F9 > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.F9 < 0 || value.F9 > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -262,7 +262,7 @@ const BenchMixedMaxBits = 168
 const BenchMixedMaxBytes = 24
 
 func WriteBenchMixed(stream *serialize.WriteStream, value *BenchMixed) error {
-	if value.Sequence < 0 || value.Sequence > 65535 { // the runtime range refusal, folded (SPEC §5)
+	if value.Sequence < 0 || value.Sequence > 65535 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -271,21 +271,21 @@ func WriteBenchMixed(stream *serialize.WriteStream, value *BenchMixed) error {
 	}
 	stream.SerializeBits(&value.AckBits, 32)
 	stream.SerializeBits(&value.EntityId, 12)
-	if value.PosX < -16384 || value.PosX > 16383 { // the runtime range refusal, folded (SPEC §5)
+	if value.PosX < -16384 || value.PosX > 16383 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PosX - (-16384))
 		stream.SerializeBits(&offsetValue, 15)
 	}
-	if value.PosY < -16384 || value.PosY > 16383 { // the runtime range refusal, folded (SPEC §5)
+	if value.PosY < -16384 || value.PosY > 16383 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PosY - (-16384))
 		stream.SerializeBits(&offsetValue, 15)
 	}
-	if value.PosZ < -16384 || value.PosZ > 16383 { // the runtime range refusal, folded (SPEC §5)
+	if value.PosZ < -16384 || value.PosZ > 16383 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -296,7 +296,7 @@ func WriteBenchMixed(stream *serialize.WriteStream, value *BenchMixed) error {
 	stream.SerializeBool(&value.Moving)
 	stream.SerializeBool(&value.Firing)
 	stream.SerializeBits64(&value.Timestamp, 48)
-	if value.Weapon < 0 || value.Weapon > 15 { // the runtime range refusal, folded (SPEC §5)
+	if value.Weapon < 0 || value.Weapon > 15 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/generated/bench/go/realworld/RealWorld.go
+++ b/generated/bench/go/realworld/RealWorld.go
@@ -203,7 +203,7 @@ const RealPacketMaxBits = 1810
 const RealPacketMaxBytes = 232
 
 func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
-	if value.F001Int < -805495 || value.F001Int > 805495 { // the runtime range refusal, folded (SPEC §5)
+	if value.F001Int < -805495 || value.F001Int > 805495 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -211,7 +211,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeBits(&offsetValue, 21)
 	}
 	stream.SerializeFloat64(&value.F002F64)
-	if value.F003Int < -835897 || value.F003Int > 835897 { // the runtime range refusal, folded (SPEC §5)
+	if value.F003Int < -835897 || value.F003Int > 835897 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -230,7 +230,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F005Uint)
-		if rangeValue < 0 || rangeValue > 7316 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 7316 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -240,7 +240,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F006Int)
-		if rangeValue < -1513 || rangeValue > 1513 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -1513 || rangeValue > 1513 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -252,7 +252,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBits64(&value.F008U64, 64)
 	{
 		rangeValue := int32(value.F009Int)
-		if rangeValue < -22 || rangeValue > 22 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -22 || rangeValue > 22 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -267,7 +267,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeFloat32(&value.F013F32)
 		{
 			rangeValue := int32(value.F014Uint)
-			if rangeValue < 0 || rangeValue > 775 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < 0 || rangeValue > 775 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -277,7 +277,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		}
 		{
 			rangeValue := int32(value.F015Int)
-			if rangeValue < -21 || rangeValue > 21 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < -21 || rangeValue > 21 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -291,7 +291,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		}
 		{
 			rangeValue := int32(value.F017Uint)
-			if rangeValue < 0 || rangeValue > 4606 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < 0 || rangeValue > 4606 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -302,7 +302,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F018Int)
-		if rangeValue < -834 || rangeValue > 834 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -834 || rangeValue > 834 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -343,7 +343,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBits(&value.F031Bits, 1)
 	{
 		rangeValue := int32(value.F032Int)
-		if rangeValue < -3 || rangeValue > 3 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -3 || rangeValue > 3 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -353,7 +353,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F033Uint)
-		if rangeValue < 0 || rangeValue > 142780 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 142780 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -363,7 +363,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F034Uint)
-		if rangeValue < 0 || rangeValue > 14149 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 14149 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -374,7 +374,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBits(&value.F035Bits, 9)
 	{
 		enumValue := int32(value.F036Enum)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -391,7 +391,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F041Int)
-		if rangeValue < -55 || rangeValue > 55 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -55 || rangeValue > 55 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -406,7 +406,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeBits(&value.F045Bits, 12)
 		{
 			rangeValue := int32(value.F046Uint)
-			if rangeValue < 0 || rangeValue > 76063 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < 0 || rangeValue > 76063 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -414,7 +414,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 				stream.SerializeBits(&offsetValue, 17)
 			}
 		}
-		if value.F047Int < -430976 || value.F047Int > 430976 { // the runtime range refusal, folded (SPEC §5)
+		if value.F047Int < -430976 || value.F047Int > 430976 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -432,7 +432,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeBool(&value.F051Bool)
 		{
 			rangeValue := int32(value.F052Int)
-			if rangeValue < -57 || rangeValue > 57 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < -57 || rangeValue > 57 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -443,7 +443,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeFloat32(&value.F053F32)
 		{
 			rangeValue := int32(value.F054Int)
-			if rangeValue < -35 || rangeValue > 35 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < -35 || rangeValue > 35 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -455,7 +455,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBool(&value.F055Bool)
 	{
 		rangeValue := int32(value.F056Int)
-		if rangeValue < -13 || rangeValue > 13 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -13 || rangeValue > 13 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -465,7 +465,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F057Int)
-		if rangeValue < -15 || rangeValue > 15 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -15 || rangeValue > 15 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -488,7 +488,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F062Uint)
-		if rangeValue < 0 || rangeValue > 503 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 503 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -502,7 +502,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F064Uint)
-		if rangeValue < 0 || rangeValue > 299 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 299 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -547,7 +547,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBits(&value.F069Bits, 11)
 	{
 		rangeValue := int32(value.F070Uint)
-		if rangeValue < 0 || rangeValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -577,7 +577,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	}
 	{
 		rangeValue := int32(value.F073Int)
-		if rangeValue < -4 || rangeValue > 4 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -4 || rangeValue > 4 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -590,7 +590,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeBits64(&value.F075U64, 64)
 		{
 			rangeValue := int32(value.F076Int)
-			if rangeValue < -26218 || rangeValue > 26218 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < -26218 || rangeValue > 26218 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -600,7 +600,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		}
 		{
 			rangeValue := int32(value.F077Int)
-			if rangeValue < -17 || rangeValue > 17 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < -17 || rangeValue > 17 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -611,7 +611,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 		stream.SerializeBits(&value.F078Bits, 9)
 		{
 			rangeValue := int32(value.F079Uint)
-			if rangeValue < 0 || rangeValue > 17 { // the runtime range refusal, folded (SPEC §5)
+			if rangeValue < 0 || rangeValue > 17 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -625,7 +625,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBits(&value.F082Bits, 25)
 	{
 		enumValue := int32(value.F083Enum)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -640,7 +640,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBits(&value.F085Bits, 21)
 	{
 		rangeValue := int32(value.F086Uint)
-		if rangeValue < 0 || rangeValue > 399 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 399 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -651,7 +651,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeFloat64(&value.F087F64)
 	{
 		rangeValue := int32(value.F088Int)
-		if rangeValue < -694 || rangeValue > 694 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -694 || rangeValue > 694 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -662,7 +662,7 @@ func WriteRealPacket(stream *serialize.WriteStream, value *RealPacket) error {
 	stream.SerializeBits64(&value.F089Bits, 48)
 	{
 		rangeValue := int32(value.F090Uint)
-		if rangeValue < 0 || rangeValue > 214 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 214 {
 			return serialize.ErrValueOutOfRange
 		}
 		{

--- a/generated/bench/js/Bench.js
+++ b/generated/bench/js/Bench.js
@@ -4,22 +4,18 @@
 // AGPL-3.0, its output is not.
 // package bench — protocol id 0x694f261d887abaa5
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an out-of-contract
+// write) returns false WITHOUT latching; stream failures latch on
+// stream.error — the runtime's own sticky latch. Callers get bool always;
+// error tells the two apart.
 //
 // Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
 // the serialize.js value-domain seam. Checked/production comes from the
 // stream object; generated code never reads NODE_ENV.
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
@@ -51,8 +47,7 @@ export class BenchPacket {
 export const BenchPacketMaxBits = 392;
 export const BenchPacketMaxBytes = 56;
 
-// ZeroBenchPacket resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroBenchPacket(value) {
   value.A = 0;
   value.B = 0;
@@ -69,21 +64,21 @@ export function ZeroBenchPacket(value) {
 }
 
 export function WriteBenchPacket(stream, value) {
-  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.A >>> 0) - (-100 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.B) || value.B < 0 || value.B > 65535) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.B) || value.B < 0 || value.B > 65535) {
     return false;
   }
   NUMBER_SCRATCH.value = value.B;
   if (!stream.serializeBits(NUMBER_SCRATCH, 16)) {
     return false;
   }
-  if (!Number.isInteger(value.C) || value.C < -1000000 || value.C > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.C) || value.C < -1000000 || value.C > 1000000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.C >>> 0) - (-1000000 >>> 0)) >>> 0;
@@ -206,8 +201,7 @@ export class BenchInts {
 export const BenchIntsMaxBits = 110;
 export const BenchIntsMaxBytes = 16;
 
-// ZeroBenchInts resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroBenchInts(value) {
   value.F0 = 0;
   value.F1 = 0;
@@ -222,70 +216,70 @@ export function ZeroBenchInts(value) {
 }
 
 export function WriteBenchInts(stream, value) {
-  if (!Number.isInteger(value.F0) || value.F0 < -100 || value.F0 > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F0) || value.F0 < -100 || value.F0 > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F0 >>> 0) - (-100 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.F1) || value.F1 < 0 || value.F1 > 65535) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F1) || value.F1 < 0 || value.F1 > 65535) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F1;
   if (!stream.serializeBits(NUMBER_SCRATCH, 16)) {
     return false;
   }
-  if (!Number.isInteger(value.F2) || value.F2 < -1000000 || value.F2 > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F2) || value.F2 < -1000000 || value.F2 > 1000000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F2 >>> 0) - (-1000000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 21)) {
     return false;
   }
-  if (!Number.isInteger(value.F3) || value.F3 < 0 || value.F3 > 3) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F3) || value.F3 < 0 || value.F3 > 3) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F3;
   if (!stream.serializeBits(NUMBER_SCRATCH, 2)) {
     return false;
   }
-  if (!Number.isInteger(value.F4) || value.F4 < -15 || value.F4 > 15) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F4) || value.F4 < -15 || value.F4 > 15) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F4 >>> 0) - (-15 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 5)) {
     return false;
   }
-  if (!Number.isInteger(value.F5) || value.F5 < 0 || value.F5 > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F5) || value.F5 < 0 || value.F5 > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F5;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.F6) || value.F6 < -2048 || value.F6 > 2047) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F6) || value.F6 < -2048 || value.F6 > 2047) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F6 >>> 0) - (-2048 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.F7) || value.F7 < 0 || value.F7 > 255) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F7) || value.F7 < 0 || value.F7 > 255) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F7;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.F8) || value.F8 < -600000 || value.F8 > 600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F8) || value.F8 < -600000 || value.F8 > 600000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F8 >>> 0) - (-600000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 21)) {
     return false;
   }
-  if (!Number.isInteger(value.F9) || value.F9 < 0 || value.F9 > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F9) || value.F9 < 0 || value.F9 > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F9;
@@ -358,8 +352,7 @@ export class BenchBits {
 export const BenchBitsMaxBits = 156;
 export const BenchBitsMaxBytes = 24;
 
-// ZeroBenchBits resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroBenchBits(value) {
   value.B7 = 0;
   value.B13 = 0;
@@ -465,8 +458,7 @@ export class BenchMixed {
 export const BenchMixedMaxBits = 168;
 export const BenchMixedMaxBytes = 24;
 
-// ZeroBenchMixed resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroBenchMixed(value) {
   value.Sequence = 0;
   value.AckBits = 0;
@@ -482,7 +474,7 @@ export function ZeroBenchMixed(value) {
 }
 
 export function WriteBenchMixed(stream, value) {
-  if (!Number.isInteger(value.Sequence) || value.Sequence < 0 || value.Sequence > 65535) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Sequence) || value.Sequence < 0 || value.Sequence > 65535) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Sequence;
@@ -497,21 +489,21 @@ export function WriteBenchMixed(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.PosX) || value.PosX < -16384 || value.PosX > 16383) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PosX) || value.PosX < -16384 || value.PosX > 16383) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PosX >>> 0) - (-16384 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 15)) {
     return false;
   }
-  if (!Number.isInteger(value.PosY) || value.PosY < -16384 || value.PosY > 16383) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PosY) || value.PosY < -16384 || value.PosY > 16383) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PosY >>> 0) - (-16384 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 15)) {
     return false;
   }
-  if (!Number.isInteger(value.PosZ) || value.PosZ < -16384 || value.PosZ > 16383) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PosZ) || value.PosZ < -16384 || value.PosZ > 16383) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PosZ >>> 0) - (-16384 >>> 0)) >>> 0;
@@ -534,7 +526,7 @@ export function WriteBenchMixed(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 48)) {
     return false;
   }
-  if (!Number.isInteger(value.Weapon) || value.Weapon < 0 || value.Weapon > 15) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Weapon) || value.Weapon < 0 || value.Weapon > 15) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Weapon;

--- a/generated/bench/js/BenchFlat.js
+++ b/generated/bench/js/BenchFlat.js
@@ -322,7 +322,7 @@ function writeBenchPacketFlatChecked(value, view) {
   let v = 0, s = 0, x = 0, t0 = 0, t1 = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) {
     return -1;
   }
   v = ((((value.A >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -342,7 +342,7 @@ function writeBenchPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.B) || value.B < 0 || value.B > 65535) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.B) || value.B < 0 || value.B > 65535) {
     return -1;
   }
   v = ((value.B) & 0xffff) >>> 0;
@@ -362,7 +362,7 @@ function writeBenchPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.C) || value.C < -1000000 || value.C > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.C) || value.C < -1000000 || value.C > 1000000) {
     return -1;
   }
   v = ((((value.C >>> 0) - 4293967296) >>> 0) & 0x1fffff) >>> 0;
@@ -953,7 +953,7 @@ function writeBenchIntsFlatProduction(value, view) {
 function writeBenchIntsFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.F0) || value.F0 < -100 || value.F0 > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F0) || value.F0 < -100 || value.F0 > 100) {
     return -1;
   }
   v = ((((value.F0 >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -973,7 +973,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F1) || value.F1 < 0 || value.F1 > 65535) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F1) || value.F1 < 0 || value.F1 > 65535) {
     return -1;
   }
   v = ((value.F1) & 0xffff) >>> 0;
@@ -993,7 +993,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F2) || value.F2 < -1000000 || value.F2 > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F2) || value.F2 < -1000000 || value.F2 > 1000000) {
     return -1;
   }
   v = ((((value.F2 >>> 0) - 4293967296) >>> 0) & 0x1fffff) >>> 0;
@@ -1013,7 +1013,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F3) || value.F3 < 0 || value.F3 > 3) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F3) || value.F3 < 0 || value.F3 > 3) {
     return -1;
   }
   v = ((value.F3) & 0x3) >>> 0;
@@ -1033,7 +1033,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F4) || value.F4 < -15 || value.F4 > 15) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F4) || value.F4 < -15 || value.F4 > 15) {
     return -1;
   }
   v = ((((value.F4 >>> 0) - 4294967281) >>> 0) & 0x1f) >>> 0;
@@ -1053,7 +1053,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F5) || value.F5 < 0 || value.F5 > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F5) || value.F5 < 0 || value.F5 > 1000) {
     return -1;
   }
   v = ((value.F5) & 0x3ff) >>> 0;
@@ -1073,7 +1073,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F6) || value.F6 < -2048 || value.F6 > 2047) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F6) || value.F6 < -2048 || value.F6 > 2047) {
     return -1;
   }
   v = ((((value.F6 >>> 0) - 4294965248) >>> 0) & 0xfff) >>> 0;
@@ -1093,7 +1093,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F7) || value.F7 < 0 || value.F7 > 255) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F7) || value.F7 < 0 || value.F7 > 255) {
     return -1;
   }
   v = ((value.F7) & 0xff) >>> 0;
@@ -1113,7 +1113,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F8) || value.F8 < -600000 || value.F8 > 600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F8) || value.F8 < -600000 || value.F8 > 600000) {
     return -1;
   }
   v = ((((value.F8 >>> 0) - 4294367296) >>> 0) & 0x1fffff) >>> 0;
@@ -1133,7 +1133,7 @@ function writeBenchIntsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F9) || value.F9 < 0 || value.F9 > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F9) || value.F9 < 0 || value.F9 > 100) {
     return -1;
   }
   v = ((value.F9) & 0x7f) >>> 0;
@@ -1917,7 +1917,7 @@ function writeBenchMixedFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Sequence) || value.Sequence < 0 || value.Sequence > 65535) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Sequence) || value.Sequence < 0 || value.Sequence > 65535) {
     return -1;
   }
   v = ((value.Sequence) & 0xffff) >>> 0;
@@ -1971,7 +1971,7 @@ function writeBenchMixedFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.PosX) || value.PosX < -16384 || value.PosX > 16383) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PosX) || value.PosX < -16384 || value.PosX > 16383) {
     return -1;
   }
   v = ((((value.PosX >>> 0) - 4294950912) >>> 0) & 0x7fff) >>> 0;
@@ -1991,7 +1991,7 @@ function writeBenchMixedFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.PosY) || value.PosY < -16384 || value.PosY > 16383) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PosY) || value.PosY < -16384 || value.PosY > 16383) {
     return -1;
   }
   v = ((((value.PosY >>> 0) - 4294950912) >>> 0) & 0x7fff) >>> 0;
@@ -2011,7 +2011,7 @@ function writeBenchMixedFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.PosZ) || value.PosZ < -16384 || value.PosZ > 16383) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PosZ) || value.PosZ < -16384 || value.PosZ > 16383) {
     return -1;
   }
   v = ((((value.PosZ >>> 0) - 4294950912) >>> 0) & 0x7fff) >>> 0;
@@ -2117,7 +2117,7 @@ function writeBenchMixedFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Weapon) || value.Weapon < 0 || value.Weapon > 15) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Weapon) || value.Weapon < 0 || value.Weapon > 15) {
     return -1;
   }
   v = ((value.Weapon) & 0xf) >>> 0;

--- a/generated/bench/js/realworld/RealWorld.js
+++ b/generated/bench/js/realworld/RealWorld.js
@@ -4,22 +4,18 @@
 // AGPL-3.0, its output is not.
 // package realworld — protocol id 0x8f7228a19854fbb2
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an out-of-contract
+// write) returns false WITHOUT latching; stream failures latch on
+// stream.error — the runtime's own sticky latch. Callers get bool always;
+// error tells the two apart.
 //
 // Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
 // the serialize.js value-domain seam. Checked/production comes from the
 // stream object; generated code never reads NODE_ENV.
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
@@ -87,7 +83,7 @@ export class RealPacket {
     this.F009Int = 0; // wire [-22, 22]
     this.F010F32 = 0;
     this.F011Bits = 0;
-    this.F012Bool = true; // = true at construction; Zero* gives the §5 zero form
+    this.F012Bool = true; // specified default at construction; Zero* gives the §5 zero form
 
     // if f012_bool — wire branch; storage holds both sides, a read zeroes the
     // untaken side (SPEC §5)
@@ -122,7 +118,7 @@ export class RealPacket {
     this.F040Fixed = 0; // wire [-5, 5]
     this.F041Int = 0; // wire [-55, 55]
     this.F042Bits = 0;
-    this.F043Bool = false; // = false at construction; Zero* gives the §5 zero form
+    this.F043Bool = false; // specified default at construction; Zero* gives the §5 zero form
 
     // if f043_bool — wire branch; storage holds both sides, a read zeroes the
     // untaken side (SPEC §5)
@@ -133,7 +129,7 @@ export class RealPacket {
 
     this.F048F64 = 0;
     this.F049Ufixed = 0; // wire [0, 3]
-    this.F050Bool = true; // = true at construction; Zero* gives the §5 zero form
+    this.F050Bool = true; // specified default at construction; Zero* gives the §5 zero form
 
     // if f050_bool — wire branch; storage holds both sides, a read zeroes the
     // untaken side (SPEC §5)
@@ -161,7 +157,7 @@ export class RealPacket {
     this.F071Cf32 = 0; // compressed float [0.0, 10.0] @ 0.02
     this.F072Cf32 = 0; // compressed float [0.0, 100.0] @ 0.01
     this.F073Int = 0; // wire [-4, 4]
-    this.F074Bool = false; // = false at construction; Zero* gives the §5 zero form
+    this.F074Bool = false; // specified default at construction; Zero* gives the §5 zero form
 
     // if f074_bool — wire branch; storage holds both sides, a read zeroes the
     // untaken side (SPEC §5)
@@ -197,8 +193,7 @@ export class RealPacket {
 export const RealPacketMaxBits = 1810;
 export const RealPacketMaxBytes = 232;
 
-// ZeroRealPacket resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroRealPacket(value) {
   value.F001Int = 0;
   value.F002F64 = 0;
@@ -300,7 +295,7 @@ export function ZeroRealPacket(value) {
 }
 
 export function WriteRealPacket(stream, value) {
-  if (!Number.isInteger(value.F001Int) || value.F001Int < -805495 || value.F001Int > 805495) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F001Int) || value.F001Int < -805495 || value.F001Int > 805495) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F001Int >>> 0) - (-805495 >>> 0)) >>> 0;
@@ -311,7 +306,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeDouble(NUMBER_SCRATCH)) {
     return false;
   }
-  if (!Number.isInteger(value.F003Int) || value.F003Int < -835897 || value.F003Int > 835897) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F003Int) || value.F003Int < -835897 || value.F003Int > 835897) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F003Int >>> 0) - (-835897 >>> 0)) >>> 0;
@@ -322,14 +317,14 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeCompressedFloat(NUMBER_SCRATCH, 0.0, 2000.0, 0.1)) {
     return false;
   }
-  if (!Number.isInteger(value.F005Uint) || value.F005Uint < 0 || value.F005Uint > 7316) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F005Uint) || value.F005Uint < 0 || value.F005Uint > 7316) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F005Uint;
   if (!stream.serializeBits(NUMBER_SCRATCH, 13)) {
     return false;
   }
-  if (!Number.isInteger(value.F006Int) || value.F006Int < -1513 || value.F006Int > 1513) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F006Int) || value.F006Int < -1513 || value.F006Int > 1513) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F006Int >>> 0) - (-1513 >>> 0)) >>> 0;
@@ -344,7 +339,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (!Number.isInteger(value.F009Int) || value.F009Int < -22 || value.F009Int > 22) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F009Int) || value.F009Int < -22 || value.F009Int > 22) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F009Int >>> 0) - (-22 >>> 0)) >>> 0;
@@ -368,14 +363,14 @@ export function WriteRealPacket(stream, value) {
     if (!stream.serializeFloat(NUMBER_SCRATCH)) {
       return false;
     }
-    if (!Number.isInteger(value.F014Uint) || value.F014Uint < 0 || value.F014Uint > 775) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F014Uint) || value.F014Uint < 0 || value.F014Uint > 775) {
       return false;
     }
     NUMBER_SCRATCH.value = value.F014Uint;
     if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
       return false;
     }
-    if (!Number.isInteger(value.F015Int) || value.F015Int < -21 || value.F015Int > 21) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F015Int) || value.F015Int < -21 || value.F015Int > 21) {
       return false;
     }
     NUMBER_SCRATCH.value = ((value.F015Int >>> 0) - (-21 >>> 0)) >>> 0;
@@ -386,7 +381,7 @@ export function WriteRealPacket(stream, value) {
     if (!stream.serializeFixed(NUMBER_SCRATCH, 12, 20, -36, 36)) {
       return false;
     }
-    if (!Number.isInteger(value.F017Uint) || value.F017Uint < 0 || value.F017Uint > 4606) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F017Uint) || value.F017Uint < 0 || value.F017Uint > 4606) {
       return false;
     }
     NUMBER_SCRATCH.value = value.F017Uint;
@@ -394,7 +389,7 @@ export function WriteRealPacket(stream, value) {
       return false;
     }
   }
-  if (!Number.isInteger(value.F018Int) || value.F018Int < -834 || value.F018Int > 834) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F018Int) || value.F018Int < -834 || value.F018Int > 834) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F018Int >>> 0) - (-834 >>> 0)) >>> 0;
@@ -453,21 +448,21 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 1)) {
     return false;
   }
-  if (!Number.isInteger(value.F032Int) || value.F032Int < -3 || value.F032Int > 3) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F032Int) || value.F032Int < -3 || value.F032Int > 3) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F032Int >>> 0) - (-3 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 3)) {
     return false;
   }
-  if (!Number.isInteger(value.F033Uint) || value.F033Uint < 0 || value.F033Uint > 142780) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F033Uint) || value.F033Uint < 0 || value.F033Uint > 142780) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F033Uint;
   if (!stream.serializeBits(NUMBER_SCRATCH, 18)) {
     return false;
   }
-  if (!Number.isInteger(value.F034Uint) || value.F034Uint < 0 || value.F034Uint > 14149) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F034Uint) || value.F034Uint < 0 || value.F034Uint > 14149) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F034Uint;
@@ -501,7 +496,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeFixed(NUMBER_SCRATCH, 4, 12, -5, 5)) {
     return false;
   }
-  if (!Number.isInteger(value.F041Int) || value.F041Int < -55 || value.F041Int > 55) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F041Int) || value.F041Int < -55 || value.F041Int > 55) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F041Int >>> 0) - (-55 >>> 0)) >>> 0;
@@ -525,14 +520,14 @@ export function WriteRealPacket(stream, value) {
     if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
       return false;
     }
-    if (!Number.isInteger(value.F046Uint) || value.F046Uint < 0 || value.F046Uint > 76063) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F046Uint) || value.F046Uint < 0 || value.F046Uint > 76063) {
       return false;
     }
     NUMBER_SCRATCH.value = value.F046Uint;
     if (!stream.serializeBits(NUMBER_SCRATCH, 17)) {
       return false;
     }
-    if (!Number.isInteger(value.F047Int) || value.F047Int < -430976 || value.F047Int > 430976) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F047Int) || value.F047Int < -430976 || value.F047Int > 430976) {
       return false;
     }
     NUMBER_SCRATCH.value = ((value.F047Int >>> 0) - (-430976 >>> 0)) >>> 0;
@@ -557,7 +552,7 @@ export function WriteRealPacket(stream, value) {
     if (!stream.serializeBool(BOOL_SCRATCH)) {
       return false;
     }
-    if (!Number.isInteger(value.F052Int) || value.F052Int < -57 || value.F052Int > 57) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F052Int) || value.F052Int < -57 || value.F052Int > 57) {
       return false;
     }
     NUMBER_SCRATCH.value = ((value.F052Int >>> 0) - (-57 >>> 0)) >>> 0;
@@ -568,7 +563,7 @@ export function WriteRealPacket(stream, value) {
     if (!stream.serializeFloat(NUMBER_SCRATCH)) {
       return false;
     }
-    if (!Number.isInteger(value.F054Int) || value.F054Int < -35 || value.F054Int > 35) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F054Int) || value.F054Int < -35 || value.F054Int > 35) {
       return false;
     }
     NUMBER_SCRATCH.value = ((value.F054Int >>> 0) - (-35 >>> 0)) >>> 0;
@@ -580,14 +575,14 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeBool(BOOL_SCRATCH)) {
     return false;
   }
-  if (!Number.isInteger(value.F056Int) || value.F056Int < -13 || value.F056Int > 13) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F056Int) || value.F056Int < -13 || value.F056Int > 13) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F056Int >>> 0) - (-13 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 5)) {
     return false;
   }
-  if (!Number.isInteger(value.F057Int) || value.F057Int < -15 || value.F057Int > 15) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F057Int) || value.F057Int < -15 || value.F057Int > 15) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F057Int >>> 0) - (-15 >>> 0)) >>> 0;
@@ -610,7 +605,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeCompressedFloat(NUMBER_SCRATCH, -90.0, 90.0, 0.5)) {
     return false;
   }
-  if (!Number.isInteger(value.F062Uint) || value.F062Uint < 0 || value.F062Uint > 503) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F062Uint) || value.F062Uint < 0 || value.F062Uint > 503) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F062Uint;
@@ -621,7 +616,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (!Number.isInteger(value.F064Uint) || value.F064Uint < 0 || value.F064Uint > 299) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F064Uint) || value.F064Uint < 0 || value.F064Uint > 299) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F064Uint;
@@ -648,7 +643,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 11)) {
     return false;
   }
-  if (!Number.isInteger(value.F070Uint) || value.F070Uint < 0 || value.F070Uint > 2) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F070Uint) || value.F070Uint < 0 || value.F070Uint > 2) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F070Uint;
@@ -663,7 +658,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeCompressedFloat(NUMBER_SCRATCH, 0.0, 100.0, 0.01)) {
     return false;
   }
-  if (!Number.isInteger(value.F073Int) || value.F073Int < -4 || value.F073Int > 4) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F073Int) || value.F073Int < -4 || value.F073Int > 4) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F073Int >>> 0) - (-4 >>> 0)) >>> 0;
@@ -679,14 +674,14 @@ export function WriteRealPacket(stream, value) {
     if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
       return false;
     }
-    if (!Number.isInteger(value.F076Int) || value.F076Int < -26218 || value.F076Int > 26218) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F076Int) || value.F076Int < -26218 || value.F076Int > 26218) {
       return false;
     }
     NUMBER_SCRATCH.value = ((value.F076Int >>> 0) - (-26218 >>> 0)) >>> 0;
     if (!stream.serializeBits(NUMBER_SCRATCH, 16)) {
       return false;
     }
-    if (!Number.isInteger(value.F077Int) || value.F077Int < -17 || value.F077Int > 17) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F077Int) || value.F077Int < -17 || value.F077Int > 17) {
       return false;
     }
     NUMBER_SCRATCH.value = ((value.F077Int >>> 0) - (-17 >>> 0)) >>> 0;
@@ -697,7 +692,7 @@ export function WriteRealPacket(stream, value) {
     if (!stream.serializeBits(NUMBER_SCRATCH, 9)) {
       return false;
     }
-    if (!Number.isInteger(value.F079Uint) || value.F079Uint < 0 || value.F079Uint > 17) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F079Uint) || value.F079Uint < 0 || value.F079Uint > 17) {
       return false;
     }
     NUMBER_SCRATCH.value = value.F079Uint;
@@ -732,7 +727,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 21)) {
     return false;
   }
-  if (!Number.isInteger(value.F086Uint) || value.F086Uint < 0 || value.F086Uint > 399) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F086Uint) || value.F086Uint < 0 || value.F086Uint > 399) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F086Uint;
@@ -743,7 +738,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeDouble(NUMBER_SCRATCH)) {
     return false;
   }
-  if (!Number.isInteger(value.F088Int) || value.F088Int < -694 || value.F088Int > 694) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F088Int) || value.F088Int < -694 || value.F088Int > 694) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.F088Int >>> 0) - (-694 >>> 0)) >>> 0;
@@ -754,7 +749,7 @@ export function WriteRealPacket(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 48)) {
     return false;
   }
-  if (!Number.isInteger(value.F090Uint) || value.F090Uint < 0 || value.F090Uint > 214) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F090Uint) || value.F090Uint < 0 || value.F090Uint > 214) {
     return false;
   }
   NUMBER_SCRATCH.value = value.F090Uint;

--- a/generated/bench/js/realworld/RealWorldFlat.js
+++ b/generated/bench/js/realworld/RealWorldFlat.js
@@ -2042,7 +2042,7 @@ function writeRealPacketFlatChecked(value, view) {
   let v = 0, s = 0, x = 0, n = 0, t0 = 0, t1 = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.F001Int) || value.F001Int < -805495 || value.F001Int > 805495) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F001Int) || value.F001Int < -805495 || value.F001Int > 805495) {
     return -1;
   }
   v = ((((value.F001Int >>> 0) - 4294161801) >>> 0) & 0x1fffff) >>> 0;
@@ -2097,7 +2097,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F003Int) || value.F003Int < -835897 || value.F003Int > 835897) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F003Int) || value.F003Int < -835897 || value.F003Int > 835897) {
     return -1;
   }
   v = ((((value.F003Int >>> 0) - 4294131399) >>> 0) & 0x1fffff) >>> 0;
@@ -2118,7 +2118,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F004Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 2000.0);
@@ -2140,7 +2140,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F005Uint) || value.F005Uint < 0 || value.F005Uint > 7316) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F005Uint) || value.F005Uint < 0 || value.F005Uint > 7316) {
     return -1;
   }
   v = ((value.F005Uint) & 0x1fff) >>> 0;
@@ -2160,7 +2160,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F006Int) || value.F006Int < -1513 || value.F006Int > 1513) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F006Int) || value.F006Int < -1513 || value.F006Int > 1513) {
     return -1;
   }
   v = ((((value.F006Int >>> 0) - 4294965783) >>> 0) & 0xfff) >>> 0;
@@ -2243,7 +2243,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F009Int) || value.F009Int < -22 || value.F009Int > 22) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F009Int) || value.F009Int < -22 || value.F009Int > 22) {
     return -1;
   }
   v = ((((value.F009Int >>> 0) - 4294967274) >>> 0) & 0x3f) >>> 0;
@@ -2354,7 +2354,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F014Uint) || value.F014Uint < 0 || value.F014Uint > 775) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F014Uint) || value.F014Uint < 0 || value.F014Uint > 775) {
       return -1;
     }
     v = ((value.F014Uint) & 0x3ff) >>> 0;
@@ -2374,7 +2374,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F015Int) || value.F015Int < -21 || value.F015Int > 21) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F015Int) || value.F015Int < -21 || value.F015Int > 21) {
       return -1;
     }
     v = ((((value.F015Int >>> 0) - 4294967275) >>> 0) & 0x3f) >>> 0;
@@ -2394,7 +2394,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F016Fixed) || value.F016Fixed < -37748736 || value.F016Fixed > 37748736) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F016Fixed) || value.F016Fixed < -37748736 || value.F016Fixed > 37748736) {
       return -1;
     }
     v = ((((value.F016Fixed >>> 0) - 4257218560) >>> 0) & 0x7ffffff) >>> 0;
@@ -2414,7 +2414,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F017Uint) || value.F017Uint < 0 || value.F017Uint > 4606) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F017Uint) || value.F017Uint < 0 || value.F017Uint > 4606) {
       return -1;
     }
     v = ((value.F017Uint) & 0x1fff) >>> 0;
@@ -2435,7 +2435,7 @@ function writeRealPacketFlatChecked(value, view) {
       sb -= 64;
     }
   }
-  if (!Number.isInteger(value.F018Int) || value.F018Int < -834 || value.F018Int > 834) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F018Int) || value.F018Int < -834 || value.F018Int > 834) {
     return -1;
   }
   v = ((((value.F018Int >>> 0) - 4294966462) >>> 0) & 0x7ff) >>> 0;
@@ -2518,7 +2518,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F021Ufixed) || value.F021Ufixed < 0 || value.F021Ufixed > 102977536) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F021Ufixed) || value.F021Ufixed < 0 || value.F021Ufixed > 102977536) {
     return -1;
   }
   v = ((value.F021Ufixed) & 0x7ffffff) >>> 0;
@@ -2611,7 +2611,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F025Fixed) || value.F025Fixed < -30464 || value.F025Fixed > 30464) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F025Fixed) || value.F025Fixed < -30464 || value.F025Fixed > 30464) {
     return -1;
   }
   v = ((((value.F025Fixed >>> 0) - 4294936832) >>> 0) & 0xffff) >>> 0;
@@ -2649,7 +2649,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F027Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - -2.0) / 4.0);
@@ -2768,7 +2768,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F032Int) || value.F032Int < -3 || value.F032Int > 3) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F032Int) || value.F032Int < -3 || value.F032Int > 3) {
     return -1;
   }
   v = ((((value.F032Int >>> 0) - 4294967293) >>> 0) & 0x7) >>> 0;
@@ -2788,7 +2788,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F033Uint) || value.F033Uint < 0 || value.F033Uint > 142780) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F033Uint) || value.F033Uint < 0 || value.F033Uint > 142780) {
     return -1;
   }
   v = ((value.F033Uint) & 0x3ffff) >>> 0;
@@ -2808,7 +2808,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F034Uint) || value.F034Uint < 0 || value.F034Uint > 14149) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F034Uint) || value.F034Uint < 0 || value.F034Uint > 14149) {
     return -1;
   }
   v = ((value.F034Uint) & 0x3fff) >>> 0;
@@ -2916,7 +2916,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F040Fixed) || value.F040Fixed < -20480 || value.F040Fixed > 20480) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F040Fixed) || value.F040Fixed < -20480 || value.F040Fixed > 20480) {
     return -1;
   }
   v = ((((value.F040Fixed >>> 0) - 4294946816) >>> 0) & 0xffff) >>> 0;
@@ -2936,7 +2936,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F041Int) || value.F041Int < -55 || value.F041Int > 55) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F041Int) || value.F041Int < -55 || value.F041Int > 55) {
     return -1;
   }
   v = ((((value.F041Int >>> 0) - 4294967241) >>> 0) & 0x7f) >>> 0;
@@ -3036,7 +3036,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F046Uint) || value.F046Uint < 0 || value.F046Uint > 76063) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F046Uint) || value.F046Uint < 0 || value.F046Uint > 76063) {
       return -1;
     }
     v = ((value.F046Uint) & 0x1ffff) >>> 0;
@@ -3056,7 +3056,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F047Int) || value.F047Int < -430976 || value.F047Int > 430976) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F047Int) || value.F047Int < -430976 || value.F047Int > 430976) {
       return -1;
     }
     v = ((((value.F047Int >>> 0) - 4294536320) >>> 0) & 0xfffff) >>> 0;
@@ -3112,7 +3112,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F049Ufixed) || value.F049Ufixed < 0 || value.F049Ufixed > 49152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F049Ufixed) || value.F049Ufixed < 0 || value.F049Ufixed > 49152) {
     return -1;
   }
   v = ((value.F049Ufixed) & 0xffff) >>> 0;
@@ -3167,7 +3167,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F052Int) || value.F052Int < -57 || value.F052Int > 57) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F052Int) || value.F052Int < -57 || value.F052Int > 57) {
       return -1;
     }
     v = ((((value.F052Int >>> 0) - 4294967239) >>> 0) & 0x7f) >>> 0;
@@ -3215,7 +3215,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F054Int) || value.F054Int < -35 || value.F054Int > 35) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F054Int) || value.F054Int < -35 || value.F054Int > 35) {
       return -1;
     }
     v = ((((value.F054Int >>> 0) - 4294967261) >>> 0) & 0x7f) >>> 0;
@@ -3253,7 +3253,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F056Int) || value.F056Int < -13 || value.F056Int > 13) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F056Int) || value.F056Int < -13 || value.F056Int > 13) {
     return -1;
   }
   v = ((((value.F056Int >>> 0) - 4294967283) >>> 0) & 0x1f) >>> 0;
@@ -3273,7 +3273,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F057Int) || value.F057Int < -15 || value.F057Int > 15) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F057Int) || value.F057Int < -15 || value.F057Int > 15) {
     return -1;
   }
   v = ((((value.F057Int >>> 0) - 4294967281) >>> 0) & 0x1f) >>> 0;
@@ -3374,7 +3374,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F061Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - -90.0) / 180.0);
@@ -3396,7 +3396,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F062Uint) || value.F062Uint < 0 || value.F062Uint > 503) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F062Uint) || value.F062Uint < 0 || value.F062Uint > 503) {
     return -1;
   }
   v = ((value.F062Uint) & 0x1ff) >>> 0;
@@ -3451,7 +3451,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F064Uint) || value.F064Uint < 0 || value.F064Uint > 299) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F064Uint) || value.F064Uint < 0 || value.F064Uint > 299) {
     return -1;
   }
   v = ((value.F064Uint) & 0x1ff) >>> 0;
@@ -3472,7 +3472,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F065Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 30.0);
@@ -3494,7 +3494,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F066Ufixed) || value.F066Ufixed < 0 || value.F066Ufixed > 32768) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F066Ufixed) || value.F066Ufixed < 0 || value.F066Ufixed > 32768) {
     return -1;
   }
   v = ((value.F066Ufixed) & 0xffff) >>> 0;
@@ -3515,7 +3515,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F067Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - -100.0) / 200.0);
@@ -3538,7 +3538,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F068Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 2000.0);
@@ -3577,7 +3577,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F070Uint) || value.F070Uint < 0 || value.F070Uint > 2) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F070Uint) || value.F070Uint < 0 || value.F070Uint > 2) {
     return -1;
   }
   v = ((value.F070Uint) & 0x3) >>> 0;
@@ -3598,7 +3598,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F071Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 10.0);
@@ -3621,7 +3621,7 @@ function writeRealPacketFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.F072Cf32);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 100.0);
@@ -3643,7 +3643,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F073Int) || value.F073Int < -4 || value.F073Int > 4) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F073Int) || value.F073Int < -4 || value.F073Int > 4) {
     return -1;
   }
   v = ((((value.F073Int >>> 0) - 4294967292) >>> 0) & 0xf) >>> 0;
@@ -3716,7 +3716,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F076Int) || value.F076Int < -26218 || value.F076Int > 26218) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F076Int) || value.F076Int < -26218 || value.F076Int > 26218) {
       return -1;
     }
     v = ((((value.F076Int >>> 0) - 4294941078) >>> 0) & 0xffff) >>> 0;
@@ -3736,7 +3736,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F077Int) || value.F077Int < -17 || value.F077Int > 17) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F077Int) || value.F077Int < -17 || value.F077Int > 17) {
       return -1;
     }
     v = ((((value.F077Int >>> 0) - 4294967279) >>> 0) & 0x3f) >>> 0;
@@ -3773,7 +3773,7 @@ function writeRealPacketFlatChecked(value, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.F079Uint) || value.F079Uint < 0 || value.F079Uint > 17) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.F079Uint) || value.F079Uint < 0 || value.F079Uint > 17) {
       return -1;
     }
     v = ((value.F079Uint) & 0x1f) >>> 0;
@@ -3865,7 +3865,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F084Ufixed) || value.F084Ufixed < 0 || value.F084Ufixed > 128) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F084Ufixed) || value.F084Ufixed < 0 || value.F084Ufixed > 128) {
     return -1;
   }
   v = ((value.F084Ufixed) & 0xff) >>> 0;
@@ -3902,7 +3902,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F086Uint) || value.F086Uint < 0 || value.F086Uint > 399) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F086Uint) || value.F086Uint < 0 || value.F086Uint > 399) {
     return -1;
   }
   v = ((value.F086Uint) & 0x1ff) >>> 0;
@@ -3957,7 +3957,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F088Int) || value.F088Int < -694 || value.F088Int > 694) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F088Int) || value.F088Int < -694 || value.F088Int > 694) {
     return -1;
   }
   v = ((((value.F088Int >>> 0) - 4294966602) >>> 0) & 0x7ff) >>> 0;
@@ -4012,7 +4012,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F090Uint) || value.F090Uint < 0 || value.F090Uint > 214) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F090Uint) || value.F090Uint < 0 || value.F090Uint > 214) {
     return -1;
   }
   v = ((value.F090Uint) & 0xff) >>> 0;
@@ -4121,7 +4121,7 @@ function writeRealPacketFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.F095Fixed) || value.F095Fixed < -103350272 || value.F095Fixed > 103350272) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.F095Fixed) || value.F095Fixed < -103350272 || value.F095Fixed > 103350272) {
     return -1;
   }
   v = ((((value.F095Fixed >>> 0) - 4191617024) >>> 0) & 0xfffffff) >>> 0;

--- a/generated/bench/rust-realworld/src/realworld.rs
+++ b/generated/bench/rust-realworld/src/realworld.rs
@@ -52,13 +52,7 @@ impl PacketMode {
 
 /// Debug/log name for any `PacketMode` value, out-of-set included.
 pub fn enum_name_packet_mode(value: PacketMode) -> &'static str {
-    enum_name_packet_mode_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_packet_mode`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_packet_mode_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Idle",
         2 => "Active",
@@ -325,7 +319,7 @@ pub const REAL_PACKET_MAX_BYTES: usize = 232;
 
 #[inline(always)]
 pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Result {
-    if value.f001_int < -805495 || value.f001_int > 805495 { // out-of-contract writes are refused, not wrapped
+    if value.f001_int < -805495 || value.f001_int > 805495 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -336,7 +330,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut float_value = value.f002_f64;
         stream.serialize_f64(&mut float_value)?;
     }
-    if value.f003_int < -835897 || value.f003_int > 835897 { // out-of-contract writes are refused, not wrapped
+    if value.f003_int < -835897 || value.f003_int > 835897 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -345,16 +339,16 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     }
     {
         let mut compressed_value = value.f004_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 20000, 15, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 0.1, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 20000, 15, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 0.1, constants folded at generation
     }
-    if value.f005_uint > 7316 { // out-of-contract writes are refused, not wrapped
+    if value.f005_uint > 7316 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.f005_uint as u32;
         stream.serialize_bits(&mut offset_value, 13)?;
     }
-    if value.f006_int < -1513 || value.f006_int > 1513 { // out-of-contract writes are refused, not wrapped
+    if value.f006_int < -1513 || value.f006_int > 1513 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -369,7 +363,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut raw_value = value.f008_u64;
         stream.serialize_bits64(&mut raw_value, 64)?;
     }
-    if value.f009_int < -22 || value.f009_int > 22 { // out-of-contract writes are refused, not wrapped
+    if value.f009_int < -22 || value.f009_int > 22 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -396,28 +390,28 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
             let mut float_value = value.f013_f32;
             stream.serialize_f32(&mut float_value)?;
         }
-        if value.f014_uint > 775 { // out-of-contract writes are refused, not wrapped
+        if value.f014_uint > 775 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
             let mut offset_value = value.f014_uint as u32;
             stream.serialize_bits(&mut offset_value, 10)?;
         }
-        if value.f015_int < -21 || value.f015_int > 21 { // out-of-contract writes are refused, not wrapped
+        if value.f015_int < -21 || value.f015_int > 21 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
             let mut offset_value = (value.f015_int as u32).wrapping_sub((-21_i32) as u32);
             stream.serialize_bits(&mut offset_value, 6)?;
         }
-        if value.f016_fixed < -37748736 || value.f016_fixed > 37748736 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+        if value.f016_fixed < -37748736 || value.f016_fixed > 37748736 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
             let mut fixed_value = value.f016_fixed;
             stream.serialize_fixed(&mut fixed_value, 12, 20, -36, 36)?;
         }
-        if value.f017_uint > 4606 { // out-of-contract writes are refused, not wrapped
+        if value.f017_uint > 4606 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -425,7 +419,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
             stream.serialize_bits(&mut offset_value, 13)?;
         }
     }
-    if value.f018_int < -834 || value.f018_int > 834 { // out-of-contract writes are refused, not wrapped
+    if value.f018_int < -834 || value.f018_int > 834 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -440,7 +434,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut float_value = value.f020_f32;
         stream.serialize_f32(&mut float_value)?;
     }
-    if value.f021_ufixed > 102977536 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.f021_ufixed > 102977536 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -462,7 +456,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut float_value = value.f024_f32;
         stream.serialize_f32(&mut float_value)?;
     }
-    if value.f025_fixed < -30464 || value.f025_fixed > 30464 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.f025_fixed < -30464 || value.f025_fixed > 30464 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -478,7 +472,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     }
     {
         let mut compressed_value = value.f027_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 16, 5, 4.0_f32, -2.0_f32)?; // compressed float [-2.0, 2.0] @ 0.25, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 16, 5, 4.0_f32, -2.0_f32)?; // compressed float [-2.0, 2.0] @ 0.25, constants folded at generation
     }
     if value.f028_bits >= 1 << 4 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -502,21 +496,21 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut raw_value = value.f031_bits;
         stream.serialize_bits(&mut raw_value, 1)?;
     }
-    if value.f032_int < -3 || value.f032_int > 3 { // out-of-contract writes are refused, not wrapped
+    if value.f032_int < -3 || value.f032_int > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.f032_int as u32).wrapping_sub((-3_i32) as u32);
         stream.serialize_bits(&mut offset_value, 3)?;
     }
-    if value.f033_uint > 142780 { // out-of-contract writes are refused, not wrapped
+    if value.f033_uint > 142780 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.f033_uint;
         stream.serialize_bits(&mut offset_value, 18)?;
     }
-    if value.f034_uint > 14149 { // out-of-contract writes are refused, not wrapped
+    if value.f034_uint > 14149 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -552,14 +546,14 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut raw_value = value.f039_bits;
         stream.serialize_bits(&mut raw_value, 19)?;
     }
-    if value.f040_fixed < -20480 || value.f040_fixed > 20480 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.f040_fixed < -20480 || value.f040_fixed > 20480 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.f040_fixed;
         stream.serialize_fixed(&mut fixed_value, 4, 12, -5, 5)?;
     }
-    if value.f041_int < -55 || value.f041_int > 55 { // out-of-contract writes are refused, not wrapped
+    if value.f041_int < -55 || value.f041_int > 55 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -589,14 +583,14 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
             let mut raw_value = value.f045_bits;
             stream.serialize_bits(&mut raw_value, 12)?;
         }
-        if value.f046_uint > 76063 { // out-of-contract writes are refused, not wrapped
+        if value.f046_uint > 76063 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
             let mut offset_value = value.f046_uint;
             stream.serialize_bits(&mut offset_value, 17)?;
         }
-        if value.f047_int < -430976 || value.f047_int > 430976 { // out-of-contract writes are refused, not wrapped
+        if value.f047_int < -430976 || value.f047_int > 430976 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -608,7 +602,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut float_value = value.f048_f64;
         stream.serialize_f64(&mut float_value)?;
     }
-    if value.f049_ufixed > 49152 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.f049_ufixed > 49152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -624,7 +618,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
             let mut bool_value = value.f051_bool;
             stream.serialize_bool(&mut bool_value)?;
         }
-        if value.f052_int < -57 || value.f052_int > 57 { // out-of-contract writes are refused, not wrapped
+        if value.f052_int < -57 || value.f052_int > 57 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -635,7 +629,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
             let mut float_value = value.f053_f32;
             stream.serialize_f32(&mut float_value)?;
         }
-        if value.f054_int < -35 || value.f054_int > 35 { // out-of-contract writes are refused, not wrapped
+        if value.f054_int < -35 || value.f054_int > 35 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -647,14 +641,14 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut bool_value = value.f055_bool;
         stream.serialize_bool(&mut bool_value)?;
     }
-    if value.f056_int < -13 || value.f056_int > 13 { // out-of-contract writes are refused, not wrapped
+    if value.f056_int < -13 || value.f056_int > 13 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.f056_int as u32).wrapping_sub((-13_i32) as u32);
         stream.serialize_bits(&mut offset_value, 5)?;
     }
-    if value.f057_int < -15 || value.f057_int > 15 { // out-of-contract writes are refused, not wrapped
+    if value.f057_int < -15 || value.f057_int > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -678,9 +672,9 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     }
     {
         let mut compressed_value = value.f061_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 360, 9, 180.0_f32, -90.0_f32)?; // compressed float [-90.0, 90.0] @ 0.5, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 360, 9, 180.0_f32, -90.0_f32)?; // compressed float [-90.0, 90.0] @ 0.5, constants folded at generation
     }
-    if value.f062_uint > 503 { // out-of-contract writes are refused, not wrapped
+    if value.f062_uint > 503 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -691,7 +685,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut raw_value = value.f063_i64 as u64;
         stream.serialize_bits64(&mut raw_value, 64)?;
     }
-    if value.f064_uint > 299 { // out-of-contract writes are refused, not wrapped
+    if value.f064_uint > 299 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -700,9 +694,9 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     }
     {
         let mut compressed_value = value.f065_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 60, 6, 30.0_f32, 0.0_f32)?; // compressed float [0.0, 30.0] @ 0.5, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 60, 6, 30.0_f32, 0.0_f32)?; // compressed float [0.0, 30.0] @ 0.5, constants folded at generation
     }
-    if value.f066_ufixed > 32768 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.f066_ufixed > 32768 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -711,11 +705,11 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     }
     {
         let mut compressed_value = value.f067_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 800, 10, 200.0_f32, -100.0_f32)?; // compressed float [-100.0, 100.0] @ 0.25, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 800, 10, 200.0_f32, -100.0_f32)?; // compressed float [-100.0, 100.0] @ 0.25, constants folded at generation
     }
     {
         let mut compressed_value = value.f068_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 2000, 11, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 1.0, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 2000, 11, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 1.0, constants folded at generation
     }
     if value.f069_bits >= 1 << 11 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
@@ -724,7 +718,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut raw_value = value.f069_bits;
         stream.serialize_bits(&mut raw_value, 11)?;
     }
-    if value.f070_uint > 2 { // out-of-contract writes are refused, not wrapped
+    if value.f070_uint > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -733,13 +727,13 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     }
     {
         let mut compressed_value = value.f071_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 500, 9, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.02, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 500, 9, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.02, constants folded at generation
     }
     {
         let mut compressed_value = value.f072_cf32;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 10000, 14, 100.0_f32, 0.0_f32)?; // compressed float [0.0, 100.0] @ 0.01, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 10000, 14, 100.0_f32, 0.0_f32)?; // compressed float [0.0, 100.0] @ 0.01, constants folded at generation
     }
-    if value.f073_int < -4 || value.f073_int > 4 { // out-of-contract writes are refused, not wrapped
+    if value.f073_int < -4 || value.f073_int > 4 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -755,14 +749,14 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
             let mut raw_value = value.f075_u64;
             stream.serialize_bits64(&mut raw_value, 64)?;
         }
-        if value.f076_int < -26218 || value.f076_int > 26218 { // out-of-contract writes are refused, not wrapped
+        if value.f076_int < -26218 || value.f076_int > 26218 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
             let mut offset_value = (value.f076_int as u32).wrapping_sub((-26218_i32) as u32);
             stream.serialize_bits(&mut offset_value, 16)?;
         }
-        if value.f077_int < -17 || value.f077_int > 17 { // out-of-contract writes are refused, not wrapped
+        if value.f077_int < -17 || value.f077_int > 17 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -776,7 +770,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
             let mut raw_value = value.f078_bits;
             stream.serialize_bits(&mut raw_value, 9)?;
         }
-        if value.f079_uint > 17 { // out-of-contract writes are refused, not wrapped
+        if value.f079_uint > 17 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -809,7 +803,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut offset_value = value.f083_enum.0 as u32;
         stream.serialize_bits(&mut offset_value, 3)?;
     }
-    if value.f084_ufixed > 128 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.f084_ufixed > 128 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -823,7 +817,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut raw_value = value.f085_bits;
         stream.serialize_bits(&mut raw_value, 21)?;
     }
-    if value.f086_uint > 399 { // out-of-contract writes are refused, not wrapped
+    if value.f086_uint > 399 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -834,7 +828,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut float_value = value.f087_f64;
         stream.serialize_f64(&mut float_value)?;
     }
-    if value.f088_int < -694 || value.f088_int > 694 { // out-of-contract writes are refused, not wrapped
+    if value.f088_int < -694 || value.f088_int > 694 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -848,7 +842,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut raw_value = value.f089_bits;
         stream.serialize_bits64(&mut raw_value, 48)?;
     }
-    if value.f090_uint > 214 { // out-of-contract writes are refused, not wrapped
+    if value.f090_uint > 214 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -875,7 +869,7 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut bool_value = value.f094_bool;
         stream.serialize_bool(&mut bool_value)?;
     }
-    if value.f095_fixed < -103350272 || value.f095_fixed > 103350272 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.f095_fixed < -103350272 || value.f095_fixed > 103350272 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -904,7 +898,7 @@ pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> 
     stream.serialize_int(&mut value.f001_int, -805495, 805495)?;
     stream.serialize_f64(&mut value.f002_f64)?;
     stream.serialize_int(&mut value.f003_int, -835897, 835897)?;
-    stream.serialize_compressed_float_precomputed(&mut value.f004_cf32, 20000, 15, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 0.1, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.f004_cf32, 20000, 15, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 0.1, constants folded at generation
     {
         let mut range_value: i32 = 0;
         stream.serialize_int(&mut range_value, 0, 7316)?;
@@ -963,7 +957,7 @@ pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> 
     stream.serialize_f32(&mut value.f024_f32)?;
     stream.serialize_fixed(&mut value.f025_fixed, 8, 8, -119, 119)?;
     stream.serialize_bits(&mut value.f026_bits, 9)?;
-    stream.serialize_compressed_float_precomputed(&mut value.f027_cf32, 16, 5, 4.0_f32, -2.0_f32)?; // compressed float [-2.0, 2.0] @ 0.25, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.f027_cf32, 16, 5, 4.0_f32, -2.0_f32)?; // compressed float [-2.0, 2.0] @ 0.25, constants folded at generation
     stream.serialize_bits(&mut value.f028_bits, 4)?;
     {
         let mut raw_value: u64 = 0;
@@ -1055,7 +1049,7 @@ pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> 
     stream.serialize_f32(&mut value.f058_f32)?;
     stream.serialize_f64(&mut value.f059_f64)?;
     stream.serialize_bits(&mut value.f060_bits, 8)?;
-    stream.serialize_compressed_float_precomputed(&mut value.f061_cf32, 360, 9, 180.0_f32, -90.0_f32)?; // compressed float [-90.0, 90.0] @ 0.5, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.f061_cf32, 360, 9, 180.0_f32, -90.0_f32)?; // compressed float [-90.0, 90.0] @ 0.5, constants folded at generation
     {
         let mut range_value: i32 = 0;
         stream.serialize_int(&mut range_value, 0, 503)?;
@@ -1071,18 +1065,18 @@ pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> 
         stream.serialize_int(&mut range_value, 0, 299)?;
         value.f064_uint = range_value as u16;
     }
-    stream.serialize_compressed_float_precomputed(&mut value.f065_cf32, 60, 6, 30.0_f32, 0.0_f32)?; // compressed float [0.0, 30.0] @ 0.5, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.f065_cf32, 60, 6, 30.0_f32, 0.0_f32)?; // compressed float [0.0, 30.0] @ 0.5, constants folded at generation
     stream.serialize_fixed(&mut value.f066_ufixed, 2, 14, 0, 2)?;
-    stream.serialize_compressed_float_precomputed(&mut value.f067_cf32, 800, 10, 200.0_f32, -100.0_f32)?; // compressed float [-100.0, 100.0] @ 0.25, constants folded at generation (issue #82)
-    stream.serialize_compressed_float_precomputed(&mut value.f068_cf32, 2000, 11, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 1.0, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.f067_cf32, 800, 10, 200.0_f32, -100.0_f32)?; // compressed float [-100.0, 100.0] @ 0.25, constants folded at generation
+    stream.serialize_compressed_float_precomputed(&mut value.f068_cf32, 2000, 11, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 1.0, constants folded at generation
     stream.serialize_bits(&mut value.f069_bits, 11)?;
     {
         let mut range_value: i32 = 0;
         stream.serialize_int(&mut range_value, 0, 2)?;
         value.f070_uint = range_value as u8;
     }
-    stream.serialize_compressed_float_precomputed(&mut value.f071_cf32, 500, 9, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.02, constants folded at generation (issue #82)
-    stream.serialize_compressed_float_precomputed(&mut value.f072_cf32, 10000, 14, 100.0_f32, 0.0_f32)?; // compressed float [0.0, 100.0] @ 0.01, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.f071_cf32, 500, 9, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.02, constants folded at generation
+    stream.serialize_compressed_float_precomputed(&mut value.f072_cf32, 10000, 14, 100.0_f32, 0.0_f32)?; // compressed float [0.0, 100.0] @ 0.01, constants folded at generation
     {
         let mut range_value: i32 = 0;
         stream.serialize_int(&mut range_value, -4, 4)?;

--- a/generated/bench/rust/src/bench.rs
+++ b/generated/bench/rust/src/bench.rs
@@ -79,21 +79,21 @@ pub const BENCH_PACKET_MAX_BYTES: usize = 56;
 
 #[inline(always)]
 pub fn write_bench_packet(stream: &mut WriteStream<'_>, value: &BenchPacket) -> Result {
-    if value.a < -100 || value.a > 100 { // out-of-contract writes are refused, not wrapped
+    if value.a < -100 || value.a > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.a as u32).wrapping_sub((-100_i32) as u32);
         stream.serialize_bits(&mut offset_value, 8)?;
     }
-    if value.b < 0 || value.b > 65535 { // out-of-contract writes are refused, not wrapped
+    if value.b < 0 || value.b > 65535 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.b as u32;
         stream.serialize_bits(&mut offset_value, 16)?;
     }
-    if value.c < -1000000 || value.c > 1000000 { // out-of-contract writes are refused, not wrapped
+    if value.c < -1000000 || value.c > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -205,70 +205,70 @@ pub const BENCH_INTS_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_bench_ints(stream: &mut WriteStream<'_>, value: &BenchInts) -> Result {
-    if value.f0 < -100 || value.f0 > 100 { // out-of-contract writes are refused, not wrapped
+    if value.f0 < -100 || value.f0 > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.f0 as u32).wrapping_sub((-100_i32) as u32);
         stream.serialize_bits(&mut offset_value, 8)?;
     }
-    if value.f1 < 0 || value.f1 > 65535 { // out-of-contract writes are refused, not wrapped
+    if value.f1 < 0 || value.f1 > 65535 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.f1 as u32;
         stream.serialize_bits(&mut offset_value, 16)?;
     }
-    if value.f2 < -1000000 || value.f2 > 1000000 { // out-of-contract writes are refused, not wrapped
+    if value.f2 < -1000000 || value.f2 > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.f2 as u32).wrapping_sub((-1000000_i32) as u32);
         stream.serialize_bits(&mut offset_value, 21)?;
     }
-    if value.f3 < 0 || value.f3 > 3 { // out-of-contract writes are refused, not wrapped
+    if value.f3 < 0 || value.f3 > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.f3 as u32;
         stream.serialize_bits(&mut offset_value, 2)?;
     }
-    if value.f4 < -15 || value.f4 > 15 { // out-of-contract writes are refused, not wrapped
+    if value.f4 < -15 || value.f4 > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.f4 as u32).wrapping_sub((-15_i32) as u32);
         stream.serialize_bits(&mut offset_value, 5)?;
     }
-    if value.f5 < 0 || value.f5 > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.f5 < 0 || value.f5 > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.f5 as u32;
         stream.serialize_bits(&mut offset_value, 10)?;
     }
-    if value.f6 < -2048 || value.f6 > 2047 { // out-of-contract writes are refused, not wrapped
+    if value.f6 < -2048 || value.f6 > 2047 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.f6 as u32).wrapping_sub((-2048_i32) as u32);
         stream.serialize_bits(&mut offset_value, 12)?;
     }
-    if value.f7 < 0 || value.f7 > 255 { // out-of-contract writes are refused, not wrapped
+    if value.f7 < 0 || value.f7 > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.f7 as u32;
         stream.serialize_bits(&mut offset_value, 8)?;
     }
-    if value.f8 < -600000 || value.f8 > 600000 { // out-of-contract writes are refused, not wrapped
+    if value.f8 < -600000 || value.f8 > 600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.f8 as u32).wrapping_sub((-600000_i32) as u32);
         stream.serialize_bits(&mut offset_value, 21)?;
     }
-    if value.f9 < 0 || value.f9 > 100 { // out-of-contract writes are refused, not wrapped
+    if value.f9 < 0 || value.f9 > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -442,7 +442,7 @@ pub const BENCH_MIXED_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Result {
-    if value.sequence < 0 || value.sequence > 65535 { // out-of-contract writes are refused, not wrapped
+    if value.sequence < 0 || value.sequence > 65535 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -460,21 +460,21 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
         let mut raw_value = value.entity_id;
         stream.serialize_bits(&mut raw_value, 12)?;
     }
-    if value.pos_x < -16384 || value.pos_x > 16383 { // out-of-contract writes are refused, not wrapped
+    if value.pos_x < -16384 || value.pos_x > 16383 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.pos_x as u32).wrapping_sub((-16384_i32) as u32);
         stream.serialize_bits(&mut offset_value, 15)?;
     }
-    if value.pos_y < -16384 || value.pos_y > 16383 { // out-of-contract writes are refused, not wrapped
+    if value.pos_y < -16384 || value.pos_y > 16383 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.pos_y as u32).wrapping_sub((-16384_i32) as u32);
         stream.serialize_bits(&mut offset_value, 15)?;
     }
-    if value.pos_z < -16384 || value.pos_z > 16383 { // out-of-contract writes are refused, not wrapped
+    if value.pos_z < -16384 || value.pos_z > 16383 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -503,7 +503,7 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
         let mut raw_value = value.timestamp;
         stream.serialize_bits64(&mut raw_value, 48)?;
     }
-    if value.weapon < 0 || value.weapon > 15 { // out-of-contract writes are refused, not wrapped
+    if value.weapon < 0 || value.weapon > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {

--- a/generated/c-ludicrous/Ludicrous.h
+++ b/generated/c-ludicrous/Ludicrous.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 #include "serialize.h"   /* serialize_int128_t: C has no 128-bit builtin */
 
 #ifndef SCHEMA_UNUSED
@@ -47,23 +46,9 @@ static SCHEMA_UNUSED const char * enum_name_drive_mode( DriveMode value )
     switch ( value )
     {
         case DRIVE_MODE_NONE: return "None";
-        case 1: return "Cruise";
-        case 2: return "Warp";
-        case 3: return "Ludicrous";
-        default: return "???";
-    }
-}
-
-/* As enum_name_drive_mode, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_drive_mode_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Cruise";
-        case 2: return "Warp";
-        case 3: return "Ludicrous";
+        case DRIVE_MODE_CRUISE: return "Cruise";
+        case DRIVE_MODE_WARP: return "Warp";
+        case DRIVE_MODE_LUDICROUS: return "Ludicrous";
         default: return "???";
     }
 }
@@ -94,7 +79,7 @@ typedef struct UnsignedProbe {
 } UnsignedProbe;
 
 #define UNSIGNED_PROBE_MAX_BITS 196   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define UNSIGNED_PROBE_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define UNSIGNED_PROBE_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type WideProbe */
@@ -107,7 +92,7 @@ typedef struct WideProbe {
 } WideProbe;
 
 #define WIDE_PROBE_MAX_BITS 403   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define WIDE_PROBE_MAX_BYTES 56  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define WIDE_PROBE_MAX_BYTES 56  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a WideProbe with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -134,7 +119,7 @@ typedef struct LudicrousState {
 } LudicrousState;
 
 #define LUDICROUS_STATE_MAX_BITS 1205   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define LUDICROUS_STATE_MAX_BYTES 152  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define LUDICROUS_STATE_MAX_BYTES 152  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a LudicrousState with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -157,7 +142,7 @@ typedef struct DegenerateProbe {
 } DegenerateProbe;
 
 #define DEGENERATE_PROBE_MAX_BITS 8   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define DEGENERATE_PROBE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define DEGENERATE_PROBE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type FixedVec */
@@ -168,7 +153,7 @@ typedef struct FixedVec {
 } FixedVec;
 
 #define FIXED_VEC_MAX_BITS 102   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define FIXED_VEC_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define FIXED_VEC_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type FixedQuat */
@@ -180,7 +165,7 @@ typedef struct FixedQuat {
 } FixedQuat;
 
 #define FIXED_QUAT_MAX_BITS 128   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define FIXED_QUAT_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define FIXED_QUAT_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a FixedQuat with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a

--- a/generated/c-ludicrous/LudicrousWire.h
+++ b/generated/c-ludicrous/LudicrousWire.h
@@ -23,6 +23,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -45,8 +51,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes FixedProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes FixedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_write_stream_t * stream, const FixedProbe * value )
 {
     {
@@ -93,8 +98,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_writ
     return 1;
 }
 
-/* Reads FixedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads FixedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
 {
     {
@@ -151,8 +155,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_s
     return 1;
 }
 
-/* Writes UnsignedProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes UnsignedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_write_stream_t * stream, const UnsignedProbe * value )
 {
     {
@@ -207,8 +210,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_w
     return 1;
 }
 
-/* Reads UnsignedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads UnsignedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
 {
     {
@@ -269,8 +271,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_rea
     return 1;
 }
 
-/* Writes WideProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes WideProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write_stream_t * stream, const WideProbe * value )
 {
     if ( !serialize_write_uint128( stream, value->entity_id ) )
@@ -296,8 +297,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write
     return 1;
 }
 
-/* Reads WideProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads WideProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
 {
     if ( !serialize_read_uint128( stream, &value->entity_id ) )
@@ -323,8 +323,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_st
     return 1;
 }
 
-/* Writes LudicrousState. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes LudicrousState. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
 {
     if ( value->mode > 3 )
@@ -371,8 +370,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_
     return 1;
 }
 
-/* Reads LudicrousState. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads LudicrousState. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_read_stream_t * stream, LudicrousState * value )
 {
     {
@@ -427,8 +425,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_re
     return 1;
 }
 
-/* Writes DegenerateProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
 {
     if ( (serialize_int64_t) value->locked_fixed != -196608LL )
@@ -450,8 +447,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize
     return 1;
 }
 
-/* Reads DegenerateProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
 {
     value->locked_fixed = (int32_t) -196608LL;
@@ -468,8 +464,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_r
     return 1;
 }
 
-/* Writes FixedVec. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes FixedVec. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_stream_t * stream, const FixedVec * value )
 {
     {
@@ -496,8 +491,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_
     return 1;
 }
 
-/* Reads FixedVec. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads FixedVec. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
 {
     {
@@ -530,8 +524,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_str
     return 1;
 }
 
-/* Writes FixedQuat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes FixedQuat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write_stream_t * stream, const FixedQuat * value )
 {
     {
@@ -565,8 +558,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write
     return 1;
 }
 
-/* Reads FixedQuat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads FixedQuat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
 {
     {

--- a/generated/c/Constants.h
+++ b/generated/c/Constants.h
@@ -8,16 +8,6 @@
 #define SCHEMA_EXAMPLE_CONSTANTS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/generated/c/ConstantsWire.h
+++ b/generated/c/ConstantsWire.h
@@ -8,16 +8,7 @@
 #define SCHEMA_EXAMPLE_CONSTANTSWIRE_H
 
 #include "Constants.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/generated/c/Contexts.h
+++ b/generated/c/Contexts.h
@@ -8,16 +8,6 @@
 #define SCHEMA_EXAMPLE_CONTEXTS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/generated/c/ContextsWire.h
+++ b/generated/c/ContextsWire.h
@@ -8,16 +8,7 @@
 #define SCHEMA_EXAMPLE_CONTEXTSWIRE_H
 
 #include "Contexts.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/generated/c/Enums.h
+++ b/generated/c/Enums.h
@@ -8,8 +8,6 @@
 #define SCHEMA_EXAMPLE_ENUMS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED
 #if defined(__GNUC__) || defined(__clang__)
@@ -40,21 +38,8 @@ static SCHEMA_UNUSED const char * enum_name_team( Team value )
     switch ( value )
     {
         case TEAM_NONE: return "None";
-        case 1: return "Red";
-        case 2: return "Blue";
-        default: return "???";
-    }
-}
-
-/* As enum_name_team, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_team_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Red";
-        case 2: return "Blue";
+        case TEAM_RED: return "Red";
+        case TEAM_BLUE: return "Blue";
         default: return "???";
     }
 }
@@ -79,27 +64,11 @@ static SCHEMA_UNUSED const char * enum_name_ship_type( ShipType value )
     switch ( value )
     {
         case SHIP_TYPE_NONE: return "None";
-        case 1: return "Fighter";
-        case 2: return "Corvette";
-        case 3: return "Bomber";
-        case 4: return "Destroyer";
-        case 5: return "Carrier";
-        default: return "???";
-    }
-}
-
-/* As enum_name_ship_type, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_ship_type_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Fighter";
-        case 2: return "Corvette";
-        case 3: return "Bomber";
-        case 4: return "Destroyer";
-        case 5: return "Carrier";
+        case SHIP_TYPE_FIGHTER: return "Fighter";
+        case SHIP_TYPE_CORVETTE: return "Corvette";
+        case SHIP_TYPE_BOMBER: return "Bomber";
+        case SHIP_TYPE_DESTROYER: return "Destroyer";
+        case SHIP_TYPE_CARRIER: return "Carrier";
         default: return "???";
     }
 }
@@ -122,23 +91,9 @@ static SCHEMA_UNUSED const char * enum_name_missile_type( MissileType value )
     switch ( value )
     {
         case MISSILE_TYPE_NONE: return "None";
-        case 1: return "Heatseeker";
-        case 2: return "Torpedo";
-        case 3: return "Nuke";
-        default: return "???";
-    }
-}
-
-/* As enum_name_missile_type, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_missile_type_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Heatseeker";
-        case 2: return "Torpedo";
-        case 3: return "Nuke";
+        case MISSILE_TYPE_HEATSEEKER: return "Heatseeker";
+        case MISSILE_TYPE_TORPEDO: return "Torpedo";
+        case MISSILE_TYPE_NUKE: return "Nuke";
         default: return "???";
     }
 }
@@ -164,29 +119,12 @@ static SCHEMA_UNUSED const char * enum_name_prop_type( PropType value )
     switch ( value )
     {
         case PROP_TYPE_NONE: return "None";
-        case 1: return "Asteroid";
-        case 2: return "Chunk";
-        case 3: return "Fragment";
-        case 4: return "Sphere";
-        case 5: return "BlackHole";
-        case 6: return "DysonPanel";
-        default: return "???";
-    }
-}
-
-/* As enum_name_prop_type, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_prop_type_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Asteroid";
-        case 2: return "Chunk";
-        case 3: return "Fragment";
-        case 4: return "Sphere";
-        case 5: return "BlackHole";
-        case 6: return "DysonPanel";
+        case PROP_TYPE_ASTEROID: return "Asteroid";
+        case PROP_TYPE_CHUNK: return "Chunk";
+        case PROP_TYPE_FRAGMENT: return "Fragment";
+        case PROP_TYPE_SPHERE: return "Sphere";
+        case PROP_TYPE_BLACK_HOLE: return "BlackHole";
+        case PROP_TYPE_DYSON_PANEL: return "DysonPanel";
         default: return "???";
     }
 }
@@ -206,17 +144,6 @@ static SCHEMA_UNUSED const char * enum_name_pending( Pending value )
     switch ( value )
     {
         case PENDING_NONE: return "None";
-        default: return "???";
-    }
-}
-
-/* As enum_name_pending, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_pending_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
         default: return "???";
     }
 }

--- a/generated/c/EnumsWire.h
+++ b/generated/c/EnumsWire.h
@@ -8,16 +8,7 @@
 #define SCHEMA_EXAMPLE_ENUMSWIRE_H
 
 #include "Enums.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/generated/c/Messages.h
+++ b/generated/c/Messages.h
@@ -8,8 +8,6 @@
 #define SCHEMA_EXAMPLE_MESSAGES_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED
 #if defined(__GNUC__) || defined(__clang__)
@@ -50,7 +48,7 @@ typedef struct Block {
 } Block;
 
 #define BLOCK_MAX_BITS 16018   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define BLOCK_MAX_BYTES 2008  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define BLOCK_MAX_BYTES 2008  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* message Chat */
@@ -60,7 +58,7 @@ typedef struct Chat {
 } Chat;
 
 #define CHAT_MAX_BITS 2064   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define CHAT_MAX_BYTES 264  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define CHAT_MAX_BYTES 264  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* message Synchronize */
@@ -70,7 +68,7 @@ typedef struct Synchronize {
 } Synchronize;
 
 #define SYNCHRONIZE_MAX_BITS 80   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define SYNCHRONIZE_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define SYNCHRONIZE_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* message Timescale */
@@ -81,7 +79,7 @@ typedef struct Timescale {
 } Timescale;
 
 #define TIMESCALE_MAX_BITS 128   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define TIMESCALE_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define TIMESCALE_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* The message tag: the discriminant for a heterogeneous stream. None = 0 is

--- a/generated/c/MessagesWire.h
+++ b/generated/c/MessagesWire.h
@@ -24,6 +24,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -158,8 +164,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 }
 #endif /* SCHEMA_INTERIOR_NULL_DEFINED */
 
-/* Writes Heartbeat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Heartbeat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
 {
     (void) stream;
@@ -167,8 +172,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_
     return 1; /* no fields: no wire bits */
 }
 
-/* Reads Heartbeat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Heartbeat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_heartbeat( serialize_read_stream_t * stream, Heartbeat * value )
 {
     (void) stream;
@@ -176,8 +180,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_heartbeat( serialize_read_str
     return 1;
 }
 
-/* Writes Test. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Test. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_stream_t * stream, const Test * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->test_a, 16 ) )
@@ -211,8 +214,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_strea
     return 1;
 }
 
-/* Reads Test. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Test. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t * stream, Test * value )
 {
     {
@@ -268,8 +270,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Block. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Block. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_block( serialize_write_stream_t * stream, const Block * value )
 {
     if ( !serialize_write_int( stream, value->data_length, 0, MAX_BLOCK_SIZE ) )
@@ -283,8 +284,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_block( serialize_write_stre
     return 1;
 }
 
-/* Reads Block. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Block. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_t * stream, Block * value )
 {
     if ( !serialize_read_int( stream, &value->data_length, 0, MAX_BLOCK_SIZE ) )
@@ -298,8 +298,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_
     return 1;
 }
 
-/* Writes Chat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Chat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_stream_t * stream, const Chat * value )
 {
     serialize_assert( schema_utf8_valid_( (const serialize_uint8_t *) value->text, value->text_length ) );
@@ -314,8 +313,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_strea
     return 1;
 }
 
-/* Reads Chat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Chat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t * stream, Chat * value )
 {
     if ( !serialize_read_int( stream, &value->text_length, 0, MAX_CHAT_LENGTH ) )
@@ -334,8 +332,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Synchronize. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Synchronize. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_synchronize( serialize_write_stream_t * stream, const Synchronize * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sync_frame ) )
@@ -349,8 +346,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_synchronize( serialize_writ
     return 1;
 }
 
-/* Reads Synchronize. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Synchronize. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_synchronize( serialize_read_stream_t * stream, Synchronize * value )
 {
     {
@@ -372,8 +368,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_synchronize( serialize_read_s
     return 1;
 }
 
-/* Writes Timescale. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Timescale. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_timescale( serialize_write_stream_t * stream, const Timescale * value )
 {
     if ( !serialize_write_double( stream, value->scale ) )
@@ -391,8 +386,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_timescale( serialize_write_
     return 1;
 }
 
-/* Reads Timescale. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Timescale. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_timescale( serialize_read_stream_t * stream, Timescale * value )
 {
     if ( !serialize_read_double( stream, &value->scale ) )

--- a/generated/c/Objects.h
+++ b/generated/c/Objects.h
@@ -8,7 +8,6 @@
 #define SCHEMA_EXAMPLE_OBJECTS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
 #include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED

--- a/generated/c/ObjectsWire.h
+++ b/generated/c/ObjectsWire.h
@@ -8,7 +8,6 @@
 #define SCHEMA_EXAMPLE_OBJECTSWIRE_H
 
 #include "Objects.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
 
 #ifndef SCHEMA_UNUSED
@@ -25,6 +24,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED

--- a/generated/c/Render.h
+++ b/generated/c/Render.h
@@ -8,16 +8,6 @@
 #define SCHEMA_EXAMPLE_RENDER_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 #include "Enums.h"
 
 #ifdef __cplusplus
@@ -48,7 +38,7 @@ typedef struct RenderBlock {
 } RenderBlock;
 
 #define RENDER_BLOCK_MAX_BITS 8903   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define RENDER_BLOCK_MAX_BYTES 1120  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define RENDER_BLOCK_MAX_BYTES 1120  /* 8-byte write granularity; read slack per the contract above */
 
 #ifdef __cplusplus
 }

--- a/generated/c/RenderWire.h
+++ b/generated/c/RenderWire.h
@@ -8,7 +8,6 @@
 #define SCHEMA_EXAMPLE_RENDERWIRE_H
 
 #include "Render.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
 
 #ifndef SCHEMA_UNUSED
@@ -23,6 +22,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -46,8 +51,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes RenderSprite. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes RenderSprite. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_write_stream_t * stream, const RenderSprite * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sort_key ) )
@@ -77,8 +81,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_wr
     return 1;
 }
 
-/* Reads RenderSprite. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads RenderSprite. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
 {
     {
@@ -128,8 +131,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read
     return 1;
 }
 
-/* Writes RenderBlock. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes RenderBlock. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_write_stream_t * stream, const RenderBlock * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->worker_index, 32 ) )
@@ -157,8 +159,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_wri
     return 1;
 }
 
-/* Reads RenderBlock. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads RenderBlock. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_block( serialize_read_stream_t * stream, RenderBlock * value )
 {
     {

--- a/generated/c/Types.h
+++ b/generated/c/Types.h
@@ -46,7 +46,7 @@ typedef struct Quat {
 } Quat;
 
 #define QUAT_MAX_BITS 256   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUAT_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUAT_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type Handle */
@@ -56,7 +56,7 @@ typedef struct Handle {
 } Handle;
 
 #define HANDLE_MAX_BITS 22   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define HANDLE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define HANDLE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type QuantizedPosition */
@@ -67,7 +67,7 @@ typedef struct QuantizedPosition {
 } QuantizedPosition;
 
 #define QUANTIZED_POSITION_MAX_BITS 75   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUANTIZED_POSITION_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUANTIZED_POSITION_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type QuantizedVelocity */
@@ -78,7 +78,7 @@ typedef struct QuantizedVelocity {
 } QuantizedVelocity;
 
 #define QUANTIZED_VELOCITY_MAX_BITS 69   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUANTIZED_VELOCITY_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUANTIZED_VELOCITY_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type QuantizedRotation */
@@ -90,7 +90,7 @@ typedef struct QuantizedRotation {
 } QuantizedRotation;
 
 #define QUANTIZED_ROTATION_MAX_BITS 48   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUANTIZED_ROTATION_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUANTIZED_ROTATION_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type RigidBody */
@@ -103,7 +103,7 @@ typedef struct RigidBody {
 } RigidBody;
 
 #define RIGID_BODY_MAX_BITS 833   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define RIGID_BODY_MAX_BYTES 112  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define RIGID_BODY_MAX_BYTES 112  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type Input */
@@ -124,7 +124,7 @@ typedef struct Input {
 } Input;
 
 #define INPUT_MAX_BITS 168   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define INPUT_MAX_BYTES 24  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define INPUT_MAX_BYTES 24  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type InputPacket */
@@ -137,7 +137,7 @@ typedef struct InputPacket {
 } InputPacket;
 
 #define INPUT_PACKET_MAX_BITS 2837   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define INPUT_PACKET_MAX_BYTES 360  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define INPUT_PACKET_MAX_BYTES 360  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ShipCreate */
@@ -155,7 +155,7 @@ typedef struct ShipCreate {
 } ShipCreate;
 
 #define SHIP_CREATE_MAX_BITS 219   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define SHIP_CREATE_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define SHIP_CREATE_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ExpressionProbe */
@@ -165,7 +165,7 @@ typedef struct ExpressionProbe {
 } ExpressionProbe;
 
 #define EXPRESSION_PROBE_MAX_BITS 16   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define EXPRESSION_PROBE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define EXPRESSION_PROBE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 #define FLOOR_LIMIT (( -9223372036854775807LL - 1 ))
 #define CEILING_COUNT (18446744073709551615ULL)
@@ -180,7 +180,7 @@ typedef struct ExtremeProbe {
 } ExtremeProbe;
 
 #define EXTREME_PROBE_MAX_BITS 320   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define EXTREME_PROBE_MAX_BYTES 40  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define EXTREME_PROBE_MAX_BYTES 40  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ExtremeProbe with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -204,7 +204,7 @@ typedef struct ExtremeRow {
 } ExtremeRow;
 
 #define EXTREME_ROW_MAX_BITS 256   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define EXTREME_ROW_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define EXTREME_ROW_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ExtremeRow with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a

--- a/generated/c/TypesWire.h
+++ b/generated/c/TypesWire.h
@@ -25,6 +25,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -47,8 +53,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes Vec3. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Vec3. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_stream_t * stream, const Vec3 * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
@@ -66,8 +71,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_strea
     return 1;
 }
 
-/* Reads Vec3. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Vec3. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
@@ -85,8 +89,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Quat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Quat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_stream_t * stream, const Quat * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
@@ -108,8 +111,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_strea
     return 1;
 }
 
-/* Reads Quat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Quat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t * stream, Quat * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
@@ -131,8 +133,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Handle. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Handle. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_stream_t * stream, const Handle * value )
 {
     if ( (serialize_int64_t) value->object_id < 0 || (serialize_int64_t) value->object_id > MAX_OBJECTS - 1 )
@@ -150,8 +151,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_str
     return 1;
 }
 
-/* Reads Handle. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Handle. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream_t * stream, Handle * value )
 {
     {
@@ -179,8 +179,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream
     return 1;
 }
 
-/* Writes QuantizedPosition. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
 {
     if ( (serialize_int64_t) value->x < -MAX_POSITION_UNITS || (serialize_int64_t) value->x > MAX_POSITION_UNITS )
@@ -210,8 +209,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( seriali
     return 1;
 }
 
-/* Reads QuantizedPosition. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
 {
     {
@@ -259,8 +257,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize
     return 1;
 }
 
-/* Writes QuantizedVelocity. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
 {
     if ( (serialize_int64_t) value->x < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->x > MAX_VELOCITY_UNITS )
@@ -290,8 +287,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( seriali
     return 1;
 }
 
-/* Reads QuantizedVelocity. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
 {
     {
@@ -339,8 +335,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize
     return 1;
 }
 
-/* Writes QuantizedRotation. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
 {
     if ( (serialize_int64_t) value->x < -ROTATION_UNITS || (serialize_int64_t) value->x > ROTATION_UNITS )
@@ -378,8 +373,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( seriali
     return 1;
 }
 
-/* Reads QuantizedRotation. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
 {
     {
@@ -441,8 +435,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize
     return 1;
 }
 
-/* Writes RigidBody. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes RigidBody. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_rigid_body( serialize_write_stream_t * stream, const RigidBody * value )
 {
     if ( !write_vec3( stream, &value->position ) )
@@ -471,8 +464,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_rigid_body( serialize_write
     return 1;
 }
 
-/* Reads RigidBody. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads RigidBody. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_rigid_body( serialize_read_stream_t * stream, RigidBody * value )
 {
     if ( !read_vec3( stream, &value->position ) )
@@ -506,8 +498,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_rigid_body( serialize_read_st
     return 1;
 }
 
-/* Writes Input. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Input. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stream_t * stream, const Input * value )
 {
     if ( !serialize_write_float( stream, value->stick_x ) )
@@ -565,8 +556,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stre
     return 1;
 }
 
-/* Reads Input. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Input. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_t * stream, Input * value )
 {
     if ( !serialize_read_float( stream, &value->stick_x ) )
@@ -624,8 +614,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_
     return 1;
 }
 
-/* Writes InputPacket. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes InputPacket. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_write_stream_t * stream, const InputPacket * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->synchronize_sequence, 16 ) )
@@ -657,8 +646,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_wri
     return 1;
 }
 
-/* Reads InputPacket. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads InputPacket. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_stream_t * stream, InputPacket * value )
 {
     {
@@ -702,8 +690,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_
     return 1;
 }
 
-/* Writes ShipCreate. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ShipCreate. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
 {
     if ( value->ship_type > 5 )
@@ -768,8 +755,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_writ
     return 1;
 }
 
-/* Reads ShipCreate. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ShipCreate. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_stream_t * stream, ShipCreate * value )
 {
     {
@@ -859,8 +845,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_s
     return 1;
 }
 
-/* Writes ExpressionProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize_write_stream_t * stream, const ExpressionProbe * value )
 {
     if ( (serialize_int64_t) value->hardpoint_index < 0 || (serialize_int64_t) value->hardpoint_index > (SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1 )
@@ -882,8 +867,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize
     return 1;
 }
 
-/* Reads ExpressionProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_read_stream_t * stream, ExpressionProbe * value )
 {
     {
@@ -917,8 +901,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_r
     return 1;
 }
 
-/* Writes ExtremeProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_write_stream_t * stream, const ExtremeProbe * value )
 {
     if ( (serialize_int64_t) value->floor_bound > 100 )
@@ -977,8 +960,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
     return 1;
 }
 
-/* Reads ExtremeProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read_stream_t * stream, ExtremeProbe * value )
 {
     {
@@ -1057,8 +1039,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read
     return 1;
 }
 
-/* Writes ExtremeRow. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_write_stream_t * stream, const ExtremeRow * value )
 {
     if ( (serialize_int64_t) value->clamped_floor > 100 )
@@ -1102,8 +1083,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_writ
     return 1;
 }
 
-/* Reads ExtremeRow. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_row( serialize_read_stream_t * stream, ExtremeRow * value )
 {
     {

--- a/generated/c/Wire.h
+++ b/generated/c/Wire.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED
 #if defined(__GNUC__) || defined(__clang__)
@@ -46,23 +45,9 @@ static SCHEMA_UNUSED const char * enum_name_weapon( Weapon value )
     switch ( value )
     {
         case WEAPON_NONE: return "None";
-        case 1: return "Laser";
-        case 2: return "Missile";
-        case 3: return "Railgun";
-        default: return "???";
-    }
-}
-
-/* As enum_name_weapon, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_weapon_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Laser";
-        case 2: return "Missile";
-        case 3: return "Railgun";
+        case WEAPON_LASER: return "Laser";
+        case WEAPON_MISSILE: return "Missile";
+        case WEAPON_RAILGUN: return "Railgun";
         default: return "???";
     }
 }
@@ -97,7 +82,7 @@ typedef struct ProbeBits {
 } ProbeBits;
 
 #define PROBE_BITS_MAX_BITS 202   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_BITS_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_BITS_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeSample */
@@ -115,7 +100,7 @@ typedef struct ProbeSample {
 } ProbeSample;
 
 #define PROBE_SAMPLE_MAX_BITS 276   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_SAMPLE_MAX_BYTES 40  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_SAMPLE_MAX_BYTES 40  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ProbeSample with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -135,7 +120,7 @@ typedef struct ProbeRing {
 } ProbeRing;
 
 #define PROBE_RING_MAX_BITS 16   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_RING_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_RING_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeSlab */
@@ -145,7 +130,7 @@ typedef struct ProbeSlab {
 } ProbeSlab;
 
 #define PROBE_SLAB_MAX_BITS 15   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_SLAB_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_SLAB_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* union ProbeShape — first-class one-of (SPEC §4.8): the tag says which arm is
@@ -177,7 +162,7 @@ typedef struct ProbeShape {
 } ProbeShape;
 
 #define PROBE_SHAPE_MAX_BITS 18   /* tag + the largest arm; None costs the tag only (SPEC §4.8) */
-#define PROBE_SHAPE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_SHAPE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeCollider */
@@ -190,7 +175,7 @@ typedef struct ProbeCollider {
 } ProbeCollider;
 
 #define PROBE_COLLIDER_MAX_BITS 82   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_COLLIDER_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_COLLIDER_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeConfig */
@@ -200,7 +185,7 @@ typedef struct ProbeConfig {
 } ProbeConfig;
 
 #define PROBE_CONFIG_MAX_BITS 36   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_CONFIG_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_CONFIG_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ProbeConfig with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -222,7 +207,7 @@ typedef struct ProbeArray {
 } ProbeArray;
 
 #define PROBE_ARRAY_MAX_BITS 588   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_ARRAY_MAX_BYTES 80  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_ARRAY_MAX_BYTES 80  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ProbeArray with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -251,7 +236,7 @@ typedef struct ProbeReport {
 } ProbeReport;
 
 #define PROBE_REPORT_MAX_BITS 141   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_REPORT_MAX_BYTES 24  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_REPORT_MAX_BYTES 24  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type TestData */
@@ -282,7 +267,7 @@ typedef struct TestData {
 } TestData;
 
 #define TEST_DATA_MAX_BITS 2735   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define TEST_DATA_MAX_BYTES 344  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define TEST_DATA_MAX_BYTES 344  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type CompressedProbe */
@@ -292,7 +277,7 @@ typedef struct CompressedProbe {
 } CompressedProbe;
 
 #define COMPRESSED_PROBE_MAX_BITS 24   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define COMPRESSED_PROBE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define COMPRESSED_PROBE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 #ifdef __cplusplus
 }

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -24,6 +24,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -158,8 +164,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 }
 #endif /* SCHEMA_INTERIOR_NULL_DEFINED */
 
-/* Writes ProbeHeader. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeHeader. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) 171ULL, 8 ) /* const(171, 8) — SPEC §4.3 */ )
@@ -185,8 +190,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_wri
     return 1;
 }
 
-/* Reads ProbeHeader. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeHeader. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_header( serialize_read_stream_t * stream, ProbeHeader * value )
 {
     {
@@ -234,8 +238,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_header( serialize_read_
     return 1;
 }
 
-/* Writes ProbeBits. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeBits. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write_stream_t * stream, const ProbeBits * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->small, 9 ) )
@@ -282,8 +285,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write
     return 1;
 }
 
-/* Reads ProbeBits. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeBits. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
 {
     {
@@ -352,8 +354,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_st
     return 1;
 }
 
-/* Writes ProbeSample. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeSample. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_write_stream_t * stream, const ProbeSample * value )
 {
     if ( !serialize_write_bool( stream, value->active ) )
@@ -418,8 +419,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_wri
     return 1;
 }
 
-/* Reads ProbeSample. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeSample. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_sample( serialize_read_stream_t * stream, ProbeSample * value )
 {
     if ( !serialize_read_bool( stream, &value->active ) )
@@ -516,8 +516,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_sample( serialize_read_
     return 1;
 }
 
-/* Writes ProbeRing. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeRing. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_ring( serialize_write_stream_t * stream, const ProbeRing * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->radius, 16 ) )
@@ -527,8 +526,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_ring( serialize_write
     return 1;
 }
 
-/* Reads ProbeRing. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeRing. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_stream_t * stream, ProbeRing * value )
 {
     {
@@ -542,8 +540,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_st
     return 1;
 }
 
-/* Writes ProbeSlab. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write_stream_t * stream, const ProbeSlab * value )
 {
     if ( (serialize_int64_t) value->width > 100 )
@@ -561,8 +558,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write
     return 1;
 }
 
-/* Reads ProbeSlab. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_stream_t * stream, ProbeSlab * value )
 {
     {
@@ -590,8 +586,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_st
     return 1;
 }
 
-/* Writes ProbeShape. Returns 1 on success, 0 on failure. The tag is validated
-   BEFORE it rides: an out-of-set tag writes nothing (SPEC §4.8). */
+/* Writes ProbeShape. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_shape( serialize_write_stream_t * stream, const ProbeShape * value )
 {
     if ( value->type > PROBE_SHAPE_TYPE_MAX )
@@ -613,8 +608,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_shape( serialize_writ
     }
 }
 
-/* Reads ProbeShape. Returns 1 on success, 0 on failure — a tag above PROBE_SHAPE_TYPE_MAX is
-   refused (SPEC §4.8); the selected arm is zero-established before decoding (§5). */
+/* Reads ProbeShape. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_shape( serialize_read_stream_t * stream, ProbeShape * value )
 {
     {
@@ -642,8 +636,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_shape( serialize_read_s
     }
 }
 
-/* Writes ProbeCollider. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeCollider. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_collider( serialize_write_stream_t * stream, const ProbeCollider * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->armor, 8 ) )
@@ -675,8 +668,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_collider( serialize_w
     return 1;
 }
 
-/* Reads ProbeCollider. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeCollider. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_collider( serialize_read_stream_t * stream, ProbeCollider * value )
 {
     {
@@ -712,8 +704,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_collider( serialize_rea
     return 1;
 }
 
-/* Writes ProbeConfig. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeConfig. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_write_stream_t * stream, const ProbeConfig * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->retries, 32 ) )
@@ -731,8 +722,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_wri
     return 1;
 }
 
-/* Reads ProbeConfig. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeConfig. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
 {
     {
@@ -758,8 +748,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_
     return 1;
 }
 
-/* Writes ProbeArray. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeArray. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_array( serialize_write_stream_t * stream, const ProbeArray * value )
 {
     {
@@ -779,8 +768,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_array( serialize_writ
     return 1;
 }
 
-/* Reads ProbeArray. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeArray. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_array( serialize_read_stream_t * stream, ProbeArray * value )
 {
     {
@@ -800,8 +788,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_array( serialize_read_s
     return 1;
 }
 
-/* Writes ProbeReport. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeReport. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_write_stream_t * stream, const ProbeReport * value )
 {
     if ( !write_probe_header( stream, &value->header ) )
@@ -819,8 +806,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_wri
     return 1;
 }
 
-/* Reads ProbeReport. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeReport. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_stream_t * stream, ProbeReport * value )
 {
     if ( !read_probe_header( stream, &value->header ) )
@@ -842,8 +828,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_
     return 1;
 }
 
-/* Writes TestData. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes TestData. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_stream_t * stream, const TestData * value )
 {
     if ( (serialize_int64_t) value->a < -100 || (serialize_int64_t) value->a > 100 )
@@ -979,8 +964,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     return 1;
 }
 
-/* Reads TestData. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads TestData. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_stream_t * stream, TestData * value )
 {
     {
@@ -1188,8 +1172,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
     return 1;
 }
 
-/* Writes CompressedProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes CompressedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize_write_stream_t * stream, const CompressedProbe * value )
 {
     if ( !serialize_write_compressed_float_precomputed( stream, value->boundary, 1000u, 10, 10.0f, 0.0f ) )
@@ -1203,8 +1186,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize
     return 1;
 }
 
-/* Reads CompressedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads CompressedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
 {
     if ( !serialize_read_compressed_float_precomputed( stream, &value->boundary, 1000u, 10, 10.0f, 0.0f ) )

--- a/generated/cpp/Messages.h
+++ b/generated/cpp/Messages.h
@@ -40,7 +40,7 @@ struct Test {
 };
 
 inline constexpr int64_t TestMaxBits = 46; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TestMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TestMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // message Block
 struct Block {
@@ -49,7 +49,7 @@ struct Block {
 };
 
 inline constexpr int64_t BlockMaxBits = 16018; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t BlockMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BlockMaxBytes = 2008; // 8-byte write granularity; read slack per the contract above
 
 // message Chat
 struct Chat {
@@ -58,7 +58,7 @@ struct Chat {
 };
 
 inline constexpr int64_t ChatMaxBits = 2064; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ChatMaxBytes = 264; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ChatMaxBytes = 264; // 8-byte write granularity; read slack per the contract above
 
 // message Synchronize
 struct Synchronize {
@@ -67,7 +67,7 @@ struct Synchronize {
 };
 
 inline constexpr int64_t SynchronizeMaxBits = 80; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t SynchronizeMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t SynchronizeMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // message Timescale
 struct Timescale {
@@ -77,11 +77,11 @@ struct Timescale {
 };
 
 inline constexpr int64_t TimescaleMaxBits = 128; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TimescaleMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TimescaleMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // The message-level bound: the tag plus the largest message (SPEC §6.1)
 inline constexpr int64_t MessageMaxBits = 16021;
-inline constexpr int64_t MessageMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MessageMaxBytes = 2008; // 8-byte write granularity; read slack per the contract above
 
 // The message value: a tagged union — the payload member matching `type` is
 // the active one. Construction is the None message: the tag alone is

--- a/generated/cpp/Objects.h
+++ b/generated/cpp/Objects.h
@@ -58,11 +58,11 @@ struct ClientShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; //  | local — no wire
-    ::VecMath previous_position; //  | local — no wire
-    int32_t num_colliders = 0; //  | local — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
-    bool predicted_explode = false; //  | local, context = client
+    bool invulnerable = false; // | local — no wire
+    ::VecMath previous_position; // | local — no wire
+    int32_t num_colliders = 0; // | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; // | local — no wire
+    bool predicted_explode = false; // | local, context = client
 };
 
 // ServerShipState — the full simulation struct for the server context: every `all`
@@ -93,10 +93,10 @@ struct ServerShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; //  | local — no wire
-    ::VecMath previous_position; //  | local — no wire
-    int32_t num_colliders = 0; //  | local — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
+    bool invulnerable = false; // | local — no wire
+    ::VecMath previous_position; // | local — no wire
+    int32_t num_colliders = 0; // | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; // | local — no wire
 };
 
 // ShipData_Deep — every non- | local field, deep encodings: full state for
@@ -338,7 +338,7 @@ inline constexpr int64_t ShipData_DeepMaxBits = 1703;
 inline constexpr int64_t ShipData_DeepMaxBytes = 216; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
 
 inline constexpr int64_t ShipData_ShallowMaxBits = 218;
-inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -351,8 +351,8 @@ struct ClientMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; //  | local — no wire
-    Handle target; //  | local — no wire
+    ::VecMath angular_velocity; // | local — no wire
+    Handle target; // | local — no wire
 };
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
@@ -364,9 +364,9 @@ struct ServerMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; //  | local — no wire
-    Handle target; //  | local — no wire
-    double timer = 0.0; //  | local, context = server
+    ::VecMath angular_velocity; // | local — no wire
+    Handle target; // | local — no wire
+    double timer = 0.0; // | local, context = server
 };
 
 // MissileData_Deep — every non- | local field, deep encodings: full state for
@@ -578,10 +578,10 @@ inline void UnquantizeMissile( const MissileData_Shallow & input, MissileData_In
 }
 
 inline constexpr int64_t MissileData_DeepMaxBits = 708;
-inline constexpr int64_t MissileData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MissileData_DeepMaxBytes = 96; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t MissileData_ShallowMaxBits = 260;
-inline constexpr int64_t MissileData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MissileData_ShallowMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // ---- object DynamicProp — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -593,7 +593,7 @@ struct DynamicPropState {
     ::VecMath linear_velocity;
     uint64_t flags = 0;
     Team team = Team::None;
-    ::VecMath angular_velocity; //  | local — no wire
+    ::VecMath angular_velocity; // | local — no wire
 };
 
 // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
@@ -805,10 +805,10 @@ inline void UnquantizeDynamicProp( const DynamicPropData_Shallow & input, Dynami
 }
 
 inline constexpr int64_t DynamicPropData_DeepMaxBits = 709;
-inline constexpr int64_t DynamicPropData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DynamicPropData_DeepMaxBytes = 96; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t DynamicPropData_ShallowMaxBits = 261;
-inline constexpr int64_t DynamicPropData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DynamicPropData_ShallowMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Turret — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -818,7 +818,7 @@ struct TurretState {
     int32_t turret_index = 0; // wire [0, 255]
     Quat rotation;
     uint64_t flags = 0;
-    Team team = Team::None; //  | local — no wire
+    Team team = Team::None; // | local — no wire
 };
 
 // TurretData_Deep — every non- | local field, deep encodings: full state for
@@ -928,9 +928,9 @@ inline void UnquantizeTurret( const TurretData_Shallow & input, TurretData_Inter
 }
 
 inline constexpr int64_t TurretData_DeepMaxBits = 350;
-inline constexpr int64_t TurretData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TurretData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t TurretData_ShallowMaxBits = 142;
-inline constexpr int64_t TurretData_ShallowMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TurretData_ShallowMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/generated/cpp/Render.h
+++ b/generated/cpp/Render.h
@@ -34,6 +34,6 @@ struct RenderBlock {
 };
 
 inline constexpr int64_t RenderBlockMaxBits = 8903; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t RenderBlockMaxBytes = 1120; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t RenderBlockMaxBytes = 1120; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/generated/cpp/Types.h
+++ b/generated/cpp/Types.h
@@ -13,8 +13,7 @@
 
 namespace example {
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct Vec3 {
     double x = 0.0;
     double y = 0.0;
@@ -24,8 +23,7 @@ struct Vec3 {
 inline constexpr int64_t Vec3MaxBits = 192; // longest wire path; align pads at worst case (SPEC §6.1)
 inline constexpr int64_t Vec3MaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct Quat {
     double x = 0.0;
     double y = 0.0;
@@ -34,7 +32,7 @@ struct Quat {
 };
 
 inline constexpr int64_t QuatMaxBits = 256; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuatMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuatMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type Handle
 struct Handle {
@@ -43,7 +41,7 @@ struct Handle {
 };
 
 inline constexpr int64_t HandleMaxBits = 22; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t HandleMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t HandleMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedPosition
 struct QuantizedPosition {
@@ -53,7 +51,7 @@ struct QuantizedPosition {
 };
 
 inline constexpr int64_t QuantizedPositionMaxBits = 75; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedPositionMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedPositionMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedVelocity
 struct QuantizedVelocity {
@@ -63,7 +61,7 @@ struct QuantizedVelocity {
 };
 
 inline constexpr int64_t QuantizedVelocityMaxBits = 69; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedVelocityMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedVelocityMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedRotation
 struct QuantizedRotation {
@@ -74,7 +72,7 @@ struct QuantizedRotation {
 };
 
 inline constexpr int64_t QuantizedRotationMaxBits = 48; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedRotationMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedRotationMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type RigidBody
 struct RigidBody {
@@ -89,7 +87,7 @@ struct RigidBody {
 };
 
 inline constexpr int64_t RigidBodyMaxBits = 833; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t RigidBodyMaxBytes = 112; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t RigidBodyMaxBytes = 112; // 8-byte write granularity; read slack per the contract above
 
 // type Input
 struct Input {
@@ -109,7 +107,7 @@ struct Input {
 };
 
 inline constexpr int64_t InputMaxBits = 168; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t InputMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t InputMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 // type InputPacket
 struct InputPacket {
@@ -121,7 +119,7 @@ struct InputPacket {
 };
 
 inline constexpr int64_t InputPacketMaxBits = 2837; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t InputPacketMaxBytes = 360; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t InputPacketMaxBytes = 360; // 8-byte write granularity; read slack per the contract above
 
 // type ShipCreate
 struct ShipCreate {
@@ -142,7 +140,7 @@ struct ShipCreate {
 };
 
 inline constexpr int64_t ShipCreateMaxBits = 219; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ShipCreateMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ShipCreateMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type ExpressionProbe
 struct ExpressionProbe {
@@ -151,7 +149,7 @@ struct ExpressionProbe {
 };
 
 inline constexpr int64_t ExpressionProbeMaxBits = 16; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExpressionProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExpressionProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t FloorLimit = ( -9223372036854775807ll - 1 );
 inline constexpr uint64_t CeilingCount = 18446744073709551615ull; // = 18446744073709551615
@@ -165,7 +163,7 @@ struct ExtremeProbe {
 };
 
 inline constexpr int64_t ExtremeProbeMaxBits = 320; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExtremeProbeMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExtremeProbeMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // type ExtremeRow
 struct ExtremeRow {
@@ -176,6 +174,6 @@ struct ExtremeRow {
 };
 
 inline constexpr int64_t ExtremeRowMaxBits = 256; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExtremeRowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExtremeRowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/generated/cpp/Wire.h
+++ b/generated/cpp/Wire.h
@@ -65,7 +65,7 @@ struct ProbeBits {
 };
 
 inline constexpr int64_t ProbeBitsMaxBits = 202; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeBitsMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeBitsMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeSample
 struct ProbeSample {
@@ -92,7 +92,7 @@ struct ProbeSample {
 };
 
 inline constexpr int64_t ProbeSampleMaxBits = 276; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeSampleMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeSampleMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeRing
 struct ProbeRing {
@@ -100,7 +100,7 @@ struct ProbeRing {
 };
 
 inline constexpr int64_t ProbeRingMaxBits = 16; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeRingMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeRingMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeSlab
 struct ProbeSlab {
@@ -109,7 +109,7 @@ struct ProbeSlab {
 };
 
 inline constexpr int64_t ProbeSlabMaxBits = 15; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeSlabMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeSlabMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // ProbeShapeType: union ProbeShape's tag — None = 0, then each variant in declared order (SPEC §4.8)
 enum class ProbeShapeType : uint8_t {
@@ -137,7 +137,7 @@ struct ProbeShape
 };
 
 inline constexpr int64_t ProbeShapeMaxBits = 18; // tag + the largest arm; None costs the tag only (SPEC §4.8)
-inline constexpr int64_t ProbeShapeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeShapeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeCollider
 struct ProbeCollider {
@@ -149,7 +149,7 @@ struct ProbeCollider {
 };
 
 inline constexpr int64_t ProbeColliderMaxBits = 82; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeColliderMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeColliderMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeConfig
 struct ProbeConfig {
@@ -158,7 +158,7 @@ struct ProbeConfig {
 };
 
 inline constexpr int64_t ProbeConfigMaxBits = 36; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeConfigMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeConfigMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeArray
 struct ProbeArray {
@@ -167,7 +167,7 @@ struct ProbeArray {
 };
 
 inline constexpr int64_t ProbeArrayMaxBits = 588; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeArrayMaxBytes = 80; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeArrayMaxBytes = 80; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeReport
 struct ProbeReport {
@@ -177,7 +177,7 @@ struct ProbeReport {
 };
 
 inline constexpr int64_t ProbeReportMaxBits = 141; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeReportMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeReportMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 // type TestData
 struct TestData {
@@ -207,7 +207,7 @@ struct TestData {
 };
 
 inline constexpr int64_t TestDataMaxBits = 2735; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TestDataMaxBytes = 344; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TestDataMaxBytes = 344; // 8-byte write granularity; read slack per the contract above
 
 // type CompressedProbe
 struct CompressedProbe {
@@ -216,6 +216,6 @@ struct CompressedProbe {
 };
 
 inline constexpr int64_t CompressedProbeMaxBits = 24; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t CompressedProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t CompressedProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/generated/cpp/ludicrous/Ludicrous.h
+++ b/generated/cpp/ludicrous/Ludicrous.h
@@ -78,7 +78,7 @@ struct UnsignedProbe {
 };
 
 inline constexpr int64_t UnsignedProbeMaxBits = 196; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t UnsignedProbeMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t UnsignedProbeMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type WideProbe
 struct WideProbe {
@@ -90,7 +90,7 @@ struct WideProbe {
 };
 
 inline constexpr int64_t WideProbeMaxBits = 403; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t WideProbeMaxBytes = 56; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t WideProbeMaxBytes = 56; // 8-byte write granularity; read slack per the contract above
 
 // message LudicrousState
 struct LudicrousState {
@@ -107,7 +107,7 @@ struct LudicrousState {
 };
 
 inline constexpr int64_t LudicrousStateMaxBits = 1205; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t LudicrousStateMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t LudicrousStateMaxBytes = 152; // 8-byte write granularity; read slack per the contract above
 
 // type DegenerateProbe
 struct DegenerateProbe {
@@ -118,10 +118,9 @@ struct DegenerateProbe {
 };
 
 inline constexpr int64_t DegenerateProbeMaxBits = 8; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t DegenerateProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DegenerateProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct FixedVec {
     int64_t x = 0; // fixed(48, 16) — Q48.16, raw value scaled by 2^16; bounds in whole units; wire [-100000, 100000]
     int64_t y = 0; // fixed(48, 16) — Q48.16, raw value scaled by 2^16; bounds in whole units; wire [-100000, 100000]
@@ -129,10 +128,9 @@ struct FixedVec {
 };
 
 inline constexpr int64_t FixedVecMaxBits = 102; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t FixedVecMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t FixedVecMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct FixedQuat {
     int32_t x = 0; // fixed(2, 30) — Q2.30, raw value scaled by 2^30; bounds in whole units; wire [-1, 1]
     int32_t y = 0; // fixed(2, 30) — Q2.30, raw value scaled by 2^30; bounds in whole units; wire [-1, 1]
@@ -141,7 +139,7 @@ struct FixedQuat {
 };
 
 inline constexpr int64_t FixedQuatMaxBits = 128; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t FixedQuatMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t FixedQuatMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Body — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -150,7 +148,7 @@ struct BodyState {
     FixedVec position;
     FixedQuat rotation;
     FixedVec velocity;
-    double spin = 0.0; //  | local — no wire
+    double spin = 0.0; // | local — no wire
 };
 
 // BodyData_Deep — every non- | local field, deep encodings: full state for
@@ -183,10 +181,10 @@ struct BodyData_Interpolate {
 // SPEC §4.8) — Interpolate and Shallow are the same values.
 
 inline constexpr int64_t BodyData_DeepMaxBits = 332;
-inline constexpr int64_t BodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BodyData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t BodyData_ShallowMaxBits = 332;
-inline constexpr int64_t BodyData_ShallowMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BodyData_ShallowMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 // ---- object NarrowBody — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -277,14 +275,14 @@ inline void UnquantizeNarrowBody( const NarrowBodyData_Shallow & input, NarrowBo
 }
 
 inline constexpr int64_t NarrowBodyData_DeepMaxBits = 332;
-inline constexpr int64_t NarrowBodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t NarrowBodyData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t NarrowBodyData_ShallowMaxBits = 228;
-inline constexpr int64_t NarrowBodyData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t NarrowBodyData_ShallowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // The message-level bound: the tag plus the largest message (SPEC §6.1)
 inline constexpr int64_t MessageMaxBits = 1206;
-inline constexpr int64_t MessageMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MessageMaxBytes = 152; // 8-byte write granularity; read slack per the contract above
 
 // The message value: a tagged union — the payload member matching `type` is
 // the active one. Construction is the None message: the tag alone is

--- a/generated/cs-ludicrous/Ludicrous.cs
+++ b/generated/cs-ludicrous/Ludicrous.cs
@@ -4,12 +4,11 @@
 // AGPL-3.0, its output is not.
 // package ludicrous — protocol id 0xa925c86b46058512
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an interior null)
+// returns false WITHOUT latching; stream failures latch on stream.Error —
+// the runtime's own sticky latch. Callers get bool always; Error tells the
+// two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -83,8 +82,8 @@ namespace Ludicrous
         public UInt128Value EntityId;
         public Int128Value Energy; // wire [-5000000000, 5000000000]
         public Int128Value Flux; // wire [-1267650600228229401496703205376, 1267650600228229401496703205376]
-        public Int128Value Bias = -250; // = -250 at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
-        public UInt128Value Seed = new UInt128Value(0x2ul, 0x0ul); // = new UInt128Value(0x2ul, 0x0ul) at construction; Zero* gives the §5 zero form
+        public Int128Value Bias = -250; // specified default at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
+        public UInt128Value Seed = new UInt128Value(0x2ul, 0x0ul); // specified default at construction; Zero* gives the §5 zero form
     }
 
     // message LudicrousState
@@ -113,8 +112,7 @@ namespace Ludicrous
         public byte Tail;
     }
 
-    // type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class FixedVec
     {
         public long X; // wire [-100000, 100000]
@@ -122,14 +120,13 @@ namespace Ludicrous
         public long Z; // wire [-100000, 100000]
     }
 
-    // type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class FixedQuat
     {
         public int X; // wire [-1, 1]
         public int Y; // wire [-1, 1]
         public int Z; // wire [-1, 1]
-        public int W = 1073741824; // = 1073741824 at construction; Zero* gives the §5 zero form; wire [-1, 1]
+        public int W = 1073741824; // specified default at construction; Zero* gives the §5 zero form; wire [-1, 1]
     }
 
     // ---- object Body — one definition, a generated family per target (SPEC §4.8) ----
@@ -140,7 +137,7 @@ namespace Ludicrous
         public FixedVec Position = new FixedVec();
         public FixedQuat Rotation = new FixedQuat();
         public FixedVec Velocity = new FixedVec();
-        public double Spin; //  | local — no wire
+        public double Spin; // | local — no wire
     }
 
     // BodyData_Deep — every non- | local field, deep encodings: full state for
@@ -263,8 +260,7 @@ namespace Ludicrous
         public const long FixedProbeMaxBits = 156;
         public const long FixedProbeMaxBytes = 24;
 
-        // ZeroFixedProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroFixedProbe(FixedProbe value)
         {
             value.Angle = 0;
@@ -274,21 +270,17 @@ namespace Ludicrous
             Array.Clear(value.Samples, 0, 2);
         }
 
-        // WriteFixedProbe/ReadFixedProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteFixedProbe(WriteStream stream, FixedProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteFixedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteFixedProbeBatch(ref WriteBatch batch, FixedProbe value)
         {
@@ -322,13 +314,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadFixedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadFixedProbeBatch(ref ReadBatch batch, FixedProbe value)
         {
@@ -363,8 +353,7 @@ namespace Ludicrous
         public const long UnsignedProbeMaxBits = 196;
         public const long UnsignedProbeMaxBytes = 32;
 
-        // ZeroUnsignedProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroUnsignedProbe(UnsignedProbe value)
         {
             value.Angle = 0;
@@ -376,21 +365,17 @@ namespace Ludicrous
             value.Tail = 0;
         }
 
-        // WriteUnsignedProbe/ReadUnsignedProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteUnsignedProbe(WriteStream stream, UnsignedProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteUnsignedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteUnsignedProbeBatch(ref WriteBatch batch, UnsignedProbe value)
         {
@@ -417,7 +402,7 @@ namespace Ludicrous
                     return false;
                 }
             }
-            if ((ulong)value.Locked != 196608UL) // out-of-contract writes are refused, not wrapped
+            if ((ulong)value.Locked != 196608UL)
             {
                 return false;
             }
@@ -435,13 +420,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadUnsignedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadUnsignedProbeBatch(ref ReadBatch batch, UnsignedProbe value)
         {
@@ -485,8 +468,7 @@ namespace Ludicrous
         public const long WideProbeMaxBits = 403;
         public const long WideProbeMaxBytes = 56;
 
-        // ZeroWideProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroWideProbe(WideProbe value)
         {
             value.EntityId = 0;
@@ -496,21 +478,17 @@ namespace Ludicrous
             value.Seed = 0;
         }
 
-        // WriteWideProbe/ReadWideProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteWideProbe(WriteStream stream, WideProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteWideProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteWideProbeBatch(ref WriteBatch batch, WideProbe value)
         {
@@ -541,13 +519,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadWideProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadWideProbeBatch(ref ReadBatch batch, WideProbe value)
         {
@@ -579,8 +555,7 @@ namespace Ludicrous
         public const long LudicrousStateMaxBits = 1205;
         public const long LudicrousStateMaxBytes = 152;
 
-        // ZeroLudicrousState resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroLudicrousState(LudicrousState value)
         {
             value.Mode = DriveMode.None;
@@ -592,21 +567,17 @@ namespace Ludicrous
             value.TargetId = 0;
         }
 
-        // WriteLudicrousState/ReadLudicrousState run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteLudicrousState(WriteStream stream, LudicrousState value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteLudicrousStateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteLudicrousStateBatch(ref WriteBatch batch, LudicrousState value)
         {
@@ -665,13 +636,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadLudicrousStateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadLudicrousStateBatch(ref ReadBatch batch, LudicrousState value)
         {
@@ -725,8 +694,7 @@ namespace Ludicrous
         public const long DegenerateProbeMaxBits = 8;
         public const long DegenerateProbeMaxBytes = 8;
 
-        // ZeroDegenerateProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroDegenerateProbe(DegenerateProbe value)
         {
             value.LockedFixed = 0;
@@ -735,33 +703,29 @@ namespace Ludicrous
             value.Tail = 0;
         }
 
-        // WriteDegenerateProbe/ReadDegenerateProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteDegenerateProbe(WriteStream stream, DegenerateProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteDegenerateProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDegenerateProbeBatch(ref WriteBatch batch, DegenerateProbe value)
         {
-            if ((long)value.LockedFixed != -196608L) // out-of-contract writes are refused, not wrapped
+            if ((long)value.LockedFixed != -196608L)
             {
                 return false;
             }
-            if (value.LockedInt < 7 || value.LockedInt > 7) // out-of-contract writes are refused, not wrapped
+            if (value.LockedInt < 7 || value.LockedInt > 7)
             {
                 return false;
             }
-            if (value.LockedWide != (Int128Value)(-12345678901234L)) // out-of-contract writes are refused, not wrapped
+            if (value.LockedWide != (Int128Value)(-12345678901234L))
             {
                 return false;
             }
@@ -779,13 +743,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadDegenerateProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadDegenerateProbeBatch(ref ReadBatch batch, DegenerateProbe value)
         {
@@ -808,8 +770,7 @@ namespace Ludicrous
         public const long FixedVecMaxBits = 102;
         public const long FixedVecMaxBytes = 16;
 
-        // ZeroFixedVec resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroFixedVec(FixedVec value)
         {
             value.X = 0;
@@ -817,21 +778,17 @@ namespace Ludicrous
             value.Z = 0;
         }
 
-        // WriteFixedVec/ReadFixedVec run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteFixedVec(WriteStream stream, FixedVec value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteFixedVecBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteFixedVecBatch(ref WriteBatch batch, FixedVec value)
         {
@@ -854,13 +811,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadFixedVecBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadFixedVecBatch(ref ReadBatch batch, FixedVec value)
         {
@@ -884,8 +839,7 @@ namespace Ludicrous
         public const long FixedQuatMaxBits = 128;
         public const long FixedQuatMaxBytes = 16;
 
-        // ZeroFixedQuat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroFixedQuat(FixedQuat value)
         {
             value.X = 0;
@@ -894,21 +848,17 @@ namespace Ludicrous
             value.W = 0;
         }
 
-        // WriteFixedQuat/ReadFixedQuat run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteFixedQuat(WriteStream stream, FixedQuat value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteFixedQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteFixedQuatBatch(ref WriteBatch batch, FixedQuat value)
         {
@@ -935,13 +885,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadFixedQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadFixedQuatBatch(ref ReadBatch batch, FixedQuat value)
         {
@@ -967,21 +915,17 @@ namespace Ludicrous
         public const long BodyData_DeepMaxBits = 332;
         public const long BodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteBodyData_Deep/ReadBodyData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBodyData_Deep(WriteStream stream, BodyData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBodyData_DeepBatch(ref WriteBatch batch, BodyData_Deep value)
         {
@@ -1004,13 +948,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBodyData_DeepBatch(ref ReadBatch batch, BodyData_Deep value)
         {
@@ -1032,21 +974,17 @@ namespace Ludicrous
         public const long BodyData_ShallowMaxBits = 332;
         public const long BodyData_ShallowMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteBodyData_Shallow/ReadBodyData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBodyData_Shallow(WriteStream stream, BodyData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBodyData_ShallowBatch(ref WriteBatch batch, BodyData_Shallow value)
         {
@@ -1069,13 +1007,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBodyData_ShallowBatch(ref ReadBatch batch, BodyData_Shallow value)
         {
@@ -1097,21 +1033,17 @@ namespace Ludicrous
         public const long NarrowBodyData_DeepMaxBits = 332;
         public const long NarrowBodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteNarrowBodyData_Deep/ReadNarrowBodyData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteNarrowBodyData_Deep(WriteStream stream, NarrowBodyData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteNarrowBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteNarrowBodyData_DeepBatch(ref WriteBatch batch, NarrowBodyData_Deep value)
         {
@@ -1134,13 +1066,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadNarrowBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadNarrowBodyData_DeepBatch(ref ReadBatch batch, NarrowBodyData_Deep value)
         {
@@ -1162,21 +1092,17 @@ namespace Ludicrous
         public const long NarrowBodyData_ShallowMaxBits = 228;
         public const long NarrowBodyData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteNarrowBodyData_Shallow/ReadNarrowBodyData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteNarrowBodyData_Shallow(WriteStream stream, NarrowBodyData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteNarrowBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteNarrowBodyData_ShallowBatch(ref WriteBatch batch, NarrowBodyData_Shallow value)
         {
@@ -1268,13 +1194,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadNarrowBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadNarrowBodyData_ShallowBatch(ref ReadBatch batch, NarrowBodyData_Shallow value)
         {

--- a/generated/cs/Constants.cs
+++ b/generated/cs/Constants.cs
@@ -3,6 +3,12 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
+//
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an interior null)
+// returns false WITHOUT latching; stream failures latch on stream.Error —
+// the runtime's own sticky latch. Callers get bool always; Error tells the
+// two apart.
 
 namespace Example
 {

--- a/generated/cs/Messages.cs
+++ b/generated/cs/Messages.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -118,8 +111,7 @@ namespace Example
         public const long HeartbeatMaxBits = 0;
         public const long HeartbeatMaxBytes = 0;
 
-        // ZeroHeartbeat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroHeartbeat(Heartbeat value)
         {
             _ = value; // empty body — nothing to reset (SPEC §4.6)
@@ -141,8 +133,7 @@ namespace Example
         public const long TestMaxBits = 46;
         public const long TestMaxBytes = 8;
 
-        // ZeroTest resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroTest(Test value)
         {
             value.TestA = 0;
@@ -151,21 +142,17 @@ namespace Example
             value.TestD = 0;
         }
 
-        // WriteTest/ReadTest run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTest(WriteStream stream, Test value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTestBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTestBatch(ref WriteBatch batch, Test value)
         {
@@ -176,7 +163,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.TestB < 0 || value.TestB > 1000) // out-of-contract writes are refused, not wrapped
+            if (value.TestB < 0 || value.TestB > 1000)
             {
                 return false;
             }
@@ -187,7 +174,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.TestC < 0 || value.TestC > 1000) // out-of-contract writes are refused, not wrapped
+            if (value.TestC < 0 || value.TestC > 1000)
             {
                 return false;
             }
@@ -198,7 +185,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.TestD < 0 || value.TestD > 1000) // out-of-contract writes are refused, not wrapped
+            if (value.TestD < 0 || value.TestD > 1000)
             {
                 return false;
             }
@@ -216,13 +203,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTestBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTestBatch(ref ReadBatch batch, Test value)
         {
@@ -266,8 +251,7 @@ namespace Example
         public const long BlockMaxBits = 16018;
         public const long BlockMaxBytes = 2008;
 
-        // ZeroBlock resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroBlock(Block value)
         {
             Array.Clear(value.Data, 0, (int)MaxBlockSize);
@@ -312,8 +296,7 @@ namespace Example
         public const long ChatMaxBits = 2064;
         public const long ChatMaxBytes = 264;
 
-        // ZeroChat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroChat(Chat value)
         {
             Array.Clear(value.Text, 0, (int)MaxChatLength);
@@ -365,29 +348,24 @@ namespace Example
         public const long SynchronizeMaxBits = 80;
         public const long SynchronizeMaxBytes = 16;
 
-        // ZeroSynchronize resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroSynchronize(Synchronize value)
         {
             value.SyncFrame = 0;
             value.SyncSequence = 0;
         }
 
-        // WriteSynchronize/ReadSynchronize run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteSynchronize(WriteStream stream, Synchronize value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteSynchronizeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteSynchronizeBatch(ref WriteBatch batch, Synchronize value)
         {
@@ -409,13 +387,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadSynchronizeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadSynchronizeBatch(ref ReadBatch batch, Synchronize value)
         {
@@ -439,8 +415,7 @@ namespace Example
         public const long TimescaleMaxBits = 128;
         public const long TimescaleMaxBytes = 16;
 
-        // ZeroTimescale resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroTimescale(Timescale value)
         {
             value.Scale = 0.0;
@@ -448,21 +423,17 @@ namespace Example
             value.FrameB = 0;
         }
 
-        // WriteTimescale/ReadTimescale run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTimescale(WriteStream stream, Timescale value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTimescaleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTimescaleBatch(ref WriteBatch batch, Timescale value)
         {
@@ -485,13 +456,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTimescaleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTimescaleBatch(ref ReadBatch batch, Timescale value)
         {

--- a/generated/cs/Objects.cs
+++ b/generated/cs/Objects.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -60,11 +53,11 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; //  | local — no wire
-        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
-        public int NumColliders; //  | local — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
-        public bool PredictedExplode; //  | local, context = client
+        public bool Invulnerable; // | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); // | local — no wire
+        public int NumColliders; // | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // | local — no wire
+        public bool PredictedExplode; // | local, context = client
     }
 
     // ServerShipState — the full simulation class for the server context: every `all`
@@ -96,10 +89,10 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; //  | local — no wire
-        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
-        public int NumColliders; //  | local — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
+        public bool Invulnerable; // | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); // | local — no wire
+        public int NumColliders; // | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // | local — no wire
     }
 
     // ShipData_Deep — every non- | local field, deep encodings: full state for
@@ -184,8 +177,8 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
-        public Handle Target = new Handle(); //  | local — no wire
+        public Vec3 AngularVelocity = new Vec3(); // | local — no wire
+        public Handle Target = new Handle(); // | local — no wire
     }
 
     // ServerMissileState — the full simulation class for the server context: every `all`
@@ -198,9 +191,9 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
-        public Handle Target = new Handle(); //  | local — no wire
-        public double Timer; //  | local, context = server
+        public Vec3 AngularVelocity = new Vec3(); // | local — no wire
+        public Handle Target = new Handle(); // | local — no wire
+        public double Timer; // | local, context = server
     }
 
     // MissileData_Deep — every non- | local field, deep encodings: full state for
@@ -261,7 +254,7 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public ulong Flags;
         public Team Team;
-        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
+        public Vec3 AngularVelocity = new Vec3(); // | local — no wire
     }
 
     // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
@@ -320,7 +313,7 @@ namespace Example
         public int TurretIndex; // wire [0, 255]
         public Quat Rotation = new Quat();
         public ulong Flags;
-        public Team Team; //  | local — no wire
+        public Team Team; // | local — no wire
     }
 
     // TurretData_Deep — every non- | local field, deep encodings: full state for
@@ -366,21 +359,17 @@ namespace Example
         public const long ShipData_DeepMaxBits = 1703;
         public const long ShipData_DeepMaxBytes = 216; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteShipData_Deep/ReadShipData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteShipData_Deep(WriteStream stream, ShipData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteShipData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteShipData_DeepBatch(ref WriteBatch batch, ShipData_Deep value)
         {
@@ -489,7 +478,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.LaserIndex < 0 || value.LaserIndex > (int)(ShipMaxLasers - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.LaserIndex < 0 || value.LaserIndex > (int)(ShipMaxLasers - 1))
             {
                 return false;
             }
@@ -500,7 +489,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.MissileIndex < 0 || value.MissileIndex > (int)(ShipMaxMissiles - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.MissileIndex < 0 || value.MissileIndex > (int)(ShipMaxMissiles - 1))
             {
                 return false;
             }
@@ -526,13 +515,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadShipData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadShipData_DeepBatch(ref ReadBatch batch, ShipData_Deep value)
         {
@@ -662,21 +649,17 @@ namespace Example
         public const long ShipData_ShallowMaxBits = 218;
         public const long ShipData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteShipData_Shallow/ReadShipData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteShipData_Shallow(WriteStream stream, ShipData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteShipData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteShipData_ShallowBatch(ref WriteBatch batch, ShipData_Shallow value)
         {
@@ -852,13 +835,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadShipData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadShipData_ShallowBatch(ref ReadBatch batch, ShipData_Shallow value)
         {
@@ -1122,21 +1103,17 @@ namespace Example
         public const long MissileData_DeepMaxBits = 708;
         public const long MissileData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteMissileData_Deep/ReadMissileData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteMissileData_Deep(WriteStream stream, MissileData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteMissileData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMissileData_DeepBatch(ref WriteBatch batch, MissileData_Deep value)
         {
@@ -1185,13 +1162,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadMissileData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMissileData_DeepBatch(ref ReadBatch batch, MissileData_Deep value)
         {
@@ -1233,21 +1208,17 @@ namespace Example
         public const long MissileData_ShallowMaxBits = 260;
         public const long MissileData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteMissileData_Shallow/ReadMissileData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteMissileData_Shallow(WriteStream stream, MissileData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteMissileData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMissileData_ShallowBatch(ref WriteBatch batch, MissileData_Shallow value)
         {
@@ -1394,13 +1365,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadMissileData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMissileData_ShallowBatch(ref ReadBatch batch, MissileData_Shallow value)
         {
@@ -1640,21 +1609,17 @@ namespace Example
         public const long DynamicPropData_DeepMaxBits = 709;
         public const long DynamicPropData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteDynamicPropData_Deep/ReadDynamicPropData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteDynamicPropData_Deep(WriteStream stream, DynamicPropData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteDynamicPropData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDynamicPropData_DeepBatch(ref WriteBatch batch, DynamicPropData_Deep value)
         {
@@ -1703,13 +1668,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadDynamicPropData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadDynamicPropData_DeepBatch(ref ReadBatch batch, DynamicPropData_Deep value)
         {
@@ -1751,21 +1714,17 @@ namespace Example
         public const long DynamicPropData_ShallowMaxBits = 261;
         public const long DynamicPropData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteDynamicPropData_Shallow/ReadDynamicPropData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteDynamicPropData_Shallow(WriteStream stream, DynamicPropData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteDynamicPropData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDynamicPropData_ShallowBatch(ref WriteBatch batch, DynamicPropData_Shallow value)
         {
@@ -1912,13 +1871,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadDynamicPropData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadDynamicPropData_ShallowBatch(ref ReadBatch batch, DynamicPropData_Shallow value)
         {
@@ -2158,21 +2115,17 @@ namespace Example
         public const long TurretData_DeepMaxBits = 350;
         public const long TurretData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteTurretData_Deep/ReadTurretData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTurretData_Deep(WriteStream stream, TurretData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTurretData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTurretData_DeepBatch(ref WriteBatch batch, TurretData_Deep value)
         {
@@ -2180,7 +2133,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1))
             {
                 return false;
             }
@@ -2206,13 +2159,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTurretData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTurretData_DeepBatch(ref ReadBatch batch, TurretData_Deep value)
         {
@@ -2238,21 +2189,17 @@ namespace Example
         public const long TurretData_ShallowMaxBits = 142;
         public const long TurretData_ShallowMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteTurretData_Shallow/ReadTurretData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTurretData_Shallow(WriteStream stream, TurretData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTurretData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTurretData_ShallowBatch(ref WriteBatch batch, TurretData_Shallow value)
         {
@@ -2260,7 +2207,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1))
             {
                 return false;
             }
@@ -2326,13 +2273,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTurretData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTurretData_ShallowBatch(ref ReadBatch batch, TurretData_Shallow value)
         {

--- a/generated/cs/Render.cs
+++ b/generated/cs/Render.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System.Runtime.CompilerServices;
 using Serialize;
@@ -56,8 +49,7 @@ namespace Example
         public const long RenderSpriteMaxBits = 138;
         public const long RenderSpriteMaxBytes = 24;
 
-        // ZeroRenderSprite resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroRenderSprite(RenderSprite value)
         {
             value.SortKey = 0;
@@ -67,21 +59,17 @@ namespace Example
             value.Team = Team.None;
         }
 
-        // WriteRenderSprite/ReadRenderSprite run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRenderSprite(WriteStream stream, RenderSprite value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteRenderSpriteBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderSpriteBatch(ref WriteBatch batch, RenderSprite value)
         {
@@ -122,13 +110,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadRenderSpriteBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderSpriteBatch(ref ReadBatch batch, RenderSprite value)
         {
@@ -168,8 +154,7 @@ namespace Example
         public const long RenderBlockMaxBits = 8903;
         public const long RenderBlockMaxBytes = 1120;
 
-        // ZeroRenderBlock resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroRenderBlock(RenderBlock value)
         {
             value.WorkerIndex = 0;
@@ -181,21 +166,17 @@ namespace Example
             value.SpritesCount = 0;
         }
 
-        // WriteRenderBlock/ReadRenderBlock run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRenderBlock(WriteStream stream, RenderBlock value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteRenderBlockBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderBlockBatch(ref WriteBatch batch, RenderBlock value)
         {
@@ -232,13 +213,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadRenderBlockBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderBlockBatch(ref ReadBatch batch, RenderBlock value)
         {

--- a/generated/cs/Types.cs
+++ b/generated/cs/Types.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System.Runtime.CompilerServices;
 using Serialize;
@@ -17,8 +10,7 @@ using Serialize;
 namespace Example
 {
 
-    // type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class Vec3
     {
         public double X;
@@ -26,8 +18,7 @@ namespace Example
         public double Z;
     }
 
-    // type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class Quat
     {
         public double X;
@@ -149,8 +140,8 @@ namespace Example
         public long FloorBound; // wire [-9223372036854775808, 100]
         public long DoubledFloor; // wire [-9223372036854775808, 100]
         public ulong CeilingRange; // wire [1, 18446744073709551615]
-        public long FloorDefault = -9223372036854775808; // = -9223372036854775808 at construction; Zero* gives the §5 zero form
-        public ulong CeilingDefault = 18446744073709551615; // = 18446744073709551615 at construction; Zero* gives the §5 zero form
+        public long FloorDefault = -9223372036854775808; // specified default at construction; Zero* gives the §5 zero form
+        public ulong CeilingDefault = 18446744073709551615; // specified default at construction; Zero* gives the §5 zero form
     }
 
     // type ExtremeRow
@@ -158,8 +149,8 @@ namespace Example
     {
         public long ClampedFloor; // wire [-9223372036854775808, 100]
         public ulong ClampedCeiling; // wire [1, 18446744073709551614]
-        public long FloorDef = -9223372036854775808; // = -9223372036854775808 at construction; Zero* gives the §5 zero form
-        public ulong CeilingDef = 18446744073709551615; // = 18446744073709551615 at construction; Zero* gives the §5 zero form
+        public long FloorDef = -9223372036854775808; // specified default at construction; Zero* gives the §5 zero form
+        public ulong CeilingDef = 18446744073709551615; // specified default at construction; Zero* gives the §5 zero form
     }
 
     // Schema carries every generated function and constant of the unit — C# has
@@ -172,8 +163,7 @@ namespace Example
         public const long Vec3MaxBits = 192;
         public const long Vec3MaxBytes = 24;
 
-        // ZeroVec3 resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroVec3(Vec3 value)
         {
             value.X = 0.0;
@@ -181,21 +171,17 @@ namespace Example
             value.Z = 0.0;
         }
 
-        // WriteVec3/ReadVec3 run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteVec3(WriteStream stream, Vec3 value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteVec3Batch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteVec3Batch(ref WriteBatch batch, Vec3 value)
         {
@@ -218,13 +204,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadVec3Batch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadVec3Batch(ref ReadBatch batch, Vec3 value)
         {
@@ -248,8 +232,7 @@ namespace Example
         public const long QuatMaxBits = 256;
         public const long QuatMaxBytes = 32;
 
-        // ZeroQuat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuat(Quat value)
         {
             value.X = 0.0;
@@ -258,21 +241,17 @@ namespace Example
             value.W = 0.0;
         }
 
-        // WriteQuat/ReadQuat run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuat(WriteStream stream, Quat value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuatBatch(ref WriteBatch batch, Quat value)
         {
@@ -299,13 +278,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuatBatch(ref ReadBatch batch, Quat value)
         {
@@ -333,33 +310,28 @@ namespace Example
         public const long HandleMaxBits = 22;
         public const long HandleMaxBytes = 8;
 
-        // ZeroHandle resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroHandle(Handle value)
         {
             value.ObjectId = 0;
             value.ObjectSequence = 0;
         }
 
-        // WriteHandle/ReadHandle run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteHandle(WriteStream stream, Handle value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteHandleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteHandleBatch(ref WriteBatch batch, Handle value)
         {
-            if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
             {
                 return false;
             }
@@ -384,13 +356,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadHandleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadHandleBatch(ref ReadBatch batch, Handle value)
         {
@@ -414,8 +384,7 @@ namespace Example
         public const long QuantizedPositionMaxBits = 75;
         public const long QuantizedPositionMaxBytes = 16;
 
-        // ZeroQuantizedPosition resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuantizedPosition(QuantizedPosition value)
         {
             value.X = 0;
@@ -423,25 +392,21 @@ namespace Example
             value.Z = 0;
         }
 
-        // WriteQuantizedPosition/ReadQuantizedPosition run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuantizedPosition(WriteStream stream, QuantizedPosition value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuantizedPositionBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedPositionBatch(ref WriteBatch batch, QuantizedPosition value)
         {
-            if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits) // out-of-contract writes are refused, not wrapped
+            if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
             {
                 return false;
             }
@@ -452,7 +417,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
             {
                 return false;
             }
@@ -463,7 +428,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
             {
                 return false;
             }
@@ -481,13 +446,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuantizedPositionBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuantizedPositionBatch(ref ReadBatch batch, QuantizedPosition value)
         {
@@ -511,8 +474,7 @@ namespace Example
         public const long QuantizedVelocityMaxBits = 69;
         public const long QuantizedVelocityMaxBytes = 16;
 
-        // ZeroQuantizedVelocity resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuantizedVelocity(QuantizedVelocity value)
         {
             value.X = 0;
@@ -520,25 +482,21 @@ namespace Example
             value.Z = 0;
         }
 
-        // WriteQuantizedVelocity/ReadQuantizedVelocity run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuantizedVelocity(WriteStream stream, QuantizedVelocity value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuantizedVelocityBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedVelocityBatch(ref WriteBatch batch, QuantizedVelocity value)
         {
-            if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits) // out-of-contract writes are refused, not wrapped
+            if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
             {
                 return false;
             }
@@ -549,7 +507,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
             {
                 return false;
             }
@@ -560,7 +518,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
             {
                 return false;
             }
@@ -578,13 +536,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuantizedVelocityBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuantizedVelocityBatch(ref ReadBatch batch, QuantizedVelocity value)
         {
@@ -608,8 +564,7 @@ namespace Example
         public const long QuantizedRotationMaxBits = 48;
         public const long QuantizedRotationMaxBytes = 8;
 
-        // ZeroQuantizedRotation resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuantizedRotation(QuantizedRotation value)
         {
             value.X = 0;
@@ -618,25 +573,21 @@ namespace Example
             value.W = 0;
         }
 
-        // WriteQuantizedRotation/ReadQuantizedRotation run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuantizedRotation(WriteStream stream, QuantizedRotation value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuantizedRotationBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedRotationBatch(ref WriteBatch batch, QuantizedRotation value)
         {
-            if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
             {
                 return false;
             }
@@ -647,7 +598,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
             {
                 return false;
             }
@@ -658,7 +609,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
             {
                 return false;
             }
@@ -669,7 +620,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
             {
                 return false;
             }
@@ -687,13 +638,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuantizedRotationBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuantizedRotationBatch(ref ReadBatch batch, QuantizedRotation value)
         {
@@ -737,8 +686,7 @@ namespace Example
         public const long RigidBodyMaxBits = 833;
         public const long RigidBodyMaxBytes = 112;
 
-        // ZeroRigidBody resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroRigidBody(RigidBody value)
         {
             ZeroVec3(value.Position);
@@ -748,21 +696,17 @@ namespace Example
             ZeroVec3(value.AngularVelocity);
         }
 
-        // WriteRigidBody/ReadRigidBody run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRigidBody(WriteStream stream, RigidBody value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteRigidBodyBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRigidBodyBatch(ref WriteBatch batch, RigidBody value)
         {
@@ -796,13 +740,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadRigidBodyBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRigidBodyBatch(ref ReadBatch batch, RigidBody value)
         {
@@ -842,8 +784,7 @@ namespace Example
         public const long InputMaxBits = 168;
         public const long InputMaxBytes = 24;
 
-        // ZeroInput resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroInput(Input value)
         {
             value.StickX = 0.0f;
@@ -861,21 +802,17 @@ namespace Example
             value.Ping = false;
         }
 
-        // WriteInput/ReadInput run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteInput(WriteStream stream, Input value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteInputBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteInputBatch(ref WriteBatch batch, Input value)
         {
@@ -938,13 +875,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadInputBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadInputBatch(ref ReadBatch batch, Input value)
         {
@@ -1008,8 +943,7 @@ namespace Example
         public const long InputPacketMaxBits = 2837;
         public const long InputPacketMaxBytes = 360;
 
-        // ZeroInputPacket resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroInputPacket(InputPacket value)
         {
             value.SynchronizeSequence = 0;
@@ -1022,21 +956,17 @@ namespace Example
             value.InputsCount = 0;
         }
 
-        // WriteInputPacket/ReadInputPacket run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteInputPacket(WriteStream stream, InputPacket value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteInputPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteInputPacketBatch(ref WriteBatch batch, InputPacket value)
         {
@@ -1080,13 +1010,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadInputPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadInputPacketBatch(ref ReadBatch batch, InputPacket value)
         {
@@ -1125,8 +1053,7 @@ namespace Example
         public const long ShipCreateMaxBits = 219;
         public const long ShipCreateMaxBytes = 32;
 
-        // ZeroShipCreate resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroShipCreate(ShipCreate value)
         {
             value.ShipType = ShipType.None;
@@ -1141,21 +1068,17 @@ namespace Example
             value.Pending = Pending.None;
         }
 
-        // WriteShipCreate/ReadShipCreate run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteShipCreate(WriteStream stream, ShipCreate value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteShipCreateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteShipCreateBatch(ref WriteBatch batch, ShipCreate value)
         {
@@ -1211,7 +1134,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Health < 0 || value.Health > (int)MaxHealth) // out-of-contract writes are refused, not wrapped
+            if (value.Health < 0 || value.Health > (int)MaxHealth)
             {
                 return false;
             }
@@ -1222,7 +1145,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Thrust < 0 || value.Thrust > 100) // out-of-contract writes are refused, not wrapped
+            if (value.Thrust < 0 || value.Thrust > 100)
             {
                 return false;
             }
@@ -1247,13 +1170,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadShipCreateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadShipCreateBatch(ref ReadBatch batch, ShipCreate value)
         {
@@ -1336,33 +1257,28 @@ namespace Example
         public const long ExpressionProbeMaxBits = 16;
         public const long ExpressionProbeMaxBytes = 8;
 
-        // ZeroExpressionProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroExpressionProbe(ExpressionProbe value)
         {
             value.HardpointIndex = 0;
             value.SpinRate = 0;
         }
 
-        // WriteExpressionProbe/ReadExpressionProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteExpressionProbe(WriteStream stream, ExpressionProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteExpressionProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExpressionProbeBatch(ref WriteBatch batch, ExpressionProbe value)
         {
-            if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
             {
                 return false;
             }
@@ -1373,7 +1289,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2)) // out-of-contract writes are refused, not wrapped
+            if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
             {
                 return false;
             }
@@ -1391,13 +1307,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadExpressionProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadExpressionProbeBatch(ref ReadBatch batch, ExpressionProbe value)
         {
@@ -1421,8 +1335,7 @@ namespace Example
         public const long ExtremeProbeMaxBits = 320;
         public const long ExtremeProbeMaxBytes = 40;
 
-        // ZeroExtremeProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroExtremeProbe(ExtremeProbe value)
         {
             value.FloorBound = 0;
@@ -1432,25 +1345,21 @@ namespace Example
             value.CeilingDefault = 0;
         }
 
-        // WriteExtremeProbe/ReadExtremeProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteExtremeProbe(WriteStream stream, ExtremeProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteExtremeProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeProbeBatch(ref WriteBatch batch, ExtremeProbe value)
         {
-            if (value.FloorBound > 100) // out-of-contract writes are refused, not wrapped
+            if (value.FloorBound > 100)
             {
                 return false;
             }
@@ -1461,7 +1370,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.DoubledFloor > 100) // out-of-contract writes are refused, not wrapped
+            if (value.DoubledFloor > 100)
             {
                 return false;
             }
@@ -1472,7 +1381,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.CeilingRange < 1) // out-of-contract writes are refused, not wrapped
+            if (value.CeilingRange < 1)
             {
                 return false;
             }
@@ -1501,13 +1410,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadExtremeProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadExtremeProbeBatch(ref ReadBatch batch, ExtremeProbe value)
         {
@@ -1551,8 +1458,7 @@ namespace Example
         public const long ExtremeRowMaxBits = 256;
         public const long ExtremeRowMaxBytes = 32;
 
-        // ZeroExtremeRow resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroExtremeRow(ExtremeRow value)
         {
             value.ClampedFloor = 0;
@@ -1561,25 +1467,21 @@ namespace Example
             value.CeilingDef = 0;
         }
 
-        // WriteExtremeRow/ReadExtremeRow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteExtremeRow(WriteStream stream, ExtremeRow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteExtremeRowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeRowBatch(ref WriteBatch batch, ExtremeRow value)
         {
-            if (value.ClampedFloor > 100) // out-of-contract writes are refused, not wrapped
+            if (value.ClampedFloor > 100)
             {
                 return false;
             }
@@ -1590,7 +1492,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.ClampedCeiling < 1 || value.ClampedCeiling > 18446744073709551614) // out-of-contract writes are refused, not wrapped
+            if (value.ClampedCeiling < 1 || value.ClampedCeiling > 18446744073709551614)
             {
                 return false;
             }
@@ -1619,13 +1521,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadExtremeRowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadExtremeRowBatch(ref ReadBatch batch, ExtremeRow value)
         {

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -50,7 +43,7 @@ namespace Example
     // type ProbeSample
     public sealed class ProbeSample
     {
-        public bool Active = true; // = true at construction; Zero* gives the §5 zero form
+        public bool Active = true; // specified default at construction; Zero* gives the §5 zero form
         public float Orientation; // compressed float [-180.0, 180.0] @ 0.01
         public int RawDelta;
         public long BigDelta;
@@ -126,8 +119,8 @@ namespace Example
     // type ProbeConfig
     public sealed class ProbeConfig
     {
-        public int Retries = -1; // = -1 at construction; Zero* gives the §5 zero form
-        public Weapon Preferred = Weapon.Railgun; // = Weapon.Railgun at construction; Zero* gives the §5 zero form
+        public int Retries = -1; // specified default at construction; Zero* gives the §5 zero form
+        public Weapon Preferred = Weapon.Railgun; // specified default at construction; Zero* gives the §5 zero form
     }
 
     // type ProbeArray
@@ -233,29 +226,24 @@ namespace Example
         public const long ProbeHeaderMaxBits = 87;
         public const long ProbeHeaderMaxBytes = 16;
 
-        // ZeroProbeHeader resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeHeader(ProbeHeader value)
         {
             value.Version = 0;
             value.ProbeId = 0;
         }
 
-        // WriteProbeHeader/ReadProbeHeader run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeHeader(WriteStream stream, ProbeHeader value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeHeaderBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeHeaderBatch(ref WriteBatch batch, ProbeHeader value)
         {
@@ -292,13 +280,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeHeaderBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeHeaderBatch(ref ReadBatch batch, ProbeHeader value)
         {
@@ -344,8 +330,7 @@ namespace Example
         public const long ProbeBitsMaxBits = 202;
         public const long ProbeBitsMaxBytes = 32;
 
-        // ZeroProbeBits resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeBits(ProbeBits value)
         {
             value.Small = 0;
@@ -355,21 +340,17 @@ namespace Example
             value.Nonce = 0;
         }
 
-        // WriteProbeBits/ReadProbeBits run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeBits(WriteStream stream, ProbeBits value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeBitsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeBitsBatch(ref WriteBatch batch, ProbeBits value)
         {
@@ -406,13 +387,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeBitsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeBitsBatch(ref ReadBatch batch, ProbeBits value)
         {
@@ -452,8 +431,7 @@ namespace Example
         public const long ProbeSampleMaxBits = 276;
         public const long ProbeSampleMaxBytes = 40;
 
-        // ZeroProbeSample resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeSample(ProbeSample value)
         {
             value.Active = false;
@@ -468,21 +446,17 @@ namespace Example
             value.SamplesCount = 0;
         }
 
-        // WriteProbeSample/ReadProbeSample run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeSample(WriteStream stream, ProbeSample value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeSampleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeSampleBatch(ref WriteBatch batch, ProbeSample value)
         {
@@ -574,13 +548,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeSampleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeSampleBatch(ref ReadBatch batch, ProbeSample value)
         {
@@ -672,8 +644,7 @@ namespace Example
         public const long ProbeRingMaxBits = 16;
         public const long ProbeRingMaxBytes = 8;
 
-        // ZeroProbeRing resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeRing(ProbeRing value)
         {
             value.Radius = 0;
@@ -709,33 +680,28 @@ namespace Example
         public const long ProbeSlabMaxBits = 15;
         public const long ProbeSlabMaxBytes = 8;
 
-        // ZeroProbeSlab resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeSlab(ProbeSlab value)
         {
             value.Width = 0;
             value.Height = 0;
         }
 
-        // WriteProbeSlab/ReadProbeSlab run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeSlab(WriteStream stream, ProbeSlab value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeSlabBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeSlabBatch(ref WriteBatch batch, ProbeSlab value)
         {
-            if (value.Width > 100) // out-of-contract writes are refused, not wrapped
+            if (value.Width > 100)
             {
                 return false;
             }
@@ -760,13 +726,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeSlabBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeSlabBatch(ref ReadBatch batch, ProbeSlab value)
         {
@@ -848,8 +812,7 @@ namespace Example
         public const long ProbeColliderMaxBits = 82;
         public const long ProbeColliderMaxBytes = 16;
 
-        // ZeroProbeCollider resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeCollider(ProbeCollider value)
         {
             value.Armor = 0;
@@ -937,29 +900,24 @@ namespace Example
         public const long ProbeConfigMaxBits = 36;
         public const long ProbeConfigMaxBytes = 8;
 
-        // ZeroProbeConfig resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeConfig(ProbeConfig value)
         {
             value.Retries = 0;
             value.Preferred = Weapon.None;
         }
 
-        // WriteProbeConfig/ReadProbeConfig run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeConfig(WriteStream stream, ProbeConfig value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeConfigBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeConfigBatch(ref WriteBatch batch, ProbeConfig value)
         {
@@ -988,13 +946,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeConfigBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeConfigBatch(ref ReadBatch batch, ProbeConfig value)
         {
@@ -1022,8 +978,7 @@ namespace Example
         public const long ProbeArrayMaxBits = 588;
         public const long ProbeArrayMaxBytes = 80;
 
-        // ZeroProbeArray resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeArray(ProbeArray value)
         {
             for (int i = 0; i < 2; i++)
@@ -1033,21 +988,17 @@ namespace Example
             ZeroProbeConfig(value.Config);
         }
 
-        // WriteProbeArray/ReadProbeArray run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeArray(WriteStream stream, ProbeArray value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeArrayBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeArrayBatch(ref WriteBatch batch, ProbeArray value)
         {
@@ -1069,13 +1020,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeArrayBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeArrayBatch(ref ReadBatch batch, ProbeArray value)
         {
@@ -1098,8 +1047,7 @@ namespace Example
         public const long ProbeReportMaxBits = 141;
         public const long ProbeReportMaxBytes = 24;
 
-        // ZeroProbeReport resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeReport(ProbeReport value)
         {
             ZeroProbeHeader(value.Header);
@@ -1107,21 +1055,17 @@ namespace Example
             ZeroTest(value.Echo);
         }
 
-        // WriteProbeReport/ReadProbeReport run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeReport(WriteStream stream, ProbeReport value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeReportBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeReportBatch(ref WriteBatch batch, ProbeReport value)
         {
@@ -1151,13 +1095,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeReportBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeReportBatch(ref ReadBatch batch, ProbeReport value)
         {
@@ -1185,8 +1127,7 @@ namespace Example
         public const long TestDataMaxBits = 2735;
         public const long TestDataMaxBytes = 344;
 
-        // ZeroTestData resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroTestData(TestData value)
         {
             value.A = 0;
@@ -1214,25 +1155,21 @@ namespace Example
             value.TextLength = 0;
         }
 
-        // WriteTestData/ReadTestData run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTestData(WriteStream stream, TestData value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTestDataBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTestDataBatch(ref WriteBatch batch, TestData value)
         {
-            if (value.A < -100 || value.A > 100) // out-of-contract writes are refused, not wrapped
+            if (value.A < -100 || value.A > 100)
             {
                 return false;
             }
@@ -1243,7 +1180,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.B < -100 || value.B > 100) // out-of-contract writes are refused, not wrapped
+            if (value.B < -100 || value.B > 100)
             {
                 return false;
             }
@@ -1254,7 +1191,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.C < -100 || value.C > 150) // out-of-contract writes are refused, not wrapped
+            if (value.C < -100 || value.C > 150)
             {
                 return false;
             }
@@ -1294,7 +1231,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] < 0 || value.Items[i] > 255) // out-of-contract writes are refused, not wrapped
+                if (value.Items[i] < 0 || value.Items[i] > 255)
                 {
                     return false;
                 }
@@ -1364,7 +1301,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000) // out-of-contract writes are refused, not wrapped
+            if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
             {
                 return false;
             }
@@ -1405,13 +1342,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTestDataBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTestDataBatch(ref ReadBatch batch, TestData value)
         {
@@ -1549,29 +1484,24 @@ namespace Example
         public const long CompressedProbeMaxBits = 24;
         public const long CompressedProbeMaxBytes = 8;
 
-        // ZeroCompressedProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroCompressedProbe(CompressedProbe value)
         {
             value.Boundary = 0.0f;
             value.Offset = 0.0f;
         }
 
-        // WriteCompressedProbe/ReadCompressedProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteCompressedProbe(WriteStream stream, CompressedProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteCompressedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteCompressedProbeBatch(ref WriteBatch batch, CompressedProbe value)
         {
@@ -1596,13 +1526,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadCompressedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadCompressedProbeBatch(ref ReadBatch batch, CompressedProbe value)
         {

--- a/generated/go-ludicrous/Ludicrous.go
+++ b/generated/go-ludicrous/Ludicrous.go
@@ -164,7 +164,7 @@ func WriteUnsignedProbe(stream *serialize.WriteStream, value *UnsignedProbe) err
 			stream.SerializeFixed64(&fixedValue, 16, 16, 0, 16)
 		}
 	}
-	if uint64(value.Locked) != 196608 { // the runtime range refusal, folded (SPEC §5)
+	if uint64(value.Locked) != 196608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -284,7 +284,7 @@ const LudicrousStateMaxBytes = 152
 func WriteLudicrousState(stream *serialize.WriteStream, value *LudicrousState) error {
 	{
 		enumValue := int32(value.Mode)
-		if enumValue < 0 || enumValue > 3 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 3 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -298,7 +298,7 @@ func WriteLudicrousState(stream *serialize.WriteStream, value *LudicrousState) e
 	if err := WriteWideProbe(stream, &value.Wide); err != nil {
 		return err
 	}
-	if value.KeysCount < 0 || value.KeysCount > 4 { // the runtime range refusal, folded (SPEC §5)
+	if value.KeysCount < 0 || value.KeysCount > 4 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -360,13 +360,13 @@ const DegenerateProbeMaxBits = 8
 const DegenerateProbeMaxBytes = 8
 
 func WriteDegenerateProbe(stream *serialize.WriteStream, value *DegenerateProbe) error {
-	if int64(value.LockedFixed) != -196608 { // the runtime range refusal, folded (SPEC §5)
+	if int64(value.LockedFixed) != -196608 {
 		return serialize.ErrValueOutOfRange
 	}
-	if value.LockedInt < 7 || value.LockedInt > 7 { // the runtime range refusal, folded (SPEC §5)
+	if value.LockedInt < 7 || value.LockedInt > 7 {
 		return serialize.ErrValueOutOfRange
 	}
-	if value.LockedWide != serialize.Int128From64(-12345678901234) { // the runtime range refusal, folded (SPEC §5)
+	if value.LockedWide != serialize.Int128From64(-12345678901234) {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -388,8 +388,7 @@ func ReadDegenerateProbe(stream *serialize.ReadStream, value *DegenerateProbe) e
 	return stream.Err()
 }
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type FixedVec struct {
 	X int64 // wire [-100000, 100000]
 	Y int64 // wire [-100000, 100000]
@@ -415,8 +414,7 @@ func ReadFixedVec(stream *serialize.ReadStream, value *FixedVec) error {
 	return stream.Err()
 }
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type FixedQuat struct {
 	X int32 // wire [-1, 1]
 	Y int32 // wire [-1, 1]
@@ -489,7 +487,7 @@ type BodyState struct {
 	Position FixedVec
 	Rotation FixedQuat
 	Velocity FixedVec
-	Spin     float64 //  | local — no wire
+	Spin     float64 // | local — no wire
 }
 
 // BodyData_Deep — every non- | local field, deep encodings: full state for
@@ -651,21 +649,21 @@ const NarrowBodyData_ShallowMaxBits = 228
 const NarrowBodyData_ShallowMaxBytes = 32 // rounded up to the 8-byte write-buffer granularity
 
 func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBodyData_Shallow) error {
-	if value.PositionX < -25600000 || value.PositionX > 25600000 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -25600000 || value.PositionX > 25600000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-25600000))
 		stream.SerializeBits(&offsetValue, 26)
 	}
-	if value.PositionY < -25600000 || value.PositionY > 25600000 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -25600000 || value.PositionY > 25600000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-25600000))
 		stream.SerializeBits(&offsetValue, 26)
 	}
-	if value.PositionZ < -25600000 || value.PositionZ > 25600000 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -25600000 || value.PositionZ > 25600000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -674,7 +672,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -684,7 +682,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -694,7 +692,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -704,7 +702,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -823,7 +821,7 @@ func UnquantizeNarrowBody(input *NarrowBodyData_Shallow, output *NarrowBodyData_
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
 func WriteMessageType(stream *serialize.WriteStream, value MessageType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 1 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -901,7 +899,7 @@ func ReadMessage(stream *serialize.ReadStream, storage *MessageStorage) (Message
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
 func WriteObjectType(stream *serialize.WriteStream, value ObjectType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 2 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 2 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/generated/go/Messages.go
+++ b/generated/go/Messages.go
@@ -63,7 +63,7 @@ func WriteTest(stream *serialize.WriteStream, value *Test) error {
 	}
 	{
 		rangeValue := int32(value.TestB)
-		if rangeValue < 0 || rangeValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -73,7 +73,7 @@ func WriteTest(stream *serialize.WriteStream, value *Test) error {
 	}
 	{
 		rangeValue := int32(value.TestC)
-		if rangeValue < 0 || rangeValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -83,7 +83,7 @@ func WriteTest(stream *serialize.WriteStream, value *Test) error {
 	}
 	{
 		rangeValue := int32(value.TestD)
-		if rangeValue < 0 || rangeValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -130,7 +130,7 @@ const BlockMaxBits = 16018
 const BlockMaxBytes = 2008
 
 func WriteBlock(stream *serialize.WriteStream, value *Block) error {
-	if value.DataLength < 0 || value.DataLength > MaxBlockSize { // the runtime range refusal, folded (SPEC §5)
+	if value.DataLength < 0 || value.DataLength > MaxBlockSize {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -165,7 +165,7 @@ const ChatMaxBits = 2064
 const ChatMaxBytes = 264
 
 func WriteChat(stream *serialize.WriteStream, value *Chat) error {
-	if value.TextLength < 0 || value.TextLength > MaxChatLength { // the runtime range refusal, folded (SPEC §5)
+	if value.TextLength < 0 || value.TextLength > MaxChatLength {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -256,7 +256,7 @@ func ReadTimescale(stream *serialize.ReadStream, value *Timescale) error {
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
 func WriteMessageType(stream *serialize.WriteStream, value MessageType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 6 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 6 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/generated/go/Objects.go
+++ b/generated/go/Objects.go
@@ -54,11 +54,11 @@ type ClientShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       //  | local — no wire
-	PreviousPosition    Vec3                       //  | local — no wire
-	NumColliders        int32                      //  | local — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
-	PredictedExplode    bool                       //  | local, context = client
+	Invulnerable        bool                       // | local — no wire
+	PreviousPosition    Vec3                       // | local — no wire
+	NumColliders        int32                      // | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 // | local — no wire
+	PredictedExplode    bool                       // | local, context = client
 }
 
 // ServerShipState — the full simulation struct for the server context: every `all`
@@ -89,10 +89,10 @@ type ServerShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       //  | local — no wire
-	PreviousPosition    Vec3                       //  | local — no wire
-	NumColliders        int32                      //  | local — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
+	Invulnerable        bool                       // | local — no wire
+	PreviousPosition    Vec3                       // | local — no wire
+	NumColliders        int32                      // | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 // | local — no wire
 }
 
 // ShipData_Deep — every non- | local field, deep encodings: full state for
@@ -168,7 +168,7 @@ const ShipData_DeepMaxBytes = 216 // rounded up to the 8-byte write-buffer granu
 func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) error {
 	{
 		enumValue := int32(value.ShipType)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -194,7 +194,7 @@ func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) err
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -225,7 +225,7 @@ func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) err
 	stream.SerializeFloat32(&value.AimVelocity)
 	{
 		rangeValue := int32(value.LaserIndex)
-		if rangeValue < 0 || rangeValue > ShipMaxLasers-1 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > ShipMaxLasers-1 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -235,7 +235,7 @@ func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) err
 	}
 	{
 		rangeValue := int32(value.MissileIndex)
-		if rangeValue < 0 || rangeValue > ShipMaxMissiles-1 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > ShipMaxMissiles-1 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -319,7 +319,7 @@ const ShipData_ShallowMaxBytes = 32 // rounded up to the 8-byte write-buffer gra
 func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallow) error {
 	{
 		enumValue := int32(value.ShipType)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -327,21 +327,21 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 			stream.SerializeBits(&offsetValue, 3)
 		}
 	}
-	if value.PositionX < -8388608 || value.PositionX > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -8388608 || value.PositionX > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionY < -8388608 || value.PositionY > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -8388608 || value.PositionY > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionZ < -8388608 || value.PositionZ > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -8388608 || value.PositionZ > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -350,7 +350,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -360,7 +360,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -370,7 +370,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -380,7 +380,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -388,21 +388,21 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 			stream.SerializeBits(&offsetValue, 12)
 		}
 	}
-	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityX - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityY - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -418,7 +418,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -428,7 +428,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		projectedValue := int32(value.Health)
-		if projectedValue < 0 || projectedValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if projectedValue < 0 || projectedValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -438,7 +438,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		projectedValue := int32(value.Thrust)
-		if projectedValue < 0 || projectedValue > 100 { // the runtime range refusal, folded (SPEC §5)
+		if projectedValue < 0 || projectedValue > 100 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -651,8 +651,8 @@ type ClientMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3   //  | local — no wire
-	Target          Handle //  | local — no wire
+	AngularVelocity Vec3   // | local — no wire
+	Target          Handle // | local — no wire
 }
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
@@ -664,9 +664,9 @@ type ServerMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3    //  | local — no wire
-	Target          Handle  //  | local — no wire
-	Timer           float64 //  | local, context = server
+	AngularVelocity Vec3    // | local — no wire
+	Target          Handle  // | local — no wire
+	Timer           float64 // | local, context = server
 }
 
 // MissileData_Deep — every non- | local field, deep encodings: full state for
@@ -719,7 +719,7 @@ const MissileData_DeepMaxBytes = 96 // rounded up to the 8-byte write-buffer gra
 func WriteMissileData_Deep(stream *serialize.WriteStream, value *MissileData_Deep) error {
 	{
 		enumValue := int32(value.MissileType)
-		if enumValue < 0 || enumValue > 3 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 3 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -738,7 +738,7 @@ func WriteMissileData_Deep(stream *serialize.WriteStream, value *MissileData_Dee
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -780,7 +780,7 @@ const MissileData_ShallowMaxBytes = 40 // rounded up to the 8-byte write-buffer 
 func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_Shallow) error {
 	{
 		enumValue := int32(value.MissileType)
-		if enumValue < 0 || enumValue > 3 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 3 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -788,21 +788,21 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 			stream.SerializeBits(&offsetValue, 2)
 		}
 	}
-	if value.PositionX < -8388608 || value.PositionX > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -8388608 || value.PositionX > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionY < -8388608 || value.PositionY > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -8388608 || value.PositionY > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionZ < -8388608 || value.PositionZ > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -8388608 || value.PositionZ > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -811,7 +811,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -821,7 +821,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -831,7 +831,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -841,7 +841,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -849,21 +849,21 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 			stream.SerializeBits(&offsetValue, 12)
 		}
 	}
-	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityX - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityY - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -872,7 +872,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1067,7 +1067,7 @@ type DynamicPropState struct {
 	LinearVelocity  Vec3
 	Flags           uint64
 	Team            Team
-	AngularVelocity Vec3 //  | local — no wire
+	AngularVelocity Vec3 // | local — no wire
 }
 
 // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
@@ -1120,7 +1120,7 @@ const DynamicPropData_DeepMaxBytes = 96 // rounded up to the 8-byte write-buffer
 func WriteDynamicPropData_Deep(stream *serialize.WriteStream, value *DynamicPropData_Deep) error {
 	{
 		enumValue := int32(value.PropType)
-		if enumValue < 0 || enumValue > 6 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 6 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1140,7 +1140,7 @@ func WriteDynamicPropData_Deep(stream *serialize.WriteStream, value *DynamicProp
 	stream.SerializeBits64(&value.Flags, 64)
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1181,7 +1181,7 @@ const DynamicPropData_ShallowMaxBytes = 40 // rounded up to the 8-byte write-buf
 func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicPropData_Shallow) error {
 	{
 		enumValue := int32(value.PropType)
-		if enumValue < 0 || enumValue > 6 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 6 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1189,21 +1189,21 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 			stream.SerializeBits(&offsetValue, 3)
 		}
 	}
-	if value.PositionX < -8388608 || value.PositionX > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -8388608 || value.PositionX > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionY < -8388608 || value.PositionY > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -8388608 || value.PositionY > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionZ < -8388608 || value.PositionZ > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -8388608 || value.PositionZ > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1212,7 +1212,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1222,7 +1222,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1232,7 +1232,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1242,7 +1242,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1250,21 +1250,21 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 			stream.SerializeBits(&offsetValue, 12)
 		}
 	}
-	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityX - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityY - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1274,7 +1274,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	stream.SerializeBits64(&value.Flags, 64)
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1466,7 +1466,7 @@ type TurretState struct {
 	TurretIndex int32 // wire [0, 255]
 	Rotation    Quat
 	Flags       uint64
-	Team        Team //  | local — no wire
+	Team        Team // | local — no wire
 }
 
 // TurretData_Deep — every non- | local field, deep encodings: full state for
@@ -1508,7 +1508,7 @@ func WriteTurretData_Deep(stream *serialize.WriteStream, value *TurretData_Deep)
 	if err := WriteHandle(stream, &value.Parent); err != nil {
 		return err
 	}
-	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1541,7 +1541,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	if err := WriteHandle(stream, &value.Parent); err != nil {
 		return err
 	}
-	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1550,7 +1550,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1560,7 +1560,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1570,7 +1570,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1580,7 +1580,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1685,7 +1685,7 @@ func UnquantizeTurret(input *TurretData_Shallow, output *TurretData_Interpolate)
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
 func WriteObjectType(stream *serialize.WriteStream, value ObjectType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 4 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 4 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/generated/go/Render.go
+++ b/generated/go/Render.go
@@ -36,7 +36,7 @@ func WriteRenderSprite(stream *serialize.WriteStream, value *RenderSprite) error
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -80,7 +80,7 @@ const RenderBlockMaxBytes = 1120
 func WriteRenderBlock(stream *serialize.WriteStream, value *RenderBlock) error {
 	stream.SerializeBits(&value.WorkerIndex, 32)
 	stream.SerializeBits(&value.SpriteCountHint, 32)
-	if value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites { // the runtime range refusal, folded (SPEC §5)
+	if value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/generated/go/Types.go
+++ b/generated/go/Types.go
@@ -10,8 +10,7 @@ import (
 	"github.com/mas-bandwidth/serialize.go"
 )
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type Vec3 struct {
 	X float64
 	Y float64
@@ -37,8 +36,7 @@ func ReadVec3(stream *serialize.ReadStream, value *Vec3) error {
 	return stream.Err()
 }
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type Quat struct {
 	X float64
 	Y float64
@@ -79,7 +77,7 @@ const HandleMaxBits = 22
 const HandleMaxBytes = 8
 
 func WriteHandle(stream *serialize.WriteStream, value *Handle) error {
-	if value.ObjectId < 0 || value.ObjectId > MaxObjects-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.ObjectId < 0 || value.ObjectId > MaxObjects-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -116,21 +114,21 @@ const QuantizedPositionMaxBits = 75
 const QuantizedPositionMaxBytes = 16
 
 func WriteQuantizedPosition(stream *serialize.WriteStream, value *QuantizedPosition) error {
-	if value.X < -MaxPositionUnits || value.X > MaxPositionUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.X < -MaxPositionUnits || value.X > MaxPositionUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.X - (-MaxPositionUnits))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.Y - (-MaxPositionUnits))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -160,21 +158,21 @@ const QuantizedVelocityMaxBits = 69
 const QuantizedVelocityMaxBytes = 16
 
 func WriteQuantizedVelocity(stream *serialize.WriteStream, value *QuantizedVelocity) error {
-	if value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.X - (-MaxVelocityUnits))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.Y - (-MaxVelocityUnits))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -207,7 +205,7 @@ const QuantizedRotationMaxBytes = 8
 func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotation) error {
 	{
 		rangeValue := int32(value.X)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -217,7 +215,7 @@ func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotat
 	}
 	{
 		rangeValue := int32(value.Y)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -227,7 +225,7 @@ func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotat
 	}
 	{
 		rangeValue := int32(value.Z)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -237,7 +235,7 @@ func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotat
 	}
 	{
 		rangeValue := int32(value.W)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -407,7 +405,7 @@ func WriteInputPacket(stream *serialize.WriteStream, value *InputPacket) error {
 	}
 	stream.SerializeBits64(&value.CurrentFrame, 64)
 	stream.SerializeBits64(&value.StartFrame, 64)
-	if value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket { // the runtime range refusal, folded (SPEC §5)
+	if value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -471,7 +469,7 @@ const ShipCreateMaxBytes = 32
 func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	{
 		enumValue := int32(value.ShipType)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -500,7 +498,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -510,7 +508,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		rangeValue := int32(value.Health)
-		if rangeValue < 0 || rangeValue > MaxHealth { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > MaxHealth {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -520,7 +518,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		rangeValue := int32(value.Thrust)
-		if rangeValue < 0 || rangeValue > 100 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 100 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -530,7 +528,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		enumValue := int32(value.Pending)
-		if enumValue < 0 || enumValue > 0 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 0 {
 			return serialize.ErrValueOutOfRange
 		}
 	}
@@ -597,14 +595,14 @@ const ExpressionProbeMaxBits = 16
 const ExpressionProbeMaxBytes = 8
 
 func WriteExpressionProbe(stream *serialize.WriteStream, value *ExpressionProbe) error {
-	if value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers+ShipMaxMissiles)-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers+ShipMaxMissiles)-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.HardpointIndex)
 		stream.SerializeBits(&offsetValue, 5)
 	}
-	if value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits*2 { // the runtime range refusal, folded (SPEC §5)
+	if value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits*2 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -649,14 +647,14 @@ const ExtremeProbeMaxBits = 320
 const ExtremeProbeMaxBytes = 40
 
 func WriteExtremeProbe(stream *serialize.WriteStream, value *ExtremeProbe) error {
-	if value.FloorBound < -9223372036854775808 || value.FloorBound > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.FloorBound < -9223372036854775808 || value.FloorBound > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint64(value.FloorBound - (-9223372036854775808))
 		stream.SerializeBits64(&offsetValue, 64)
 	}
-	if value.DoubledFloor < -(-FloorLimit) || value.DoubledFloor > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.DoubledFloor < -(-FloorLimit) || value.DoubledFloor > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -725,7 +723,7 @@ const ExtremeRowMaxBits = 256
 const ExtremeRowMaxBytes = 32
 
 func WriteExtremeRow(stream *serialize.WriteStream, value *ExtremeRow) error {
-	if value.ClampedFloor < -9223372036854775808 || value.ClampedFloor > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.ClampedFloor < -9223372036854775808 || value.ClampedFloor > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/generated/go/Wire.go
+++ b/generated/go/Wire.go
@@ -131,7 +131,7 @@ func WriteProbeBits(stream *serialize.WriteStream, value *ProbeBits) error {
 	stream.SerializeBits64(&value.Wide, 64)
 	{
 		rangeValue := int64(value.Sensor)
-		if rangeValue < 0 || rangeValue > 4294967295 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 4294967295 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -224,7 +224,7 @@ func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 	if value.Active {
 		{
 			enumValue := int32(value.Weapon)
-			if enumValue < 0 || enumValue > 15 { // the runtime range refusal, folded (SPEC §5)
+			if enumValue < 0 || enumValue > 15 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -242,7 +242,7 @@ func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 	} else {
 		stream.SerializeBits(&value.IdleTicks, 32)
 	}
-	if value.SamplesCount < 1 || value.SamplesCount > 8 { // the runtime range refusal, folded (SPEC §5)
+	if value.SamplesCount < 1 || value.SamplesCount > 8 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -363,7 +363,7 @@ const ProbeSlabMaxBytes = 8
 func WriteProbeSlab(stream *serialize.WriteStream, value *ProbeSlab) error {
 	{
 		rangeValue := int32(value.Width)
-		if rangeValue < 0 || rangeValue > 100 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 100 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -478,7 +478,7 @@ func WriteProbeCollider(stream *serialize.WriteStream, value *ProbeCollider) err
 	if err := WriteProbeShape(stream, &value.Backup); err != nil {
 		return err
 	}
-	if value.ExtrasCount < 0 || value.ExtrasCount > 2 { // the runtime range refusal, folded (SPEC §5)
+	if value.ExtrasCount < 0 || value.ExtrasCount > 2 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -548,7 +548,7 @@ func WriteProbeConfig(stream *serialize.WriteStream, value *ProbeConfig) error {
 	}
 	{
 		enumValue := int32(value.Preferred)
-		if enumValue < 0 || enumValue > 15 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 15 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -697,21 +697,21 @@ const TestDataMaxBits = 2735
 const TestDataMaxBytes = 344
 
 func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
-	if value.A < -100 || value.A > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.A < -100 || value.A > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.A - (-100))
 		stream.SerializeBits(&offsetValue, 8)
 	}
-	if value.B < -100 || value.B > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.B < -100 || value.B > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.B - (-100))
 		stream.SerializeBits(&offsetValue, 8)
 	}
-	if value.C < -100 || value.C > 150 { // the runtime range refusal, folded (SPEC §5)
+	if value.C < -100 || value.C > 150 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -722,7 +722,7 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 	stream.SerializeBits(&value.E, 8)
 	stream.SerializeBits(&value.F, 8)
 	stream.SerializeBool(&value.G)
-	if value.ItemsCount < 0 || value.ItemsCount > 16 { // the runtime range refusal, folded (SPEC §5)
+	if value.ItemsCount < 0 || value.ItemsCount > 16 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -733,7 +733,7 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 		return stream.Err()
 	}
 	for i := int32(0); i < value.ItemsCount; i++ {
-		if value.Items[i] < 0 || value.Items[i] > 255 { // the runtime range refusal, folded (SPEC §5)
+		if value.Items[i] < 0 || value.Items[i] > 255 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -775,7 +775,7 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 		rawValue := uint64(value.Int64Full)
 		stream.SerializeBits64(&rawValue, 64)
 	}
-	if value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000 { // the runtime range refusal, folded (SPEC §5)
+	if value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -783,8 +783,8 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 		stream.SerializeBits64(&offsetValue, 41)
 	}
 	stream.SerializeAlign()
-	stream.SerializeBytes(value.FixedBytes[:])          // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
-	if value.TextLength < 0 || value.TextLength > 255 { // the runtime range refusal, folded (SPEC §5)
+	stream.SerializeBytes(value.FixedBytes[:]) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+	if value.TextLength < 0 || value.TextLength > 255 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/generated/js-ludicrous/Ludicrous.js
+++ b/generated/js-ludicrous/Ludicrous.js
@@ -4,22 +4,18 @@
 // AGPL-3.0, its output is not.
 // package ludicrous — protocol id 0xa925c86b46058512
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an out-of-contract
+// write) returns false WITHOUT latching; stream failures latch on
+// stream.error — the runtime's own sticky latch. Callers get bool always;
+// error tells the two apart.
 //
 // Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
 // the serialize.js value-domain seam. Checked/production comes from the
 // stream object; generated code never reads NODE_ENV.
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
@@ -89,8 +85,7 @@ export class FixedProbe {
 export const FixedProbeMaxBits = 156;
 export const FixedProbeMaxBytes = 24;
 
-// ZeroFixedProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroFixedProbe(value) {
   value.Angle = 0;
   value.Position = 0n;
@@ -169,8 +164,7 @@ export class UnsignedProbe {
 export const UnsignedProbeMaxBits = 196;
 export const UnsignedProbeMaxBytes = 32;
 
-// ZeroUnsignedProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroUnsignedProbe(value) {
   value.Angle = 0;
   value.Span = 0n;
@@ -204,7 +198,7 @@ export function WriteUnsignedProbe(stream, value) {
       return false;
     }
   }
-  if (value.Locked !== 196608) { // out-of-contract writes are refused, not wrapped
+  if (value.Locked !== 196608) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Tail;
@@ -251,8 +245,8 @@ export class WideProbe {
     this.EntityId = 0n;
     this.Energy = 0n; // wire [-5000000000, 5000000000]
     this.Flux = 0n; // wire [-1267650600228229401496703205376, 1267650600228229401496703205376]
-    this.Bias = -250n; // = -250n at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
-    this.Seed = 36893488147419103232n; // = 36893488147419103232n at construction; Zero* gives the §5 zero form
+    this.Bias = -250n; // specified default at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
+    this.Seed = 36893488147419103232n; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -261,8 +255,7 @@ export class WideProbe {
 export const WideProbeMaxBits = 403;
 export const WideProbeMaxBytes = 56;
 
-// ZeroWideProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroWideProbe(value) {
   value.EntityId = 0n;
   value.Energy = 0n;
@@ -346,8 +339,7 @@ export class LudicrousState {
 export const LudicrousStateMaxBits = 1205;
 export const LudicrousStateMaxBytes = 152;
 
-// ZeroLudicrousState resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroLudicrousState(value) {
   value.Mode = DriveMode.None;
   ZeroFixedProbe(value.Probe);
@@ -372,7 +364,7 @@ export function WriteLudicrousState(stream, value) {
   if (!WriteWideProbe(stream, value.Wide)) {
     return false;
   }
-  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.KeysCount;
@@ -449,8 +441,7 @@ export class DegenerateProbe {
 export const DegenerateProbeMaxBits = 8;
 export const DegenerateProbeMaxBytes = 8;
 
-// ZeroDegenerateProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroDegenerateProbe(value) {
   value.LockedFixed = 0;
   value.LockedInt = 0;
@@ -459,13 +450,13 @@ export function ZeroDegenerateProbe(value) {
 }
 
 export function WriteDegenerateProbe(stream, value) {
-  if (value.LockedFixed !== -196608) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedFixed !== -196608) {
     return false;
   }
-  if (!Number.isInteger(value.LockedInt) || value.LockedInt < 7 || value.LockedInt > 7) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LockedInt) || value.LockedInt < 7 || value.LockedInt > 7) {
     return false;
   }
-  if (value.LockedWide !== -12345678901234n) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedWide !== -12345678901234n) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Tail;
@@ -486,8 +477,7 @@ export function ReadDegenerateProbe(stream, value) {
   return true;
 }
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class FixedVec {
   constructor() {
     this.X = 0n; // wire [-100000, 100000]
@@ -501,8 +491,7 @@ export class FixedVec {
 export const FixedVecMaxBits = 102;
 export const FixedVecMaxBytes = 16;
 
-// ZeroFixedVec resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroFixedVec(value) {
   value.X = 0n;
   value.Y = 0n;
@@ -541,14 +530,13 @@ export function ReadFixedVec(stream, value) {
   return true;
 }
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class FixedQuat {
   constructor() {
     this.X = 0; // wire [-1, 1]
     this.Y = 0; // wire [-1, 1]
     this.Z = 0; // wire [-1, 1]
-    this.W = 1073741824; // = 1073741824 at construction; Zero* gives the §5 zero form; wire [-1, 1]
+    this.W = 1073741824; // specified default at construction; Zero* gives the §5 zero form; wire [-1, 1]
   }
 }
 
@@ -557,8 +545,7 @@ export class FixedQuat {
 export const FixedQuatMaxBits = 128;
 export const FixedQuatMaxBytes = 16;
 
-// ZeroFixedQuat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroFixedQuat(value) {
   value.X = 0;
   value.Y = 0;
@@ -614,7 +601,7 @@ export class BodyState {
     this.Position = new FixedVec();
     this.Rotation = new FixedQuat();
     this.Velocity = new FixedVec();
-    this.Spin = 0; //  | local — no wire
+    this.Spin = 0; // | local — no wire
   }
 }
 
@@ -791,49 +778,49 @@ export const NarrowBodyData_ShallowMaxBits = 228;
 export const NarrowBodyData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity
 
 export function WriteNarrowBodyData_Shallow(stream, value) {
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -25600000 || value.PositionX > 25600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -25600000 || value.PositionX > 25600000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-25600000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 26)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -25600000 || value.PositionY > 25600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -25600000 || value.PositionY > 25600000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-25600000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 26)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -25600000 || value.PositionZ > 25600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -25600000 || value.PositionZ > 25600000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-25600000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 26)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;

--- a/generated/js-ludicrous/LudicrousFlat.js
+++ b/generated/js-ludicrous/LudicrousFlat.js
@@ -160,7 +160,7 @@ function writeFixedProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Angle) || value.Angle < -11796480 || value.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Angle) || value.Angle < -11796480 || value.Angle > 11796480) {
     return -1;
   }
   v = ((((value.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -180,7 +180,7 @@ function writeFixedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Position < -1966080000n || value.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Position < -1966080000n || value.Position > 1966080000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Position - -1966080000n));
@@ -200,7 +200,7 @@ function writeFixedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Reach < -65536000000n || value.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Reach < -65536000000n || value.Reach > 65536000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Reach - -65536000000n), true);
@@ -238,7 +238,7 @@ function writeFixedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) {
     return -1;
   }
   v = ((value.Ticks) & 0xfffff) >>> 0;
@@ -259,7 +259,7 @@ function writeFixedProbeFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < 2; i0++) {
-    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < -524288 || value.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < -524288 || value.Samples[i0] > 524288) {
       return -1;
     }
     v = ((((value.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -528,7 +528,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Angle) || value.Angle < 0 || value.Angle > 23592960) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Angle) || value.Angle < 0 || value.Angle > 23592960) {
     return -1;
   }
   v = ((value.Angle) & 0x1ffffff) >>> 0;
@@ -548,7 +548,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Span < 0n || value.Span > 18446744073709486080n) { // out-of-contract writes are refused, not wrapped
+  if (value.Span < 0n || value.Span > 18446744073709486080n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Span), true);
@@ -586,7 +586,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Reach < 0n || value.Reach > 131072000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Reach < 0n || value.Reach > 131072000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Reach), true);
@@ -624,7 +624,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) {
     return -1;
   }
   v = ((value.Ticks) & 0xfffff) >>> 0;
@@ -645,7 +645,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < 2; i0++) {
-    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < 0 || value.Samples[i0] > 1048576) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < 0 || value.Samples[i0] > 1048576) {
       return -1;
     }
     v = ((value.Samples[i0]) & 0x1fffff) >>> 0;
@@ -666,7 +666,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
       sb -= 64;
     }
   }
-  if (value.Locked !== 196608) { // out-of-contract writes are refused, not wrapped
+  if (value.Locked !== 196608) {
     return -1;
   }
   v = ((value.Tail) & 0xff) >>> 0;
@@ -1140,7 +1140,7 @@ function writeWideProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Energy < -5000000000n || value.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Energy < -5000000000n || value.Energy > 5000000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Energy - -5000000000n), true);
@@ -1178,7 +1178,7 @@ function writeWideProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Flux < -1267650600228229401496703205376n || value.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+  if (value.Flux < -1267650600228229401496703205376n || value.Flux > 1267650600228229401496703205376n) {
     return -1;
   }
   bg = BigInt.asUintN(128, value.Flux - -1267650600228229401496703205376n);
@@ -1250,7 +1250,7 @@ function writeWideProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Bias < -1000n || value.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Bias < -1000n || value.Bias > 1000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Bias - -1000n));
@@ -2091,7 +2091,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) {
     return -1;
   }
   v = ((((value.Probe.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -2111,7 +2111,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Probe.Position - -1966080000n));
@@ -2131,7 +2131,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Probe.Reach - -65536000000n), true);
@@ -2169,7 +2169,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) {
     return -1;
   }
   v = ((value.Probe.Ticks) & 0xfffff) >>> 0;
@@ -2190,7 +2190,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < 2; i0++) {
-    if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) {
       return -1;
     }
     v = ((((value.Probe.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -2280,7 +2280,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Wide.Energy - -5000000000n), true);
@@ -2318,7 +2318,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+  if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) {
     return -1;
   }
   bg = BigInt.asUintN(128, value.Wide.Flux - -1267650600228229401496703205376n);
@@ -2390,7 +2390,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Wide.Bias - -1000n));
@@ -3603,7 +3603,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) {
       return -1;
     }
     v = ((((value.Probe.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -3623,7 +3623,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, value.Probe.Position - -1966080000n));
@@ -3643,7 +3643,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, value.Probe.Reach - -65536000000n), true);
@@ -3681,7 +3681,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) {
       return -1;
     }
     v = ((value.Probe.Ticks) & 0xfffff) >>> 0;
@@ -3702,7 +3702,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       sb -= 64;
     }
     for (let i0 = 0; i0 < 2; i0++) {
-      if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) {
         return -1;
       }
       v = ((((value.Probe.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -3792,7 +3792,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, value.Wide.Energy - -5000000000n), true);
@@ -3830,7 +3830,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+    if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) {
       return -1;
     }
     bg = BigInt.asUintN(128, value.Wide.Flux - -1267650600228229401496703205376n);
@@ -3902,7 +3902,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, value.Wide.Bias - -1000n));
@@ -4548,13 +4548,13 @@ function writeDegenerateProbeFlatProduction(value, view) {
 function writeDegenerateProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.LockedFixed !== -196608) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedFixed !== -196608) {
     return -1;
   }
-  if (value.LockedInt !== 7) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedInt !== 7) {
     return -1;
   }
-  if (value.LockedWide !== -12345678901234n) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedWide !== -12345678901234n) {
     return -1;
   }
   v = ((value.Tail) & 0xff) >>> 0;
@@ -4729,7 +4729,7 @@ function writeFixedVecFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.X < -6553600000n || value.X > 6553600000n) { // out-of-contract writes are refused, not wrapped
+  if (value.X < -6553600000n || value.X > 6553600000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.X - -6553600000n), true);
@@ -4767,7 +4767,7 @@ function writeFixedVecFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Y < -6553600000n || value.Y > 6553600000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Y < -6553600000n || value.Y > 6553600000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Y - -6553600000n), true);
@@ -4805,7 +4805,7 @@ function writeFixedVecFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Z < -6553600000n || value.Z > 6553600000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Z < -6553600000n || value.Z > 6553600000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Z - -6553600000n), true);
@@ -5012,7 +5012,7 @@ function writeFixedQuatFlatProduction(value, view) {
 function writeFixedQuatFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -1073741824 || value.X > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -1073741824 || value.X > 1073741824) {
     return -1;
   }
   v = (((value.X >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5032,7 +5032,7 @@ function writeFixedQuatFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -1073741824 || value.Y > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -1073741824 || value.Y > 1073741824) {
     return -1;
   }
   v = (((value.Y >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5052,7 +5052,7 @@ function writeFixedQuatFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -1073741824 || value.Z > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -1073741824 || value.Z > 1073741824) {
     return -1;
   }
   v = (((value.Z >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5072,7 +5072,7 @@ function writeFixedQuatFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.W) || value.W < -1073741824 || value.W > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.W) || value.W < -1073741824 || value.W > 1073741824) {
     return -1;
   }
   v = (((value.W >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5836,7 +5836,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.Probe.Angle) || message.Probe.Angle < -11796480 || message.Probe.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.Probe.Angle) || message.Probe.Angle < -11796480 || message.Probe.Angle > 11796480) {
       return -1;
     }
     v = ((((message.Probe.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -5856,7 +5856,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Probe.Position < -1966080000n || message.Probe.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Probe.Position < -1966080000n || message.Probe.Position > 1966080000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, message.Probe.Position - -1966080000n));
@@ -5876,7 +5876,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Probe.Reach < -65536000000n || message.Probe.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Probe.Reach < -65536000000n || message.Probe.Reach > 65536000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, message.Probe.Reach - -65536000000n), true);
@@ -5914,7 +5914,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.Probe.Ticks) || message.Probe.Ticks < 0 || message.Probe.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.Probe.Ticks) || message.Probe.Ticks < 0 || message.Probe.Ticks > 1000000) {
       return -1;
     }
     v = ((message.Probe.Ticks) & 0xfffff) >>> 0;
@@ -5935,7 +5935,7 @@ function writeMessageFlatChecked(message, view) {
       sb -= 64;
     }
     for (let i0 = 0; i0 < 2; i0++) {
-      if (!Number.isInteger(message.Probe.Samples[i0]) || message.Probe.Samples[i0] < -524288 || message.Probe.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(message.Probe.Samples[i0]) || message.Probe.Samples[i0] < -524288 || message.Probe.Samples[i0] > 524288) {
         return -1;
       }
       v = ((((message.Probe.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -6025,7 +6025,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Wide.Energy < -5000000000n || message.Wide.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Wide.Energy < -5000000000n || message.Wide.Energy > 5000000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, message.Wide.Energy - -5000000000n), true);
@@ -6063,7 +6063,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Wide.Flux < -1267650600228229401496703205376n || message.Wide.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+    if (message.Wide.Flux < -1267650600228229401496703205376n || message.Wide.Flux > 1267650600228229401496703205376n) {
       return -1;
     }
     bg = BigInt.asUintN(128, message.Wide.Flux - -1267650600228229401496703205376n);
@@ -6135,7 +6135,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Wide.Bias < -1000n || message.Wide.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Wide.Bias < -1000n || message.Wide.Bias > 1000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, message.Wide.Bias - -1000n));

--- a/generated/js/Constants.js
+++ b/generated/js/Constants.js
@@ -4,12 +4,11 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an out-of-contract
+// write) returns false WITHOUT latching; stream failures latch on
+// stream.error — the runtime's own sticky latch. Callers get bool always;
+// error tells the two apart.
 //
 // Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
 // the serialize.js value-domain seam. Checked/production comes from the

--- a/generated/js/Contexts.js
+++ b/generated/js/Contexts.js
@@ -3,17 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries

--- a/generated/js/Enums.js
+++ b/generated/js/Enums.js
@@ -3,17 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's

--- a/generated/js/Messages.js
+++ b/generated/js/Messages.js
@@ -3,25 +3,11 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { MaxBlockSize, MaxChatLength } from "./Constants.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 
@@ -55,8 +41,7 @@ export class Heartbeat {
 export const HeartbeatMaxBits = 0;
 export const HeartbeatMaxBytes = 0;
 
-// ZeroHeartbeat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroHeartbeat(value) {
   // empty body — nothing to reset (SPEC §4.6)
 }
@@ -91,8 +76,7 @@ export class Test {
 export const TestMaxBits = 46;
 export const TestMaxBytes = 8;
 
-// ZeroTest resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroTest(value) {
   value.TestA = 0;
   value.TestB = 0;
@@ -105,21 +89,21 @@ export function WriteTest(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 16)) {
     return false;
   }
-  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TestB;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TestC;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TestD;
@@ -168,8 +152,7 @@ export class Block {
 export const BlockMaxBits = 16018;
 export const BlockMaxBytes = 2008;
 
-// ZeroBlock resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroBlock(value) {
   value.Data.fill(0);
   value.DataLength = 0;
@@ -219,8 +202,7 @@ export class Chat {
 export const ChatMaxBits = 2064;
 export const ChatMaxBytes = 264;
 
-// ZeroChat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroChat(value) {
   value.Text.fill(0);
   value.TextLength = 0;
@@ -275,8 +257,7 @@ export class Synchronize {
 export const SynchronizeMaxBits = 80;
 export const SynchronizeMaxBytes = 16;
 
-// ZeroSynchronize resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroSynchronize(value) {
   value.SyncFrame = 0n;
   value.SyncSequence = 0;
@@ -326,8 +307,7 @@ export class Timescale {
 export const TimescaleMaxBits = 128;
 export const TimescaleMaxBytes = 16;
 
-// ZeroTimescale resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroTimescale(value) {
   value.Scale = 0;
   value.FrameA = 0;

--- a/generated/js/MessagesFlat.js
+++ b/generated/js/MessagesFlat.js
@@ -229,7 +229,7 @@ function writeTestFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) {
     return -1;
   }
   v = ((value.TestB) & 0x3ff) >>> 0;
@@ -249,7 +249,7 @@ function writeTestFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) {
     return -1;
   }
   v = ((value.TestC) & 0x3ff) >>> 0;
@@ -269,7 +269,7 @@ function writeTestFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) {
     return -1;
   }
   v = ((value.TestD) & 0x3ff) >>> 0;
@@ -466,7 +466,7 @@ function writeTestFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) {
       return -1;
     }
     v = ((value.TestB) & 0x3ff) >>> 0;
@@ -486,7 +486,7 @@ function writeTestFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) {
       return -1;
     }
     v = ((value.TestC) & 0x3ff) >>> 0;
@@ -506,7 +506,7 @@ function writeTestFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) {
       return -1;
     }
     v = ((value.TestD) & 0x3ff) >>> 0;
@@ -2889,7 +2889,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.TestB) || message.TestB < 0 || message.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.TestB) || message.TestB < 0 || message.TestB > 1000) {
       return -1;
     }
     v = ((message.TestB) & 0x3ff) >>> 0;
@@ -2909,7 +2909,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.TestC) || message.TestC < 0 || message.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.TestC) || message.TestC < 0 || message.TestC > 1000) {
       return -1;
     }
     v = ((message.TestC) & 0x3ff) >>> 0;
@@ -2929,7 +2929,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.TestD) || message.TestD < 0 || message.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.TestD) || message.TestD < 0 || message.TestD > 1000) {
       return -1;
     }
     v = ((message.TestD) & 0x3ff) >>> 0;

--- a/generated/js/Objects.js
+++ b/generated/js/Objects.js
@@ -3,27 +3,13 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { MaxCollidersPerShip, MaxTurretsPerShip, PositionUnits, RotationUnits, ShipMaxLasers, ShipMaxMissiles, VelocityUnits } from "./Constants.js";
 import { MissileType, PropType, ShipType, Team } from "./Enums.js";
 import { Handle, Quat, ReadHandle, ReadQuat, ReadVec3, Vec3, WriteHandle, WriteQuat, WriteVec3 } from "./Types.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 
@@ -68,11 +54,11 @@ export class ClientShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; //  | local — no wire
-    this.PreviousPosition = new Vec3(); //  | local — no wire
-    this.NumColliders = 0; //  | local — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
-    this.PredictedExplode = false; //  | local, context = client
+    this.Invulnerable = false; // | local — no wire
+    this.PreviousPosition = new Vec3(); // | local — no wire
+    this.NumColliders = 0; // | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // | local — no wire
+    this.PredictedExplode = false; // | local, context = client
   }
 }
 
@@ -105,10 +91,10 @@ export class ServerShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; //  | local — no wire
-    this.PreviousPosition = new Vec3(); //  | local — no wire
-    this.NumColliders = 0; //  | local — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
+    this.Invulnerable = false; // | local — no wire
+    this.PreviousPosition = new Vec3(); // | local — no wire
+    this.NumColliders = 0; // | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // | local — no wire
   }
 }
 
@@ -279,14 +265,14 @@ export function WriteShipData_Deep(stream, value) {
   if (!stream.serializeFloat(NUMBER_SCRATCH)) {
     return false;
   }
-  if (!Number.isInteger(value.LaserIndex) || value.LaserIndex < 0 || value.LaserIndex > ShipMaxLasers - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LaserIndex) || value.LaserIndex < 0 || value.LaserIndex > ShipMaxLasers - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.LaserIndex;
   if (!stream.serializeBits(NUMBER_SCRATCH, 4)) {
     return false;
   }
-  if (!Number.isInteger(value.MissileIndex) || value.MissileIndex < 0 || value.MissileIndex > ShipMaxMissiles - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.MissileIndex) || value.MissileIndex < 0 || value.MissileIndex > ShipMaxMissiles - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.MissileIndex;
@@ -411,70 +397,70 @@ export function WriteShipData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 3)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityX >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityY >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityZ >>> 0) - (-2097152 >>> 0)) >>> 0;
@@ -498,14 +484,14 @@ export function WriteShipData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 2)) {
     return false;
   }
-  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Health;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Thrust;
@@ -720,8 +706,8 @@ export class ClientMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); //  | local — no wire
-    this.Target = new Handle(); //  | local — no wire
+    this.AngularVelocity = new Vec3(); // | local — no wire
+    this.Target = new Handle(); // | local — no wire
   }
 }
 
@@ -735,9 +721,9 @@ export class ServerMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); //  | local — no wire
-    this.Target = new Handle(); //  | local — no wire
-    this.Timer = 0; //  | local, context = server
+    this.AngularVelocity = new Vec3(); // | local — no wire
+    this.Target = new Handle(); // | local — no wire
+    this.Timer = 0; // | local, context = server
   }
 }
 
@@ -861,70 +847,70 @@ export function WriteMissileData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 2)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityX >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityY >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityZ >>> 0) - (-2097152 >>> 0)) >>> 0;
@@ -1137,7 +1123,7 @@ export class DynamicPropState {
     this.LinearVelocity = new Vec3();
     this.Flags = 0n;
     this.Team = Team.None;
-    this.AngularVelocity = new Vec3(); //  | local — no wire
+    this.AngularVelocity = new Vec3(); // | local — no wire
   }
 }
 
@@ -1261,70 +1247,70 @@ export function WriteDynamicPropData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 3)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityX >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityY >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityZ >>> 0) - (-2097152 >>> 0)) >>> 0;
@@ -1535,7 +1521,7 @@ export class TurretState {
     this.TurretIndex = 0; // wire [0, 255]
     this.Rotation = new Quat();
     this.Flags = 0n;
-    this.Team = Team.None; //  | local — no wire
+    this.Team = Team.None; // | local — no wire
   }
 }
 
@@ -1584,7 +1570,7 @@ export function WriteTurretData_Deep(stream, value) {
   if (!WriteHandle(stream, value.Parent)) {
     return false;
   }
-  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TurretIndex;
@@ -1626,35 +1612,35 @@ export function WriteTurretData_Shallow(stream, value) {
   if (!WriteHandle(stream, value.Parent)) {
     return false;
   }
-  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TurretIndex;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;

--- a/generated/js/Render.js
+++ b/generated/js/Render.js
@@ -3,25 +3,11 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { Team } from "./Enums.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 
@@ -43,8 +29,7 @@ export class RenderSprite {
 export const RenderSpriteMaxBits = 138;
 export const RenderSpriteMaxBytes = 24;
 
-// ZeroRenderSprite resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroRenderSprite(value) {
   value.SortKey = 0n;
   value.MeshId = 0;
@@ -119,8 +104,7 @@ export class RenderBlock {
 export const RenderBlockMaxBits = 8903;
 export const RenderBlockMaxBytes = 1120;
 
-// ZeroRenderBlock resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroRenderBlock(value) {
   value.WorkerIndex = 0;
   value.SpriteCountHint = 0;
@@ -139,7 +123,7 @@ export function WriteRenderBlock(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 32)) {
     return false;
   }
-  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.SpritesCount;

--- a/generated/js/RenderFlat.js
+++ b/generated/js/RenderFlat.js
@@ -3,25 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js
-// two-lane bitpacker inlined at every field, constant widths and masks,
-// zero function calls. Same generated classes, same bytes as the runtime
-// tier (a standing CI gate); the runtime tier remains the diagnostic and
-// reference surface — re-read a failing buffer through it to learn WHICH
-// operation failed and why.
-//
-// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked
-// writer refuses an out-of-contract value (the production writer trusts
-// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at
-// module load). Read<Name>Flat(value, view, numBits) -> bool, the family
-// read verdict; reader obligations ride in every mode.
-//
-// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes
-// (the constants live in the runtime-tier module). Read buffers: at least
-// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load
-// unconditionally; copy exactly-sized receive buffers into a persistent
-// MaxBytes + 8 scratch first.
 
 // The 8-byte conversion scratch — serialize.js's FLOAT_SCRATCH twin. Module
 // scope is safe: single threaded per realm, consumed in the same op that

--- a/generated/js/Types.js
+++ b/generated/js/Types.js
@@ -3,32 +3,17 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { MaxHealth, MaxInputsPerPacket, MaxObjects, MaxPositionUnits, MaxVelocityUnits, RotationUnits, ShipMaxLasers, ShipMaxMissiles } from "./Constants.js";
 import { Pending, ShipType, Team } from "./Enums.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class Vec3 {
   constructor() {
     this.X = 0;
@@ -42,8 +27,7 @@ export class Vec3 {
 export const Vec3MaxBits = 192;
 export const Vec3MaxBytes = 24;
 
-// ZeroVec3 resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroVec3(value) {
   value.X = 0;
   value.Y = 0;
@@ -82,8 +66,7 @@ export function ReadVec3(stream, value) {
   return true;
 }
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class Quat {
   constructor() {
     this.X = 0;
@@ -98,8 +81,7 @@ export class Quat {
 export const QuatMaxBits = 256;
 export const QuatMaxBytes = 32;
 
-// ZeroQuat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuat(value) {
   value.X = 0;
   value.Y = 0;
@@ -160,15 +142,14 @@ export class Handle {
 export const HandleMaxBits = 22;
 export const HandleMaxBytes = 8;
 
-// ZeroHandle resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroHandle(value) {
   value.ObjectId = 0;
   value.ObjectSequence = 0;
 }
 
 export function WriteHandle(stream, value) {
-  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > MaxObjects - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > MaxObjects - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.ObjectId;
@@ -208,8 +189,7 @@ export class QuantizedPosition {
 export const QuantizedPositionMaxBits = 75;
 export const QuantizedPositionMaxBytes = 16;
 
-// ZeroQuantizedPosition resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuantizedPosition(value) {
   value.X = 0;
   value.Y = 0;
@@ -217,21 +197,21 @@ export function ZeroQuantizedPosition(value) {
 }
 
 export function WriteQuantizedPosition(stream, value) {
-  if (!Number.isInteger(value.X) || value.X < -MaxPositionUnits || value.X > MaxPositionUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -MaxPositionUnits || value.X > MaxPositionUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.X >>> 0) - (-MaxPositionUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Y >>> 0) - (-MaxPositionUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Z >>> 0) - (-MaxPositionUnits >>> 0)) >>> 0;
@@ -271,8 +251,7 @@ export class QuantizedVelocity {
 export const QuantizedVelocityMaxBits = 69;
 export const QuantizedVelocityMaxBytes = 16;
 
-// ZeroQuantizedVelocity resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuantizedVelocity(value) {
   value.X = 0;
   value.Y = 0;
@@ -280,21 +259,21 @@ export function ZeroQuantizedVelocity(value) {
 }
 
 export function WriteQuantizedVelocity(stream, value) {
-  if (!Number.isInteger(value.X) || value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.X >>> 0) - (-MaxVelocityUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Y >>> 0) - (-MaxVelocityUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Z >>> 0) - (-MaxVelocityUnits >>> 0)) >>> 0;
@@ -335,8 +314,7 @@ export class QuantizedRotation {
 export const QuantizedRotationMaxBits = 48;
 export const QuantizedRotationMaxBytes = 8;
 
-// ZeroQuantizedRotation resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuantizedRotation(value) {
   value.X = 0;
   value.Y = 0;
@@ -345,28 +323,28 @@ export function ZeroQuantizedRotation(value) {
 }
 
 export function WriteQuantizedRotation(stream, value) {
-  if (!Number.isInteger(value.X) || value.X < -RotationUnits || value.X > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -RotationUnits || value.X > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.X >>> 0) - (-RotationUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -RotationUnits || value.Y > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -RotationUnits || value.Y > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Y >>> 0) - (-RotationUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -RotationUnits || value.Z > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -RotationUnits || value.Z > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Z >>> 0) - (-RotationUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.W) || value.W < -RotationUnits || value.W > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.W) || value.W < -RotationUnits || value.W > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.W >>> 0) - (-RotationUnits >>> 0)) >>> 0;
@@ -415,8 +393,7 @@ export class RigidBody {
 export const RigidBodyMaxBits = 833;
 export const RigidBodyMaxBytes = 112;
 
-// ZeroRigidBody resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroRigidBody(value) {
   ZeroVec3(value.Position);
   ZeroQuat(value.Orientation);
@@ -496,8 +473,7 @@ export class Input {
 export const InputMaxBits = 168;
 export const InputMaxBytes = 24;
 
-// ZeroInput resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroInput(value) {
   value.StickX = 0;
   value.StickY = 0;
@@ -642,8 +618,7 @@ export class InputPacket {
 export const InputPacketMaxBits = 2837;
 export const InputPacketMaxBytes = 360;
 
-// ZeroInputPacket resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroInputPacket(value) {
   value.SynchronizeSequence = 0;
   value.CurrentFrame = 0n;
@@ -667,7 +642,7 @@ export function WriteInputPacket(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.InputsCount;
@@ -732,8 +707,7 @@ export class ShipCreate {
 export const ShipCreateMaxBits = 219;
 export const ShipCreateMaxBytes = 32;
 
-// ZeroShipCreate resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroShipCreate(value) {
   value.ShipType = ShipType.None;
   ZeroQuantizedPosition(value.Position);
@@ -787,14 +761,14 @@ export function WriteShipCreate(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 2)) {
     return false;
   }
-  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > MaxHealth) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > MaxHealth) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Health;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Thrust;
@@ -865,22 +839,21 @@ export class ExpressionProbe {
 export const ExpressionProbeMaxBits = 16;
 export const ExpressionProbeMaxBytes = 8;
 
-// ZeroExpressionProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroExpressionProbe(value) {
   value.HardpointIndex = 0;
   value.SpinRate = 0;
 }
 
 export function WriteExpressionProbe(stream, value) {
-  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers + ShipMaxMissiles) - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers + ShipMaxMissiles) - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.HardpointIndex;
   if (!stream.serializeBits(NUMBER_SCRATCH, 5)) {
     return false;
   }
-  if (!Number.isInteger(value.SpinRate) || value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits * 2) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.SpinRate) || value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits * 2) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.SpinRate >>> 0) - (-(-RotationUnits) >>> 0)) >>> 0;
@@ -912,8 +885,8 @@ export class ExtremeProbe {
     this.FloorBound = 0n; // wire [-9223372036854775808, 100]
     this.DoubledFloor = 0n; // wire [-9223372036854775808, 100]
     this.CeilingRange = 0n; // wire [1, 18446744073709551615]
-    this.FloorDefault = -9223372036854775808n; // = -9223372036854775808n at construction; Zero* gives the §5 zero form
-    this.CeilingDefault = 18446744073709551615n; // = 18446744073709551615n at construction; Zero* gives the §5 zero form
+    this.FloorDefault = -9223372036854775808n; // specified default at construction; Zero* gives the §5 zero form
+    this.CeilingDefault = 18446744073709551615n; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -922,8 +895,7 @@ export class ExtremeProbe {
 export const ExtremeProbeMaxBits = 320;
 export const ExtremeProbeMaxBytes = 40;
 
-// ZeroExtremeProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroExtremeProbe(value) {
   value.FloorBound = 0n;
   value.DoubledFloor = 0n;
@@ -933,21 +905,21 @@ export function ZeroExtremeProbe(value) {
 }
 
 export function WriteExtremeProbe(stream, value) {
-  if (value.FloorBound > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.FloorBound > 100n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.FloorBound - -9223372036854775808n);
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.DoubledFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.DoubledFloor > 100n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.DoubledFloor - -9223372036854775808n);
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.CeilingRange < 1n) { // out-of-contract writes are refused, not wrapped
+  if (value.CeilingRange < 1n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.CeilingRange - 1n);
@@ -997,8 +969,8 @@ export class ExtremeRow {
   constructor() {
     this.ClampedFloor = 0n; // wire [-9223372036854775808, 100]
     this.ClampedCeiling = 0n; // wire [1, 18446744073709551614]
-    this.FloorDef = -9223372036854775808n; // = -9223372036854775808n at construction; Zero* gives the §5 zero form
-    this.CeilingDef = 18446744073709551615n; // = 18446744073709551615n at construction; Zero* gives the §5 zero form
+    this.FloorDef = -9223372036854775808n; // specified default at construction; Zero* gives the §5 zero form
+    this.CeilingDef = 18446744073709551615n; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -1007,8 +979,7 @@ export class ExtremeRow {
 export const ExtremeRowMaxBits = 256;
 export const ExtremeRowMaxBytes = 32;
 
-// ZeroExtremeRow resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroExtremeRow(value) {
   value.ClampedFloor = 0n;
   value.ClampedCeiling = 0n;
@@ -1017,14 +988,14 @@ export function ZeroExtremeRow(value) {
 }
 
 export function WriteExtremeRow(stream, value) {
-  if (value.ClampedFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedFloor > 100n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.ClampedFloor - -9223372036854775808n);
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.ClampedCeiling - 1n);

--- a/generated/js/TypesFlat.js
+++ b/generated/js/TypesFlat.js
@@ -3,25 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js
-// two-lane bitpacker inlined at every field, constant widths and masks,
-// zero function calls. Same generated classes, same bytes as the runtime
-// tier (a standing CI gate); the runtime tier remains the diagnostic and
-// reference surface — re-read a failing buffer through it to learn WHICH
-// operation failed and why.
-//
-// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked
-// writer refuses an out-of-contract value (the production writer trusts
-// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at
-// module load). Read<Name>Flat(value, view, numBits) -> bool, the family
-// read verdict; reader obligations ride in every mode.
-//
-// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes
-// (the constants live in the runtime-tier module). Read buffers: at least
-// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load
-// unconditionally; copy exactly-sized receive buffers into a persistent
-// MaxBytes + 8 scratch first.
 
 // The 8-byte conversion scratch — serialize.js's FLOAT_SCRATCH twin. Module
 // scope is safe: single threaded per realm, consumed in the same op that
@@ -768,7 +749,7 @@ function writeHandleFlatProduction(value, view) {
 function writeHandleFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > 9999) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > 9999) {
     return -1;
   }
   v = ((value.ObjectId) & 0x3fff) >>> 0;
@@ -912,7 +893,7 @@ function writeQuantizedPositionFlatProduction(value, view) {
 function writeQuantizedPositionFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -8388608 || value.X > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -8388608 || value.X > 8388608) {
     return -1;
   }
   v = ((((value.X >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -932,7 +913,7 @@ function writeQuantizedPositionFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -8388608 || value.Y > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -8388608 || value.Y > 8388608) {
     return -1;
   }
   v = ((((value.Y >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -952,7 +933,7 @@ function writeQuantizedPositionFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -8388608 || value.Z > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -8388608 || value.Z > 8388608) {
     return -1;
   }
   v = ((((value.Z >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -1093,7 +1074,7 @@ function writeQuantizedVelocityFlatProduction(value, view) {
 function writeQuantizedVelocityFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -2097152 || value.X > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -2097152 || value.X > 2097152) {
     return -1;
   }
   v = ((((value.X >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -1113,7 +1094,7 @@ function writeQuantizedVelocityFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -2097152 || value.Y > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -2097152 || value.Y > 2097152) {
     return -1;
   }
   v = ((((value.Y >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -1133,7 +1114,7 @@ function writeQuantizedVelocityFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -2097152 || value.Z > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -2097152 || value.Z > 2097152) {
     return -1;
   }
   v = ((((value.Z >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -1291,7 +1272,7 @@ function writeQuantizedRotationFlatProduction(value, view) {
 function writeQuantizedRotationFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -1024 || value.X > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -1024 || value.X > 1024) {
     return -1;
   }
   v = ((((value.X >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -1311,7 +1292,7 @@ function writeQuantizedRotationFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -1024 || value.Y > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -1024 || value.Y > 1024) {
     return -1;
   }
   v = ((((value.Y >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -1331,7 +1312,7 @@ function writeQuantizedRotationFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -1024 || value.Z > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -1024 || value.Z > 1024) {
     return -1;
   }
   v = ((((value.Z >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -1351,7 +1332,7 @@ function writeQuantizedRotationFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.W) || value.W < -1024 || value.W > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.W) || value.W < -1024 || value.W > 1024) {
     return -1;
   }
   v = ((((value.W >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4704,7 +4685,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Position.X) || value.Position.X < -8388608 || value.Position.X > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Position.X) || value.Position.X < -8388608 || value.Position.X > 8388608) {
     return -1;
   }
   v = ((((value.Position.X >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -4724,7 +4705,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Position.Y) || value.Position.Y < -8388608 || value.Position.Y > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Position.Y) || value.Position.Y < -8388608 || value.Position.Y > 8388608) {
     return -1;
   }
   v = ((((value.Position.Y >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -4744,7 +4725,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Position.Z) || value.Position.Z < -8388608 || value.Position.Z > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Position.Z) || value.Position.Z < -8388608 || value.Position.Z > 8388608) {
     return -1;
   }
   v = ((((value.Position.Z >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -4764,7 +4745,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.X) || value.Rotation.X < -1024 || value.Rotation.X > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.X) || value.Rotation.X < -1024 || value.Rotation.X > 1024) {
     return -1;
   }
   v = ((((value.Rotation.X >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4784,7 +4765,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.Y) || value.Rotation.Y < -1024 || value.Rotation.Y > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.Y) || value.Rotation.Y < -1024 || value.Rotation.Y > 1024) {
     return -1;
   }
   v = ((((value.Rotation.Y >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4804,7 +4785,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.Z) || value.Rotation.Z < -1024 || value.Rotation.Z > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.Z) || value.Rotation.Z < -1024 || value.Rotation.Z > 1024) {
     return -1;
   }
   v = ((((value.Rotation.Z >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4824,7 +4805,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.W) || value.Rotation.W < -1024 || value.Rotation.W > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.W) || value.Rotation.W < -1024 || value.Rotation.W > 1024) {
     return -1;
   }
   v = ((((value.Rotation.W >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4844,7 +4825,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.LinearVelocity.X) || value.LinearVelocity.X < -2097152 || value.LinearVelocity.X > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocity.X) || value.LinearVelocity.X < -2097152 || value.LinearVelocity.X > 2097152) {
     return -1;
   }
   v = ((((value.LinearVelocity.X >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -4864,7 +4845,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.LinearVelocity.Y) || value.LinearVelocity.Y < -2097152 || value.LinearVelocity.Y > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocity.Y) || value.LinearVelocity.Y < -2097152 || value.LinearVelocity.Y > 2097152) {
     return -1;
   }
   v = ((((value.LinearVelocity.Y >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -4884,7 +4865,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.LinearVelocity.Z) || value.LinearVelocity.Z < -2097152 || value.LinearVelocity.Z > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocity.Z) || value.LinearVelocity.Z < -2097152 || value.LinearVelocity.Z > 2097152) {
     return -1;
   }
   v = ((((value.LinearVelocity.Z >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -4963,7 +4944,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) {
     return -1;
   }
   v = ((value.Health) & 0x3ff) >>> 0;
@@ -4983,7 +4964,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) {
     return -1;
   }
   v = ((value.Thrust) & 0x7f) >>> 0;
@@ -5258,7 +5239,7 @@ function writeExpressionProbeFlatProduction(value, view) {
 function writeExpressionProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > 31) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > 31) {
     return -1;
   }
   v = ((value.HardpointIndex) & 0x1f) >>> 0;
@@ -5278,7 +5259,7 @@ function writeExpressionProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.SpinRate) || value.SpinRate < 1024 || value.SpinRate > 2048) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.SpinRate) || value.SpinRate < 1024 || value.SpinRate > 2048) {
     return -1;
   }
   v = ((((value.SpinRate >>> 0) - 1024) >>> 0) & 0x7ff) >>> 0;
@@ -5531,7 +5512,7 @@ function writeExtremeProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.FloorBound > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.FloorBound > 100n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.FloorBound - -9223372036854775808n), true);
@@ -5569,7 +5550,7 @@ function writeExtremeProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.DoubledFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.DoubledFloor > 100n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.DoubledFloor - -9223372036854775808n), true);
@@ -5607,7 +5588,7 @@ function writeExtremeProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.CeilingRange < 1n) { // out-of-contract writes are refused, not wrapped
+  if (value.CeilingRange < 1n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.CeilingRange - 1n), true);
@@ -5994,7 +5975,7 @@ function writeExtremeRowFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.ClampedFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedFloor > 100n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.ClampedFloor - -9223372036854775808n), true);
@@ -6032,7 +6013,7 @@ function writeExtremeRowFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.ClampedCeiling - 1n), true);

--- a/generated/js/Wire.js
+++ b/generated/js/Wire.js
@@ -3,25 +3,11 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { ReadTest, Test, WriteTest, ZeroTest } from "./Messages.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
@@ -84,8 +70,7 @@ export class ProbeHeader {
 export const ProbeHeaderMaxBits = 87;
 export const ProbeHeaderMaxBytes = 16;
 
-// ZeroProbeHeader resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeHeader(value) {
   value.Version = 0;
   value.ProbeId = 0n;
@@ -157,8 +142,7 @@ export class ProbeBits {
 export const ProbeBitsMaxBits = 202;
 export const ProbeBitsMaxBytes = 32;
 
-// ZeroProbeBits resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeBits(value) {
   value.Small = 0;
   value.Boundary = 0n;
@@ -180,7 +164,7 @@ export function WriteProbeBits(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Sensor;
@@ -221,7 +205,7 @@ export function ReadProbeBits(stream, value) {
 // type ProbeSample
 export class ProbeSample {
   constructor() {
-    this.Active = true; // = true at construction; Zero* gives the §5 zero form
+    this.Active = true; // specified default at construction; Zero* gives the §5 zero form
     this.Orientation = 0; // compressed float [-180.0, 180.0] @ 0.01
     this.RawDelta = 0;
     this.BigDelta = 0n;
@@ -249,8 +233,7 @@ export class ProbeSample {
 export const ProbeSampleMaxBits = 276;
 export const ProbeSampleMaxBytes = 40;
 
-// ZeroProbeSample resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeSample(value) {
   value.Active = false;
   value.Orientation = 0;
@@ -305,7 +288,7 @@ export function WriteProbeSample(stream, value) {
       return false;
     }
   }
-  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = ((value.SamplesCount >>> 0) - (1 >>> 0)) >>> 0;
@@ -390,8 +373,7 @@ export class ProbeRing {
 export const ProbeRingMaxBits = 16;
 export const ProbeRingMaxBytes = 8;
 
-// ZeroProbeRing resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeRing(value) {
   value.Radius = 0;
 }
@@ -425,15 +407,14 @@ export class ProbeSlab {
 export const ProbeSlabMaxBits = 15;
 export const ProbeSlabMaxBytes = 8;
 
-// ZeroProbeSlab resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeSlab(value) {
   value.Width = 0;
   value.Height = 0;
 }
 
 export function WriteProbeSlab(stream, value) {
-  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Width;
@@ -540,8 +521,7 @@ export class ProbeCollider {
 export const ProbeColliderMaxBits = 82;
 export const ProbeColliderMaxBytes = 16;
 
-// ZeroProbeCollider resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeCollider(value) {
   value.Armor = 0;
   ZeroProbeShape(value.Shape);
@@ -563,7 +543,7 @@ export function WriteProbeCollider(stream, value) {
   if (!WriteProbeShape(stream, value.Backup)) {
     return false;
   }
-  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.ExtrasCount;
@@ -604,8 +584,8 @@ export function ReadProbeCollider(stream, value) {
 // type ProbeConfig
 export class ProbeConfig {
   constructor() {
-    this.Retries = -1; // = -1 at construction; Zero* gives the §5 zero form
-    this.Preferred = Weapon.Railgun; // = Weapon.Railgun at construction; Zero* gives the §5 zero form
+    this.Retries = -1; // specified default at construction; Zero* gives the §5 zero form
+    this.Preferred = Weapon.Railgun; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -614,8 +594,7 @@ export class ProbeConfig {
 export const ProbeConfigMaxBits = 36;
 export const ProbeConfigMaxBytes = 8;
 
-// ZeroProbeConfig resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeConfig(value) {
   value.Retries = 0;
   value.Preferred = Weapon.None;
@@ -661,8 +640,7 @@ export class ProbeArray {
 export const ProbeArrayMaxBits = 588;
 export const ProbeArrayMaxBytes = 80;
 
-// ZeroProbeArray resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeArray(value) {
   for (let i = 0; i < 2; i++) {
     ZeroProbeSample(value.Samples[i]);
@@ -708,8 +686,7 @@ export class ProbeReport {
 export const ProbeReportMaxBits = 141;
 export const ProbeReportMaxBytes = 24;
 
-// ZeroProbeReport resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeReport(value) {
   ZeroProbeHeader(value.Header);
   value.Flags = 0n;
@@ -784,8 +761,7 @@ export class TestData {
 export const TestDataMaxBits = 2735;
 export const TestDataMaxBytes = 344;
 
-// ZeroTestData resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroTestData(value) {
   value.A = 0;
   value.B = 0;
@@ -813,21 +789,21 @@ export function ZeroTestData(value) {
 }
 
 export function WriteTestData(stream, value) {
-  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.A >>> 0) - (-100 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.B >>> 0) - (-100 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.C >>> 0) - (-100 >>> 0)) >>> 0;
@@ -850,7 +826,7 @@ export function WriteTestData(stream, value) {
   if (!stream.serializeBool(BOOL_SCRATCH)) {
     return false;
   }
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.ItemsCount;
@@ -858,7 +834,7 @@ export function WriteTestData(stream, value) {
     return false;
   }
   for (let i = 0; i < value.ItemsCount; i++) {
-    if (!Number.isInteger(value.Items[i]) || value.Items[i] < 0 || value.Items[i] > 255) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Items[i]) || value.Items[i] < 0 || value.Items[i] > 255) {
       return false;
     }
     NUMBER_SCRATCH.value = value.Items[i];
@@ -906,7 +882,7 @@ export function WriteTestData(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.Int64Range - -1000000000000n);
@@ -1049,8 +1025,7 @@ export class CompressedProbe {
 export const CompressedProbeMaxBits = 24;
 export const CompressedProbeMaxBytes = 8;
 
-// ZeroCompressedProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroCompressedProbe(value) {
   value.Boundary = 0;
   value.Offset = 0;

--- a/generated/js/WireFlat.js
+++ b/generated/js/WireFlat.js
@@ -3,25 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js
-// two-lane bitpacker inlined at every field, constant widths and masks,
-// zero function calls. Same generated classes, same bytes as the runtime
-// tier (a standing CI gate); the runtime tier remains the diagnostic and
-// reference surface — re-read a failing buffer through it to learn WHICH
-// operation failed and why.
-//
-// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked
-// writer refuses an out-of-contract value (the production writer trusts
-// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at
-// module load). Read<Name>Flat(value, view, numBits) -> bool, the family
-// read verdict; reader obligations ride in every mode.
-//
-// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes
-// (the constants live in the runtime-tier module). Read buffers: at least
-// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load
-// unconditionally; copy exactly-sized receive buffers into a persistent
-// MaxBytes + 8 scratch first.
 
 // The 8-byte conversion scratch — serialize.js's FLOAT_SCRATCH twin. Module
 // scope is safe: single threaded per realm, consumed in the same op that
@@ -574,7 +555,7 @@ function writeProbeBitsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) {
     return -1;
   }
   v = (value.Sensor) >>> 0;
@@ -955,7 +936,7 @@ function writeProbeSampleFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.Orientation);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - -180.0) / 360.0);
@@ -1416,7 +1397,7 @@ function writeProbeSlabFlatProduction(value, view) {
 function writeProbeSlabFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) {
     return -1;
   }
   v = ((value.Width) & 0x7f) >>> 0;
@@ -1833,7 +1814,7 @@ function writeProbeColliderFlatChecked(value, view) {
       break;
     }
     case 2: {
-      if (!Number.isInteger(value.Shape.Slab.Width) || value.Shape.Slab.Width < 0 || value.Shape.Slab.Width > 100) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(value.Shape.Slab.Width) || value.Shape.Slab.Width < 0 || value.Shape.Slab.Width > 100) {
         return -1;
       }
       v = ((value.Shape.Slab.Width) & 0x7f) >>> 0;
@@ -1915,7 +1896,7 @@ function writeProbeColliderFlatChecked(value, view) {
       break;
     }
     case 2: {
-      if (!Number.isInteger(value.Backup.Slab.Width) || value.Backup.Slab.Width < 0 || value.Backup.Slab.Width > 100) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(value.Backup.Slab.Width) || value.Backup.Slab.Width < 0 || value.Backup.Slab.Width > 100) {
         return -1;
       }
       v = ((value.Backup.Slab.Width) & 0x7f) >>> 0;
@@ -2019,7 +2000,7 @@ function writeProbeColliderFlatChecked(value, view) {
         break;
       }
       case 2: {
-        if (!Number.isInteger(e0.Slab.Width) || e0.Slab.Width < 0 || e0.Slab.Width > 100) { // out-of-contract writes are refused, not wrapped
+        if (!Number.isInteger(e0.Slab.Width) || e0.Slab.Width < 0 || e0.Slab.Width > 100) {
           return -1;
         }
         v = ((e0.Slab.Width) & 0x7f) >>> 0;
@@ -2653,7 +2634,7 @@ function writeProbeArrayFlatChecked(value, view) {
       sb -= 64;
     }
     x = Math.fround(e0.Orientation);
-    if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isFinite(x)) {
       return -1;
     }
     n = Math.fround(Math.fround(x - -180.0) / 360.0);
@@ -3381,7 +3362,7 @@ function writeProbeReportFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Echo.TestB) || value.Echo.TestB < 0 || value.Echo.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Echo.TestB) || value.Echo.TestB < 0 || value.Echo.TestB > 1000) {
     return -1;
   }
   v = ((value.Echo.TestB) & 0x3ff) >>> 0;
@@ -3401,7 +3382,7 @@ function writeProbeReportFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Echo.TestC) || value.Echo.TestC < 0 || value.Echo.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Echo.TestC) || value.Echo.TestC < 0 || value.Echo.TestC > 1000) {
     return -1;
   }
   v = ((value.Echo.TestC) & 0x3ff) >>> 0;
@@ -3421,7 +3402,7 @@ function writeProbeReportFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Echo.TestD) || value.Echo.TestD < 0 || value.Echo.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Echo.TestD) || value.Echo.TestD < 0 || value.Echo.TestD > 1000) {
     return -1;
   }
   v = ((value.Echo.TestD) & 0x3ff) >>> 0;
@@ -4099,7 +4080,7 @@ function writeTestDataFlatChecked(value, view) {
   let v = 0, s = 0, x = 0, n = 0, t0 = 0, t1 = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) {
     return -1;
   }
   v = ((((value.A >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -4119,7 +4100,7 @@ function writeTestDataFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) {
     return -1;
   }
   v = ((((value.B >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -4139,7 +4120,7 @@ function writeTestDataFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) {
     return -1;
   }
   v = ((((value.C >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -4248,7 +4229,7 @@ function writeTestDataFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < value.ItemsCount; i0++) {
-    if (!Number.isInteger(value.Items[i0]) || value.Items[i0] < 0 || value.Items[i0] > 255) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Items[i0]) || value.Items[i0] < 0 || value.Items[i0] > 255) {
       return -1;
     }
     v = ((value.Items[i0]) & 0xff) >>> 0;
@@ -4298,7 +4279,7 @@ function writeTestDataFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.CompressedFloatValue);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 10.0);
@@ -4510,7 +4491,7 @@ function writeTestDataFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Int64Range - -1000000000000n), true);
@@ -5000,7 +4981,7 @@ function writeCompressedProbeFlatChecked(value, view) {
   let v = 0, s = 0, x = 0, n = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
   x = Math.fround(value.Boundary);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 10.0);
@@ -5023,7 +5004,7 @@ function writeCompressedProbeFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.Offset);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - -5.0) / 10.0);

--- a/generated/rust-ludicrous/src/ludicrous.rs
+++ b/generated/rust-ludicrous/src/ludicrous.rs
@@ -75,13 +75,7 @@ impl DriveMode {
 
 /// Debug/log name for any `DriveMode` value, out-of-set included.
 pub fn enum_name_drive_mode(value: DriveMode) -> &'static str {
-    enum_name_drive_mode_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_drive_mode`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_drive_mode_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Cruise",
         2 => "Warp",
@@ -121,28 +115,28 @@ pub const FIXED_PROBE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_fixed_probe(stream: &mut WriteStream<'_>, value: &FixedProbe) -> Result {
-    if value.angle < -11796480 || value.angle > 11796480 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.angle < -11796480 || value.angle > 11796480 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, -180, 180)?;
     }
-    if value.position < -1966080000 || value.position > 1966080000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.position < -1966080000 || value.position > 1966080000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.position;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -MAX_WORLD_UNITS, MAX_WORLD_UNITS)?;
     }
-    if value.reach < -65536000000 || value.reach > 65536000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.reach < -65536000000 || value.reach > 65536000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, -1000000, 1000000)?;
     }
-    if value.ticks < 0 || value.ticks > 1000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.ticks < 0 || value.ticks > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -150,7 +144,7 @@ pub fn write_fixed_probe(stream: &mut WriteStream<'_>, value: &FixedProbe) -> Re
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] < -524288 || value.samples[i] > 524288 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+        if value.samples[i] < -524288 || value.samples[i] > 524288 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -208,28 +202,28 @@ pub const UNSIGNED_PROBE_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe) -> Result {
-    if value.angle > 23592960 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.angle > 23592960 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 360)?;
     }
-    if value.span > 18446744073709486080 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.span > 18446744073709486080 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.span;
         stream.serialize_fixed(&mut fixed_value, 48, 16, 0, 281474976710655)?;
     }
-    if value.reach > 131072000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.reach > 131072000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, 0, 2000000)?;
     }
-    if value.ticks > 1000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.ticks > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -237,7 +231,7 @@ pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe)
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] > 1048576 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+        if value.samples[i] > 1048576 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -245,7 +239,7 @@ pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe)
             stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 16)?;
         }
     }
-    if value.locked < 196608 || value.locked > 196608 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.locked < 196608 || value.locked > 196608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -320,21 +314,21 @@ pub fn write_wide_probe(stream: &mut WriteStream<'_>, value: &WideProbe) -> Resu
         let mut raw_value = value.entity_id;
         stream.serialize_u128(&mut raw_value)?;
     }
-    if value.energy < -5000000000 || value.energy > 5000000000 { // out-of-contract writes are refused, not wrapped
+    if value.energy < -5000000000 || value.energy > 5000000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut range_value = value.energy;
         stream.serialize_int128(&mut range_value, -5000000000, 5000000000)?;
     }
-    if value.flux < -1267650600228229401496703205376 || value.flux > 1267650600228229401496703205376 { // out-of-contract writes are refused, not wrapped
+    if value.flux < -1267650600228229401496703205376 || value.flux > 1267650600228229401496703205376 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut range_value = value.flux;
         stream.serialize_int128(&mut range_value, -1267650600228229401496703205376, 1267650600228229401496703205376)?;
     }
-    if value.bias < -1000 || value.bias > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.bias < -1000 || value.bias > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -416,7 +410,7 @@ pub fn write_ludicrous_state(stream: &mut WriteStream<'_>, value: &LudicrousStat
     }
     write_fixed_probe(stream, &value.probe)?;
     write_wide_probe(stream, &value.wide)?;
-    if value.keys_count < 0 || value.keys_count > 4 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.keys_count < 0 || value.keys_count > 4 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -493,13 +487,13 @@ pub const DEGENERATE_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_degenerate_probe(stream: &mut WriteStream<'_>, value: &DegenerateProbe) -> Result {
-    if value.locked_fixed < -196608 || value.locked_fixed > -196608 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.locked_fixed < -196608 || value.locked_fixed > -196608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    if value.locked_int < 7 || value.locked_int > 7 { // out-of-contract writes are refused, not wrapped
+    if value.locked_int < 7 || value.locked_int > 7 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    if value.locked_wide < -12345678901234 || value.locked_wide > -12345678901234 { // out-of-contract writes are refused, not wrapped
+    if value.locked_wide < -12345678901234 || value.locked_wide > -12345678901234 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -522,8 +516,7 @@ pub fn read_degenerate_probe(stream: &mut ReadStream<'_>, value: &mut Degenerate
     Ok(())
 }
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct FixedVec {
@@ -550,21 +543,21 @@ pub const FIXED_VEC_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_vec(stream: &mut WriteStream<'_>, value: &FixedVec) -> Result {
-    if value.x < -6553600000 || value.x > 6553600000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.x < -6553600000 || value.x > 6553600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.y < -6553600000 || value.y > 6553600000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.y < -6553600000 || value.y > 6553600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.z < -6553600000 || value.z > 6553600000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.z < -6553600000 || value.z > 6553600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -582,8 +575,7 @@ pub fn read_fixed_vec(stream: &mut ReadStream<'_>, value: &mut FixedVec) -> Resu
     Ok(())
 }
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct FixedQuat {
@@ -623,28 +615,28 @@ pub const FIXED_QUAT_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_quat(stream: &mut WriteStream<'_>, value: &FixedQuat) -> Result {
-    if value.x < -1073741824 || value.x > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.x < -1073741824 || value.x > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.y < -1073741824 || value.y > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.y < -1073741824 || value.y > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.z < -1073741824 || value.z > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.z < -1073741824 || value.z > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.z;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.w < -1073741824 || value.w > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.w < -1073741824 || value.w > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -671,7 +663,7 @@ pub struct BodyState {
     pub position: FixedVec,
     pub rotation: FixedQuat,
     pub velocity: FixedVec,
-    pub spin: f64, //  | local — no wire
+    pub spin: f64, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1063,7 +1055,7 @@ pub enum Message {
 // write_*) flatten into its body, but the dispatch match itself stays a
 // call boundary — demanding the C++ twin into a batch build loop was
 // measured to slow that loop ~21% while every per-message row kept its
-// win with the boundary in place (schema #60). The compiler remains free
+// win with the boundary in place. The compiler remains free
 // to inline it where that pays.
 #[inline]
 pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result {
@@ -1085,7 +1077,7 @@ pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result 
 // read_message_into for reuse loops — hoist ONE Message and read every
 // message into it (the Go/C# MessageStorage discipline). Reuse removes the
 // per-message copy-out of the union and measured 2.6x on the steady-state
-// batch read (M2, 2026-08-06). The two surfaces stay separate on purpose —
+// batch read. The two surfaces stay separate on purpose —
 // see the note on read_message.
 #[inline]
 pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {
@@ -1112,8 +1104,8 @@ pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> 
 // read_message decodes the next message by value — the one-shot surface.
 // It deliberately does NOT delegate to read_message_into: routing the
 // return through a &mut out-param defeated LLVM's in-place construction
-// of the returned union and cost the batch read 23% (measured M2,
-// 2026-08-06). Both surfaces stay; reuse loops call read_message_into.
+// of the returned union, measured at 23% on the batch read. Both
+// surfaces stay; reuse loops call read_message_into.
 #[inline]
 pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {
     let mut tag_value = MessageType::NONE;

--- a/generated/rust/src/enums.rs
+++ b/generated/rust/src/enums.rs
@@ -19,13 +19,7 @@ impl Team {
 
 /// Debug/log name for any `Team` value, out-of-set included.
 pub fn enum_name_team(value: Team) -> &'static str {
-    enum_name_team_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_team`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_team_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Red",
         2 => "Blue",
@@ -51,13 +45,7 @@ impl ShipType {
 
 /// Debug/log name for any `ShipType` value, out-of-set included.
 pub fn enum_name_ship_type(value: ShipType) -> &'static str {
-    enum_name_ship_type_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_ship_type`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_ship_type_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Fighter",
         2 => "Corvette",
@@ -84,13 +72,7 @@ impl MissileType {
 
 /// Debug/log name for any `MissileType` value, out-of-set included.
 pub fn enum_name_missile_type(value: MissileType) -> &'static str {
-    enum_name_missile_type_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_missile_type`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_missile_type_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Heatseeker",
         2 => "Torpedo",
@@ -118,13 +100,7 @@ impl PropType {
 
 /// Debug/log name for any `PropType` value, out-of-set included.
 pub fn enum_name_prop_type(value: PropType) -> &'static str {
-    enum_name_prop_type_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_prop_type`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_prop_type_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Asteroid",
         2 => "Chunk",
@@ -149,13 +125,7 @@ impl Pending {
 
 /// Debug/log name for any `Pending` value, out-of-set included.
 pub fn enum_name_pending(value: Pending) -> &'static str {
-    enum_name_pending_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_pending`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_pending_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         _ => "???",
     }

--- a/generated/rust/src/messages.rs
+++ b/generated/rust/src/messages.rs
@@ -85,21 +85,21 @@ pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
         let mut raw_value = value.test_a as u32;
         stream.serialize_bits(&mut raw_value, 16)?;
     }
-    if value.test_b < 0 || value.test_b > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.test_b < 0 || value.test_b > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.test_b as u32;
         stream.serialize_bits(&mut offset_value, 10)?;
     }
-    if value.test_c < 0 || value.test_c > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.test_c < 0 || value.test_c > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.test_c as u32;
         stream.serialize_bits(&mut offset_value, 10)?;
     }
-    if value.test_d < 0 || value.test_d > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.test_d < 0 || value.test_d > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -159,7 +159,7 @@ pub const BLOCK_MAX_BYTES: usize = 2008;
 
 #[inline(always)]
 pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
-    if value.data_length < 0 || value.data_length > 2000 { // refused, not wrapped or panicked: guards the slice too
+    if value.data_length < 0 || value.data_length > 2000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -202,7 +202,7 @@ pub const CHAT_MAX_BYTES: usize = 264;
 
 #[inline(always)]
 pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
-    if value.text_length < 0 || value.text_length > 256 { // refused, not wrapped or panicked: guards the slice too
+    if value.text_length < 0 || value.text_length > 256 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     debug_assert!(
@@ -372,7 +372,7 @@ pub enum Message {
 // write_*) flatten into its body, but the dispatch match itself stays a
 // call boundary — demanding the C++ twin into a batch build loop was
 // measured to slow that loop ~21% while every per-message row kept its
-// win with the boundary in place (schema #60). The compiler remains free
+// win with the boundary in place. The compiler remains free
 // to inline it where that pays.
 #[inline]
 pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result {
@@ -414,7 +414,7 @@ pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result 
 // read_message_into for reuse loops — hoist ONE Message and read every
 // message into it (the Go/C# MessageStorage discipline). Reuse removes the
 // per-message copy-out of the union and measured 2.6x on the steady-state
-// batch read (M2, 2026-08-06). The two surfaces stay separate on purpose —
+// batch read. The two surfaces stay separate on purpose —
 // see the note on read_message.
 #[inline]
 pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {
@@ -476,8 +476,8 @@ pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> 
 // read_message decodes the next message by value — the one-shot surface.
 // It deliberately does NOT delegate to read_message_into: routing the
 // return through a &mut out-param defeated LLVM's in-place construction
-// of the returned union and cost the batch read 23% (measured M2,
-// 2026-08-06). Both surfaces stay; reuse loops call read_message_into.
+// of the returned union, measured at 23% on the batch read. Both
+// surfaces stay; reuse loops call read_message_into.
 #[inline]
 pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {
     let mut tag_value = MessageType::NONE;

--- a/generated/rust/src/objects.rs
+++ b/generated/rust/src/objects.rs
@@ -52,11 +52,11 @@ pub struct ClientShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, //  | local — no wire
-    pub previous_position: Vec3, //  | local — no wire
-    pub num_colliders: i32, //  | local — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
-    pub predicted_explode: bool, //  | local, context = client
+    pub invulnerable: bool, // | local — no wire
+    pub previous_position: Vec3, // | local — no wire
+    pub num_colliders: i32, // | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // | local — no wire
+    pub predicted_explode: bool, // | local, context = client
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -126,10 +126,10 @@ pub struct ServerShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, //  | local — no wire
-    pub previous_position: Vec3, //  | local — no wire
-    pub num_colliders: i32, //  | local — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
+    pub invulnerable: bool, // | local — no wire
+    pub previous_position: Vec3, // | local — no wire
+    pub num_colliders: i32, // | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -395,14 +395,14 @@ pub fn write_ship_data_deep(stream: &mut WriteStream<'_>, value: &ShipData_Deep)
         let mut float_value = value.aim_velocity;
         stream.serialize_f32(&mut float_value)?;
     }
-    if value.laser_index < 0 || value.laser_index > 15 { // out-of-contract writes are refused, not wrapped
+    if value.laser_index < 0 || value.laser_index > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.laser_index as u32;
         stream.serialize_bits(&mut offset_value, 4)?;
     }
-    if value.missile_index < 0 || value.missile_index > 15 { // out-of-contract writes are refused, not wrapped
+    if value.missile_index < 0 || value.missile_index > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -761,8 +761,8 @@ pub struct ClientMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, //  | local — no wire
-    pub target: Handle, //  | local — no wire
+    pub angular_velocity: Vec3, // | local — no wire
+    pub target: Handle, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -791,9 +791,9 @@ pub struct ServerMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, //  | local — no wire
-    pub target: Handle, //  | local — no wire
-    pub timer: f64, //  | local, context = server
+    pub angular_velocity: Vec3, // | local — no wire
+    pub target: Handle, // | local — no wire
+    pub timer: f64, // | local, context = server
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1221,7 +1221,7 @@ pub struct DynamicPropState {
     pub linear_velocity: Vec3,
     pub flags: u64,
     pub team: Team,
-    pub angular_velocity: Vec3, //  | local — no wire
+    pub angular_velocity: Vec3, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1645,7 +1645,7 @@ pub struct TurretState {
     pub turret_index: i32, // wire [0, 255]
     pub rotation: Quat,
     pub flags: u64,
-    pub team: Team, //  | local — no wire
+    pub team: Team, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1744,7 +1744,7 @@ pub const TURRET_DATA_DEEP_MAX_BYTES: usize = 48; // rounded up to the 8-byte wr
 #[inline(always)]
 pub fn write_turret_data_deep(stream: &mut WriteStream<'_>, value: &TurretData_Deep) -> Result {
     write_handle(stream, &value.parent)?;
-    if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
+    if value.turret_index < 0 || value.turret_index > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -1774,7 +1774,7 @@ pub const TURRET_DATA_SHALLOW_MAX_BYTES: usize = 24; // rounded up to the 8-byte
 #[inline(always)]
 pub fn write_turret_data_shallow(stream: &mut WriteStream<'_>, value: &TurretData_Shallow) -> Result {
     write_handle(stream, &value.parent)?;
-    if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
+    if value.turret_index < 0 || value.turret_index > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {

--- a/generated/rust/src/render.rs
+++ b/generated/rust/src/render.rs
@@ -121,7 +121,7 @@ pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> 
         let mut raw_value = value.sprite_count_hint;
         stream.serialize_bits(&mut raw_value, 32)?;
     }
-    if value.sprites_count < 0 || value.sprites_count > 64 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.sprites_count < 0 || value.sprites_count > 64 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {

--- a/generated/rust/src/types.rs
+++ b/generated/rust/src/types.rs
@@ -7,8 +7,7 @@
 use crate::*;
 use serialize::{ReadStream, Stream, WriteStream};
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Vec3 {
@@ -58,8 +57,7 @@ pub fn read_vec3(stream: &mut ReadStream<'_>, value: &mut Vec3) -> Result {
     Ok(())
 }
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Quat {
@@ -141,7 +139,7 @@ pub const HANDLE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
-    if value.object_id < 0 || value.object_id > 9999 { // out-of-contract writes are refused, not wrapped
+    if value.object_id < 0 || value.object_id > 9999 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -193,21 +191,21 @@ pub const QUANTIZED_POSITION_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedPosition) -> Result {
-    if value.x < -8388608 || value.x > 8388608 { // out-of-contract writes are refused, not wrapped
+    if value.x < -8388608 || value.x > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 25)?;
     }
-    if value.y < -8388608 || value.y > 8388608 { // out-of-contract writes are refused, not wrapped
+    if value.y < -8388608 || value.y > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 25)?;
     }
-    if value.z < -8388608 || value.z > 8388608 { // out-of-contract writes are refused, not wrapped
+    if value.z < -8388608 || value.z > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -252,21 +250,21 @@ pub const QUANTIZED_VELOCITY_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedVelocity) -> Result {
-    if value.x < -2097152 || value.x > 2097152 { // out-of-contract writes are refused, not wrapped
+    if value.x < -2097152 || value.x > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 23)?;
     }
-    if value.y < -2097152 || value.y > 2097152 { // out-of-contract writes are refused, not wrapped
+    if value.y < -2097152 || value.y > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 23)?;
     }
-    if value.z < -2097152 || value.z > 2097152 { // out-of-contract writes are refused, not wrapped
+    if value.z < -2097152 || value.z > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -313,28 +311,28 @@ pub const QUANTIZED_ROTATION_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedRotation) -> Result {
-    if value.x < -1024 || value.x > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.x < -1024 || value.x > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 12)?;
     }
-    if value.y < -1024 || value.y > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.y < -1024 || value.y > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 12)?;
     }
-    if value.z < -1024 || value.z > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.z < -1024 || value.z > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 12)?;
     }
-    if value.w < -1024 || value.w > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.w < -1024 || value.w > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -594,7 +592,7 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
         let mut raw_value = value.start_frame;
         stream.serialize_bits64(&mut raw_value, 64)?;
     }
-    if value.inputs_count < 0 || value.inputs_count > 16 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.inputs_count < 0 || value.inputs_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -699,14 +697,14 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
         let mut offset_value = value.team.0 as u32;
         stream.serialize_bits(&mut offset_value, 2)?;
     }
-    if value.health < 0 || value.health > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.health < 0 || value.health > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.health as u32;
         stream.serialize_bits(&mut offset_value, 10)?;
     }
-    if value.thrust < 0 || value.thrust > 100 { // out-of-contract writes are refused, not wrapped
+    if value.thrust < 0 || value.thrust > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -787,14 +785,14 @@ pub const EXPRESSION_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_expression_probe(stream: &mut WriteStream<'_>, value: &ExpressionProbe) -> Result {
-    if value.hardpoint_index < 0 || value.hardpoint_index > 31 { // out-of-contract writes are refused, not wrapped
+    if value.hardpoint_index < 0 || value.hardpoint_index > 31 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.hardpoint_index as u32;
         stream.serialize_bits(&mut offset_value, 5)?;
     }
-    if value.spin_rate < 1024 || value.spin_rate > 2048 { // out-of-contract writes are refused, not wrapped
+    if value.spin_rate < 1024 || value.spin_rate > 2048 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -858,14 +856,14 @@ pub const EXTREME_PROBE_MAX_BYTES: usize = 40;
 
 #[inline(always)]
 pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -> Result {
-    if value.floor_bound > 100 { // out-of-contract writes are refused, not wrapped
+    if value.floor_bound > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
         stream.serialize_bits64(&mut offset_value, 64)?;
     }
-    if value.doubled_floor > 100 { // out-of-contract writes are refused, not wrapped
+    if value.doubled_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -953,7 +951,7 @@ pub const EXTREME_ROW_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_extreme_row(stream: &mut WriteStream<'_>, value: &ExtremeRow) -> Result {
-    if value.clamped_floor > 100 { // out-of-contract writes are refused, not wrapped
+    if value.clamped_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -31,13 +31,7 @@ impl Weapon {
 
 /// Debug/log name for any `Weapon` value, out-of-set included.
 pub fn enum_name_weapon(value: Weapon) -> &'static str {
-    enum_name_weapon_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_weapon`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_weapon_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Laser",
         2 => "Missile",
@@ -273,7 +267,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
     }
     {
         let mut compressed_value = value.orientation;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
     }
     {
         let mut raw_value = value.raw_delta as u32;
@@ -307,7 +301,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
             stream.serialize_bits(&mut raw_value, 32)?;
         }
     }
-    if value.samples_count < 1 || value.samples_count > 8 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.samples_count < 1 || value.samples_count > 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -326,7 +320,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
 #[inline]
 pub fn read_probe_sample(stream: &mut ReadStream<'_>, value: &mut ProbeSample) -> Result {
     stream.serialize_bool(&mut value.active)?;
-    stream.serialize_compressed_float_precomputed(&mut value.orientation, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.orientation, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
     {
         let mut raw_value: u32 = 0;
         stream.serialize_bits(&mut raw_value, 32)?;
@@ -436,7 +430,7 @@ pub const PROBE_SLAB_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_slab(stream: &mut WriteStream<'_>, value: &ProbeSlab) -> Result {
-    if value.width > 100 { // out-of-contract writes are refused, not wrapped
+    if value.width > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -568,7 +562,7 @@ pub fn write_probe_collider(stream: &mut WriteStream<'_>, value: &ProbeCollider)
     }
     write_probe_shape(stream, &value.shape)?;
     write_probe_shape(stream, &value.backup)?;
-    if value.extras_count < 0 || value.extras_count > 2 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.extras_count < 0 || value.extras_count > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -837,21 +831,21 @@ pub const TEST_DATA_MAX_BYTES: usize = 344;
 
 #[inline(always)]
 pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result {
-    if value.a < -100 || value.a > 100 { // out-of-contract writes are refused, not wrapped
+    if value.a < -100 || value.a > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.a as u32).wrapping_sub((-100_i32) as u32);
         stream.serialize_bits(&mut offset_value, 8)?;
     }
-    if value.b < -100 || value.b > 100 { // out-of-contract writes are refused, not wrapped
+    if value.b < -100 || value.b > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.b as u32).wrapping_sub((-100_i32) as u32);
         stream.serialize_bits(&mut offset_value, 8)?;
     }
-    if value.c < -100 || value.c > 150 { // out-of-contract writes are refused, not wrapped
+    if value.c < -100 || value.c > 150 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -883,7 +877,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut bool_value = value.g;
         stream.serialize_bool(&mut bool_value)?;
     }
-    if value.items_count < 0 || value.items_count > 16 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.items_count < 0 || value.items_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -891,7 +885,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] < 0 || value.items[i] > 255 { // out-of-contract writes are refused, not wrapped
+        if value.items[i] < 0 || value.items[i] > 255 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -905,7 +899,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     }
     {
         let mut compressed_value = value.compressed_float_value;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     }
     {
         let mut float_value = value.double_value;
@@ -939,7 +933,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut raw_value = value.int64_full as u64;
         stream.serialize_bits64(&mut raw_value, 64)?;
     }
-    if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 { // out-of-contract writes are refused, not wrapped
+    if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -948,7 +942,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     }
     stream.serialize_align()?;
     stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
-    if value.text_length < 0 || value.text_length > 255 { // refused, not wrapped or panicked: guards the slice too
+    if value.text_length < 0 || value.text_length > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     debug_assert!(
@@ -977,7 +971,7 @@ pub fn read_test_data(stream: &mut ReadStream<'_>, value: &mut TestData) -> Resu
         stream.serialize_int(&mut value.items[i], 0, 255)?;
     }
     stream.serialize_f32(&mut value.float_value)?;
-    stream.serialize_compressed_float_precomputed(&mut value.compressed_float_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.compressed_float_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     stream.serialize_f64(&mut value.double_value)?;
     {
         let mut raw_value: u32 = 0;
@@ -1046,19 +1040,19 @@ pub const COMPRESSED_PROBE_MAX_BYTES: usize = 8;
 pub fn write_compressed_probe(stream: &mut WriteStream<'_>, value: &CompressedProbe) -> Result {
     {
         let mut compressed_value = value.boundary;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     }
     {
         let mut compressed_value = value.offset;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation
     }
     Ok(())
 }
 
 #[inline]
 pub fn read_compressed_probe(stream: &mut ReadStream<'_>, value: &mut CompressedProbe) -> Result {
-    stream.serialize_compressed_float_precomputed(&mut value.boundary, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
-    stream.serialize_compressed_float_precomputed(&mut value.offset, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.boundary, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
+    stream.serialize_compressed_float_precomputed(&mut value.offset, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation
     Ok(())
 }
 

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -109,6 +109,7 @@ type gen struct {
 	needs128 bool // a 128-bit or Q112.16 storage member needs serialize.h in the DATA header
 
 	emitMessagesPending bool // this file owns the message dispatch surface
+	saidReadSlack       bool // the read-slack buffer contract is stated once per file, on its first MAX_BYTES
 	file                *ir.File
 	msgOwner            string
 	objOwner            string
@@ -155,13 +156,25 @@ func (g *gen) assembleHeader() []byte {
 	g.header(&h, g.file.Base)
 	guard := g.guardName("")
 	fmt.Fprintf(&h, "#ifndef %s\n#define %s\n\n", guard, guard)
-	h.WriteString("#include <stdint.h>\n#include <string.h>   /* memset — the zero form (SPEC §4.2) */\n#include <math.h>     /* floor — the quantize pair */\n")
+	// includes follow what the body actually emitted, so a header never
+	// carries an include nothing in it uses (a contains check can only ever
+	// keep one too many, never drop one in use)
+	body := g.body.String()
+	h.WriteString("#include <stdint.h>\n")
+	if strings.Contains(body, "memset") {
+		h.WriteString("#include <string.h>   /* memset — the zero form (SPEC §4.2) */\n")
+	}
+	if strings.Contains(body, "floor") {
+		h.WriteString("#include <math.h>     /* floor — the quantize pair */\n")
+	}
 	if g.needs128 {
 		// serialize_int128_t / serialize_uint128_t are STORAGE here, so the
 		// runtime header has to reach the data header and not only the wire one
 		h.WriteString("#include \"serialize.h\"   /* serialize_int128_t: C has no 128-bit builtin */\n")
 	}
-	h.WriteString(unusedMacro)
+	if strings.Contains(body, "SCHEMA_UNUSED") {
+		h.WriteString(unusedMacro)
+	}
 	for _, d := range g.deps {
 		fmt.Fprintf(&h, "#include \"%s.h\"\n", d)
 	}
@@ -178,8 +191,14 @@ func (g *gen) assembleWireHeader() []byte {
 	guard := g.guardName("WIRE")
 	fmt.Fprintf(&h, "#ifndef %s\n#define %s\n\n", guard, guard)
 	fmt.Fprintf(&h, "#include \"%s.h\"\n", g.file.Base)
-	h.WriteString("#include <string.h>   /* memset, strlen */\n#include \"serialize.h\"\n")
-	h.WriteString(unusedMacro)
+	body := g.body.String()
+	if strings.Contains(body, "memset") || strings.Contains(body, "strlen") {
+		h.WriteString("#include <string.h>   /* memset, strlen */\n")
+	}
+	h.WriteString("#include \"serialize.h\"\n")
+	if strings.Contains(body, "SCHEMA_UNUSED") {
+		h.WriteString(unusedMacro)
+	}
 	for _, d := range g.deps {
 		fmt.Fprintf(&h, "#include \"%sWire.h\"\n", d)
 	}
@@ -323,22 +342,8 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	g.pf("static SCHEMA_UNUSED const char * enum_name_%s( %s value )\n{\n", snake(d.Name), d.Name)
 	g.pf("    switch ( value )\n    {\n")
 	g.pf("        case %s_NONE: return \"None\";\n", screaming(d.Name))
-	for i, v := range d.Variants {
-		g.pf("        case %d: return %q;\n", i+1, v)
-	}
-	g.pf("        default: return \"???\";\n    }\n}\n\n")
-
-	// The wire-value form the table reflection descriptors hold. They store a
-	// uint64_t-taking function pointer, so the typed one above cannot be used
-	// directly -- a function pointer conversion between differing parameter
-	// types is undefined behaviour, not merely a warning.
-	g.pf("/* As enum_name_%s, over a raw wire value — the form the table reflection\n", snake(d.Name))
-	g.pf("   descriptors hold. */\n")
-	g.pf("static SCHEMA_UNUSED const char * enum_name_%s_dyn( uint64_t value )\n{\n", snake(d.Name))
-	g.pf("    switch ( value )\n    {\n")
-	g.pf("        case 0: return \"None\";\n")
-	for i, v := range d.Variants {
-		g.pf("        case %d: return %q;\n", i+1, v)
+	for _, v := range d.Variants {
+		g.pf("        case %s_%s: return %q;\n", screaming(d.Name), screaming(v), v)
 	}
 	g.pf("        default: return \"???\";\n    }\n}\n\n")
 }
@@ -418,7 +423,17 @@ func (g *gen) emitUnion(d *ir.Union) {
 
 	maxBits := ir.MaxBitsUnion(d)
 	g.pf("#define %s_MAX_BITS %d   /* tag + the largest arm; None costs the tag only (SPEC §4.8) */\n", screaming(d.Name), maxBits)
-	g.pf("#define %s_MAX_BYTES %d  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */\n\n", screaming(d.Name), ir.MaxBytes(maxBits))
+	g.pf("#define %s_MAX_BYTES %d  %s\n\n", screaming(d.Name), ir.MaxBytes(maxBits), g.maxBytesTail())
+}
+
+// maxBytesTail is the comment after a MAX_BYTES define: the whole buffer
+// contract on the file's first, the short form after.
+func (g *gen) maxBytesTail() string {
+	if g.saidReadSlack {
+		return "/* 8-byte write granularity; read slack per the contract above */"
+	}
+	g.saidReadSlack = true
+	return "/* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */"
 }
 
 func (g *gen) emitField(f *ir.Field) {
@@ -544,6 +559,13 @@ func (g *gen) emitWireHeader() {
 	}
 
 	if g.fileEmitsWire() {
+		// the calling convention, once per wire header — the per-function
+		// comments below it stay one line each
+		g.pf("/* Every write_x/read_x returns 1 on success, 0 on failure — the stream\n")
+		g.pf("   latches the error, so a caller may check once at the end of a message.\n")
+		g.pf("   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE\n")
+		g.pf("   it rides, and a read zero-establishes the selected arm before decoding\n")
+		g.pf("   it (SPEC §4.8, §5). */\n\n")
 		g.emitSpineInlineMacros()
 	}
 	if fileHasStrings(g.file) {
@@ -577,8 +599,7 @@ func (g *gen) emitUnionWire(d *ir.Union) {
 	tag := d.Name + "Type"
 	bits := ir.BitsRequired(big.NewInt(0), big.NewInt(d.Max))
 
-	g.pf("/* Writes %s. Returns 1 on success, 0 on failure. The tag is validated\n", d.Name)
-	g.pf("   BEFORE it rides: an out-of-set tag writes nothing (SPEC §4.8). */\n")
+	g.pf("/* Writes %s. */\n", d.Name)
 	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_%s( serialize_write_stream_t * stream, const %s * value )\n{\n", snake(d.Name), d.Name)
 	if d.Max == 0 {
 		g.pf("    (void) stream; /* only None exists; the degenerate tag range [0, 0] costs zero bits */\n")
@@ -594,8 +615,7 @@ func (g *gen) emitUnionWire(d *ir.Union) {
 		g.pf("    }\n}\n\n")
 	}
 
-	g.pf("/* Reads %s. Returns 1 on success, 0 on failure — a tag above %s_MAX is\n", d.Name, screaming(tag))
-	g.pf("   refused (SPEC §4.8); the selected arm is zero-established before decoding (§5). */\n")
+	g.pf("/* Reads %s. */\n", d.Name)
 	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_%s( serialize_read_stream_t * stream, %s * value )\n{\n", snake(d.Name), d.Name)
 	if d.Max == 0 {
 		g.pf("    (void) stream; /* zero wire bits — only None exists */\n")
@@ -623,8 +643,7 @@ func (g *gen) emitWriteFunc(st *ir.Struct) {
 	// is byte-identical (the same switch, off the same analysis, as the C++
 	// backend)
 	g.bulkBytes = ir.AlignedFixedByteArrays(st)
-	g.pf("/* Writes %s. Returns 1 on success, 0 on failure — the stream latches the\n", st.Name)
-	g.pf("   error, so a caller may check once at the end of a message. */\n")
+	g.pf("/* Writes %s. */\n", st.Name)
 	g.pf("static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_%s( serialize_write_stream_t * stream, const %s * value )\n{\n", snake(st.Name), st.Name)
 	// The early-out is keyed on ITEMS, not fields: a struct whose only items
 	// are reserved/const/align has no storage but DOES have wire bits, and
@@ -650,8 +669,7 @@ func (g *gen) emitWriteFunc(st *ir.Struct) {
 
 func (g *gen) emitReadFunc(st *ir.Struct) {
 	g.bulkBytes = ir.AlignedFixedByteArrays(st) // see emitWriteFunc
-	g.pf("/* Reads %s. Returns 1 on success, 0 on failure. Out-of-range values are\n", st.Name)
-	g.pf("   REFUSED, never clamped. */\n")
+	g.pf("/* Reads %s. */\n", st.Name)
 	g.pf("static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_%s( serialize_read_stream_t * stream, %s * value )\n{\n", snake(st.Name), st.Name)
 	if len(st.Items) == 0 {
 		g.pf("    (void) stream;\n    (void) value;\n    return 1;\n}\n\n")

--- a/internal/codegen/c/dispatch.go
+++ b/internal/codegen/c/dispatch.go
@@ -22,8 +22,8 @@ func (g *gen) emitMaxBits(st *ir.Struct) {
 	bits := ir.MaxBitsStruct(st)
 	g.pf("#define %s_MAX_BITS %d   /* longest wire path; align pads at worst case (SPEC §6.1) */\n",
 		screaming(st.Name), bits)
-	g.pf("#define %s_MAX_BYTES %d  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */\n\n",
-		screaming(st.Name), ir.MaxBytes(bits))
+	g.pf("#define %s_MAX_BYTES %d  %s\n\n",
+		screaming(st.Name), ir.MaxBytes(bits), g.maxBytesTail())
 }
 
 // ---- specified defaults ----

--- a/internal/codegen/c/spineinline.go
+++ b/internal/codegen/c/spineinline.go
@@ -37,11 +37,10 @@ func (g *gen) fileEmitsWire() bool {
 // probe_header-sized messages. Unlike the C++ read-spine case this is not
 // the fallible-chain frequency decay — it is a plain cost-over-threshold
 // refusal, the same in both directions, hence the demand covers both. Both
-// halves shipped first as default-off switches, then swept their tournament
-// A/Bs with zero regressions across 34 rows (tournament-air; the write half's
-// rigidbody_moving write +1016%; reconfirmed confirmation-air r2), so per the
-// feature lifecycle the winners became unconditional code and the switches
-// were deleted. The demand is a DEMAND, not a branch-weight hint:
+// halves swept their tournament A/Bs with zero regressions across 34 rows
+// (tournament-air; the write half's rigidbody_moving write +1016%;
+// reconfirmed confirmation-air r2). The demand is a DEMAND, not a
+// branch-weight hint:
 // __builtin_expect-style cold hints were measured in this family to activate
 // the machine outliner and shred hot bodies (bits write -25%) — do not swap
 // this for hints. Guarded against redefinition because several wire headers

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -196,6 +196,7 @@ type gen struct {
 	nativeIncludes map[string]bool    // cpp_include headers of referenced native-mapped types
 	emitted        map[string]bool    // consts of this file emitted so far (symbolic-reference safety)
 	bulkBytes      map[*ir.Field]bool // fixed [N]uint8 arrays at statically byte-aligned positions (ir.AlignedFixedByteArrays)
+	saidReadSlack  bool               // the read-slack buffer contract is stated once per file, on its first MaxBytes
 	needsSerialize bool               // the file emits wire functions -> include "serialize.h"
 	needsCstring   bool               // the file emits memset -> include <cstring>
 	needsCmath     bool               // the file emits floor() -> include <cmath>
@@ -512,8 +513,7 @@ func (g *gen) emitStruct(d *ir.Struct) {
 		kind = "message"
 	}
 	if len(d.Tags) > 0 {
-		g.pf("// %s %s [%s] — the tag is user-chosen and inert in v1; the delta pass\n", kind, d.Name, strings.Join(d.Tags, ", "))
-		g.pf("// claims tags and assigns actions (SPEC §4.2, Type tags)\n")
+		g.pf("// %s %s [%s] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)\n", kind, d.Name, strings.Join(d.Tags, ", "))
 	} else {
 		g.pf("// %s %s\n", kind, d.Name)
 	}
@@ -752,9 +752,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
+			parts = append(parts, fmt.Sprintf("| local, context = %s", f.Context))
 		} else {
-			parts = append(parts, " | local — no wire")
+			parts = append(parts, "| local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -27,11 +27,22 @@ func (g *gen) maxBitsStruct(st *ir.Struct) int64 { return ir.MaxBitsStruct(st) }
 // the allocation backing a read buffer must extend at least 8 bytes past
 // the data (serialize::BitReader loads unconditional 64-bit windows), so a
 // caller sizing a receive allocation at exactly MaxBytes would be handing
-// the reader undefined behavior.
+// the reader undefined behavior. The full contract is stated once per file
+// (maxBytesTail); every later MaxBytes carries the short form.
 func (g *gen) emitStructMaxBits(st *ir.Struct) {
 	maxBits := g.maxBitsStruct(st)
 	g.pf("inline constexpr int64_t %sMaxBits = %d; // longest wire path; align pads at worst case (SPEC §6.1)\n", st.Name, maxBits)
-	g.pf("inline constexpr int64_t %sMaxBytes = %d; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows\n\n", st.Name, ir.MaxBytes(maxBits))
+	g.pf("inline constexpr int64_t %sMaxBytes = %d;%s\n\n", st.Name, ir.MaxBytes(maxBits), g.maxBytesTail())
+}
+
+// maxBytesTail is the comment after a MaxBytes constant: the whole buffer
+// contract on the file's first, the short form after.
+func (g *gen) maxBytesTail() string {
+	if g.saidReadSlack {
+		return " // 8-byte write granularity; read slack per the contract above"
+	}
+	g.saidReadSlack = true
+	return " // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows"
 }
 
 // emitUnionMaxBits mirrors emitStructMaxBits: the tag plus the largest arm
@@ -39,7 +50,7 @@ func (g *gen) emitStructMaxBits(st *ir.Struct) {
 func (g *gen) emitUnionMaxBits(d *ir.Union) {
 	maxBits := ir.MaxBitsUnion(d)
 	g.pf("inline constexpr int64_t %sMaxBits = %d; // tag + the largest arm; None costs the tag only (SPEC §4.8)\n", d.Name, maxBits)
-	g.pf("inline constexpr int64_t %sMaxBytes = %d; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows\n\n", d.Name, ir.MaxBytes(maxBits))
+	g.pf("inline constexpr int64_t %sMaxBytes = %d;%s\n\n", d.Name, ir.MaxBytes(maxBits), g.maxBytesTail())
 }
 
 // emitUnionWire is the message dispatch pair scaled down to a field type
@@ -704,7 +715,7 @@ func (g *gen) emitMessageData() {
 	}
 	g.pf("// The message-level bound: the tag plus the largest message (SPEC §6.1)\n")
 	g.pf("inline constexpr int64_t MessageMaxBits = %d;\n", tagBits+largest)
-	g.pf("inline constexpr int64_t MessageMaxBytes = %d; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows\n\n", ir.MaxBytes(tagBits+largest))
+	g.pf("inline constexpr int64_t MessageMaxBytes = %d;%s\n\n", ir.MaxBytes(tagBits+largest), g.maxBytesTail())
 
 	if g.opts.MessageRepr == "variant" {
 		g.emitMessageStorageVariant()

--- a/internal/codegen/cpp/objects.go
+++ b/internal/codegen/cpp/objects.go
@@ -28,11 +28,11 @@ func (g *gen) emitObjectMaxBits(d *ir.Object) {
 	deepName := d.Name + "Data_Deep"
 	deepBits := g.maxBitsView(deep, viewDeep)
 	g.pf("inline constexpr int64_t %sMaxBits = %d;\n", deepName, deepBits)
-	g.pf("inline constexpr int64_t %sMaxBytes = %d; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows\n\n", deepName, ir.MaxBytes(deepBits))
+	g.pf("inline constexpr int64_t %sMaxBytes = %d;%s\n\n", deepName, ir.MaxBytes(deepBits), g.maxBytesTail())
 	shName := d.Name + "Data_Shallow"
 	shBits := g.maxBitsView(interp, viewShallow)
 	g.pf("inline constexpr int64_t %sMaxBits = %d;\n", shName, shBits)
-	g.pf("inline constexpr int64_t %sMaxBytes = %d; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows\n\n", shName, ir.MaxBytes(shBits))
+	g.pf("inline constexpr int64_t %sMaxBytes = %d;%s\n\n", shName, ir.MaxBytes(shBits), g.maxBytesTail())
 }
 
 // voidIfEmpty emits (void) casts for params when no statement has been

--- a/internal/codegen/cpp/readinline.go
+++ b/internal/codegen/cpp/readinline.go
@@ -39,11 +39,10 @@ func (g *gen) fileEmitsWire() bool {
 // timed loop at cost=1055 against threshold=45, while the C backend's
 // read_message — static in one TU — inlines into its identical loop
 // (last-call-to-static, cost=-13285) and carries no per-message call at all.
-// The demand shipped first as a default-off switch, then won its tournament
+// The demand won its tournament
 // (tournament-air off→armed with the serialize read demand: batch read +68%,
 // rigidbody_at_rest read +244%, testdata read +109%, zero regressions;
-// reconfirmed confirmation-air r2), so per the feature lifecycle the winner
-// became unconditional code and the switch was deleted. The demand is a
+// reconfirmed confirmation-air r2). The demand is a
 // DEMAND, not a branch-weight hint: __builtin_expect-style cold hints were
 // measured in this family to activate the machine outliner and shred hot
 // bodies (bits write -25%) — do not swap this for hints. Guarded against

--- a/internal/codegen/cpp/writeinline.go
+++ b/internal/codegen/cpp/writeinline.go
@@ -22,22 +22,20 @@ package cpp
 // last-call-to-static bonus exists for a linkonce_odr function, so unlike
 // C's static entries these sites never flatten on their own.
 //
-// The demand shipped first as a default-off switch
-// (SCHEMA_WRITE_SPINE_DEMAND, #55). Blanket — WriteMessage included — it
-// swept the per-message write rows but demanded the dispatcher (inline cost
-// ~1555) whole into the batch build loop and regressed it. Scoped —
-// WriteMessage exempted, its callees still flattening into its outlined
-// body — it won the cross-architecture tournament (eras space-55-scoped /
-// air-55-scoped: blended geomean 81.8 vs 99.7 off on Zen 4 gcc, 100.8 vs
-// 137.8 off on Apple M-series clang, % of the C baseline), so per the
-// feature lifecycle the winner became unconditional code and the switch was
-// deleted. The accepted residual: message_batch write +7-16% vs the old off
-// state on both architectures — bounded, and bought back many times over by
-// the per-message rows. The demand is a DEMAND, not a branch-weight hint:
-// __builtin_expect-style cold hints were measured in this family to
-// activate the machine outliner and shred hot bodies (bits write -25%) — do
-// not swap this for hints. Guarded against redefinition because several
-// wire headers can land in one translation unit.
+// The demand is SCOPED: blanket — WriteMessage included — it swept the
+// per-message write rows but demanded the dispatcher (inline cost ~1555)
+// whole into the batch build loop and regressed it; scoped — WriteMessage
+// exempted, its callees still flattening into its outlined body — it won
+// the cross-architecture tournament (bench/results/tournament-air: blended
+// geomean 81.8 vs 99.7 off on Zen 4 gcc, 100.8 vs 137.8 off on Apple
+// M-series clang, % of the C baseline). The accepted residual:
+// message_batch write +7-16% vs no demand on both architectures — bounded,
+// and bought back many times over by the per-message rows. The demand is a
+// DEMAND, not a branch-weight hint: __builtin_expect-style cold hints were
+// measured in this family to activate the machine outliner and shred hot
+// bodies (bits write -25%) — do not swap this for hints. Guarded against
+// redefinition because several wire headers can land in one translation
+// unit.
 func (g *gen) emitWriteInlineMacro() {
 	g.pf("#ifndef SCHEMA_WRITE_INLINE_DEFINED\n#define SCHEMA_WRITE_INLINE_DEFINED\n")
 	g.pf("// SCHEMA_WRITE_INLINE — how every generated Write function is spelled,\n")

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -62,8 +62,8 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	objOwner := ir.ObjectOwner(u)
 	batched, needCore := batchPlan(u)
 	for _, f := range u.Files {
-		g := &gen{unit: u, file: f, msgOwner: msgOwner, objOwner: objOwner, batched: batched, needCore: needCore}
-		g.emitFile(f.Base == home)
+		g := &gen{unit: u, file: f, home: f.Base == home, msgOwner: msgOwner, objOwner: objOwner, batched: batched, needCore: needCore}
+		g.emitFile(g.home)
 		out[f.Base+".cs"] = g.assemble()
 	}
 	return out, nil
@@ -87,6 +87,7 @@ func protocolIdHome(u *ir.Unit) string {
 type gen struct {
 	unit     *ir.Unit
 	file     *ir.File
+	home     bool   // this file carries ProtocolId and the unit-level target notes
 	msgOwner string // the one file that carries the message dispatch surface
 	objOwner string // the one file that carries the object tag surface
 	owner    string // the class whose members are being emitted (CS0542 escape)
@@ -143,14 +144,15 @@ func (g *gen) assemble() []byte {
 	h.WriteString("// your choice. See the LICENSE exception in the schema compiler; the compiler is\n")
 	h.WriteString("// AGPL-3.0, its output is not.\n")
 	fmt.Fprintf(&h, "// package %s — protocol id 0x%016x\n", g.unit.Package, g.unit.ProtocolId)
-	if g.needsSerialize {
+	if g.home {
+		// the unit-level target notes ride the home file only — said once
+		// per unit, not once per file
 		h.WriteString("//\n")
-		h.WriteString("// Storage members are PascalCase via the same mapping as the Go target, so\n")
-		h.WriteString("// the checker's collision registry covers C# for free. Wire functions return\n")
-		h.WriteString("// bool — the C++-style early-out. A schema validation failure (a wrong wire\n")
-		h.WriteString("// constant, nonzero reserved bits, an interior null) returns false WITHOUT\n")
-		h.WriteString("// latching; stream failures latch on stream.Error — the runtime's own sticky\n")
-		h.WriteString("// latch. Callers get bool always; Error tells the two apart.\n")
+		h.WriteString("// Wire functions return bool — the C++-style early-out. A schema validation\n")
+		h.WriteString("// failure (a wrong wire constant, nonzero reserved bits, an interior null)\n")
+		h.WriteString("// returns false WITHOUT latching; stream failures latch on stream.Error —\n")
+		h.WriteString("// the runtime's own sticky latch. Callers get bool always; Error tells the\n")
+		h.WriteString("// two apart.\n")
 	}
 	h.WriteString("\n")
 	if g.needsSystem {
@@ -364,8 +366,7 @@ func (g *gen) emitClass(d *ir.Struct) {
 		kind = "message"
 	}
 	if len(d.Tags) > 0 {
-		g.tf("// %s %s [%s] — the tag is user-chosen and inert in v1; the delta pass\n", kind, d.Name, strings.Join(d.Tags, ", "))
-		g.tf("// claims tags and assigns actions (SPEC §4.2, Type tags)\n")
+		g.tf("// %s %s [%s] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)\n", kind, d.Name, strings.Join(d.Tags, ", "))
 	} else {
 		g.tf("// %s %s\n", kind, d.Name)
 	}
@@ -605,7 +606,7 @@ func (g *gen) fieldComment(f *ir.Field) string {
 		}
 	}
 	if f.HasDefault {
-		parts = append(parts, fmt.Sprintf("= %s at construction; Zero* gives the §5 zero form", g.defaultValue(f, false)))
+		parts = append(parts, "specified default at construction; Zero* gives the §5 zero form")
 	}
 	if f.HasIntRange {
 		parts = append(parts, fmt.Sprintf("wire [%s, %s]", f.IntMin, f.IntMax))
@@ -625,9 +626,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
+			parts = append(parts, fmt.Sprintf("| local, context = %s", f.Context))
 		} else {
-			parts = append(parts, " | local — no wire")
+			parts = append(parts, "| local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -58,22 +58,20 @@ func (g *gen) emitStructFunctions(st *ir.Struct) {
 // emitPair emits the Write/Read pair named pair over the C# type typ, honoring
 // the batch plan: a batched pair keeps its public stream signature but runs an
 // AggressiveInlining batch-form core against register-resident stream state
-// (serialize.cs WriteBatch/ReadBatch — PR #3's emitter follow-up); a pair
-// composed under a batched one gets the core beside its stream form. The two
-// laws the shape obeys — inline-only composition and per-type opt-in by
-// scalar density — are #3's measured rules; see batch.go for the density
-// threshold. Wire bytes and the error model are identical on every path.
+// (serialize.cs WriteBatch/ReadBatch); a pair composed under a batched one
+// gets the core beside its stream form. The two measured laws the shape
+// obeys: inline-only composition and per-type opt-in by scalar density — see
+// batch.go for the density threshold. Wire bytes and the error model are
+// identical on every path.
 func (g *gen) emitPair(pair, typ string, writeBody, readBody func()) {
 	batched := g.batched[pair]
 	if batched {
-		g.sf("// Write%s/Read%s run as a batch: the stream state lives in registers\n", pair, pair)
-		g.sf("// across the body's serialize calls and is stored back once at End —\n")
-		g.sf("// the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same\n")
-		g.sf("// wire bytes, same validation, same latched-error model.\n")
+		g.sf("// batch form: stream state stays in registers across the body and End\n")
+		g.sf("// publishes it — same wire bytes, same validation, same error model.\n")
 		g.sf("public static bool Write%s(WriteStream stream, %s value)\n{\n", pair, typ)
 		g.sf("    WriteBatch batch = stream.BeginBatch();\n")
 		g.sf("    bool result = Write%sBatch(ref batch, value);\n", pair)
-		g.sf("    batch.End(); // on every path out — End publishes the state and the error\n")
+		g.sf("    batch.End();\n")
 		g.sf("    return result;\n}\n\n")
 	} else {
 		g.sf("public static bool Write%s(WriteStream stream, %s value)\n{\n", pair, typ)
@@ -92,7 +90,7 @@ func (g *gen) emitPair(pair, typ string, writeBody, readBody func()) {
 		g.sf("public static bool Read%s(ReadStream stream, %s value)\n{\n", pair, typ)
 		g.sf("    ReadBatch batch = stream.BeginBatch();\n")
 		g.sf("    bool result = Read%sBatch(ref batch, value);\n", pair)
-		g.sf("    batch.End(); // on every path out — End publishes the cursor and the error\n")
+		g.sf("    batch.End();\n")
 		g.sf("    return result;\n}\n\n")
 	} else {
 		g.sf("public static bool Read%s(ReadStream stream, %s value)\n{\n", pair, typ)
@@ -109,15 +107,14 @@ func (g *gen) emitPair(pair, typ string, writeBody, readBody func()) {
 	}
 }
 
-// emitCoreAttr marks a batch core INLINE-ONLY. Law (serialize.cs #3): a real
+// emitCoreAttr marks a batch core INLINE-ONLY. The law, measured: a real
 // call taking `ref WriteBatch` address-exposes the ref struct and
-// enregistration dies for the whole calling scope — measured 0.71x, slower
-// than no batch at all. Composition is core-to-core by ref, always inlined.
+// enregistration dies for the whole calling scope — 0.71x, slower than no
+// batch at all. Composition is core-to-core by ref, always inlined; the
+// emitted comment states the rule once per core without the numbers.
 func (g *gen) emitCoreAttr() {
 	g.needsCompiler = true
-	g.sf("// The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by\n")
-	g.sf("// ref address-exposes it and enregistration dies (measured 0.71x, worse than\n")
-	g.sf("// no batch). Nested types compose core-to-core by ref, never via the stream.\n")
+	g.sf("// inline-only batch core — a real call would address-expose the batch\n")
 	g.sf("[MethodImpl(MethodImplOptions.AggressiveInlining)]\n")
 }
 
@@ -127,8 +124,7 @@ func (g *gen) emitCoreAttr() {
 // C++ target's memset: branch zeroing and ReadMessage's storage reset both go
 // through here.
 func (g *gen) emitZeroFunction(st *ir.Struct) {
-	g.sf("// Zero%s resets value to the §5 ZERO form — all-zero storage; specified\n", st.Name)
-	g.sf("// defaults live in construction only and are NOT reapplied here.\n")
+	g.sf("// The §5 zero form: all-zero storage; specified defaults live only in construction.\n")
 	g.sf("public static void Zero%s(%s value)\n{\n", st.Name, st.Name)
 	if len(st.Fields) == 0 {
 		g.sf("    _ = value; // empty body — nothing to reset (SPEC §4.6)\n")
@@ -460,7 +456,7 @@ func (g *gen) emitWriteFoldedInt(f *ir.Field, name, ind string) {
 	}
 	lo, hi := g.rangeArgs(f, typ)
 	g.emitWriteFoldedRange(name, lo, hi, f.IntMin, f.IntMax, wide, guardLo, guardHi,
-		" // out-of-contract writes are refused, not wrapped", ind)
+		"", ind)
 }
 
 // maxUint64 is 2^64 - 1, the top of unsigned-64 storage — the bound against
@@ -528,16 +524,16 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 			rawMin := new(big.Int).Lsh(f.IntMin, uint(f.Type.FracBits))
 			switch {
 			case f.Type.Width == 128 && f.Type.Signed:
-				g.sf("%sif (%s != (Int128Value)(%s)) // out-of-contract writes are refused, not wrapped\n%s{\n%s    return false;\n%s}\n",
+				g.sf("%sif (%s != (Int128Value)(%s))\n%s{\n%s    return false;\n%s}\n",
 					ind, name, csRender128(rawMin), ind, ind, ind)
 			case f.Type.Width == 128:
-				g.sf("%sif (%s != (UInt128Value)(%s)) // out-of-contract writes are refused, not wrapped\n%s{\n%s    return false;\n%s}\n",
+				g.sf("%sif (%s != (UInt128Value)(%s))\n%s{\n%s    return false;\n%s}\n",
 					ind, name, csRenderU128(rawMin), ind, ind, ind)
 			case f.Type.Signed:
-				g.sf("%sif ((long)%s != %sL) // out-of-contract writes are refused, not wrapped\n%s{\n%s    return false;\n%s}\n",
+				g.sf("%sif ((long)%s != %sL)\n%s{\n%s    return false;\n%s}\n",
 					ind, name, rawMin.String(), ind, ind, ind)
 			default:
-				g.sf("%sif ((ulong)%s != %sUL) // out-of-contract writes are refused, not wrapped\n%s{\n%s    return false;\n%s}\n",
+				g.sf("%sif ((ulong)%s != %sUL)\n%s{\n%s    return false;\n%s}\n",
 					ind, name, rawMin.String(), ind, ind, ind)
 			}
 			return
@@ -561,7 +557,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 			if f.HasIntRange {
 				if f.IntMin.Cmp(f.IntMax) == 0 {
 					// degenerate range: ZERO bits — refusal only (SPEC §4.6)
-					g.sf("%sif (%s != (Int128Value)(%s)) // out-of-contract writes are refused, not wrapped\n%s{\n%s    return false;\n%s}\n",
+					g.sf("%sif (%s != (Int128Value)(%s))\n%s{\n%s    return false;\n%s}\n",
 						ind, name, csRender128(f.IntMin), ind, ind, ind)
 					return
 				}
@@ -591,13 +587,13 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 				hiVacuous := f.IntMax.Cmp(maxUint64) == 0
 				switch {
 				case !loVacuous && !hiVacuous:
-					g.sf("%sif (%s < %s || %s > %s) // out-of-contract writes are refused, not wrapped\n", ind, name, lo, name, f.IntMax.String())
+					g.sf("%sif (%s < %s || %s > %s)\n", ind, name, lo, name, f.IntMax.String())
 					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
 				case !loVacuous:
-					g.sf("%sif (%s < %s) // out-of-contract writes are refused, not wrapped\n", ind, name, lo)
+					g.sf("%sif (%s < %s)\n", ind, name, lo)
 					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
 				case !hiVacuous:
-					g.sf("%sif (%s > %s) // out-of-contract writes are refused, not wrapped\n", ind, name, f.IntMax.String())
+					g.sf("%sif (%s > %s)\n", ind, name, f.IntMax.String())
 					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
 				}
 				if loVacuous {

--- a/internal/codegen/golang/functions.go
+++ b/internal/codegen/golang/functions.go
@@ -282,7 +282,7 @@ func (g *gen) rangeArgs(f *ir.Field) (string, string) {
 // generation-time bit count (the int32 family: SerializeInt's encoding).
 // expr must be an int32-typed expression.
 func (g *gen) emitWriteRangedFold32(expr, lo, hi string, bits int64, loZero bool, ind string) {
-	g.pf("%sif %s < %s || %s > %s { // the runtime range refusal, folded (SPEC §5)\n%s\treturn serialize.ErrValueOutOfRange\n%s}\n",
+	g.pf("%sif %s < %s || %s > %s {\n%s\treturn serialize.ErrValueOutOfRange\n%s}\n",
 		ind, expr, lo, expr, hi, ind, ind)
 	// A degenerate range costs ZERO BITS -- the value is known from the range
 	// alone, so nothing rides. The bit packer requires at least one bit, so
@@ -303,7 +303,7 @@ func (g *gen) emitWriteRangedFold32(expr, lo, hi string, bits int64, loZero bool
 // then the high remainder — SerializeBits64's own split, byte-identical).
 // expr must be an int64-typed expression.
 func (g *gen) emitWriteRangedFold64(expr, lo, hi string, bits int64, loZero bool, ind string) {
-	g.pf("%sif %s < %s || %s > %s { // the runtime range refusal, folded (SPEC §5)\n%s\treturn serialize.ErrValueOutOfRange\n%s}\n",
+	g.pf("%sif %s < %s || %s > %s {\n%s\treturn serialize.ErrValueOutOfRange\n%s}\n",
 		ind, expr, lo, expr, hi, ind, ind)
 	offset := "uint64(" + expr + ")"
 	if !loZero {
@@ -445,13 +445,13 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 			rawMin := new(big.Int).Lsh(f.IntMin, uint(f.Type.FracBits))
 			switch {
 			case f.Type.Width == 128 && f.Type.Signed:
-				g.pf("%sif %s != %s { // the runtime range refusal, folded (SPEC §5)\n", ind, name, g.render128(nil, rawMin))
+				g.pf("%sif %s != %s {\n", ind, name, g.render128(nil, rawMin))
 			case f.Type.Width == 128:
-				g.pf("%sif %s != %s { // the runtime range refusal, folded (SPEC §5)\n", ind, name, g.renderU128(nil, rawMin))
+				g.pf("%sif %s != %s {\n", ind, name, g.renderU128(nil, rawMin))
 			case f.Type.Signed:
-				g.pf("%sif int64(%s) != %s { // the runtime range refusal, folded (SPEC §5)\n", ind, name, rawMin.String())
+				g.pf("%sif int64(%s) != %s {\n", ind, name, rawMin.String())
 			default:
-				g.pf("%sif uint64(%s) != %s { // the runtime range refusal, folded (SPEC §5)\n", ind, name, rawMin.String())
+				g.pf("%sif uint64(%s) != %s {\n", ind, name, rawMin.String())
 			}
 			g.pf("%s\treturn serialize.ErrValueOutOfRange\n%s}\n", ind, ind)
 			return
@@ -484,7 +484,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 			if f.HasIntRange {
 				if f.IntMin.Cmp(f.IntMax) == 0 {
 					// degenerate range: ZERO bits — refusal only (SPEC §4.6)
-					g.pf("%sif %s != %s { // the runtime range refusal, folded (SPEC §5)\n", ind, name, g.render128(f.IntMinExpr, f.IntMin))
+					g.pf("%sif %s != %s {\n", ind, name, g.render128(f.IntMinExpr, f.IntMin))
 					g.pf("%s\treturn serialize.ErrValueOutOfRange\n%s}\n", ind, ind)
 					return
 				}

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -292,8 +292,7 @@ func (g *gen) emitStruct(d *ir.Struct) {
 		kind = "message"
 	}
 	if len(d.Tags) > 0 {
-		g.pf("// %s %s [%s] — the tag is user-chosen and inert in v1; the delta pass\n", kind, d.Name, strings.Join(d.Tags, ", "))
-		g.pf("// claims tags and assigns actions (SPEC §4.2, Type tags)\n")
+		g.pf("// %s %s [%s] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)\n", kind, d.Name, strings.Join(d.Tags, ", "))
 	} else {
 		g.pf("// %s %s\n", kind, d.Name)
 	}
@@ -595,9 +594,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
+			parts = append(parts, fmt.Sprintf("| local, context = %s", f.Context))
 		} else {
-			parts = append(parts, " | local — no wire")
+			parts = append(parts, "| local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/js/flat.go
+++ b/internal/codegen/js/flat.go
@@ -78,6 +78,7 @@ import (
 type fgen struct {
 	unit     *ir.Unit
 	file     *ir.File
+	home     bool // the unit's first flat module — carries the tier-level notes
 	msgOwner string
 
 	body    strings.Builder
@@ -105,14 +106,18 @@ func flatFileHasSurface(u *ir.Unit, f *ir.File, msgOwner string) bool {
 	return f.Base == msgOwner && len(u.Messages) > 0
 }
 
-// generateFlat returns basename+"Flat.js" -> contents for every carrying file.
+// generateFlat returns basename+"Flat.js" -> contents for every carrying
+// file. The tier-level notes ride the FIRST carrying file (basename order)
+// only — said once per unit, not once per file.
 func generateFlat(u *ir.Unit, msgOwner string) map[string][]byte {
 	out := map[string][]byte{}
+	first := true
 	for _, f := range u.Files {
 		if !flatFileHasSurface(u, f, msgOwner) {
 			continue
 		}
-		g := &fgen{unit: u, file: f, msgOwner: msgOwner, imports: map[string]map[string]bool{}}
+		g := &fgen{unit: u, file: f, home: first, msgOwner: msgOwner, imports: map[string]map[string]bool{}}
+		first = false
 		g.emitModule()
 		out[f.Base+"Flat.js"] = g.assemble()
 	}
@@ -150,25 +155,28 @@ func (g *fgen) assemble() []byte {
 	h.WriteString("// your choice. See the LICENSE exception in the schema compiler; the compiler is\n")
 	h.WriteString("// AGPL-3.0, its output is not.\n")
 	fmt.Fprintf(&h, "// package %s — protocol id 0x%016x\n", g.unit.Package, g.unit.ProtocolId)
-	h.WriteString("//\n")
-	h.WriteString("// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js\n")
-	h.WriteString("// two-lane bitpacker inlined at every field, constant widths and masks,\n")
-	h.WriteString("// zero function calls. Same generated classes, same bytes as the runtime\n")
-	h.WriteString("// tier (a standing CI gate); the runtime tier remains the diagnostic and\n")
-	h.WriteString("// reference surface — re-read a failing buffer through it to learn WHICH\n")
-	h.WriteString("// operation failed and why.\n")
-	h.WriteString("//\n")
-	h.WriteString("// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked\n")
-	h.WriteString("// writer refuses an out-of-contract value (the production writer trusts\n")
-	h.WriteString("// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at\n")
-	h.WriteString("// module load). Read<Name>Flat(value, view, numBits) -> bool, the family\n")
-	h.WriteString("// read verdict; reader obligations ride in every mode.\n")
-	h.WriteString("//\n")
-	h.WriteString("// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes\n")
-	h.WriteString("// (the constants live in the runtime-tier module). Read buffers: at least\n")
-	h.WriteString("// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load\n")
-	h.WriteString("// unconditionally; copy exactly-sized receive buffers into a persistent\n")
-	h.WriteString("// MaxBytes + 8 scratch first.\n\n")
+	if g.home {
+		h.WriteString("//\n")
+		h.WriteString("// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js\n")
+		h.WriteString("// two-lane bitpacker inlined at every field, constant widths and masks,\n")
+		h.WriteString("// zero function calls. Same generated classes, same bytes as the runtime\n")
+		h.WriteString("// tier (a standing CI gate); the runtime tier remains the diagnostic and\n")
+		h.WriteString("// reference surface — re-read a failing buffer through it to learn WHICH\n")
+		h.WriteString("// operation failed and why.\n")
+		h.WriteString("//\n")
+		h.WriteString("// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked\n")
+		h.WriteString("// writer refuses an out-of-contract value (the production writer trusts\n")
+		h.WriteString("// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at\n")
+		h.WriteString("// module load). Read<Name>Flat(value, view, numBits) -> bool, the family\n")
+		h.WriteString("// read verdict; reader obligations ride in every mode.\n")
+		h.WriteString("//\n")
+		h.WriteString("// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes\n")
+		h.WriteString("// (the constants live in the runtime-tier module). Read buffers: at least\n")
+		h.WriteString("// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load\n")
+		h.WriteString("// unconditionally; copy exactly-sized receive buffers into a persistent\n")
+		h.WriteString("// MaxBytes + 8 scratch first.\n")
+	}
+	h.WriteString("\n")
 	if len(g.imports) > 0 {
 		bases := make([]string, 0, len(g.imports))
 		for b := range g.imports {
@@ -694,7 +702,6 @@ func (g *fgen) emitWriteWideOffset(offExpr string, bits int64, ind string) {
 	}
 }
 
-const refuseComment = " // out-of-contract writes are refused, not wrapped"
 
 func (g *fgen) emitWriteScalar(f *ir.Field, name, ind string) {
 	switch f.Type.Kind {
@@ -782,7 +789,7 @@ func (g *fgen) emitWriteCompressedFloat(f *ir.Field, name, ind string) {
 	deltaF := float32(f.FMax) - minF
 	mivF := float32(maxInt)
 	g.pf("%sx = Math.fround(%s);\n", ind, name)
-	g.guard("!Number.isFinite(x)", refuseComment, ind)
+	g.guard("!Number.isFinite(x)", "", ind)
 	g.pf("%sn = Math.fround(Math.fround(x - %s) / %s);\n", ind, f32lit(float64(minF)), f32lit(float64(deltaF)))
 	g.pf("%sif (!(n >= 0.0)) { n = 0.0; } else if (!(n <= 1.0)) { n = 1.0; }\n", ind)
 	g.pf("%sv = Math.floor(Math.fround(Math.fround(n * %s) + 0.5));\n", ind, f32lit(float64(mivF)))
@@ -804,15 +811,15 @@ func (g *fgen) emitWriteFixed(f *ir.Field, name, ind string) {
 	if f.IntMin.Cmp(f.IntMax) == 0 {
 		// degenerate: zero bits — the checked refusal is the whole write
 		if f.Type.Width > 32 {
-			g.guard(fmt.Sprintf("%s !== %sn", name, rawMin.String()), refuseComment, ind)
+			g.guard(fmt.Sprintf("%s !== %sn", name, rawMin.String()), "", ind)
 		} else {
-			g.guard(fmt.Sprintf("%s !== %s", name, rawMin.String()), refuseComment, ind)
+			g.guard(fmt.Sprintf("%s !== %s", name, rawMin.String()), "", ind)
 		}
 		return
 	}
 	if f.Type.Width <= 32 {
 		g.guard(fmt.Sprintf("!Number.isInteger(%s) || %s < %s || %s > %s", name, name, rawMin.String(), name, rawMax.String()),
-			refuseComment, ind)
+			"", ind)
 		var off string
 		switch {
 		case rawMin.Sign() == 0:
@@ -831,7 +838,7 @@ func (g *fgen) emitWriteFixed(f *ir.Field, name, ind string) {
 		return
 	}
 	// wide lane: BigInt raw storage, offset in 32-bit groups
-	g.guard(fmt.Sprintf("%s < %sn || %s > %sn", name, rawMin.String(), name, rawMax.String()), refuseComment, ind)
+	g.guard(fmt.Sprintf("%s < %sn || %s > %sn", name, rawMin.String(), name, rawMax.String()), "", ind)
 	off := fmt.Sprintf("BigInt.asUintN(%d, %s - %sn)", wideOffsetWidth(bits), name, rawMin.String())
 	if rawMin.Sign() == 0 {
 		off = fmt.Sprintf("BigInt.asUintN(%d, %s)", wideOffsetWidth(bits), name)
@@ -854,11 +861,11 @@ func (g *fgen) emitWriteInt(f *ir.Field, name, ind string) {
 	if w == 128 {
 		if f.HasIntRange {
 			if f.IntMin.Cmp(f.IntMax) == 0 {
-				g.guard(fmt.Sprintf("%s !== %sn", name, f.IntMin.String()), refuseComment, ind)
+				g.guard(fmt.Sprintf("%s !== %sn", name, f.IntMin.String()), "", ind)
 				return
 			}
 			bits := ir.BitsRequired(f.IntMin, f.IntMax)
-			g.guard(fmt.Sprintf("%s < %sn || %s > %sn", name, f.IntMin.String(), name, f.IntMax.String()), refuseComment, ind)
+			g.guard(fmt.Sprintf("%s < %sn || %s > %sn", name, f.IntMin.String(), name, f.IntMax.String()), "", ind)
 			off := fmt.Sprintf("BigInt.asUintN(%d, %s - %sn)", wideOffsetWidth(bits), name, f.IntMin.String())
 			if f.IntMin.Sign() == 0 {
 				off = fmt.Sprintf("BigInt.asUintN(%d, %s)", wideOffsetWidth(bits), name)
@@ -873,9 +880,9 @@ func (g *fgen) emitWriteInt(f *ir.Field, name, ind string) {
 	if f.HasIntRange {
 		if f.IntMin.Cmp(f.IntMax) == 0 {
 			if w > 32 {
-				g.guard(fmt.Sprintf("%s !== %sn", name, f.IntMin.String()), refuseComment, ind)
+				g.guard(fmt.Sprintf("%s !== %sn", name, f.IntMin.String()), "", ind)
 			} else {
-				g.guard(fmt.Sprintf("%s !== %s", name, f.IntMin.String()), refuseComment, ind)
+				g.guard(fmt.Sprintf("%s !== %s", name, f.IntMin.String()), "", ind)
 			}
 			return
 		}
@@ -887,19 +894,19 @@ func (g *fgen) emitWriteInt(f *ir.Field, name, ind string) {
 				// Number-domain offset
 				g.needN = true
 				g.pf("%sn = Number(BigInt.asIntN(32, %s));\n", ind, name)
-				g.guard(fmt.Sprintf("n < %s || n > %s", f.IntMin.String(), f.IntMax.String()), refuseComment, ind)
+				g.guard(fmt.Sprintf("n < %s || n > %s", f.IntMin.String(), f.IntMax.String()), "", ind)
 				g.emitWriteRangedNum("n", f.IntMin.Int64(), f.IntMax.Int64(), ind)
 				return
 			}
 			g.guard(fmt.Sprintf("!Number.isInteger(%s) || %s < %s || %s > %s", name, name, f.IntMin.String(), name, f.IntMax.String()),
-				refuseComment, ind)
+				"", ind)
 			g.emitWriteRangedNum(name, f.IntMin.Int64(), f.IntMax.Int64(), ind)
 		case "int64":
 			if w <= 32 {
 				// uint32 storage whose range escapes int32: values and offsets
 				// stay below 2^32 — exact in doubles
 				g.guard(fmt.Sprintf("!Number.isInteger(%s) || %s < %s || %s > %s", name, name, f.IntMin.String(), name, f.IntMax.String()),
-					refuseComment, ind)
+					"", ind)
 				g.emitWriteRangedNum(name, f.IntMin.Int64(), f.IntMax.Int64(), ind)
 				return
 			}
@@ -943,11 +950,11 @@ func (g *fgen) emitWriteRangedBig(f *ir.Field, name, ind string) {
 	guardHi := f.IntMax.Cmp(sMax) < 0
 	switch {
 	case guardLo && guardHi:
-		g.guard(fmt.Sprintf("%s < %sn || %s > %sn", name, f.IntMin.String(), name, f.IntMax.String()), refuseComment, ind)
+		g.guard(fmt.Sprintf("%s < %sn || %s > %sn", name, f.IntMin.String(), name, f.IntMax.String()), "", ind)
 	case guardLo:
-		g.guard(fmt.Sprintf("%s < %sn", name, f.IntMin.String()), refuseComment, ind)
+		g.guard(fmt.Sprintf("%s < %sn", name, f.IntMin.String()), "", ind)
 	case guardHi:
-		g.guard(fmt.Sprintf("%s > %sn", name, f.IntMax.String()), refuseComment, ind)
+		g.guard(fmt.Sprintf("%s > %sn", name, f.IntMax.String()), "", ind)
 	}
 	off := fmt.Sprintf("BigInt.asUintN(64, %s - %sn)", name, f.IntMin.String())
 	if f.IntMin.Sign() == 0 {

--- a/internal/codegen/js/flat.go
+++ b/internal/codegen/js/flat.go
@@ -702,7 +702,6 @@ func (g *fgen) emitWriteWideOffset(offExpr string, bits int64, ind string) {
 	}
 }
 
-
 func (g *fgen) emitWriteScalar(f *ir.Field, name, ind string) {
 	switch f.Type.Kind {
 	case ir.TFixed:

--- a/internal/codegen/js/functions.go
+++ b/internal/codegen/js/functions.go
@@ -118,8 +118,7 @@ func (g *gen) emitStructFunctions(st *ir.Struct) {
 // reference types, so this is the C# in-place-zero idiom: branch zeroing
 // and ReadMessage's storage reset both go through here.
 func (g *gen) emitZeroFunction(st *ir.Struct) {
-	g.pf("// Zero%s resets value to the §5 ZERO form — all-zero storage; specified\n", st.Name)
-	g.pf("// defaults live in construction only and are NOT reapplied here.\n")
+	g.pf("// The §5 zero form: all-zero storage; specified defaults live only in construction.\n")
 	g.pf("export function Zero%s(value) {\n", st.Name)
 	if len(st.Fields) == 0 {
 		g.pf("  // empty body — nothing to reset (SPEC §4.6)\n")
@@ -430,7 +429,7 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 			count := name + "Count"
 			g.emitWriteFoldedNum(count, fmt.Sprintf("%d", f.ArrayMin), bound,
 				big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), true,
-				" // the count guards the loop (§6.3); out-of-contract writes are refused", ind)
+				" // the count guards the loop (§6.3)", ind)
 			g.pf("%sfor (let i = 0; i < %s; i++) {\n", ind, count)
 		} else {
 			// the SCHEMA bound, never the storage's length: reassigned-short
@@ -445,15 +444,14 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 }
 
 func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
-	const refuse = " // out-of-contract writes are refused, not wrapped"
-	switch f.Type.Kind {
+		switch f.Type.Kind {
 	case ir.TFixed:
 		if f.IntMin.Cmp(f.IntMax) == 0 {
 			// degenerate range: ZERO bits — the folded range refusal and no
 			// wire call at all (SPEC §4.6, decided 2026-08-15). The one legal
 			// raw is min << F, an exact literal in either value domain.
 			rawMin := new(big.Int).Lsh(f.IntMin, uint(f.Type.FracBits))
-			g.pf("%sif (%s !== %s) {%s\n%s  return false;\n%s}\n", ind, name, g.rawLit(f.Type, rawMin), refuse, ind, ind)
+			g.pf("%sif (%s !== %s) {%s\n%s  return false;\n%s}\n", ind, name, g.rawLit(f.Type, rawMin), "", ind, ind)
 			return
 		}
 		// the Q format and whole-unit bounds are compile-time constants of
@@ -475,7 +473,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 			if f.HasIntRange {
 				if f.IntMin.Cmp(f.IntMax) == 0 {
 					// degenerate range: ZERO bits — refusal only (SPEC §4.6)
-					g.pf("%sif (%s !== %s) {%s\n%s  return false;\n%s}\n", ind, name, bigLit(f.IntMin), refuse, ind, ind)
+					g.pf("%sif (%s !== %s) {%s\n%s  return false;\n%s}\n", ind, name, bigLit(f.IntMin), "", ind, ind)
 					return
 				}
 				// int128 is ALWAYS ranged (SPEC §4.3): offset from min —
@@ -500,11 +498,11 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 					// the call family's domain first — the C# (int) cast's
 					// twin — then guard in the Number domain
 					g.pf("%s{\n%s  const rangeValue = Number(BigInt.asIntN(32, %s));\n", ind, ind, name)
-					g.emitWriteFoldedNum("rangeValue", lo, hi, f.IntMin, f.IntMax, false, refuse, ind+"  ")
+					g.emitWriteFoldedNum("rangeValue", lo, hi, f.IntMin, f.IntMax, false, "", ind+"  ")
 					g.pf("%s}\n", ind)
 					return
 				}
-				g.emitWriteFoldedNum(name, lo, hi, f.IntMin, f.IntMax, true, refuse, ind)
+				g.emitWriteFoldedNum(name, lo, hi, f.IntMin, f.IntMax, true, "", ind)
 			case "int64":
 				if f.Type.Width <= 32 {
 					// Number storage on the int64 path: only uint32 storage
@@ -513,13 +511,13 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 					// the double domain, no BigInt needed. Byte-identical: the
 					// same offset in the same bit count.
 					lo, hi := g.rangeArgsNum(f)
-					g.emitWriteFoldedNum(name, lo, hi, f.IntMin, f.IntMax, true, refuse, ind)
+					g.emitWriteFoldedNum(name, lo, hi, f.IntMin, f.IntMax, true, "", ind)
 					return
 				}
 				lo, hi := g.rangeArgsBig(f)
 				sMin, sMax := storageBoundsBig(f.Type)
 				g.emitWriteFoldedBig(name, lo, hi, f.IntMin, f.IntMax,
-					f.IntMin.Cmp(sMin) > 0, f.IntMax.Cmp(sMax) < 0, refuse, ind)
+					f.IntMin.Cmp(sMin) > 0, f.IntMax.Cmp(sMax) < 0, "", ind)
 			default:
 				// full-range unsigned: raw offset bits (uint64 storage only —
 				// no narrower storage can hold a range past int64); vacuous
@@ -527,7 +525,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 				// two's-complement wrap C# ulong storage performs by type
 				lo, hi := g.rangeArgsBig(f)
 				g.emitWriteFoldedBig(name, lo, hi, f.IntMin, f.IntMax,
-					f.IntMin.Sign() != 0, f.IntMax.Cmp(maxUint64) != 0, refuse, ind)
+					f.IntMin.Sign() != 0, f.IntMax.Cmp(maxUint64) != 0, "", ind)
 			}
 			return
 		}

--- a/internal/codegen/js/functions.go
+++ b/internal/codegen/js/functions.go
@@ -444,7 +444,7 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 }
 
 func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
-		switch f.Type.Kind {
+	switch f.Type.Kind {
 	case ir.TFixed:
 		if f.IntMin.Cmp(f.IntMax) == 0 {
 			// degenerate range: ZERO bits — the folded range refusal and no

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -84,8 +84,8 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		}
 	}
 	for _, f := range u.Files {
-		g := &gen{unit: u, file: f, msgOwner: msgOwner, objOwner: objOwner, imports: map[string]map[string]bool{}}
-		g.emitFile(f.Base == home)
+		g := &gen{unit: u, file: f, home: f.Base == home, msgOwner: msgOwner, objOwner: objOwner, imports: map[string]map[string]bool{}}
+		g.emitFile(g.home)
 		out[f.Base+".js"] = g.assemble()
 	}
 	// the flat tier: BaseFlat.js beside Base.js wherever the file carries a
@@ -114,6 +114,7 @@ func protocolIdHome(u *ir.Unit) string {
 type gen struct {
 	unit     *ir.Unit
 	file     *ir.File
+	home     bool   // this file carries ProtocolId and the unit-level target notes
 	msgOwner string // the one file that carries the message dispatch surface
 	objOwner string // the one file that carries the object tag surface
 
@@ -176,17 +177,21 @@ func (g *gen) assemble() []byte {
 	h.WriteString("// your choice. See the LICENSE exception in the schema compiler; the compiler is\n")
 	h.WriteString("// AGPL-3.0, its output is not.\n")
 	fmt.Fprintf(&h, "// package %s — protocol id 0x%016x\n", g.unit.Package, g.unit.ProtocolId)
-	h.WriteString("//\n")
-	h.WriteString("// Storage members are PascalCase via the same mapping as the Go target, so\n")
-	h.WriteString("// the checker's collision registry covers JS for free. Wire functions return\n")
-	h.WriteString("// bool — the C++-style early-out. A schema validation failure (a wrong wire\n")
-	h.WriteString("// constant, nonzero reserved bits, an out-of-contract write) returns false\n")
-	h.WriteString("// WITHOUT latching; stream failures latch on stream.error — the runtime's own\n")
-	h.WriteString("// sticky latch. Callers get bool always; error tells the two apart.\n")
-	h.WriteString("//\n")
-	h.WriteString("// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —\n")
-	h.WriteString("// the serialize.js value-domain seam. Checked/production comes from the\n")
-	h.WriteString("// stream object; generated code never reads NODE_ENV.\n\n")
+	if g.home {
+		// the unit-level target notes ride the home file only — said once
+		// per unit, not once per file
+		h.WriteString("//\n")
+		h.WriteString("// Wire functions return bool — the C++-style early-out. A schema validation\n")
+		h.WriteString("// failure (a wrong wire constant, nonzero reserved bits, an out-of-contract\n")
+		h.WriteString("// write) returns false WITHOUT latching; stream failures latch on\n")
+		h.WriteString("// stream.error — the runtime's own sticky latch. Callers get bool always;\n")
+		h.WriteString("// error tells the two apart.\n")
+		h.WriteString("//\n")
+		h.WriteString("// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —\n")
+		h.WriteString("// the serialize.js value-domain seam. Checked/production comes from the\n")
+		h.WriteString("// stream object; generated code never reads NODE_ENV.\n")
+	}
+	h.WriteString("\n")
 	if len(g.imports) > 0 {
 		bases := make([]string, 0, len(g.imports))
 		for b := range g.imports {
@@ -204,11 +209,8 @@ func (g *gen) assemble() []byte {
 		h.WriteString("\n")
 	}
 	if g.needNumScratch || g.needBigScratch || g.needBoolScratch {
-		h.WriteString("// Scratch holders for the runtime's {value} refs (streams.js has no ref\n")
-		h.WriteString("// parameters). Module scope is safe — JavaScript is single threaded per\n")
-		h.WriteString("// realm and a holder is consumed in the same call that fills it, the\n")
-		h.WriteString("// runtime's own FLOAT_SCRATCH argument; generated code never holds one\n")
-		h.WriteString("// across a nested Write/Read call.\n")
+		h.WriteString("// Scratch holders for the runtime's {value} refs — single threaded per\n")
+		h.WriteString("// realm, always consumed in the same call that fills them.\n")
 		if g.needNumScratch {
 			h.WriteString("const NUMBER_SCRATCH = { value: 0 };\n")
 		}
@@ -382,8 +384,7 @@ func (g *gen) emitClass(d *ir.Struct) {
 		kind = "message"
 	}
 	if len(d.Tags) > 0 {
-		g.pf("// %s %s [%s] — the tag is user-chosen and inert in v1; the delta pass\n", kind, d.Name, strings.Join(d.Tags, ", "))
-		g.pf("// claims tags and assigns actions (SPEC §4.2, Type tags)\n")
+		g.pf("// %s %s [%s] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)\n", kind, d.Name, strings.Join(d.Tags, ", "))
 	} else {
 		g.pf("// %s %s\n", kind, d.Name)
 	}
@@ -554,7 +555,7 @@ func (g *gen) fieldComment(f *ir.Field) string {
 		}
 	}
 	if f.HasDefault {
-		parts = append(parts, fmt.Sprintf("= %s at construction; Zero* gives the §5 zero form", g.defaultValue(f)))
+		parts = append(parts, "specified default at construction; Zero* gives the §5 zero form")
 	}
 	if f.HasIntRange {
 		parts = append(parts, fmt.Sprintf("wire [%s, %s]", f.IntMin, f.IntMax))
@@ -574,9 +575,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
+			parts = append(parts, fmt.Sprintf("| local, context = %s", f.Context))
 		} else {
-			parts = append(parts, " | local — no wire")
+			parts = append(parts, "| local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/internal/codegen/js/objects.go
+++ b/internal/codegen/js/objects.go
@@ -259,14 +259,13 @@ func smallestSigned(bound int64) int {
 // emitViewRangedWrite is the shallow write fold for a view component: the
 // generated guard plus offset bits, in the storage's value domain.
 func (g *gen) emitViewRangedWrite(name string, lo, hi *big.Int, storageBig bool, ind string) {
-	const refuse = " // out-of-contract writes are refused, not wrapped"
 	if storageBig {
 		sMin, sMax := storageBoundsBig(ir.FieldType{Kind: ir.TInt, Signed: true, Width: 64})
 		g.emitWriteFoldedBig(name, bigLit(lo), bigLit(hi), lo, hi,
-			lo.Cmp(sMin) > 0, hi.Cmp(sMax) < 0, refuse, ind)
+			lo.Cmp(sMin) > 0, hi.Cmp(sMax) < 0, "", ind)
 		return
 	}
-	g.emitWriteFoldedNum(name, lo.String(), hi.String(), lo, hi, true, refuse, ind)
+	g.emitWriteFoldedNum(name, lo.String(), hi.String(), lo, hi, true, "", ind)
 }
 
 // emitViewRangedRead is the shallow read for a view component: the runtime

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -88,7 +88,7 @@ func (g *gen) emitStructFunctions(st *ir.Struct) {
 	// Both spines carry an attribute because the generated crate is a separate
 	// compilation unit from the caller, and without one a 6-10 byte message
 	// pays a full call (and loses constant folding of its bit widths) per
-	// serialize — measured 2-6x on tiny messages (bench 2026-08-06).
+	// serialize — measured 2-6x on tiny messages.
 	//
 	// The WRITE spine demands (see inline.go): the plain hint only raises
 	// LLVM's threshold, and these spines price far over it and were refused
@@ -405,13 +405,13 @@ func (g *gen) emitWriteRangeGuard(name string, f *ir.Field, ind string) {
 	hiVacuous := f.IntMax.Cmp(storageMax(f.Type)) >= 0
 	switch {
 	case !loVacuous && !hiVacuous:
-		g.pf("%sif %s < %s || %s > %s { // out-of-contract writes are refused, not wrapped\n", ind, name, f.IntMin.String(), name, f.IntMax.String())
+		g.pf("%sif %s < %s || %s > %s {\n", ind, name, f.IntMin.String(), name, f.IntMax.String())
 		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 	case !loVacuous:
-		g.pf("%sif %s < %s { // out-of-contract writes are refused, not wrapped\n", ind, name, f.IntMin.String())
+		g.pf("%sif %s < %s {\n", ind, name, f.IntMin.String())
 		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 	case !hiVacuous:
-		g.pf("%sif %s > %s { // out-of-contract writes are refused, not wrapped\n", ind, name, f.IntMax.String())
+		g.pf("%sif %s > %s {\n", ind, name, f.IntMax.String())
 		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 	}
 }
@@ -439,13 +439,13 @@ func (g *gen) emitWriteFixedRawGuard(name string, f *ir.Field, ind string) {
 	hiVacuous := rawMax.Cmp(smax) >= 0
 	switch {
 	case !loVacuous && !hiVacuous:
-		g.pf("%sif %s < %s || %s > %s { // out-of-contract writes are refused, not wrapped (raw scaled domain)\n", ind, name, rawMin.String(), name, rawMax.String())
+		g.pf("%sif %s < %s || %s > %s {\n", ind, name, rawMin.String(), name, rawMax.String())
 		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 	case !loVacuous:
-		g.pf("%sif %s < %s { // out-of-contract writes are refused, not wrapped (raw scaled domain)\n", ind, name, rawMin.String())
+		g.pf("%sif %s < %s {\n", ind, name, rawMin.String())
 		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 	case !hiVacuous:
-		g.pf("%sif %s > %s { // out-of-contract writes are refused, not wrapped (raw scaled domain)\n", ind, name, rawMax.String())
+		g.pf("%sif %s > %s {\n", ind, name, rawMax.String())
 		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 	}
 }
@@ -463,7 +463,7 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 			return
 		}
 		if f.Array == ir.ArrayCounted {
-			g.pf("%sif %s_count < %d || %s_count > %d { // refused, not wrapped: the runtime's write side only debug_asserts\n", ind, name, f.ArrayMin, name, f.ArrayBound)
+			g.pf("%sif %s_count < %d || %s_count > %d {\n", ind, name, f.ArrayMin, name, f.ArrayBound)
 			g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 			g.emitWriteRangedFold32(name+"_count", false, fmt.Sprintf("%d_i32", f.ArrayMin), f.ArrayMin == 0,
 				ir.BitsRequired(big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound)), " // the count guards the loop (§6.3)", ind)
@@ -599,7 +599,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		// length in [0, N], align, then the used bytes — the classic
 		// serialize_string framing over a buffer of N + 1 (SPEC §4.7).
 		// Interior nulls are writer misuse; the read side rejects them (§4.7).
-		g.pf("%sif %s_length < 0 || %s_length > %d { // refused, not wrapped or panicked: guards the slice too\n", ind, name, name, f.Type.Size)
+		g.pf("%sif %s_length < 0 || %s_length > %d {\n", ind, name, name, f.Type.Size)
 		g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
 		if f.Type.Kind == ir.TString {
 			// well-formed UTF-8 by contract, writer-trusted: debug-only
@@ -612,7 +612,7 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 		// the write side borrows the used bytes in place: WriteStream::write_bytes
 		// takes &[u8] (same wire as serialize_bytes — align, then the block copy),
 		// where the unified &mut signature forced a whole-array copy into a mutable
-		// local first — 256 B per chat, 2 KB per block, visible in perf (2026-08-06)
+		// local first — 256 B per chat, 2 KB per block, visible in perf
 		g.pf("%sstream.write_bytes(&%s[..%s_length as usize]); // borrowed in place: the write side never mutates (infallible: returns () in serialize.rs 2.0.0)\n", ind, name, name)
 	case ir.TNamed:
 		switch ref := f.Type.Ref.(type) {
@@ -660,7 +660,7 @@ func compressedFloatArgs(f *ir.Field) string {
 // consumed by the step count — and a reader auditing a call site should not
 // have to run the derivation backwards.
 func compressedFloatNote(f *ir.Field) string {
-	return fmt.Sprintf(" // compressed float [%s, %s] @ %s, constants folded at generation (issue #82)",
+	return fmt.Sprintf(" // compressed float [%s, %s] @ %s, constants folded at generation",
 		formatFloat(f.FMin), formatFloat(f.FMax), formatFloat(f.Resolution))
 }
 
@@ -979,7 +979,7 @@ func (g *gen) emitMessageTagFunctions() {
 	g.pf("// read_message_into for reuse loops — hoist ONE Message and read every\n")
 	g.pf("// message into it (the Go/C# MessageStorage discipline). Reuse removes the\n")
 	g.pf("// per-message copy-out of the union and measured 2.6x on the steady-state\n")
-	g.pf("// batch read (M2, 2026-08-06). The two surfaces stay separate on purpose —\n")
+	g.pf("// batch read. The two surfaces stay separate on purpose —\n")
 	g.pf("// see the note on read_message.\n")
 	g.pf(readSpineInline)
 	g.pf("pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {\n")
@@ -1004,16 +1004,16 @@ func (g *gen) emitMessageTagFunctions() {
 	g.pf("        _ => Err(Error::Validation),\n")
 	g.pf("    }\n}\n\n")
 
-	// read_message keeps its original by-value body rather than delegating to
-	// read_message_into: routing the return through a &mut out-param defeated
-	// LLVM's in-place construction of the returned union and cost the batch
-	// read 23% (measured M2, 2026-08-06) — each arm constructing directly
-	// into the return slot is what keeps the by-value surface cheap
+	// read_message keeps its own by-value body rather than delegating to
+	// read_message_into: routing the return through a &mut out-param defeats
+	// LLVM's in-place construction of the returned union, measured at 23% on
+	// the batch read — each arm constructing directly into the return slot is
+	// what keeps the by-value surface cheap
 	g.pf("// read_message decodes the next message by value — the one-shot surface.\n")
 	g.pf("// It deliberately does NOT delegate to read_message_into: routing the\n")
 	g.pf("// return through a &mut out-param defeated LLVM's in-place construction\n")
-	g.pf("// of the returned union and cost the batch read 23%% (measured M2,\n")
-	g.pf("// 2026-08-06). Both surfaces stay; reuse loops call read_message_into.\n")
+	g.pf("// of the returned union, measured at 23%% on the batch read. Both\n")
+	g.pf("// surfaces stay; reuse loops call read_message_into.\n")
 	g.pf(readSpineInline)
 	g.pf("pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {\n")
 	g.pf("    let mut tag_value = MessageType::NONE;\n")

--- a/internal/codegen/rust/inline.go
+++ b/internal/codegen/rust/inline.go
@@ -76,7 +76,7 @@ const dispatchInline = "#[inline]\n"
 // emitWriteDispatchComment is the emitted rationale for why write_message —
 // the write dispatch surface — keeps the plain #[inline] hint while every
 // write spine it calls carries the demand. Mirrors cpp's
-// emitWriteDispatchComment (schema #60): the blanket demand closed every
+// emitWriteDispatchComment: the blanket demand closed every
 // per-message write row but regressed the batch dispatch loop, because the
 // dispatcher itself was forced whole into the loop body. Exempting it keeps
 // the per-message write spines flattening INTO the dispatcher's outlined body
@@ -87,6 +87,6 @@ func (g *gen) emitWriteDispatchComment() {
 	g.pf("// write_*) flatten into its body, but the dispatch match itself stays a\n")
 	g.pf("// call boundary — demanding the C++ twin into a batch build loop was\n")
 	g.pf("// measured to slow that loop ~21%% while every per-message row kept its\n")
-	g.pf("// win with the boundary in place (schema #60). The compiler remains free\n")
+	g.pf("// win with the boundary in place. The compiler remains free\n")
 	g.pf("// to inline it where that pays.\n")
 }

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -346,18 +346,11 @@ func (g *gen) emitEnum(d *ir.Enum) {
 	g.pf("}\n\n")
 
 	// Debug/log name for any value, out-of-set included — the counterpart of
-	// C++'s and Go's EnumName. The wire-value form (u64) is what the table
-	// reflection descriptors carry, so both spellings exist and neither
-	// forces a cast at the call site.
+	// C++'s and Go's EnumName.
 	snake := ir.RustSnake(d.Name)
 	g.pf("/// Debug/log name for any `%s` value, out-of-set included.\n", d.Name)
 	g.pf("pub fn enum_name_%s(value: %s) -> &'static str {\n", snake, d.Name)
-	g.pf("    enum_name_%s_dyn(value.0 as u64)\n}\n\n", snake)
-
-	g.pf("/// As [`enum_name_%s`], over a raw wire value — the form the table\n", snake)
-	g.pf("/// reflection descriptors hold.\n")
-	g.pf("pub fn enum_name_%s_dyn(value: u64) -> &'static str {\n", snake)
-	g.pf("    match value {\n")
+	g.pf("    match value.0 {\n")
 	g.pf("        0 => \"None\",\n")
 	for i, v := range d.Variants {
 		g.pf("        %d => %q,\n", i+1, v)
@@ -384,8 +377,7 @@ func (g *gen) emitStruct(d *ir.Struct) {
 		kind = "message"
 	}
 	if len(d.Tags) > 0 {
-		g.pf("// %s %s [%s] — the tag is user-chosen and inert in v1; the delta pass\n", kind, d.Name, strings.Join(d.Tags, ", "))
-		g.pf("// claims tags and assigns actions (SPEC §4.2, Type tags)\n")
+		g.pf("// %s %s [%s] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)\n", kind, d.Name, strings.Join(d.Tags, ", "))
 	} else {
 		g.pf("// %s %s\n", kind, d.Name)
 	}
@@ -752,9 +744,9 @@ func (g *gen) fieldComment(f *ir.Field) string {
 	}
 	if f.Local {
 		if f.Context != "" {
-			parts = append(parts, fmt.Sprintf(" | local, context = %s", f.Context))
+			parts = append(parts, fmt.Sprintf("| local, context = %s", f.Context))
 		} else {
-			parts = append(parts, " | local — no wire")
+			parts = append(parts, "| local — no wire")
 		}
 	}
 	if len(parts) == 0 {

--- a/testdata/golden/c/Constants.h
+++ b/testdata/golden/c/Constants.h
@@ -8,16 +8,6 @@
 #define SCHEMA_EXAMPLE_CONSTANTS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/testdata/golden/c/ConstantsWire.h
+++ b/testdata/golden/c/ConstantsWire.h
@@ -8,16 +8,7 @@
 #define SCHEMA_EXAMPLE_CONSTANTSWIRE_H
 
 #include "Constants.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/testdata/golden/c/Contexts.h
+++ b/testdata/golden/c/Contexts.h
@@ -8,16 +8,6 @@
 #define SCHEMA_EXAMPLE_CONTEXTS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/testdata/golden/c/ContextsWire.h
+++ b/testdata/golden/c/ContextsWire.h
@@ -8,16 +8,7 @@
 #define SCHEMA_EXAMPLE_CONTEXTSWIRE_H
 
 #include "Contexts.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/testdata/golden/c/Enums.h
+++ b/testdata/golden/c/Enums.h
@@ -8,8 +8,6 @@
 #define SCHEMA_EXAMPLE_ENUMS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED
 #if defined(__GNUC__) || defined(__clang__)
@@ -40,21 +38,8 @@ static SCHEMA_UNUSED const char * enum_name_team( Team value )
     switch ( value )
     {
         case TEAM_NONE: return "None";
-        case 1: return "Red";
-        case 2: return "Blue";
-        default: return "???";
-    }
-}
-
-/* As enum_name_team, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_team_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Red";
-        case 2: return "Blue";
+        case TEAM_RED: return "Red";
+        case TEAM_BLUE: return "Blue";
         default: return "???";
     }
 }
@@ -79,27 +64,11 @@ static SCHEMA_UNUSED const char * enum_name_ship_type( ShipType value )
     switch ( value )
     {
         case SHIP_TYPE_NONE: return "None";
-        case 1: return "Fighter";
-        case 2: return "Corvette";
-        case 3: return "Bomber";
-        case 4: return "Destroyer";
-        case 5: return "Carrier";
-        default: return "???";
-    }
-}
-
-/* As enum_name_ship_type, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_ship_type_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Fighter";
-        case 2: return "Corvette";
-        case 3: return "Bomber";
-        case 4: return "Destroyer";
-        case 5: return "Carrier";
+        case SHIP_TYPE_FIGHTER: return "Fighter";
+        case SHIP_TYPE_CORVETTE: return "Corvette";
+        case SHIP_TYPE_BOMBER: return "Bomber";
+        case SHIP_TYPE_DESTROYER: return "Destroyer";
+        case SHIP_TYPE_CARRIER: return "Carrier";
         default: return "???";
     }
 }
@@ -122,23 +91,9 @@ static SCHEMA_UNUSED const char * enum_name_missile_type( MissileType value )
     switch ( value )
     {
         case MISSILE_TYPE_NONE: return "None";
-        case 1: return "Heatseeker";
-        case 2: return "Torpedo";
-        case 3: return "Nuke";
-        default: return "???";
-    }
-}
-
-/* As enum_name_missile_type, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_missile_type_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Heatseeker";
-        case 2: return "Torpedo";
-        case 3: return "Nuke";
+        case MISSILE_TYPE_HEATSEEKER: return "Heatseeker";
+        case MISSILE_TYPE_TORPEDO: return "Torpedo";
+        case MISSILE_TYPE_NUKE: return "Nuke";
         default: return "???";
     }
 }
@@ -164,29 +119,12 @@ static SCHEMA_UNUSED const char * enum_name_prop_type( PropType value )
     switch ( value )
     {
         case PROP_TYPE_NONE: return "None";
-        case 1: return "Asteroid";
-        case 2: return "Chunk";
-        case 3: return "Fragment";
-        case 4: return "Sphere";
-        case 5: return "BlackHole";
-        case 6: return "DysonPanel";
-        default: return "???";
-    }
-}
-
-/* As enum_name_prop_type, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_prop_type_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Asteroid";
-        case 2: return "Chunk";
-        case 3: return "Fragment";
-        case 4: return "Sphere";
-        case 5: return "BlackHole";
-        case 6: return "DysonPanel";
+        case PROP_TYPE_ASTEROID: return "Asteroid";
+        case PROP_TYPE_CHUNK: return "Chunk";
+        case PROP_TYPE_FRAGMENT: return "Fragment";
+        case PROP_TYPE_SPHERE: return "Sphere";
+        case PROP_TYPE_BLACK_HOLE: return "BlackHole";
+        case PROP_TYPE_DYSON_PANEL: return "DysonPanel";
         default: return "???";
     }
 }
@@ -206,17 +144,6 @@ static SCHEMA_UNUSED const char * enum_name_pending( Pending value )
     switch ( value )
     {
         case PENDING_NONE: return "None";
-        default: return "???";
-    }
-}
-
-/* As enum_name_pending, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_pending_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
         default: return "???";
     }
 }

--- a/testdata/golden/c/EnumsWire.h
+++ b/testdata/golden/c/EnumsWire.h
@@ -8,16 +8,7 @@
 #define SCHEMA_EXAMPLE_ENUMSWIRE_H
 
 #include "Enums.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/testdata/golden/c/Messages.h
+++ b/testdata/golden/c/Messages.h
@@ -8,8 +8,6 @@
 #define SCHEMA_EXAMPLE_MESSAGES_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED
 #if defined(__GNUC__) || defined(__clang__)
@@ -50,7 +48,7 @@ typedef struct Block {
 } Block;
 
 #define BLOCK_MAX_BITS 16018   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define BLOCK_MAX_BYTES 2008  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define BLOCK_MAX_BYTES 2008  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* message Chat */
@@ -60,7 +58,7 @@ typedef struct Chat {
 } Chat;
 
 #define CHAT_MAX_BITS 2064   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define CHAT_MAX_BYTES 264  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define CHAT_MAX_BYTES 264  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* message Synchronize */
@@ -70,7 +68,7 @@ typedef struct Synchronize {
 } Synchronize;
 
 #define SYNCHRONIZE_MAX_BITS 80   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define SYNCHRONIZE_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define SYNCHRONIZE_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* message Timescale */
@@ -81,7 +79,7 @@ typedef struct Timescale {
 } Timescale;
 
 #define TIMESCALE_MAX_BITS 128   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define TIMESCALE_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define TIMESCALE_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* The message tag: the discriminant for a heterogeneous stream. None = 0 is

--- a/testdata/golden/c/MessagesWire.h
+++ b/testdata/golden/c/MessagesWire.h
@@ -24,6 +24,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -158,8 +164,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 }
 #endif /* SCHEMA_INTERIOR_NULL_DEFINED */
 
-/* Writes Heartbeat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Heartbeat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_stream_t * stream, const Heartbeat * value )
 {
     (void) stream;
@@ -167,8 +172,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_heartbeat( serialize_write_
     return 1; /* no fields: no wire bits */
 }
 
-/* Reads Heartbeat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Heartbeat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_heartbeat( serialize_read_stream_t * stream, Heartbeat * value )
 {
     (void) stream;
@@ -176,8 +180,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_heartbeat( serialize_read_str
     return 1;
 }
 
-/* Writes Test. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Test. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_stream_t * stream, const Test * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->test_a, 16 ) )
@@ -211,8 +214,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_strea
     return 1;
 }
 
-/* Reads Test. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Test. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t * stream, Test * value )
 {
     {
@@ -268,8 +270,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Block. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Block. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_block( serialize_write_stream_t * stream, const Block * value )
 {
     if ( !serialize_write_int( stream, value->data_length, 0, MAX_BLOCK_SIZE ) )
@@ -283,8 +284,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_block( serialize_write_stre
     return 1;
 }
 
-/* Reads Block. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Block. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_t * stream, Block * value )
 {
     if ( !serialize_read_int( stream, &value->data_length, 0, MAX_BLOCK_SIZE ) )
@@ -298,8 +298,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_block( serialize_read_stream_
     return 1;
 }
 
-/* Writes Chat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Chat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_stream_t * stream, const Chat * value )
 {
     serialize_assert( schema_utf8_valid_( (const serialize_uint8_t *) value->text, value->text_length ) );
@@ -314,8 +313,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_chat( serialize_write_strea
     return 1;
 }
 
-/* Reads Chat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Chat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t * stream, Chat * value )
 {
     if ( !serialize_read_int( stream, &value->text_length, 0, MAX_CHAT_LENGTH ) )
@@ -334,8 +332,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_chat( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Synchronize. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Synchronize. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_synchronize( serialize_write_stream_t * stream, const Synchronize * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sync_frame ) )
@@ -349,8 +346,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_synchronize( serialize_writ
     return 1;
 }
 
-/* Reads Synchronize. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Synchronize. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_synchronize( serialize_read_stream_t * stream, Synchronize * value )
 {
     {
@@ -372,8 +368,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_synchronize( serialize_read_s
     return 1;
 }
 
-/* Writes Timescale. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Timescale. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_timescale( serialize_write_stream_t * stream, const Timescale * value )
 {
     if ( !serialize_write_double( stream, value->scale ) )
@@ -391,8 +386,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_timescale( serialize_write_
     return 1;
 }
 
-/* Reads Timescale. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Timescale. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_timescale( serialize_read_stream_t * stream, Timescale * value )
 {
     if ( !serialize_read_double( stream, &value->scale ) )

--- a/testdata/golden/c/Objects.h
+++ b/testdata/golden/c/Objects.h
@@ -8,7 +8,6 @@
 #define SCHEMA_EXAMPLE_OBJECTS_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
 #include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED

--- a/testdata/golden/c/ObjectsWire.h
+++ b/testdata/golden/c/ObjectsWire.h
@@ -8,7 +8,6 @@
 #define SCHEMA_EXAMPLE_OBJECTSWIRE_H
 
 #include "Objects.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
 
 #ifndef SCHEMA_UNUSED
@@ -25,6 +24,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED

--- a/testdata/golden/c/Render.h
+++ b/testdata/golden/c/Render.h
@@ -8,16 +8,6 @@
 #define SCHEMA_EXAMPLE_RENDER_H
 
 #include <stdint.h>
-#include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
-
-#ifndef SCHEMA_UNUSED
-#if defined(__GNUC__) || defined(__clang__)
-#define SCHEMA_UNUSED __attribute__((unused))
-#else
-#define SCHEMA_UNUSED
-#endif
-#endif
 #include "Enums.h"
 
 #ifdef __cplusplus
@@ -48,7 +38,7 @@ typedef struct RenderBlock {
 } RenderBlock;
 
 #define RENDER_BLOCK_MAX_BITS 8903   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define RENDER_BLOCK_MAX_BYTES 1120  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define RENDER_BLOCK_MAX_BYTES 1120  /* 8-byte write granularity; read slack per the contract above */
 
 #ifdef __cplusplus
 }

--- a/testdata/golden/c/RenderWire.h
+++ b/testdata/golden/c/RenderWire.h
@@ -8,7 +8,6 @@
 #define SCHEMA_EXAMPLE_RENDERWIRE_H
 
 #include "Render.h"
-#include <string.h>   /* memset, strlen */
 #include "serialize.h"
 
 #ifndef SCHEMA_UNUSED
@@ -23,6 +22,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
 
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
@@ -46,8 +51,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes RenderSprite. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes RenderSprite. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_write_stream_t * stream, const RenderSprite * value )
 {
     if ( !serialize_write_uint64( stream, (serialize_uint64_t) value->sort_key ) )
@@ -77,8 +81,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_wr
     return 1;
 }
 
-/* Reads RenderSprite. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads RenderSprite. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read_stream_t * stream, RenderSprite * value )
 {
     {
@@ -128,8 +131,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_sprite( serialize_read
     return 1;
 }
 
-/* Writes RenderBlock. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes RenderBlock. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_write_stream_t * stream, const RenderBlock * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->worker_index, 32 ) )
@@ -157,8 +159,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_block( serialize_wri
     return 1;
 }
 
-/* Reads RenderBlock. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads RenderBlock. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_render_block( serialize_read_stream_t * stream, RenderBlock * value )
 {
     {

--- a/testdata/golden/c/Types.h
+++ b/testdata/golden/c/Types.h
@@ -46,7 +46,7 @@ typedef struct Quat {
 } Quat;
 
 #define QUAT_MAX_BITS 256   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUAT_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUAT_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type Handle */
@@ -56,7 +56,7 @@ typedef struct Handle {
 } Handle;
 
 #define HANDLE_MAX_BITS 22   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define HANDLE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define HANDLE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type QuantizedPosition */
@@ -67,7 +67,7 @@ typedef struct QuantizedPosition {
 } QuantizedPosition;
 
 #define QUANTIZED_POSITION_MAX_BITS 75   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUANTIZED_POSITION_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUANTIZED_POSITION_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type QuantizedVelocity */
@@ -78,7 +78,7 @@ typedef struct QuantizedVelocity {
 } QuantizedVelocity;
 
 #define QUANTIZED_VELOCITY_MAX_BITS 69   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUANTIZED_VELOCITY_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUANTIZED_VELOCITY_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type QuantizedRotation */
@@ -90,7 +90,7 @@ typedef struct QuantizedRotation {
 } QuantizedRotation;
 
 #define QUANTIZED_ROTATION_MAX_BITS 48   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define QUANTIZED_ROTATION_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define QUANTIZED_ROTATION_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type RigidBody */
@@ -103,7 +103,7 @@ typedef struct RigidBody {
 } RigidBody;
 
 #define RIGID_BODY_MAX_BITS 833   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define RIGID_BODY_MAX_BYTES 112  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define RIGID_BODY_MAX_BYTES 112  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type Input */
@@ -124,7 +124,7 @@ typedef struct Input {
 } Input;
 
 #define INPUT_MAX_BITS 168   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define INPUT_MAX_BYTES 24  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define INPUT_MAX_BYTES 24  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type InputPacket */
@@ -137,7 +137,7 @@ typedef struct InputPacket {
 } InputPacket;
 
 #define INPUT_PACKET_MAX_BITS 2837   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define INPUT_PACKET_MAX_BYTES 360  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define INPUT_PACKET_MAX_BYTES 360  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ShipCreate */
@@ -155,7 +155,7 @@ typedef struct ShipCreate {
 } ShipCreate;
 
 #define SHIP_CREATE_MAX_BITS 219   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define SHIP_CREATE_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define SHIP_CREATE_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ExpressionProbe */
@@ -165,7 +165,7 @@ typedef struct ExpressionProbe {
 } ExpressionProbe;
 
 #define EXPRESSION_PROBE_MAX_BITS 16   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define EXPRESSION_PROBE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define EXPRESSION_PROBE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 #define FLOOR_LIMIT (( -9223372036854775807LL - 1 ))
 #define CEILING_COUNT (18446744073709551615ULL)
@@ -180,7 +180,7 @@ typedef struct ExtremeProbe {
 } ExtremeProbe;
 
 #define EXTREME_PROBE_MAX_BITS 320   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define EXTREME_PROBE_MAX_BYTES 40  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define EXTREME_PROBE_MAX_BYTES 40  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ExtremeProbe with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -204,7 +204,7 @@ typedef struct ExtremeRow {
 } ExtremeRow;
 
 #define EXTREME_ROW_MAX_BITS 256   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define EXTREME_ROW_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define EXTREME_ROW_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ExtremeRow with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a

--- a/testdata/golden/c/TypesWire.h
+++ b/testdata/golden/c/TypesWire.h
@@ -25,6 +25,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -47,8 +53,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes Vec3. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Vec3. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_stream_t * stream, const Vec3 * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
@@ -66,8 +71,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_vec3( serialize_write_strea
     return 1;
 }
 
-/* Reads Vec3. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Vec3. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t * stream, Vec3 * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
@@ -85,8 +89,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_vec3( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Quat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Quat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_stream_t * stream, const Quat * value )
 {
     if ( !serialize_write_double( stream, value->x ) )
@@ -108,8 +111,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quat( serialize_write_strea
     return 1;
 }
 
-/* Reads Quat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Quat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t * stream, Quat * value )
 {
     if ( !serialize_read_double( stream, &value->x ) )
@@ -131,8 +133,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t
     return 1;
 }
 
-/* Writes Handle. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Handle. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_stream_t * stream, const Handle * value )
 {
     if ( (serialize_int64_t) value->object_id < 0 || (serialize_int64_t) value->object_id > MAX_OBJECTS - 1 )
@@ -150,8 +151,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_str
     return 1;
 }
 
-/* Reads Handle. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Handle. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream_t * stream, Handle * value )
 {
     {
@@ -179,8 +179,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream
     return 1;
 }
 
-/* Writes QuantizedPosition. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
 {
     if ( (serialize_int64_t) value->x < -MAX_POSITION_UNITS || (serialize_int64_t) value->x > MAX_POSITION_UNITS )
@@ -210,8 +209,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( seriali
     return 1;
 }
 
-/* Reads QuantizedPosition. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize_read_stream_t * stream, QuantizedPosition * value )
 {
     {
@@ -259,8 +257,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize
     return 1;
 }
 
-/* Writes QuantizedVelocity. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
 {
     if ( (serialize_int64_t) value->x < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->x > MAX_VELOCITY_UNITS )
@@ -290,8 +287,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( seriali
     return 1;
 }
 
-/* Reads QuantizedVelocity. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize_read_stream_t * stream, QuantizedVelocity * value )
 {
     {
@@ -339,8 +335,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize
     return 1;
 }
 
-/* Writes QuantizedRotation. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
 {
     if ( (serialize_int64_t) value->x < -ROTATION_UNITS || (serialize_int64_t) value->x > ROTATION_UNITS )
@@ -378,8 +373,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( seriali
     return 1;
 }
 
-/* Reads QuantizedRotation. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize_read_stream_t * stream, QuantizedRotation * value )
 {
     {
@@ -441,8 +435,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_rotation( serialize
     return 1;
 }
 
-/* Writes RigidBody. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes RigidBody. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_rigid_body( serialize_write_stream_t * stream, const RigidBody * value )
 {
     if ( !write_vec3( stream, &value->position ) )
@@ -471,8 +464,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_rigid_body( serialize_write
     return 1;
 }
 
-/* Reads RigidBody. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads RigidBody. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_rigid_body( serialize_read_stream_t * stream, RigidBody * value )
 {
     if ( !read_vec3( stream, &value->position ) )
@@ -506,8 +498,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_rigid_body( serialize_read_st
     return 1;
 }
 
-/* Writes Input. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes Input. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stream_t * stream, const Input * value )
 {
     if ( !serialize_write_float( stream, value->stick_x ) )
@@ -565,8 +556,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input( serialize_write_stre
     return 1;
 }
 
-/* Reads Input. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads Input. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_t * stream, Input * value )
 {
     if ( !serialize_read_float( stream, &value->stick_x ) )
@@ -624,8 +614,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input( serialize_read_stream_
     return 1;
 }
 
-/* Writes InputPacket. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes InputPacket. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_write_stream_t * stream, const InputPacket * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->synchronize_sequence, 16 ) )
@@ -657,8 +646,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_input_packet( serialize_wri
     return 1;
 }
 
-/* Reads InputPacket. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads InputPacket. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_stream_t * stream, InputPacket * value )
 {
     {
@@ -702,8 +690,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_
     return 1;
 }
 
-/* Writes ShipCreate. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ShipCreate. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
 {
     if ( value->ship_type > 5 )
@@ -768,8 +755,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_writ
     return 1;
 }
 
-/* Reads ShipCreate. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ShipCreate. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_stream_t * stream, ShipCreate * value )
 {
     {
@@ -859,8 +845,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_s
     return 1;
 }
 
-/* Writes ExpressionProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize_write_stream_t * stream, const ExpressionProbe * value )
 {
     if ( (serialize_int64_t) value->hardpoint_index < 0 || (serialize_int64_t) value->hardpoint_index > (SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1 )
@@ -882,8 +867,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize
     return 1;
 }
 
-/* Reads ExpressionProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_read_stream_t * stream, ExpressionProbe * value )
 {
     {
@@ -917,8 +901,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_r
     return 1;
 }
 
-/* Writes ExtremeProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_write_stream_t * stream, const ExtremeProbe * value )
 {
     if ( (serialize_int64_t) value->floor_bound > 100 )
@@ -977,8 +960,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
     return 1;
 }
 
-/* Reads ExtremeProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read_stream_t * stream, ExtremeProbe * value )
 {
     {
@@ -1057,8 +1039,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read
     return 1;
 }
 
-/* Writes ExtremeRow. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_write_stream_t * stream, const ExtremeRow * value )
 {
     if ( (serialize_int64_t) value->clamped_floor > 100 )
@@ -1102,8 +1083,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_writ
     return 1;
 }
 
-/* Reads ExtremeRow. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_row( serialize_read_stream_t * stream, ExtremeRow * value )
 {
     {

--- a/testdata/golden/c/Wire.h
+++ b/testdata/golden/c/Wire.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 
 #ifndef SCHEMA_UNUSED
 #if defined(__GNUC__) || defined(__clang__)
@@ -46,23 +45,9 @@ static SCHEMA_UNUSED const char * enum_name_weapon( Weapon value )
     switch ( value )
     {
         case WEAPON_NONE: return "None";
-        case 1: return "Laser";
-        case 2: return "Missile";
-        case 3: return "Railgun";
-        default: return "???";
-    }
-}
-
-/* As enum_name_weapon, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_weapon_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Laser";
-        case 2: return "Missile";
-        case 3: return "Railgun";
+        case WEAPON_LASER: return "Laser";
+        case WEAPON_MISSILE: return "Missile";
+        case WEAPON_RAILGUN: return "Railgun";
         default: return "???";
     }
 }
@@ -97,7 +82,7 @@ typedef struct ProbeBits {
 } ProbeBits;
 
 #define PROBE_BITS_MAX_BITS 202   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_BITS_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_BITS_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeSample */
@@ -115,7 +100,7 @@ typedef struct ProbeSample {
 } ProbeSample;
 
 #define PROBE_SAMPLE_MAX_BITS 276   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_SAMPLE_MAX_BYTES 40  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_SAMPLE_MAX_BYTES 40  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ProbeSample with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -135,7 +120,7 @@ typedef struct ProbeRing {
 } ProbeRing;
 
 #define PROBE_RING_MAX_BITS 16   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_RING_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_RING_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeSlab */
@@ -145,7 +130,7 @@ typedef struct ProbeSlab {
 } ProbeSlab;
 
 #define PROBE_SLAB_MAX_BITS 15   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_SLAB_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_SLAB_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* union ProbeShape — first-class one-of (SPEC §4.8): the tag says which arm is
@@ -177,7 +162,7 @@ typedef struct ProbeShape {
 } ProbeShape;
 
 #define PROBE_SHAPE_MAX_BITS 18   /* tag + the largest arm; None costs the tag only (SPEC §4.8) */
-#define PROBE_SHAPE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_SHAPE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeCollider */
@@ -190,7 +175,7 @@ typedef struct ProbeCollider {
 } ProbeCollider;
 
 #define PROBE_COLLIDER_MAX_BITS 82   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_COLLIDER_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_COLLIDER_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type ProbeConfig */
@@ -200,7 +185,7 @@ typedef struct ProbeConfig {
 } ProbeConfig;
 
 #define PROBE_CONFIG_MAX_BITS 36   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_CONFIG_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_CONFIG_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ProbeConfig with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -222,7 +207,7 @@ typedef struct ProbeArray {
 } ProbeArray;
 
 #define PROBE_ARRAY_MAX_BITS 588   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_ARRAY_MAX_BYTES 80  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_ARRAY_MAX_BYTES 80  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a ProbeArray with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -251,7 +236,7 @@ typedef struct ProbeReport {
 } ProbeReport;
 
 #define PROBE_REPORT_MAX_BITS 141   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define PROBE_REPORT_MAX_BYTES 24  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define PROBE_REPORT_MAX_BYTES 24  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type TestData */
@@ -282,7 +267,7 @@ typedef struct TestData {
 } TestData;
 
 #define TEST_DATA_MAX_BITS 2735   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define TEST_DATA_MAX_BYTES 344  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define TEST_DATA_MAX_BYTES 344  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type CompressedProbe */
@@ -292,7 +277,7 @@ typedef struct CompressedProbe {
 } CompressedProbe;
 
 #define COMPRESSED_PROBE_MAX_BITS 24   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define COMPRESSED_PROBE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define COMPRESSED_PROBE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 #ifdef __cplusplus
 }

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -24,6 +24,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -158,8 +164,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 }
 #endif /* SCHEMA_INTERIOR_NULL_DEFINED */
 
-/* Writes ProbeHeader. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeHeader. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_write_stream_t * stream, const ProbeHeader * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) 171ULL, 8 ) /* const(171, 8) — SPEC §4.3 */ )
@@ -185,8 +190,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_header( serialize_wri
     return 1;
 }
 
-/* Reads ProbeHeader. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeHeader. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_header( serialize_read_stream_t * stream, ProbeHeader * value )
 {
     {
@@ -234,8 +238,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_header( serialize_read_
     return 1;
 }
 
-/* Writes ProbeBits. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeBits. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write_stream_t * stream, const ProbeBits * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->small, 9 ) )
@@ -282,8 +285,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_bits( serialize_write
     return 1;
 }
 
-/* Reads ProbeBits. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeBits. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_stream_t * stream, ProbeBits * value )
 {
     {
@@ -352,8 +354,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_bits( serialize_read_st
     return 1;
 }
 
-/* Writes ProbeSample. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeSample. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_write_stream_t * stream, const ProbeSample * value )
 {
     if ( !serialize_write_bool( stream, value->active ) )
@@ -418,8 +419,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_wri
     return 1;
 }
 
-/* Reads ProbeSample. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeSample. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_sample( serialize_read_stream_t * stream, ProbeSample * value )
 {
     if ( !serialize_read_bool( stream, &value->active ) )
@@ -516,8 +516,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_sample( serialize_read_
     return 1;
 }
 
-/* Writes ProbeRing. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeRing. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_ring( serialize_write_stream_t * stream, const ProbeRing * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->radius, 16 ) )
@@ -527,8 +526,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_ring( serialize_write
     return 1;
 }
 
-/* Reads ProbeRing. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeRing. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_stream_t * stream, ProbeRing * value )
 {
     {
@@ -542,8 +540,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_st
     return 1;
 }
 
-/* Writes ProbeSlab. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write_stream_t * stream, const ProbeSlab * value )
 {
     if ( (serialize_int64_t) value->width > 100 )
@@ -561,8 +558,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write
     return 1;
 }
 
-/* Reads ProbeSlab. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_stream_t * stream, ProbeSlab * value )
 {
     {
@@ -590,8 +586,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_slab( serialize_read_st
     return 1;
 }
 
-/* Writes ProbeShape. Returns 1 on success, 0 on failure. The tag is validated
-   BEFORE it rides: an out-of-set tag writes nothing (SPEC §4.8). */
+/* Writes ProbeShape. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_shape( serialize_write_stream_t * stream, const ProbeShape * value )
 {
     if ( value->type > PROBE_SHAPE_TYPE_MAX )
@@ -613,8 +608,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_shape( serialize_writ
     }
 }
 
-/* Reads ProbeShape. Returns 1 on success, 0 on failure — a tag above PROBE_SHAPE_TYPE_MAX is
-   refused (SPEC §4.8); the selected arm is zero-established before decoding (§5). */
+/* Reads ProbeShape. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_shape( serialize_read_stream_t * stream, ProbeShape * value )
 {
     {
@@ -642,8 +636,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_shape( serialize_read_s
     }
 }
 
-/* Writes ProbeCollider. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeCollider. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_collider( serialize_write_stream_t * stream, const ProbeCollider * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->armor, 8 ) )
@@ -675,8 +668,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_collider( serialize_w
     return 1;
 }
 
-/* Reads ProbeCollider. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeCollider. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_collider( serialize_read_stream_t * stream, ProbeCollider * value )
 {
     {
@@ -712,8 +704,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_collider( serialize_rea
     return 1;
 }
 
-/* Writes ProbeConfig. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeConfig. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_write_stream_t * stream, const ProbeConfig * value )
 {
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->retries, 32 ) )
@@ -731,8 +722,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_wri
     return 1;
 }
 
-/* Reads ProbeConfig. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeConfig. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_stream_t * stream, ProbeConfig * value )
 {
     {
@@ -758,8 +748,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_config( serialize_read_
     return 1;
 }
 
-/* Writes ProbeArray. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeArray. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_array( serialize_write_stream_t * stream, const ProbeArray * value )
 {
     {
@@ -779,8 +768,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_array( serialize_writ
     return 1;
 }
 
-/* Reads ProbeArray. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeArray. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_array( serialize_read_stream_t * stream, ProbeArray * value )
 {
     {
@@ -800,8 +788,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_array( serialize_read_s
     return 1;
 }
 
-/* Writes ProbeReport. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes ProbeReport. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_write_stream_t * stream, const ProbeReport * value )
 {
     if ( !write_probe_header( stream, &value->header ) )
@@ -819,8 +806,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_report( serialize_wri
     return 1;
 }
 
-/* Reads ProbeReport. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads ProbeReport. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_stream_t * stream, ProbeReport * value )
 {
     if ( !read_probe_header( stream, &value->header ) )
@@ -842,8 +828,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_
     return 1;
 }
 
-/* Writes TestData. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes TestData. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_stream_t * stream, const TestData * value )
 {
     if ( (serialize_int64_t) value->a < -100 || (serialize_int64_t) value->a > 100 )
@@ -979,8 +964,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     return 1;
 }
 
-/* Reads TestData. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads TestData. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_stream_t * stream, TestData * value )
 {
     {
@@ -1188,8 +1172,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_test_data( serialize_read_str
     return 1;
 }
 
-/* Writes CompressedProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes CompressedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize_write_stream_t * stream, const CompressedProbe * value )
 {
     if ( !serialize_write_compressed_float_precomputed( stream, value->boundary, 1000u, 10, 10.0f, 0.0f ) )
@@ -1203,8 +1186,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_compressed_probe( serialize
     return 1;
 }
 
-/* Reads CompressedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads CompressedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_compressed_probe( serialize_read_stream_t * stream, CompressedProbe * value )
 {
     if ( !serialize_read_compressed_float_precomputed( stream, &value->boundary, 1000u, 10, 10.0f, 0.0f ) )

--- a/testdata/golden/cs/Constants.cs
+++ b/testdata/golden/cs/Constants.cs
@@ -3,6 +3,12 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
+//
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an interior null)
+// returns false WITHOUT latching; stream failures latch on stream.Error —
+// the runtime's own sticky latch. Callers get bool always; Error tells the
+// two apart.
 
 namespace Example
 {

--- a/testdata/golden/cs/Messages.cs
+++ b/testdata/golden/cs/Messages.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -118,8 +111,7 @@ namespace Example
         public const long HeartbeatMaxBits = 0;
         public const long HeartbeatMaxBytes = 0;
 
-        // ZeroHeartbeat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroHeartbeat(Heartbeat value)
         {
             _ = value; // empty body — nothing to reset (SPEC §4.6)
@@ -141,8 +133,7 @@ namespace Example
         public const long TestMaxBits = 46;
         public const long TestMaxBytes = 8;
 
-        // ZeroTest resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroTest(Test value)
         {
             value.TestA = 0;
@@ -151,21 +142,17 @@ namespace Example
             value.TestD = 0;
         }
 
-        // WriteTest/ReadTest run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTest(WriteStream stream, Test value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTestBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTestBatch(ref WriteBatch batch, Test value)
         {
@@ -176,7 +163,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.TestB < 0 || value.TestB > 1000) // out-of-contract writes are refused, not wrapped
+            if (value.TestB < 0 || value.TestB > 1000)
             {
                 return false;
             }
@@ -187,7 +174,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.TestC < 0 || value.TestC > 1000) // out-of-contract writes are refused, not wrapped
+            if (value.TestC < 0 || value.TestC > 1000)
             {
                 return false;
             }
@@ -198,7 +185,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.TestD < 0 || value.TestD > 1000) // out-of-contract writes are refused, not wrapped
+            if (value.TestD < 0 || value.TestD > 1000)
             {
                 return false;
             }
@@ -216,13 +203,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTestBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTestBatch(ref ReadBatch batch, Test value)
         {
@@ -266,8 +251,7 @@ namespace Example
         public const long BlockMaxBits = 16018;
         public const long BlockMaxBytes = 2008;
 
-        // ZeroBlock resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroBlock(Block value)
         {
             Array.Clear(value.Data, 0, (int)MaxBlockSize);
@@ -312,8 +296,7 @@ namespace Example
         public const long ChatMaxBits = 2064;
         public const long ChatMaxBytes = 264;
 
-        // ZeroChat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroChat(Chat value)
         {
             Array.Clear(value.Text, 0, (int)MaxChatLength);
@@ -365,29 +348,24 @@ namespace Example
         public const long SynchronizeMaxBits = 80;
         public const long SynchronizeMaxBytes = 16;
 
-        // ZeroSynchronize resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroSynchronize(Synchronize value)
         {
             value.SyncFrame = 0;
             value.SyncSequence = 0;
         }
 
-        // WriteSynchronize/ReadSynchronize run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteSynchronize(WriteStream stream, Synchronize value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteSynchronizeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteSynchronizeBatch(ref WriteBatch batch, Synchronize value)
         {
@@ -409,13 +387,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadSynchronizeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadSynchronizeBatch(ref ReadBatch batch, Synchronize value)
         {
@@ -439,8 +415,7 @@ namespace Example
         public const long TimescaleMaxBits = 128;
         public const long TimescaleMaxBytes = 16;
 
-        // ZeroTimescale resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroTimescale(Timescale value)
         {
             value.Scale = 0.0;
@@ -448,21 +423,17 @@ namespace Example
             value.FrameB = 0;
         }
 
-        // WriteTimescale/ReadTimescale run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTimescale(WriteStream stream, Timescale value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTimescaleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTimescaleBatch(ref WriteBatch batch, Timescale value)
         {
@@ -485,13 +456,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTimescaleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTimescaleBatch(ref ReadBatch batch, Timescale value)
         {

--- a/testdata/golden/cs/Objects.cs
+++ b/testdata/golden/cs/Objects.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -60,11 +53,11 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; //  | local — no wire
-        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
-        public int NumColliders; //  | local — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
-        public bool PredictedExplode; //  | local, context = client
+        public bool Invulnerable; // | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); // | local — no wire
+        public int NumColliders; // | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // | local — no wire
+        public bool PredictedExplode; // | local, context = client
     }
 
     // ServerShipState — the full simulation class for the server context: every `all`
@@ -96,10 +89,10 @@ namespace Example
         public sbyte MissileIndex; // wire [0, 15]
         public Handle Target = new Handle();
         public double LockStartTime;
-        public bool Invulnerable; //  | local — no wire
-        public Vec3 PreviousPosition = new Vec3(); //  | local — no wire
-        public int NumColliders; //  | local — no wire
-        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; //  | local — no wire
+        public bool Invulnerable; // | local — no wire
+        public Vec3 PreviousPosition = new Vec3(); // | local — no wire
+        public int NumColliders; // | local — no wire
+        public int[] ColliderArmor = new int[Schema.MaxCollidersPerShip]; // | local — no wire
     }
 
     // ShipData_Deep — every non- | local field, deep encodings: full state for
@@ -184,8 +177,8 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
-        public Handle Target = new Handle(); //  | local — no wire
+        public Vec3 AngularVelocity = new Vec3(); // | local — no wire
+        public Handle Target = new Handle(); // | local — no wire
     }
 
     // ServerMissileState — the full simulation class for the server context: every `all`
@@ -198,9 +191,9 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public Team Team;
         public ulong Flags;
-        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
-        public Handle Target = new Handle(); //  | local — no wire
-        public double Timer; //  | local, context = server
+        public Vec3 AngularVelocity = new Vec3(); // | local — no wire
+        public Handle Target = new Handle(); // | local — no wire
+        public double Timer; // | local, context = server
     }
 
     // MissileData_Deep — every non- | local field, deep encodings: full state for
@@ -261,7 +254,7 @@ namespace Example
         public Vec3 LinearVelocity = new Vec3();
         public ulong Flags;
         public Team Team;
-        public Vec3 AngularVelocity = new Vec3(); //  | local — no wire
+        public Vec3 AngularVelocity = new Vec3(); // | local — no wire
     }
 
     // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
@@ -320,7 +313,7 @@ namespace Example
         public int TurretIndex; // wire [0, 255]
         public Quat Rotation = new Quat();
         public ulong Flags;
-        public Team Team; //  | local — no wire
+        public Team Team; // | local — no wire
     }
 
     // TurretData_Deep — every non- | local field, deep encodings: full state for
@@ -366,21 +359,17 @@ namespace Example
         public const long ShipData_DeepMaxBits = 1703;
         public const long ShipData_DeepMaxBytes = 216; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteShipData_Deep/ReadShipData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteShipData_Deep(WriteStream stream, ShipData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteShipData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteShipData_DeepBatch(ref WriteBatch batch, ShipData_Deep value)
         {
@@ -489,7 +478,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.LaserIndex < 0 || value.LaserIndex > (int)(ShipMaxLasers - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.LaserIndex < 0 || value.LaserIndex > (int)(ShipMaxLasers - 1))
             {
                 return false;
             }
@@ -500,7 +489,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.MissileIndex < 0 || value.MissileIndex > (int)(ShipMaxMissiles - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.MissileIndex < 0 || value.MissileIndex > (int)(ShipMaxMissiles - 1))
             {
                 return false;
             }
@@ -526,13 +515,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadShipData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadShipData_DeepBatch(ref ReadBatch batch, ShipData_Deep value)
         {
@@ -662,21 +649,17 @@ namespace Example
         public const long ShipData_ShallowMaxBits = 218;
         public const long ShipData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteShipData_Shallow/ReadShipData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteShipData_Shallow(WriteStream stream, ShipData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteShipData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteShipData_ShallowBatch(ref WriteBatch batch, ShipData_Shallow value)
         {
@@ -852,13 +835,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadShipData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadShipData_ShallowBatch(ref ReadBatch batch, ShipData_Shallow value)
         {
@@ -1122,21 +1103,17 @@ namespace Example
         public const long MissileData_DeepMaxBits = 708;
         public const long MissileData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteMissileData_Deep/ReadMissileData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteMissileData_Deep(WriteStream stream, MissileData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteMissileData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMissileData_DeepBatch(ref WriteBatch batch, MissileData_Deep value)
         {
@@ -1185,13 +1162,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadMissileData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMissileData_DeepBatch(ref ReadBatch batch, MissileData_Deep value)
         {
@@ -1233,21 +1208,17 @@ namespace Example
         public const long MissileData_ShallowMaxBits = 260;
         public const long MissileData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteMissileData_Shallow/ReadMissileData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteMissileData_Shallow(WriteStream stream, MissileData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteMissileData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMissileData_ShallowBatch(ref WriteBatch batch, MissileData_Shallow value)
         {
@@ -1394,13 +1365,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadMissileData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMissileData_ShallowBatch(ref ReadBatch batch, MissileData_Shallow value)
         {
@@ -1640,21 +1609,17 @@ namespace Example
         public const long DynamicPropData_DeepMaxBits = 709;
         public const long DynamicPropData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteDynamicPropData_Deep/ReadDynamicPropData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteDynamicPropData_Deep(WriteStream stream, DynamicPropData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteDynamicPropData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDynamicPropData_DeepBatch(ref WriteBatch batch, DynamicPropData_Deep value)
         {
@@ -1703,13 +1668,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadDynamicPropData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadDynamicPropData_DeepBatch(ref ReadBatch batch, DynamicPropData_Deep value)
         {
@@ -1751,21 +1714,17 @@ namespace Example
         public const long DynamicPropData_ShallowMaxBits = 261;
         public const long DynamicPropData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteDynamicPropData_Shallow/ReadDynamicPropData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteDynamicPropData_Shallow(WriteStream stream, DynamicPropData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteDynamicPropData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDynamicPropData_ShallowBatch(ref WriteBatch batch, DynamicPropData_Shallow value)
         {
@@ -1912,13 +1871,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadDynamicPropData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadDynamicPropData_ShallowBatch(ref ReadBatch batch, DynamicPropData_Shallow value)
         {
@@ -2158,21 +2115,17 @@ namespace Example
         public const long TurretData_DeepMaxBits = 350;
         public const long TurretData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteTurretData_Deep/ReadTurretData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTurretData_Deep(WriteStream stream, TurretData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTurretData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTurretData_DeepBatch(ref WriteBatch batch, TurretData_Deep value)
         {
@@ -2180,7 +2133,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1))
             {
                 return false;
             }
@@ -2206,13 +2159,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTurretData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTurretData_DeepBatch(ref ReadBatch batch, TurretData_Deep value)
         {
@@ -2238,21 +2189,17 @@ namespace Example
         public const long TurretData_ShallowMaxBits = 142;
         public const long TurretData_ShallowMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteTurretData_Shallow/ReadTurretData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTurretData_Shallow(WriteStream stream, TurretData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTurretData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTurretData_ShallowBatch(ref WriteBatch batch, TurretData_Shallow value)
         {
@@ -2260,7 +2207,7 @@ namespace Example
             {
                 return false;
             }
-            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.TurretIndex < 0 || value.TurretIndex > (int)(MaxTurretsPerShip - 1))
             {
                 return false;
             }
@@ -2326,13 +2273,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTurretData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTurretData_ShallowBatch(ref ReadBatch batch, TurretData_Shallow value)
         {

--- a/testdata/golden/cs/Render.cs
+++ b/testdata/golden/cs/Render.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System.Runtime.CompilerServices;
 using Serialize;
@@ -56,8 +49,7 @@ namespace Example
         public const long RenderSpriteMaxBits = 138;
         public const long RenderSpriteMaxBytes = 24;
 
-        // ZeroRenderSprite resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroRenderSprite(RenderSprite value)
         {
             value.SortKey = 0;
@@ -67,21 +59,17 @@ namespace Example
             value.Team = Team.None;
         }
 
-        // WriteRenderSprite/ReadRenderSprite run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRenderSprite(WriteStream stream, RenderSprite value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteRenderSpriteBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderSpriteBatch(ref WriteBatch batch, RenderSprite value)
         {
@@ -122,13 +110,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadRenderSpriteBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderSpriteBatch(ref ReadBatch batch, RenderSprite value)
         {
@@ -168,8 +154,7 @@ namespace Example
         public const long RenderBlockMaxBits = 8903;
         public const long RenderBlockMaxBytes = 1120;
 
-        // ZeroRenderBlock resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroRenderBlock(RenderBlock value)
         {
             value.WorkerIndex = 0;
@@ -181,21 +166,17 @@ namespace Example
             value.SpritesCount = 0;
         }
 
-        // WriteRenderBlock/ReadRenderBlock run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRenderBlock(WriteStream stream, RenderBlock value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteRenderBlockBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderBlockBatch(ref WriteBatch batch, RenderBlock value)
         {
@@ -232,13 +213,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadRenderBlockBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderBlockBatch(ref ReadBatch batch, RenderBlock value)
         {

--- a/testdata/golden/cs/Types.cs
+++ b/testdata/golden/cs/Types.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System.Runtime.CompilerServices;
 using Serialize;
@@ -17,8 +10,7 @@ using Serialize;
 namespace Example
 {
 
-    // type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class Vec3
     {
         public double X;
@@ -26,8 +18,7 @@ namespace Example
         public double Z;
     }
 
-    // type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class Quat
     {
         public double X;
@@ -149,8 +140,8 @@ namespace Example
         public long FloorBound; // wire [-9223372036854775808, 100]
         public long DoubledFloor; // wire [-9223372036854775808, 100]
         public ulong CeilingRange; // wire [1, 18446744073709551615]
-        public long FloorDefault = -9223372036854775808; // = -9223372036854775808 at construction; Zero* gives the §5 zero form
-        public ulong CeilingDefault = 18446744073709551615; // = 18446744073709551615 at construction; Zero* gives the §5 zero form
+        public long FloorDefault = -9223372036854775808; // specified default at construction; Zero* gives the §5 zero form
+        public ulong CeilingDefault = 18446744073709551615; // specified default at construction; Zero* gives the §5 zero form
     }
 
     // type ExtremeRow
@@ -158,8 +149,8 @@ namespace Example
     {
         public long ClampedFloor; // wire [-9223372036854775808, 100]
         public ulong ClampedCeiling; // wire [1, 18446744073709551614]
-        public long FloorDef = -9223372036854775808; // = -9223372036854775808 at construction; Zero* gives the §5 zero form
-        public ulong CeilingDef = 18446744073709551615; // = 18446744073709551615 at construction; Zero* gives the §5 zero form
+        public long FloorDef = -9223372036854775808; // specified default at construction; Zero* gives the §5 zero form
+        public ulong CeilingDef = 18446744073709551615; // specified default at construction; Zero* gives the §5 zero form
     }
 
     // Schema carries every generated function and constant of the unit — C# has
@@ -172,8 +163,7 @@ namespace Example
         public const long Vec3MaxBits = 192;
         public const long Vec3MaxBytes = 24;
 
-        // ZeroVec3 resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroVec3(Vec3 value)
         {
             value.X = 0.0;
@@ -181,21 +171,17 @@ namespace Example
             value.Z = 0.0;
         }
 
-        // WriteVec3/ReadVec3 run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteVec3(WriteStream stream, Vec3 value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteVec3Batch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteVec3Batch(ref WriteBatch batch, Vec3 value)
         {
@@ -218,13 +204,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadVec3Batch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadVec3Batch(ref ReadBatch batch, Vec3 value)
         {
@@ -248,8 +232,7 @@ namespace Example
         public const long QuatMaxBits = 256;
         public const long QuatMaxBytes = 32;
 
-        // ZeroQuat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuat(Quat value)
         {
             value.X = 0.0;
@@ -258,21 +241,17 @@ namespace Example
             value.W = 0.0;
         }
 
-        // WriteQuat/ReadQuat run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuat(WriteStream stream, Quat value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuatBatch(ref WriteBatch batch, Quat value)
         {
@@ -299,13 +278,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuatBatch(ref ReadBatch batch, Quat value)
         {
@@ -333,33 +310,28 @@ namespace Example
         public const long HandleMaxBits = 22;
         public const long HandleMaxBytes = 8;
 
-        // ZeroHandle resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroHandle(Handle value)
         {
             value.ObjectId = 0;
             value.ObjectSequence = 0;
         }
 
-        // WriteHandle/ReadHandle run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteHandle(WriteStream stream, Handle value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteHandleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteHandleBatch(ref WriteBatch batch, Handle value)
         {
-            if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
             {
                 return false;
             }
@@ -384,13 +356,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadHandleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadHandleBatch(ref ReadBatch batch, Handle value)
         {
@@ -414,8 +384,7 @@ namespace Example
         public const long QuantizedPositionMaxBits = 75;
         public const long QuantizedPositionMaxBytes = 16;
 
-        // ZeroQuantizedPosition resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuantizedPosition(QuantizedPosition value)
         {
             value.X = 0;
@@ -423,25 +392,21 @@ namespace Example
             value.Z = 0;
         }
 
-        // WriteQuantizedPosition/ReadQuantizedPosition run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuantizedPosition(WriteStream stream, QuantizedPosition value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuantizedPositionBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedPositionBatch(ref WriteBatch batch, QuantizedPosition value)
         {
-            if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits) // out-of-contract writes are refused, not wrapped
+            if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
             {
                 return false;
             }
@@ -452,7 +417,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
             {
                 return false;
             }
@@ -463,7 +428,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
             {
                 return false;
             }
@@ -481,13 +446,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuantizedPositionBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuantizedPositionBatch(ref ReadBatch batch, QuantizedPosition value)
         {
@@ -511,8 +474,7 @@ namespace Example
         public const long QuantizedVelocityMaxBits = 69;
         public const long QuantizedVelocityMaxBytes = 16;
 
-        // ZeroQuantizedVelocity resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuantizedVelocity(QuantizedVelocity value)
         {
             value.X = 0;
@@ -520,25 +482,21 @@ namespace Example
             value.Z = 0;
         }
 
-        // WriteQuantizedVelocity/ReadQuantizedVelocity run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuantizedVelocity(WriteStream stream, QuantizedVelocity value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuantizedVelocityBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedVelocityBatch(ref WriteBatch batch, QuantizedVelocity value)
         {
-            if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits) // out-of-contract writes are refused, not wrapped
+            if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
             {
                 return false;
             }
@@ -549,7 +507,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
             {
                 return false;
             }
@@ -560,7 +518,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
             {
                 return false;
             }
@@ -578,13 +536,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuantizedVelocityBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuantizedVelocityBatch(ref ReadBatch batch, QuantizedVelocity value)
         {
@@ -608,8 +564,7 @@ namespace Example
         public const long QuantizedRotationMaxBits = 48;
         public const long QuantizedRotationMaxBytes = 8;
 
-        // ZeroQuantizedRotation resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroQuantizedRotation(QuantizedRotation value)
         {
             value.X = 0;
@@ -618,25 +573,21 @@ namespace Example
             value.W = 0;
         }
 
-        // WriteQuantizedRotation/ReadQuantizedRotation run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteQuantizedRotation(WriteStream stream, QuantizedRotation value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteQuantizedRotationBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedRotationBatch(ref WriteBatch batch, QuantizedRotation value)
         {
-            if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
             {
                 return false;
             }
@@ -647,7 +598,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
             {
                 return false;
             }
@@ -658,7 +609,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
             {
                 return false;
             }
@@ -669,7 +620,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits) // out-of-contract writes are refused, not wrapped
+            if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
             {
                 return false;
             }
@@ -687,13 +638,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadQuantizedRotationBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadQuantizedRotationBatch(ref ReadBatch batch, QuantizedRotation value)
         {
@@ -737,8 +686,7 @@ namespace Example
         public const long RigidBodyMaxBits = 833;
         public const long RigidBodyMaxBytes = 112;
 
-        // ZeroRigidBody resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroRigidBody(RigidBody value)
         {
             ZeroVec3(value.Position);
@@ -748,21 +696,17 @@ namespace Example
             ZeroVec3(value.AngularVelocity);
         }
 
-        // WriteRigidBody/ReadRigidBody run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRigidBody(WriteStream stream, RigidBody value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteRigidBodyBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRigidBodyBatch(ref WriteBatch batch, RigidBody value)
         {
@@ -796,13 +740,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadRigidBodyBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRigidBodyBatch(ref ReadBatch batch, RigidBody value)
         {
@@ -842,8 +784,7 @@ namespace Example
         public const long InputMaxBits = 168;
         public const long InputMaxBytes = 24;
 
-        // ZeroInput resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroInput(Input value)
         {
             value.StickX = 0.0f;
@@ -861,21 +802,17 @@ namespace Example
             value.Ping = false;
         }
 
-        // WriteInput/ReadInput run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteInput(WriteStream stream, Input value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteInputBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteInputBatch(ref WriteBatch batch, Input value)
         {
@@ -938,13 +875,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadInputBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadInputBatch(ref ReadBatch batch, Input value)
         {
@@ -1008,8 +943,7 @@ namespace Example
         public const long InputPacketMaxBits = 2837;
         public const long InputPacketMaxBytes = 360;
 
-        // ZeroInputPacket resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroInputPacket(InputPacket value)
         {
             value.SynchronizeSequence = 0;
@@ -1022,21 +956,17 @@ namespace Example
             value.InputsCount = 0;
         }
 
-        // WriteInputPacket/ReadInputPacket run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteInputPacket(WriteStream stream, InputPacket value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteInputPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteInputPacketBatch(ref WriteBatch batch, InputPacket value)
         {
@@ -1080,13 +1010,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadInputPacketBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadInputPacketBatch(ref ReadBatch batch, InputPacket value)
         {
@@ -1125,8 +1053,7 @@ namespace Example
         public const long ShipCreateMaxBits = 219;
         public const long ShipCreateMaxBytes = 32;
 
-        // ZeroShipCreate resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroShipCreate(ShipCreate value)
         {
             value.ShipType = ShipType.None;
@@ -1141,21 +1068,17 @@ namespace Example
             value.Pending = Pending.None;
         }
 
-        // WriteShipCreate/ReadShipCreate run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteShipCreate(WriteStream stream, ShipCreate value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteShipCreateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteShipCreateBatch(ref WriteBatch batch, ShipCreate value)
         {
@@ -1211,7 +1134,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Health < 0 || value.Health > (int)MaxHealth) // out-of-contract writes are refused, not wrapped
+            if (value.Health < 0 || value.Health > (int)MaxHealth)
             {
                 return false;
             }
@@ -1222,7 +1145,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Thrust < 0 || value.Thrust > 100) // out-of-contract writes are refused, not wrapped
+            if (value.Thrust < 0 || value.Thrust > 100)
             {
                 return false;
             }
@@ -1247,13 +1170,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadShipCreateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadShipCreateBatch(ref ReadBatch batch, ShipCreate value)
         {
@@ -1336,33 +1257,28 @@ namespace Example
         public const long ExpressionProbeMaxBits = 16;
         public const long ExpressionProbeMaxBytes = 8;
 
-        // ZeroExpressionProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroExpressionProbe(ExpressionProbe value)
         {
             value.HardpointIndex = 0;
             value.SpinRate = 0;
         }
 
-        // WriteExpressionProbe/ReadExpressionProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteExpressionProbe(WriteStream stream, ExpressionProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteExpressionProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExpressionProbeBatch(ref WriteBatch batch, ExpressionProbe value)
         {
-            if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1)) // out-of-contract writes are refused, not wrapped
+            if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
             {
                 return false;
             }
@@ -1373,7 +1289,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2)) // out-of-contract writes are refused, not wrapped
+            if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
             {
                 return false;
             }
@@ -1391,13 +1307,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadExpressionProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadExpressionProbeBatch(ref ReadBatch batch, ExpressionProbe value)
         {
@@ -1421,8 +1335,7 @@ namespace Example
         public const long ExtremeProbeMaxBits = 320;
         public const long ExtremeProbeMaxBytes = 40;
 
-        // ZeroExtremeProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroExtremeProbe(ExtremeProbe value)
         {
             value.FloorBound = 0;
@@ -1432,25 +1345,21 @@ namespace Example
             value.CeilingDefault = 0;
         }
 
-        // WriteExtremeProbe/ReadExtremeProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteExtremeProbe(WriteStream stream, ExtremeProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteExtremeProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeProbeBatch(ref WriteBatch batch, ExtremeProbe value)
         {
-            if (value.FloorBound > 100) // out-of-contract writes are refused, not wrapped
+            if (value.FloorBound > 100)
             {
                 return false;
             }
@@ -1461,7 +1370,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.DoubledFloor > 100) // out-of-contract writes are refused, not wrapped
+            if (value.DoubledFloor > 100)
             {
                 return false;
             }
@@ -1472,7 +1381,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.CeilingRange < 1) // out-of-contract writes are refused, not wrapped
+            if (value.CeilingRange < 1)
             {
                 return false;
             }
@@ -1501,13 +1410,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadExtremeProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadExtremeProbeBatch(ref ReadBatch batch, ExtremeProbe value)
         {
@@ -1551,8 +1458,7 @@ namespace Example
         public const long ExtremeRowMaxBits = 256;
         public const long ExtremeRowMaxBytes = 32;
 
-        // ZeroExtremeRow resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroExtremeRow(ExtremeRow value)
         {
             value.ClampedFloor = 0;
@@ -1561,25 +1467,21 @@ namespace Example
             value.CeilingDef = 0;
         }
 
-        // WriteExtremeRow/ReadExtremeRow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteExtremeRow(WriteStream stream, ExtremeRow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteExtremeRowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExtremeRowBatch(ref WriteBatch batch, ExtremeRow value)
         {
-            if (value.ClampedFloor > 100) // out-of-contract writes are refused, not wrapped
+            if (value.ClampedFloor > 100)
             {
                 return false;
             }
@@ -1590,7 +1492,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.ClampedCeiling < 1 || value.ClampedCeiling > 18446744073709551614) // out-of-contract writes are refused, not wrapped
+            if (value.ClampedCeiling < 1 || value.ClampedCeiling > 18446744073709551614)
             {
                 return false;
             }
@@ -1619,13 +1521,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadExtremeRowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadExtremeRowBatch(ref ReadBatch batch, ExtremeRow value)
         {

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -3,13 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -50,7 +43,7 @@ namespace Example
     // type ProbeSample
     public sealed class ProbeSample
     {
-        public bool Active = true; // = true at construction; Zero* gives the §5 zero form
+        public bool Active = true; // specified default at construction; Zero* gives the §5 zero form
         public float Orientation; // compressed float [-180.0, 180.0] @ 0.01
         public int RawDelta;
         public long BigDelta;
@@ -126,8 +119,8 @@ namespace Example
     // type ProbeConfig
     public sealed class ProbeConfig
     {
-        public int Retries = -1; // = -1 at construction; Zero* gives the §5 zero form
-        public Weapon Preferred = Weapon.Railgun; // = Weapon.Railgun at construction; Zero* gives the §5 zero form
+        public int Retries = -1; // specified default at construction; Zero* gives the §5 zero form
+        public Weapon Preferred = Weapon.Railgun; // specified default at construction; Zero* gives the §5 zero form
     }
 
     // type ProbeArray
@@ -233,29 +226,24 @@ namespace Example
         public const long ProbeHeaderMaxBits = 87;
         public const long ProbeHeaderMaxBytes = 16;
 
-        // ZeroProbeHeader resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeHeader(ProbeHeader value)
         {
             value.Version = 0;
             value.ProbeId = 0;
         }
 
-        // WriteProbeHeader/ReadProbeHeader run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeHeader(WriteStream stream, ProbeHeader value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeHeaderBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeHeaderBatch(ref WriteBatch batch, ProbeHeader value)
         {
@@ -292,13 +280,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeHeaderBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeHeaderBatch(ref ReadBatch batch, ProbeHeader value)
         {
@@ -344,8 +330,7 @@ namespace Example
         public const long ProbeBitsMaxBits = 202;
         public const long ProbeBitsMaxBytes = 32;
 
-        // ZeroProbeBits resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeBits(ProbeBits value)
         {
             value.Small = 0;
@@ -355,21 +340,17 @@ namespace Example
             value.Nonce = 0;
         }
 
-        // WriteProbeBits/ReadProbeBits run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeBits(WriteStream stream, ProbeBits value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeBitsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeBitsBatch(ref WriteBatch batch, ProbeBits value)
         {
@@ -406,13 +387,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeBitsBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeBitsBatch(ref ReadBatch batch, ProbeBits value)
         {
@@ -452,8 +431,7 @@ namespace Example
         public const long ProbeSampleMaxBits = 276;
         public const long ProbeSampleMaxBytes = 40;
 
-        // ZeroProbeSample resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeSample(ProbeSample value)
         {
             value.Active = false;
@@ -468,21 +446,17 @@ namespace Example
             value.SamplesCount = 0;
         }
 
-        // WriteProbeSample/ReadProbeSample run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeSample(WriteStream stream, ProbeSample value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeSampleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeSampleBatch(ref WriteBatch batch, ProbeSample value)
         {
@@ -574,13 +548,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeSampleBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeSampleBatch(ref ReadBatch batch, ProbeSample value)
         {
@@ -672,8 +644,7 @@ namespace Example
         public const long ProbeRingMaxBits = 16;
         public const long ProbeRingMaxBytes = 8;
 
-        // ZeroProbeRing resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeRing(ProbeRing value)
         {
             value.Radius = 0;
@@ -709,33 +680,28 @@ namespace Example
         public const long ProbeSlabMaxBits = 15;
         public const long ProbeSlabMaxBytes = 8;
 
-        // ZeroProbeSlab resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeSlab(ProbeSlab value)
         {
             value.Width = 0;
             value.Height = 0;
         }
 
-        // WriteProbeSlab/ReadProbeSlab run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeSlab(WriteStream stream, ProbeSlab value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeSlabBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeSlabBatch(ref WriteBatch batch, ProbeSlab value)
         {
-            if (value.Width > 100) // out-of-contract writes are refused, not wrapped
+            if (value.Width > 100)
             {
                 return false;
             }
@@ -760,13 +726,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeSlabBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeSlabBatch(ref ReadBatch batch, ProbeSlab value)
         {
@@ -848,8 +812,7 @@ namespace Example
         public const long ProbeColliderMaxBits = 82;
         public const long ProbeColliderMaxBytes = 16;
 
-        // ZeroProbeCollider resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeCollider(ProbeCollider value)
         {
             value.Armor = 0;
@@ -937,29 +900,24 @@ namespace Example
         public const long ProbeConfigMaxBits = 36;
         public const long ProbeConfigMaxBytes = 8;
 
-        // ZeroProbeConfig resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeConfig(ProbeConfig value)
         {
             value.Retries = 0;
             value.Preferred = Weapon.None;
         }
 
-        // WriteProbeConfig/ReadProbeConfig run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeConfig(WriteStream stream, ProbeConfig value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeConfigBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeConfigBatch(ref WriteBatch batch, ProbeConfig value)
         {
@@ -988,13 +946,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeConfigBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeConfigBatch(ref ReadBatch batch, ProbeConfig value)
         {
@@ -1022,8 +978,7 @@ namespace Example
         public const long ProbeArrayMaxBits = 588;
         public const long ProbeArrayMaxBytes = 80;
 
-        // ZeroProbeArray resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeArray(ProbeArray value)
         {
             for (int i = 0; i < 2; i++)
@@ -1033,21 +988,17 @@ namespace Example
             ZeroProbeConfig(value.Config);
         }
 
-        // WriteProbeArray/ReadProbeArray run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeArray(WriteStream stream, ProbeArray value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeArrayBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeArrayBatch(ref WriteBatch batch, ProbeArray value)
         {
@@ -1069,13 +1020,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeArrayBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeArrayBatch(ref ReadBatch batch, ProbeArray value)
         {
@@ -1098,8 +1047,7 @@ namespace Example
         public const long ProbeReportMaxBits = 141;
         public const long ProbeReportMaxBytes = 24;
 
-        // ZeroProbeReport resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroProbeReport(ProbeReport value)
         {
             ZeroProbeHeader(value.Header);
@@ -1107,21 +1055,17 @@ namespace Example
             ZeroTest(value.Echo);
         }
 
-        // WriteProbeReport/ReadProbeReport run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeReport(WriteStream stream, ProbeReport value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteProbeReportBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeReportBatch(ref WriteBatch batch, ProbeReport value)
         {
@@ -1151,13 +1095,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadProbeReportBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeReportBatch(ref ReadBatch batch, ProbeReport value)
         {
@@ -1185,8 +1127,7 @@ namespace Example
         public const long TestDataMaxBits = 2735;
         public const long TestDataMaxBytes = 344;
 
-        // ZeroTestData resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroTestData(TestData value)
         {
             value.A = 0;
@@ -1214,25 +1155,21 @@ namespace Example
             value.TextLength = 0;
         }
 
-        // WriteTestData/ReadTestData run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTestData(WriteStream stream, TestData value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteTestDataBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTestDataBatch(ref WriteBatch batch, TestData value)
         {
-            if (value.A < -100 || value.A > 100) // out-of-contract writes are refused, not wrapped
+            if (value.A < -100 || value.A > 100)
             {
                 return false;
             }
@@ -1243,7 +1180,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.B < -100 || value.B > 100) // out-of-contract writes are refused, not wrapped
+            if (value.B < -100 || value.B > 100)
             {
                 return false;
             }
@@ -1254,7 +1191,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.C < -100 || value.C > 150) // out-of-contract writes are refused, not wrapped
+            if (value.C < -100 || value.C > 150)
             {
                 return false;
             }
@@ -1294,7 +1231,7 @@ namespace Example
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (value.Items[i] < 0 || value.Items[i] > 255) // out-of-contract writes are refused, not wrapped
+                if (value.Items[i] < 0 || value.Items[i] > 255)
                 {
                     return false;
                 }
@@ -1364,7 +1301,7 @@ namespace Example
                     return false;
                 }
             }
-            if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000) // out-of-contract writes are refused, not wrapped
+            if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
             {
                 return false;
             }
@@ -1405,13 +1342,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadTestDataBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTestDataBatch(ref ReadBatch batch, TestData value)
         {
@@ -1549,29 +1484,24 @@ namespace Example
         public const long CompressedProbeMaxBits = 24;
         public const long CompressedProbeMaxBytes = 8;
 
-        // ZeroCompressedProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroCompressedProbe(CompressedProbe value)
         {
             value.Boundary = 0.0f;
             value.Offset = 0.0f;
         }
 
-        // WriteCompressedProbe/ReadCompressedProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteCompressedProbe(WriteStream stream, CompressedProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteCompressedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteCompressedProbeBatch(ref WriteBatch batch, CompressedProbe value)
         {
@@ -1596,13 +1526,11 @@ namespace Example
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadCompressedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadCompressedProbeBatch(ref ReadBatch batch, CompressedProbe value)
         {

--- a/testdata/golden/go/Messages.go
+++ b/testdata/golden/go/Messages.go
@@ -63,7 +63,7 @@ func WriteTest(stream *serialize.WriteStream, value *Test) error {
 	}
 	{
 		rangeValue := int32(value.TestB)
-		if rangeValue < 0 || rangeValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -73,7 +73,7 @@ func WriteTest(stream *serialize.WriteStream, value *Test) error {
 	}
 	{
 		rangeValue := int32(value.TestC)
-		if rangeValue < 0 || rangeValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -83,7 +83,7 @@ func WriteTest(stream *serialize.WriteStream, value *Test) error {
 	}
 	{
 		rangeValue := int32(value.TestD)
-		if rangeValue < 0 || rangeValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -130,7 +130,7 @@ const BlockMaxBits = 16018
 const BlockMaxBytes = 2008
 
 func WriteBlock(stream *serialize.WriteStream, value *Block) error {
-	if value.DataLength < 0 || value.DataLength > MaxBlockSize { // the runtime range refusal, folded (SPEC §5)
+	if value.DataLength < 0 || value.DataLength > MaxBlockSize {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -165,7 +165,7 @@ const ChatMaxBits = 2064
 const ChatMaxBytes = 264
 
 func WriteChat(stream *serialize.WriteStream, value *Chat) error {
-	if value.TextLength < 0 || value.TextLength > MaxChatLength { // the runtime range refusal, folded (SPEC §5)
+	if value.TextLength < 0 || value.TextLength > MaxChatLength {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -256,7 +256,7 @@ func ReadTimescale(stream *serialize.ReadStream, value *Timescale) error {
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
 func WriteMessageType(stream *serialize.WriteStream, value MessageType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 6 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 6 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/testdata/golden/go/Objects.go
+++ b/testdata/golden/go/Objects.go
@@ -54,11 +54,11 @@ type ClientShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       //  | local — no wire
-	PreviousPosition    Vec3                       //  | local — no wire
-	NumColliders        int32                      //  | local — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
-	PredictedExplode    bool                       //  | local, context = client
+	Invulnerable        bool                       // | local — no wire
+	PreviousPosition    Vec3                       // | local — no wire
+	NumColliders        int32                      // | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 // | local — no wire
+	PredictedExplode    bool                       // | local, context = client
 }
 
 // ServerShipState — the full simulation struct for the server context: every `all`
@@ -89,10 +89,10 @@ type ServerShipState struct {
 	MissileIndex        int8 // wire [0, 15]
 	Target              Handle
 	LockStartTime       float64
-	Invulnerable        bool                       //  | local — no wire
-	PreviousPosition    Vec3                       //  | local — no wire
-	NumColliders        int32                      //  | local — no wire
-	ColliderArmor       [MaxCollidersPerShip]int32 //  | local — no wire
+	Invulnerable        bool                       // | local — no wire
+	PreviousPosition    Vec3                       // | local — no wire
+	NumColliders        int32                      // | local — no wire
+	ColliderArmor       [MaxCollidersPerShip]int32 // | local — no wire
 }
 
 // ShipData_Deep — every non- | local field, deep encodings: full state for
@@ -168,7 +168,7 @@ const ShipData_DeepMaxBytes = 216 // rounded up to the 8-byte write-buffer granu
 func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) error {
 	{
 		enumValue := int32(value.ShipType)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -194,7 +194,7 @@ func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) err
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -225,7 +225,7 @@ func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) err
 	stream.SerializeFloat32(&value.AimVelocity)
 	{
 		rangeValue := int32(value.LaserIndex)
-		if rangeValue < 0 || rangeValue > ShipMaxLasers-1 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > ShipMaxLasers-1 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -235,7 +235,7 @@ func WriteShipData_Deep(stream *serialize.WriteStream, value *ShipData_Deep) err
 	}
 	{
 		rangeValue := int32(value.MissileIndex)
-		if rangeValue < 0 || rangeValue > ShipMaxMissiles-1 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > ShipMaxMissiles-1 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -319,7 +319,7 @@ const ShipData_ShallowMaxBytes = 32 // rounded up to the 8-byte write-buffer gra
 func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallow) error {
 	{
 		enumValue := int32(value.ShipType)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -327,21 +327,21 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 			stream.SerializeBits(&offsetValue, 3)
 		}
 	}
-	if value.PositionX < -8388608 || value.PositionX > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -8388608 || value.PositionX > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionY < -8388608 || value.PositionY > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -8388608 || value.PositionY > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionZ < -8388608 || value.PositionZ > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -8388608 || value.PositionZ > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -350,7 +350,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -360,7 +360,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -370,7 +370,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -380,7 +380,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -388,21 +388,21 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 			stream.SerializeBits(&offsetValue, 12)
 		}
 	}
-	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityX - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityY - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -418,7 +418,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -428,7 +428,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		projectedValue := int32(value.Health)
-		if projectedValue < 0 || projectedValue > 1000 { // the runtime range refusal, folded (SPEC §5)
+		if projectedValue < 0 || projectedValue > 1000 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -438,7 +438,7 @@ func WriteShipData_Shallow(stream *serialize.WriteStream, value *ShipData_Shallo
 	}
 	{
 		projectedValue := int32(value.Thrust)
-		if projectedValue < 0 || projectedValue > 100 { // the runtime range refusal, folded (SPEC §5)
+		if projectedValue < 0 || projectedValue > 100 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -651,8 +651,8 @@ type ClientMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3   //  | local — no wire
-	Target          Handle //  | local — no wire
+	AngularVelocity Vec3   // | local — no wire
+	Target          Handle // | local — no wire
 }
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
@@ -664,9 +664,9 @@ type ServerMissileState struct {
 	LinearVelocity  Vec3
 	Team            Team
 	Flags           uint64
-	AngularVelocity Vec3    //  | local — no wire
-	Target          Handle  //  | local — no wire
-	Timer           float64 //  | local, context = server
+	AngularVelocity Vec3    // | local — no wire
+	Target          Handle  // | local — no wire
+	Timer           float64 // | local, context = server
 }
 
 // MissileData_Deep — every non- | local field, deep encodings: full state for
@@ -719,7 +719,7 @@ const MissileData_DeepMaxBytes = 96 // rounded up to the 8-byte write-buffer gra
 func WriteMissileData_Deep(stream *serialize.WriteStream, value *MissileData_Deep) error {
 	{
 		enumValue := int32(value.MissileType)
-		if enumValue < 0 || enumValue > 3 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 3 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -738,7 +738,7 @@ func WriteMissileData_Deep(stream *serialize.WriteStream, value *MissileData_Dee
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -780,7 +780,7 @@ const MissileData_ShallowMaxBytes = 40 // rounded up to the 8-byte write-buffer 
 func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_Shallow) error {
 	{
 		enumValue := int32(value.MissileType)
-		if enumValue < 0 || enumValue > 3 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 3 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -788,21 +788,21 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 			stream.SerializeBits(&offsetValue, 2)
 		}
 	}
-	if value.PositionX < -8388608 || value.PositionX > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -8388608 || value.PositionX > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionY < -8388608 || value.PositionY > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -8388608 || value.PositionY > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionZ < -8388608 || value.PositionZ > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -8388608 || value.PositionZ > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -811,7 +811,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -821,7 +821,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -831,7 +831,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -841,7 +841,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -849,21 +849,21 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 			stream.SerializeBits(&offsetValue, 12)
 		}
 	}
-	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityX - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityY - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -872,7 +872,7 @@ func WriteMissileData_Shallow(stream *serialize.WriteStream, value *MissileData_
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1067,7 +1067,7 @@ type DynamicPropState struct {
 	LinearVelocity  Vec3
 	Flags           uint64
 	Team            Team
-	AngularVelocity Vec3 //  | local — no wire
+	AngularVelocity Vec3 // | local — no wire
 }
 
 // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
@@ -1120,7 +1120,7 @@ const DynamicPropData_DeepMaxBytes = 96 // rounded up to the 8-byte write-buffer
 func WriteDynamicPropData_Deep(stream *serialize.WriteStream, value *DynamicPropData_Deep) error {
 	{
 		enumValue := int32(value.PropType)
-		if enumValue < 0 || enumValue > 6 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 6 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1140,7 +1140,7 @@ func WriteDynamicPropData_Deep(stream *serialize.WriteStream, value *DynamicProp
 	stream.SerializeBits64(&value.Flags, 64)
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1181,7 +1181,7 @@ const DynamicPropData_ShallowMaxBytes = 40 // rounded up to the 8-byte write-buf
 func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicPropData_Shallow) error {
 	{
 		enumValue := int32(value.PropType)
-		if enumValue < 0 || enumValue > 6 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 6 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1189,21 +1189,21 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 			stream.SerializeBits(&offsetValue, 3)
 		}
 	}
-	if value.PositionX < -8388608 || value.PositionX > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -8388608 || value.PositionX > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionY < -8388608 || value.PositionY > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -8388608 || value.PositionY > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-8388608))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.PositionZ < -8388608 || value.PositionZ > 8388608 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -8388608 || value.PositionZ > 8388608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1212,7 +1212,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1222,7 +1222,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1232,7 +1232,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1242,7 +1242,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1250,21 +1250,21 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 			stream.SerializeBits(&offsetValue, 12)
 		}
 	}
-	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityX - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.LinearVelocityY - (-2097152))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 { // the runtime range refusal, folded (SPEC §5)
+	if value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1274,7 +1274,7 @@ func WriteDynamicPropData_Shallow(stream *serialize.WriteStream, value *DynamicP
 	stream.SerializeBits64(&value.Flags, 64)
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1466,7 +1466,7 @@ type TurretState struct {
 	TurretIndex int32 // wire [0, 255]
 	Rotation    Quat
 	Flags       uint64
-	Team        Team //  | local — no wire
+	Team        Team // | local — no wire
 }
 
 // TurretData_Deep — every non- | local field, deep encodings: full state for
@@ -1508,7 +1508,7 @@ func WriteTurretData_Deep(stream *serialize.WriteStream, value *TurretData_Deep)
 	if err := WriteHandle(stream, &value.Parent); err != nil {
 		return err
 	}
-	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1541,7 +1541,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	if err := WriteHandle(stream, &value.Parent); err != nil {
 		return err
 	}
-	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -1550,7 +1550,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1560,7 +1560,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1570,7 +1570,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1580,7 +1580,7 @@ func WriteTurretData_Shallow(stream *serialize.WriteStream, value *TurretData_Sh
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -1685,7 +1685,7 @@ func UnquantizeTurret(input *TurretData_Shallow, output *TurretData_Interpolate)
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
 func WriteObjectType(stream *serialize.WriteStream, value ObjectType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 4 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 4 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/testdata/golden/go/Render.go
+++ b/testdata/golden/go/Render.go
@@ -36,7 +36,7 @@ func WriteRenderSprite(stream *serialize.WriteStream, value *RenderSprite) error
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -80,7 +80,7 @@ const RenderBlockMaxBytes = 1120
 func WriteRenderBlock(stream *serialize.WriteStream, value *RenderBlock) error {
 	stream.SerializeBits(&value.WorkerIndex, 32)
 	stream.SerializeBits(&value.SpriteCountHint, 32)
-	if value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites { // the runtime range refusal, folded (SPEC §5)
+	if value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/testdata/golden/go/Types.go
+++ b/testdata/golden/go/Types.go
@@ -10,8 +10,7 @@ import (
 	"github.com/mas-bandwidth/serialize.go"
 )
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type Vec3 struct {
 	X float64
 	Y float64
@@ -37,8 +36,7 @@ func ReadVec3(stream *serialize.ReadStream, value *Vec3) error {
 	return stream.Err()
 }
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type Quat struct {
 	X float64
 	Y float64
@@ -79,7 +77,7 @@ const HandleMaxBits = 22
 const HandleMaxBytes = 8
 
 func WriteHandle(stream *serialize.WriteStream, value *Handle) error {
-	if value.ObjectId < 0 || value.ObjectId > MaxObjects-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.ObjectId < 0 || value.ObjectId > MaxObjects-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -116,21 +114,21 @@ const QuantizedPositionMaxBits = 75
 const QuantizedPositionMaxBytes = 16
 
 func WriteQuantizedPosition(stream *serialize.WriteStream, value *QuantizedPosition) error {
-	if value.X < -MaxPositionUnits || value.X > MaxPositionUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.X < -MaxPositionUnits || value.X > MaxPositionUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.X - (-MaxPositionUnits))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.Y - (-MaxPositionUnits))
 		stream.SerializeBits(&offsetValue, 25)
 	}
-	if value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -160,21 +158,21 @@ const QuantizedVelocityMaxBits = 69
 const QuantizedVelocityMaxBytes = 16
 
 func WriteQuantizedVelocity(stream *serialize.WriteStream, value *QuantizedVelocity) error {
-	if value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.X - (-MaxVelocityUnits))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.Y - (-MaxVelocityUnits))
 		stream.SerializeBits(&offsetValue, 23)
 	}
-	if value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits { // the runtime range refusal, folded (SPEC §5)
+	if value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -207,7 +205,7 @@ const QuantizedRotationMaxBytes = 8
 func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotation) error {
 	{
 		rangeValue := int32(value.X)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -217,7 +215,7 @@ func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotat
 	}
 	{
 		rangeValue := int32(value.Y)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -227,7 +225,7 @@ func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotat
 	}
 	{
 		rangeValue := int32(value.Z)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -237,7 +235,7 @@ func WriteQuantizedRotation(stream *serialize.WriteStream, value *QuantizedRotat
 	}
 	{
 		rangeValue := int32(value.W)
-		if rangeValue < -RotationUnits || rangeValue > RotationUnits { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < -RotationUnits || rangeValue > RotationUnits {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -407,7 +405,7 @@ func WriteInputPacket(stream *serialize.WriteStream, value *InputPacket) error {
 	}
 	stream.SerializeBits64(&value.CurrentFrame, 64)
 	stream.SerializeBits64(&value.StartFrame, 64)
-	if value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket { // the runtime range refusal, folded (SPEC §5)
+	if value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -471,7 +469,7 @@ const ShipCreateMaxBytes = 32
 func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	{
 		enumValue := int32(value.ShipType)
-		if enumValue < 0 || enumValue > 5 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 5 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -500,7 +498,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		enumValue := int32(value.Team)
-		if enumValue < 0 || enumValue > 2 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 2 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -510,7 +508,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		rangeValue := int32(value.Health)
-		if rangeValue < 0 || rangeValue > MaxHealth { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > MaxHealth {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -520,7 +518,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		rangeValue := int32(value.Thrust)
-		if rangeValue < 0 || rangeValue > 100 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 100 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -530,7 +528,7 @@ func WriteShipCreate(stream *serialize.WriteStream, value *ShipCreate) error {
 	}
 	{
 		enumValue := int32(value.Pending)
-		if enumValue < 0 || enumValue > 0 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 0 {
 			return serialize.ErrValueOutOfRange
 		}
 	}
@@ -597,14 +595,14 @@ const ExpressionProbeMaxBits = 16
 const ExpressionProbeMaxBytes = 8
 
 func WriteExpressionProbe(stream *serialize.WriteStream, value *ExpressionProbe) error {
-	if value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers+ShipMaxMissiles)-1 { // the runtime range refusal, folded (SPEC §5)
+	if value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers+ShipMaxMissiles)-1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.HardpointIndex)
 		stream.SerializeBits(&offsetValue, 5)
 	}
-	if value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits*2 { // the runtime range refusal, folded (SPEC §5)
+	if value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits*2 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -649,14 +647,14 @@ const ExtremeProbeMaxBits = 320
 const ExtremeProbeMaxBytes = 40
 
 func WriteExtremeProbe(stream *serialize.WriteStream, value *ExtremeProbe) error {
-	if value.FloorBound < -9223372036854775808 || value.FloorBound > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.FloorBound < -9223372036854775808 || value.FloorBound > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint64(value.FloorBound - (-9223372036854775808))
 		stream.SerializeBits64(&offsetValue, 64)
 	}
-	if value.DoubledFloor < -(-FloorLimit) || value.DoubledFloor > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.DoubledFloor < -(-FloorLimit) || value.DoubledFloor > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -725,7 +723,7 @@ const ExtremeRowMaxBits = 256
 const ExtremeRowMaxBytes = 32
 
 func WriteExtremeRow(stream *serialize.WriteStream, value *ExtremeRow) error {
-	if value.ClampedFloor < -9223372036854775808 || value.ClampedFloor > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.ClampedFloor < -9223372036854775808 || value.ClampedFloor > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/testdata/golden/go/Wire.go
+++ b/testdata/golden/go/Wire.go
@@ -131,7 +131,7 @@ func WriteProbeBits(stream *serialize.WriteStream, value *ProbeBits) error {
 	stream.SerializeBits64(&value.Wide, 64)
 	{
 		rangeValue := int64(value.Sensor)
-		if rangeValue < 0 || rangeValue > 4294967295 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 4294967295 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -224,7 +224,7 @@ func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 	if value.Active {
 		{
 			enumValue := int32(value.Weapon)
-			if enumValue < 0 || enumValue > 15 { // the runtime range refusal, folded (SPEC §5)
+			if enumValue < 0 || enumValue > 15 {
 				return serialize.ErrValueOutOfRange
 			}
 			{
@@ -242,7 +242,7 @@ func WriteProbeSample(stream *serialize.WriteStream, value *ProbeSample) error {
 	} else {
 		stream.SerializeBits(&value.IdleTicks, 32)
 	}
-	if value.SamplesCount < 1 || value.SamplesCount > 8 { // the runtime range refusal, folded (SPEC §5)
+	if value.SamplesCount < 1 || value.SamplesCount > 8 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -363,7 +363,7 @@ const ProbeSlabMaxBytes = 8
 func WriteProbeSlab(stream *serialize.WriteStream, value *ProbeSlab) error {
 	{
 		rangeValue := int32(value.Width)
-		if rangeValue < 0 || rangeValue > 100 { // the runtime range refusal, folded (SPEC §5)
+		if rangeValue < 0 || rangeValue > 100 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -478,7 +478,7 @@ func WriteProbeCollider(stream *serialize.WriteStream, value *ProbeCollider) err
 	if err := WriteProbeShape(stream, &value.Backup); err != nil {
 		return err
 	}
-	if value.ExtrasCount < 0 || value.ExtrasCount > 2 { // the runtime range refusal, folded (SPEC §5)
+	if value.ExtrasCount < 0 || value.ExtrasCount > 2 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -548,7 +548,7 @@ func WriteProbeConfig(stream *serialize.WriteStream, value *ProbeConfig) error {
 	}
 	{
 		enumValue := int32(value.Preferred)
-		if enumValue < 0 || enumValue > 15 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 15 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -697,21 +697,21 @@ const TestDataMaxBits = 2735
 const TestDataMaxBytes = 344
 
 func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
-	if value.A < -100 || value.A > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.A < -100 || value.A > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.A - (-100))
 		stream.SerializeBits(&offsetValue, 8)
 	}
-	if value.B < -100 || value.B > 100 { // the runtime range refusal, folded (SPEC §5)
+	if value.B < -100 || value.B > 100 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.B - (-100))
 		stream.SerializeBits(&offsetValue, 8)
 	}
-	if value.C < -100 || value.C > 150 { // the runtime range refusal, folded (SPEC §5)
+	if value.C < -100 || value.C > 150 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -722,7 +722,7 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 	stream.SerializeBits(&value.E, 8)
 	stream.SerializeBits(&value.F, 8)
 	stream.SerializeBool(&value.G)
-	if value.ItemsCount < 0 || value.ItemsCount > 16 { // the runtime range refusal, folded (SPEC §5)
+	if value.ItemsCount < 0 || value.ItemsCount > 16 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -733,7 +733,7 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 		return stream.Err()
 	}
 	for i := int32(0); i < value.ItemsCount; i++ {
-		if value.Items[i] < 0 || value.Items[i] > 255 { // the runtime range refusal, folded (SPEC §5)
+		if value.Items[i] < 0 || value.Items[i] > 255 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -775,7 +775,7 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 		rawValue := uint64(value.Int64Full)
 		stream.SerializeBits64(&rawValue, 64)
 	}
-	if value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000 { // the runtime range refusal, folded (SPEC §5)
+	if value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -783,8 +783,8 @@ func WriteTestData(stream *serialize.WriteStream, value *TestData) error {
 		stream.SerializeBits64(&offsetValue, 41)
 	}
 	stream.SerializeAlign()
-	stream.SerializeBytes(value.FixedBytes[:])          // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
-	if value.TextLength < 0 || value.TextLength > 255 { // the runtime range refusal, folded (SPEC §5)
+	stream.SerializeBytes(value.FixedBytes[:]) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+	if value.TextLength < 0 || value.TextLength > 255 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/testdata/golden/js/Constants.js
+++ b/testdata/golden/js/Constants.js
@@ -4,12 +4,11 @@
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an out-of-contract
+// write) returns false WITHOUT latching; stream failures latch on
+// stream.error — the runtime's own sticky latch. Callers get bool always;
+// error tells the two apart.
 //
 // Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
 // the serialize.js value-domain seam. Checked/production comes from the

--- a/testdata/golden/js/Contexts.js
+++ b/testdata/golden/js/Contexts.js
@@ -3,17 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 // contexts declared for this unit: client, server (SPEC §4.2).
 // Contexts generate no standalone artifacts — where an object carries

--- a/testdata/golden/js/Enums.js
+++ b/testdata/golden/js/Enums.js
@@ -3,17 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 // Team — None = 0 implicit, variants dense from 1, wire range [0, 2] (SPEC §4.2);
 // a frozen object of Number values — the JS translation of the family's

--- a/testdata/golden/js/Messages.js
+++ b/testdata/golden/js/Messages.js
@@ -3,25 +3,11 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { MaxBlockSize, MaxChatLength } from "./Constants.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 
@@ -55,8 +41,7 @@ export class Heartbeat {
 export const HeartbeatMaxBits = 0;
 export const HeartbeatMaxBytes = 0;
 
-// ZeroHeartbeat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroHeartbeat(value) {
   // empty body — nothing to reset (SPEC §4.6)
 }
@@ -91,8 +76,7 @@ export class Test {
 export const TestMaxBits = 46;
 export const TestMaxBytes = 8;
 
-// ZeroTest resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroTest(value) {
   value.TestA = 0;
   value.TestB = 0;
@@ -105,21 +89,21 @@ export function WriteTest(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 16)) {
     return false;
   }
-  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TestB;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TestC;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TestD;
@@ -168,8 +152,7 @@ export class Block {
 export const BlockMaxBits = 16018;
 export const BlockMaxBytes = 2008;
 
-// ZeroBlock resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroBlock(value) {
   value.Data.fill(0);
   value.DataLength = 0;
@@ -219,8 +202,7 @@ export class Chat {
 export const ChatMaxBits = 2064;
 export const ChatMaxBytes = 264;
 
-// ZeroChat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroChat(value) {
   value.Text.fill(0);
   value.TextLength = 0;
@@ -275,8 +257,7 @@ export class Synchronize {
 export const SynchronizeMaxBits = 80;
 export const SynchronizeMaxBytes = 16;
 
-// ZeroSynchronize resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroSynchronize(value) {
   value.SyncFrame = 0n;
   value.SyncSequence = 0;
@@ -326,8 +307,7 @@ export class Timescale {
 export const TimescaleMaxBits = 128;
 export const TimescaleMaxBytes = 16;
 
-// ZeroTimescale resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroTimescale(value) {
   value.Scale = 0;
   value.FrameA = 0;

--- a/testdata/golden/js/MessagesFlat.js
+++ b/testdata/golden/js/MessagesFlat.js
@@ -229,7 +229,7 @@ function writeTestFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) {
     return -1;
   }
   v = ((value.TestB) & 0x3ff) >>> 0;
@@ -249,7 +249,7 @@ function writeTestFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) {
     return -1;
   }
   v = ((value.TestC) & 0x3ff) >>> 0;
@@ -269,7 +269,7 @@ function writeTestFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) {
     return -1;
   }
   v = ((value.TestD) & 0x3ff) >>> 0;
@@ -466,7 +466,7 @@ function writeTestFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.TestB) || value.TestB < 0 || value.TestB > 1000) {
       return -1;
     }
     v = ((value.TestB) & 0x3ff) >>> 0;
@@ -486,7 +486,7 @@ function writeTestFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.TestC) || value.TestC < 0 || value.TestC > 1000) {
       return -1;
     }
     v = ((value.TestC) & 0x3ff) >>> 0;
@@ -506,7 +506,7 @@ function writeTestFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.TestD) || value.TestD < 0 || value.TestD > 1000) {
       return -1;
     }
     v = ((value.TestD) & 0x3ff) >>> 0;
@@ -2889,7 +2889,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.TestB) || message.TestB < 0 || message.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.TestB) || message.TestB < 0 || message.TestB > 1000) {
       return -1;
     }
     v = ((message.TestB) & 0x3ff) >>> 0;
@@ -2909,7 +2909,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.TestC) || message.TestC < 0 || message.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.TestC) || message.TestC < 0 || message.TestC > 1000) {
       return -1;
     }
     v = ((message.TestC) & 0x3ff) >>> 0;
@@ -2929,7 +2929,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.TestD) || message.TestD < 0 || message.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.TestD) || message.TestD < 0 || message.TestD > 1000) {
       return -1;
     }
     v = ((message.TestD) & 0x3ff) >>> 0;

--- a/testdata/golden/js/Objects.js
+++ b/testdata/golden/js/Objects.js
@@ -3,27 +3,13 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { MaxCollidersPerShip, MaxTurretsPerShip, PositionUnits, RotationUnits, ShipMaxLasers, ShipMaxMissiles, VelocityUnits } from "./Constants.js";
 import { MissileType, PropType, ShipType, Team } from "./Enums.js";
 import { Handle, Quat, ReadHandle, ReadQuat, ReadVec3, Vec3, WriteHandle, WriteQuat, WriteVec3 } from "./Types.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 
@@ -68,11 +54,11 @@ export class ClientShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; //  | local — no wire
-    this.PreviousPosition = new Vec3(); //  | local — no wire
-    this.NumColliders = 0; //  | local — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
-    this.PredictedExplode = false; //  | local, context = client
+    this.Invulnerable = false; // | local — no wire
+    this.PreviousPosition = new Vec3(); // | local — no wire
+    this.NumColliders = 0; // | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // | local — no wire
+    this.PredictedExplode = false; // | local, context = client
   }
 }
 
@@ -105,10 +91,10 @@ export class ServerShipState {
     this.MissileIndex = 0; // wire [0, 15]
     this.Target = new Handle();
     this.LockStartTime = 0;
-    this.Invulnerable = false; //  | local — no wire
-    this.PreviousPosition = new Vec3(); //  | local — no wire
-    this.NumColliders = 0; //  | local — no wire
-    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); //  | local — no wire
+    this.Invulnerable = false; // | local — no wire
+    this.PreviousPosition = new Vec3(); // | local — no wire
+    this.NumColliders = 0; // | local — no wire
+    this.ColliderArmor = new Array(MaxCollidersPerShip).fill(0); // | local — no wire
   }
 }
 
@@ -279,14 +265,14 @@ export function WriteShipData_Deep(stream, value) {
   if (!stream.serializeFloat(NUMBER_SCRATCH)) {
     return false;
   }
-  if (!Number.isInteger(value.LaserIndex) || value.LaserIndex < 0 || value.LaserIndex > ShipMaxLasers - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LaserIndex) || value.LaserIndex < 0 || value.LaserIndex > ShipMaxLasers - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.LaserIndex;
   if (!stream.serializeBits(NUMBER_SCRATCH, 4)) {
     return false;
   }
-  if (!Number.isInteger(value.MissileIndex) || value.MissileIndex < 0 || value.MissileIndex > ShipMaxMissiles - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.MissileIndex) || value.MissileIndex < 0 || value.MissileIndex > ShipMaxMissiles - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.MissileIndex;
@@ -411,70 +397,70 @@ export function WriteShipData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 3)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityX >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityY >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityZ >>> 0) - (-2097152 >>> 0)) >>> 0;
@@ -498,14 +484,14 @@ export function WriteShipData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 2)) {
     return false;
   }
-  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Health;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Thrust;
@@ -720,8 +706,8 @@ export class ClientMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); //  | local — no wire
-    this.Target = new Handle(); //  | local — no wire
+    this.AngularVelocity = new Vec3(); // | local — no wire
+    this.Target = new Handle(); // | local — no wire
   }
 }
 
@@ -735,9 +721,9 @@ export class ServerMissileState {
     this.LinearVelocity = new Vec3();
     this.Team = Team.None;
     this.Flags = 0n;
-    this.AngularVelocity = new Vec3(); //  | local — no wire
-    this.Target = new Handle(); //  | local — no wire
-    this.Timer = 0; //  | local, context = server
+    this.AngularVelocity = new Vec3(); // | local — no wire
+    this.Target = new Handle(); // | local — no wire
+    this.Timer = 0; // | local, context = server
   }
 }
 
@@ -861,70 +847,70 @@ export function WriteMissileData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 2)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityX >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityY >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityZ >>> 0) - (-2097152 >>> 0)) >>> 0;
@@ -1137,7 +1123,7 @@ export class DynamicPropState {
     this.LinearVelocity = new Vec3();
     this.Flags = 0n;
     this.Team = Team.None;
-    this.AngularVelocity = new Vec3(); //  | local — no wire
+    this.AngularVelocity = new Vec3(); // | local — no wire
   }
 }
 
@@ -1261,70 +1247,70 @@ export function WriteDynamicPropData_Shallow(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 3)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -8388608 || value.PositionX > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -8388608 || value.PositionY > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -8388608 || value.PositionZ > 8388608) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-8388608 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityX) || value.LinearVelocityX < -2097152 || value.LinearVelocityX > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityX >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityY) || value.LinearVelocityY < -2097152 || value.LinearVelocityY > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityY >>> 0) - (-2097152 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocityZ) || value.LinearVelocityZ < -2097152 || value.LinearVelocityZ > 2097152) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.LinearVelocityZ >>> 0) - (-2097152 >>> 0)) >>> 0;
@@ -1535,7 +1521,7 @@ export class TurretState {
     this.TurretIndex = 0; // wire [0, 255]
     this.Rotation = new Quat();
     this.Flags = 0n;
-    this.Team = Team.None; //  | local — no wire
+    this.Team = Team.None; // | local — no wire
   }
 }
 
@@ -1584,7 +1570,7 @@ export function WriteTurretData_Deep(stream, value) {
   if (!WriteHandle(stream, value.Parent)) {
     return false;
   }
-  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TurretIndex;
@@ -1626,35 +1612,35 @@ export function WriteTurretData_Shallow(stream, value) {
   if (!WriteHandle(stream, value.Parent)) {
     return false;
   }
-  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.TurretIndex) || value.TurretIndex < 0 || value.TurretIndex > MaxTurretsPerShip - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.TurretIndex;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;

--- a/testdata/golden/js/Render.js
+++ b/testdata/golden/js/Render.js
@@ -3,25 +3,11 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { Team } from "./Enums.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 
@@ -43,8 +29,7 @@ export class RenderSprite {
 export const RenderSpriteMaxBits = 138;
 export const RenderSpriteMaxBytes = 24;
 
-// ZeroRenderSprite resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroRenderSprite(value) {
   value.SortKey = 0n;
   value.MeshId = 0;
@@ -119,8 +104,7 @@ export class RenderBlock {
 export const RenderBlockMaxBits = 8903;
 export const RenderBlockMaxBytes = 1120;
 
-// ZeroRenderBlock resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroRenderBlock(value) {
   value.WorkerIndex = 0;
   value.SpriteCountHint = 0;
@@ -139,7 +123,7 @@ export function WriteRenderBlock(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 32)) {
     return false;
   }
-  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.SpritesCount) || value.SpritesCount < 0 || value.SpritesCount > RenderBlockMaxSprites) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.SpritesCount;

--- a/testdata/golden/js/RenderFlat.js
+++ b/testdata/golden/js/RenderFlat.js
@@ -3,25 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js
-// two-lane bitpacker inlined at every field, constant widths and masks,
-// zero function calls. Same generated classes, same bytes as the runtime
-// tier (a standing CI gate); the runtime tier remains the diagnostic and
-// reference surface — re-read a failing buffer through it to learn WHICH
-// operation failed and why.
-//
-// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked
-// writer refuses an out-of-contract value (the production writer trusts
-// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at
-// module load). Read<Name>Flat(value, view, numBits) -> bool, the family
-// read verdict; reader obligations ride in every mode.
-//
-// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes
-// (the constants live in the runtime-tier module). Read buffers: at least
-// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load
-// unconditionally; copy exactly-sized receive buffers into a persistent
-// MaxBytes + 8 scratch first.
 
 // The 8-byte conversion scratch — serialize.js's FLOAT_SCRATCH twin. Module
 // scope is safe: single threaded per realm, consumed in the same op that

--- a/testdata/golden/js/Types.js
+++ b/testdata/golden/js/Types.js
@@ -3,32 +3,17 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { MaxHealth, MaxInputsPerPacket, MaxObjects, MaxPositionUnits, MaxVelocityUnits, RotationUnits, ShipMaxLasers, ShipMaxMissiles } from "./Constants.js";
 import { Pending, ShipType, Team } from "./Enums.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class Vec3 {
   constructor() {
     this.X = 0;
@@ -42,8 +27,7 @@ export class Vec3 {
 export const Vec3MaxBits = 192;
 export const Vec3MaxBytes = 24;
 
-// ZeroVec3 resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroVec3(value) {
   value.X = 0;
   value.Y = 0;
@@ -82,8 +66,7 @@ export function ReadVec3(stream, value) {
   return true;
 }
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class Quat {
   constructor() {
     this.X = 0;
@@ -98,8 +81,7 @@ export class Quat {
 export const QuatMaxBits = 256;
 export const QuatMaxBytes = 32;
 
-// ZeroQuat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuat(value) {
   value.X = 0;
   value.Y = 0;
@@ -160,15 +142,14 @@ export class Handle {
 export const HandleMaxBits = 22;
 export const HandleMaxBytes = 8;
 
-// ZeroHandle resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroHandle(value) {
   value.ObjectId = 0;
   value.ObjectSequence = 0;
 }
 
 export function WriteHandle(stream, value) {
-  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > MaxObjects - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > MaxObjects - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.ObjectId;
@@ -208,8 +189,7 @@ export class QuantizedPosition {
 export const QuantizedPositionMaxBits = 75;
 export const QuantizedPositionMaxBytes = 16;
 
-// ZeroQuantizedPosition resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuantizedPosition(value) {
   value.X = 0;
   value.Y = 0;
@@ -217,21 +197,21 @@ export function ZeroQuantizedPosition(value) {
 }
 
 export function WriteQuantizedPosition(stream, value) {
-  if (!Number.isInteger(value.X) || value.X < -MaxPositionUnits || value.X > MaxPositionUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -MaxPositionUnits || value.X > MaxPositionUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.X >>> 0) - (-MaxPositionUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -MaxPositionUnits || value.Y > MaxPositionUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Y >>> 0) - (-MaxPositionUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 25)) {
     return false;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -MaxPositionUnits || value.Z > MaxPositionUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Z >>> 0) - (-MaxPositionUnits >>> 0)) >>> 0;
@@ -271,8 +251,7 @@ export class QuantizedVelocity {
 export const QuantizedVelocityMaxBits = 69;
 export const QuantizedVelocityMaxBytes = 16;
 
-// ZeroQuantizedVelocity resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuantizedVelocity(value) {
   value.X = 0;
   value.Y = 0;
@@ -280,21 +259,21 @@ export function ZeroQuantizedVelocity(value) {
 }
 
 export function WriteQuantizedVelocity(stream, value) {
-  if (!Number.isInteger(value.X) || value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -MaxVelocityUnits || value.X > MaxVelocityUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.X >>> 0) - (-MaxVelocityUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -MaxVelocityUnits || value.Y > MaxVelocityUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Y >>> 0) - (-MaxVelocityUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 23)) {
     return false;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -MaxVelocityUnits || value.Z > MaxVelocityUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Z >>> 0) - (-MaxVelocityUnits >>> 0)) >>> 0;
@@ -335,8 +314,7 @@ export class QuantizedRotation {
 export const QuantizedRotationMaxBits = 48;
 export const QuantizedRotationMaxBytes = 8;
 
-// ZeroQuantizedRotation resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroQuantizedRotation(value) {
   value.X = 0;
   value.Y = 0;
@@ -345,28 +323,28 @@ export function ZeroQuantizedRotation(value) {
 }
 
 export function WriteQuantizedRotation(stream, value) {
-  if (!Number.isInteger(value.X) || value.X < -RotationUnits || value.X > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -RotationUnits || value.X > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.X >>> 0) - (-RotationUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -RotationUnits || value.Y > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -RotationUnits || value.Y > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Y >>> 0) - (-RotationUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -RotationUnits || value.Z > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -RotationUnits || value.Z > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.Z >>> 0) - (-RotationUnits >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.W) || value.W < -RotationUnits || value.W > RotationUnits) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.W) || value.W < -RotationUnits || value.W > RotationUnits) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.W >>> 0) - (-RotationUnits >>> 0)) >>> 0;
@@ -415,8 +393,7 @@ export class RigidBody {
 export const RigidBodyMaxBits = 833;
 export const RigidBodyMaxBytes = 112;
 
-// ZeroRigidBody resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroRigidBody(value) {
   ZeroVec3(value.Position);
   ZeroQuat(value.Orientation);
@@ -496,8 +473,7 @@ export class Input {
 export const InputMaxBits = 168;
 export const InputMaxBytes = 24;
 
-// ZeroInput resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroInput(value) {
   value.StickX = 0;
   value.StickY = 0;
@@ -642,8 +618,7 @@ export class InputPacket {
 export const InputPacketMaxBits = 2837;
 export const InputPacketMaxBytes = 360;
 
-// ZeroInputPacket resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroInputPacket(value) {
   value.SynchronizeSequence = 0;
   value.CurrentFrame = 0n;
@@ -667,7 +642,7 @@ export function WriteInputPacket(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.InputsCount) || value.InputsCount < 0 || value.InputsCount > MaxInputsPerPacket) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.InputsCount;
@@ -732,8 +707,7 @@ export class ShipCreate {
 export const ShipCreateMaxBits = 219;
 export const ShipCreateMaxBytes = 32;
 
-// ZeroShipCreate resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroShipCreate(value) {
   value.ShipType = ShipType.None;
   ZeroQuantizedPosition(value.Position);
@@ -787,14 +761,14 @@ export function WriteShipCreate(stream, value) {
   if (!stream.serializeBits(NUMBER_SCRATCH, 2)) {
     return false;
   }
-  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > MaxHealth) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > MaxHealth) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Health;
   if (!stream.serializeBits(NUMBER_SCRATCH, 10)) {
     return false;
   }
-  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Thrust;
@@ -865,22 +839,21 @@ export class ExpressionProbe {
 export const ExpressionProbeMaxBits = 16;
 export const ExpressionProbeMaxBytes = 8;
 
-// ZeroExpressionProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroExpressionProbe(value) {
   value.HardpointIndex = 0;
   value.SpinRate = 0;
 }
 
 export function WriteExpressionProbe(stream, value) {
-  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers + ShipMaxMissiles) - 1) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > (ShipMaxLasers + ShipMaxMissiles) - 1) {
     return false;
   }
   NUMBER_SCRATCH.value = value.HardpointIndex;
   if (!stream.serializeBits(NUMBER_SCRATCH, 5)) {
     return false;
   }
-  if (!Number.isInteger(value.SpinRate) || value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits * 2) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.SpinRate) || value.SpinRate < -(-RotationUnits) || value.SpinRate > RotationUnits * 2) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.SpinRate >>> 0) - (-(-RotationUnits) >>> 0)) >>> 0;
@@ -912,8 +885,8 @@ export class ExtremeProbe {
     this.FloorBound = 0n; // wire [-9223372036854775808, 100]
     this.DoubledFloor = 0n; // wire [-9223372036854775808, 100]
     this.CeilingRange = 0n; // wire [1, 18446744073709551615]
-    this.FloorDefault = -9223372036854775808n; // = -9223372036854775808n at construction; Zero* gives the §5 zero form
-    this.CeilingDefault = 18446744073709551615n; // = 18446744073709551615n at construction; Zero* gives the §5 zero form
+    this.FloorDefault = -9223372036854775808n; // specified default at construction; Zero* gives the §5 zero form
+    this.CeilingDefault = 18446744073709551615n; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -922,8 +895,7 @@ export class ExtremeProbe {
 export const ExtremeProbeMaxBits = 320;
 export const ExtremeProbeMaxBytes = 40;
 
-// ZeroExtremeProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroExtremeProbe(value) {
   value.FloorBound = 0n;
   value.DoubledFloor = 0n;
@@ -933,21 +905,21 @@ export function ZeroExtremeProbe(value) {
 }
 
 export function WriteExtremeProbe(stream, value) {
-  if (value.FloorBound > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.FloorBound > 100n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.FloorBound - -9223372036854775808n);
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.DoubledFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.DoubledFloor > 100n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.DoubledFloor - -9223372036854775808n);
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.CeilingRange < 1n) { // out-of-contract writes are refused, not wrapped
+  if (value.CeilingRange < 1n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.CeilingRange - 1n);
@@ -997,8 +969,8 @@ export class ExtremeRow {
   constructor() {
     this.ClampedFloor = 0n; // wire [-9223372036854775808, 100]
     this.ClampedCeiling = 0n; // wire [1, 18446744073709551614]
-    this.FloorDef = -9223372036854775808n; // = -9223372036854775808n at construction; Zero* gives the §5 zero form
-    this.CeilingDef = 18446744073709551615n; // = 18446744073709551615n at construction; Zero* gives the §5 zero form
+    this.FloorDef = -9223372036854775808n; // specified default at construction; Zero* gives the §5 zero form
+    this.CeilingDef = 18446744073709551615n; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -1007,8 +979,7 @@ export class ExtremeRow {
 export const ExtremeRowMaxBits = 256;
 export const ExtremeRowMaxBytes = 32;
 
-// ZeroExtremeRow resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroExtremeRow(value) {
   value.ClampedFloor = 0n;
   value.ClampedCeiling = 0n;
@@ -1017,14 +988,14 @@ export function ZeroExtremeRow(value) {
 }
 
 export function WriteExtremeRow(stream, value) {
-  if (value.ClampedFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedFloor > 100n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.ClampedFloor - -9223372036854775808n);
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.ClampedCeiling - 1n);

--- a/testdata/golden/js/TypesFlat.js
+++ b/testdata/golden/js/TypesFlat.js
@@ -3,25 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js
-// two-lane bitpacker inlined at every field, constant widths and masks,
-// zero function calls. Same generated classes, same bytes as the runtime
-// tier (a standing CI gate); the runtime tier remains the diagnostic and
-// reference surface — re-read a failing buffer through it to learn WHICH
-// operation failed and why.
-//
-// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked
-// writer refuses an out-of-contract value (the production writer trusts
-// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at
-// module load). Read<Name>Flat(value, view, numBits) -> bool, the family
-// read verdict; reader obligations ride in every mode.
-//
-// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes
-// (the constants live in the runtime-tier module). Read buffers: at least
-// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load
-// unconditionally; copy exactly-sized receive buffers into a persistent
-// MaxBytes + 8 scratch first.
 
 // The 8-byte conversion scratch — serialize.js's FLOAT_SCRATCH twin. Module
 // scope is safe: single threaded per realm, consumed in the same op that
@@ -768,7 +749,7 @@ function writeHandleFlatProduction(value, view) {
 function writeHandleFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > 9999) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.ObjectId) || value.ObjectId < 0 || value.ObjectId > 9999) {
     return -1;
   }
   v = ((value.ObjectId) & 0x3fff) >>> 0;
@@ -912,7 +893,7 @@ function writeQuantizedPositionFlatProduction(value, view) {
 function writeQuantizedPositionFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -8388608 || value.X > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -8388608 || value.X > 8388608) {
     return -1;
   }
   v = ((((value.X >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -932,7 +913,7 @@ function writeQuantizedPositionFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -8388608 || value.Y > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -8388608 || value.Y > 8388608) {
     return -1;
   }
   v = ((((value.Y >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -952,7 +933,7 @@ function writeQuantizedPositionFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -8388608 || value.Z > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -8388608 || value.Z > 8388608) {
     return -1;
   }
   v = ((((value.Z >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -1093,7 +1074,7 @@ function writeQuantizedVelocityFlatProduction(value, view) {
 function writeQuantizedVelocityFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -2097152 || value.X > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -2097152 || value.X > 2097152) {
     return -1;
   }
   v = ((((value.X >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -1113,7 +1094,7 @@ function writeQuantizedVelocityFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -2097152 || value.Y > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -2097152 || value.Y > 2097152) {
     return -1;
   }
   v = ((((value.Y >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -1133,7 +1114,7 @@ function writeQuantizedVelocityFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -2097152 || value.Z > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -2097152 || value.Z > 2097152) {
     return -1;
   }
   v = ((((value.Z >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -1291,7 +1272,7 @@ function writeQuantizedRotationFlatProduction(value, view) {
 function writeQuantizedRotationFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -1024 || value.X > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -1024 || value.X > 1024) {
     return -1;
   }
   v = ((((value.X >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -1311,7 +1292,7 @@ function writeQuantizedRotationFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -1024 || value.Y > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -1024 || value.Y > 1024) {
     return -1;
   }
   v = ((((value.Y >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -1331,7 +1312,7 @@ function writeQuantizedRotationFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -1024 || value.Z > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -1024 || value.Z > 1024) {
     return -1;
   }
   v = ((((value.Z >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -1351,7 +1332,7 @@ function writeQuantizedRotationFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.W) || value.W < -1024 || value.W > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.W) || value.W < -1024 || value.W > 1024) {
     return -1;
   }
   v = ((((value.W >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4704,7 +4685,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Position.X) || value.Position.X < -8388608 || value.Position.X > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Position.X) || value.Position.X < -8388608 || value.Position.X > 8388608) {
     return -1;
   }
   v = ((((value.Position.X >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -4724,7 +4705,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Position.Y) || value.Position.Y < -8388608 || value.Position.Y > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Position.Y) || value.Position.Y < -8388608 || value.Position.Y > 8388608) {
     return -1;
   }
   v = ((((value.Position.Y >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -4744,7 +4725,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Position.Z) || value.Position.Z < -8388608 || value.Position.Z > 8388608) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Position.Z) || value.Position.Z < -8388608 || value.Position.Z > 8388608) {
     return -1;
   }
   v = ((((value.Position.Z >>> 0) - 4286578688) >>> 0) & 0x1ffffff) >>> 0;
@@ -4764,7 +4745,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.X) || value.Rotation.X < -1024 || value.Rotation.X > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.X) || value.Rotation.X < -1024 || value.Rotation.X > 1024) {
     return -1;
   }
   v = ((((value.Rotation.X >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4784,7 +4765,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.Y) || value.Rotation.Y < -1024 || value.Rotation.Y > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.Y) || value.Rotation.Y < -1024 || value.Rotation.Y > 1024) {
     return -1;
   }
   v = ((((value.Rotation.Y >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4804,7 +4785,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.Z) || value.Rotation.Z < -1024 || value.Rotation.Z > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.Z) || value.Rotation.Z < -1024 || value.Rotation.Z > 1024) {
     return -1;
   }
   v = ((((value.Rotation.Z >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4824,7 +4805,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Rotation.W) || value.Rotation.W < -1024 || value.Rotation.W > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Rotation.W) || value.Rotation.W < -1024 || value.Rotation.W > 1024) {
     return -1;
   }
   v = ((((value.Rotation.W >>> 0) - 4294966272) >>> 0) & 0xfff) >>> 0;
@@ -4844,7 +4825,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.LinearVelocity.X) || value.LinearVelocity.X < -2097152 || value.LinearVelocity.X > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocity.X) || value.LinearVelocity.X < -2097152 || value.LinearVelocity.X > 2097152) {
     return -1;
   }
   v = ((((value.LinearVelocity.X >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -4864,7 +4845,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.LinearVelocity.Y) || value.LinearVelocity.Y < -2097152 || value.LinearVelocity.Y > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocity.Y) || value.LinearVelocity.Y < -2097152 || value.LinearVelocity.Y > 2097152) {
     return -1;
   }
   v = ((((value.LinearVelocity.Y >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -4884,7 +4865,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.LinearVelocity.Z) || value.LinearVelocity.Z < -2097152 || value.LinearVelocity.Z > 2097152) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LinearVelocity.Z) || value.LinearVelocity.Z < -2097152 || value.LinearVelocity.Z > 2097152) {
     return -1;
   }
   v = ((((value.LinearVelocity.Z >>> 0) - 4292870144) >>> 0) & 0x7fffff) >>> 0;
@@ -4963,7 +4944,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Health) || value.Health < 0 || value.Health > 1000) {
     return -1;
   }
   v = ((value.Health) & 0x3ff) >>> 0;
@@ -4983,7 +4964,7 @@ function writeShipCreateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Thrust) || value.Thrust < 0 || value.Thrust > 100) {
     return -1;
   }
   v = ((value.Thrust) & 0x7f) >>> 0;
@@ -5258,7 +5239,7 @@ function writeExpressionProbeFlatProduction(value, view) {
 function writeExpressionProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > 31) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.HardpointIndex) || value.HardpointIndex < 0 || value.HardpointIndex > 31) {
     return -1;
   }
   v = ((value.HardpointIndex) & 0x1f) >>> 0;
@@ -5278,7 +5259,7 @@ function writeExpressionProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.SpinRate) || value.SpinRate < 1024 || value.SpinRate > 2048) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.SpinRate) || value.SpinRate < 1024 || value.SpinRate > 2048) {
     return -1;
   }
   v = ((((value.SpinRate >>> 0) - 1024) >>> 0) & 0x7ff) >>> 0;
@@ -5531,7 +5512,7 @@ function writeExtremeProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.FloorBound > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.FloorBound > 100n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.FloorBound - -9223372036854775808n), true);
@@ -5569,7 +5550,7 @@ function writeExtremeProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.DoubledFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.DoubledFloor > 100n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.DoubledFloor - -9223372036854775808n), true);
@@ -5607,7 +5588,7 @@ function writeExtremeProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.CeilingRange < 1n) { // out-of-contract writes are refused, not wrapped
+  if (value.CeilingRange < 1n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.CeilingRange - 1n), true);
@@ -5994,7 +5975,7 @@ function writeExtremeRowFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.ClampedFloor > 100n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedFloor > 100n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.ClampedFloor - -9223372036854775808n), true);
@@ -6032,7 +6013,7 @@ function writeExtremeRowFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) { // out-of-contract writes are refused, not wrapped
+  if (value.ClampedCeiling < 1n || value.ClampedCeiling > 18446744073709551614n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.ClampedCeiling - 1n), true);

--- a/testdata/golden/js/Wire.js
+++ b/testdata/golden/js/Wire.js
@@ -3,25 +3,11 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
-//
-// Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
-// the serialize.js value-domain seam. Checked/production comes from the
-// stream object; generated code never reads NODE_ENV.
 
 import { ReadTest, Test, WriteTest, ZeroTest } from "./Messages.js";
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
@@ -84,8 +70,7 @@ export class ProbeHeader {
 export const ProbeHeaderMaxBits = 87;
 export const ProbeHeaderMaxBytes = 16;
 
-// ZeroProbeHeader resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeHeader(value) {
   value.Version = 0;
   value.ProbeId = 0n;
@@ -157,8 +142,7 @@ export class ProbeBits {
 export const ProbeBitsMaxBits = 202;
 export const ProbeBitsMaxBytes = 32;
 
-// ZeroProbeBits resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeBits(value) {
   value.Small = 0;
   value.Boundary = 0n;
@@ -180,7 +164,7 @@ export function WriteProbeBits(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Sensor;
@@ -221,7 +205,7 @@ export function ReadProbeBits(stream, value) {
 // type ProbeSample
 export class ProbeSample {
   constructor() {
-    this.Active = true; // = true at construction; Zero* gives the §5 zero form
+    this.Active = true; // specified default at construction; Zero* gives the §5 zero form
     this.Orientation = 0; // compressed float [-180.0, 180.0] @ 0.01
     this.RawDelta = 0;
     this.BigDelta = 0n;
@@ -249,8 +233,7 @@ export class ProbeSample {
 export const ProbeSampleMaxBits = 276;
 export const ProbeSampleMaxBytes = 40;
 
-// ZeroProbeSample resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeSample(value) {
   value.Active = false;
   value.Orientation = 0;
@@ -305,7 +288,7 @@ export function WriteProbeSample(stream, value) {
       return false;
     }
   }
-  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.SamplesCount) || value.SamplesCount < 1 || value.SamplesCount > 8) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = ((value.SamplesCount >>> 0) - (1 >>> 0)) >>> 0;
@@ -390,8 +373,7 @@ export class ProbeRing {
 export const ProbeRingMaxBits = 16;
 export const ProbeRingMaxBytes = 8;
 
-// ZeroProbeRing resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeRing(value) {
   value.Radius = 0;
 }
@@ -425,15 +407,14 @@ export class ProbeSlab {
 export const ProbeSlabMaxBits = 15;
 export const ProbeSlabMaxBytes = 8;
 
-// ZeroProbeSlab resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeSlab(value) {
   value.Width = 0;
   value.Height = 0;
 }
 
 export function WriteProbeSlab(stream, value) {
-  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Width;
@@ -540,8 +521,7 @@ export class ProbeCollider {
 export const ProbeColliderMaxBits = 82;
 export const ProbeColliderMaxBytes = 16;
 
-// ZeroProbeCollider resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeCollider(value) {
   value.Armor = 0;
   ZeroProbeShape(value.Shape);
@@ -563,7 +543,7 @@ export function WriteProbeCollider(stream, value) {
   if (!WriteProbeShape(stream, value.Backup)) {
     return false;
   }
-  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.ExtrasCount) || value.ExtrasCount < 0 || value.ExtrasCount > 2) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.ExtrasCount;
@@ -604,8 +584,8 @@ export function ReadProbeCollider(stream, value) {
 // type ProbeConfig
 export class ProbeConfig {
   constructor() {
-    this.Retries = -1; // = -1 at construction; Zero* gives the §5 zero form
-    this.Preferred = Weapon.Railgun; // = Weapon.Railgun at construction; Zero* gives the §5 zero form
+    this.Retries = -1; // specified default at construction; Zero* gives the §5 zero form
+    this.Preferred = Weapon.Railgun; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -614,8 +594,7 @@ export class ProbeConfig {
 export const ProbeConfigMaxBits = 36;
 export const ProbeConfigMaxBytes = 8;
 
-// ZeroProbeConfig resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeConfig(value) {
   value.Retries = 0;
   value.Preferred = Weapon.None;
@@ -661,8 +640,7 @@ export class ProbeArray {
 export const ProbeArrayMaxBits = 588;
 export const ProbeArrayMaxBytes = 80;
 
-// ZeroProbeArray resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeArray(value) {
   for (let i = 0; i < 2; i++) {
     ZeroProbeSample(value.Samples[i]);
@@ -708,8 +686,7 @@ export class ProbeReport {
 export const ProbeReportMaxBits = 141;
 export const ProbeReportMaxBytes = 24;
 
-// ZeroProbeReport resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroProbeReport(value) {
   ZeroProbeHeader(value.Header);
   value.Flags = 0n;
@@ -784,8 +761,7 @@ export class TestData {
 export const TestDataMaxBits = 2735;
 export const TestDataMaxBytes = 344;
 
-// ZeroTestData resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroTestData(value) {
   value.A = 0;
   value.B = 0;
@@ -813,21 +789,21 @@ export function ZeroTestData(value) {
 }
 
 export function WriteTestData(stream, value) {
-  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.A >>> 0) - (-100 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.B >>> 0) - (-100 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 8)) {
     return false;
   }
-  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.C >>> 0) - (-100 >>> 0)) >>> 0;
@@ -850,7 +826,7 @@ export function WriteTestData(stream, value) {
   if (!stream.serializeBool(BOOL_SCRATCH)) {
     return false;
   }
-  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.ItemsCount) || value.ItemsCount < 0 || value.ItemsCount > 16) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.ItemsCount;
@@ -858,7 +834,7 @@ export function WriteTestData(stream, value) {
     return false;
   }
   for (let i = 0; i < value.ItemsCount; i++) {
-    if (!Number.isInteger(value.Items[i]) || value.Items[i] < 0 || value.Items[i] > 255) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Items[i]) || value.Items[i] < 0 || value.Items[i] > 255) {
       return false;
     }
     NUMBER_SCRATCH.value = value.Items[i];
@@ -906,7 +882,7 @@ export function WriteTestData(stream, value) {
   if (!stream.serializeBits64(BIGINT_SCRATCH, 64)) {
     return false;
   }
-  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) {
     return false;
   }
   BIGINT_SCRATCH.value = BigInt.asUintN(64, value.Int64Range - -1000000000000n);
@@ -1049,8 +1025,7 @@ export class CompressedProbe {
 export const CompressedProbeMaxBits = 24;
 export const CompressedProbeMaxBytes = 8;
 
-// ZeroCompressedProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroCompressedProbe(value) {
   value.Boundary = 0;
   value.Offset = 0;

--- a/testdata/golden/js/WireFlat.js
+++ b/testdata/golden/js/WireFlat.js
@@ -3,25 +3,6 @@
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
 // package example — protocol id 0xbc05d83a8135cdb9
-//
-// THE FLAT TIER — the shipped JavaScript wire path: the serialize.js
-// two-lane bitpacker inlined at every field, constant widths and masks,
-// zero function calls. Same generated classes, same bytes as the runtime
-// tier (a standing CI gate); the runtime tier remains the diagnostic and
-// reference surface — re-read a failing buffer through it to learn WHICH
-// operation failed and why.
-//
-// Write<Name>Flat(value, view) -> bytes written, or -1 when the checked
-// writer refuses an out-of-contract value (the production writer trusts
-// the caller — serialize.js src/mode.js's own NODE_ENV fork, frozen at
-// module load). Read<Name>Flat(value, view, numBits) -> bool, the family
-// read verdict; reader obligations ride in every mode.
-//
-// Buffers are caller-owned DataViews. Write buffers: at least <Name>MaxBytes
-// (the constants live in the runtime-tier module). Read buffers: at least
-// FLAT_READ_SLACK = 8 bytes past the payload — 64-bit windows load
-// unconditionally; copy exactly-sized receive buffers into a persistent
-// MaxBytes + 8 scratch first.
 
 // The 8-byte conversion scratch — serialize.js's FLOAT_SCRATCH twin. Module
 // scope is safe: single threaded per realm, consumed in the same op that
@@ -574,7 +555,7 @@ function writeProbeBitsFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Sensor) || value.Sensor < 0 || value.Sensor > 4294967295) {
     return -1;
   }
   v = (value.Sensor) >>> 0;
@@ -955,7 +936,7 @@ function writeProbeSampleFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.Orientation);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - -180.0) / 360.0);
@@ -1416,7 +1397,7 @@ function writeProbeSlabFlatProduction(value, view) {
 function writeProbeSlabFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Width) || value.Width < 0 || value.Width > 100) {
     return -1;
   }
   v = ((value.Width) & 0x7f) >>> 0;
@@ -1833,7 +1814,7 @@ function writeProbeColliderFlatChecked(value, view) {
       break;
     }
     case 2: {
-      if (!Number.isInteger(value.Shape.Slab.Width) || value.Shape.Slab.Width < 0 || value.Shape.Slab.Width > 100) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(value.Shape.Slab.Width) || value.Shape.Slab.Width < 0 || value.Shape.Slab.Width > 100) {
         return -1;
       }
       v = ((value.Shape.Slab.Width) & 0x7f) >>> 0;
@@ -1915,7 +1896,7 @@ function writeProbeColliderFlatChecked(value, view) {
       break;
     }
     case 2: {
-      if (!Number.isInteger(value.Backup.Slab.Width) || value.Backup.Slab.Width < 0 || value.Backup.Slab.Width > 100) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(value.Backup.Slab.Width) || value.Backup.Slab.Width < 0 || value.Backup.Slab.Width > 100) {
         return -1;
       }
       v = ((value.Backup.Slab.Width) & 0x7f) >>> 0;
@@ -2019,7 +2000,7 @@ function writeProbeColliderFlatChecked(value, view) {
         break;
       }
       case 2: {
-        if (!Number.isInteger(e0.Slab.Width) || e0.Slab.Width < 0 || e0.Slab.Width > 100) { // out-of-contract writes are refused, not wrapped
+        if (!Number.isInteger(e0.Slab.Width) || e0.Slab.Width < 0 || e0.Slab.Width > 100) {
           return -1;
         }
         v = ((e0.Slab.Width) & 0x7f) >>> 0;
@@ -2653,7 +2634,7 @@ function writeProbeArrayFlatChecked(value, view) {
       sb -= 64;
     }
     x = Math.fround(e0.Orientation);
-    if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isFinite(x)) {
       return -1;
     }
     n = Math.fround(Math.fround(x - -180.0) / 360.0);
@@ -3381,7 +3362,7 @@ function writeProbeReportFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Echo.TestB) || value.Echo.TestB < 0 || value.Echo.TestB > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Echo.TestB) || value.Echo.TestB < 0 || value.Echo.TestB > 1000) {
     return -1;
   }
   v = ((value.Echo.TestB) & 0x3ff) >>> 0;
@@ -3401,7 +3382,7 @@ function writeProbeReportFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Echo.TestC) || value.Echo.TestC < 0 || value.Echo.TestC > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Echo.TestC) || value.Echo.TestC < 0 || value.Echo.TestC > 1000) {
     return -1;
   }
   v = ((value.Echo.TestC) & 0x3ff) >>> 0;
@@ -3421,7 +3402,7 @@ function writeProbeReportFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Echo.TestD) || value.Echo.TestD < 0 || value.Echo.TestD > 1000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Echo.TestD) || value.Echo.TestD < 0 || value.Echo.TestD > 1000) {
     return -1;
   }
   v = ((value.Echo.TestD) & 0x3ff) >>> 0;
@@ -4099,7 +4080,7 @@ function writeTestDataFlatChecked(value, view) {
   let v = 0, s = 0, x = 0, n = 0, t0 = 0, t1 = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.A) || value.A < -100 || value.A > 100) {
     return -1;
   }
   v = ((((value.A >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -4119,7 +4100,7 @@ function writeTestDataFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.B) || value.B < -100 || value.B > 100) {
     return -1;
   }
   v = ((((value.B >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -4139,7 +4120,7 @@ function writeTestDataFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.C) || value.C < -100 || value.C > 150) {
     return -1;
   }
   v = ((((value.C >>> 0) - 4294967196) >>> 0) & 0xff) >>> 0;
@@ -4248,7 +4229,7 @@ function writeTestDataFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < value.ItemsCount; i0++) {
-    if (!Number.isInteger(value.Items[i0]) || value.Items[i0] < 0 || value.Items[i0] > 255) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Items[i0]) || value.Items[i0] < 0 || value.Items[i0] > 255) {
       return -1;
     }
     v = ((value.Items[i0]) & 0xff) >>> 0;
@@ -4298,7 +4279,7 @@ function writeTestDataFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.CompressedFloatValue);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 10.0);
@@ -4510,7 +4491,7 @@ function writeTestDataFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Int64Range < -1000000000000n || value.Int64Range > 1000000000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Int64Range - -1000000000000n), true);
@@ -5000,7 +4981,7 @@ function writeCompressedProbeFlatChecked(value, view) {
   let v = 0, s = 0, x = 0, n = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
   x = Math.fround(value.Boundary);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - 0.0) / 10.0);
@@ -5023,7 +5004,7 @@ function writeCompressedProbeFlatChecked(value, view) {
     sb -= 64;
   }
   x = Math.fround(value.Offset);
-  if (!Number.isFinite(x)) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isFinite(x)) {
     return -1;
   }
   n = Math.fround(Math.fround(x - -5.0) / 10.0);

--- a/testdata/golden/ludicrous/c/Ludicrous.h
+++ b/testdata/golden/ludicrous/c/Ludicrous.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <string.h>   /* memset — the zero form (SPEC §4.2) */
-#include <math.h>     /* floor — the quantize pair */
 #include "serialize.h"   /* serialize_int128_t: C has no 128-bit builtin */
 
 #ifndef SCHEMA_UNUSED
@@ -47,23 +46,9 @@ static SCHEMA_UNUSED const char * enum_name_drive_mode( DriveMode value )
     switch ( value )
     {
         case DRIVE_MODE_NONE: return "None";
-        case 1: return "Cruise";
-        case 2: return "Warp";
-        case 3: return "Ludicrous";
-        default: return "???";
-    }
-}
-
-/* As enum_name_drive_mode, over a raw wire value — the form the table reflection
-   descriptors hold. */
-static SCHEMA_UNUSED const char * enum_name_drive_mode_dyn( uint64_t value )
-{
-    switch ( value )
-    {
-        case 0: return "None";
-        case 1: return "Cruise";
-        case 2: return "Warp";
-        case 3: return "Ludicrous";
+        case DRIVE_MODE_CRUISE: return "Cruise";
+        case DRIVE_MODE_WARP: return "Warp";
+        case DRIVE_MODE_LUDICROUS: return "Ludicrous";
         default: return "???";
     }
 }
@@ -94,7 +79,7 @@ typedef struct UnsignedProbe {
 } UnsignedProbe;
 
 #define UNSIGNED_PROBE_MAX_BITS 196   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define UNSIGNED_PROBE_MAX_BYTES 32  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define UNSIGNED_PROBE_MAX_BYTES 32  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type WideProbe */
@@ -107,7 +92,7 @@ typedef struct WideProbe {
 } WideProbe;
 
 #define WIDE_PROBE_MAX_BITS 403   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define WIDE_PROBE_MAX_BYTES 56  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define WIDE_PROBE_MAX_BYTES 56  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a WideProbe with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -134,7 +119,7 @@ typedef struct LudicrousState {
 } LudicrousState;
 
 #define LUDICROUS_STATE_MAX_BITS 1205   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define LUDICROUS_STATE_MAX_BYTES 152  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define LUDICROUS_STATE_MAX_BYTES 152  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a LudicrousState with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a
@@ -157,7 +142,7 @@ typedef struct DegenerateProbe {
 } DegenerateProbe;
 
 #define DEGENERATE_PROBE_MAX_BITS 8   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define DEGENERATE_PROBE_MAX_BYTES 8  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define DEGENERATE_PROBE_MAX_BYTES 8  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type FixedVec */
@@ -168,7 +153,7 @@ typedef struct FixedVec {
 } FixedVec;
 
 #define FIXED_VEC_MAX_BITS 102   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define FIXED_VEC_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define FIXED_VEC_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 
 /* type FixedQuat */
@@ -180,7 +165,7 @@ typedef struct FixedQuat {
 } FixedQuat;
 
 #define FIXED_QUAT_MAX_BITS 128   /* longest wire path; align pads at worst case (SPEC §6.1) */
-#define FIXED_QUAT_MAX_BYTES 16  /* rounded up to the 8-byte write-buffer granularity; a READ buffer's allocation must extend at least 8 bytes past the data — serialize.c loads 64-bit windows */
+#define FIXED_QUAT_MAX_BYTES 16  /* 8-byte write granularity; read slack per the contract above */
 
 /* Returns a FixedQuat with its SPECIFIED defaults applied. A memset to zero is
    the schema's own default (SPEC §4.2: zero initialization unless a

--- a/testdata/golden/ludicrous/c/LudicrousWire.h
+++ b/testdata/golden/ludicrous/c/LudicrousWire.h
@@ -23,6 +23,12 @@
 extern "C" {
 #endif
 
+/* Every write_x/read_x returns 1 on success, 0 on failure — the stream
+   latches the error, so a caller may check once at the end of a message.
+   Reads REFUSE out-of-range values, never clamp. A tag is validated BEFORE
+   it rides, and a read zero-establishes the selected arm before decoding
+   it (SPEC §4.8, §5). */
+
 #ifndef SCHEMA_C_SPINE_INLINE_DEFINED
 #define SCHEMA_C_SPINE_INLINE_DEFINED
 /* SCHEMA_C_READ_INLINE / SCHEMA_C_WRITE_INLINE — how every generated wire
@@ -45,8 +51,7 @@ extern "C" {
 #endif
 #endif /* SCHEMA_C_SPINE_INLINE_DEFINED */
 
-/* Writes FixedProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes FixedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_write_stream_t * stream, const FixedProbe * value )
 {
     {
@@ -93,8 +98,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_probe( serialize_writ
     return 1;
 }
 
-/* Reads FixedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads FixedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_stream_t * stream, FixedProbe * value )
 {
     {
@@ -151,8 +155,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_probe( serialize_read_s
     return 1;
 }
 
-/* Writes UnsignedProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes UnsignedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_write_stream_t * stream, const UnsignedProbe * value )
 {
     {
@@ -207,8 +210,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_w
     return 1;
 }
 
-/* Reads UnsignedProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads UnsignedProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_read_stream_t * stream, UnsignedProbe * value )
 {
     {
@@ -269,8 +271,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_unsigned_probe( serialize_rea
     return 1;
 }
 
-/* Writes WideProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes WideProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write_stream_t * stream, const WideProbe * value )
 {
     if ( !serialize_write_uint128( stream, value->entity_id ) )
@@ -296,8 +297,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_probe( serialize_write
     return 1;
 }
 
-/* Reads WideProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads WideProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_stream_t * stream, WideProbe * value )
 {
     if ( !serialize_read_uint128( stream, &value->entity_id ) )
@@ -323,8 +323,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_st
     return 1;
 }
 
-/* Writes LudicrousState. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes LudicrousState. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
 {
     if ( value->mode > 3 )
@@ -371,8 +370,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_
     return 1;
 }
 
-/* Reads LudicrousState. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads LudicrousState. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_read_stream_t * stream, LudicrousState * value )
 {
     {
@@ -427,8 +425,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_re
     return 1;
 }
 
-/* Writes DegenerateProbe. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
 {
     if ( (serialize_int64_t) value->locked_fixed != -196608LL )
@@ -450,8 +447,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize
     return 1;
 }
 
-/* Reads DegenerateProbe. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_read_stream_t * stream, DegenerateProbe * value )
 {
     value->locked_fixed = (int32_t) -196608LL;
@@ -468,8 +464,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_degenerate_probe( serialize_r
     return 1;
 }
 
-/* Writes FixedVec. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes FixedVec. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_stream_t * stream, const FixedVec * value )
 {
     {
@@ -496,8 +491,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_vec( serialize_write_
     return 1;
 }
 
-/* Reads FixedVec. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads FixedVec. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_stream_t * stream, FixedVec * value )
 {
     {
@@ -530,8 +524,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_vec( serialize_read_str
     return 1;
 }
 
-/* Writes FixedQuat. Returns 1 on success, 0 on failure — the stream latches the
-   error, so a caller may check once at the end of a message. */
+/* Writes FixedQuat. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write_stream_t * stream, const FixedQuat * value )
 {
     {
@@ -565,8 +558,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_fixed_quat( serialize_write
     return 1;
 }
 
-/* Reads FixedQuat. Returns 1 on success, 0 on failure. Out-of-range values are
-   REFUSED, never clamped. */
+/* Reads FixedQuat. */
 static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_fixed_quat( serialize_read_stream_t * stream, FixedQuat * value )
 {
     {

--- a/testdata/golden/ludicrous/cs/Ludicrous.cs
+++ b/testdata/golden/ludicrous/cs/Ludicrous.cs
@@ -4,12 +4,11 @@
 // AGPL-3.0, its output is not.
 // package ludicrous — protocol id 0xa925c86b46058512
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers C# for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an interior null) returns false WITHOUT
-// latching; stream failures latch on stream.Error — the runtime's own sticky
-// latch. Callers get bool always; Error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an interior null)
+// returns false WITHOUT latching; stream failures latch on stream.Error —
+// the runtime's own sticky latch. Callers get bool always; Error tells the
+// two apart.
 
 using System;
 using System.Runtime.CompilerServices;
@@ -83,8 +82,8 @@ namespace Ludicrous
         public UInt128Value EntityId;
         public Int128Value Energy; // wire [-5000000000, 5000000000]
         public Int128Value Flux; // wire [-1267650600228229401496703205376, 1267650600228229401496703205376]
-        public Int128Value Bias = -250; // = -250 at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
-        public UInt128Value Seed = new UInt128Value(0x2ul, 0x0ul); // = new UInt128Value(0x2ul, 0x0ul) at construction; Zero* gives the §5 zero form
+        public Int128Value Bias = -250; // specified default at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
+        public UInt128Value Seed = new UInt128Value(0x2ul, 0x0ul); // specified default at construction; Zero* gives the §5 zero form
     }
 
     // message LudicrousState
@@ -113,8 +112,7 @@ namespace Ludicrous
         public byte Tail;
     }
 
-    // type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class FixedVec
     {
         public long X; // wire [-100000, 100000]
@@ -122,14 +120,13 @@ namespace Ludicrous
         public long Z; // wire [-100000, 100000]
     }
 
-    // type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-    // claims tags and assigns actions (SPEC §4.2, Type tags)
+    // type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
     public sealed class FixedQuat
     {
         public int X; // wire [-1, 1]
         public int Y; // wire [-1, 1]
         public int Z; // wire [-1, 1]
-        public int W = 1073741824; // = 1073741824 at construction; Zero* gives the §5 zero form; wire [-1, 1]
+        public int W = 1073741824; // specified default at construction; Zero* gives the §5 zero form; wire [-1, 1]
     }
 
     // ---- object Body — one definition, a generated family per target (SPEC §4.8) ----
@@ -140,7 +137,7 @@ namespace Ludicrous
         public FixedVec Position = new FixedVec();
         public FixedQuat Rotation = new FixedQuat();
         public FixedVec Velocity = new FixedVec();
-        public double Spin; //  | local — no wire
+        public double Spin; // | local — no wire
     }
 
     // BodyData_Deep — every non- | local field, deep encodings: full state for
@@ -263,8 +260,7 @@ namespace Ludicrous
         public const long FixedProbeMaxBits = 156;
         public const long FixedProbeMaxBytes = 24;
 
-        // ZeroFixedProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroFixedProbe(FixedProbe value)
         {
             value.Angle = 0;
@@ -274,21 +270,17 @@ namespace Ludicrous
             Array.Clear(value.Samples, 0, 2);
         }
 
-        // WriteFixedProbe/ReadFixedProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteFixedProbe(WriteStream stream, FixedProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteFixedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteFixedProbeBatch(ref WriteBatch batch, FixedProbe value)
         {
@@ -322,13 +314,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadFixedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadFixedProbeBatch(ref ReadBatch batch, FixedProbe value)
         {
@@ -363,8 +353,7 @@ namespace Ludicrous
         public const long UnsignedProbeMaxBits = 196;
         public const long UnsignedProbeMaxBytes = 32;
 
-        // ZeroUnsignedProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroUnsignedProbe(UnsignedProbe value)
         {
             value.Angle = 0;
@@ -376,21 +365,17 @@ namespace Ludicrous
             value.Tail = 0;
         }
 
-        // WriteUnsignedProbe/ReadUnsignedProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteUnsignedProbe(WriteStream stream, UnsignedProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteUnsignedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteUnsignedProbeBatch(ref WriteBatch batch, UnsignedProbe value)
         {
@@ -417,7 +402,7 @@ namespace Ludicrous
                     return false;
                 }
             }
-            if ((ulong)value.Locked != 196608UL) // out-of-contract writes are refused, not wrapped
+            if ((ulong)value.Locked != 196608UL)
             {
                 return false;
             }
@@ -435,13 +420,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadUnsignedProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadUnsignedProbeBatch(ref ReadBatch batch, UnsignedProbe value)
         {
@@ -485,8 +468,7 @@ namespace Ludicrous
         public const long WideProbeMaxBits = 403;
         public const long WideProbeMaxBytes = 56;
 
-        // ZeroWideProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroWideProbe(WideProbe value)
         {
             value.EntityId = 0;
@@ -496,21 +478,17 @@ namespace Ludicrous
             value.Seed = 0;
         }
 
-        // WriteWideProbe/ReadWideProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteWideProbe(WriteStream stream, WideProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteWideProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteWideProbeBatch(ref WriteBatch batch, WideProbe value)
         {
@@ -541,13 +519,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadWideProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadWideProbeBatch(ref ReadBatch batch, WideProbe value)
         {
@@ -579,8 +555,7 @@ namespace Ludicrous
         public const long LudicrousStateMaxBits = 1205;
         public const long LudicrousStateMaxBytes = 152;
 
-        // ZeroLudicrousState resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroLudicrousState(LudicrousState value)
         {
             value.Mode = DriveMode.None;
@@ -592,21 +567,17 @@ namespace Ludicrous
             value.TargetId = 0;
         }
 
-        // WriteLudicrousState/ReadLudicrousState run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteLudicrousState(WriteStream stream, LudicrousState value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteLudicrousStateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteLudicrousStateBatch(ref WriteBatch batch, LudicrousState value)
         {
@@ -665,13 +636,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadLudicrousStateBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadLudicrousStateBatch(ref ReadBatch batch, LudicrousState value)
         {
@@ -725,8 +694,7 @@ namespace Ludicrous
         public const long DegenerateProbeMaxBits = 8;
         public const long DegenerateProbeMaxBytes = 8;
 
-        // ZeroDegenerateProbe resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroDegenerateProbe(DegenerateProbe value)
         {
             value.LockedFixed = 0;
@@ -735,33 +703,29 @@ namespace Ludicrous
             value.Tail = 0;
         }
 
-        // WriteDegenerateProbe/ReadDegenerateProbe run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteDegenerateProbe(WriteStream stream, DegenerateProbe value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteDegenerateProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteDegenerateProbeBatch(ref WriteBatch batch, DegenerateProbe value)
         {
-            if ((long)value.LockedFixed != -196608L) // out-of-contract writes are refused, not wrapped
+            if ((long)value.LockedFixed != -196608L)
             {
                 return false;
             }
-            if (value.LockedInt < 7 || value.LockedInt > 7) // out-of-contract writes are refused, not wrapped
+            if (value.LockedInt < 7 || value.LockedInt > 7)
             {
                 return false;
             }
-            if (value.LockedWide != (Int128Value)(-12345678901234L)) // out-of-contract writes are refused, not wrapped
+            if (value.LockedWide != (Int128Value)(-12345678901234L))
             {
                 return false;
             }
@@ -779,13 +743,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadDegenerateProbeBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadDegenerateProbeBatch(ref ReadBatch batch, DegenerateProbe value)
         {
@@ -808,8 +770,7 @@ namespace Ludicrous
         public const long FixedVecMaxBits = 102;
         public const long FixedVecMaxBytes = 16;
 
-        // ZeroFixedVec resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroFixedVec(FixedVec value)
         {
             value.X = 0;
@@ -817,21 +778,17 @@ namespace Ludicrous
             value.Z = 0;
         }
 
-        // WriteFixedVec/ReadFixedVec run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteFixedVec(WriteStream stream, FixedVec value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteFixedVecBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteFixedVecBatch(ref WriteBatch batch, FixedVec value)
         {
@@ -854,13 +811,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadFixedVecBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadFixedVecBatch(ref ReadBatch batch, FixedVec value)
         {
@@ -884,8 +839,7 @@ namespace Ludicrous
         public const long FixedQuatMaxBits = 128;
         public const long FixedQuatMaxBytes = 16;
 
-        // ZeroFixedQuat resets value to the §5 ZERO form — all-zero storage; specified
-        // defaults live in construction only and are NOT reapplied here.
+        // The §5 zero form: all-zero storage; specified defaults live only in construction.
         public static void ZeroFixedQuat(FixedQuat value)
         {
             value.X = 0;
@@ -894,21 +848,17 @@ namespace Ludicrous
             value.W = 0;
         }
 
-        // WriteFixedQuat/ReadFixedQuat run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteFixedQuat(WriteStream stream, FixedQuat value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteFixedQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteFixedQuatBatch(ref WriteBatch batch, FixedQuat value)
         {
@@ -935,13 +885,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadFixedQuatBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadFixedQuatBatch(ref ReadBatch batch, FixedQuat value)
         {
@@ -967,21 +915,17 @@ namespace Ludicrous
         public const long BodyData_DeepMaxBits = 332;
         public const long BodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteBodyData_Deep/ReadBodyData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBodyData_Deep(WriteStream stream, BodyData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBodyData_DeepBatch(ref WriteBatch batch, BodyData_Deep value)
         {
@@ -1004,13 +948,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBodyData_DeepBatch(ref ReadBatch batch, BodyData_Deep value)
         {
@@ -1032,21 +974,17 @@ namespace Ludicrous
         public const long BodyData_ShallowMaxBits = 332;
         public const long BodyData_ShallowMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteBodyData_Shallow/ReadBodyData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBodyData_Shallow(WriteStream stream, BodyData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBodyData_ShallowBatch(ref WriteBatch batch, BodyData_Shallow value)
         {
@@ -1069,13 +1007,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBodyData_ShallowBatch(ref ReadBatch batch, BodyData_Shallow value)
         {
@@ -1097,21 +1033,17 @@ namespace Ludicrous
         public const long NarrowBodyData_DeepMaxBits = 332;
         public const long NarrowBodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteNarrowBodyData_Deep/ReadNarrowBodyData_Deep run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteNarrowBodyData_Deep(WriteStream stream, NarrowBodyData_Deep value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteNarrowBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteNarrowBodyData_DeepBatch(ref WriteBatch batch, NarrowBodyData_Deep value)
         {
@@ -1134,13 +1066,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadNarrowBodyData_DeepBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadNarrowBodyData_DeepBatch(ref ReadBatch batch, NarrowBodyData_Deep value)
         {
@@ -1162,21 +1092,17 @@ namespace Ludicrous
         public const long NarrowBodyData_ShallowMaxBits = 228;
         public const long NarrowBodyData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity
 
-        // WriteNarrowBodyData_Shallow/ReadNarrowBodyData_Shallow run as a batch: the stream state lives in registers
-        // across the body's serialize calls and is stored back once at End —
-        // the tiny-message hot path (serialize.cs WriteBatch/ReadBatch). Same
-        // wire bytes, same validation, same latched-error model.
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteNarrowBodyData_Shallow(WriteStream stream, NarrowBodyData_Shallow value)
         {
             WriteBatch batch = stream.BeginBatch();
             bool result = WriteNarrowBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the state and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteNarrowBodyData_ShallowBatch(ref WriteBatch batch, NarrowBodyData_Shallow value)
         {
@@ -1268,13 +1194,11 @@ namespace Ludicrous
         {
             ReadBatch batch = stream.BeginBatch();
             bool result = ReadNarrowBodyData_ShallowBatch(ref batch, value);
-            batch.End(); // on every path out — End publishes the cursor and the error
+            batch.End();
             return result;
         }
 
-        // The batch-form core — INLINE-ONLY: a non-inlined call taking the batch by
-        // ref address-exposes it and enregistration dies (measured 0.71x, worse than
-        // no batch). Nested types compose core-to-core by ref, never via the stream.
+        // inline-only batch core — a real call would address-expose the batch
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadNarrowBodyData_ShallowBatch(ref ReadBatch batch, NarrowBodyData_Shallow value)
         {

--- a/testdata/golden/ludicrous/go/Ludicrous.go
+++ b/testdata/golden/ludicrous/go/Ludicrous.go
@@ -164,7 +164,7 @@ func WriteUnsignedProbe(stream *serialize.WriteStream, value *UnsignedProbe) err
 			stream.SerializeFixed64(&fixedValue, 16, 16, 0, 16)
 		}
 	}
-	if uint64(value.Locked) != 196608 { // the runtime range refusal, folded (SPEC §5)
+	if uint64(value.Locked) != 196608 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -284,7 +284,7 @@ const LudicrousStateMaxBytes = 152
 func WriteLudicrousState(stream *serialize.WriteStream, value *LudicrousState) error {
 	{
 		enumValue := int32(value.Mode)
-		if enumValue < 0 || enumValue > 3 { // the runtime range refusal, folded (SPEC §5)
+		if enumValue < 0 || enumValue > 3 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -298,7 +298,7 @@ func WriteLudicrousState(stream *serialize.WriteStream, value *LudicrousState) e
 	if err := WriteWideProbe(stream, &value.Wide); err != nil {
 		return err
 	}
-	if value.KeysCount < 0 || value.KeysCount > 4 { // the runtime range refusal, folded (SPEC §5)
+	if value.KeysCount < 0 || value.KeysCount > 4 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -360,13 +360,13 @@ const DegenerateProbeMaxBits = 8
 const DegenerateProbeMaxBytes = 8
 
 func WriteDegenerateProbe(stream *serialize.WriteStream, value *DegenerateProbe) error {
-	if int64(value.LockedFixed) != -196608 { // the runtime range refusal, folded (SPEC §5)
+	if int64(value.LockedFixed) != -196608 {
 		return serialize.ErrValueOutOfRange
 	}
-	if value.LockedInt < 7 || value.LockedInt > 7 { // the runtime range refusal, folded (SPEC §5)
+	if value.LockedInt < 7 || value.LockedInt > 7 {
 		return serialize.ErrValueOutOfRange
 	}
-	if value.LockedWide != serialize.Int128From64(-12345678901234) { // the runtime range refusal, folded (SPEC §5)
+	if value.LockedWide != serialize.Int128From64(-12345678901234) {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -388,8 +388,7 @@ func ReadDegenerateProbe(stream *serialize.ReadStream, value *DegenerateProbe) e
 	return stream.Err()
 }
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type FixedVec struct {
 	X int64 // wire [-100000, 100000]
 	Y int64 // wire [-100000, 100000]
@@ -415,8 +414,7 @@ func ReadFixedVec(stream *serialize.ReadStream, value *FixedVec) error {
 	return stream.Err()
 }
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 type FixedQuat struct {
 	X int32 // wire [-1, 1]
 	Y int32 // wire [-1, 1]
@@ -489,7 +487,7 @@ type BodyState struct {
 	Position FixedVec
 	Rotation FixedQuat
 	Velocity FixedVec
-	Spin     float64 //  | local — no wire
+	Spin     float64 // | local — no wire
 }
 
 // BodyData_Deep — every non- | local field, deep encodings: full state for
@@ -651,21 +649,21 @@ const NarrowBodyData_ShallowMaxBits = 228
 const NarrowBodyData_ShallowMaxBytes = 32 // rounded up to the 8-byte write-buffer granularity
 
 func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBodyData_Shallow) error {
-	if value.PositionX < -25600000 || value.PositionX > 25600000 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionX < -25600000 || value.PositionX > 25600000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionX - (-25600000))
 		stream.SerializeBits(&offsetValue, 26)
 	}
-	if value.PositionY < -25600000 || value.PositionY > 25600000 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionY < -25600000 || value.PositionY > 25600000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
 		offsetValue := uint32(value.PositionY - (-25600000))
 		stream.SerializeBits(&offsetValue, 26)
 	}
-	if value.PositionZ < -25600000 || value.PositionZ > 25600000 { // the runtime range refusal, folded (SPEC §5)
+	if value.PositionZ < -25600000 || value.PositionZ > 25600000 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -674,7 +672,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationX)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -684,7 +682,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationY)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -694,7 +692,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationZ)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -704,7 +702,7 @@ func WriteNarrowBodyData_Shallow(stream *serialize.WriteStream, value *NarrowBod
 	}
 	{
 		componentValue := int32(value.RotationW)
-		if componentValue < -1024 || componentValue > 1024 { // the runtime range refusal, folded (SPEC §5)
+		if componentValue < -1024 || componentValue > 1024 {
 			return serialize.ErrValueOutOfRange
 		}
 		{
@@ -823,7 +821,7 @@ func UnquantizeNarrowBody(input *NarrowBodyData_Shallow, output *NarrowBodyData_
 // valid wire value meaning *no message* — the stream terminator (SPEC §4.8).
 func WriteMessageType(stream *serialize.WriteStream, value MessageType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 1 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 1 {
 		return serialize.ErrValueOutOfRange
 	}
 	{
@@ -901,7 +899,7 @@ func ReadMessage(stream *serialize.ReadStream, storage *MessageStorage) (Message
 // null — the sentinel the surveyed baseline streams terminate with (SPEC §4.8).
 func WriteObjectType(stream *serialize.WriteStream, value ObjectType) error {
 	tagValue := int32(value)
-	if tagValue < 0 || tagValue > 2 { // the runtime range refusal, folded (SPEC §5)
+	if tagValue < 0 || tagValue > 2 {
 		return serialize.ErrValueOutOfRange
 	}
 	{

--- a/testdata/golden/ludicrous/js/Ludicrous.js
+++ b/testdata/golden/ludicrous/js/Ludicrous.js
@@ -4,22 +4,18 @@
 // AGPL-3.0, its output is not.
 // package ludicrous — protocol id 0xa925c86b46058512
 //
-// Storage members are PascalCase via the same mapping as the Go target, so
-// the checker's collision registry covers JS for free. Wire functions return
-// bool — the C++-style early-out. A schema validation failure (a wrong wire
-// constant, nonzero reserved bits, an out-of-contract write) returns false
-// WITHOUT latching; stream failures latch on stream.error — the runtime's own
-// sticky latch. Callers get bool always; error tells the two apart.
+// Wire functions return bool — the C++-style early-out. A schema validation
+// failure (a wrong wire constant, nonzero reserved bits, an out-of-contract
+// write) returns false WITHOUT latching; stream failures latch on
+// stream.error — the runtime's own sticky latch. Callers get bool always;
+// error tells the two apart.
 //
 // Number storage for widths of 32 bits or fewer, BigInt for 64 and 128 —
 // the serialize.js value-domain seam. Checked/production comes from the
 // stream object; generated code never reads NODE_ENV.
 
-// Scratch holders for the runtime's {value} refs (streams.js has no ref
-// parameters). Module scope is safe — JavaScript is single threaded per
-// realm and a holder is consumed in the same call that fills it, the
-// runtime's own FLOAT_SCRATCH argument; generated code never holds one
-// across a nested Write/Read call.
+// Scratch holders for the runtime's {value} refs — single threaded per
+// realm, always consumed in the same call that fills them.
 const NUMBER_SCRATCH = { value: 0 };
 const BIGINT_SCRATCH = { value: 0n };
 const BOOL_SCRATCH = { value: false };
@@ -89,8 +85,7 @@ export class FixedProbe {
 export const FixedProbeMaxBits = 156;
 export const FixedProbeMaxBytes = 24;
 
-// ZeroFixedProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroFixedProbe(value) {
   value.Angle = 0;
   value.Position = 0n;
@@ -169,8 +164,7 @@ export class UnsignedProbe {
 export const UnsignedProbeMaxBits = 196;
 export const UnsignedProbeMaxBytes = 32;
 
-// ZeroUnsignedProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroUnsignedProbe(value) {
   value.Angle = 0;
   value.Span = 0n;
@@ -204,7 +198,7 @@ export function WriteUnsignedProbe(stream, value) {
       return false;
     }
   }
-  if (value.Locked !== 196608) { // out-of-contract writes are refused, not wrapped
+  if (value.Locked !== 196608) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Tail;
@@ -251,8 +245,8 @@ export class WideProbe {
     this.EntityId = 0n;
     this.Energy = 0n; // wire [-5000000000, 5000000000]
     this.Flux = 0n; // wire [-1267650600228229401496703205376, 1267650600228229401496703205376]
-    this.Bias = -250n; // = -250n at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
-    this.Seed = 36893488147419103232n; // = 36893488147419103232n at construction; Zero* gives the §5 zero form
+    this.Bias = -250n; // specified default at construction; Zero* gives the §5 zero form; wire [-1000, 1000]
+    this.Seed = 36893488147419103232n; // specified default at construction; Zero* gives the §5 zero form
   }
 }
 
@@ -261,8 +255,7 @@ export class WideProbe {
 export const WideProbeMaxBits = 403;
 export const WideProbeMaxBytes = 56;
 
-// ZeroWideProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroWideProbe(value) {
   value.EntityId = 0n;
   value.Energy = 0n;
@@ -346,8 +339,7 @@ export class LudicrousState {
 export const LudicrousStateMaxBits = 1205;
 export const LudicrousStateMaxBytes = 152;
 
-// ZeroLudicrousState resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroLudicrousState(value) {
   value.Mode = DriveMode.None;
   ZeroFixedProbe(value.Probe);
@@ -372,7 +364,7 @@ export function WriteLudicrousState(stream, value) {
   if (!WriteWideProbe(stream, value.Wide)) {
     return false;
   }
-  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop (§6.3); out-of-contract writes are refused
+  if (!Number.isInteger(value.KeysCount) || value.KeysCount < 0 || value.KeysCount > 4) { // the count guards the loop (§6.3)
     return false;
   }
   NUMBER_SCRATCH.value = value.KeysCount;
@@ -449,8 +441,7 @@ export class DegenerateProbe {
 export const DegenerateProbeMaxBits = 8;
 export const DegenerateProbeMaxBytes = 8;
 
-// ZeroDegenerateProbe resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroDegenerateProbe(value) {
   value.LockedFixed = 0;
   value.LockedInt = 0;
@@ -459,13 +450,13 @@ export function ZeroDegenerateProbe(value) {
 }
 
 export function WriteDegenerateProbe(stream, value) {
-  if (value.LockedFixed !== -196608) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedFixed !== -196608) {
     return false;
   }
-  if (!Number.isInteger(value.LockedInt) || value.LockedInt < 7 || value.LockedInt > 7) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.LockedInt) || value.LockedInt < 7 || value.LockedInt > 7) {
     return false;
   }
-  if (value.LockedWide !== -12345678901234n) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedWide !== -12345678901234n) {
     return false;
   }
   NUMBER_SCRATCH.value = value.Tail;
@@ -486,8 +477,7 @@ export function ReadDegenerateProbe(stream, value) {
   return true;
 }
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class FixedVec {
   constructor() {
     this.X = 0n; // wire [-100000, 100000]
@@ -501,8 +491,7 @@ export class FixedVec {
 export const FixedVecMaxBits = 102;
 export const FixedVecMaxBytes = 16;
 
-// ZeroFixedVec resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroFixedVec(value) {
   value.X = 0n;
   value.Y = 0n;
@@ -541,14 +530,13 @@ export function ReadFixedVec(stream, value) {
   return true;
 }
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 export class FixedQuat {
   constructor() {
     this.X = 0; // wire [-1, 1]
     this.Y = 0; // wire [-1, 1]
     this.Z = 0; // wire [-1, 1]
-    this.W = 1073741824; // = 1073741824 at construction; Zero* gives the §5 zero form; wire [-1, 1]
+    this.W = 1073741824; // specified default at construction; Zero* gives the §5 zero form; wire [-1, 1]
   }
 }
 
@@ -557,8 +545,7 @@ export class FixedQuat {
 export const FixedQuatMaxBits = 128;
 export const FixedQuatMaxBytes = 16;
 
-// ZeroFixedQuat resets value to the §5 ZERO form — all-zero storage; specified
-// defaults live in construction only and are NOT reapplied here.
+// The §5 zero form: all-zero storage; specified defaults live only in construction.
 export function ZeroFixedQuat(value) {
   value.X = 0;
   value.Y = 0;
@@ -614,7 +601,7 @@ export class BodyState {
     this.Position = new FixedVec();
     this.Rotation = new FixedQuat();
     this.Velocity = new FixedVec();
-    this.Spin = 0; //  | local — no wire
+    this.Spin = 0; // | local — no wire
   }
 }
 
@@ -791,49 +778,49 @@ export const NarrowBodyData_ShallowMaxBits = 228;
 export const NarrowBodyData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity
 
 export function WriteNarrowBodyData_Shallow(stream, value) {
-  if (!Number.isInteger(value.PositionX) || value.PositionX < -25600000 || value.PositionX > 25600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionX) || value.PositionX < -25600000 || value.PositionX > 25600000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionX >>> 0) - (-25600000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 26)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionY) || value.PositionY < -25600000 || value.PositionY > 25600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionY) || value.PositionY < -25600000 || value.PositionY > 25600000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionY >>> 0) - (-25600000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 26)) {
     return false;
   }
-  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -25600000 || value.PositionZ > 25600000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.PositionZ) || value.PositionZ < -25600000 || value.PositionZ > 25600000) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.PositionZ >>> 0) - (-25600000 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 26)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationX) || value.RotationX < -1024 || value.RotationX > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationX >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationY) || value.RotationY < -1024 || value.RotationY > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationY >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationZ) || value.RotationZ < -1024 || value.RotationZ > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationZ >>> 0) - (-1024 >>> 0)) >>> 0;
   if (!stream.serializeBits(NUMBER_SCRATCH, 12)) {
     return false;
   }
-  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.RotationW) || value.RotationW < -1024 || value.RotationW > 1024) {
     return false;
   }
   NUMBER_SCRATCH.value = ((value.RotationW >>> 0) - (-1024 >>> 0)) >>> 0;

--- a/testdata/golden/ludicrous/js/LudicrousFlat.js
+++ b/testdata/golden/ludicrous/js/LudicrousFlat.js
@@ -160,7 +160,7 @@ function writeFixedProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Angle) || value.Angle < -11796480 || value.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Angle) || value.Angle < -11796480 || value.Angle > 11796480) {
     return -1;
   }
   v = ((((value.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -180,7 +180,7 @@ function writeFixedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Position < -1966080000n || value.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Position < -1966080000n || value.Position > 1966080000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Position - -1966080000n));
@@ -200,7 +200,7 @@ function writeFixedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Reach < -65536000000n || value.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Reach < -65536000000n || value.Reach > 65536000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Reach - -65536000000n), true);
@@ -238,7 +238,7 @@ function writeFixedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) {
     return -1;
   }
   v = ((value.Ticks) & 0xfffff) >>> 0;
@@ -259,7 +259,7 @@ function writeFixedProbeFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < 2; i0++) {
-    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < -524288 || value.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < -524288 || value.Samples[i0] > 524288) {
       return -1;
     }
     v = ((((value.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -528,7 +528,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.Angle) || value.Angle < 0 || value.Angle > 23592960) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Angle) || value.Angle < 0 || value.Angle > 23592960) {
     return -1;
   }
   v = ((value.Angle) & 0x1ffffff) >>> 0;
@@ -548,7 +548,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Span < 0n || value.Span > 18446744073709486080n) { // out-of-contract writes are refused, not wrapped
+  if (value.Span < 0n || value.Span > 18446744073709486080n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Span), true);
@@ -586,7 +586,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Reach < 0n || value.Reach > 131072000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Reach < 0n || value.Reach > 131072000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Reach), true);
@@ -624,7 +624,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Ticks) || value.Ticks < 0 || value.Ticks > 1000000) {
     return -1;
   }
   v = ((value.Ticks) & 0xfffff) >>> 0;
@@ -645,7 +645,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < 2; i0++) {
-    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < 0 || value.Samples[i0] > 1048576) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Samples[i0]) || value.Samples[i0] < 0 || value.Samples[i0] > 1048576) {
       return -1;
     }
     v = ((value.Samples[i0]) & 0x1fffff) >>> 0;
@@ -666,7 +666,7 @@ function writeUnsignedProbeFlatChecked(value, view) {
       sb -= 64;
     }
   }
-  if (value.Locked !== 196608) { // out-of-contract writes are refused, not wrapped
+  if (value.Locked !== 196608) {
     return -1;
   }
   v = ((value.Tail) & 0xff) >>> 0;
@@ -1140,7 +1140,7 @@ function writeWideProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Energy < -5000000000n || value.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Energy < -5000000000n || value.Energy > 5000000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Energy - -5000000000n), true);
@@ -1178,7 +1178,7 @@ function writeWideProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Flux < -1267650600228229401496703205376n || value.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+  if (value.Flux < -1267650600228229401496703205376n || value.Flux > 1267650600228229401496703205376n) {
     return -1;
   }
   bg = BigInt.asUintN(128, value.Flux - -1267650600228229401496703205376n);
@@ -1250,7 +1250,7 @@ function writeWideProbeFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Bias < -1000n || value.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Bias < -1000n || value.Bias > 1000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Bias - -1000n));
@@ -2091,7 +2091,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) {
     return -1;
   }
   v = ((((value.Probe.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -2111,7 +2111,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Probe.Position - -1966080000n));
@@ -2131,7 +2131,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Probe.Reach - -65536000000n), true);
@@ -2169,7 +2169,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) {
     return -1;
   }
   v = ((value.Probe.Ticks) & 0xfffff) >>> 0;
@@ -2190,7 +2190,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     sb -= 64;
   }
   for (let i0 = 0; i0 < 2; i0++) {
-    if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) {
       return -1;
     }
     v = ((((value.Probe.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -2280,7 +2280,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Wide.Energy - -5000000000n), true);
@@ -2318,7 +2318,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+  if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) {
     return -1;
   }
   bg = BigInt.asUintN(128, value.Wide.Flux - -1267650600228229401496703205376n);
@@ -2390,7 +2390,7 @@ function writeLudicrousStateFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) {
     return -1;
   }
   v = Number(BigInt.asUintN(64, value.Wide.Bias - -1000n));
@@ -3603,7 +3603,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Probe.Angle) || value.Probe.Angle < -11796480 || value.Probe.Angle > 11796480) {
       return -1;
     }
     v = ((((value.Probe.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -3623,7 +3623,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Probe.Position < -1966080000n || value.Probe.Position > 1966080000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, value.Probe.Position - -1966080000n));
@@ -3643,7 +3643,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Probe.Reach < -65536000000n || value.Probe.Reach > 65536000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, value.Probe.Reach - -65536000000n), true);
@@ -3681,7 +3681,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(value.Probe.Ticks) || value.Probe.Ticks < 0 || value.Probe.Ticks > 1000000) {
       return -1;
     }
     v = ((value.Probe.Ticks) & 0xfffff) >>> 0;
@@ -3702,7 +3702,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       sb -= 64;
     }
     for (let i0 = 0; i0 < 2; i0++) {
-      if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(value.Probe.Samples[i0]) || value.Probe.Samples[i0] < -524288 || value.Probe.Samples[i0] > 524288) {
         return -1;
       }
       v = ((((value.Probe.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -3792,7 +3792,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Wide.Energy < -5000000000n || value.Wide.Energy > 5000000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, value.Wide.Energy - -5000000000n), true);
@@ -3830,7 +3830,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+    if (value.Wide.Flux < -1267650600228229401496703205376n || value.Wide.Flux > 1267650600228229401496703205376n) {
       return -1;
     }
     bg = BigInt.asUintN(128, value.Wide.Flux - -1267650600228229401496703205376n);
@@ -3902,7 +3902,7 @@ function writeLudicrousStateFlatArrayChecked(values, count, view) {
       hi = 0;
       sb -= 64;
     }
-    if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+    if (value.Wide.Bias < -1000n || value.Wide.Bias > 1000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, value.Wide.Bias - -1000n));
@@ -4548,13 +4548,13 @@ function writeDegenerateProbeFlatProduction(value, view) {
 function writeDegenerateProbeFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.LockedFixed !== -196608) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedFixed !== -196608) {
     return -1;
   }
-  if (value.LockedInt !== 7) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedInt !== 7) {
     return -1;
   }
-  if (value.LockedWide !== -12345678901234n) { // out-of-contract writes are refused, not wrapped
+  if (value.LockedWide !== -12345678901234n) {
     return -1;
   }
   v = ((value.Tail) & 0xff) >>> 0;
@@ -4729,7 +4729,7 @@ function writeFixedVecFlatChecked(value, view) {
   let v = 0, s = 0;
   let bg = 0n;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (value.X < -6553600000n || value.X > 6553600000n) { // out-of-contract writes are refused, not wrapped
+  if (value.X < -6553600000n || value.X > 6553600000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.X - -6553600000n), true);
@@ -4767,7 +4767,7 @@ function writeFixedVecFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Y < -6553600000n || value.Y > 6553600000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Y < -6553600000n || value.Y > 6553600000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Y - -6553600000n), true);
@@ -4805,7 +4805,7 @@ function writeFixedVecFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (value.Z < -6553600000n || value.Z > 6553600000n) { // out-of-contract writes are refused, not wrapped
+  if (value.Z < -6553600000n || value.Z > 6553600000n) {
     return -1;
   }
   SC.setBigUint64(0, BigInt.asUintN(64, value.Z - -6553600000n), true);
@@ -5012,7 +5012,7 @@ function writeFixedQuatFlatProduction(value, view) {
 function writeFixedQuatFlatChecked(value, view) {
   let v = 0, s = 0;
   let lo = 0, hi = 0, sb = 0, wi = 0;
-  if (!Number.isInteger(value.X) || value.X < -1073741824 || value.X > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.X) || value.X < -1073741824 || value.X > 1073741824) {
     return -1;
   }
   v = (((value.X >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5032,7 +5032,7 @@ function writeFixedQuatFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Y) || value.Y < -1073741824 || value.Y > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Y) || value.Y < -1073741824 || value.Y > 1073741824) {
     return -1;
   }
   v = (((value.Y >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5052,7 +5052,7 @@ function writeFixedQuatFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.Z) || value.Z < -1073741824 || value.Z > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.Z) || value.Z < -1073741824 || value.Z > 1073741824) {
     return -1;
   }
   v = (((value.Z >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5072,7 +5072,7 @@ function writeFixedQuatFlatChecked(value, view) {
     hi = 0;
     sb -= 64;
   }
-  if (!Number.isInteger(value.W) || value.W < -1073741824 || value.W > 1073741824) { // out-of-contract writes are refused, not wrapped
+  if (!Number.isInteger(value.W) || value.W < -1073741824 || value.W > 1073741824) {
     return -1;
   }
   v = (((value.W >>> 0) - 3221225472) >>> 0) >>> 0;
@@ -5836,7 +5836,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.Probe.Angle) || message.Probe.Angle < -11796480 || message.Probe.Angle > 11796480) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.Probe.Angle) || message.Probe.Angle < -11796480 || message.Probe.Angle > 11796480) {
       return -1;
     }
     v = ((((message.Probe.Angle >>> 0) - 4283170816) >>> 0) & 0x1ffffff) >>> 0;
@@ -5856,7 +5856,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Probe.Position < -1966080000n || message.Probe.Position > 1966080000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Probe.Position < -1966080000n || message.Probe.Position > 1966080000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, message.Probe.Position - -1966080000n));
@@ -5876,7 +5876,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Probe.Reach < -65536000000n || message.Probe.Reach > 65536000000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Probe.Reach < -65536000000n || message.Probe.Reach > 65536000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, message.Probe.Reach - -65536000000n), true);
@@ -5914,7 +5914,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (!Number.isInteger(message.Probe.Ticks) || message.Probe.Ticks < 0 || message.Probe.Ticks > 1000000) { // out-of-contract writes are refused, not wrapped
+    if (!Number.isInteger(message.Probe.Ticks) || message.Probe.Ticks < 0 || message.Probe.Ticks > 1000000) {
       return -1;
     }
     v = ((message.Probe.Ticks) & 0xfffff) >>> 0;
@@ -5935,7 +5935,7 @@ function writeMessageFlatChecked(message, view) {
       sb -= 64;
     }
     for (let i0 = 0; i0 < 2; i0++) {
-      if (!Number.isInteger(message.Probe.Samples[i0]) || message.Probe.Samples[i0] < -524288 || message.Probe.Samples[i0] > 524288) { // out-of-contract writes are refused, not wrapped
+      if (!Number.isInteger(message.Probe.Samples[i0]) || message.Probe.Samples[i0] < -524288 || message.Probe.Samples[i0] > 524288) {
         return -1;
       }
       v = ((((message.Probe.Samples[i0] >>> 0) - 4294443008) >>> 0) & 0x1fffff) >>> 0;
@@ -6025,7 +6025,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Wide.Energy < -5000000000n || message.Wide.Energy > 5000000000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Wide.Energy < -5000000000n || message.Wide.Energy > 5000000000n) {
       return -1;
     }
     SC.setBigUint64(0, BigInt.asUintN(64, message.Wide.Energy - -5000000000n), true);
@@ -6063,7 +6063,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Wide.Flux < -1267650600228229401496703205376n || message.Wide.Flux > 1267650600228229401496703205376n) { // out-of-contract writes are refused, not wrapped
+    if (message.Wide.Flux < -1267650600228229401496703205376n || message.Wide.Flux > 1267650600228229401496703205376n) {
       return -1;
     }
     bg = BigInt.asUintN(128, message.Wide.Flux - -1267650600228229401496703205376n);
@@ -6135,7 +6135,7 @@ function writeMessageFlatChecked(message, view) {
       hi = 0;
       sb -= 64;
     }
-    if (message.Wide.Bias < -1000n || message.Wide.Bias > 1000n) { // out-of-contract writes are refused, not wrapped
+    if (message.Wide.Bias < -1000n || message.Wide.Bias > 1000n) {
       return -1;
     }
     v = Number(BigInt.asUintN(64, message.Wide.Bias - -1000n));

--- a/testdata/golden/ludicrous/rust/ludicrous.rs
+++ b/testdata/golden/ludicrous/rust/ludicrous.rs
@@ -75,13 +75,7 @@ impl DriveMode {
 
 /// Debug/log name for any `DriveMode` value, out-of-set included.
 pub fn enum_name_drive_mode(value: DriveMode) -> &'static str {
-    enum_name_drive_mode_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_drive_mode`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_drive_mode_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Cruise",
         2 => "Warp",
@@ -121,28 +115,28 @@ pub const FIXED_PROBE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_fixed_probe(stream: &mut WriteStream<'_>, value: &FixedProbe) -> Result {
-    if value.angle < -11796480 || value.angle > 11796480 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.angle < -11796480 || value.angle > 11796480 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, -180, 180)?;
     }
-    if value.position < -1966080000 || value.position > 1966080000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.position < -1966080000 || value.position > 1966080000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.position;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -MAX_WORLD_UNITS, MAX_WORLD_UNITS)?;
     }
-    if value.reach < -65536000000 || value.reach > 65536000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.reach < -65536000000 || value.reach > 65536000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, -1000000, 1000000)?;
     }
-    if value.ticks < 0 || value.ticks > 1000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.ticks < 0 || value.ticks > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -150,7 +144,7 @@ pub fn write_fixed_probe(stream: &mut WriteStream<'_>, value: &FixedProbe) -> Re
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] < -524288 || value.samples[i] > 524288 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+        if value.samples[i] < -524288 || value.samples[i] > 524288 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -208,28 +202,28 @@ pub const UNSIGNED_PROBE_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe) -> Result {
-    if value.angle > 23592960 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.angle > 23592960 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.angle;
         stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 360)?;
     }
-    if value.span > 18446744073709486080 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.span > 18446744073709486080 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.span;
         stream.serialize_fixed(&mut fixed_value, 48, 16, 0, 281474976710655)?;
     }
-    if value.reach > 131072000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.reach > 131072000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.reach;
         stream.serialize_fixed(&mut fixed_value, 112, 16, 0, 2000000)?;
     }
-    if value.ticks > 1000000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.ticks > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -237,7 +231,7 @@ pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe)
         stream.serialize_fixed(&mut fixed_value, 32, 0, 0, 1000000)?;
     }
     for i in 0..2 {
-        if value.samples[i] > 1048576 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+        if value.samples[i] > 1048576 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -245,7 +239,7 @@ pub fn write_unsigned_probe(stream: &mut WriteStream<'_>, value: &UnsignedProbe)
             stream.serialize_fixed(&mut fixed_value, 16, 16, 0, 16)?;
         }
     }
-    if value.locked < 196608 || value.locked > 196608 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.locked < 196608 || value.locked > 196608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -320,21 +314,21 @@ pub fn write_wide_probe(stream: &mut WriteStream<'_>, value: &WideProbe) -> Resu
         let mut raw_value = value.entity_id;
         stream.serialize_u128(&mut raw_value)?;
     }
-    if value.energy < -5000000000 || value.energy > 5000000000 { // out-of-contract writes are refused, not wrapped
+    if value.energy < -5000000000 || value.energy > 5000000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut range_value = value.energy;
         stream.serialize_int128(&mut range_value, -5000000000, 5000000000)?;
     }
-    if value.flux < -1267650600228229401496703205376 || value.flux > 1267650600228229401496703205376 { // out-of-contract writes are refused, not wrapped
+    if value.flux < -1267650600228229401496703205376 || value.flux > 1267650600228229401496703205376 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut range_value = value.flux;
         stream.serialize_int128(&mut range_value, -1267650600228229401496703205376, 1267650600228229401496703205376)?;
     }
-    if value.bias < -1000 || value.bias > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.bias < -1000 || value.bias > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -416,7 +410,7 @@ pub fn write_ludicrous_state(stream: &mut WriteStream<'_>, value: &LudicrousStat
     }
     write_fixed_probe(stream, &value.probe)?;
     write_wide_probe(stream, &value.wide)?;
-    if value.keys_count < 0 || value.keys_count > 4 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.keys_count < 0 || value.keys_count > 4 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -493,13 +487,13 @@ pub const DEGENERATE_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_degenerate_probe(stream: &mut WriteStream<'_>, value: &DegenerateProbe) -> Result {
-    if value.locked_fixed < -196608 || value.locked_fixed > -196608 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.locked_fixed < -196608 || value.locked_fixed > -196608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    if value.locked_int < 7 || value.locked_int > 7 { // out-of-contract writes are refused, not wrapped
+    if value.locked_int < 7 || value.locked_int > 7 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    if value.locked_wide < -12345678901234 || value.locked_wide > -12345678901234 { // out-of-contract writes are refused, not wrapped
+    if value.locked_wide < -12345678901234 || value.locked_wide > -12345678901234 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -522,8 +516,7 @@ pub fn read_degenerate_probe(stream: &mut ReadStream<'_>, value: &mut Degenerate
     Ok(())
 }
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct FixedVec {
@@ -550,21 +543,21 @@ pub const FIXED_VEC_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_vec(stream: &mut WriteStream<'_>, value: &FixedVec) -> Result {
-    if value.x < -6553600000 || value.x > 6553600000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.x < -6553600000 || value.x > 6553600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.y < -6553600000 || value.y > 6553600000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.y < -6553600000 || value.y > 6553600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 48, 16, -100000, 100000)?;
     }
-    if value.z < -6553600000 || value.z > 6553600000 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.z < -6553600000 || value.z > 6553600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -582,8 +575,7 @@ pub fn read_fixed_vec(stream: &mut ReadStream<'_>, value: &mut FixedVec) -> Resu
     Ok(())
 }
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct FixedQuat {
@@ -623,28 +615,28 @@ pub const FIXED_QUAT_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_fixed_quat(stream: &mut WriteStream<'_>, value: &FixedQuat) -> Result {
-    if value.x < -1073741824 || value.x > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.x < -1073741824 || value.x > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.x;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.y < -1073741824 || value.y > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.y < -1073741824 || value.y > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.y;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.z < -1073741824 || value.z > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.z < -1073741824 || value.z > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut fixed_value = value.z;
         stream.serialize_fixed(&mut fixed_value, 2, 30, -1, 1)?;
     }
-    if value.w < -1073741824 || value.w > 1073741824 { // out-of-contract writes are refused, not wrapped (raw scaled domain)
+    if value.w < -1073741824 || value.w > 1073741824 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -671,7 +663,7 @@ pub struct BodyState {
     pub position: FixedVec,
     pub rotation: FixedQuat,
     pub velocity: FixedVec,
-    pub spin: f64, //  | local — no wire
+    pub spin: f64, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1063,7 +1055,7 @@ pub enum Message {
 // write_*) flatten into its body, but the dispatch match itself stays a
 // call boundary — demanding the C++ twin into a batch build loop was
 // measured to slow that loop ~21% while every per-message row kept its
-// win with the boundary in place (schema #60). The compiler remains free
+// win with the boundary in place. The compiler remains free
 // to inline it where that pays.
 #[inline]
 pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result {
@@ -1085,7 +1077,7 @@ pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result 
 // read_message_into for reuse loops — hoist ONE Message and read every
 // message into it (the Go/C# MessageStorage discipline). Reuse removes the
 // per-message copy-out of the union and measured 2.6x on the steady-state
-// batch read (M2, 2026-08-06). The two surfaces stay separate on purpose —
+// batch read. The two surfaces stay separate on purpose —
 // see the note on read_message.
 #[inline]
 pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {
@@ -1112,8 +1104,8 @@ pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> 
 // read_message decodes the next message by value — the one-shot surface.
 // It deliberately does NOT delegate to read_message_into: routing the
 // return through a &mut out-param defeated LLVM's in-place construction
-// of the returned union and cost the batch read 23% (measured M2,
-// 2026-08-06). Both surfaces stay; reuse loops call read_message_into.
+// of the returned union, measured at 23% on the batch read. Both
+// surfaces stay; reuse loops call read_message_into.
 #[inline]
 pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {
     let mut tag_value = MessageType::NONE;

--- a/testdata/golden/ludicrous/union/Ludicrous.h
+++ b/testdata/golden/ludicrous/union/Ludicrous.h
@@ -78,7 +78,7 @@ struct UnsignedProbe {
 };
 
 inline constexpr int64_t UnsignedProbeMaxBits = 196; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t UnsignedProbeMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t UnsignedProbeMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type WideProbe
 struct WideProbe {
@@ -90,7 +90,7 @@ struct WideProbe {
 };
 
 inline constexpr int64_t WideProbeMaxBits = 403; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t WideProbeMaxBytes = 56; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t WideProbeMaxBytes = 56; // 8-byte write granularity; read slack per the contract above
 
 // message LudicrousState
 struct LudicrousState {
@@ -107,7 +107,7 @@ struct LudicrousState {
 };
 
 inline constexpr int64_t LudicrousStateMaxBits = 1205; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t LudicrousStateMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t LudicrousStateMaxBytes = 152; // 8-byte write granularity; read slack per the contract above
 
 // type DegenerateProbe
 struct DegenerateProbe {
@@ -118,10 +118,9 @@ struct DegenerateProbe {
 };
 
 inline constexpr int64_t DegenerateProbeMaxBits = 8; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t DegenerateProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DegenerateProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct FixedVec {
     int64_t x = 0; // fixed(48, 16) — Q48.16, raw value scaled by 2^16; bounds in whole units; wire [-100000, 100000]
     int64_t y = 0; // fixed(48, 16) — Q48.16, raw value scaled by 2^16; bounds in whole units; wire [-100000, 100000]
@@ -129,10 +128,9 @@ struct FixedVec {
 };
 
 inline constexpr int64_t FixedVecMaxBits = 102; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t FixedVecMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t FixedVecMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct FixedQuat {
     int32_t x = 0; // fixed(2, 30) — Q2.30, raw value scaled by 2^30; bounds in whole units; wire [-1, 1]
     int32_t y = 0; // fixed(2, 30) — Q2.30, raw value scaled by 2^30; bounds in whole units; wire [-1, 1]
@@ -141,7 +139,7 @@ struct FixedQuat {
 };
 
 inline constexpr int64_t FixedQuatMaxBits = 128; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t FixedQuatMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t FixedQuatMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Body — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -150,7 +148,7 @@ struct BodyState {
     FixedVec position;
     FixedQuat rotation;
     FixedVec velocity;
-    double spin = 0.0; //  | local — no wire
+    double spin = 0.0; // | local — no wire
 };
 
 // BodyData_Deep — every non- | local field, deep encodings: full state for
@@ -183,10 +181,10 @@ struct BodyData_Interpolate {
 // SPEC §4.8) — Interpolate and Shallow are the same values.
 
 inline constexpr int64_t BodyData_DeepMaxBits = 332;
-inline constexpr int64_t BodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BodyData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t BodyData_ShallowMaxBits = 332;
-inline constexpr int64_t BodyData_ShallowMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BodyData_ShallowMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 // ---- object NarrowBody — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -277,14 +275,14 @@ inline void UnquantizeNarrowBody( const NarrowBodyData_Shallow & input, NarrowBo
 }
 
 inline constexpr int64_t NarrowBodyData_DeepMaxBits = 332;
-inline constexpr int64_t NarrowBodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t NarrowBodyData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t NarrowBodyData_ShallowMaxBits = 228;
-inline constexpr int64_t NarrowBodyData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t NarrowBodyData_ShallowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // The message-level bound: the tag plus the largest message (SPEC §6.1)
 inline constexpr int64_t MessageMaxBits = 1206;
-inline constexpr int64_t MessageMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MessageMaxBytes = 152; // 8-byte write granularity; read slack per the contract above
 
 // The message value: a tagged union — the payload member matching `type` is
 // the active one. Construction is the None message: the tag alone is

--- a/testdata/golden/ludicrous/variant/Ludicrous.h
+++ b/testdata/golden/ludicrous/variant/Ludicrous.h
@@ -79,7 +79,7 @@ struct UnsignedProbe {
 };
 
 inline constexpr int64_t UnsignedProbeMaxBits = 196; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t UnsignedProbeMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t UnsignedProbeMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type WideProbe
 struct WideProbe {
@@ -91,7 +91,7 @@ struct WideProbe {
 };
 
 inline constexpr int64_t WideProbeMaxBits = 403; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t WideProbeMaxBytes = 56; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t WideProbeMaxBytes = 56; // 8-byte write granularity; read slack per the contract above
 
 // message LudicrousState
 struct LudicrousState {
@@ -108,7 +108,7 @@ struct LudicrousState {
 };
 
 inline constexpr int64_t LudicrousStateMaxBits = 1205; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t LudicrousStateMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t LudicrousStateMaxBytes = 152; // 8-byte write granularity; read slack per the contract above
 
 // type DegenerateProbe
 struct DegenerateProbe {
@@ -119,10 +119,9 @@ struct DegenerateProbe {
 };
 
 inline constexpr int64_t DegenerateProbeMaxBits = 8; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t DegenerateProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DegenerateProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
-// type FixedVec [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedVec [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct FixedVec {
     int64_t x = 0; // fixed(48, 16) — Q48.16, raw value scaled by 2^16; bounds in whole units; wire [-100000, 100000]
     int64_t y = 0; // fixed(48, 16) — Q48.16, raw value scaled by 2^16; bounds in whole units; wire [-100000, 100000]
@@ -130,10 +129,9 @@ struct FixedVec {
 };
 
 inline constexpr int64_t FixedVecMaxBits = 102; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t FixedVecMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t FixedVecMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
-// type FixedQuat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type FixedQuat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct FixedQuat {
     int32_t x = 0; // fixed(2, 30) — Q2.30, raw value scaled by 2^30; bounds in whole units; wire [-1, 1]
     int32_t y = 0; // fixed(2, 30) — Q2.30, raw value scaled by 2^30; bounds in whole units; wire [-1, 1]
@@ -142,7 +140,7 @@ struct FixedQuat {
 };
 
 inline constexpr int64_t FixedQuatMaxBits = 128; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t FixedQuatMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t FixedQuatMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Body — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -151,7 +149,7 @@ struct BodyState {
     FixedVec position;
     FixedQuat rotation;
     FixedVec velocity;
-    double spin = 0.0; //  | local — no wire
+    double spin = 0.0; // | local — no wire
 };
 
 // BodyData_Deep — every non- | local field, deep encodings: full state for
@@ -184,10 +182,10 @@ struct BodyData_Interpolate {
 // SPEC §4.8) — Interpolate and Shallow are the same values.
 
 inline constexpr int64_t BodyData_DeepMaxBits = 332;
-inline constexpr int64_t BodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BodyData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t BodyData_ShallowMaxBits = 332;
-inline constexpr int64_t BodyData_ShallowMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BodyData_ShallowMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 // ---- object NarrowBody — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -278,14 +276,14 @@ inline void UnquantizeNarrowBody( const NarrowBodyData_Shallow & input, NarrowBo
 }
 
 inline constexpr int64_t NarrowBodyData_DeepMaxBits = 332;
-inline constexpr int64_t NarrowBodyData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t NarrowBodyData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t NarrowBodyData_ShallowMaxBits = 228;
-inline constexpr int64_t NarrowBodyData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t NarrowBodyData_ShallowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // The message-level bound: the tag plus the largest message (SPEC §6.1)
 inline constexpr int64_t MessageMaxBits = 1206;
-inline constexpr int64_t MessageMaxBytes = 152; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MessageMaxBytes = 152; // 8-byte write granularity; read slack per the contract above
 
 // The message value: index == wire tag (std::monostate is None = 0, then each
 // message in tag order). Inline storage, no heap, trivially copyable.

--- a/testdata/golden/rust/enums.rs
+++ b/testdata/golden/rust/enums.rs
@@ -19,13 +19,7 @@ impl Team {
 
 /// Debug/log name for any `Team` value, out-of-set included.
 pub fn enum_name_team(value: Team) -> &'static str {
-    enum_name_team_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_team`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_team_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Red",
         2 => "Blue",
@@ -51,13 +45,7 @@ impl ShipType {
 
 /// Debug/log name for any `ShipType` value, out-of-set included.
 pub fn enum_name_ship_type(value: ShipType) -> &'static str {
-    enum_name_ship_type_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_ship_type`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_ship_type_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Fighter",
         2 => "Corvette",
@@ -84,13 +72,7 @@ impl MissileType {
 
 /// Debug/log name for any `MissileType` value, out-of-set included.
 pub fn enum_name_missile_type(value: MissileType) -> &'static str {
-    enum_name_missile_type_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_missile_type`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_missile_type_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Heatseeker",
         2 => "Torpedo",
@@ -118,13 +100,7 @@ impl PropType {
 
 /// Debug/log name for any `PropType` value, out-of-set included.
 pub fn enum_name_prop_type(value: PropType) -> &'static str {
-    enum_name_prop_type_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_prop_type`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_prop_type_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Asteroid",
         2 => "Chunk",
@@ -149,13 +125,7 @@ impl Pending {
 
 /// Debug/log name for any `Pending` value, out-of-set included.
 pub fn enum_name_pending(value: Pending) -> &'static str {
-    enum_name_pending_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_pending`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_pending_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         _ => "???",
     }

--- a/testdata/golden/rust/messages.rs
+++ b/testdata/golden/rust/messages.rs
@@ -85,21 +85,21 @@ pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
         let mut raw_value = value.test_a as u32;
         stream.serialize_bits(&mut raw_value, 16)?;
     }
-    if value.test_b < 0 || value.test_b > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.test_b < 0 || value.test_b > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.test_b as u32;
         stream.serialize_bits(&mut offset_value, 10)?;
     }
-    if value.test_c < 0 || value.test_c > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.test_c < 0 || value.test_c > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.test_c as u32;
         stream.serialize_bits(&mut offset_value, 10)?;
     }
-    if value.test_d < 0 || value.test_d > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.test_d < 0 || value.test_d > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -159,7 +159,7 @@ pub const BLOCK_MAX_BYTES: usize = 2008;
 
 #[inline(always)]
 pub fn write_block(stream: &mut WriteStream<'_>, value: &Block) -> Result {
-    if value.data_length < 0 || value.data_length > 2000 { // refused, not wrapped or panicked: guards the slice too
+    if value.data_length < 0 || value.data_length > 2000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -202,7 +202,7 @@ pub const CHAT_MAX_BYTES: usize = 264;
 
 #[inline(always)]
 pub fn write_chat(stream: &mut WriteStream<'_>, value: &Chat) -> Result {
-    if value.text_length < 0 || value.text_length > 256 { // refused, not wrapped or panicked: guards the slice too
+    if value.text_length < 0 || value.text_length > 256 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     debug_assert!(
@@ -372,7 +372,7 @@ pub enum Message {
 // write_*) flatten into its body, but the dispatch match itself stays a
 // call boundary — demanding the C++ twin into a batch build loop was
 // measured to slow that loop ~21% while every per-message row kept its
-// win with the boundary in place (schema #60). The compiler remains free
+// win with the boundary in place. The compiler remains free
 // to inline it where that pays.
 #[inline]
 pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result {
@@ -414,7 +414,7 @@ pub fn write_message(stream: &mut WriteStream<'_>, message: &Message) -> Result 
 // read_message_into for reuse loops — hoist ONE Message and read every
 // message into it (the Go/C# MessageStorage discipline). Reuse removes the
 // per-message copy-out of the union and measured 2.6x on the steady-state
-// batch read (M2, 2026-08-06). The two surfaces stay separate on purpose —
+// batch read. The two surfaces stay separate on purpose —
 // see the note on read_message.
 #[inline]
 pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> Result {
@@ -476,8 +476,8 @@ pub fn read_message_into(stream: &mut ReadStream<'_>, message: &mut Message) -> 
 // read_message decodes the next message by value — the one-shot surface.
 // It deliberately does NOT delegate to read_message_into: routing the
 // return through a &mut out-param defeated LLVM's in-place construction
-// of the returned union and cost the batch read 23% (measured M2,
-// 2026-08-06). Both surfaces stay; reuse loops call read_message_into.
+// of the returned union, measured at 23% on the batch read. Both
+// surfaces stay; reuse loops call read_message_into.
 #[inline]
 pub fn read_message(stream: &mut ReadStream<'_>) -> Result<Message> {
     let mut tag_value = MessageType::NONE;

--- a/testdata/golden/rust/objects.rs
+++ b/testdata/golden/rust/objects.rs
@@ -52,11 +52,11 @@ pub struct ClientShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, //  | local — no wire
-    pub previous_position: Vec3, //  | local — no wire
-    pub num_colliders: i32, //  | local — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
-    pub predicted_explode: bool, //  | local, context = client
+    pub invulnerable: bool, // | local — no wire
+    pub previous_position: Vec3, // | local — no wire
+    pub num_colliders: i32, // | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // | local — no wire
+    pub predicted_explode: bool, // | local, context = client
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -126,10 +126,10 @@ pub struct ServerShipState {
     pub missile_index: i8, // wire [0, 15]
     pub target: Handle,
     pub lock_start_time: f64,
-    pub invulnerable: bool, //  | local — no wire
-    pub previous_position: Vec3, //  | local — no wire
-    pub num_colliders: i32, //  | local — no wire
-    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], //  | local — no wire
+    pub invulnerable: bool, // | local — no wire
+    pub previous_position: Vec3, // | local — no wire
+    pub num_colliders: i32, // | local — no wire
+    pub collider_armor: [i32; MAX_COLLIDERS_PER_SHIP as usize], // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -395,14 +395,14 @@ pub fn write_ship_data_deep(stream: &mut WriteStream<'_>, value: &ShipData_Deep)
         let mut float_value = value.aim_velocity;
         stream.serialize_f32(&mut float_value)?;
     }
-    if value.laser_index < 0 || value.laser_index > 15 { // out-of-contract writes are refused, not wrapped
+    if value.laser_index < 0 || value.laser_index > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.laser_index as u32;
         stream.serialize_bits(&mut offset_value, 4)?;
     }
-    if value.missile_index < 0 || value.missile_index > 15 { // out-of-contract writes are refused, not wrapped
+    if value.missile_index < 0 || value.missile_index > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -761,8 +761,8 @@ pub struct ClientMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, //  | local — no wire
-    pub target: Handle, //  | local — no wire
+    pub angular_velocity: Vec3, // | local — no wire
+    pub target: Handle, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -791,9 +791,9 @@ pub struct ServerMissileState {
     pub linear_velocity: Vec3,
     pub team: Team,
     pub flags: u64,
-    pub angular_velocity: Vec3, //  | local — no wire
-    pub target: Handle, //  | local — no wire
-    pub timer: f64, //  | local, context = server
+    pub angular_velocity: Vec3, // | local — no wire
+    pub target: Handle, // | local — no wire
+    pub timer: f64, // | local, context = server
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1221,7 +1221,7 @@ pub struct DynamicPropState {
     pub linear_velocity: Vec3,
     pub flags: u64,
     pub team: Team,
-    pub angular_velocity: Vec3, //  | local — no wire
+    pub angular_velocity: Vec3, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1645,7 +1645,7 @@ pub struct TurretState {
     pub turret_index: i32, // wire [0, 255]
     pub rotation: Quat,
     pub flags: u64,
-    pub team: Team, //  | local — no wire
+    pub team: Team, // | local — no wire
 }
 
 // The zero form (SPEC §5): specified defaults live only in new(), never here.
@@ -1744,7 +1744,7 @@ pub const TURRET_DATA_DEEP_MAX_BYTES: usize = 48; // rounded up to the 8-byte wr
 #[inline(always)]
 pub fn write_turret_data_deep(stream: &mut WriteStream<'_>, value: &TurretData_Deep) -> Result {
     write_handle(stream, &value.parent)?;
-    if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
+    if value.turret_index < 0 || value.turret_index > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -1774,7 +1774,7 @@ pub const TURRET_DATA_SHALLOW_MAX_BYTES: usize = 24; // rounded up to the 8-byte
 #[inline(always)]
 pub fn write_turret_data_shallow(stream: &mut WriteStream<'_>, value: &TurretData_Shallow) -> Result {
     write_handle(stream, &value.parent)?;
-    if value.turret_index < 0 || value.turret_index > 255 { // out-of-contract writes are refused, not wrapped
+    if value.turret_index < 0 || value.turret_index > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {

--- a/testdata/golden/rust/render.rs
+++ b/testdata/golden/rust/render.rs
@@ -121,7 +121,7 @@ pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> 
         let mut raw_value = value.sprite_count_hint;
         stream.serialize_bits(&mut raw_value, 32)?;
     }
-    if value.sprites_count < 0 || value.sprites_count > 64 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.sprites_count < 0 || value.sprites_count > 64 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {

--- a/testdata/golden/rust/types.rs
+++ b/testdata/golden/rust/types.rs
@@ -7,8 +7,7 @@
 use crate::*;
 use serialize::{ReadStream, Stream, WriteStream};
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Vec3 {
@@ -58,8 +57,7 @@ pub fn read_vec3(stream: &mut ReadStream<'_>, value: &mut Vec3) -> Result {
     Ok(())
 }
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 #[repr(C)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Quat {
@@ -141,7 +139,7 @@ pub const HANDLE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
-    if value.object_id < 0 || value.object_id > 9999 { // out-of-contract writes are refused, not wrapped
+    if value.object_id < 0 || value.object_id > 9999 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -193,21 +191,21 @@ pub const QUANTIZED_POSITION_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedPosition) -> Result {
-    if value.x < -8388608 || value.x > 8388608 { // out-of-contract writes are refused, not wrapped
+    if value.x < -8388608 || value.x > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 25)?;
     }
-    if value.y < -8388608 || value.y > 8388608 { // out-of-contract writes are refused, not wrapped
+    if value.y < -8388608 || value.y > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 25)?;
     }
-    if value.z < -8388608 || value.z > 8388608 { // out-of-contract writes are refused, not wrapped
+    if value.z < -8388608 || value.z > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -252,21 +250,21 @@ pub const QUANTIZED_VELOCITY_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedVelocity) -> Result {
-    if value.x < -2097152 || value.x > 2097152 { // out-of-contract writes are refused, not wrapped
+    if value.x < -2097152 || value.x > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 23)?;
     }
-    if value.y < -2097152 || value.y > 2097152 { // out-of-contract writes are refused, not wrapped
+    if value.y < -2097152 || value.y > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 23)?;
     }
-    if value.z < -2097152 || value.z > 2097152 { // out-of-contract writes are refused, not wrapped
+    if value.z < -2097152 || value.z > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -313,28 +311,28 @@ pub const QUANTIZED_ROTATION_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedRotation) -> Result {
-    if value.x < -1024 || value.x > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.x < -1024 || value.x > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 12)?;
     }
-    if value.y < -1024 || value.y > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.y < -1024 || value.y > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 12)?;
     }
-    if value.z < -1024 || value.z > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.z < -1024 || value.z > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
         stream.serialize_bits(&mut offset_value, 12)?;
     }
-    if value.w < -1024 || value.w > 1024 { // out-of-contract writes are refused, not wrapped
+    if value.w < -1024 || value.w > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -594,7 +592,7 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
         let mut raw_value = value.start_frame;
         stream.serialize_bits64(&mut raw_value, 64)?;
     }
-    if value.inputs_count < 0 || value.inputs_count > 16 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.inputs_count < 0 || value.inputs_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -699,14 +697,14 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
         let mut offset_value = value.team.0 as u32;
         stream.serialize_bits(&mut offset_value, 2)?;
     }
-    if value.health < 0 || value.health > 1000 { // out-of-contract writes are refused, not wrapped
+    if value.health < 0 || value.health > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.health as u32;
         stream.serialize_bits(&mut offset_value, 10)?;
     }
-    if value.thrust < 0 || value.thrust > 100 { // out-of-contract writes are refused, not wrapped
+    if value.thrust < 0 || value.thrust > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -787,14 +785,14 @@ pub const EXPRESSION_PROBE_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_expression_probe(stream: &mut WriteStream<'_>, value: &ExpressionProbe) -> Result {
-    if value.hardpoint_index < 0 || value.hardpoint_index > 31 { // out-of-contract writes are refused, not wrapped
+    if value.hardpoint_index < 0 || value.hardpoint_index > 31 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = value.hardpoint_index as u32;
         stream.serialize_bits(&mut offset_value, 5)?;
     }
-    if value.spin_rate < 1024 || value.spin_rate > 2048 { // out-of-contract writes are refused, not wrapped
+    if value.spin_rate < 1024 || value.spin_rate > 2048 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -858,14 +856,14 @@ pub const EXTREME_PROBE_MAX_BYTES: usize = 40;
 
 #[inline(always)]
 pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -> Result {
-    if value.floor_bound > 100 { // out-of-contract writes are refused, not wrapped
+    if value.floor_bound > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
         stream.serialize_bits64(&mut offset_value, 64)?;
     }
-    if value.doubled_floor > 100 { // out-of-contract writes are refused, not wrapped
+    if value.doubled_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -953,7 +951,7 @@ pub const EXTREME_ROW_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_extreme_row(stream: &mut WriteStream<'_>, value: &ExtremeRow) -> Result {
-    if value.clamped_floor > 100 { // out-of-contract writes are refused, not wrapped
+    if value.clamped_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -31,13 +31,7 @@ impl Weapon {
 
 /// Debug/log name for any `Weapon` value, out-of-set included.
 pub fn enum_name_weapon(value: Weapon) -> &'static str {
-    enum_name_weapon_dyn(value.0 as u64)
-}
-
-/// As [`enum_name_weapon`], over a raw wire value — the form the table
-/// reflection descriptors hold.
-pub fn enum_name_weapon_dyn(value: u64) -> &'static str {
-    match value {
+    match value.0 {
         0 => "None",
         1 => "Laser",
         2 => "Missile",
@@ -273,7 +267,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
     }
     {
         let mut compressed_value = value.orientation;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
     }
     {
         let mut raw_value = value.raw_delta as u32;
@@ -307,7 +301,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
             stream.serialize_bits(&mut raw_value, 32)?;
         }
     }
-    if value.samples_count < 1 || value.samples_count > 8 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.samples_count < 1 || value.samples_count > 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -326,7 +320,7 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
 #[inline]
 pub fn read_probe_sample(stream: &mut ReadStream<'_>, value: &mut ProbeSample) -> Result {
     stream.serialize_bool(&mut value.active)?;
-    stream.serialize_compressed_float_precomputed(&mut value.orientation, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.orientation, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
     {
         let mut raw_value: u32 = 0;
         stream.serialize_bits(&mut raw_value, 32)?;
@@ -436,7 +430,7 @@ pub const PROBE_SLAB_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_slab(stream: &mut WriteStream<'_>, value: &ProbeSlab) -> Result {
-    if value.width > 100 { // out-of-contract writes are refused, not wrapped
+    if value.width > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -568,7 +562,7 @@ pub fn write_probe_collider(stream: &mut WriteStream<'_>, value: &ProbeCollider)
     }
     write_probe_shape(stream, &value.shape)?;
     write_probe_shape(stream, &value.backup)?;
-    if value.extras_count < 0 || value.extras_count > 2 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.extras_count < 0 || value.extras_count > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -837,21 +831,21 @@ pub const TEST_DATA_MAX_BYTES: usize = 344;
 
 #[inline(always)]
 pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result {
-    if value.a < -100 || value.a > 100 { // out-of-contract writes are refused, not wrapped
+    if value.a < -100 || value.a > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.a as u32).wrapping_sub((-100_i32) as u32);
         stream.serialize_bits(&mut offset_value, 8)?;
     }
-    if value.b < -100 || value.b > 100 { // out-of-contract writes are refused, not wrapped
+    if value.b < -100 || value.b > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
         let mut offset_value = (value.b as u32).wrapping_sub((-100_i32) as u32);
         stream.serialize_bits(&mut offset_value, 8)?;
     }
-    if value.c < -100 || value.c > 150 { // out-of-contract writes are refused, not wrapped
+    if value.c < -100 || value.c > 150 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -883,7 +877,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut bool_value = value.g;
         stream.serialize_bool(&mut bool_value)?;
     }
-    if value.items_count < 0 || value.items_count > 16 { // refused, not wrapped: the runtime's write side only debug_asserts
+    if value.items_count < 0 || value.items_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -891,7 +885,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         stream.serialize_bits(&mut offset_value, 5)?; // the count guards the loop (§6.3)
     }
     for i in 0..value.items_count as usize {
-        if value.items[i] < 0 || value.items[i] > 255 { // out-of-contract writes are refused, not wrapped
+        if value.items[i] < 0 || value.items[i] > 255 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
         {
@@ -905,7 +899,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     }
     {
         let mut compressed_value = value.compressed_float_value;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     }
     {
         let mut float_value = value.double_value;
@@ -939,7 +933,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut raw_value = value.int64_full as u64;
         stream.serialize_bits64(&mut raw_value, 64)?;
     }
-    if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 { // out-of-contract writes are refused, not wrapped
+    if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     {
@@ -948,7 +942,7 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     }
     stream.serialize_align()?;
     stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
-    if value.text_length < 0 || value.text_length > 255 { // refused, not wrapped or panicked: guards the slice too
+    if value.text_length < 0 || value.text_length > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
     debug_assert!(
@@ -977,7 +971,7 @@ pub fn read_test_data(stream: &mut ReadStream<'_>, value: &mut TestData) -> Resu
         stream.serialize_int(&mut value.items[i], 0, 255)?;
     }
     stream.serialize_f32(&mut value.float_value)?;
-    stream.serialize_compressed_float_precomputed(&mut value.compressed_float_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.compressed_float_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     stream.serialize_f64(&mut value.double_value)?;
     {
         let mut raw_value: u32 = 0;
@@ -1046,19 +1040,19 @@ pub const COMPRESSED_PROBE_MAX_BYTES: usize = 8;
 pub fn write_compressed_probe(stream: &mut WriteStream<'_>, value: &CompressedProbe) -> Result {
     {
         let mut compressed_value = value.boundary;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     }
     {
         let mut compressed_value = value.offset;
-        stream.serialize_compressed_float_precomputed(&mut compressed_value, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation (issue #82)
+        stream.serialize_compressed_float_precomputed(&mut compressed_value, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation
     }
     Ok(())
 }
 
 #[inline]
 pub fn read_compressed_probe(stream: &mut ReadStream<'_>, value: &mut CompressedProbe) -> Result {
-    stream.serialize_compressed_float_precomputed(&mut value.boundary, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation (issue #82)
-    stream.serialize_compressed_float_precomputed(&mut value.offset, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation (issue #82)
+    stream.serialize_compressed_float_precomputed(&mut value.boundary, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
+    stream.serialize_compressed_float_precomputed(&mut value.offset, 10000, 14, 10.0_f32, -5.0_f32)?; // compressed float [-5.0, 5.0] @ 0.001, constants folded at generation
     Ok(())
 }
 

--- a/testdata/golden/union/Messages.h
+++ b/testdata/golden/union/Messages.h
@@ -40,7 +40,7 @@ struct Test {
 };
 
 inline constexpr int64_t TestMaxBits = 46; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TestMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TestMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // message Block
 struct Block {
@@ -49,7 +49,7 @@ struct Block {
 };
 
 inline constexpr int64_t BlockMaxBits = 16018; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t BlockMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BlockMaxBytes = 2008; // 8-byte write granularity; read slack per the contract above
 
 // message Chat
 struct Chat {
@@ -58,7 +58,7 @@ struct Chat {
 };
 
 inline constexpr int64_t ChatMaxBits = 2064; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ChatMaxBytes = 264; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ChatMaxBytes = 264; // 8-byte write granularity; read slack per the contract above
 
 // message Synchronize
 struct Synchronize {
@@ -67,7 +67,7 @@ struct Synchronize {
 };
 
 inline constexpr int64_t SynchronizeMaxBits = 80; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t SynchronizeMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t SynchronizeMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // message Timescale
 struct Timescale {
@@ -77,11 +77,11 @@ struct Timescale {
 };
 
 inline constexpr int64_t TimescaleMaxBits = 128; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TimescaleMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TimescaleMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // The message-level bound: the tag plus the largest message (SPEC §6.1)
 inline constexpr int64_t MessageMaxBits = 16021;
-inline constexpr int64_t MessageMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MessageMaxBytes = 2008; // 8-byte write granularity; read slack per the contract above
 
 // The message value: a tagged union — the payload member matching `type` is
 // the active one. Construction is the None message: the tag alone is

--- a/testdata/golden/union/Objects.h
+++ b/testdata/golden/union/Objects.h
@@ -58,11 +58,11 @@ struct ClientShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; //  | local — no wire
-    ::VecMath previous_position; //  | local — no wire
-    int32_t num_colliders = 0; //  | local — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
-    bool predicted_explode = false; //  | local, context = client
+    bool invulnerable = false; // | local — no wire
+    ::VecMath previous_position; // | local — no wire
+    int32_t num_colliders = 0; // | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; // | local — no wire
+    bool predicted_explode = false; // | local, context = client
 };
 
 // ServerShipState — the full simulation struct for the server context: every `all`
@@ -93,10 +93,10 @@ struct ServerShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; //  | local — no wire
-    ::VecMath previous_position; //  | local — no wire
-    int32_t num_colliders = 0; //  | local — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
+    bool invulnerable = false; // | local — no wire
+    ::VecMath previous_position; // | local — no wire
+    int32_t num_colliders = 0; // | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; // | local — no wire
 };
 
 // ShipData_Deep — every non- | local field, deep encodings: full state for
@@ -338,7 +338,7 @@ inline constexpr int64_t ShipData_DeepMaxBits = 1703;
 inline constexpr int64_t ShipData_DeepMaxBytes = 216; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
 
 inline constexpr int64_t ShipData_ShallowMaxBits = 218;
-inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -351,8 +351,8 @@ struct ClientMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; //  | local — no wire
-    Handle target; //  | local — no wire
+    ::VecMath angular_velocity; // | local — no wire
+    Handle target; // | local — no wire
 };
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
@@ -364,9 +364,9 @@ struct ServerMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; //  | local — no wire
-    Handle target; //  | local — no wire
-    double timer = 0.0; //  | local, context = server
+    ::VecMath angular_velocity; // | local — no wire
+    Handle target; // | local — no wire
+    double timer = 0.0; // | local, context = server
 };
 
 // MissileData_Deep — every non- | local field, deep encodings: full state for
@@ -578,10 +578,10 @@ inline void UnquantizeMissile( const MissileData_Shallow & input, MissileData_In
 }
 
 inline constexpr int64_t MissileData_DeepMaxBits = 708;
-inline constexpr int64_t MissileData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MissileData_DeepMaxBytes = 96; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t MissileData_ShallowMaxBits = 260;
-inline constexpr int64_t MissileData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MissileData_ShallowMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // ---- object DynamicProp — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -593,7 +593,7 @@ struct DynamicPropState {
     ::VecMath linear_velocity;
     uint64_t flags = 0;
     Team team = Team::None;
-    ::VecMath angular_velocity; //  | local — no wire
+    ::VecMath angular_velocity; // | local — no wire
 };
 
 // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
@@ -805,10 +805,10 @@ inline void UnquantizeDynamicProp( const DynamicPropData_Shallow & input, Dynami
 }
 
 inline constexpr int64_t DynamicPropData_DeepMaxBits = 709;
-inline constexpr int64_t DynamicPropData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DynamicPropData_DeepMaxBytes = 96; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t DynamicPropData_ShallowMaxBits = 261;
-inline constexpr int64_t DynamicPropData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DynamicPropData_ShallowMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Turret — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -818,7 +818,7 @@ struct TurretState {
     int32_t turret_index = 0; // wire [0, 255]
     Quat rotation;
     uint64_t flags = 0;
-    Team team = Team::None; //  | local — no wire
+    Team team = Team::None; // | local — no wire
 };
 
 // TurretData_Deep — every non- | local field, deep encodings: full state for
@@ -928,9 +928,9 @@ inline void UnquantizeTurret( const TurretData_Shallow & input, TurretData_Inter
 }
 
 inline constexpr int64_t TurretData_DeepMaxBits = 350;
-inline constexpr int64_t TurretData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TurretData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t TurretData_ShallowMaxBits = 142;
-inline constexpr int64_t TurretData_ShallowMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TurretData_ShallowMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/testdata/golden/union/Render.h
+++ b/testdata/golden/union/Render.h
@@ -34,6 +34,6 @@ struct RenderBlock {
 };
 
 inline constexpr int64_t RenderBlockMaxBits = 8903; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t RenderBlockMaxBytes = 1120; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t RenderBlockMaxBytes = 1120; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/testdata/golden/union/Types.h
+++ b/testdata/golden/union/Types.h
@@ -13,8 +13,7 @@
 
 namespace example {
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct Vec3 {
     double x = 0.0;
     double y = 0.0;
@@ -24,8 +23,7 @@ struct Vec3 {
 inline constexpr int64_t Vec3MaxBits = 192; // longest wire path; align pads at worst case (SPEC §6.1)
 inline constexpr int64_t Vec3MaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct Quat {
     double x = 0.0;
     double y = 0.0;
@@ -34,7 +32,7 @@ struct Quat {
 };
 
 inline constexpr int64_t QuatMaxBits = 256; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuatMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuatMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type Handle
 struct Handle {
@@ -43,7 +41,7 @@ struct Handle {
 };
 
 inline constexpr int64_t HandleMaxBits = 22; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t HandleMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t HandleMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedPosition
 struct QuantizedPosition {
@@ -53,7 +51,7 @@ struct QuantizedPosition {
 };
 
 inline constexpr int64_t QuantizedPositionMaxBits = 75; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedPositionMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedPositionMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedVelocity
 struct QuantizedVelocity {
@@ -63,7 +61,7 @@ struct QuantizedVelocity {
 };
 
 inline constexpr int64_t QuantizedVelocityMaxBits = 69; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedVelocityMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedVelocityMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedRotation
 struct QuantizedRotation {
@@ -74,7 +72,7 @@ struct QuantizedRotation {
 };
 
 inline constexpr int64_t QuantizedRotationMaxBits = 48; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedRotationMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedRotationMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type RigidBody
 struct RigidBody {
@@ -89,7 +87,7 @@ struct RigidBody {
 };
 
 inline constexpr int64_t RigidBodyMaxBits = 833; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t RigidBodyMaxBytes = 112; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t RigidBodyMaxBytes = 112; // 8-byte write granularity; read slack per the contract above
 
 // type Input
 struct Input {
@@ -109,7 +107,7 @@ struct Input {
 };
 
 inline constexpr int64_t InputMaxBits = 168; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t InputMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t InputMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 // type InputPacket
 struct InputPacket {
@@ -121,7 +119,7 @@ struct InputPacket {
 };
 
 inline constexpr int64_t InputPacketMaxBits = 2837; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t InputPacketMaxBytes = 360; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t InputPacketMaxBytes = 360; // 8-byte write granularity; read slack per the contract above
 
 // type ShipCreate
 struct ShipCreate {
@@ -142,7 +140,7 @@ struct ShipCreate {
 };
 
 inline constexpr int64_t ShipCreateMaxBits = 219; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ShipCreateMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ShipCreateMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type ExpressionProbe
 struct ExpressionProbe {
@@ -151,7 +149,7 @@ struct ExpressionProbe {
 };
 
 inline constexpr int64_t ExpressionProbeMaxBits = 16; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExpressionProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExpressionProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t FloorLimit = ( -9223372036854775807ll - 1 );
 inline constexpr uint64_t CeilingCount = 18446744073709551615ull; // = 18446744073709551615
@@ -165,7 +163,7 @@ struct ExtremeProbe {
 };
 
 inline constexpr int64_t ExtremeProbeMaxBits = 320; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExtremeProbeMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExtremeProbeMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // type ExtremeRow
 struct ExtremeRow {
@@ -176,6 +174,6 @@ struct ExtremeRow {
 };
 
 inline constexpr int64_t ExtremeRowMaxBits = 256; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExtremeRowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExtremeRowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/testdata/golden/union/Wire.h
+++ b/testdata/golden/union/Wire.h
@@ -65,7 +65,7 @@ struct ProbeBits {
 };
 
 inline constexpr int64_t ProbeBitsMaxBits = 202; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeBitsMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeBitsMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeSample
 struct ProbeSample {
@@ -92,7 +92,7 @@ struct ProbeSample {
 };
 
 inline constexpr int64_t ProbeSampleMaxBits = 276; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeSampleMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeSampleMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeRing
 struct ProbeRing {
@@ -100,7 +100,7 @@ struct ProbeRing {
 };
 
 inline constexpr int64_t ProbeRingMaxBits = 16; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeRingMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeRingMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeSlab
 struct ProbeSlab {
@@ -109,7 +109,7 @@ struct ProbeSlab {
 };
 
 inline constexpr int64_t ProbeSlabMaxBits = 15; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeSlabMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeSlabMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // ProbeShapeType: union ProbeShape's tag — None = 0, then each variant in declared order (SPEC §4.8)
 enum class ProbeShapeType : uint8_t {
@@ -137,7 +137,7 @@ struct ProbeShape
 };
 
 inline constexpr int64_t ProbeShapeMaxBits = 18; // tag + the largest arm; None costs the tag only (SPEC §4.8)
-inline constexpr int64_t ProbeShapeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeShapeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeCollider
 struct ProbeCollider {
@@ -149,7 +149,7 @@ struct ProbeCollider {
 };
 
 inline constexpr int64_t ProbeColliderMaxBits = 82; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeColliderMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeColliderMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeConfig
 struct ProbeConfig {
@@ -158,7 +158,7 @@ struct ProbeConfig {
 };
 
 inline constexpr int64_t ProbeConfigMaxBits = 36; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeConfigMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeConfigMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeArray
 struct ProbeArray {
@@ -167,7 +167,7 @@ struct ProbeArray {
 };
 
 inline constexpr int64_t ProbeArrayMaxBits = 588; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeArrayMaxBytes = 80; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeArrayMaxBytes = 80; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeReport
 struct ProbeReport {
@@ -177,7 +177,7 @@ struct ProbeReport {
 };
 
 inline constexpr int64_t ProbeReportMaxBits = 141; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeReportMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeReportMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 // type TestData
 struct TestData {
@@ -207,7 +207,7 @@ struct TestData {
 };
 
 inline constexpr int64_t TestDataMaxBits = 2735; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TestDataMaxBytes = 344; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TestDataMaxBytes = 344; // 8-byte write granularity; read slack per the contract above
 
 // type CompressedProbe
 struct CompressedProbe {
@@ -216,6 +216,6 @@ struct CompressedProbe {
 };
 
 inline constexpr int64_t CompressedProbeMaxBits = 24; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t CompressedProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t CompressedProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/testdata/golden/variant/Messages.h
+++ b/testdata/golden/variant/Messages.h
@@ -41,7 +41,7 @@ struct Test {
 };
 
 inline constexpr int64_t TestMaxBits = 46; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TestMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TestMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // message Block
 struct Block {
@@ -50,7 +50,7 @@ struct Block {
 };
 
 inline constexpr int64_t BlockMaxBits = 16018; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t BlockMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t BlockMaxBytes = 2008; // 8-byte write granularity; read slack per the contract above
 
 // message Chat
 struct Chat {
@@ -59,7 +59,7 @@ struct Chat {
 };
 
 inline constexpr int64_t ChatMaxBits = 2064; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ChatMaxBytes = 264; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ChatMaxBytes = 264; // 8-byte write granularity; read slack per the contract above
 
 // message Synchronize
 struct Synchronize {
@@ -68,7 +68,7 @@ struct Synchronize {
 };
 
 inline constexpr int64_t SynchronizeMaxBits = 80; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t SynchronizeMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t SynchronizeMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // message Timescale
 struct Timescale {
@@ -78,11 +78,11 @@ struct Timescale {
 };
 
 inline constexpr int64_t TimescaleMaxBits = 128; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TimescaleMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TimescaleMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // The message-level bound: the tag plus the largest message (SPEC §6.1)
 inline constexpr int64_t MessageMaxBits = 16021;
-inline constexpr int64_t MessageMaxBytes = 2008; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MessageMaxBytes = 2008; // 8-byte write granularity; read slack per the contract above
 
 // The message value: index == wire tag (std::monostate is None = 0, then each
 // message in tag order). Inline storage, no heap, trivially copyable.

--- a/testdata/golden/variant/Objects.h
+++ b/testdata/golden/variant/Objects.h
@@ -58,11 +58,11 @@ struct ClientShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; //  | local — no wire
-    ::VecMath previous_position; //  | local — no wire
-    int32_t num_colliders = 0; //  | local — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
-    bool predicted_explode = false; //  | local, context = client
+    bool invulnerable = false; // | local — no wire
+    ::VecMath previous_position; // | local — no wire
+    int32_t num_colliders = 0; // | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; // | local — no wire
+    bool predicted_explode = false; // | local, context = client
 };
 
 // ServerShipState — the full simulation struct for the server context: every `all`
@@ -93,10 +93,10 @@ struct ServerShipState {
     int8_t missile_index = 0; // wire [0, 15]
     Handle target;
     double lock_start_time = 0.0;
-    bool invulnerable = false; //  | local — no wire
-    ::VecMath previous_position; //  | local — no wire
-    int32_t num_colliders = 0; //  | local — no wire
-    int32_t collider_armor[MaxCollidersPerShip] = {}; //  | local — no wire
+    bool invulnerable = false; // | local — no wire
+    ::VecMath previous_position; // | local — no wire
+    int32_t num_colliders = 0; // | local — no wire
+    int32_t collider_armor[MaxCollidersPerShip] = {}; // | local — no wire
 };
 
 // ShipData_Deep — every non- | local field, deep encodings: full state for
@@ -338,7 +338,7 @@ inline constexpr int64_t ShipData_DeepMaxBits = 1703;
 inline constexpr int64_t ShipData_DeepMaxBytes = 216; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
 
 inline constexpr int64_t ShipData_ShallowMaxBits = 218;
-inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ShipData_ShallowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Missile — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -351,8 +351,8 @@ struct ClientMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; //  | local — no wire
-    Handle target; //  | local — no wire
+    ::VecMath angular_velocity; // | local — no wire
+    Handle target; // | local — no wire
 };
 
 // ServerMissileState — the full simulation struct for the server context: every `all`
@@ -364,9 +364,9 @@ struct ServerMissileState {
     ::VecMath linear_velocity;
     Team team = Team::None;
     uint64_t flags = 0;
-    ::VecMath angular_velocity; //  | local — no wire
-    Handle target; //  | local — no wire
-    double timer = 0.0; //  | local, context = server
+    ::VecMath angular_velocity; // | local — no wire
+    Handle target; // | local — no wire
+    double timer = 0.0; // | local, context = server
 };
 
 // MissileData_Deep — every non- | local field, deep encodings: full state for
@@ -578,10 +578,10 @@ inline void UnquantizeMissile( const MissileData_Shallow & input, MissileData_In
 }
 
 inline constexpr int64_t MissileData_DeepMaxBits = 708;
-inline constexpr int64_t MissileData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MissileData_DeepMaxBytes = 96; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t MissileData_ShallowMaxBits = 260;
-inline constexpr int64_t MissileData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t MissileData_ShallowMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // ---- object DynamicProp — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -593,7 +593,7 @@ struct DynamicPropState {
     ::VecMath linear_velocity;
     uint64_t flags = 0;
     Team team = Team::None;
-    ::VecMath angular_velocity; //  | local — no wire
+    ::VecMath angular_velocity; // | local — no wire
 };
 
 // DynamicPropData_Deep — every non- | local field, deep encodings: full state for
@@ -805,10 +805,10 @@ inline void UnquantizeDynamicProp( const DynamicPropData_Shallow & input, Dynami
 }
 
 inline constexpr int64_t DynamicPropData_DeepMaxBits = 709;
-inline constexpr int64_t DynamicPropData_DeepMaxBytes = 96; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DynamicPropData_DeepMaxBytes = 96; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t DynamicPropData_ShallowMaxBits = 261;
-inline constexpr int64_t DynamicPropData_ShallowMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t DynamicPropData_ShallowMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // ---- object Turret — one definition, a generated family per target (SPEC §4.8) ----
 
@@ -818,7 +818,7 @@ struct TurretState {
     int32_t turret_index = 0; // wire [0, 255]
     Quat rotation;
     uint64_t flags = 0;
-    Team team = Team::None; //  | local — no wire
+    Team team = Team::None; // | local — no wire
 };
 
 // TurretData_Deep — every non- | local field, deep encodings: full state for
@@ -928,9 +928,9 @@ inline void UnquantizeTurret( const TurretData_Shallow & input, TurretData_Inter
 }
 
 inline constexpr int64_t TurretData_DeepMaxBits = 350;
-inline constexpr int64_t TurretData_DeepMaxBytes = 48; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TurretData_DeepMaxBytes = 48; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t TurretData_ShallowMaxBits = 142;
-inline constexpr int64_t TurretData_ShallowMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TurretData_ShallowMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/testdata/golden/variant/Render.h
+++ b/testdata/golden/variant/Render.h
@@ -34,6 +34,6 @@ struct RenderBlock {
 };
 
 inline constexpr int64_t RenderBlockMaxBits = 8903; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t RenderBlockMaxBytes = 1120; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t RenderBlockMaxBytes = 1120; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/testdata/golden/variant/Types.h
+++ b/testdata/golden/variant/Types.h
@@ -13,8 +13,7 @@
 
 namespace example {
 
-// type Vec3 [vec3] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Vec3 [vec3] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct Vec3 {
     double x = 0.0;
     double y = 0.0;
@@ -24,8 +23,7 @@ struct Vec3 {
 inline constexpr int64_t Vec3MaxBits = 192; // longest wire path; align pads at worst case (SPEC §6.1)
 inline constexpr int64_t Vec3MaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
 
-// type Quat [quat4] — the tag is user-chosen and inert in v1; the delta pass
-// claims tags and assigns actions (SPEC §4.2, Type tags)
+// type Quat [quat4] — tags are user-chosen and inert in v1 (SPEC §4.2, Type tags)
 struct Quat {
     double x = 0.0;
     double y = 0.0;
@@ -34,7 +32,7 @@ struct Quat {
 };
 
 inline constexpr int64_t QuatMaxBits = 256; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuatMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuatMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type Handle
 struct Handle {
@@ -43,7 +41,7 @@ struct Handle {
 };
 
 inline constexpr int64_t HandleMaxBits = 22; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t HandleMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t HandleMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedPosition
 struct QuantizedPosition {
@@ -53,7 +51,7 @@ struct QuantizedPosition {
 };
 
 inline constexpr int64_t QuantizedPositionMaxBits = 75; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedPositionMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedPositionMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedVelocity
 struct QuantizedVelocity {
@@ -63,7 +61,7 @@ struct QuantizedVelocity {
 };
 
 inline constexpr int64_t QuantizedVelocityMaxBits = 69; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedVelocityMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedVelocityMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type QuantizedRotation
 struct QuantizedRotation {
@@ -74,7 +72,7 @@ struct QuantizedRotation {
 };
 
 inline constexpr int64_t QuantizedRotationMaxBits = 48; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t QuantizedRotationMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t QuantizedRotationMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type RigidBody
 struct RigidBody {
@@ -89,7 +87,7 @@ struct RigidBody {
 };
 
 inline constexpr int64_t RigidBodyMaxBits = 833; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t RigidBodyMaxBytes = 112; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t RigidBodyMaxBytes = 112; // 8-byte write granularity; read slack per the contract above
 
 // type Input
 struct Input {
@@ -109,7 +107,7 @@ struct Input {
 };
 
 inline constexpr int64_t InputMaxBits = 168; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t InputMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t InputMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 // type InputPacket
 struct InputPacket {
@@ -121,7 +119,7 @@ struct InputPacket {
 };
 
 inline constexpr int64_t InputPacketMaxBits = 2837; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t InputPacketMaxBytes = 360; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t InputPacketMaxBytes = 360; // 8-byte write granularity; read slack per the contract above
 
 // type ShipCreate
 struct ShipCreate {
@@ -142,7 +140,7 @@ struct ShipCreate {
 };
 
 inline constexpr int64_t ShipCreateMaxBits = 219; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ShipCreateMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ShipCreateMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type ExpressionProbe
 struct ExpressionProbe {
@@ -151,7 +149,7 @@ struct ExpressionProbe {
 };
 
 inline constexpr int64_t ExpressionProbeMaxBits = 16; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExpressionProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExpressionProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 inline constexpr int64_t FloorLimit = ( -9223372036854775807ll - 1 );
 inline constexpr uint64_t CeilingCount = 18446744073709551615ull; // = 18446744073709551615
@@ -165,7 +163,7 @@ struct ExtremeProbe {
 };
 
 inline constexpr int64_t ExtremeProbeMaxBits = 320; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExtremeProbeMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExtremeProbeMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // type ExtremeRow
 struct ExtremeRow {
@@ -176,6 +174,6 @@ struct ExtremeRow {
 };
 
 inline constexpr int64_t ExtremeRowMaxBits = 256; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ExtremeRowMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ExtremeRowMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example

--- a/testdata/golden/variant/Wire.h
+++ b/testdata/golden/variant/Wire.h
@@ -65,7 +65,7 @@ struct ProbeBits {
 };
 
 inline constexpr int64_t ProbeBitsMaxBits = 202; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeBitsMaxBytes = 32; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeBitsMaxBytes = 32; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeSample
 struct ProbeSample {
@@ -92,7 +92,7 @@ struct ProbeSample {
 };
 
 inline constexpr int64_t ProbeSampleMaxBits = 276; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeSampleMaxBytes = 40; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeSampleMaxBytes = 40; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeRing
 struct ProbeRing {
@@ -100,7 +100,7 @@ struct ProbeRing {
 };
 
 inline constexpr int64_t ProbeRingMaxBits = 16; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeRingMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeRingMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeSlab
 struct ProbeSlab {
@@ -109,7 +109,7 @@ struct ProbeSlab {
 };
 
 inline constexpr int64_t ProbeSlabMaxBits = 15; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeSlabMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeSlabMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // ProbeShapeType: union ProbeShape's tag — None = 0, then each variant in declared order (SPEC §4.8)
 enum class ProbeShapeType : uint8_t {
@@ -137,7 +137,7 @@ struct ProbeShape
 };
 
 inline constexpr int64_t ProbeShapeMaxBits = 18; // tag + the largest arm; None costs the tag only (SPEC §4.8)
-inline constexpr int64_t ProbeShapeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeShapeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeCollider
 struct ProbeCollider {
@@ -149,7 +149,7 @@ struct ProbeCollider {
 };
 
 inline constexpr int64_t ProbeColliderMaxBits = 82; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeColliderMaxBytes = 16; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeColliderMaxBytes = 16; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeConfig
 struct ProbeConfig {
@@ -158,7 +158,7 @@ struct ProbeConfig {
 };
 
 inline constexpr int64_t ProbeConfigMaxBits = 36; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeConfigMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeConfigMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeArray
 struct ProbeArray {
@@ -167,7 +167,7 @@ struct ProbeArray {
 };
 
 inline constexpr int64_t ProbeArrayMaxBits = 588; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeArrayMaxBytes = 80; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeArrayMaxBytes = 80; // 8-byte write granularity; read slack per the contract above
 
 // type ProbeReport
 struct ProbeReport {
@@ -177,7 +177,7 @@ struct ProbeReport {
 };
 
 inline constexpr int64_t ProbeReportMaxBits = 141; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t ProbeReportMaxBytes = 24; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t ProbeReportMaxBytes = 24; // 8-byte write granularity; read slack per the contract above
 
 // type TestData
 struct TestData {
@@ -207,7 +207,7 @@ struct TestData {
 };
 
 inline constexpr int64_t TestDataMaxBits = 2735; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t TestDataMaxBytes = 344; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t TestDataMaxBytes = 344; // 8-byte write granularity; read slack per the contract above
 
 // type CompressedProbe
 struct CompressedProbe {
@@ -216,6 +216,6 @@ struct CompressedProbe {
 };
 
 inline constexpr int64_t CompressedProbeMaxBits = 24; // longest wire path; align pads at worst case (SPEC §6.1)
-inline constexpr int64_t CompressedProbeMaxBytes = 8; // rounded up to the 8-byte write-buffer granularity; a read buffer's allocation must extend at least 8 bytes past the data — the reader loads 64-bit windows
+inline constexpr int64_t CompressedProbeMaxBytes = 8; // 8-byte write granularity; read slack per the contract above
 
 } // namespace example


### PR DESCRIPTION
Pre-v1.0.0 review pass 3 (stacked on #141): the generated-output quality pass — dead surface and comment spew out, at the emitters.

- **Dead since the table removal:** C's `enum_name_*_dyn` functions existed only to feed the departed table reflection descriptors' u64 function pointers — gone, and the typed switch now uses the variant macros beside it. Rust's `_dyn` indirection folds into the one typed `enum_name_*`.
- **Say it once per unit/file, not per symbol:** JS/C# banner boilerplate paragraphs ride the protocol-id home file only; C wire headers get one calling-convention block instead of a 2-line contract on all ~50 functions; cpp/c `MaxBytes` states the read-slack buffer contract on the file's first constant, short form after; C# batch prose shrinks from 4-line essays ×26 to one line per site.
- **Cut:** ~350 identical per-guard `// out-of-contract writes are refused…` / `// the runtime range refusal, folded` trailing comments; emitted archaeology ("(issue #82)", "(schema #60)", "M2, 2026-08-06", the shipped-then-deleted switch stories in the inline-macro comments); comments restating the visible initializer.
- **Hygiene:** C headers include `<string.h>`/`<math.h>`/the SCHEMA_UNUSED block only when the body uses them (Constants.h drops all three); the doubled space in `//  | local` comments closes up; the delta-pass future-work sentence leaves the tag comments.

Generated output + source goldens: **−4704/+3017 lines**. Wire goldens byte-identical, all four protocol ids unchanged, full local gauntlet green (make test: 12 binaries + all language legs + bench corpus gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)