### PR TITLE
NEGATIVE CONTROL: cpp-lock must refuse this PR (do not merge)

### DIFF
--- a/bench/cpp/bench_main.cpp
+++ b/bench/cpp/bench_main.cpp
@@ -1418,3 +1418,4 @@ int main( int argc, char ** argv )
     ( void ) g_sink;
     return 0;
 }
+


### PR DESCRIPTION
One appended newline to bench/cpp/bench_main.cpp — a locked path under bench/LOCK. This PR exists to prove the cpp-lock guard goes red on the class it guards; it closes unmerged once the red is observed. A guard never seen to fail is decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)