### PR TITLE
The C/C++ reference lock: a CI guard that makes the freeze mechanical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,3 +343,37 @@ jobs:
           cache: false
       - run: go vet ./...
       - run: go build ./...
+
+  # The C/C++ reference lock (owner ruling 2026-08-31, issue #170): while
+  # bench/LOCK exists, a PR touching any locked prefix refuses. The lift is
+  # a PR whose whole diff is bench/LOCK itself — visible by construction.
+  cpp-lock:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: refuse locked-path changes
+        run: |
+          [ -f bench/LOCK ] || { echo "no bench/LOCK — guard inactive"; exit 0; }
+          base="origin/${{ github.base_ref }}"
+          changed="$(git diff --name-only "$base"...HEAD)"
+          echo "changed files vs $base:"; echo "$changed"
+          if [ "$changed" = "bench/LOCK" ]; then
+            echo "diff touches only bench/LOCK — the lift act, allowed"; exit 0
+          fi
+          prefixes="$(grep -v '^#' bench/LOCK | grep -v '^[[:space:]]*$')"
+          violations=""
+          while IFS= read -r f; do
+            while IFS= read -r p; do
+              case "$f" in "$p"*) violations="$violations$f (locked: $p)"$'\n';; esac
+            done <<< "$prefixes"
+          done <<< "$changed"
+          if [ -n "$violations" ]; then
+            echo "C/C++ LOCK REFUSAL — these paths are frozen while bench/LOCK stands (issue #170):"
+            printf '%s' "$violations"
+            exit 1
+          fi
+          echo "no locked paths touched — clean"

--- a/bench/LOCK
+++ b/bench/LOCK
@@ -1,0 +1,26 @@
+# The C/C++ reference lock — owner ruling, 2026-08-31, on issue #170:
+#
+#   "Please lock and do not make further changes to C/C++ during optimization
+#    and profiling."
+#
+# While this file exists, CI's cpp-lock job REFUSES any pull request that
+# modifies a path under the prefixes below. The C and C++ generated legs,
+# bench code, and emitters are the frozen reference for the laggard round —
+# any movement in the C/C++ rows is an alarm, never a breakthrough.
+#
+# Lifting the lock is deliberate and visible: a PR whose diff touches ONLY
+# this file (deleting it) passes the guard by construction and says what it
+# is doing in the open. The lift condition is the round closing, on the
+# owner's word (issue #170).
+#
+# Locked prefixes, one per line (matched against changed paths):
+internal/codegen/c/
+internal/codegen/cpp/
+bench/c/
+bench/cpp/
+generated/c/
+generated/cpp/
+generated/c-ludicrous/
+generated/cpp-ludicrous/
+generated/bench/c/
+generated/bench/cpp/


### PR DESCRIPTION
Enacts the owner ruling on #170 (2026-08-31): C/C++ is locked during the optimization round. While `bench/LOCK` exists, the new `cpp-lock` job refuses any PR touching the locked prefixes (the c/cpp emitters, bench legs, and generated outputs). A PR whose entire diff is `bench/LOCK` itself passes — that is the visible lift act, taken on the owner's word when the round closes.

The guard turns the ruling from a promise into a refuser: with the #178 baselines committed and these paths frozen, any movement in the C/C++ reference rows is an alarm by definition, not a breakthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)