### PR TITLE
Bench equalization pass: full-struct sinks across the nine legs, loud skips, the caption — the blended table republished (#175)

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -642,6 +642,24 @@ stride clause was added 2026-08-15, with the measurement that demanded it):
 - **Escape barriers.** Empty-asm memory clobber (C/C++), `std::hint::black_box`
   (Rust), `runtime.KeepAlive` + package sink (Go), `GC.KeepAlive` + static sink (C#).
   Write barriers observe the **buffer**, not `buffer[0]`.
+- **Read-side sink discipline (#175): every read loop observes the FULL
+  decoded struct per iteration, by one of two mechanisms, each meeting one
+  bar — every decoded field store materializes in memory every iteration
+  and cannot be elided.** The native legs get it free: the C/C++ clobber
+  and Rust's `black_box(&out)` are zero-cost memory barriers over the whole
+  struct, and the Go and C# read calls are opaque out-of-line calls taking
+  the decode target's pointer (verified in the emitted assembly — an
+  indirect call through a function value / delegate per iteration), with
+  KeepAlive pinning liveness. The JIT/managed legs whose decode call the
+  compiler inlines (java, dart, js, elixir) have no free barrier, so their
+  idiom is a per-iteration fold of every decoded field into the sink —
+  numbers added, booleans as 0/1, arrays element-by-element over the
+  decoded extent, floats bitcast or truncated, JS BigInt observed by
+  allocation-free comparison. The fold is real work the barrier languages
+  do not pay; those legs' read numbers are therefore **upper bounds**
+  carrying the observation cost (measured on bench_mixed, M2: java -20%,
+  js-flat -29%, dart -5%, elixir -28% read rate against the pre-#175
+  narrow sinks).
 - **The decode target is hoisted out of the timed loop** and reused, in every
   language. Constructing a fresh zeroed message per iteration is harness overhead
   charged to the library. `bench/cpp/bench_main.cpp:250-256` already documents this;
@@ -659,9 +677,24 @@ comparison costs minutes, not an evening; nothing it prints publishes.
   cannot hold quick mode's one-minute-per-leg bound: elixir runs 8,000,000
   (the BEAM is ~2 orders behind the native legs). Every count is recorded
   in the `iters` column as always.
-- The driver prints the blended table: per-language per-message time
-  `t = (1/w + 1/r) / 2` over the §2.2 headline (max) rates, sorted
-  ascending, fastest = 100%, every other language as its time multiple.
+- The driver prints **two blended sections, one per subject, never ranked
+  against each other** (the profiling doctrine's apples-to-apples rule,
+  enacted for the table by #177/#178): the headline section is family
+  `gen` — every language's schema-GENERATED code, the native legs included
+  since their generated Bench legs landed — and the second labeled section
+  is family `rt`, the serialize runtime API called by hand. Within a
+  section: per-language per-message time `t = (1/w + 1/r) / 2` over the
+  §2.2 headline (max) rates, sorted ascending, fastest = 100%, every other
+  language as its time multiple. Family and `checks` mode print per row
+  (checks is a recorded, NOT equalized property — §3.4), the js blend takes
+  the `codec=flat` tier only (THE js path; `codec=runtime` rows never
+  blend), and a caption above the sections names what is held constant:
+  contract, corpus, machine, sitting, and the equalized full-struct sink
+  discipline (#175).
+- A language whose leg cannot run prints as an **ABSENT row with the
+  reason** in the headline section, and an `--only` invocation that
+  produced zero data rows **exits non-zero** — a skipped leg is a refusal,
+  never a quietly green empty table (#175).
 - Warmup stays adequate for the JIT legs — the discarded run is tens of
   millions of iterations, which carries the JVM to C2/OSR; a quick leg that
   shortened warmup below that would measure the interpreter and be wrong

--- a/bench/README.md
+++ b/bench/README.md
@@ -250,6 +250,10 @@ A runner is a standalone program in `bench/<lang>/` that:
    the batch builder exactly);
 4. uses the same discipline: escape barriers (or the language's equivalent,
    e.g. `runtime.KeepAlive` / `std::hint::black_box` / `GC.KeepAlive`),
+   the read-side full-struct sink (BENCH-STANDARD §2.7: every read loop
+   observes every decoded field per iteration — a zero-cost memory barrier
+   or opaque call where the language has one, a per-iteration field fold
+   into the sink where it does not),
    warmup, 7 measured runs, median + min/max + spread;
 5. emits CSV v2 rows on stdout (given `--csv`) in the format above with its
    own `lang` value and its recorded `linkage`/`checks`/`opt` constants,

--- a/bench/dart/main.dart
+++ b/bench/dart/main.dart
@@ -61,6 +61,54 @@ double now() => _clock.elapsedMicroseconds * 1e-6;
 // loop's work can be deleted
 int sink = 0;
 
+/* --------------------------------------------------------------------------
+   read-side sink discipline (#175, equalized to the cpp/c reference): every
+   read loop observes the FULL decoded struct per iteration. The C/C++ legs
+   get this for free from an empty-asm memory clobber over the whole struct;
+   Dart has no zero-cost clobber, so the leg's idiom is a per-iteration sum
+   of every decoded field — doubles truncated via toInt(), booleans as 0/1,
+   byte arrays element-by-element. The sink adds are real work the clobber
+   languages do not pay; the published number is an upper bound on the
+   observation cost.
+   -------------------------------------------------------------------------- */
+
+int sinkOfBenchPacket(BenchPacket d) {
+  var s = d.a +
+      d.b +
+      d.c +
+      d.bits7 +
+      d.bits13 +
+      d.bits23 +
+      (d.flag ? 1 : 0) +
+      d.x.toInt() +
+      d.y.toInt() +
+      d.z.toInt() +
+      d.big;
+  for (var i = 0; i < 17; i++) {
+    s += d.blob[i];
+  }
+  return s;
+}
+
+int sinkOfBenchInts(BenchInts d) =>
+    d.f0 + d.f1 + d.f2 + d.f3 + d.f4 + d.f5 + d.f6 + d.f7 + d.f8 + d.f9;
+
+int sinkOfBenchBits(BenchBits d) =>
+    d.b7 + d.b13 + d.b23 + d.b3 + d.b32 + d.b11 + d.b19 + d.b48;
+
+int sinkOfBenchMixed(BenchMixed d) =>
+    d.sequence +
+    d.ackBits +
+    d.entityId +
+    d.posX +
+    d.posY +
+    d.posZ +
+    d.yaw +
+    (d.moving ? 1 : 0) +
+    (d.firing ? 1 : 0) +
+    d.timestamp +
+    d.weapon;
+
 Never gateFail(String row, String what) {
   stderr.write('GOLDEN GATE FAILED: $row $what\nreporting nothing.\n');
   exit(1);
@@ -530,7 +578,7 @@ void main(List<String> arguments) {
       varyBenchMixed,
       writeBenchMixed,
       readBenchMixed,
-      (BenchMixed d) => d.sequence,
+      sinkOfBenchMixed, // full-struct observation (#175)
     );
   } else {
     final gatedPacket = gateShape(
@@ -574,7 +622,7 @@ void main(List<String> arguments) {
       varyBenchPacket,
       writeBenchPacket,
       readBenchPacket,
-      (BenchPacket d) => d.b,
+      sinkOfBenchPacket, // full-struct observation (#175)
     );
     benchShape(
       'bench_ints',
@@ -583,7 +631,7 @@ void main(List<String> arguments) {
       varyBenchInts,
       writeBenchInts,
       readBenchInts,
-      (BenchInts d) => d.f0,
+      sinkOfBenchInts, // full-struct observation (#175)
     );
     benchShape(
       'bench_bits',
@@ -592,7 +640,7 @@ void main(List<String> arguments) {
       varyBenchBits,
       writeBenchBits,
       readBenchBits,
-      (BenchBits d) => d.b7,
+      sinkOfBenchBits, // full-struct observation (#175)
     );
     benchShape(
       'bench_mixed',
@@ -601,7 +649,7 @@ void main(List<String> arguments) {
       varyBenchMixed,
       writeBenchMixed,
       readBenchMixed,
-      (BenchMixed d) => d.sequence,
+      sinkOfBenchMixed, // full-struct observation (#175)
     );
   }
 

--- a/bench/elixir/main.exs
+++ b/bench/elixir/main.exs
@@ -1,29 +1,18 @@
-# schema bench — the Elixir runner (minimal form): the generated monomorphic
-# codecs over the four family `rt` shapes (BENCH-STANDARD.md §1.3), measured
-# with serialize.elixir's own bench methodology so the rows read side by side
-# with that library's — same LCG, same vary-function field mappings, same
-# iteration counts, same 64 read variants, same best-of-five discipline,
-# same units and reporting format (serialize.elixir bench/bench.exs is the
-# reference for all of it). This is the issue #167 prediction instrument:
-# generated single-function accumulator-threaded code vs the library's
-# per-op immutable streams (the measured 7x allocation ceiling).
+# schema bench — the Elixir runner's entry point. The generated monomorphic
+# codecs over the four bench/corpus/Bench.schema shapes, measured under the
+# BENCH-STANDARD contract: fixed iteration counts identical to every other
+# runner's rows, 1 discarded warmup run then 7 measured runs per
+# (bench, path) (--round K: one measured run; --quick: bench_mixed only,
+# 3 runs at a reduced count), per-iteration LCG variation, 64 rotating
+# variant read buffers, CSV v2 rows on stdout under --csv. The contract,
+# the golden gate, and the full-struct read sink live in runner.exs — this
+# file only loads, because an .exs compiles as a whole before it runs, so
+# the struct literals must live in a file required after the generated
+# modules.
 #
-# GOLDEN GATED (§1.5): before any row is timed, every pinned corpus
-# instance is written and byte-compared against the C++-pinned
-# testdata/wire golden, and all 64 LCG variant buffers of every shape are
-# decoded back with every field verified. A runner that mismatches REFUSES
-# to bench.
+# run.sh invokes it from bench/elixir under the repo-pinned BEAM toolchain:
 #
-#   cd bench/elixir && PATH="<dist toolchain>:$PATH" elixir main.exs
-#
-# Iteration counts are overridable, the library bench's own env names:
-#   BENCH_STREAM_PACKETS=100000 elixir main.exs
-#
-# Full run.sh/CSV-preamble integration per bench/README.md is a named
-# follow-on (the same standing as the Dart runner); this runner carries the
-# golden gate, the methodology and the rows.
-#
-# This file only loads — an .exs compiles as a whole before it runs, so the
-# struct literals live in runner.exs, required after the generated modules.
+#   cd bench/elixir && PATH="<dist otp>:<dist elixir>:$PATH" \
+#       elixir main.exs [--csv] [--round K] [--quick]
 Code.require_file("Bench.ex", Path.join(__DIR__, "../../generated/bench/elixir"))
 Code.require_file("runner.exs", __DIR__)

--- a/bench/elixir/runner.exs
+++ b/bench/elixir/runner.exs
@@ -329,6 +329,81 @@ defmodule SchemaBenchElixir do
     read_loop(n - 1, i + 1, variants, read, num_bits, sink_of, acc + sink_of.(decoded))
   end
 
+  # read-side sink discipline (#175, equalized to the cpp/c reference): every
+  # read loop observes the FULL decoded struct per iteration. The C/C++ legs
+  # get this for free from an empty-asm memory clobber over the whole struct;
+  # the BEAM has no zero-cost clobber, so the leg's idiom is a per-iteration
+  # sum of every decoded field — floats truncated, booleans as 0/1, the blob
+  # list element-by-element. The sink adds are real work the clobber
+  # languages do not pay; the published number is an upper bound on the
+  # observation cost.
+
+  defp bool_bit(true), do: 1
+  defp bool_bit(false), do: 0
+
+  defp sink_of_bench_packet(%Bench.BenchPacket{
+         a: a,
+         b: b,
+         c: c,
+         bits7: b7,
+         bits13: b13,
+         bits23: b23,
+         flag: flag,
+         x: x,
+         y: y,
+         z: z,
+         big: big,
+         blob: blob
+       }) do
+    a + b + c + b7 + b13 + b23 + bool_bit(flag) +
+      trunc(x) + trunc(y) + trunc(z) + big + Enum.sum(blob)
+  end
+
+  defp sink_of_bench_ints(%Bench.BenchInts{
+         f0: f0,
+         f1: f1,
+         f2: f2,
+         f3: f3,
+         f4: f4,
+         f5: f5,
+         f6: f6,
+         f7: f7,
+         f8: f8,
+         f9: f9
+       }) do
+    f0 + f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8 + f9
+  end
+
+  defp sink_of_bench_bits(%Bench.BenchBits{
+         b7: b7,
+         b13: b13,
+         b23: b23,
+         b3: b3,
+         b32: b32,
+         b11: b11,
+         b19: b19,
+         b48: b48
+       }) do
+    b7 + b13 + b23 + b3 + b32 + b11 + b19 + b48
+  end
+
+  defp sink_of_bench_mixed(%Bench.BenchMixed{
+         sequence: sequence,
+         ack_bits: ack_bits,
+         entity_id: entity_id,
+         pos_x: pos_x,
+         pos_y: pos_y,
+         pos_z: pos_z,
+         yaw: yaw,
+         moving: moving,
+         firing: firing,
+         timestamp: timestamp,
+         weapon: weapon
+       }) do
+    sequence + ack_bits + entity_id + pos_x + pos_y + pos_z +
+      yaw + bool_bit(moving) + bool_bit(firing) + timestamp + weapon
+  end
+
   # per (bench, path): 1 discarded warmup run then num_runs measured runs;
   # the rng threads across runs (the write stream keeps varying, never
   # replaying one sequence the branch predictor could memorize)
@@ -446,7 +521,8 @@ defmodule SchemaBenchElixir do
       vary: &vary_bench_mixed/2,
       write: &Bench.Bench.write_bench_mixed/1,
       read: &Bench.Bench.read_bench_mixed/2,
-      sink_of: & &1.sequence
+      # full-struct observation (#175)
+      sink_of: &sink_of_bench_mixed/1
     ]
 
     {rows, goldens} =
@@ -497,21 +573,21 @@ defmodule SchemaBenchElixir do
             vary: &vary_bench_packet/2,
             write: &Bench.Bench.write_bench_packet/1,
             read: &Bench.Bench.read_bench_packet/2,
-            sink_of: & &1.b
+            sink_of: &sink_of_bench_packet/1
           ) ++
             bench_shape("bench_ints", gated_ints, @ints_iters, num_runs,
               init: &init_bench_ints/0,
               vary: &vary_bench_ints/2,
               write: &Bench.Bench.write_bench_ints/1,
               read: &Bench.Bench.read_bench_ints/2,
-              sink_of: & &1.f0
+              sink_of: &sink_of_bench_ints/1
             ) ++
             bench_shape("bench_bits", gated_bits, @bits_iters, num_runs,
               init: &init_bench_bits/0,
               vary: &vary_bench_bits/2,
               write: &Bench.Bench.write_bench_bits/1,
               read: &Bench.Bench.read_bench_bits/2,
-              sink_of: & &1.b7
+              sink_of: &sink_of_bench_bits/1
             ) ++
             bench_shape("bench_mixed", gated_mixed, @mixed_iters, num_runs, mixed_opts)
 

--- a/bench/java/Main.java
+++ b/bench/java/Main.java
@@ -480,7 +480,42 @@ public final class Main {
        item 5 — a shared generic loop pools its type profile across shapes
        and turns the timings bimodal), each a normally-compiled method body
        calling the generated statics directly.
+
+       Read-side sink discipline (#175, equalized to the cpp/c reference):
+       every read loop observes the FULL decoded struct per iteration. The
+       C/C++ legs get this for free from an empty-asm memory clobber over
+       the whole struct; Java has no zero-cost clobber, so the leg's idiom
+       is a per-iteration sum of every decoded field into the static sink —
+       floats via floatToRawIntBits (a bitcast, not a conversion), booleans
+       as 0/1, byte arrays element-by-element. The sink adds are real work
+       the clobber languages do not pay; the published number is therefore
+       an upper bound on the observation cost (the PR #178 review measured
+       the widening at -23% read on bench_mixed for exactly this loop).
        ---------------------------------------------------------------------- */
+
+    static long sinkOfBenchPacket(Bench.BenchPacket d) {
+        long s = d.a + d.b + d.c + d.bits7 + d.bits13 + d.bits23
+                + (d.flag ? 1 : 0)
+                + Float.floatToRawIntBits(d.x) + Float.floatToRawIntBits(d.y)
+                + Float.floatToRawIntBits(d.z) + d.big;
+        for (int i = 0; i < 17; i++) {
+            s += d.blob[i];
+        }
+        return s;
+    }
+
+    static long sinkOfBenchInts(Bench.BenchInts d) {
+        return (long) d.f0 + d.f1 + d.f2 + d.f3 + d.f4 + d.f5 + d.f6 + d.f7 + d.f8 + d.f9;
+    }
+
+    static long sinkOfBenchBits(Bench.BenchBits d) {
+        return (long) d.b7 + d.b13 + d.b23 + d.b3 + d.b32 + d.b11 + d.b19 + d.b48;
+    }
+
+    static long sinkOfBenchMixed(Bench.BenchMixed d) {
+        return (long) d.sequence + d.ackBits + d.entityId + d.posX + d.posY + d.posZ
+                + d.yaw + (d.moving ? 1 : 0) + (d.firing ? 1 : 0) + d.timestamp + d.weapon;
+    }
 
     static double timePacketWrite(int iters) {
         final double start = now();
@@ -498,7 +533,7 @@ public final class Main {
             if (!Bench.readBenchPacket(packetDecoded, packetVariants[i & (NUM_VARIANTS - 1)], numBits)) {
                 System.exit(1);
             }
-            sink += packetDecoded.b;
+            sink += sinkOfBenchPacket(packetDecoded); // full-struct observation (#175)
         }
         return now() - start;
     }
@@ -519,7 +554,7 @@ public final class Main {
             if (!Bench.readBenchInts(intsDecoded, intsVariants[i & (NUM_VARIANTS - 1)], numBits)) {
                 System.exit(1);
             }
-            sink += intsDecoded.f0;
+            sink += sinkOfBenchInts(intsDecoded); // full-struct observation (#175)
         }
         return now() - start;
     }
@@ -540,7 +575,7 @@ public final class Main {
             if (!Bench.readBenchBits(bitsDecoded, bitsVariants[i & (NUM_VARIANTS - 1)], numBits)) {
                 System.exit(1);
             }
-            sink += bitsDecoded.b7;
+            sink += sinkOfBenchBits(bitsDecoded); // full-struct observation (#175)
         }
         return now() - start;
     }
@@ -561,7 +596,7 @@ public final class Main {
             if (!Bench.readBenchMixed(mixedDecoded, mixedVariants[i & (NUM_VARIANTS - 1)], numBits)) {
                 System.exit(1);
             }
-            sink += mixedDecoded.sequence;
+            sink += sinkOfBenchMixed(mixedDecoded); // full-struct observation (#175)
         }
         return now() - start;
     }

--- a/bench/js/main.mjs
+++ b/bench/js/main.mjs
@@ -176,6 +176,11 @@ function flushCsv() {
     return;
   }
   const id = corpusId();
+  // the CSV v2 header (§5.1), as every other runner emits — its absence
+  // under --only js was the #175 cosmetic
+  process.stdout.write(
+    "lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec," +
+    "max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline\n");
   for (const r of gCsvRows) {
     // the §5.1 codec column is appended only on rows that carry one (the
     // generated-tier rows: flat is THE js path, runtime is supplementary)

--- a/bench/js/main.mjs
+++ b/bench/js/main.mjs
@@ -207,6 +207,164 @@ for (let k = 0; k < NumVariants; k++) {
 }
 
 let gSink = 0; // defeats dead code elimination of computed values
+
+/* --------------------------------------------------------------------------
+   read-side sink discipline (#175, equalized to the cpp/c reference): every
+   read loop observes the FULL decoded struct per iteration. The C/C++ legs
+   get this for free from an empty-asm memory clobber over the whole struct;
+   JS has no clobber, so the leg's idiom is a per-iteration fold of every
+   decoded field into gSink — numbers added, booleans as 0/1, byte/number
+   arrays element-by-element over the decoded extent, and BigInt fields
+   observed through an allocation-free comparison (a BigInt add would
+   allocate per iteration and measure the allocator, not the observation).
+   The folds are real work the clobber languages do not pay; the published
+   number is an upper bound on the observation cost. Each sinkOf is checked
+   finite at the gate, so a typo'd field name (undefined -> NaN) refuses to
+   bench instead of silently poisoning the sink.
+   -------------------------------------------------------------------------- */
+
+const boolBit = (b) => (b ? 1 : 0);
+const bigBit = (x) => (x !== 0n ? 1 : 0);
+function sumBytes(a, n) {
+  let s = 0;
+  for (let i = 0; i < n; i++) {
+    s += a[i];
+  }
+  return s;
+}
+
+function sinkOfBenchPacketGen(d) {
+  return d.A + d.B + d.C + d.Bits7 + d.Bits13 + d.Bits23 + boolBit(d.Flag) +
+    d.X + d.Y + d.Z + bigBit(d.Big) + sumBytes(d.Blob, 17);
+}
+
+function sinkOfBenchIntsGen(d) {
+  return d.F0 + d.F1 + d.F2 + d.F3 + d.F4 + d.F5 + d.F6 + d.F7 + d.F8 + d.F9;
+}
+
+function sinkOfBenchBitsGen(d) {
+  return d.B7 + d.B13 + d.B23 + d.B3 + d.B32 + d.B11 + d.B19 + bigBit(d.B48);
+}
+
+function sinkOfBenchMixedGen(d) {
+  return d.Sequence + d.AckBits + d.EntityId + d.PosX + d.PosY + d.PosZ +
+    d.Yaw + boolBit(d.Moving) + boolBit(d.Firing) + bigBit(d.Timestamp) + d.Weapon;
+}
+
+function sinkOfRigidBody(d) {
+  return d.Position.X + d.Position.Y + d.Position.Z +
+    d.Orientation.X + d.Orientation.Y + d.Orientation.Z + d.Orientation.W +
+    boolBit(d.AtRest) +
+    d.LinearVelocity.X + d.LinearVelocity.Y + d.LinearVelocity.Z +
+    d.AngularVelocity.X + d.AngularVelocity.Y + d.AngularVelocity.Z;
+}
+
+function sinkOfChat(d) {
+  return d.TextLength + sumBytes(d.Text, d.TextLength);
+}
+
+function sinkOfTest(d) {
+  return d.TestA + d.TestB + d.TestC + d.TestD;
+}
+
+function sinkOfInputPacket(d) {
+  let s = d.SynchronizeSequence + bigBit(d.CurrentFrame) + bigBit(d.StartFrame) + d.InputsCount;
+  for (let i = 0; i < d.InputsCount; i++) {
+    const inp = d.Inputs[i];
+    s += inp.StickX + inp.StickY + inp.Throttle + inp.Yaw + inp.Pitch +
+      boolBit(inp.Fire) + boolBit(inp.AltFire) + boolBit(inp.Boost) + boolBit(inp.Brake) +
+      boolBit(inp.Aim) + boolBit(inp.LockOn) + boolBit(inp.Zoom) + boolBit(inp.Ping);
+  }
+  return s;
+}
+
+function sinkOfShipCreate(d) {
+  return d.ShipType +
+    d.Position.X + d.Position.Y + d.Position.Z +
+    d.Rotation.X + d.Rotation.Y + d.Rotation.Z + d.Rotation.W +
+    d.LinearVelocity.X + d.LinearVelocity.Y + d.LinearVelocity.Z +
+    boolBit(d.HasFlags) + bigBit(d.Flags) + d.Team + d.Health + d.Thrust + d.Pending;
+}
+
+function sinkOfProbeHeader(d) {
+  return d.Version + bigBit(d.ProbeId);
+}
+
+function sinkOfProbeBits(d) {
+  return d.Small + bigBit(d.Boundary) + bigBit(d.Wide) + d.Sensor + bigBit(d.Nonce);
+}
+
+function sinkOfProbeSample(s) {
+  let v = boolBit(s.Active) + s.Orientation + s.RawDelta + bigBit(s.BigDelta) +
+    s.Weapon + boolBit(s.HasTarget) + s.TargetId + s.IdleTicks + s.SamplesCount;
+  for (let i = 0; i < s.SamplesCount; i++) {
+    v += s.Samples[i];
+  }
+  return v;
+}
+
+function sinkOfProbeArray(d) {
+  return sinkOfProbeSample(d.Samples[0]) + sinkOfProbeSample(d.Samples[1]) +
+    d.Config.Retries + d.Config.Preferred;
+}
+
+function sinkOfTestData(d) {
+  let s = d.A + d.B + d.C + d.D + d.E + d.F + boolBit(d.G) + d.ItemsCount;
+  for (let i = 0; i < d.ItemsCount; i++) {
+    s += d.Items[i];
+  }
+  s += d.FloatValue + d.CompressedFloatValue + d.DoubleValue +
+    d.Int8Value + d.Int16Value + d.Uint8Value + d.Uint16Value + d.Uint32Value +
+    bigBit(d.Uint64Value) + bigBit(d.Int64Full) + bigBit(d.Int64Range) +
+    sumBytes(d.FixedBytes, 17) + d.TextLength + sumBytes(d.Text, d.TextLength);
+  return s;
+}
+
+function sinkOfRealPacket(d) {
+  return d.F001Int + d.F002F64 + d.F003Int + d.F004Cf32 + d.F005Uint +
+    d.F006Int + d.F007F32 + bigBit(d.F008U64) + d.F009Int + d.F010F32 +
+    d.F011Bits + boolBit(d.F012Bool) + d.F013F32 + d.F014Uint + d.F015Int +
+    d.F016Fixed + d.F017Uint + d.F018Int + d.F019F64 + d.F020F32 +
+    d.F021Ufixed + d.F022F32 + d.F023Bits + d.F024F32 + d.F025Fixed +
+    d.F026Bits + d.F027Cf32 + d.F028Bits + bigBit(d.F029I64) + d.F030F32 +
+    d.F031Bits + d.F032Int + d.F033Uint + d.F034Uint + d.F035Bits +
+    d.F036Enum + boolBit(d.F037Bool) + boolBit(d.F038Bool) + d.F039Bits + d.F040Fixed +
+    d.F041Int + d.F042Bits + boolBit(d.F043Bool) + d.F044F32 + d.F045Bits +
+    d.F046Uint + d.F047Int + d.F048F64 + d.F049Ufixed + boolBit(d.F050Bool) +
+    boolBit(d.F051Bool) + d.F052Int + d.F053F32 + d.F054Int + boolBit(d.F055Bool) +
+    d.F056Int + d.F057Int + d.F058F32 + d.F059F64 + d.F060Bits +
+    d.F061Cf32 + d.F062Uint + bigBit(d.F063I64) + d.F064Uint + d.F065Cf32 +
+    d.F066Ufixed + d.F067Cf32 + d.F068Cf32 + d.F069Bits + d.F070Uint +
+    d.F071Cf32 + d.F072Cf32 + d.F073Int + boolBit(d.F074Bool) + bigBit(d.F075U64) +
+    d.F076Int + d.F077Int + d.F078Bits + d.F079Uint + boolBit(d.F080Bool) +
+    d.F081Bits + d.F082Bits + d.F083Enum + d.F084Ufixed + d.F085Bits +
+    d.F086Uint + d.F087F64 + d.F088Int + bigBit(d.F089Bits) + d.F090Uint +
+    bigBit(d.F091Flags) + boolBit(d.F092Bool) + bigBit(d.F093Bits) + boolBit(d.F094Bool) + d.F095Fixed +
+    d.F096Bits + d.F097Bits;
+}
+
+// family rt: the holder-object shapes (see makeRt*)
+function sinkOfRtPacket(f) {
+  return f.a.value + f.b.value + f.c.value + f.bits7.value + f.bits13.value +
+    f.bits23.value + boolBit(f.flag.value) + f.x.value + f.y.value + f.z.value +
+    bigBit(f.big.value) + sumBytes(f.blob, 17);
+}
+
+function sinkOfRtInts(f) {
+  return f.f0.value + f.f1.value + f.f2.value + f.f3.value + f.f4.value +
+    f.f5.value + f.f6.value + f.f7.value + f.f8.value + f.f9.value;
+}
+
+function sinkOfRtBits(f) {
+  return f.b7.value + f.b13.value + f.b23.value + f.b3.value + f.b32.value +
+    f.b11.value + f.b19.value + bigBit(f.b48.value);
+}
+
+function sinkOfRtMixed(f) {
+  return f.sequence.value + f.ackBits.value + f.entityId.value + f.posX.value +
+    f.posY.value + f.posZ.value + f.yaw.value + boolBit(f.moving.value) +
+    boolBit(f.firing.value) + bigBit(f.timestamp.value) + f.weapon.value;
+}
 let gCsv = false;
 let gWireDir = "../../testdata/wire";
 let failed = false;
@@ -364,7 +522,7 @@ function deepEqual(a, b) {
 // bytes, fields and verdicts, pinned instance plus all 64 variants) before
 // any timing. Timed loops are per-call flat functions — §3.2's comparable
 // call shape — over caller-owned DataViews, no stream object at all.
-function benchMessageFlat(name, golden, iters, pinned, writeFn, readFn, flatWriteFn, flatReadFn, varyFn) {
+function benchMessageFlat(name, golden, iters, pinned, writeFn, readFn, flatWriteFn, flatReadFn, varyFn, sinkOf) {
   const base = pinned;
   const gView = new DataView(gBuffer.buffer);
 
@@ -408,6 +566,10 @@ function benchMessageFlat(name, golden, iters, pinned, writeFn, readFn, flatWrit
     }
     if (!deepEqual(flOut, rtOut)) {
       fail(name, "flat and runtime reads disagree on fields");
+      return;
+    }
+    if (!Number.isFinite(sinkOf(flOut))) {
+      fail(name, "sinkOf not finite on the decoded pinned instance (typo'd field?)");
       return;
     }
     if (flatWriteFn(flOut, new DataView(gTwin.buffer)) !== bytesPerOp ||
@@ -486,7 +648,7 @@ function benchMessageFlat(name, golden, iters, pinned, writeFn, readFn, flatWrit
         fail(name, "flat read failed in loop");
         return;
       }
-      gSink = (gSink + 1) >>> 0;
+      gSink = (gSink + sinkOf(outValue)) >>> 0; // full-struct observation (#175)
     }
     const elapsed = (performance.now() - start) / 1000.0;
     if (run >= 0) {
@@ -498,7 +660,7 @@ function benchMessageFlat(name, golden, iters, pinned, writeFn, readFn, flatWrit
   report(name, "read", iters, bytesPerOp, stats(readRates), "gen", "flat");
 }
 
-function benchMessage(name, golden, iters, pinned, writeFn, readFn, varyFn, codec = "runtime") {
+function benchMessage(name, golden, iters, pinned, writeFn, readFn, varyFn, sinkOf, codec = "runtime") {
   // self-check 1: the pinned instance matches its wire golden byte-for-byte
   const base = pinned;
   const ws = new WriteStream(gBuffer);
@@ -519,6 +681,10 @@ function benchMessage(name, golden, iters, pinned, writeFn, readFn, varyFn, code
     const checkRs = new ReadStream(gBuffer.subarray(0, bytesPerOp));
     if (!readFn(checkRs, output)) {
       fail(name, "read of pinned instance failed");
+      return;
+    }
+    if (!Number.isFinite(sinkOf(output))) {
+      fail(name, "sinkOf not finite on the decoded pinned instance (typo'd field?)");
       return;
     }
     const tws = new WriteStream(gTwin);
@@ -589,7 +755,7 @@ function benchMessage(name, golden, iters, pinned, writeFn, readFn, varyFn, code
         fail(name, "read failed in loop");
         return;
       }
-      gSink = (gSink + 1) >>> 0;
+      gSink = (gSink + sinkOf(outValue)) >>> 0; // full-struct observation (#175)
     }
     const elapsed = (performance.now() - start) / 1000.0;
     if (run >= 0) {
@@ -1324,7 +1490,7 @@ function rtBenchPacketReadLoop(outValue, iters, views) {
     if (!readRtPacket(rs, outValue)) {
       return false;
     }
-    gSink = (gSink + 1) >>> 0;
+    gSink = (gSink + sinkOfRtPacket(outValue)) >>> 0; // full-struct observation (#175)
   }
   return true;
 }
@@ -1351,7 +1517,7 @@ function rtBenchIntsReadLoop(outValue, iters, views) {
     if (!readRtInts(rs, outValue)) {
       return false;
     }
-    gSink = (gSink + 1) >>> 0;
+    gSink = (gSink + sinkOfRtInts(outValue)) >>> 0; // full-struct observation (#175)
   }
   return true;
 }
@@ -1378,7 +1544,7 @@ function rtBenchBitsReadLoop(outValue, iters, views) {
     if (!readRtBits(rs, outValue)) {
       return false;
     }
-    gSink = (gSink + 1) >>> 0;
+    gSink = (gSink + sinkOfRtBits(outValue)) >>> 0; // full-struct observation (#175)
   }
   return true;
 }
@@ -1405,14 +1571,14 @@ function rtBenchMixedReadLoop(outValue, iters, views) {
     if (!readRtMixed(rs, outValue)) {
       return false;
     }
-    gSink = (gSink + 1) >>> 0;
+    gSink = (gSink + sinkOfRtMixed(outValue)) >>> 0; // full-struct observation (#175)
   }
   return true;
 }
 
 // ---- the family rt driver: §1.5 oracle gate, then the timed loops ----
 
-function benchRt(name, iters, base, outValue, onceWrite, onceRead, writeLoop, readLoop, vary) {
+function benchRt(name, iters, base, outValue, onceWrite, onceRead, writeLoop, readLoop, vary, sinkOf) {
   // oracle 1: the hand-written wire must equal the generated-code golden
   const bytesPerOp = onceWrite(base, gBuffer);
   if (bytesPerOp < 0) {
@@ -1431,6 +1597,10 @@ function benchRt(name, iters, base, outValue, onceWrite, onceRead, writeLoop, re
   }
   if (onceWrite(outValue, gTwin) !== bytesPerOp || !bytesEqual(gTwin.subarray(0, bytesPerOp), gBuffer.subarray(0, bytesPerOp))) {
     fail(name, "round-trip bytes differ");
+    return;
+  }
+  if (!Number.isFinite(sinkOf(outValue))) {
+    fail(name, "sinkOf not finite on the decoded pinned instance (typo'd field?)");
     return;
   }
 
@@ -1783,7 +1953,7 @@ function main() {
   if (gQuick) {
     // --quick: the flat bench_mixed leg only (THE js path for the shape),
     // golden-gated and cross-validated like every flat leg
-    benchMessageFlat("bench_mixed", "bench_mixed", QuickMixedIters, pinBenchMixedGen(), bench.WriteBenchMixed, bench.ReadBenchMixed, benchFlat.WriteBenchMixedFlat, benchFlat.ReadBenchMixedFlat, varyBenchMixedGen);
+    benchMessageFlat("bench_mixed", "bench_mixed", QuickMixedIters, pinBenchMixedGen(), bench.WriteBenchMixed, bench.ReadBenchMixed, benchFlat.WriteBenchMixedFlat, benchFlat.ReadBenchMixedFlat, varyBenchMixedGen, sinkOfBenchMixedGen);
     flushCsv();
     if (failed) {
       process.stderr.write(`BENCH FAILED (corpus_id ${corpusId()})\n`);
@@ -1801,16 +1971,16 @@ function main() {
   // THE js rows: the flat tier, per-call (§3.2's comparable shape), each
   // leg bound to the corpus pins AND cross-validated against the runtime
   // tier (bytes/fields/verdicts, 64 variants) before any timing
-  benchMessageFlat("rigidbody_moving", "rigidbody_moving", 24000000, pinRigidBodyMoving(), ex.WriteRigidBody, ex.ReadRigidBody, exFlat.WriteRigidBodyFlat, exFlat.ReadRigidBodyFlat, varyRigidBody);
-  benchMessageFlat("rigidbody_at_rest", "rigidbody_at_rest", 32000000, atRest, ex.WriteRigidBody, ex.ReadRigidBody, exFlat.WriteRigidBodyFlat, exFlat.ReadRigidBodyFlat, varyRigidBodyAtRest);
-  benchMessageFlat("chat", "chat", 48000000, pinChat(), ex.WriteChat, ex.ReadChat, exFlat.WriteChatFlat, exFlat.ReadChatFlat, varyChat);
-  benchMessageFlat("test", null, 192000000, new ex.Test(), ex.WriteTest, ex.ReadTest, exFlat.WriteTestFlat, exFlat.ReadTestFlat, varyTest);
-  benchMessageFlat("inputpacket", "inputpacket", 16000000, pinInputPacket(), ex.WriteInputPacket, ex.ReadInputPacket, exFlat.WriteInputPacketFlat, exFlat.ReadInputPacketFlat, varyInputPacket);
-  benchMessageFlat("shipcreate", "shipcreate_flags", 32000000, pinShipCreate(), ex.WriteShipCreate, ex.ReadShipCreate, exFlat.WriteShipCreateFlat, exFlat.ReadShipCreateFlat, varyShipCreate);
-  benchMessageFlat("probe_header", "probe_header", 256000000, pinProbeHeader(), ex.WriteProbeHeader, ex.ReadProbeHeader, exFlat.WriteProbeHeaderFlat, exFlat.ReadProbeHeaderFlat, varyProbeHeader);
-  benchMessageFlat("probebits", "probebits", 128000000, pinProbeBits(), ex.WriteProbeBits, ex.ReadProbeBits, exFlat.WriteProbeBitsFlat, exFlat.ReadProbeBitsFlat, varyProbeBits);
-  benchMessageFlat("probearray", "probearray", 20000000, pinProbeArray(), ex.WriteProbeArray, ex.ReadProbeArray, exFlat.WriteProbeArrayFlat, exFlat.ReadProbeArrayFlat, varyProbeArray);
-  benchMessageFlat("testdata", "testdata", 8000000, pinTestData(), ex.WriteTestData, ex.ReadTestData, exFlat.WriteTestDataFlat, exFlat.ReadTestDataFlat, varyTestData);
+  benchMessageFlat("rigidbody_moving", "rigidbody_moving", 24000000, pinRigidBodyMoving(), ex.WriteRigidBody, ex.ReadRigidBody, exFlat.WriteRigidBodyFlat, exFlat.ReadRigidBodyFlat, varyRigidBody, sinkOfRigidBody);
+  benchMessageFlat("rigidbody_at_rest", "rigidbody_at_rest", 32000000, atRest, ex.WriteRigidBody, ex.ReadRigidBody, exFlat.WriteRigidBodyFlat, exFlat.ReadRigidBodyFlat, varyRigidBodyAtRest, sinkOfRigidBody);
+  benchMessageFlat("chat", "chat", 48000000, pinChat(), ex.WriteChat, ex.ReadChat, exFlat.WriteChatFlat, exFlat.ReadChatFlat, varyChat, sinkOfChat);
+  benchMessageFlat("test", null, 192000000, new ex.Test(), ex.WriteTest, ex.ReadTest, exFlat.WriteTestFlat, exFlat.ReadTestFlat, varyTest, sinkOfTest);
+  benchMessageFlat("inputpacket", "inputpacket", 16000000, pinInputPacket(), ex.WriteInputPacket, ex.ReadInputPacket, exFlat.WriteInputPacketFlat, exFlat.ReadInputPacketFlat, varyInputPacket, sinkOfInputPacket);
+  benchMessageFlat("shipcreate", "shipcreate_flags", 32000000, pinShipCreate(), ex.WriteShipCreate, ex.ReadShipCreate, exFlat.WriteShipCreateFlat, exFlat.ReadShipCreateFlat, varyShipCreate, sinkOfShipCreate);
+  benchMessageFlat("probe_header", "probe_header", 256000000, pinProbeHeader(), ex.WriteProbeHeader, ex.ReadProbeHeader, exFlat.WriteProbeHeaderFlat, exFlat.ReadProbeHeaderFlat, varyProbeHeader, sinkOfProbeHeader);
+  benchMessageFlat("probebits", "probebits", 128000000, pinProbeBits(), ex.WriteProbeBits, ex.ReadProbeBits, exFlat.WriteProbeBitsFlat, exFlat.ReadProbeBitsFlat, varyProbeBits, sinkOfProbeBits);
+  benchMessageFlat("probearray", "probearray", 20000000, pinProbeArray(), ex.WriteProbeArray, ex.ReadProbeArray, exFlat.WriteProbeArrayFlat, exFlat.ReadProbeArrayFlat, varyProbeArray, sinkOfProbeArray);
+  benchMessageFlat("testdata", "testdata", 8000000, pinTestData(), ex.WriteTestData, ex.ReadTestData, exFlat.WriteTestDataFlat, exFlat.ReadTestDataFlat, varyTestData, sinkOfTestData);
 
   // real_packet (§1.7): the realistic snapshot — ~93 riding individually
   // serialized small fields, 204 wire bytes, 0% bulk share by bits. The
@@ -1818,24 +1988,24 @@ function main() {
   // defaults (the four branch gates: f012 true, f043 false, f050 true,
   // f074 false) exactly as C++ RealPacket{} does. base_iters sized in the
   // C++ reference (§2.1).
-  benchMessageFlat("real_packet", "real_packet", 8000000, new realworld.RealPacket(), realworld.WriteRealPacket, realworld.ReadRealPacket, realworldFlat.WriteRealPacketFlat, realworldFlat.ReadRealPacketFlat, varyRealPacket);
+  benchMessageFlat("real_packet", "real_packet", 8000000, new realworld.RealPacket(), realworld.WriteRealPacket, realworld.ReadRealPacket, realworldFlat.WriteRealPacketFlat, realworldFlat.ReadRealPacketFlat, varyRealPacket, sinkOfRealPacket);
 
   // the runtime-call generated tier: labeled supplementary rows
   // (codec=runtime) so the compat tier's regressions stay visible — never
   // the js number
   const atRestRt = pinRigidBodyMoving(); // fresh pin — the flat leg's vary mutated atRest
   atRestRt.AtRest = true;
-  benchMessage("rigidbody_moving", "rigidbody_moving", 24000000, pinRigidBodyMoving(), ex.WriteRigidBody, ex.ReadRigidBody, varyRigidBody);
-  benchMessage("rigidbody_at_rest", "rigidbody_at_rest", 32000000, atRestRt, ex.WriteRigidBody, ex.ReadRigidBody, varyRigidBodyAtRest);
-  benchMessage("chat", "chat", 48000000, pinChat(), ex.WriteChat, ex.ReadChat, varyChat);
-  benchMessage("test", null, 192000000, new ex.Test(), ex.WriteTest, ex.ReadTest, varyTest);
-  benchMessage("inputpacket", "inputpacket", 16000000, pinInputPacket(), ex.WriteInputPacket, ex.ReadInputPacket, varyInputPacket);
-  benchMessage("shipcreate", "shipcreate_flags", 32000000, pinShipCreate(), ex.WriteShipCreate, ex.ReadShipCreate, varyShipCreate);
-  benchMessage("probe_header", "probe_header", 256000000, pinProbeHeader(), ex.WriteProbeHeader, ex.ReadProbeHeader, varyProbeHeader);
-  benchMessage("probebits", "probebits", 128000000, pinProbeBits(), ex.WriteProbeBits, ex.ReadProbeBits, varyProbeBits);
-  benchMessage("probearray", "probearray", 20000000, pinProbeArray(), ex.WriteProbeArray, ex.ReadProbeArray, varyProbeArray);
-  benchMessage("testdata", "testdata", 8000000, pinTestData(), ex.WriteTestData, ex.ReadTestData, varyTestData);
-  benchMessage("real_packet", "real_packet", 8000000, new realworld.RealPacket(), realworld.WriteRealPacket, realworld.ReadRealPacket, varyRealPacket);
+  benchMessage("rigidbody_moving", "rigidbody_moving", 24000000, pinRigidBodyMoving(), ex.WriteRigidBody, ex.ReadRigidBody, varyRigidBody, sinkOfRigidBody);
+  benchMessage("rigidbody_at_rest", "rigidbody_at_rest", 32000000, atRestRt, ex.WriteRigidBody, ex.ReadRigidBody, varyRigidBodyAtRest, sinkOfRigidBody);
+  benchMessage("chat", "chat", 48000000, pinChat(), ex.WriteChat, ex.ReadChat, varyChat, sinkOfChat);
+  benchMessage("test", null, 192000000, new ex.Test(), ex.WriteTest, ex.ReadTest, varyTest, sinkOfTest);
+  benchMessage("inputpacket", "inputpacket", 16000000, pinInputPacket(), ex.WriteInputPacket, ex.ReadInputPacket, varyInputPacket, sinkOfInputPacket);
+  benchMessage("shipcreate", "shipcreate_flags", 32000000, pinShipCreate(), ex.WriteShipCreate, ex.ReadShipCreate, varyShipCreate, sinkOfShipCreate);
+  benchMessage("probe_header", "probe_header", 256000000, pinProbeHeader(), ex.WriteProbeHeader, ex.ReadProbeHeader, varyProbeHeader, sinkOfProbeHeader);
+  benchMessage("probebits", "probebits", 128000000, pinProbeBits(), ex.WriteProbeBits, ex.ReadProbeBits, varyProbeBits, sinkOfProbeBits);
+  benchMessage("probearray", "probearray", 20000000, pinProbeArray(), ex.WriteProbeArray, ex.ReadProbeArray, varyProbeArray, sinkOfProbeArray);
+  benchMessage("testdata", "testdata", 8000000, pinTestData(), ex.WriteTestData, ex.ReadTestData, varyTestData, sinkOfTestData);
+  benchMessage("real_packet", "real_packet", 8000000, new realworld.RealPacket(), realworld.WriteRealPacket, realworld.ReadRealPacket, varyRealPacket, sinkOfRealPacket);
 
   // the four Bench.schema shapes as GENERATED code — the flat tier is THE
   // js entry for these shapes in any cross-language comparison, exactly as
@@ -1843,18 +2013,18 @@ function main() {
   // against the runtime-call tier by the same oracle. The family rt rows
   // below keep the same bench names and measure the serialize.js runtime
   // API instead — honest library-context data, never the js number.
-  benchMessageFlat("bench_packet", "bench_packet", 32000000, pinBenchPacketGen(), bench.WriteBenchPacket, bench.ReadBenchPacket, benchFlat.WriteBenchPacketFlat, benchFlat.ReadBenchPacketFlat, varyBenchPacketGen);
-  benchMessageFlat("bench_ints", "bench_ints", 40000000, pinBenchIntsGen(), bench.WriteBenchInts, bench.ReadBenchInts, benchFlat.WriteBenchIntsFlat, benchFlat.ReadBenchIntsFlat, varyBenchIntsGen);
-  benchMessageFlat("bench_bits", "bench_bits", 48000000, pinBenchBitsGen(), bench.WriteBenchBits, bench.ReadBenchBits, benchFlat.WriteBenchBitsFlat, benchFlat.ReadBenchBitsFlat, varyBenchBitsGen);
-  benchMessageFlat("bench_mixed", "bench_mixed", 40000000, pinBenchMixedGen(), bench.WriteBenchMixed, bench.ReadBenchMixed, benchFlat.WriteBenchMixedFlat, benchFlat.ReadBenchMixedFlat, varyBenchMixedGen);
+  benchMessageFlat("bench_packet", "bench_packet", 32000000, pinBenchPacketGen(), bench.WriteBenchPacket, bench.ReadBenchPacket, benchFlat.WriteBenchPacketFlat, benchFlat.ReadBenchPacketFlat, varyBenchPacketGen, sinkOfBenchPacketGen);
+  benchMessageFlat("bench_ints", "bench_ints", 40000000, pinBenchIntsGen(), bench.WriteBenchInts, bench.ReadBenchInts, benchFlat.WriteBenchIntsFlat, benchFlat.ReadBenchIntsFlat, varyBenchIntsGen, sinkOfBenchIntsGen);
+  benchMessageFlat("bench_bits", "bench_bits", 48000000, pinBenchBitsGen(), bench.WriteBenchBits, bench.ReadBenchBits, benchFlat.WriteBenchBitsFlat, benchFlat.ReadBenchBitsFlat, varyBenchBitsGen, sinkOfBenchBitsGen);
+  benchMessageFlat("bench_mixed", "bench_mixed", 40000000, pinBenchMixedGen(), bench.WriteBenchMixed, bench.ReadBenchMixed, benchFlat.WriteBenchMixedFlat, benchFlat.ReadBenchMixedFlat, varyBenchMixedGen, sinkOfBenchMixedGen);
 
   // family rt (§1.3/§1.5): the runtime API by hand, oracle-gated against
   // the goldens the generated code pinned. Iteration counts are fixed and
   // identical across all six runners (§2.1; sized in the C++ reference).
-  benchRt("bench_packet", 32000000, pinRtPacket(), makeRtPacket(), rtOnceWritePacket, rtOnceReadPacket, rtBenchPacketWriteLoop, rtBenchPacketReadLoop, varyRtPacket);
-  benchRt("bench_ints", 40000000, pinRtInts(), makeRtInts(), rtOnceWriteInts, rtOnceReadInts, rtBenchIntsWriteLoop, rtBenchIntsReadLoop, varyRtInts);
-  benchRt("bench_bits", 48000000, pinRtBits(), makeRtBits(), rtOnceWriteBits, rtOnceReadBits, rtBenchBitsWriteLoop, rtBenchBitsReadLoop, varyRtBits);
-  benchRt("bench_mixed", 40000000, pinRtMixed(), makeRtMixed(), rtOnceWriteMixed, rtOnceReadMixed, rtBenchMixedWriteLoop, rtBenchMixedReadLoop, varyRtMixed);
+  benchRt("bench_packet", 32000000, pinRtPacket(), makeRtPacket(), rtOnceWritePacket, rtOnceReadPacket, rtBenchPacketWriteLoop, rtBenchPacketReadLoop, varyRtPacket, sinkOfRtPacket);
+  benchRt("bench_ints", 40000000, pinRtInts(), makeRtInts(), rtOnceWriteInts, rtOnceReadInts, rtBenchIntsWriteLoop, rtBenchIntsReadLoop, varyRtInts, sinkOfRtInts);
+  benchRt("bench_bits", 48000000, pinRtBits(), makeRtBits(), rtOnceWriteBits, rtOnceReadBits, rtBenchBitsWriteLoop, rtBenchBitsReadLoop, varyRtBits, sinkOfRtBits);
+  benchRt("bench_mixed", 40000000, pinRtMixed(), makeRtMixed(), rtOnceWriteMixed, rtOnceReadMixed, rtBenchMixedWriteLoop, rtBenchMixedReadLoop, varyRtMixed, sinkOfRtMixed);
 
   // family bits (§1.4): the one bitpacker workload in the estate
   benchBitpacker(24576);

--- a/bench/results/2026-08-31-equalized-full-dart-arm64-macbook.csv
+++ b/bench/results/2026-08-31-equalized-full-dart-arm64-macbook.csv
@@ -1,0 +1,34 @@
+# schema bench results
+# date: 2026-08-31T01:41:10Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Igenerated/bench/cpp -Itest -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: c89b509
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ecfb3c9 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_packet,write,32000000,49,7,16804772,16730933,16828324,785.29,0.58,ae6b776d05ca52f1,gen,aot,contract,default,unknown
+dart,bench_packet,read,32000000,49,7,12693899,12671656,12705133,593.19,0.26,ae6b776d05ca52f1,gen,aot,contract,default,unknown
+dart,bench_ints,write,40000000,14,7,59231267,59153397,59657862,790.82,0.85,ae6b776d05ca52f1,gen,aot,contract,default,unknown
+dart,bench_ints,read,40000000,14,7,79293023,79107196,79750699,1058.68,0.81,ae6b776d05ca52f1,gen,aot,contract,default,unknown
+dart,bench_bits,write,48000000,20,7,56848733,56743223,57179275,1084.30,0.77,ae6b776d05ca52f1,gen,aot,contract,default,unknown
+dart,bench_bits,read,48000000,20,7,85212143,84965828,85576904,1625.29,0.72,ae6b776d05ca52f1,gen,aot,contract,default,unknown
+dart,bench_mixed,write,40000000,21,7,52475671,52417907,52825086,1050.94,0.78,ae6b776d05ca52f1,gen,aot,contract,default,unknown
+dart,bench_mixed,read,40000000,21,7,73258195,73203093,73802917,1467.15,0.82,ae6b776d05ca52f1,gen,aot,contract,default,unknown

--- a/bench/results/2026-08-31-equalized-full-elixir-arm64-macbook.csv
+++ b/bench/results/2026-08-31-equalized-full-elixir-arm64-macbook.csv
@@ -1,0 +1,34 @@
+# schema bench results
+# date: 2026-08-31T01:42:19Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Igenerated/bench/cpp -Itest -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: c89b509
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ecfb3c9 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_packet,write,32000000,49,7,1934119,1914967,1934926,90.38,1.03,ae6b776d05ca52f1,gen,beam,contract,default,unknown
+elixir,bench_packet,read,32000000,49,7,2001651,1988729,2016128,93.54,1.37,ae6b776d05ca52f1,gen,beam,contract,default,unknown
+elixir,bench_ints,write,40000000,14,7,2407699,2407177,2408691,32.15,0.06,ae6b776d05ca52f1,gen,beam,contract,default,unknown
+elixir,bench_ints,read,40000000,14,7,9099408,8674337,9147652,121.49,5.20,ae6b776d05ca52f1,gen,beam,contract,default,unknown
+elixir,bench_bits,write,48000000,20,7,3260293,3247304,3263846,62.19,0.51,ae6b776d05ca52f1,gen,beam,contract,default,unknown
+elixir,bench_bits,read,48000000,20,7,9689257,9663711,9762536,184.81,1.02,ae6b776d05ca52f1,gen,beam,contract,default,unknown
+elixir,bench_mixed,write,40000000,21,7,2310060,2126221,2329460,46.26,8.80,ae6b776d05ca52f1,gen,beam,contract,default,unknown
+elixir,bench_mixed,read,40000000,21,7,6546809,6331260,6653685,131.11,4.92,ae6b776d05ca52f1,gen,beam,contract,default,unknown

--- a/bench/results/2026-08-31-equalized-full-java-arm64-macbook.csv
+++ b/bench/results/2026-08-31-equalized-full-java-arm64-macbook.csv
@@ -1,0 +1,34 @@
+# schema bench results
+# date: 2026-08-31T01:40:44Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Igenerated/bench/cpp -Itest -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: c89b509
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ecfb3c9 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_packet,write,32000000,49,7,129738036,128255356,129981239,6062.66,1.33,ae6b776d05ca52f1,gen,class,contract,default,unknown
+java,bench_packet,read,32000000,49,7,93340099,90614936,94039016,4361.79,3.67,ae6b776d05ca52f1,gen,class,contract,default,unknown
+java,bench_ints,write,40000000,14,7,177870237,175581256,178014405,2374.82,1.37,ae6b776d05ca52f1,gen,class,contract,default,unknown
+java,bench_ints,read,40000000,14,7,137313086,131736142,138177650,1833.33,4.69,ae6b776d05ca52f1,gen,class,contract,default,unknown
+java,bench_bits,write,48000000,20,7,216691001,206383595,218599683,4133.05,5.64,ae6b776d05ca52f1,gen,class,contract,default,unknown
+java,bench_bits,read,48000000,20,7,173911232,172306386,174473260,3317.09,1.25,ae6b776d05ca52f1,gen,class,contract,default,unknown
+java,bench_mixed,write,40000000,21,7,177444281,168450281,178107639,3553.71,5.44,ae6b776d05ca52f1,gen,class,contract,default,unknown
+java,bench_mixed,read,40000000,21,7,135756185,135163656,136302107,2718.81,0.84,ae6b776d05ca52f1,gen,class,contract,default,unknown

--- a/bench/results/2026-08-31-equalized-full-js-arm64-macbook.csv
+++ b/bench/results/2026-08-31-equalized-full-js-arm64-macbook.csv
@@ -1,0 +1,88 @@
+# schema bench results
+# date: 2026-08-31T03:04:26Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Igenerated/bench/cpp -Itest -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: cfe75e0
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ecfb3c9 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,rigidbody_moving,write,24000000,105,7,14070614,13666389,14306098,1408.97,4.55,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,rigidbody_moving,read,24000000,105,7,35144718,34860862,35320604,3519.24,1.31,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,rigidbody_at_rest,write,32000000,57,7,16556143,15670544,17225732,899.98,9.39,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,rigidbody_at_rest,read,32000000,57,7,47878598,47802224,48038824,2602.65,0.49,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,chat,write,48000000,13,7,13827269,13488064,14330437,171.43,6.09,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,chat,read,48000000,13,7,35676125,35572503,35750871,442.30,0.50,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,test,write,192000000,6,7,22021063,21746351,23009440,126.01,5.74,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,test,read,192000000,6,7,74931854,74850068,75008259,428.76,0.21,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,inputpacket,write,16000000,61,7,4742639,4656042,4800186,275.90,3.04,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,inputpacket,read,16000000,61,7,13677167,13583325,13717099,795.66,0.98,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,shipcreate,write,32000000,28,7,7374207,7169485,7503970,196.91,4.54,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,shipcreate,read,32000000,28,7,32866657,32573964,32973615,877.63,1.22,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,probe_header,write,256000000,10,7,9014175,8876638,9134590,85.97,2.86,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,probe_header,read,256000000,10,7,56997948,48676048,62076402,543.57,23.51,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,probebits,write,128000000,26,7,4549025,4509402,4561458,112.80,1.14,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,probebits,read,128000000,26,7,24890665,24804352,24969727,617.18,0.66,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,probearray,write,20000000,47,7,6108561,5983793,6159239,273.80,2.87,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,probearray,read,20000000,47,7,12296743,12217350,12528524,551.17,2.53,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,testdata,write,8000000,92,7,2723773,2704321,2732575,238.98,1.04,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,testdata,read,8000000,92,7,7417305,7384549,7433797,650.78,0.66,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,real_packet,write,8000000,204,7,1414843,1384962,1420844,275.26,2.54,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,real_packet,read,8000000,204,7,3634513,3418040,3651673,707.09,6.43,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,rigidbody_moving,write,24000000,105,7,3335684,3302134,3373249,334.02,2.13,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,rigidbody_moving,read,24000000,105,7,2746656,2743664,2752135,275.04,0.31,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,rigidbody_at_rest,write,32000000,57,7,5025135,4958369,5064589,273.16,2.11,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,rigidbody_at_rest,read,32000000,57,7,4931440,4899154,4934432,268.07,0.72,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,chat,write,48000000,13,7,5710194,5667068,5811985,70.79,2.54,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,chat,read,48000000,13,7,9713411,9699083,9737216,120.42,0.39,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,test,write,192000000,6,7,10523927,10359554,10767394,60.22,3.88,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,test,read,192000000,6,7,16721760,16678523,16734935,95.68,0.34,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,inputpacket,write,16000000,61,7,1841283,1838339,1853109,107.12,0.80,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,inputpacket,read,16000000,61,7,2027610,2026849,2030571,117.95,0.18,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,shipcreate,write,32000000,28,7,3226332,3202320,3246524,86.15,1.37,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,shipcreate,read,32000000,28,7,4016585,4008054,4023315,107.25,0.38,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,probe_header,write,256000000,10,7,5314932,5282963,5347560,50.69,1.22,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,probe_header,read,256000000,10,7,8545872,8316932,8724522,81.50,4.77,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,probebits,write,128000000,26,7,2749834,2733959,2764865,68.18,1.12,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,probebits,read,128000000,26,7,3434016,3430776,3435248,85.15,0.13,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,probearray,write,20000000,47,7,2061388,2057406,2075017,92.40,0.85,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,probearray,read,20000000,47,7,2169360,2166592,2172797,97.24,0.29,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,testdata,write,8000000,92,7,1187880,1183819,1196492,104.22,1.07,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,testdata,read,8000000,92,7,1271054,1257786,1278045,111.52,1.59,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,real_packet,write,8000000,204,7,482209,479041,485118,93.81,1.26,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,real_packet,read,8000000,204,7,531635,527250,536940,103.43,1.82,bc776c004485e408,gen,esm,contract,default,unknown,runtime
+js,bench_packet,write,32000000,49,7,6645115,6555356,6825297,310.53,4.06,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_packet,read,32000000,49,7,19282086,19089520,19536378,901.05,2.32,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_ints,write,40000000,14,7,19163175,18961839,20592449,255.86,8.51,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_ints,read,40000000,14,7,55705755,54036079,55783551,743.75,3.14,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_bits,write,48000000,20,7,8061429,7727872,8550458,153.76,10.20,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_bits,read,48000000,20,7,33319567,33267281,33367423,635.52,0.30,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_mixed,write,40000000,21,7,7887897,7751665,7973288,157.97,2.81,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_mixed,read,40000000,21,7,29686400,29567857,29719472,594.53,0.51,bc776c004485e408,gen,esm,contract,default,unknown,flat
+js,bench_packet,write,32000000,49,7,3359403,3335233,3377911,156.99,1.27,bc776c004485e408,rt,esm,contract,default,unknown
+js,bench_packet,read,32000000,49,7,3850511,3838946,3855281,179.93,0.42,bc776c004485e408,rt,esm,contract,default,unknown
+js,bench_ints,write,40000000,14,7,5839423,5781177,5909432,77.96,2.20,bc776c004485e408,rt,esm,contract,default,unknown
+js,bench_ints,read,40000000,14,7,6487143,6405166,6493000,86.61,1.35,bc776c004485e408,rt,esm,contract,default,unknown
+js,bench_bits,write,48000000,20,7,4225201,4170669,4255992,80.59,2.02,bc776c004485e408,rt,esm,contract,default,unknown
+js,bench_bits,read,48000000,20,7,6678338,6636984,6718696,127.38,1.22,bc776c004485e408,rt,esm,contract,default,unknown
+js,bench_mixed,write,40000000,21,7,3613256,3520400,3653178,72.36,3.67,bc776c004485e408,rt,esm,contract,default,unknown
+js,bench_mixed,read,40000000,21,7,5318003,5301791,5324231,106.50,0.42,bc776c004485e408,rt,esm,contract,default,unknown
+js,bitpacker,write,24576,65518,7,6225,3164,6337,388.93,50.98,bc776c004485e408,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,4841,4818,4877,302.45,1.20,bc776c004485e408,bits,esm,contract,default,unknown

--- a/bench/results/2026-08-31-equalized-quick-arm64-macbook.csv
+++ b/bench/results/2026-08-31-equalized-quick-arm64-macbook.csv
@@ -1,0 +1,58 @@
+# schema bench results
+# date: 2026-08-31T01:38:52Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Igenerated/bench/cpp -Itest -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: c89b509
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ecfb3c9 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,40000000,21,3,610048260,610035468,612746271,12217.53,0.44,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,read,40000000,21,3,547186572,539954369,553027567,10958.59,2.39,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,write,40000000,21,3,152044162,151962092,152183259,3045.01,0.15,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+cpp,bench_mixed,read,40000000,21,3,186522868,183828352,186562305,3735.52,1.47,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,40000000,21,3,604439609,596845671,618228466,12105.21,3.54,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+c,bench_mixed,read,40000000,21,3,479116509,476173470,481469445,9595.34,1.11,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+c,bench_mixed,write,40000000,21,3,157544822,157409047,158027189,3155.18,0.39,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+c,bench_mixed,read,40000000,21,3,173436470,172416023,173657842,3473.44,0.72,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+go,bench_mixed,write,40000000,21,3,40069166,39914677,40223913,802.47,0.77,457b96dfc5a0ffcd,gen,pkg,always,default,unknown
+go,bench_mixed,read,40000000,21,3,34331644,33532725,34473946,687.57,2.74,457b96dfc5a0ffcd,gen,pkg,always,default,unknown
+go,bench_mixed,write,40000000,21,3,43253075,43248190,43453728,866.24,0.48,457b96dfc5a0ffcd,rt,pkg,always,default,unknown
+go,bench_mixed,read,40000000,21,3,36429769,36360741,36527362,729.58,0.46,457b96dfc5a0ffcd,rt,pkg,always,default,unknown
+rust,bench_mixed,write,40000000,21,3,96229314,96189368,96270733,1927.20,0.08,457b96dfc5a0ffcd,gen,crate,always,O3,unknown
+rust,bench_mixed,read,40000000,21,3,99468393,99324243,99481711,1992.07,0.16,457b96dfc5a0ffcd,gen,crate,always,O3,unknown
+rust,bench_mixed,write,40000000,21,3,101262479,101238185,101415860,2028.00,0.18,457b96dfc5a0ffcd,rt,crate,always,O3,unknown
+rust,bench_mixed,read,40000000,21,3,99324870,98739264,99424879,1989.20,0.69,457b96dfc5a0ffcd,rt,crate,always,O3,unknown
+cs,bench_mixed,write,40000000,21,3,75992173,75892299,76509748,1521.91,0.81,457b96dfc5a0ffcd,gen,asm,always,default,unknown
+cs,bench_mixed,read,40000000,21,3,70609140,70543913,70911550,1414.10,0.52,457b96dfc5a0ffcd,gen,asm,always,default,unknown
+cs,bench_mixed,write,40000000,21,3,47379039,46626041,47680709,948.87,2.23,457b96dfc5a0ffcd,rt,asm,always,default,unknown
+cs,bench_mixed,read,40000000,21,3,41547279,38638469,41797318,832.07,7.60,457b96dfc5a0ffcd,rt,asm,always,default,unknown
+js,bench_mixed,write,40000000,21,3,7872052,7707957,8002874,157.65,3.75,457b96dfc5a0ffcd,gen,esm,contract,default,unknown,flat
+js,bench_mixed,read,40000000,21,3,37747494,37574716,38303796,755.98,1.93,457b96dfc5a0ffcd,gen,esm,contract,default,unknown,flat
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,40000000,21,3,177624658,169625123,177652237,3557.32,4.52,457b96dfc5a0ffcd,gen,class,contract,default,unknown
+java,bench_mixed,read,40000000,21,3,135399358,135312752,136044126,2711.66,0.54,457b96dfc5a0ffcd,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,40000000,21,3,51838182,51654026,51860966,1038.17,0.40,457b96dfc5a0ffcd,gen,aot,contract,default,unknown
+dart,bench_mixed,read,40000000,21,3,74151521,74009658,74293653,1485.04,0.38,457b96dfc5a0ffcd,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,8000000,21,3,2336785,2334440,2337642,46.80,0.14,457b96dfc5a0ffcd,gen,beam,contract,default,unknown
+elixir,bench_mixed,read,8000000,21,3,6499146,6445627,6685656,130.16,3.69,457b96dfc5a0ffcd,gen,beam,contract,default,unknown

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -21,11 +21,16 @@
 #                 tables — per-message time averaged over write and read,
 #                 fastest language = 100% — after the CSV lands. The
 #                 headline table is SINGLE-SUBJECT: family gen (generated
-#                 code) for every language, family printed per row; the rt
-#                 blend prints as a second labeled section (#177).
+#                 code) for every language, family and checks mode printed
+#                 per row under a caption naming what is held constant; the
+#                 rt blend prints as a second labeled section (#177), and a
+#                 leg whose toolchain is missing prints as an ABSENT row
+#                 with the reason (#175).
 #                 Scaling constants are PROPOSED in BENCH-STANDARD.md terms.
 #   --only LANG   run a single language leg (c|cpp|go|rust|cs|js|java|dart|elixir).
-#                 For shared boxes
+#                 An --only run whose leg is skipped (missing toolchain)
+#                 exits non-zero with the reason — zero rows is a refusal,
+#                 never a quietly green empty CSV (#175). For shared boxes
 #                 under one-profile-at-a-time discipline: a driver runs the
 #                 legs serially with quiet-window checks between them. Each
 #                 leg's CSV carries the full preamble; measurement code and
@@ -118,6 +123,16 @@ if [ ! -f "$SERIALIZE/serialize.h" ]; then
     exit 1
 fi
 CC_BIN="${CC:-cc}"
+
+# Loud skips (#175): a leg that cannot run is RECORDED, printed as an ABSENT
+# row in the quick tables, and an --only invocation that produced zero rows
+# exits non-zero — never a silently green empty table.
+SKIP_NOTES=""
+skip_leg() {
+    # ";"-joined lang|reason pairs (BWK awk rejects newlines in -v strings)
+    SKIP_NOTES="${SKIP_NOTES}${1}|${2};"
+    echo "SKIP $1: $2" >&2
+}
 
 ARCH="$(uname -m)"
 HOST="$(hostname -s)"
@@ -355,9 +370,9 @@ fi
 # ---- C (the fifth target; serialize.c is a compiled TU, not a header) ----
 if [ -z "$ONLY" ] || [ "$ONLY" = c ]; then
     if [ ! -f generated/c/TypesWire.h ]; then
-        echo "SKIP c: generated/c is missing — run make first" >&2
+        skip_leg c "generated/c is missing — run make first"
     elif [ ! -f "$SERIALIZE_C/serialize.c" ]; then
-        echo "SKIP c: serialize.c not found at $SERIALIZE_C (set SERIALIZE_C)" >&2
+        skip_leg c "serialize.c not found at $SERIALIZE_C (set SERIALIZE_C)"
     else
         if [ "$REUSE" = 1 ] && [ -x build/bench/schema_bench_c ]; then
             echo "== c: reusing build/bench/schema_bench_c ==" >&2
@@ -387,10 +402,10 @@ if [ -z "$ONLY" ] || [ "$ONLY" = go ]; then
             # modfile when SERIALIZE_GO points elsewhere
             ( cd bench/go && $PIN go run $GO_MODFILE_ARG . $RUNNER_ARGS ) >> "$OUT"
         else
-            echo "SKIP go: runner present but no go toolchain" >&2
+            skip_leg go "runner present but no go toolchain"
         fi
     else
-        echo "SKIP go: runner not landed yet (bench/go/main.go — see bench/go/README.md)" >&2
+        skip_leg go "runner not landed yet (bench/go/main.go — see bench/go/README.md)"
     fi
 fi
 
@@ -413,10 +428,10 @@ if [ -z "$ONLY" ] || [ "$ONLY" = rust ]; then
               CARGO_PROFILE_RELEASE_OPT_LEVEL="${OPT_LEVEL#O}" \
               $PIN cargo run --release --quiet $RS_CARGO_ARGS -- $RUNNER_ARGS ) >> "$OUT"
         else
-            echo "SKIP rust: runner present but no cargo" >&2
+            skip_leg rust "runner present but no cargo"
         fi
     else
-        echo "SKIP rust: runner not landed yet (bench/rust/Cargo.toml — see bench/rust/README.md)" >&2
+        skip_leg rust "runner not landed yet (bench/rust/Cargo.toml — see bench/rust/README.md)"
     fi
 fi
 
@@ -429,10 +444,10 @@ if [ -z "$ONLY" ] || [ "$ONLY" = cs ]; then
             # SerializeCsRoot=<abs> (consumed by the csproj includes) otherwise
             ( cd bench/cs && $PIN dotnet run -c Release $CS_PROP_ARGS -- $RUNNER_ARGS ) >> "$OUT"
         else
-            echo "SKIP cs: runner present but no dotnet" >&2
+            skip_leg cs "runner present but no dotnet"
         fi
     else
-        echo "SKIP cs: runner not landed yet (bench/cs/*.csproj — see bench/cs/README.md)" >&2
+        skip_leg cs "runner not landed yet (bench/cs/*.csproj — see bench/cs/README.md)"
     fi
 fi
 
@@ -448,10 +463,10 @@ if [ -z "$ONLY" ] || [ "$ONLY" = js ]; then
             # override otherwise (already verified by the provenance guard).
             ( cd bench/js && $PIN env NODE_ENV=production $JS_ENV node main.mjs $RUNNER_ARGS ) >> "$OUT"
         else
-            echo "SKIP js: runner present but no node" >&2
+            skip_leg js "runner present but no node"
         fi
     else
-        echo "SKIP js: runner not landed yet (bench/js/main.mjs — see bench/README.md)" >&2
+        skip_leg js "runner not landed yet (bench/js/main.mjs — see bench/README.md)"
     fi
 fi
 
@@ -470,10 +485,10 @@ if [ -z "$ONLY" ] || [ "$ONLY" = java ]; then
             echo "== java: run ==" >&2
             ( cd bench/java && $PIN "$JAVA_BIN" -cp ../../build/bench/java Main $RUNNER_ARGS ) >> "$OUT"
         else
-            echo "SKIP java: runner present but no javac at $JAVAC_BIN (populate dist/ per the Makefile, or set JAVA/JAVAC)" >&2
+            skip_leg java "runner present but no javac at $JAVAC_BIN (populate dist/ per the Makefile, or set JAVA/JAVAC)"
         fi
     else
-        echo "SKIP java: runner not landed yet (bench/java/Main.java)" >&2
+        skip_leg java "runner not landed yet (bench/java/Main.java)"
     fi
 fi
 
@@ -490,10 +505,10 @@ if [ -z "$ONLY" ] || [ "$ONLY" = dart ]; then
             echo "== dart: run ==" >&2
             ( cd bench/dart && $PIN ../../build/bench/schema_bench_dart $RUNNER_ARGS ) >> "$OUT"
         else
-            echo "SKIP dart: runner present but no dart at $DART_BIN (populate dist/ per the Makefile, or set DART)" >&2
+            skip_leg dart "runner present but no dart at $DART_BIN (populate dist/ per the Makefile, or set DART)"
         fi
     else
-        echo "SKIP dart: runner not landed yet (bench/dart/main.dart)" >&2
+        skip_leg dart "runner not landed yet (bench/dart/main.dart)"
     fi
 fi
 
@@ -504,10 +519,10 @@ if [ -z "$ONLY" ] || [ "$ONLY" = elixir ]; then
             echo "== elixir: run ==" >&2
             ( cd bench/elixir && $PIN env PATH="$BEAM_PATH:$PATH" elixir main.exs $RUNNER_ARGS ) >> "$OUT"
         else
-            echo "SKIP elixir: runner present but no elixir on $BEAM_PATH (populate dist/ per the Makefile, or set BEAM_PATH)" >&2
+            skip_leg elixir "runner present but no elixir on $BEAM_PATH (populate dist/ per the Makefile, or set BEAM_PATH)"
         fi
     else
-        echo "SKIP elixir: runner not landed yet (bench/elixir/main.exs)" >&2
+        skip_leg elixir "runner not landed yet (bench/elixir/main.exs)"
     fi
 fi
 
@@ -536,14 +551,18 @@ if [ "$QUICK" = 1 ]; then
     {
         echo ""
         echo "quick mode — iteration instrument, not certification (bench_mixed only, blended write+read)"
-        awk -F, '
+        # the caption (#175): every printed comparison names what it holds
+        # constant — the profiling doctrine's apples-to-apples rule
+        echo "held constant: contract (BENCH-STANDARD §2.8 quick — bench_mixed, blended write+read over max rates), corpus (id per CSV row), machine ($HOST, $CPU), one sitting; sink discipline equalized to full-struct observation (#175)"
+        echo "NOT equalized: checks mode — printed per row below; a cross-language checks ruling is deferred to the owner (#175)"
+        awk -F, -v skips="$SKIP_NOTES" '
             # js emits two gen tiers; the flat tier is THE js path (codec
             # column, $18), so codec=runtime rows never blend
-            $2 == "bench_mixed" && $13 == "gen" && $18 != "runtime" && $3 == "write" { gw[$1] = $9 }
-            $2 == "bench_mixed" && $13 == "gen" && $18 != "runtime" && $3 == "read"  { gr[$1] = $9 }
-            $2 == "bench_mixed" && $13 == "rt" && $3 == "write" { rw[$1] = $9 }
-            $2 == "bench_mixed" && $13 == "rt" && $3 == "read"  { rr[$1] = $9 }
-            function render(family, w, r,    n, langs, ts, i, j, t, tt, tl, lang) {
+            $2 == "bench_mixed" && $13 == "gen" && $18 != "runtime" && $3 == "write" { gw[$1] = $9; gc[$1] = $15 }
+            $2 == "bench_mixed" && $13 == "gen" && $18 != "runtime" && $3 == "read"  { gr[$1] = $9; gc[$1] = $15 }
+            $2 == "bench_mixed" && $13 == "rt" && $3 == "write" { rw[$1] = $9; rc[$1] = $15 }
+            $2 == "bench_mixed" && $13 == "rt" && $3 == "read"  { rr[$1] = $9; rc[$1] = $15 }
+            function render(family, w, r, c, absent,    n, langs, ts, i, j, t, tt, tl, lang, m, sk, parts) {
                 n = 0
                 for (lang in w) {
                     if (r[lang] > 0 && w[lang] > 0) {
@@ -551,7 +570,7 @@ if [ "$QUICK" = 1 ]; then
                         n++; langs[n] = lang; ts[n] = t
                     }
                 }
-                if (n == 0) return
+                if (n == 0 && !absent) return
                 # sort ascending by blended time
                 for (i = 1; i <= n; i++)
                     for (j = i + 1; j <= n; j++)
@@ -559,18 +578,37 @@ if [ "$QUICK" = 1 ]; then
                             tt = ts[i]; ts[i] = ts[j]; ts[j] = tt
                             tl = langs[i]; langs[i] = langs[j]; langs[j] = tl
                         }
-                printf "  %-8s %-6s %14s %10s\n", "lang", "family", "ns/msg", "% of best"
+                printf "  %-8s %-6s %-9s %14s %10s\n", "lang", "family", "checks", "ns/msg", "% of best"
                 for (i = 1; i <= n; i++)
-                    printf "  %-8s %-6s %14.2f %9.0f%%\n", langs[i], family, ts[i], ts[i] / ts[1] * 100.0
+                    printf "  %-8s %-6s %-9s %14.2f %9.0f%%\n", langs[i], family, c[langs[i]], ts[i], ts[i] / ts[1] * 100.0
+                # loud skips (#175): a missing leg is an ABSENT row with its
+                # reason, never a silently narrower table
+                if (absent) {
+                    m = split(skips, sk, ";")
+                    for (i = 1; i <= m; i++) {
+                        if (sk[i] == "") continue
+                        split(sk[i], parts, "|")
+                        printf "  %-8s %-6s %-9s %14s   ABSENT — %s\n", parts[1], family, "-", "-", parts[2]
+                    }
+                }
             }
             END {
                 print "subject: schema-GENERATED code (family gen) — what the compiler delivers"
-                render("gen", gw, gr)
+                render("gen", gw, gr, gc, 1)
                 print ""
                 print "subject: hand-written runtime usage (family rt) — what the serialize libraries deliver by hand; never ranked against gen"
-                render("rt", rw, rr)
+                render("rt", rw, rr, rc, 0)
             }' "$OUT"
     } >&2
+fi
+
+# ---- #175: an --only run that produced zero data rows is a failure, not a
+# quietly green empty CSV — the leg was skipped, not measured. Refuse. ----
+DATA_ROWS="$(grep -c -E '^(c|cpp|go|rust|cs|js|java|dart|elixir),' "$OUT" 2>/dev/null || true)"
+if [ -n "$ONLY" ] && [ "${DATA_ROWS:-0}" -eq 0 ]; then
+    echo "REFUSED (#175): --only $ONLY produced ZERO rows — see the SKIP reason above; nothing was measured" >&2
+    echo "results: $OUT (EMPTY — refused)" >&2
+    exit 1
 fi
 
 echo "results: $OUT" >&2


### PR DESCRIPTION
The bench equalization pass (#175): every read loop in the estate now observes the FULL decoded struct per iteration, the quick table carries its caption, a skipped leg is loud, and the blended table republishes measured under the equalized discipline — one contract, one subject, one corpus, one machine, one caffeinated sitting.

## The equalized blended quick table

`bench/run.sh --quick`, nine languages, M2 Air, 2026-08-31, corpus `457b96dfc5a0ffcd`, CSV: `bench/results/2026-08-31-equalized-quick-arm64-macbook.csv`.

subject: schema-GENERATED code (family gen) — what the compiler delivers

| lang | family | checks | ns/msg | % of best |
|---|---|---|---:|---:|
| cpp | gen | removed | 1.72 | 100% |
| c | gen | removed | 1.85 | 107% |
| java | gen | contract | 6.49 | 377% |
| rust | gen | always | 10.22 | 594% |
| cs | gen | always | 13.59 | 790% |
| dart | gen | contract | 16.37 | 952% |
| go | gen | always | 26.93 | 1566% |
| js | gen | contract | 75.53 | 4391% |
| elixir | gen | contract | 288.68 | 16782% |

subject: hand-written runtime usage (family rt) — never ranked against gen

| lang | family | checks | ns/msg | % of best |
|---|---|---|---:|---:|
| cpp | rt | removed | 5.97 | 100% |
| c | rt | removed | 6.04 | 101% |
| rust | rt | always | 9.96 | 167% |
| cs | rt | always | 22.45 | 376% |
| go | rt | always | 25.19 | 422% |

**Caption (now printed by the driver above every quick table):** held constant — contract (BENCH-STANDARD §2.8 quick: bench_mixed, blended write+read over max rates), corpus (id per CSV row), machine, one sitting; sink discipline equalized to full-struct observation (#175). NOT equalized: checks mode — printed per row; a cross-language checks ruling is deferred to the owner (no repo-recorded ruling names a fastest-correct checks form per language, and this pass never silently changes what a leg measures).

## The sink effect, per language (bench_mixed quick, max rates, frozen #178 baseline sitting → this sitting)

| lang | read M msg/s | Δ read | blended ns/msg | Δ blend | % of best | leg changed? |
|---|---|---:|---|---:|---|---|
| cpp | 554.5 → 553.0 | -0.3% | 1.73 → 1.72 | -0.8% | 100% → 100% | NO (frozen reference) |
| c | 475.4 → 481.5 | +1.3% | 1.88 → 1.85 | -1.6% | 108% → 107% | NO (frozen reference) |
| java | 171.9 → 136.0 | **-20.9%** | 5.70 → 6.49 | **+13.8%** | 329% → 377% | YES — one field → full fold |
| rust | 99.9 → 99.5 | -0.5% | 10.19 → 10.22 | +0.3% | 588% → 594% | NO (verified conformant) |
| cs | 69.9 → 70.9 | +1.5% | 13.85 → 13.59 | -1.9% | 799% → 790% | NO (verified conformant) |
| dart | 79.3 → 74.3 | **-6.4%** | 16.04 → 16.37 | +2.1% | 925% → 952% | YES — one field → full fold |
| go | 34.7 → 34.5 | -0.5% | 26.82 → 26.93 | +0.4% | 1546% → 1566% | NO (verified conformant) |
| js | 53.0 → 38.3 | **-27.7%** | 72.96 → 75.53 | +3.5% | 4207% → 4391% | YES — sink+1 → full fold |
| elixir | 9.0 → 6.7 | **-26.1%** | 282.3 → 288.68 | +2.3% | 16275% → 16782% | YES — one field → full fold |

The java movement lands on the PR #178 review's measured prediction (-23% read / ~16% blend at the widest sink, upper bound including the sink adds): measured here -20.9% read / +13.8% blend, published 329% → sink-equalized 377% (the review predicted ~380%). Every unchanged leg moved ≤1.9% across the two sittings — the window is clean. **No ranking changed anywhere.**

## What equalization means, per leg

One bar (BENCH-STANDARD §2.7, added by this PR): every decoded field store materializes in memory every iteration and cannot be elided. Two mechanisms:

- **cpp / c — FROZEN, untouched** per the owner's C/C++ lock during the optimization round (#170): their empty-asm whole-struct clobber is the reference discipline the other legs were equalized TO. Re-run for same-sitting comparability only.
- **rust — already conformant, verified in the emitted asm**: the timed read loop carries one out-of-line `bl read_bench_mixed` per iteration with `&out` in a register, plus `black_box(&out)` (a zero-cost memory barrier). No change.
- **go — already conformant, verified in `go tool objdump`**: the gen loop's `readFn` is an opaque indirect `CALL (R2)` through the function value per iteration; the rt loops carry a direct out-of-line `CALL main.readRtMixed(SB)`; `runtime.KeepAlive(&out)` pins liveness. Materialization is forced by the call ABI. No change.
- **cs — already conformant, verified in JitDisasm**: the shared-generic BenchMessage invokes `readFn` as a delegate (`ldr x3, [delegate, #0x18]; blr x3`) into a long-lived heap decode target; RyuJIT does no cross-iteration heap dead-store elimination. No change.
- **java — widened (the review's measured offender)**: each of the four read loops published ONE field; now a full-struct fold (floats via `floatToRawIntBits` bitcast, booleans 0/1, blob element-wise).
- **dart — widened**: same single-field → full-fold change (doubles truncated via `toInt()`).
- **js — widened everywhere**: the gen rows (flat AND runtime tiers — all corpus shapes, `real_packet`'s 97 fields included) and the rt rows sank `+1`; now full-struct folds. BigInt fields are observed through an allocation-free comparison — a per-iteration BigInt add allocates and would measure the allocator, not the observation. Every `sinkOf` is checked finite at the golden gate, so a typo'd field name (`undefined` → NaN) refuses to bench instead of silently poisoning the sink.
- **elixir — widened**: single field → full pattern-match fold (destructuring measured 19% faster than dot access — the fold ships in its fastest correct form; the remaining -26% read is the BEAM's honest full-observation price, an upper bound carrying the fold's own adds).

**Write side — unchanged everywhere, audited**: cpp/c/rust escape the whole buffer per iteration through zero-cost barriers; go/cs/js/java/dart write through opaque calls or globally-reachable heap buffers and sink the per-iteration byte count (§2.7's named barriers); elixir's write constructs the binary itself. Every leg already met the bar.

The fold legs' read numbers are upper bounds — the fold is real per-iteration work the clobber languages get free. The caption and §2.7 say so; nothing is smoothed.

## #176 — DEFERRED by owner ruling

C/C++ is locked during the optimization round (owner ruling on #170): no PGO, no `-mcpu=native`, no build-flag changes to the c/cpp legs — they are the frozen reference. The PGO/native tie-breaker experiment #176 describes is deferred until the lock lifts. Note the tie it was opened on is already dissolved: it compared library-C++ (rt) against generated Java — a mixed-subject artifact; under one subject and equalized sinks, generated C++ leads Java 3.8x.

## #175 items landed here

1. **Sink equalization** (the MEASURED inheritance from the #178 review) — done, republished, numbers above.
2. **Loud skip**: `--quick --only <lang>` with a missing toolchain now prints an ABSENT row with the reason in the headline table, and any `--only` run that produced zero data rows exits non-zero (was: SKIP + empty table + exit 0).
3. **BENCH-STANDARD §2.8** rewritten present-state to the two-section family-aware quick output; §2.7 gains the read-side sink-discipline clause (the bar, the two mechanisms, the measured fold costs).
4. **The caption**: the printed quick table names what is held constant and prints the checks mode per row.
5. **bench/elixir/main.exs** stale pre-conformance header (best-of-five wording, a `BENCH_STREAM_PACKETS` override that no longer exists, a delivered follow-on named as pending) rewritten present-state.
6. **js CSV header** now emitted under `--only js` (the #175 cosmetic).
7. **Full-standard legs for java, dart, js, elixir** recorded under the equalized sinks (`bench/results/2026-08-31-equalized-full-{java,dart,js,elixir}-arm64-macbook.csv`) — the four legs the ninelang full-sweep record was missing, with their provenance in each preamble.

Still open on #175: the doubled java compile-path documentation cosmetic.

**Negative control** (run before the sweeps): one byte doctored in `testdata/wire/bench_mixed.bin` →
```
GOLDEN GATE FAILED: bench_mixed pinned instance vs testdata/wire/bench_mixed.bin
reporting nothing.
```
exit 1; golden restored byte-identical (git-clean), gate green, corpus_id `457b96dfc5a0ffcd` unchanged through the whole pass — wire bytes never moved. No emitter or runtime changes anywhere in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
