### PR TITLE
Version 2.0.0: module path gains /v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all: test
 # (a source tarball, say) the stamp is left empty and internal/version falls
 # back to the toolchain's own build info.
 VERSION ?= $(shell git describe --tags --dirty 2>/dev/null)
-LDFLAGS := $(if $(VERSION),-X github.com/mas-bandwidth/schema/internal/version.version=$(VERSION),)
+LDFLAGS := $(if $(VERSION),-X github.com/mas-bandwidth/schema/v2/internal/version.version=$(VERSION),)
 
 bin/schema: $(GO_SOURCES)
 	go build -ldflags "$(LDFLAGS)" -o $@ ./cmd/schema

--- a/USAGE.md
+++ b/USAGE.md
@@ -549,8 +549,8 @@ so anything the CLI does, your program can do.
 
 ```go
 import (
-	"github.com/mas-bandwidth/schema/compiler"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 c := compiler.New() // the six built-in targets, registered
@@ -628,7 +628,7 @@ fmt.Println(c.Targets()) // [c cpp cs docs go js rust]
 files, err := c.Generate(unit, "docs", nil)
 ```
 
-The unit your generator receives is the same fully-resolved [`ir`](https://pkg.go.dev/github.com/mas-bandwidth/schema/ir)
+The unit your generator receives is the same fully-resolved [`ir`](https://pkg.go.dev/github.com/mas-bandwidth/schema/v2/ir)
 the built-in backends read: types resolved, constants folded, ranges and bit
 widths derived, wire order fixed. The derived parameters the six emitters
 share are functions there rather than per-backend arithmetic — `ir.BitsRequired`,

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -50,8 +50,10 @@ carries it wears the number these rules assign.
 
 ## History: the v2 line
 
-v2.0.0 and v2.1.0 were re-versioned into the 1.x line as v1.6.0; the 1.x
-line is the line that exists.
+An early v2.0.0 and v2.1.0 were re-versioned into the 1.x line as v1.6.0 and
+their tags retired; the 2.x line that exists today starts at the v2.0.0 that
+follows v1.16.0, and — per Go's major-version rule — carries the module path
+`github.com/mas-bandwidth/schema/v2`.
 
 ## Recorded wire-affecting amendments
 
@@ -87,9 +89,9 @@ thing that governs compatibility. If you want to know which compiler produced a
 tree, that belongs in your build system, not in every file.
 
 **The Go API under `compiler/` and `ir/` IS covered; `internal/` is not.** The
-compiler is also a library — `github.com/mas-bandwidth/schema/compiler` loads
+compiler is also a library — `github.com/mas-bandwidth/schema/v2/compiler` loads
 and checks units and generates through registered generators;
-`github.com/mas-bandwidth/schema/ir` is the checked unit those generators read.
+`github.com/mas-bandwidth/schema/v2/ir` is the checked unit those generators read.
 From the first release that carries them, their exported surface follows the
 rules above: breaking it is a major, adding to it is a minor. Everything under
 `internal/` — the scanner, parser, AST, checker and the six per-language

--- a/bench/tools/realpacket-gen/main.go
+++ b/bench/tools/realpacket-gen/main.go
@@ -43,8 +43,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/format"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/format"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 const (

--- a/bench/tools/realpacket-gen/pin_test.go
+++ b/bench/tools/realpacket-gen/pin_test.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 const (

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -8,7 +8,7 @@
 //	schema version                                   print the build identity
 //
 // Every command here is a few lines over the public API in
-// github.com/mas-bandwidth/schema/compiler: this binary holds the CLI's
+// github.com/mas-bandwidth/schema/v2/compiler: this binary holds the CLI's
 // policy — which flags exist, what gets printed, what the exit code is, where
 // the bytes land — and none of the compiler. Anything it can do, an embedder
 // can do.
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/mas-bandwidth/schema/compiler"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 func main() {

--- a/compiler/builtin.go
+++ b/compiler/builtin.go
@@ -1,13 +1,13 @@
 package compiler
 
 import (
-	cgen "github.com/mas-bandwidth/schema/internal/codegen/c"
-	"github.com/mas-bandwidth/schema/internal/codegen/cpp"
-	"github.com/mas-bandwidth/schema/internal/codegen/csharp"
-	"github.com/mas-bandwidth/schema/internal/codegen/golang"
-	"github.com/mas-bandwidth/schema/internal/codegen/js"
-	"github.com/mas-bandwidth/schema/internal/codegen/rust"
-	"github.com/mas-bandwidth/schema/ir"
+	cgen "github.com/mas-bandwidth/schema/v2/internal/codegen/c"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/cpp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/csharp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/golang"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/js"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/rust"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // builtins is the set [New] registers. The per-language emitters stay

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -20,11 +20,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/format"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/internal/version"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/format"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/internal/version"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // A Compiler is one driver instance: the generator registry plus the load

--- a/compiler/generate.go
+++ b/compiler/generate.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Options carries the per-target settings a generate request names, keyed by

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mas-bandwidth/schema
+module github.com/mas-bandwidth/schema/v2
 
 go 1.26

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -4,7 +4,7 @@ package ast
 import (
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/internal/scanner"
+	"github.com/mas-bandwidth/schema/v2/internal/scanner"
 )
 
 type Pos = scanner.Pos

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -15,8 +15,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // SourceFile is one *.schema file of the unit.

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
 )
 
 func runUnit(t *testing.T, sources map[string]string) []error {

--- a/internal/check/projection_test.go
+++ b/internal/check/projection_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // build compiles a one-file unit and returns it, failing the test on any error.

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -40,7 +40,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Generate returns filename -> contents for the unit: a header and a source

--- a/internal/codegen/c/c_test.go
+++ b/internal/codegen/c/c_test.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 func unitFromSource(t *testing.T, name, src string) *ir.Unit {

--- a/internal/codegen/c/dispatch.go
+++ b/internal/codegen/c/dispatch.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // emitMaxBits emits a type's worst-case wire size. Callers size their buffers

--- a/internal/codegen/c/expr.go
+++ b/internal/codegen/c/expr.go
@@ -12,8 +12,8 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // renderInt renders an integer expression symbolically where its constant

--- a/internal/codegen/c/fields.go
+++ b/internal/codegen/c/fields.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // call wraps an expression that returns 1/0 in the early-out the whole target

--- a/internal/codegen/c/spineinline.go
+++ b/internal/codegen/c/spineinline.go
@@ -1,6 +1,6 @@
 package c
 
-import "github.com/mas-bandwidth/schema/ir"
+import "github.com/mas-bandwidth/schema/v2/ir"
 
 // fileEmitsWire reports whether this wire file will emit any read/write wire
 // function — struct or union wire pairs.

--- a/internal/codegen/c/utf8.go
+++ b/internal/codegen/c/utf8.go
@@ -1,6 +1,6 @@
 package c
 
-import "github.com/mas-bandwidth/schema/ir"
+import "github.com/mas-bandwidth/schema/v2/ir"
 
 // fileHasStrings reports whether any declaration in the file carries a
 // string(N) field — the trigger for emitting the UTF-8 validator the

--- a/internal/codegen/cpp/cpp.go
+++ b/internal/codegen/cpp/cpp.go
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Generate returns basename.h -> file contents for every file of the unit.

--- a/internal/codegen/cpp/cpp_test.go
+++ b/internal/codegen/cpp/cpp_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 func unitFromSources(t *testing.T, sources map[string]string) *ir.Unit {

--- a/internal/codegen/cpp/functions.go
+++ b/internal/codegen/cpp/functions.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // ---- worst-case wire size: shared in ir/wire.go ----

--- a/internal/codegen/cpp/readinline.go
+++ b/internal/codegen/cpp/readinline.go
@@ -1,6 +1,6 @@
 package cpp
 
-import "github.com/mas-bandwidth/schema/ir"
+import "github.com/mas-bandwidth/schema/v2/ir"
 
 // fileEmitsWire reports whether this wire file will emit any Write/Read wire
 // function — struct or union wire pairs. Files that only carry

--- a/internal/codegen/cpp/utf8.go
+++ b/internal/codegen/cpp/utf8.go
@@ -1,6 +1,6 @@
 package cpp
 
-import "github.com/mas-bandwidth/schema/ir"
+import "github.com/mas-bandwidth/schema/v2/ir"
 
 // fileHasStrings reports whether any declaration in the file carries a
 // string(N) field — the trigger for emitting the UTF-8 validator the

--- a/internal/codegen/csharp/batch.go
+++ b/internal/codegen/csharp/batch.go
@@ -40,7 +40,7 @@
 package csharp
 
 import (
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // batchWorthwhile is the density threshold — see the package comment above.

--- a/internal/codegen/csharp/csharp.go
+++ b/internal/codegen/csharp/csharp.go
@@ -45,8 +45,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Generate returns basename.cs -> file contents for every file of the unit.

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // emitStructFunctions emits MaxBits/MaxBytes, the Zero helper, and the split

--- a/internal/codegen/golang/functions.go
+++ b/internal/codegen/golang/functions.go
@@ -9,7 +9,7 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // emitUnionFunctions emits the union's bounds and wire pair (SPEC §4.8): the

--- a/internal/codegen/golang/golang.go
+++ b/internal/codegen/golang/golang.go
@@ -25,8 +25,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Generate returns basename.go -> file contents for every file of the unit.

--- a/internal/codegen/golang/golang_test.go
+++ b/internal/codegen/golang/golang_test.go
@@ -4,14 +4,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	cgen "github.com/mas-bandwidth/schema/internal/codegen/c"
-	"github.com/mas-bandwidth/schema/internal/codegen/cpp"
-	"github.com/mas-bandwidth/schema/internal/codegen/csharp"
-	"github.com/mas-bandwidth/schema/internal/codegen/js"
-	"github.com/mas-bandwidth/schema/internal/codegen/rust"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	cgen "github.com/mas-bandwidth/schema/v2/internal/codegen/c"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/cpp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/csharp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/js"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/rust"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 func countAcross(files map[string][]byte, needle string) int {

--- a/internal/codegen/js/flat.go
+++ b/internal/codegen/js/flat.go
@@ -54,7 +54,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // fgen emits one BaseFlat.js module.

--- a/internal/codegen/js/functions.go
+++ b/internal/codegen/js/functions.go
@@ -23,7 +23,7 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // emitUnionFunctions emits the union's bounds, Zero helper and wire pair

--- a/internal/codegen/js/js.go
+++ b/internal/codegen/js/js.go
@@ -54,8 +54,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Generate returns basename.js -> file contents for every file of the unit.

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -13,8 +13,8 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // emitUnionFunctions emits the union's bounds and wire pair (SPEC §4.8). The

--- a/internal/codegen/rust/rust.go
+++ b/internal/codegen/rust/rust.go
@@ -26,8 +26,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Generate returns module filename -> file contents for every file of the

--- a/internal/codegen/rust/rust_test.go
+++ b/internal/codegen/rust/rust_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 func unitFromSource(t *testing.T, name, src string) *ir.Unit {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -13,9 +13,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/internal/scanner"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/internal/scanner"
 )
 
 // Format canonicalizes one schema file. The returned bytes may equal the

--- a/internal/format/migrate.go
+++ b/internal/format/migrate.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/scanner"
+	"github.com/mas-bandwidth/schema/v2/internal/scanner"
 )
 
 // Migrate rewrites retired spellings in src into the current grammar, then

--- a/internal/fuzz/fuzz_test.go
+++ b/internal/fuzz/fuzz_test.go
@@ -25,14 +25,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	cgen "github.com/mas-bandwidth/schema/internal/codegen/c"
-	"github.com/mas-bandwidth/schema/internal/codegen/cpp"
-	"github.com/mas-bandwidth/schema/internal/codegen/csharp"
-	"github.com/mas-bandwidth/schema/internal/codegen/golang"
-	"github.com/mas-bandwidth/schema/internal/codegen/rust"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	cgen "github.com/mas-bandwidth/schema/v2/internal/codegen/c"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/cpp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/csharp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/golang"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/rust"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // backends is the full emitter set, shared by drive and the compile fuzz

--- a/internal/fuzz/property_test.go
+++ b/internal/fuzz/property_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/format"
-	"github.com/mas-bandwidth/schema/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/format"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
 )
 
 func corpusUnits(t *testing.T) map[string][]check.SourceFile {

--- a/internal/goldens/goldens_test.go
+++ b/internal/goldens/goldens_test.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/compiler"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 var update = flag.Bool("update", false, "rewrite the golden files from current output")

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
-	"github.com/mas-bandwidth/schema/internal/scanner"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/internal/scanner"
 )
 
 // Parse scans and parses one file.

--- a/internal/publicapi/publicapi_test.go
+++ b/internal/publicapi/publicapi_test.go
@@ -1,6 +1,6 @@
 // Package publicapi is the acceptance gate on the public compiler API
 // : a Go module OUTSIDE this one, importing nothing but
-// github.com/mas-bandwidth/schema/compiler and .../ir, builds a schema
+// github.com/mas-bandwidth/schema/v2/compiler and .../ir, builds a schema
 // compiler that emits the same bytes this repo's own binary emits.
 //
 // Two legs, because the claim has two halves.
@@ -36,8 +36,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/compiler"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // the corpora, from this package's directory.
@@ -103,13 +103,13 @@ func TestExternalModuleBuildsTheCLI(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Contains(main, []byte("mas-bandwidth/schema/internal/")) {
+	if bytes.Contains(main, []byte("mas-bandwidth/schema/v2/internal/")) {
 		t.Fatal("cmd/schema imports an internal package — the CLI is supposed to be a client of the public API")
 	}
 	if err := os.WriteFile(filepath.Join(clientDir, "main.go"), main, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	gomod := fmt.Sprintf("module schemacli\n\ngo 1.26\n\nrequire github.com/mas-bandwidth/schema v0.0.0\n\nreplace github.com/mas-bandwidth/schema => %s\n", root)
+	gomod := fmt.Sprintf("module schemacli\n\ngo 1.26\n\nrequire github.com/mas-bandwidth/schema/v2 v2.0.0\n\nreplace github.com/mas-bandwidth/schema/v2 => %s\n", root)
 	if err := os.WriteFile(filepath.Join(clientDir, "go.mod"), []byte(gomod), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/publicapi/testdata/client/go.mod
+++ b/internal/publicapi/testdata/client/go.mod
@@ -2,6 +2,6 @@ module schemaclient
 
 go 1.26
 
-require github.com/mas-bandwidth/schema v0.0.0
+require github.com/mas-bandwidth/schema/v2 v2.0.0
 
-replace github.com/mas-bandwidth/schema => ../../../..
+replace github.com/mas-bandwidth/schema/v2 => ../../../..

--- a/internal/publicapi/testdata/client/main.go
+++ b/internal/publicapi/testdata/client/main.go
@@ -5,7 +5,7 @@
 //
 // It is a module of its own (see go.mod), so Go's internal rule applies to it
 // exactly as it applies to a stranger's repository: an import of
-// github.com/mas-bandwidth/schema/internal/... does not compile here. What
+// github.com/mas-bandwidth/schema/v2/internal/... does not compile here. What
 // this program does is therefore what anyone can do.
 package main
 
@@ -15,8 +15,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/compiler"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // widths is a generator that emits nothing a language would compile — it

--- a/ir/align_test.go
+++ b/ir/align_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 // Each type carries one fixed byte array named data; the table below says

--- a/ir/emission.go
+++ b/ir/emission.go
@@ -1,7 +1,7 @@
 package ir
 
 import (
-	"github.com/mas-bandwidth/schema/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
 )
 
 // EmissionOrder returns the file's declarations in an order where every

--- a/ir/expr.go
+++ b/ir/expr.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
 )
 
 // RenderExpr renders a kept expression in schema source form: literals keep

--- a/ir/expr_test.go
+++ b/ir/expr_test.go
@@ -9,9 +9,9 @@ package ir_test
 import (
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 const exprCorpus = `package exprtest

--- a/ir/filedeps_test.go
+++ b/ir/filedeps_test.go
@@ -10,9 +10,9 @@ package ir_test
 import (
 	"testing"
 
-	"github.com/mas-bandwidth/schema/internal/check"
-	"github.com/mas-bandwidth/schema/internal/parser"
-	"github.com/mas-bandwidth/schema/ir"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
 func loadFiles(t *testing.T, srcs map[string]string) *ir.Unit {

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -7,7 +7,7 @@ package ir
 import (
 	"math/big"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
 )
 
 // Expr is a schema expression the checker resolved but kept, so a backend can

--- a/ir/wire.go
+++ b/ir/wire.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"math/bits"
 
-	"github.com/mas-bandwidth/schema/internal/ast"
+	"github.com/mas-bandwidth/schema/v2/internal/ast"
 )
 
 // BitsRequired mirrors the runtimes' bits_required(min, max): the bit length


### PR DESCRIPTION
Prepares the v2.0.0 major. Version/path bump only — no emission, grammar, or behavior change. The tag itself is cut separately, on Glenn's word.

## Version sites found

The compiler version is stamped at link time from \`git describe\` (\`internal/version/version.go\` + Makefile \`LDFLAGS\`), deliberately never embedded in generated output — so there is **no source version constant to bump** and **no golden churn** (zero diffs under \`generated/\` and \`testdata/\`). The sites that carry the version are the module path and the docs that quote it:

- \`go.mod\` — module path → \`github.com/mas-bandwidth/schema/v2\`
- every internal self-import across 45 \`.go\` files (cmd, compiler, ir, internal/*, bench/tools) → \`/v2\` path
- \`Makefile\` — the \`-X …/internal/version.version\` linker stamp path → \`/v2\`
- \`internal/publicapi/publicapi_test.go\` — the generated client \`go.mod\` (\`require …/v2 v2.0.0\`, \`replace …/v2\`) and the internal-import guard string → \`/v2\` form
- \`internal/publicapi/testdata/client/go.mod\` — require/replace → \`/v2 v2.0.0\`
- \`USAGE.md\` — the custom-generator import example and the pkg.go.dev/ir link → \`/v2\`
- \`VERSIONING.md\` — the library import paths → \`/v2\`; the "History: the v2 line" section updated to present state: the retired early v2.0.0/v2.1.0 tags were re-versioned into 1.x as v1.6.0, and today's 2.x line starts at the v2.0.0 following v1.16.0 with the \`/v2\` module path
- no \`go install\`/\`go get\` instructions exist anywhere in the docs — nothing to update there

Left alone, correctly: the README CI-badge URL and CONTRIBUTING's \`git clone\` URL (GitHub web/git URLs, not module paths), and the serialize runtime repo links.

## Proxy safety

proxy.golang.org has **no cached versions** under \`github.com/mas-bandwidth/schema/v2\` — the retired early v2 tags never indexed, so the future v2.0.0 tag lands on a clean slate. Base module lists through v1.16.0 as expected.

## Receipts

- \`go build ./...\` — clean
- \`go vet ./...\` — clean; \`gofmt\` — clean
- \`go test ./...\` — all 12 test packages pass, including \`internal/publicapi\`, which builds an external client module against the \`/v2\` path (the strongest proof of the sweep)
- \`make test\` — full six-language conformance green, all legs OK
- \`git status\` clean after \`make test\` — the committed \`generated/\` tree is current under the new path

Diff: 54 files, +126/−124 — import paths and doc lines only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)