### PR TITLE
Dead public surface and dead parameters out; the API documented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ generated/cpp/.stamp: bin/schema $(SCHEMAS)
 	./bin/schema generate --lang cpp --out generated/cpp examples
 	@touch $@
 
-# the fixed-point + 128-bit unit (examples128/) — all five targets since the
+# the fixed-point + 128-bit unit (examples128/) — all six targets since the
 # serialize ports carry the phase-1 surface; each generated unit gets the same
 # module/manifest wiring as its main-corpus twin
 generated/cpp/ludicrous/.stamp: bin/schema $(SCHEMAS128)
@@ -151,7 +151,7 @@ generated/c-ludicrous/.stamp: bin/schema $(SCHEMAS128)
 #     (BENCH-STANDARD.md §1.3); goldens testdata/wire/bench_*.bin
 #   bench/corpus/RealWorld.schema  package realworld  — the §1.7 realistic
 #     snapshot (RealPacket); golden testdata/wire/real_packet.bin
-# Both are generated into all five languages so the bench shapes have ONE
+# Both are generated into all six languages so the bench shapes have ONE
 # definition; the goldens come from the generated C++ (test/bench/main.cpp)
 # and every bench runner is §1.5-gated against them. Languages whose module
 # layout cannot hold two packages in one directory put the realworld unit in

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -1,8 +1,11 @@
 // The schema compiler CLI (SPEC §7).
 //
-//	schema check    [dir|files...]                 parse + typecheck; exit code for CI
-//	schema generate --lang cpp --out <dir> [dir]   emit generated code
-//	schema id       [dir|files...]                 print the protocol id
+//	schema check      [dir|files...]                 parse + typecheck; exit code for CI
+//	schema generate   --lang cpp --out <dir> [dir]   emit generated code
+//	schema id         [dir|files...]                 print the protocol id
+//	schema projection [dir|files...]                 print the wire shape the id hashes
+//	schema fmt        [dir|files...]                 canonicalize schema files in place
+//	schema version                                   print the build identity
 //
 // Every command here is a few lines over the public API in
 // github.com/mas-bandwidth/schema/compiler: this binary holds the CLI's

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -242,13 +242,10 @@ func MigrateFile(path string) (canonical []byte, rewrote bool, err error) {
 	return out, true, nil
 }
 
-// Version reports which build of the compiler is running: the linker stamp if
-// the build carried one, otherwise the module version or a VCS revision.
-// Never empty. Deliberately absent from generated output — generated code
+// UserAgent reports which build of the compiler is running, as the one-line
+// form `schema version` prints and the form to quote in a bug report: the
+// linker stamp if the build carried one, otherwise the module version or a
+// VCS revision. Deliberately absent from generated output — generated code
 // carries the protocol id, which is what actually governs compatibility (see
 // VERSIONING.md).
-func Version() string { return version.Version() }
-
-// UserAgent is the one-line form `schema version` prints, and the form to
-// quote in a bug report.
 func UserAgent() string { return version.UserAgent() }

--- a/compiler/generate.go
+++ b/compiler/generate.go
@@ -71,13 +71,6 @@ func (c *Compiler) Targets() []string {
 	return out
 }
 
-// Generator returns the generator that `--lang name` selects, by canonical
-// name or alias.
-func (c *Compiler) Generator(name string) (Generator, bool) {
-	g, ok := c.gens[name]
-	return g, ok
-}
-
 // Generate emits target's source for the unit and returns the files, keyed by
 // output file name. It writes nothing — the caller chooses the destination —
 // and it is pure in the unit: generating twice yields the same bytes.

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -213,11 +213,11 @@ func (c *checker) resolveAllConsts() {
 	}
 	sort.Strings(names)
 	for _, n := range names {
-		c.resolveConst(n, ast.Pos{})
+		c.resolveConst(n)
 	}
 }
 
