### PR TITLE
Support line: link to Patreon membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml/badge.svg)](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
+If this work helps you, please support it: **[Become a supporter](https://www.patreon.com/MasBandwidth/membership)**
+
 Write your data types once and generate code to read and write them in six languages.
 
 ```


### PR DESCRIPTION
One support line in the house position linking to https://www.patreon.com/MasBandwidth/membership. Existing support mentions converged on the same URL. Per-repo FUNDING.yml (where present) removed so the org-wide default in mas-bandwidth/.github governs the Sponsor button.