### PR TITLE
Object subsystem: cut the write-only ir.Field.QuantMax and a checker no-op

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1466,10 +1466,8 @@ func (c *checker) resolveAttrs(kind declKind, f *ast.Field, out *ir.Field) {
 			c.errf(f.Pos, "field %s: a float range is min, max and resolution, all three together (SPEC §4.6)", f.Name)
 			return
 		}
-		if kind == objectD && !out.Interpolate {
-			// deep-only float with a range triple: legal — it is §4.3's compressed float
-			_ = kind
-		}
+		// a deep-only float with a range triple in an object body is legal —
+		// it is §4.3's compressed float, no view rule involved
 		fmin, ok1 := c.evalFloat(byKey["min"].Value)
 		fmax, ok2 := c.evalFloat(byKey["max"].Value)
 		res, ok3 := c.evalFloat(byKey["resolution"].Value)
@@ -1724,7 +1722,6 @@ func (c *checker) checkCompositeQuantize(f *ast.Field, out *ir.Field, byKey map[
 	out.HasQuantize = true
 	out.QuantScale = k.Int64()
 	out.QuantScaleExpr = a.Value
-	out.QuantMax = b
 	out.QuantMaxExpr = byKey["max"].Value
 	out.QuantBound = int64(math.Round(bound))
 }

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -229,9 +229,8 @@ type Field struct {
 	HasQuantize    bool   // composite quantization (SPEC §4.8 rule 2)
 	QuantScale     int64
 	QuantScaleExpr Expr
-	QuantMax       float64
-	QuantMaxExpr   Expr
-	QuantBound     int64 // round(QuantScale * QuantMax) — per-component wire range is [-QuantBound, +QuantBound]
+	QuantMaxExpr   Expr  // the declared max = B, for symbolic rendering
+	QuantBound     int64 // round(QuantScale * B) — per-component wire range is [-QuantBound, +QuantBound]
 
 	// fixed-composite shallow narrowing (SPEC §4.8 rule 2b): the composite's
 	// components are all fixed(I, F); the shallow wire keeps QuantShift =
@@ -239,7 +238,7 @@ type Field struct {
 	// HALF AWAY FROM ZERO over (F - QuantShift) dropped bits — the one
 	// fixed-point rounding rule (SPEC §4.8). Unquantize is the left shift
 	// back; the per-component wire bound is the component's own whole-unit
-	// [IntMin, IntMax] times QuantScale. QuantMax/QuantBound are
+	// [IntMin, IntMax] times QuantScale. QuantMaxExpr/QuantBound are
 	// meaningless here — bounds live on the components, not the field.
 	FixedShallow bool
 	QuantShift   int


### PR DESCRIPTION
Dead-code findings from the rigorous object-subsystem study (Glenn's charge). Two provable cuts, both id-neutral and consumer-safe:

- **ir.Field.QuantMax** — written once at composite-quantize resolution, read by nothing anywhere: no backend, no test, not the wire projection. Backends render the declared bound from QuantMaxExpr and take the range from QuantBound. replicant (the one known embedder) reads neither — its schema-consuming code has no QuantMax reference and its data-domain fork carries its own IR copy.
- **internal/check** — the `if kind == objectD && !out.Interpolate { _ = kind }` no-op block; its comment (deep-only float triple in an object body is §4.3's compressed float, legal) survives as a plain comment.

Receipts: full `make` gauntlet green; generated/, testdata/golden and id.txt untouched (0xbc05d83a8135cdb9) — the working tree after the gauntlet shows only these two source files. Space's generated trees regenerate identically by the same receipt: no emitter reads the cut field, and the whole corpus re-emitted byte-for-byte.

The study's HALF-DELIVERED findings (the C target's missing ObjectType surface, `round` acceptance outside rule-4 projections) are reported separately for Glenn's ruling, not cut here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)