-func (c *checker) resolveConst(name string, usePos ast.Pos) *ir.Const {
+func (c *checker) resolveConst(name string) *ir.Const {
 	e := c.constant[name]
 	if e == nil {
 		return nil
@@ -392,7 +392,7 @@ func (c *checker) evalInt(e ast.Expr) (*big.Int, bool) {
 			}
 			return nil, false
 		}
-		out := c.resolveConst(e.Name, e.Pos)
+		out := c.resolveConst(e.Name)
 		if out == nil {
 			return nil, false
 		}
@@ -459,7 +459,7 @@ func (c *checker) evalFloat(e ast.Expr) (float64, bool) {
 			c.errf(e.Pos, "undefined constant %s", e.Name)
 			return 0, false
 		}
-		out := c.resolveConst(e.Name, e.Pos)
+		out := c.resolveConst(e.Name)
 		if out == nil {
 			return 0, false
 		}
@@ -1191,7 +1191,7 @@ func (c *checker) resolveField(kind declKind, owner string, f *ast.Field) *ir.Fi
 		}
 	}
 
-	c.resolveAttrs(kind, owner, f, out)
+	c.resolveAttrs(kind, f, out)
 
 	// the fixed and 128-bit families mirror serialize's own surface exactly
 	// (SPEC §4.3, runtime-first): fixed(I, F) and int128 are RANGED — the
@@ -1335,7 +1335,7 @@ func scalarName(k ir.FieldTypeKind) string {
 	return "?"
 }
 
-func (c *checker) resolveAttrs(kind declKind, owner string, f *ast.Field, out *ir.Field) {
+func (c *checker) resolveAttrs(kind declKind, f *ast.Field, out *ir.Field) {
 	byKey := map[string]*ast.Attr{}
 	for i := range f.Attrs {
 		a := &f.Attrs[i]

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -57,7 +57,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	}
 
 	out := map[string][]byte{}
-	home := protocolIdHome(u)
+	home := ir.ProtocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	deps := ir.FileDeps(u)
@@ -89,18 +89,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	}
 
 	return out, nil
-}
-
-func protocolIdHome(u *ir.Unit) string {
-	for _, f := range u.Files {
-		if f.Base == "Constants" {
-			return f.Base
-		}
-	}
-	if len(u.Files) > 0 {
-		return u.Files[0].Base
-	}
-	return ""
 }
 
 type gen struct {

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -72,12 +72,12 @@ func Generate(u *ir.Unit, opts Options) (map[string][]byte, error) {
 		}
 	}
 	out := map[string][]byte{}
-	protocolIdHome := protocolIdHome(u)
+	home := ir.ProtocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	for _, f := range u.Files {
 		g := &gen{unit: u, file: f, opts: opts, msgOwner: msgOwner, objOwner: objOwner}
-		g.emitDataFile(f.Base == protocolIdHome)
+		g.emitDataFile(f.Base == home)
 		out[f.Base+".h"] = g.assemble()
 
 		w := &gen{unit: u, file: f, opts: opts, msgOwner: msgOwner, objOwner: objOwner, wire: true}
@@ -165,20 +165,6 @@ func includeCycle(u *ir.Unit) string {
 		if !visit(f.Base) {
 			return found
 		}
-	}
-	return ""
-}
-
-// protocolIdHome picks the file that carries the unit-level ProtocolId
-// constant: the constants aspect file if the unit has one, else the first.
-func protocolIdHome(u *ir.Unit) string {
-	for _, f := range u.Files {
-		if f.Base == "Constants" {
-			return f.Base
-		}
-	}
-	if len(u.Files) > 0 {
-		return u.Files[0].Base
 	}
 	return ""
 }

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -57,7 +57,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// on every TFM since the Int128Value/UInt128Value pair landed (2026-08-12,
 	// option b) — storage maps to the pair, wire calls mirror the C++ macros.
 	out := map[string][]byte{}
-	home := protocolIdHome(u)
+	home := ir.ProtocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	batched, needCore := batchPlan(u)
@@ -67,21 +67,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		out[f.Base+".cs"] = g.assemble()
 	}
 	return out, nil
-}
-
-// protocolIdHome picks the file that carries ProtocolId: the constants aspect
-// file if the unit has one, else the first — the same rule as the other
-// targets.
-func protocolIdHome(u *ir.Unit) string {
-	for _, f := range u.Files {
-		if f.Base == "Constants" {
-			return f.Base
-		}
-	}
-	if len(u.Files) > 0 {
-		return u.Files[0].Base
-	}
-	return ""
 }
 
 type gen struct {

--- a/internal/codegen/csharp/objects.go
+++ b/internal/codegen/csharp/objects.go
@@ -258,7 +258,7 @@ func (g *gen) emitQuantizeField(f *ir.Field, ind string) {
 			g.sf("%s    output.%s%s = (%s)componentValue;\n%s}\n", ind, name, compName, compT, ind)
 		}
 	default:
-		g.emitCopyField("output", "input", "", f, ind, 0)
+		g.emitCopyField("output", "input", f, ind, 0)
 	}
 }
 
@@ -294,7 +294,7 @@ func (g *gen) emitUnquantizeField(f *ir.Field, ind string) {
 				ind, name, compName, cast, name, compName, scale)
 		}
 	default:
-		g.emitCopyField("output", "input", "", f, ind, 0)
+		g.emitCopyField("output", "input", f, ind, 0)
 	}
 }
 
@@ -302,11 +302,9 @@ func (g *gen) emitUnquantizeField(f *ir.Field, ind string) {
 // other targets copy with one value assignment; C# classes and arrays are
 // references, so buffers copy element-wise into the destination's
 // pre-allocated storage and composed classes copy member-wise (recursion ends
-// because composition cycles are compile errors). owner is the class the
-// field belongs to, for the CS0542 member escape ("" for the view classes,
-// whose underscored names the mapping can never produce); depth uniquifies
-// nested loop variables.
-func (g *gen) emitCopyField(dstPrefix, srcPrefix, owner string, f *ir.Field, ind string, depth int) {
+// because composition cycles are compile errors). depth uniquifies nested
+// loop variables.
+func (g *gen) emitCopyField(dstPrefix, srcPrefix string, f *ir.Field, ind string, depth int) {
 	base := ir.GoExportName(f.Name)
 	dst := dstPrefix + "." + base
 	src := srcPrefix + "." + base
@@ -341,7 +339,7 @@ func (g *gen) emitCopyField(dstPrefix, srcPrefix, owner string, f *ir.Field, ind
 
 func (g *gen) emitCopyStruct(dst, src string, st *ir.Struct, ind string, depth int) {
 	for _, f := range st.Fields {
-		g.emitCopyField(dst, src, st.Name, f, ind, depth)
+		g.emitCopyField(dst, src, f, ind, depth)
 	}
 }
 

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -38,7 +38,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// SerializeFixed64/SerializeFixed128) — storage maps to the pair at 128
 	// bits, wire calls mirror the C++ macros.
 	out := map[string][]byte{}
-	home := protocolIdHome(u)
+	home := ir.ProtocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	for _, f := range u.Files {
@@ -51,20 +51,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		out[f.Base+".go"] = src
 	}
 	return out, nil
-}
-
-// protocolIdHome picks the file that carries ProtocolId and ErrValidation:
-// the constants aspect file if the unit has one, else the first.
-func protocolIdHome(u *ir.Unit) string {
-	for _, f := range u.Files {
-		if f.Base == "Constants" {
-			return f.Base
-		}
-	}
-	if len(u.Files) > 0 {
-		return u.Files[0].Base
-	}
-	return ""
 }
 
 type gen struct {

--- a/internal/codegen/js/flat.go
+++ b/internal/codegen/js/flat.go
@@ -702,7 +702,6 @@ func (g *fgen) emitWriteWideOffset(offExpr string, bits int64, ind string) {
 	}
 }
 
-
 func (g *fgen) emitWriteScalar(f *ir.Field, name, ind string) {
 	switch f.Type.Kind {
 	case ir.TFixed:

--- a/internal/codegen/js/functions.go
+++ b/internal/codegen/js/functions.go
@@ -444,7 +444,7 @@ func (g *gen) emitWriteField(f *ir.Field, ind string) {
 }
 
 func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
-		switch f.Type.Kind {
+	switch f.Type.Kind {
 	case ir.TFixed:
 		if f.IntMin.Cmp(f.IntMax) == 0 {
 			// degenerate range: ZERO bits — the folded range refusal and no

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -65,7 +65,7 @@ import (
 // initializer referencing a later const would hit the temporal dead zone).
 func Generate(u *ir.Unit) (map[string][]byte, error) {
 	out := map[string][]byte{}
-	home := protocolIdHome(u)
+	home := ir.ProtocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	bases := map[string]bool{}
@@ -94,21 +94,6 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// regardless because it is the flat tier's CI oracle
 	maps.Copy(out, generateFlat(u, msgOwner))
 	return out, nil
-}
-
-// protocolIdHome picks the file that carries ProtocolId: the constants aspect
-// file if the unit has one, else the first — the same rule as the other
-// targets.
-func protocolIdHome(u *ir.Unit) string {
-	for _, f := range u.Files {
-		if f.Base == "Constants" {
-			return f.Base
-		}
-	}
-	if len(u.Files) > 0 {
-		return u.Files[0].Base
-	}
-	return ""
 }
 
 type gen struct {

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -40,7 +40,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	// over FixedPointStorage) — storage is native, wire calls mirror the C++
 	// macros.
 	out := map[string][]byte{}
-	home := protocolIdHome(u)
+	home := ir.ProtocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	deps := ir.FileDeps(u)
@@ -73,27 +73,12 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	return out, nil
 }
 
-// protocolIdHome picks the file that carries PROTOCOL_ID and the Error/Result
-// pair: the constants aspect file if the unit has one, else the first — the
-// same rule as the Go target.
-func protocolIdHome(u *ir.Unit) string {
-	for _, f := range u.Files {
-		if f.Base == "Constants" {
-			return f.Base
-		}
-	}
-	if len(u.Files) > 0 {
-		return u.Files[0].Base
-	}
-	return ""
-}
-
 func assembleLib(u *ir.Unit, modules map[string]string) []byte {
 	// a module re-exports into the crate root only if it declares anything: a
 	// glob over an item-less module (a contexts aspect file — comments only)
 	// is an unused import
 	exports := map[string]bool{}
-	home := protocolIdHome(u)
+	home := ir.ProtocolIdHome(u)
 	msgOwner := ir.MessageOwner(u)
 	objOwner := ir.ObjectOwner(u)
 	for _, f := range u.Files {

--- a/internal/goldens/goldens_test.go
+++ b/internal/goldens/goldens_test.go
@@ -24,7 +24,7 @@ var update = flag.Bool("update", false, "rewrite the golden files from current o
 
 const (
 	corpusDir = "../../examples"
-	// the fixed-point + 128-bit unit: all five targets, pinned like the main
+	// the fixed-point + 128-bit unit: all six targets, pinned like the main
 	// corpus (the serialize ports all carry the phase-1 surface).
 	corpus128Dir = "../../examples128"
 	goldenDir    = "../../testdata/golden"

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -183,7 +183,7 @@ func (s *state) peek2() byte {
 	return s.src[s.off+1]
 }
 
-func (s *state) advance() byte {
+func (s *state) advance() {
 	c := s.src[s.off]
 	s.off++
 	if c == '\n' {
@@ -192,7 +192,6 @@ func (s *state) advance() byte {
 	} else {
 		s.col++
 	}
-	return c
 }
 
 func isIdentStart(c byte) bool {

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -23,6 +23,8 @@ import (
 // backends go through.
 type Expr = ast.Expr
 
+// Unit is one checked compilation unit — the checker's output and every
+// generator's input (SPEC §3.2).
 type Unit struct {
 	Package    string
 	ProtocolId uint64
@@ -42,14 +44,17 @@ type Unit struct {
 	ObjNames []string // sorted by name — the ObjectType order
 }
 
+// File is one schema file's declarations, in declaration order.
 type File struct {
 	Base  string // "Constants"
 	Path  string // as given, e.g. "examples/Constants.schema"
 	Decls []Decl
 }
 
+// Decl is one top-level declaration.
 type Decl interface{ irDecl() }
 
+// Const is a `const` declaration, its value folded.
 type Const struct {
 	Name     string
 	IsFloat  bool
@@ -60,6 +65,8 @@ type Const struct {
 	Expr     Expr // for symbolic rendering in generated code
 }
 
+// Enum is an `enum` declaration: None = 0 implicit, variants dense from 1
+// (SPEC §4.2).
 type Enum struct {
 	Name        string
 	Variants    []string // implicit None = 0 is not listed; variants pack from 1
@@ -67,6 +74,8 @@ type Enum struct {
 	StorageBits int      // 8 / 16 / 32 / 64 — smallest unsigned fitting Max
 }
 
+// Flags is a `flags` declaration: one bit per variant, consumed as masks
+// (SPEC §4.2).
 type Flags struct {
 	Name     string
 	Variants []string // bit i is variant i
@@ -79,7 +88,6 @@ type ContextsMarker struct {
 	Names []string
 }
 
-// Struct is a `type` or `message` declaration.
 // Union is a first-class one-of type (SPEC §4.8): the implicit None row at
 // tag 0, then each variant in DECLARED order, dense from 1. The tag encodes
 // in minimal bits for [0, Max]; the wire then carries the selected variant's
@@ -91,12 +99,14 @@ type Union struct {
 	StorageBits int            // 8 / 16 / 32 / 64 — smallest unsigned fitting Max
 }
 
+// UnionVariant is one arm of a [Union].
 type UnionVariant struct {
 	Name string  // declared, field-style lower_snake
 	Type string  // the payload type's name
 	Ref  *Struct // the payload
 }
 
+// Struct is a `type` or `message` declaration.
 type Struct struct {
 	Name      string
 	IsMessage bool
@@ -119,10 +129,12 @@ type Struct struct {
 // constructs (const, reserved, align — SPEC §4.3).
 type Item interface{ irItem() }
 
+// FieldItem wraps a [Field] as an [Item].
 type FieldItem struct {
 	F *Field
 }
 
+// Branch is an if/else wire branch (SPEC §4.5).
 type Branch struct {
 	Neg  bool   // if !cond
 	Cond string // the back-referenced bool field's name (SPEC §4.5)
@@ -152,6 +164,7 @@ func (*ConstItem) irItem()    {}
 func (*ReservedItem) irItem() {}
 func (*AlignItem) irItem()    {}
 
+// Object is an `object` declaration — the view-family surface (SPEC §4.8).
 type Object struct {
 	Name   string
 	Fields []*Field
@@ -165,6 +178,7 @@ func (*Struct) irDecl()         {}
 func (*Object) irDecl()         {}
 func (*Union) irDecl()          {}
 
+// ArrayKind classifies a field's array form.
 type ArrayKind int
 
 const (
@@ -173,6 +187,8 @@ const (
 	ArrayCounted // [..N]T and [Min..N]T
 )
 
+// Field is one storage-carrying member of a struct or object, with its
+// resolved wire refinements.
 type Field struct {
 	Name  string
 	Guard string // "" or "if !at_rest" — branch context, kept as a comment
@@ -189,8 +205,8 @@ type Field struct {
 
 	Type FieldType
 
-	// specified default (SPEC: zero initialization everywhere unless a
-	// specified default overrides it — Glenn, 2026-08-05)
+	// specified default (SPEC §5: zero initialization everywhere unless a
+	// specified default overrides it)
 	HasDefault bool
 	DefBool    bool
 	DefInt     *big.Int
@@ -221,10 +237,7 @@ type Field struct {
 	// components are all fixed(I, F); the shallow wire keeps QuantShift =
 	// log2(QuantScale) fractional bits. Quantize rounds to nearest with ties
 	// HALF AWAY FROM ZERO over (F - QuantShift) dropped bits — the one
-	// fixed-point rounding rule (SPEC §4.8, decided 2026-08-15; before the
-	// unification the emitters shipped the bare shift, ties toward
-	// +infinity, and this comment already said half-away — the code moved to
-	// match the words, not the other way). Unquantize is the left shift
+	// fixed-point rounding rule (SPEC §4.8). Unquantize is the left shift
 	// back; the per-component wire bound is the component's own whole-unit
 	// [IntMin, IntMax] times QuantScale. QuantMax/QuantBound are
 	// meaningless here — bounds live on the components, not the field.
@@ -337,7 +350,7 @@ func StorageBitsFor(max int64) int {
 // FixedShallowBounds is the per-component shallow wire range of a narrowed
 // fixed composite (SPEC §4.8 rule 2b): the component's own whole-unit
 // [IntMin, IntMax] scaled by QuantScale. Every backend derives storage and
-// wire bounds from this one function, or the five wires disagree.
+// wire bounds from this one function, or the generated wires disagree.
 func FixedShallowBounds(f *Field, cf *Field) (lo, hi *big.Int) {
 	k := big.NewInt(f.QuantScale)
 	lo = new(big.Int).Mul(cf.IntMin, k)

--- a/ir/wire.go
+++ b/ir/wire.go
@@ -430,6 +430,7 @@ func MessageOwner(u *Unit) string {
 	})
 }
 
+// ObjectOwner is MessageOwner's twin for the object tag surface.
 func ObjectOwner(u *Unit) string {
 	return dispatchOwner(u, func(f *File) bool {
 		for _, d := range f.Decls {
@@ -439,6 +440,22 @@ func ObjectOwner(u *Unit) string {
 		}
 		return false
 	})
+}
+
+// ProtocolIdHome picks the file whose output carries the unit-level protocol
+// id constant (and, per target, its companions): the constants aspect file if
+// the unit has one, else the first file. One rule for every backend, so the
+// id lives in the same schema file's output across all targets.
+func ProtocolIdHome(u *Unit) string {
+	for _, f := range u.Files {
+		if f.Base == "Constants" {
+			return f.Base
+		}
+	}
+	if len(u.Files) > 0 {
+		return u.Files[0].Base
+	}
+	return ""
 }
 
 func dispatchOwner(u *Unit, has func(*File) bool) string {


### PR DESCRIPTION
Pre-v1.0.0 review pass 4 (stacked on #142).

- `compiler.Version()` and `Compiler.Generator()` removed — zero consumers anywhere including the publicapi external-module rebuild; the repo's own #85 rule says an export justifies itself on schema's needs or goes. UserAgent absorbs Version's doc.
- Six per-backend `protocolIdHome` copies collapse into `ir.ProtocolIdHome` beside MessageOwner/ObjectOwner (the same justified-export precedent: every backend consumes it).
- Dead parameters: `resolveConst(usePos)`, `resolveAttrs(owner)`, C# `emitCopyField(owner)` (whose doc described a CS0542 escape it never performed), scanner `advance()`'s unread return byte.
- Everything documented: doc comments on every exported `ir` type (Unit, File, Decl, Const, Enum, Flags, UnionVariant, Struct, Branch, FieldItem, Object, ArrayKind, Field); the `Struct` doc line had been sitting on top of `Union`'s comment block; `cmd/schema`'s package doc listed 3 of 6 subcommands.
- Counts and dates in code comments: five→six for the ludicrous/bench corpora (Makefile, goldens test), "the five wires" in ir, two dated decision breadcrumbs trimmed to their SPEC citations.

No generated-output changes. `go test ./...` green, golangci-lint clean, ids untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)