### PR TITLE
rust: the self-contained flat word codec — 594% to 444% of generated C/C++

### DIFF
--- a/bench/results/2026-08-31-rustcodec-after-rust-arm64-macbook.csv
+++ b/bench/results/2026-08-31-rustcodec-after-rust-arm64-macbook.csv
@@ -1,0 +1,65 @@
+# schema bench results
+# date: 2026-08-31T05:07:52Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Igenerated/bench/cpp -Itest -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 75cfe97
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ecfb3c9 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+rust,rigidbody_moving,write,24000000,105,7,50810198,49606293,50907659,5087.92,2.56,bc776c004485e408,gen,crate,always,O3,unknown
+rust,rigidbody_moving,read,24000000,105,7,44483069,43667132,44986898,4454.35,2.97,bc776c004485e408,gen,crate,always,O3,unknown
+rust,rigidbody_at_rest,write,32000000,57,7,81738702,81483345,82149273,4443.27,0.81,bc776c004485e408,gen,crate,always,O3,unknown
+rust,rigidbody_at_rest,read,32000000,57,7,78452564,78217664,78718520,4264.64,0.64,bc776c004485e408,gen,crate,always,O3,unknown
+rust,chat,write,48000000,13,7,68827376,68182791,68894610,853.31,1.03,bc776c004485e408,gen,crate,always,O3,unknown
+rust,chat,read,48000000,13,7,103273325,103185965,103328700,1280.36,0.14,bc776c004485e408,gen,crate,always,O3,unknown
+rust,test,write,192000000,6,7,876364184,868338057,888094501,5014.60,2.25,bc776c004485e408,gen,crate,always,O3,unknown
+rust,test,read,192000000,6,7,278495926,261472919,285903487,1593.57,8.77,bc776c004485e408,gen,crate,always,O3,unknown
+rust,inputpacket,write,16000000,61,7,70729890,70658361,70781753,4114.65,0.17,bc776c004485e408,gen,crate,always,O3,unknown
+rust,inputpacket,read,16000000,61,7,72983503,72818033,73035210,4245.75,0.30,bc776c004485e408,gen,crate,always,O3,unknown
+rust,shipcreate,write,32000000,28,7,84901252,84839005,84983306,2267.11,0.17,bc776c004485e408,gen,crate,always,O3,unknown
+rust,shipcreate,read,32000000,28,7,91417645,91124606,91578367,2441.11,0.50,bc776c004485e408,gen,crate,always,O3,unknown
+rust,probe_header,write,256000000,10,7,249325322,249172467,249407323,2377.75,0.09,bc776c004485e408,gen,crate,always,O3,unknown
+rust,probe_header,read,256000000,10,7,182848093,179800460,188528825,1743.78,4.77,bc776c004485e408,gen,crate,always,O3,unknown
+rust,probebits,write,128000000,26,7,134737463,133831775,134827940,3340.89,0.74,bc776c004485e408,gen,crate,always,O3,unknown
+rust,probebits,read,128000000,26,7,149699052,149411662,149742010,3711.87,0.22,bc776c004485e408,gen,crate,always,O3,unknown
+rust,probearray,write,20000000,47,7,62555958,60334912,62686427,2803.93,3.76,bc776c004485e408,gen,crate,always,O3,unknown
+rust,probearray,read,20000000,47,7,66067762,65658750,66146808,2961.34,0.74,bc776c004485e408,gen,crate,always,O3,unknown
+rust,testdata,write,8000000,92,7,26479753,26338392,26606897,2323.28,1.01,bc776c004485e408,gen,crate,always,O3,unknown
+rust,testdata,read,8000000,92,7,24291326,24193021,24388909,2131.27,0.81,bc776c004485e408,gen,crate,always,O3,unknown
+rust,real_packet,write,8000000,204,7,10009000,10005813,10011704,1947.25,0.06,bc776c004485e408,gen,crate,always,O3,unknown
+rust,real_packet,read,8000000,204,7,9796531,9788773,9800563,1905.91,0.12,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_packet,write,32000000,49,7,70782125,70741226,70801708,3307.65,0.09,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_packet,read,32000000,49,7,87588474,87543964,87625020,4093.01,0.09,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_ints,write,40000000,14,7,132803686,132660377,132901202,1773.12,0.18,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_ints,read,40000000,14,7,146300183,143790928,149230623,1953.32,3.72,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_bits,write,48000000,20,7,148366233,148308873,148478425,2829.86,0.11,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_bits,read,48000000,20,7,159156119,155809356,162280468,3035.66,4.07,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_mixed,write,40000000,21,7,126075582,125879105,126179913,2524.94,0.24,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_mixed,read,40000000,21,7,135992573,135760505,136030902,2723.55,0.20,bc776c004485e408,gen,crate,always,O3,unknown
+rust,bench_packet,write,32000000,49,7,77207439,77154052,77223711,3607.91,0.09,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bench_packet,read,32000000,49,7,90673681,90609686,90695225,4237.18,0.09,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bench_ints,write,40000000,14,7,124274226,123446836,124316277,1659.24,0.70,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bench_ints,read,40000000,14,7,116328343,114027767,118246988,1553.15,3.63,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bench_bits,write,48000000,20,7,122996647,122872281,123069928,2345.97,0.16,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bench_bits,read,48000000,20,7,113165577,111097406,113688982,2158.46,2.29,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bench_mixed,write,40000000,21,7,102557463,102262940,102642894,2053.93,0.37,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bench_mixed,read,40000000,21,7,104582284,104515312,104713481,2094.49,0.19,bc776c004485e408,rt,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,7,33617,33512,33746,2100.49,0.70,bc776c004485e408,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,7,36610,36569,36621,2287.53,0.14,bc776c004485e408,bits,crate,always,O3,unknown

--- a/bench/results/2026-08-31-rustcodec-quick-arm64-macbook.csv
+++ b/bench/results/2026-08-31-rustcodec-quick-arm64-macbook.csv
@@ -1,0 +1,59 @@
+# schema bench results
+# date: 2026-08-31T05:10:50Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/cpp -Igenerated/bench/cpp -Itest -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/c -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 75cfe97
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ecfb3c9 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,40000000,21,3,618336774,604567508,627434987,12383.53,3.70,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,read,40000000,21,3,554142623,541571539,555766863,11097.90,2.56,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,write,40000000,21,3,150277026,148586363,151047016,3009.62,1.64,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+cpp,bench_mixed,read,40000000,21,3,185776344,178364664,189759435,3720.57,6.13,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,40000000,21,3,610379503,598381379,616741446,12224.17,3.01,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+c,bench_mixed,read,40000000,21,3,477811623,473238370,477925802,9569.21,0.98,457b96dfc5a0ffcd,gen,hdr,removed,O3,unknown
+c,bench_mixed,write,40000000,21,3,158789390,158580388,158890310,3180.10,0.20,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+c,bench_mixed,read,40000000,21,3,173858618,173591522,174250180,3481.89,0.38,457b96dfc5a0ffcd,rt,hdr,removed,O3,unknown
+go,bench_mixed,write,40000000,21,3,40810229,40603184,40844690,817.31,0.59,457b96dfc5a0ffcd,gen,pkg,always,default,unknown
+go,bench_mixed,read,40000000,21,3,34938509,34908244,34940415,699.72,0.09,457b96dfc5a0ffcd,gen,pkg,always,default,unknown
+go,bench_mixed,write,40000000,21,3,43735321,43712789,43744450,875.89,0.07,457b96dfc5a0ffcd,rt,pkg,always,default,unknown
+go,bench_mixed,read,40000000,21,3,36738144,36729786,36748763,735.76,0.05,457b96dfc5a0ffcd,rt,pkg,always,default,unknown
+rust,bench_mixed,write,40000000,21,3,126075963,126023217,126178985,2524.94,0.12,457b96dfc5a0ffcd,gen,crate,always,O3,unknown
+rust,bench_mixed,read,40000000,21,3,140006347,140000487,140256532,2803.93,0.18,457b96dfc5a0ffcd,gen,crate,always,O3,unknown
+rust,bench_mixed,write,40000000,21,3,102603456,102594168,102616211,2054.86,0.02,457b96dfc5a0ffcd,rt,crate,always,O3,unknown
+rust,bench_mixed,read,40000000,21,3,99820334,99765593,99879676,1999.12,0.11,457b96dfc5a0ffcd,rt,crate,always,O3,unknown
+cs,bench_mixed,write,40000000,21,3,76467142,76330590,76722639,1531.42,0.51,457b96dfc5a0ffcd,gen,asm,always,default,unknown
+cs,bench_mixed,read,40000000,21,3,71292517,71290548,71301159,1427.79,0.01,457b96dfc5a0ffcd,gen,asm,always,default,unknown
+cs,bench_mixed,write,40000000,21,3,48130202,47920192,48203492,963.91,0.59,457b96dfc5a0ffcd,rt,asm,always,default,unknown
+cs,bench_mixed,read,40000000,21,3,41638218,38543228,41811500,833.90,7.85,457b96dfc5a0ffcd,rt,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,40000000,21,3,7995172,7836305,8097342,160.12,3.26,457b96dfc5a0ffcd,gen,esm,contract,default,unknown,flat
+js,bench_mixed,read,40000000,21,3,38131277,38045732,38635217,763.66,1.55,457b96dfc5a0ffcd,gen,esm,contract,default,unknown,flat
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,40000000,21,3,175386512,175330200,175473326,3512.49,0.08,457b96dfc5a0ffcd,gen,class,contract,default,unknown
+java,bench_mixed,read,40000000,21,3,136780058,136519296,136861782,2739.32,0.25,457b96dfc5a0ffcd,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,40000000,21,3,52786605,52738444,52838344,1057.17,0.19,457b96dfc5a0ffcd,gen,aot,contract,default,unknown
+dart,bench_mixed,read,40000000,21,3,75332120,75287740,75400423,1508.69,0.15,457b96dfc5a0ffcd,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,8000000,21,3,2359955,2356839,2366423,47.26,0.41,457b96dfc5a0ffcd,gen,beam,contract,default,unknown
+elixir,bench_mixed,read,8000000,21,3,6457263,6346965,6595646,129.32,3.85,457b96dfc5a0ffcd,gen,beam,contract,default,unknown

--- a/bench/rust/README.md
+++ b/bench/rust/README.md
@@ -33,8 +33,19 @@ profile on your own whole-program evidence. Full table:
 
 Escape barrier: `std::hint::black_box` on the written buffer and every
 decoded value. Streams borrow their buffers, so per-iteration construction
-is free — the C++ shape exactly; the generic driver monomorphizes and
-inlines like the C++ template reference. The batch read hoists ONE reused
+is free — the C++ shape exactly. The generic driver monomorphizes, but it
+does NOT inline like the C++ template reference, and the difference is
+measured: `#[inline(always)]` on a generated spine is honoured only into the
+`Fn::call` shim standing between the driver and the spine, and LLVM then
+prices that shim against its caller and refuses it, so every generated call
+in a timed loop is an out-of-line call entered with an unknown stream
+position. clang honours `always_inline` unconditionally, so the C and C++
+legs never see that regime. Rebuilding this leg with
+`RUSTFLAGS="-C llvm-args=--inline-threshold=5000"` — a diagnostic, not a
+shipped flag — moves the generated rows 2.3x and the hand-written `rt` rows
+4.5x on the same binary. Equalizing that discipline is a named open item on
+issue #170; until it is ruled, every rust row here is measured out of line.
+The batch read hoists ONE reused
 `Message` and fills it through `read_message_into` — the Rust shape of the
 go/cs runners' hoisted `MessageStorage` and the C++ runner's reused
 `Message` (`read_message`'s by-value return copies the ~2 KB enum out of

--- a/generated/bench/rust-realworld/src/realworld.rs
+++ b/generated/bench/rust-realworld/src/realworld.rs
@@ -380,21 +380,20 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f001_int < -805495 || value.f001_int > 805495 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f001_int as u32).wrapping_sub((-805495_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 21)?;
-    }
-    {
-        let mut float_value = value.f002_f64;
-        stream.serialize_f64(&mut float_value)?;
-    }
     if value.f003_int < -835897 || value.f003_int > 835897 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f003_int as u32).wrapping_sub((-835897_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 21)?;
-    }
+    let f0: u64 = u64::from((value.f001_int as u32).wrapping_sub((-805495_i32) as u32));
+    let f1: u64 = value.f002_f64.to_bits();
+    let f2: u64 = u64::from((value.f003_int as u32).wrapping_sub((-835897_i32) as u32));
+    let mut w0 = (f0 | (f1 << 21)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f1 >> 11) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f1 >> 43) | (f2 << 21)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f2 >> 11) as u32;
+    stream.serialize_bits(&mut w3, 10)?;
     {
         let mut compressed_value = value.f004_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 20000, 15, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 0.1, constants folded at generation
@@ -402,66 +401,49 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f005_uint > 7316 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f005_uint as u32;
-        stream.serialize_bits(&mut offset_value, 13)?;
-    }
     if value.f006_int < -1513 || value.f006_int > 1513 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.f006_int as u32).wrapping_sub((-1513_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
-    {
-        let mut float_value = value.f007_f32;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut raw_value = value.f008_u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
     }
     if value.f009_int < -22 || value.f009_int > 22 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f009_int as u32).wrapping_sub((-22_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 6)?;
-    }
-    {
-        let mut float_value = value.f010_f32;
-        stream.serialize_f32(&mut float_value)?;
-    }
     if value.f011_bits >= 1 << 10 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f011_bits;
-        stream.serialize_bits(&mut raw_value, 10)?;
-    }
-    {
-        let mut bool_value = value.f012_bool;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from(value.f005_uint as u32);
+    let f1: u64 = u64::from((value.f006_int as u32).wrapping_sub((-1513_i32) as u32));
+    let f2: u64 = u64::from(value.f007_f32.to_bits());
+    let f3: u64 = value.f008_u64;
+    let f4: u64 = u64::from((value.f009_int as u32).wrapping_sub((-22_i32) as u32));
+    let f5: u64 = u64::from(value.f010_f32.to_bits());
+    let f6: u64 = u64::from(value.f011_bits);
+    let f7: u64 = u64::from(value.f012_bool);
+    let mut w0 = (f0 | (f1 << 13) | (f2 << 25)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 7) | (f3 << 25)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f3 >> 7) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f3 >> 39) | (f4 << 25) | (f5 << 31)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f5 >> 1) | (f6 << 31)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = ((f6 >> 1) | (f7 << 9)) as u32;
+    stream.serialize_bits(&mut w5, 10)?;
     if value.f012_bool {
-        {
-            let mut float_value = value.f013_f32;
-            stream.serialize_f32(&mut float_value)?;
-        }
         if value.f014_uint > 775 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        {
-            let mut offset_value = value.f014_uint as u32;
-            stream.serialize_bits(&mut offset_value, 10)?;
         }
         if value.f015_int < -21 || value.f015_int > 21 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = (value.f015_int as u32).wrapping_sub((-21_i32) as u32);
-            stream.serialize_bits(&mut offset_value, 6)?;
-        }
+        let f0: u64 = u64::from(value.f013_f32.to_bits());
+        let f1: u64 = u64::from(value.f014_uint as u32);
+        let f2: u64 = u64::from((value.f015_int as u32).wrapping_sub((-21_i32) as u32));
+        let mut w0 = f0 as u32;
+        stream.serialize_bits(&mut w0, 32)?;
+        let mut w1 = (f1 | (f2 << 10)) as u32;
+        stream.serialize_bits(&mut w1, 16)?;
         if value.f016_fixed < -37748736 || value.f016_fixed > 37748736 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
@@ -480,18 +462,17 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f018_int < -834 || value.f018_int > 834 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f018_int as u32).wrapping_sub((-834_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 11)?;
-    }
-    {
-        let mut float_value = value.f019_f64;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.f020_f32;
-        stream.serialize_f32(&mut float_value)?;
-    }
+    let f0: u64 = u64::from((value.f018_int as u32).wrapping_sub((-834_i32) as u32));
+    let f1: u64 = value.f019_f64.to_bits();
+    let f2: u64 = u64::from(value.f020_f32.to_bits());
+    let mut w0 = (f0 | (f1 << 11)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f1 >> 21) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f1 >> 53) | (f2 << 11)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f2 >> 21) as u32;
+    stream.serialize_bits(&mut w3, 11)?;
     if value.f021_ufixed > 102977536 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -499,21 +480,18 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         let mut fixed_value = value.f021_ufixed;
         stream.serialize_fixed(&mut fixed_value, 20, 12, 0, 25141)?;
     }
-    {
-        let mut float_value = value.f022_f32;
-        stream.serialize_f32(&mut float_value)?;
-    }
     if value.f023_bits >= 1 << 25 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f023_bits;
-        stream.serialize_bits(&mut raw_value, 25)?;
-    }
-    {
-        let mut float_value = value.f024_f32;
-        stream.serialize_f32(&mut float_value)?;
-    }
+    let f0: u64 = u64::from(value.f022_f32.to_bits());
+    let f1: u64 = u64::from(value.f023_bits);
+    let f2: u64 = u64::from(value.f024_f32.to_bits());
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f1 | (f2 << 25)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f2 >> 7) as u32;
+    stream.serialize_bits(&mut w2, 25)?;
     if value.f025_fixed < -30464 || value.f025_fixed > 30464 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -535,75 +513,51 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f028_bits >= 1 << 4 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f028_bits;
-        stream.serialize_bits(&mut raw_value, 4)?;
-    }
-    {
-        let mut raw_value = value.f029_i64 as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut float_value = value.f030_f32;
-        stream.serialize_f32(&mut float_value)?;
-    }
     if value.f031_bits >= 1 << 1 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.f031_bits;
-        stream.serialize_bits(&mut raw_value, 1)?;
     }
     if value.f032_int < -3 || value.f032_int > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f032_int as u32).wrapping_sub((-3_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 3)?;
-    }
     if value.f033_uint > 142780 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.f033_uint;
-        stream.serialize_bits(&mut offset_value, 18)?;
     }
     if value.f034_uint > 14149 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f034_uint as u32;
-        stream.serialize_bits(&mut offset_value, 14)?;
-    }
     if value.f035_bits >= 1 << 9 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.f035_bits;
-        stream.serialize_bits(&mut raw_value, 9)?;
     }
     if value.f036_enum.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f036_enum.0 as u32;
-        stream.serialize_bits(&mut offset_value, 3)?;
-    }
-    {
-        let mut bool_value = value.f037_bool;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.f038_bool;
-        stream.serialize_bool(&mut bool_value)?;
-    }
     if value.f039_bits >= 1 << 19 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f039_bits;
-        stream.serialize_bits(&mut raw_value, 19)?;
-    }
+    let f0: u64 = u64::from(value.f028_bits);
+    let f1: u64 = value.f029_i64 as u64;
+    let f2: u64 = u64::from(value.f030_f32.to_bits());
+    let f3: u64 = u64::from(value.f031_bits);
+    let f4: u64 = u64::from((value.f032_int as u32).wrapping_sub((-3_i32) as u32));
+    let f5: u64 = u64::from(value.f033_uint);
+    let f6: u64 = u64::from(value.f034_uint as u32);
+    let f7: u64 = u64::from(value.f035_bits);
+    let f8: u64 = u64::from(value.f036_enum.0);
+    let f9: u64 = u64::from(value.f037_bool);
+    let f10: u64 = u64::from(value.f038_bool);
+    let f11: u64 = u64::from(value.f039_bits);
+    let mut w0 = (f0 | (f1 << 4)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f1 >> 28) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f1 >> 60) | (f2 << 4)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f2 >> 28) | (f3 << 4) | (f4 << 5) | (f5 << 8) | (f6 << 26)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f6 >> 6) | (f7 << 8) | (f8 << 17) | (f9 << 20) | (f10 << 21) | (f11 << 22)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f11 >> 10) as u32;
+    stream.serialize_bits(&mut w5, 9)?;
     if value.f040_fixed < -20480 || value.f040_fixed > 20480 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -614,47 +568,36 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f041_int < -55 || value.f041_int > 55 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f041_int as u32).wrapping_sub((-55_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 7)?;
-    }
     if value.f042_bits >= 1 << 30 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f042_bits;
-        stream.serialize_bits(&mut raw_value, 30)?;
-    }
-    {
-        let mut bool_value = value.f043_bool;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from((value.f041_int as u32).wrapping_sub((-55_i32) as u32));
+    let f1: u64 = u64::from(value.f042_bits);
+    let f2: u64 = u64::from(value.f043_bool);
+    let mut w0 = (f0 | (f1 << 7)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 25) | (f2 << 5)) as u32;
+    stream.serialize_bits(&mut w1, 6)?;
     if value.f043_bool {
-        {
-            let mut float_value = value.f044_f32;
-            stream.serialize_f32(&mut float_value)?;
-        }
         if value.f045_bits >= 1 << 12 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        {
-            let mut raw_value = value.f045_bits;
-            stream.serialize_bits(&mut raw_value, 12)?;
         }
         if value.f046_uint > 76063 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = value.f046_uint;
-            stream.serialize_bits(&mut offset_value, 17)?;
-        }
         if value.f047_int < -430976 || value.f047_int > 430976 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = (value.f047_int as u32).wrapping_sub((-430976_i32) as u32);
-            stream.serialize_bits(&mut offset_value, 20)?;
-        }
+        let f0: u64 = u64::from(value.f044_f32.to_bits());
+        let f1: u64 = u64::from(value.f045_bits);
+        let f2: u64 = u64::from(value.f046_uint);
+        let f3: u64 = u64::from((value.f047_int as u32).wrapping_sub((-430976_i32) as u32));
+        let mut w0 = f0 as u32;
+        stream.serialize_bits(&mut w0, 32)?;
+        let mut w1 = (f1 | (f2 << 12) | (f3 << 29)) as u32;
+        stream.serialize_bits(&mut w1, 32)?;
+        let mut w2 = (f3 >> 3) as u32;
+        stream.serialize_bits(&mut w2, 17)?;
     }
     {
         let mut float_value = value.f048_f64;
@@ -672,62 +615,44 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
         stream.serialize_bool(&mut bool_value)?;
     }
     if value.f050_bool {
-        {
-            let mut bool_value = value.f051_bool;
-            stream.serialize_bool(&mut bool_value)?;
-        }
         if value.f052_int < -57 || value.f052_int > 57 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        {
-            let mut offset_value = (value.f052_int as u32).wrapping_sub((-57_i32) as u32);
-            stream.serialize_bits(&mut offset_value, 7)?;
-        }
-        {
-            let mut float_value = value.f053_f32;
-            stream.serialize_f32(&mut float_value)?;
         }
         if value.f054_int < -35 || value.f054_int > 35 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = (value.f054_int as u32).wrapping_sub((-35_i32) as u32);
-            stream.serialize_bits(&mut offset_value, 7)?;
-        }
-    }
-    {
-        let mut bool_value = value.f055_bool;
-        stream.serialize_bool(&mut bool_value)?;
+        let f0: u64 = u64::from(value.f051_bool);
+        let f1: u64 = u64::from((value.f052_int as u32).wrapping_sub((-57_i32) as u32));
+        let f2: u64 = u64::from(value.f053_f32.to_bits());
+        let f3: u64 = u64::from((value.f054_int as u32).wrapping_sub((-35_i32) as u32));
+        let mut w0 = (f0 | (f1 << 1) | (f2 << 8)) as u32;
+        stream.serialize_bits(&mut w0, 32)?;
+        let mut w1 = ((f2 >> 24) | (f3 << 8)) as u32;
+        stream.serialize_bits(&mut w1, 15)?;
     }
     if value.f056_int < -13 || value.f056_int > 13 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f056_int as u32).wrapping_sub((-13_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 5)?;
-    }
     if value.f057_int < -15 || value.f057_int > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.f057_int as u32).wrapping_sub((-15_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 5)?;
-    }
-    {
-        let mut float_value = value.f058_f32;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.f059_f64;
-        stream.serialize_f64(&mut float_value)?;
     }
     if value.f060_bits >= 1 << 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f060_bits;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
+    let f0: u64 = u64::from(value.f055_bool);
+    let f1: u64 = u64::from((value.f056_int as u32).wrapping_sub((-13_i32) as u32));
+    let f2: u64 = u64::from((value.f057_int as u32).wrapping_sub((-15_i32) as u32));
+    let f3: u64 = u64::from(value.f058_f32.to_bits());
+    let f4: u64 = value.f059_f64.to_bits();
+    let f5: u64 = u64::from(value.f060_bits);
+    let mut w0 = (f0 | (f1 << 1) | (f2 << 6) | (f3 << 11)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f3 >> 21) | (f4 << 11)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f4 >> 21) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f4 >> 53) | (f5 << 11)) as u32;
+    stream.serialize_bits(&mut w3, 19)?;
     {
         let mut compressed_value = value.f061_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 360, 9, 180.0_f32, -90.0_f32)?; // compressed float [-90.0, 90.0] @ 0.5, constants folded at generation
@@ -735,21 +660,18 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f062_uint > 503 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f062_uint as u32;
-        stream.serialize_bits(&mut offset_value, 9)?;
-    }
-    {
-        let mut raw_value = value.f063_i64 as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
     if value.f064_uint > 299 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f064_uint as u32;
-        stream.serialize_bits(&mut offset_value, 9)?;
-    }
+    let f0: u64 = u64::from(value.f062_uint as u32);
+    let f1: u64 = value.f063_i64 as u64;
+    let f2: u64 = u64::from(value.f064_uint as u32);
+    let mut w0 = (f0 | (f1 << 9)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f1 >> 23) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f1 >> 55) | (f2 << 9)) as u32;
+    stream.serialize_bits(&mut w2, 18)?;
     {
         let mut compressed_value = value.f065_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 60, 6, 30.0_f32, 0.0_f32)?; // compressed float [0.0, 30.0] @ 0.5, constants folded at generation
@@ -772,17 +694,13 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f069_bits >= 1 << 11 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f069_bits;
-        stream.serialize_bits(&mut raw_value, 11)?;
-    }
     if value.f070_uint > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f070_uint as u32;
-        stream.serialize_bits(&mut offset_value, 2)?;
-    }
+    let f0: u64 = u64::from(value.f069_bits);
+    let f1: u64 = u64::from(value.f070_uint as u32);
+    let mut w0 = (f0 | (f1 << 11)) as u32;
+    stream.serialize_bits(&mut w0, 13)?;
     {
         let mut compressed_value = value.f071_cf32;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 500, 9, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.02, constants folded at generation
@@ -794,73 +712,54 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f073_int < -4 || value.f073_int > 4 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f073_int as u32).wrapping_sub((-4_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 4)?;
-    }
-    {
-        let mut bool_value = value.f074_bool;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from((value.f073_int as u32).wrapping_sub((-4_i32) as u32));
+    let f1: u64 = u64::from(value.f074_bool);
+    let mut w0 = (f0 | (f1 << 4)) as u32;
+    stream.serialize_bits(&mut w0, 5)?;
     if value.f074_bool {
-        {
-            let mut raw_value = value.f075_u64;
-            stream.serialize_bits64(&mut raw_value, 64)?;
-        }
         if value.f076_int < -26218 || value.f076_int > 26218 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        {
-            let mut offset_value = (value.f076_int as u32).wrapping_sub((-26218_i32) as u32);
-            stream.serialize_bits(&mut offset_value, 16)?;
         }
         if value.f077_int < -17 || value.f077_int > 17 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = (value.f077_int as u32).wrapping_sub((-17_i32) as u32);
-            stream.serialize_bits(&mut offset_value, 6)?;
-        }
         if value.f078_bits >= 1 << 9 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-        }
-        {
-            let mut raw_value = value.f078_bits;
-            stream.serialize_bits(&mut raw_value, 9)?;
         }
         if value.f079_uint > 17 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = value.f079_uint as u32;
-            stream.serialize_bits(&mut offset_value, 5)?;
-        }
-    }
-    {
-        let mut bool_value = value.f080_bool;
-        stream.serialize_bool(&mut bool_value)?;
+        let f0: u64 = value.f075_u64;
+        let f1: u64 = u64::from((value.f076_int as u32).wrapping_sub((-26218_i32) as u32));
+        let f2: u64 = u64::from((value.f077_int as u32).wrapping_sub((-17_i32) as u32));
+        let f3: u64 = u64::from(value.f078_bits);
+        let f4: u64 = u64::from(value.f079_uint as u32);
+        let mut w0 = f0 as u32;
+        stream.serialize_bits(&mut w0, 32)?;
+        let mut w1 = (f0 >> 32) as u32;
+        stream.serialize_bits(&mut w1, 32)?;
+        let mut w2 = (f1 | (f2 << 16) | (f3 << 22) | (f4 << 31)) as u32;
+        stream.serialize_bits(&mut w2, 32)?;
+        let mut w3 = (f4 >> 1) as u32;
+        stream.serialize_bits(&mut w3, 4)?;
     }
     if value.f081_bits >= 1 << 29 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f081_bits;
-        stream.serialize_bits(&mut raw_value, 29)?;
-    }
     if value.f082_bits >= 1 << 25 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.f082_bits;
-        stream.serialize_bits(&mut raw_value, 25)?;
     }
     if value.f083_enum.0 > 5 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f083_enum.0 as u32;
-        stream.serialize_bits(&mut offset_value, 3)?;
-    }
+    let f0: u64 = u64::from(value.f080_bool);
+    let f1: u64 = u64::from(value.f081_bits);
+    let f2: u64 = u64::from(value.f082_bits);
+    let f3: u64 = u64::from(value.f083_enum.0);
+    let mut w0 = (f0 | (f1 << 1) | (f2 << 30)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 2) | (f3 << 23)) as u32;
+    stream.serialize_bits(&mut w1, 26)?;
     if value.f084_ufixed > 128 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -871,62 +770,48 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f085_bits >= 1 << 21 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f085_bits;
-        stream.serialize_bits(&mut raw_value, 21)?;
-    }
     if value.f086_uint > 399 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.f086_uint as u32;
-        stream.serialize_bits(&mut offset_value, 9)?;
-    }
-    {
-        let mut float_value = value.f087_f64;
-        stream.serialize_f64(&mut float_value)?;
     }
     if value.f088_int < -694 || value.f088_int > 694 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f088_int as u32).wrapping_sub((-694_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 11)?;
-    }
     if value.f089_bits >= 1 << 48 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f089_bits;
-        stream.serialize_bits64(&mut raw_value, 48)?;
-    }
     if value.f090_uint > 214 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.f090_uint as u32;
-        stream.serialize_bits(&mut offset_value, 8)?;
     }
     if value.f091_flags >= 1 << 5 {
         // a mask bit above the wire width cannot ride
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut flags_value = value.f091_flags as u32;
-        stream.serialize_bits(&mut flags_value, 5)?;
-    }
-    {
-        let mut bool_value = value.f092_bool;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut raw_value = value.f093_bits;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut bool_value = value.f094_bool;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from(value.f085_bits);
+    let f1: u64 = u64::from(value.f086_uint as u32);
+    let f2: u64 = value.f087_f64.to_bits();
+    let f3: u64 = u64::from((value.f088_int as u32).wrapping_sub((-694_i32) as u32));
+    let f4: u64 = value.f089_bits;
+    let f5: u64 = u64::from(value.f090_uint as u32);
+    let f6: u64 = value.f091_flags;
+    let f7: u64 = u64::from(value.f092_bool);
+    let f8: u64 = value.f093_bits;
+    let f9: u64 = u64::from(value.f094_bool);
+    let mut w0 = (f0 | (f1 << 21) | (f2 << 30)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f2 >> 2) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f2 >> 34) | (f3 << 30)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f3 >> 2) | (f4 << 9)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f4 >> 23) | (f5 << 25)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = ((f5 >> 7) | (f6 << 1) | (f7 << 6) | (f8 << 7)) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = (f8 >> 25) as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = ((f8 >> 57) | (f9 << 7)) as u32;
+    stream.serialize_bits(&mut w7, 8)?;
     if value.f095_fixed < -103350272 || value.f095_fixed > 103350272 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -937,58 +822,96 @@ pub fn write_real_packet(stream: &mut WriteStream<'_>, value: &RealPacket) -> Re
     if value.f096_bits >= 1 << 18 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f096_bits;
-        stream.serialize_bits(&mut raw_value, 18)?;
-    }
     if value.f097_bits >= 1 << 12 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f097_bits;
-        stream.serialize_bits(&mut raw_value, 12)?;
-    }
+    let f0: u64 = u64::from(value.f096_bits);
+    let f1: u64 = u64::from(value.f097_bits);
+    let mut w0 = (f0 | (f1 << 18)) as u32;
+    stream.serialize_bits(&mut w0, 30)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> Result {
-    stream.serialize_int(&mut value.f001_int, -805495, 805495)?;
-    stream.serialize_f64(&mut value.f002_f64)?;
-    stream.serialize_int(&mut value.f003_int, -835897, 835897)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 10)?;
+    let c3 = u64::from(c);
+    let v0: u64 = c0 & 0x1fffff;
+    if v0 > 1610990 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f001_int = (v0 as u32).wrapping_add((-805495_i32) as u32) as i32;
+    let v1: u64 = (c0 >> 21) | (c1 << 11) | (c2 << 43);
+    value.f002_f64 = f64::from_bits(v1);
+    let v2: u64 = ((c2 >> 21) | (c3 << 11)) & 0x1fffff;
+    if v2 > 1671794 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f003_int = (v2 as u32).wrapping_add((-835897_i32) as u32) as i32;
     stream.serialize_compressed_float_precomputed(&mut value.f004_cf32, 20000, 15, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 0.1, constants folded at generation
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 7316)?;
-        value.f005_uint = range_value as u16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 10)?;
+    let c5 = u64::from(c);
+    let v0: u64 = c0 & 0x1fff;
+    if v0 > 7316 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -1513, 1513)?;
-        value.f006_int = range_value as i16;
+    value.f005_uint = (v0 as i32) as u16;
+    let v1: u64 = (c0 >> 13) & 0xfff;
+    if v1 > 3026 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_f32(&mut value.f007_f32)?;
-    stream.serialize_bits64(&mut value.f008_u64, 64)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -22, 22)?;
-        value.f009_int = range_value as i8;
+    value.f006_int = ((v1 as u32).wrapping_add((-1513_i32) as u32) as i32) as i16;
+    let v2: u64 = ((c0 >> 25) | (c1 << 7)) & 0xffffffff;
+    value.f007_f32 = f32::from_bits(v2 as u32);
+    let v3: u64 = (c1 >> 25) | (c2 << 7) | (c3 << 39);
+    value.f008_u64 = v3;
+    let v4: u64 = (c3 >> 25) & 0x3f;
+    if v4 > 44 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_f32(&mut value.f010_f32)?;
-    stream.serialize_bits(&mut value.f011_bits, 10)?;
-    stream.serialize_bool(&mut value.f012_bool)?;
+    value.f009_int = ((v4 as u32).wrapping_add((-22_i32) as u32) as i32) as i8;
+    let v5: u64 = ((c3 >> 31) | (c4 << 1)) & 0xffffffff;
+    value.f010_f32 = f32::from_bits(v5 as u32);
+    let v6: u64 = ((c4 >> 31) | (c5 << 1)) & 0x3ff;
+    value.f011_bits = v6 as u32;
+    let v7: u64 = (c5 >> 9) & 0x1;
+    value.f012_bool = v7 != 0;
     if value.f012_bool {
-        stream.serialize_f32(&mut value.f013_f32)?;
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, 0, 775)?;
-            value.f014_uint = range_value as u16;
+        let mut c: u32 = 0;
+        stream.serialize_bits(&mut c, 32)?;
+        let c0 = u64::from(c);
+        stream.serialize_bits(&mut c, 16)?;
+        let c1 = u64::from(c);
+        let v0: u64 = c0 & 0xffffffff;
+        value.f013_f32 = f32::from_bits(v0 as u32);
+        let v1: u64 = c1 & 0x3ff;
+        if v1 > 775 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, -21, 21)?;
-            value.f015_int = range_value as i8;
+        value.f014_uint = (v1 as i32) as u16;
+        let v2: u64 = (c1 >> 10) & 0x3f;
+        if v2 > 42 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
+        value.f015_int = ((v2 as u32).wrapping_add((-21_i32) as u32) as i32) as i8;
         stream.serialize_fixed(&mut value.f016_fixed, 12, 20, -36, 36)?;
         {
             let mut range_value: i32 = 0;
@@ -1002,69 +925,127 @@ pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> 
         value.f016_fixed = 0;
         value.f017_uint = 0;
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -834, 834)?;
-        value.f018_int = range_value as i16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 11)?;
+    let c3 = u64::from(c);
+    let v0: u64 = c0 & 0x7ff;
+    if v0 > 1668 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_f64(&mut value.f019_f64)?;
-    stream.serialize_f32(&mut value.f020_f32)?;
+    value.f018_int = ((v0 as u32).wrapping_add((-834_i32) as u32) as i32) as i16;
+    let v1: u64 = (c0 >> 11) | (c1 << 21) | (c2 << 53);
+    value.f019_f64 = f64::from_bits(v1);
+    let v2: u64 = ((c2 >> 11) | (c3 << 21)) & 0xffffffff;
+    value.f020_f32 = f32::from_bits(v2 as u32);
     stream.serialize_fixed(&mut value.f021_ufixed, 20, 12, 0, 25141)?;
-    stream.serialize_f32(&mut value.f022_f32)?;
-    stream.serialize_bits(&mut value.f023_bits, 25)?;
-    stream.serialize_f32(&mut value.f024_f32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 25)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.f022_f32 = f32::from_bits(v0 as u32);
+    let v1: u64 = c1 & 0x1ffffff;
+    value.f023_bits = v1 as u32;
+    let v2: u64 = ((c1 >> 25) | (c2 << 7)) & 0xffffffff;
+    value.f024_f32 = f32::from_bits(v2 as u32);
     stream.serialize_fixed(&mut value.f025_fixed, 8, 8, -119, 119)?;
     stream.serialize_bits(&mut value.f026_bits, 9)?;
     stream.serialize_compressed_float_precomputed(&mut value.f027_cf32, 16, 5, 4.0_f32, -2.0_f32)?; // compressed float [-2.0, 2.0] @ 0.25, constants folded at generation
-    stream.serialize_bits(&mut value.f028_bits, 4)?;
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.f029_i64 = raw_value as i64;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 9)?;
+    let c5 = u64::from(c);
+    let v0: u64 = c0 & 0xf;
+    value.f028_bits = v0 as u32;
+    let v1: u64 = (c0 >> 4) | (c1 << 28) | (c2 << 60);
+    value.f029_i64 = v1 as i64;
+    let v2: u64 = ((c2 >> 4) | (c3 << 28)) & 0xffffffff;
+    value.f030_f32 = f32::from_bits(v2 as u32);
+    let v3: u64 = (c3 >> 4) & 0x1;
+    value.f031_bits = v3 as u32;
+    let v4: u64 = (c3 >> 5) & 0x7;
+    if v4 > 6 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_f32(&mut value.f030_f32)?;
-    stream.serialize_bits(&mut value.f031_bits, 1)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -3, 3)?;
-        value.f032_int = range_value as i8;
+    value.f032_int = ((v4 as u32).wrapping_add((-3_i32) as u32) as i32) as i8;
+    let v5: u64 = (c3 >> 8) & 0x3ffff;
+    if v5 > 142780 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 142780)?;
-        value.f033_uint = range_value as u32;
+    value.f033_uint = (v5 as i32) as u32;
+    let v6: u64 = ((c3 >> 26) | (c4 << 6)) & 0x3fff;
+    if v6 > 14149 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 14149)?;
-        value.f034_uint = range_value as u16;
+    value.f034_uint = (v6 as i32) as u16;
+    let v7: u64 = (c4 >> 8) & 0x1ff;
+    value.f035_bits = v7 as u32;
+    let v8: u64 = (c4 >> 17) & 0x7;
+    if v8 > 5 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_bits(&mut value.f035_bits, 9)?;
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 5)?;
-        value.f036_enum = PacketMode(enum_value as u8);
-    }
-    stream.serialize_bool(&mut value.f037_bool)?;
-    stream.serialize_bool(&mut value.f038_bool)?;
-    stream.serialize_bits(&mut value.f039_bits, 19)?;
+    value.f036_enum = PacketMode(v8 as u8);
+    let v9: u64 = (c4 >> 20) & 0x1;
+    value.f037_bool = v9 != 0;
+    let v10: u64 = (c4 >> 21) & 0x1;
+    value.f038_bool = v10 != 0;
+    let v11: u64 = ((c4 >> 22) | (c5 << 10)) & 0x7ffff;
+    value.f039_bits = v11 as u32;
     stream.serialize_fixed(&mut value.f040_fixed, 4, 12, -5, 5)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -55, 55)?;
-        value.f041_int = range_value as i8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 6)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0x7f;
+    if v0 > 110 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_bits(&mut value.f042_bits, 30)?;
-    stream.serialize_bool(&mut value.f043_bool)?;
+    value.f041_int = ((v0 as u32).wrapping_add((-55_i32) as u32) as i32) as i8;
+    let v1: u64 = ((c0 >> 7) | (c1 << 25)) & 0x3fffffff;
+    value.f042_bits = v1 as u32;
+    let v2: u64 = (c1 >> 5) & 0x1;
+    value.f043_bool = v2 != 0;
     if value.f043_bool {
-        stream.serialize_f32(&mut value.f044_f32)?;
-        stream.serialize_bits(&mut value.f045_bits, 12)?;
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, 0, 76063)?;
-            value.f046_uint = range_value as u32;
+        let mut c: u32 = 0;
+        stream.serialize_bits(&mut c, 32)?;
+        let c0 = u64::from(c);
+        stream.serialize_bits(&mut c, 32)?;
+        let c1 = u64::from(c);
+        stream.serialize_bits(&mut c, 17)?;
+        let c2 = u64::from(c);
+        let v0: u64 = c0 & 0xffffffff;
+        value.f044_f32 = f32::from_bits(v0 as u32);
+        let v1: u64 = c1 & 0xfff;
+        value.f045_bits = v1 as u32;
+        let v2: u64 = (c1 >> 12) & 0x1ffff;
+        if v2 > 76063 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        stream.serialize_int(&mut value.f047_int, -430976, 430976)?;
+        value.f046_uint = (v2 as i32) as u32;
+        let v3: u64 = ((c1 >> 29) | (c2 << 3)) & 0xfffff;
+        if v3 > 861952 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+        }
+        value.f047_int = (v3 as u32).wrapping_add((-430976_i32) as u32) as i32;
     } else {
         value.f044_f32 = 0.0;
         value.f045_bits = 0;
@@ -1075,90 +1056,133 @@ pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> 
     stream.serialize_fixed(&mut value.f049_ufixed, 2, 14, 0, 3)?;
     stream.serialize_bool(&mut value.f050_bool)?;
     if value.f050_bool {
-        stream.serialize_bool(&mut value.f051_bool)?;
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, -57, 57)?;
-            value.f052_int = range_value as i8;
+        let mut c: u32 = 0;
+        stream.serialize_bits(&mut c, 32)?;
+        let c0 = u64::from(c);
+        stream.serialize_bits(&mut c, 15)?;
+        let c1 = u64::from(c);
+        let v0: u64 = c0 & 0x1;
+        value.f051_bool = v0 != 0;
+        let v1: u64 = (c0 >> 1) & 0x7f;
+        if v1 > 114 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        stream.serialize_f32(&mut value.f053_f32)?;
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, -35, 35)?;
-            value.f054_int = range_value as i8;
+        value.f052_int = ((v1 as u32).wrapping_add((-57_i32) as u32) as i32) as i8;
+        let v2: u64 = ((c0 >> 8) | (c1 << 24)) & 0xffffffff;
+        value.f053_f32 = f32::from_bits(v2 as u32);
+        let v3: u64 = (c1 >> 8) & 0x7f;
+        if v3 > 70 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
+        value.f054_int = ((v3 as u32).wrapping_add((-35_i32) as u32) as i32) as i8;
     } else {
         value.f051_bool = false;
         value.f052_int = 0;
         value.f053_f32 = 0.0;
         value.f054_int = 0;
     }
-    stream.serialize_bool(&mut value.f055_bool)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -13, 13)?;
-        value.f056_int = range_value as i8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 19)?;
+    let c3 = u64::from(c);
+    let v0: u64 = c0 & 0x1;
+    value.f055_bool = v0 != 0;
+    let v1: u64 = (c0 >> 1) & 0x1f;
+    if v1 > 26 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -15, 15)?;
-        value.f057_int = range_value as i8;
+    value.f056_int = ((v1 as u32).wrapping_add((-13_i32) as u32) as i32) as i8;
+    let v2: u64 = (c0 >> 6) & 0x1f;
+    if v2 > 30 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_f32(&mut value.f058_f32)?;
-    stream.serialize_f64(&mut value.f059_f64)?;
-    stream.serialize_bits(&mut value.f060_bits, 8)?;
+    value.f057_int = ((v2 as u32).wrapping_add((-15_i32) as u32) as i32) as i8;
+    let v3: u64 = ((c0 >> 11) | (c1 << 21)) & 0xffffffff;
+    value.f058_f32 = f32::from_bits(v3 as u32);
+    let v4: u64 = (c1 >> 11) | (c2 << 21) | (c3 << 53);
+    value.f059_f64 = f64::from_bits(v4);
+    let v5: u64 = (c3 >> 11) & 0xff;
+    value.f060_bits = v5 as u32;
     stream.serialize_compressed_float_precomputed(&mut value.f061_cf32, 360, 9, 180.0_f32, -90.0_f32)?; // compressed float [-90.0, 90.0] @ 0.5, constants folded at generation
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 503)?;
-        value.f062_uint = range_value as u16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 18)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0x1ff;
+    if v0 > 503 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.f063_i64 = raw_value as i64;
+    value.f062_uint = (v0 as i32) as u16;
+    let v1: u64 = (c0 >> 9) | (c1 << 23) | (c2 << 55);
+    value.f063_i64 = v1 as i64;
+    let v2: u64 = (c2 >> 9) & 0x1ff;
+    if v2 > 299 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 299)?;
-        value.f064_uint = range_value as u16;
-    }
+    value.f064_uint = (v2 as i32) as u16;
     stream.serialize_compressed_float_precomputed(&mut value.f065_cf32, 60, 6, 30.0_f32, 0.0_f32)?; // compressed float [0.0, 30.0] @ 0.5, constants folded at generation
     stream.serialize_fixed(&mut value.f066_ufixed, 2, 14, 0, 2)?;
     stream.serialize_compressed_float_precomputed(&mut value.f067_cf32, 800, 10, 200.0_f32, -100.0_f32)?; // compressed float [-100.0, 100.0] @ 0.25, constants folded at generation
     stream.serialize_compressed_float_precomputed(&mut value.f068_cf32, 2000, 11, 2000.0_f32, 0.0_f32)?; // compressed float [0.0, 2000.0] @ 1.0, constants folded at generation
-    stream.serialize_bits(&mut value.f069_bits, 11)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 2)?;
-        value.f070_uint = range_value as u8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 13)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x7ff;
+    value.f069_bits = v0 as u32;
+    let v1: u64 = (c0 >> 11) & 0x3;
+    if v1 > 2 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.f070_uint = (v1 as i32) as u8;
     stream.serialize_compressed_float_precomputed(&mut value.f071_cf32, 500, 9, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.02, constants folded at generation
     stream.serialize_compressed_float_precomputed(&mut value.f072_cf32, 10000, 14, 100.0_f32, 0.0_f32)?; // compressed float [0.0, 100.0] @ 0.01, constants folded at generation
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -4, 4)?;
-        value.f073_int = range_value as i8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 5)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0xf;
+    if v0 > 8 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_bool(&mut value.f074_bool)?;
+    value.f073_int = ((v0 as u32).wrapping_add((-4_i32) as u32) as i32) as i8;
+    let v1: u64 = (c0 >> 4) & 0x1;
+    value.f074_bool = v1 != 0;
     if value.f074_bool {
-        stream.serialize_bits64(&mut value.f075_u64, 64)?;
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, -26218, 26218)?;
-            value.f076_int = range_value as i16;
+        let mut c: u32 = 0;
+        stream.serialize_bits(&mut c, 32)?;
+        let c0 = u64::from(c);
+        stream.serialize_bits(&mut c, 32)?;
+        let c1 = u64::from(c);
+        stream.serialize_bits(&mut c, 32)?;
+        let c2 = u64::from(c);
+        stream.serialize_bits(&mut c, 4)?;
+        let c3 = u64::from(c);
+        let v0: u64 = c0 | (c1 << 32);
+        value.f075_u64 = v0;
+        let v1: u64 = c2 & 0xffff;
+        if v1 > 52436 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, -17, 17)?;
-            value.f077_int = range_value as i8;
+        value.f076_int = ((v1 as u32).wrapping_add((-26218_i32) as u32) as i32) as i16;
+        let v2: u64 = (c2 >> 16) & 0x3f;
+        if v2 > 34 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        stream.serialize_bits(&mut value.f078_bits, 9)?;
-        {
-            let mut range_value: i32 = 0;
-            stream.serialize_int(&mut range_value, 0, 17)?;
-            value.f079_uint = range_value as u8;
+        value.f077_int = ((v2 as u32).wrapping_add((-17_i32) as u32) as i32) as i8;
+        let v3: u64 = (c2 >> 22) & 0x1ff;
+        value.f078_bits = v3 as u32;
+        let v4: u64 = ((c2 >> 31) | (c3 << 1)) & 0x1f;
+        if v4 > 17 {
+            return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
+        value.f079_uint = (v4 as i32) as u8;
     } else {
         value.f075_u64 = 0;
         value.f076_int = 0;
@@ -1166,44 +1190,77 @@ pub fn read_real_packet(stream: &mut ReadStream<'_>, value: &mut RealPacket) -> 
         value.f078_bits = 0;
         value.f079_uint = 0;
     }
-    stream.serialize_bool(&mut value.f080_bool)?;
-    stream.serialize_bits(&mut value.f081_bits, 29)?;
-    stream.serialize_bits(&mut value.f082_bits, 25)?;
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 5)?;
-        value.f083_enum = PacketMode(enum_value as u8);
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 26)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0x1;
+    value.f080_bool = v0 != 0;
+    let v1: u64 = (c0 >> 1) & 0x1fffffff;
+    value.f081_bits = v1 as u32;
+    let v2: u64 = ((c0 >> 30) | (c1 << 2)) & 0x1ffffff;
+    value.f082_bits = v2 as u32;
+    let v3: u64 = (c1 >> 23) & 0x7;
+    if v3 > 5 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.f083_enum = PacketMode(v3 as u8);
     stream.serialize_fixed(&mut value.f084_ufixed, 1, 7, 0, 1)?;
-    stream.serialize_bits(&mut value.f085_bits, 21)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 399)?;
-        value.f086_uint = range_value as u16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 8)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 & 0x1fffff;
+    value.f085_bits = v0 as u32;
+    let v1: u64 = (c0 >> 21) & 0x1ff;
+    if v1 > 399 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_f64(&mut value.f087_f64)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, -694, 694)?;
-        value.f088_int = range_value as i16;
+    value.f086_uint = (v1 as i32) as u16;
+    let v2: u64 = (c0 >> 30) | (c1 << 2) | (c2 << 34);
+    value.f087_f64 = f64::from_bits(v2);
+    let v3: u64 = ((c2 >> 30) | (c3 << 2)) & 0x7ff;
+    if v3 > 1388 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    stream.serialize_bits64(&mut value.f089_bits, 48)?;
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 214)?;
-        value.f090_uint = range_value as u8;
+    value.f088_int = ((v3 as u32).wrapping_add((-694_i32) as u32) as i32) as i16;
+    let v4: u64 = ((c3 >> 9) | (c4 << 23)) & 0xffffffffffff;
+    value.f089_bits = v4;
+    let v5: u64 = ((c4 >> 25) | (c5 << 7)) & 0xff;
+    if v5 > 214 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut flags_value: u32 = 0;
-        stream.serialize_bits(&mut flags_value, 5)?;
-        value.f091_flags = flags_value as PacketFlags;
-    }
-    stream.serialize_bool(&mut value.f092_bool)?;
-    stream.serialize_bits64(&mut value.f093_bits, 64)?;
-    stream.serialize_bool(&mut value.f094_bool)?;
+    value.f090_uint = (v5 as i32) as u8;
+    let v6: u64 = (c5 >> 1) & 0x1f;
+    value.f091_flags = v6;
+    let v7: u64 = (c5 >> 6) & 0x1;
+    value.f092_bool = v7 != 0;
+    let v8: u64 = (c5 >> 7) | (c6 << 25) | (c7 << 57);
+    value.f093_bits = v8;
+    let v9: u64 = (c7 >> 7) & 0x1;
+    value.f094_bool = v9 != 0;
     stream.serialize_fixed(&mut value.f095_fixed, 16, 16, -1577, 1577)?;
-    stream.serialize_bits(&mut value.f096_bits, 18)?;
-    stream.serialize_bits(&mut value.f097_bits, 12)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 30)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x3ffff;
+    value.f096_bits = v0 as u32;
+    let v1: u64 = (c0 >> 18) & 0xfff;
+    value.f097_bits = v1 as u32;
     Ok(())
 }
 

--- a/generated/bench/rust/src/bench.rs
+++ b/generated/bench/rust/src/bench.rs
@@ -82,65 +82,48 @@ pub fn write_bench_packet(stream: &mut WriteStream<'_>, value: &BenchPacket) -> 
     if value.a < -100 || value.a > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.a as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
-    }
     if value.b < 0 || value.b > 65535 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.b as u32;
-        stream.serialize_bits(&mut offset_value, 16)?;
     }
     if value.c < -1000000 || value.c > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.c as u32).wrapping_sub((-1000000_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 21)?;
-    }
     if value.bits7 >= 1 << 7 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.bits7;
-        stream.serialize_bits(&mut raw_value, 7)?;
     }
     if value.bits13 >= 1 << 13 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.bits13;
-        stream.serialize_bits(&mut raw_value, 13)?;
-    }
     if value.bits23 >= 1 << 23 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.bits23;
-        stream.serialize_bits(&mut raw_value, 23)?;
-    }
-    {
-        let mut bool_value = value.flag;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut float_value = value.x;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.y;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.z;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut raw_value = value.big;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = u64::from((value.a as u32).wrapping_sub((-100_i32) as u32));
+    let f1: u64 = u64::from(value.b as u32);
+    let f2: u64 = u64::from((value.c as u32).wrapping_sub((-1000000_i32) as u32));
+    let f3: u64 = u64::from(value.bits7);
+    let f4: u64 = u64::from(value.bits13);
+    let f5: u64 = u64::from(value.bits23);
+    let f6: u64 = u64::from(value.flag);
+    let f7: u64 = u64::from(value.x.to_bits());
+    let f8: u64 = u64::from(value.y.to_bits());
+    let f9: u64 = u64::from(value.z.to_bits());
+    let f10: u64 = value.big;
+    let mut w0 = (f0 | (f1 << 8) | (f2 << 24)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 8) | (f3 << 13) | (f4 << 20)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f4 >> 12) | (f5 << 1) | (f6 << 24) | (f7 << 25)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f7 >> 7) | (f8 << 25)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f8 >> 7) | (f9 << 25)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = ((f9 >> 7) | (f10 << 25)) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = (f10 >> 7) as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = (f10 >> 39) as u32;
+    stream.serialize_bits(&mut w7, 25)?;
     stream.serialize_align()?;
     stream.write_bytes(&value.blob); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
     Ok(())
@@ -148,17 +131,51 @@ pub fn write_bench_packet(stream: &mut WriteStream<'_>, value: &BenchPacket) -> 
 
 #[inline]
 pub fn read_bench_packet(stream: &mut ReadStream<'_>, value: &mut BenchPacket) -> Result {
-    stream.serialize_int(&mut value.a, -100, 100)?;
-    stream.serialize_int(&mut value.b, 0, 65535)?;
-    stream.serialize_int(&mut value.c, -1000000, 1000000)?;
-    stream.serialize_bits(&mut value.bits7, 7)?;
-    stream.serialize_bits(&mut value.bits13, 13)?;
-    stream.serialize_bits(&mut value.bits23, 23)?;
-    stream.serialize_bool(&mut value.flag)?;
-    stream.serialize_f32(&mut value.x)?;
-    stream.serialize_f32(&mut value.y)?;
-    stream.serialize_f32(&mut value.z)?;
-    stream.serialize_bits64(&mut value.big, 64)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 25)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 & 0xff;
+    if v0 > 200 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.a = (v0 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v1: u64 = (c0 >> 8) & 0xffff;
+    value.b = v1 as i32;
+    let v2: u64 = ((c0 >> 24) | (c1 << 8)) & 0x1fffff;
+    if v2 > 2000000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.c = (v2 as u32).wrapping_add((-1000000_i32) as u32) as i32;
+    let v3: u64 = (c1 >> 13) & 0x7f;
+    value.bits7 = v3 as u32;
+    let v4: u64 = ((c1 >> 20) | (c2 << 12)) & 0x1fff;
+    value.bits13 = v4 as u32;
+    let v5: u64 = (c2 >> 1) & 0x7fffff;
+    value.bits23 = v5 as u32;
+    let v6: u64 = (c2 >> 24) & 0x1;
+    value.flag = v6 != 0;
+    let v7: u64 = ((c2 >> 25) | (c3 << 7)) & 0xffffffff;
+    value.x = f32::from_bits(v7 as u32);
+    let v8: u64 = ((c3 >> 25) | (c4 << 7)) & 0xffffffff;
+    value.y = f32::from_bits(v8 as u32);
+    let v9: u64 = ((c4 >> 25) | (c5 << 7)) & 0xffffffff;
+    value.z = f32::from_bits(v9 as u32);
+    let v10: u64 = (c5 >> 25) | (c6 << 7) | (c7 << 39);
+    value.big = v10;
     stream.serialize_align()?; // rejects nonzero padding (SPEC §4.3)
     stream.serialize_bytes(&mut value.blob)?; // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop
     Ok(())
@@ -208,88 +225,103 @@ pub fn write_bench_ints(stream: &mut WriteStream<'_>, value: &BenchInts) -> Resu
     if value.f0 < -100 || value.f0 > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f0 as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
-    }
     if value.f1 < 0 || value.f1 > 65535 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.f1 as u32;
-        stream.serialize_bits(&mut offset_value, 16)?;
     }
     if value.f2 < -1000000 || value.f2 > 1000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f2 as u32).wrapping_sub((-1000000_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 21)?;
-    }
     if value.f3 < 0 || value.f3 > 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.f3 as u32;
-        stream.serialize_bits(&mut offset_value, 2)?;
     }
     if value.f4 < -15 || value.f4 > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f4 as u32).wrapping_sub((-15_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 5)?;
-    }
     if value.f5 < 0 || value.f5 > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.f5 as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
     }
     if value.f6 < -2048 || value.f6 > 2047 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f6 as u32).wrapping_sub((-2048_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
     if value.f7 < 0 || value.f7 > 255 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.f7 as u32;
-        stream.serialize_bits(&mut offset_value, 8)?;
     }
     if value.f8 < -600000 || value.f8 > 600000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.f8 as u32).wrapping_sub((-600000_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 21)?;
-    }
     if value.f9 < 0 || value.f9 > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.f9 as u32;
-        stream.serialize_bits(&mut offset_value, 7)?;
-    }
+    let f0: u64 = u64::from((value.f0 as u32).wrapping_sub((-100_i32) as u32));
+    let f1: u64 = u64::from(value.f1 as u32);
+    let f2: u64 = u64::from((value.f2 as u32).wrapping_sub((-1000000_i32) as u32));
+    let f3: u64 = u64::from(value.f3 as u32);
+    let f4: u64 = u64::from((value.f4 as u32).wrapping_sub((-15_i32) as u32));
+    let f5: u64 = u64::from(value.f5 as u32);
+    let f6: u64 = u64::from((value.f6 as u32).wrapping_sub((-2048_i32) as u32));
+    let f7: u64 = u64::from(value.f7 as u32);
+    let f8: u64 = u64::from((value.f8 as u32).wrapping_sub((-600000_i32) as u32));
+    let f9: u64 = u64::from(value.f9 as u32);
+    let mut w0 = (f0 | (f1 << 8) | (f2 << 24)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 8) | (f3 << 13) | (f4 << 15) | (f5 << 20) | (f6 << 30)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f6 >> 2) | (f7 << 10) | (f8 << 18)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f8 >> 14) | (f9 << 7)) as u32;
+    stream.serialize_bits(&mut w3, 14)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_bench_ints(stream: &mut ReadStream<'_>, value: &mut BenchInts) -> Result {
-    stream.serialize_int(&mut value.f0, -100, 100)?;
-    stream.serialize_int(&mut value.f1, 0, 65535)?;
-    stream.serialize_int(&mut value.f2, -1000000, 1000000)?;
-    stream.serialize_int(&mut value.f3, 0, 3)?;
-    stream.serialize_int(&mut value.f4, -15, 15)?;
-    stream.serialize_int(&mut value.f5, 0, 1000)?;
-    stream.serialize_int(&mut value.f6, -2048, 2047)?;
-    stream.serialize_int(&mut value.f7, 0, 255)?;
-    stream.serialize_int(&mut value.f8, -600000, 600000)?;
-    stream.serialize_int(&mut value.f9, 0, 100)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 14)?;
+    let c3 = u64::from(c);
+    let v0: u64 = c0 & 0xff;
+    if v0 > 200 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f0 = (v0 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v1: u64 = (c0 >> 8) & 0xffff;
+    value.f1 = v1 as i32;
+    let v2: u64 = ((c0 >> 24) | (c1 << 8)) & 0x1fffff;
+    if v2 > 2000000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f2 = (v2 as u32).wrapping_add((-1000000_i32) as u32) as i32;
+    let v3: u64 = (c1 >> 13) & 0x3;
+    value.f3 = v3 as i32;
+    let v4: u64 = (c1 >> 15) & 0x1f;
+    if v4 > 30 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f4 = (v4 as u32).wrapping_add((-15_i32) as u32) as i32;
+    let v5: u64 = (c1 >> 20) & 0x3ff;
+    if v5 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f5 = v5 as i32;
+    let v6: u64 = ((c1 >> 30) | (c2 << 2)) & 0xfff;
+    value.f6 = (v6 as u32).wrapping_add((-2048_i32) as u32) as i32;
+    let v7: u64 = (c2 >> 10) & 0xff;
+    value.f7 = v7 as i32;
+    let v8: u64 = ((c2 >> 18) | (c3 << 14)) & 0x1fffff;
+    if v8 > 1200000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f8 = (v8 as u32).wrapping_add((-600000_i32) as u32) as i32;
+    let v9: u64 = (c3 >> 7) & 0x7f;
+    if v9 > 100 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.f9 = v9 as i32;
     Ok(())
 }
 
@@ -333,69 +365,74 @@ pub fn write_bench_bits(stream: &mut WriteStream<'_>, value: &BenchBits) -> Resu
     if value.b7 >= 1 << 7 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.b7;
-        stream.serialize_bits(&mut raw_value, 7)?;
-    }
     if value.b13 >= 1 << 13 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.b13;
-        stream.serialize_bits(&mut raw_value, 13)?;
     }
     if value.b23 >= 1 << 23 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.b23;
-        stream.serialize_bits(&mut raw_value, 23)?;
-    }
     if value.b3 >= 1 << 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.b3;
-        stream.serialize_bits(&mut raw_value, 3)?;
-    }
-    {
-        let mut raw_value = value.b32;
-        stream.serialize_bits(&mut raw_value, 32)?;
     }
     if value.b11 >= 1 << 11 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.b11;
-        stream.serialize_bits(&mut raw_value, 11)?;
-    }
     if value.b19 >= 1 << 19 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.b19;
-        stream.serialize_bits(&mut raw_value, 19)?;
     }
     if value.b48 >= 1 << 48 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.b48;
-        stream.serialize_bits64(&mut raw_value, 48)?;
-    }
+    let f0: u64 = u64::from(value.b7);
+    let f1: u64 = u64::from(value.b13);
+    let f2: u64 = u64::from(value.b23);
+    let f3: u64 = u64::from(value.b3);
+    let f4: u64 = u64::from(value.b32);
+    let f5: u64 = u64::from(value.b11);
+    let f6: u64 = u64::from(value.b19);
+    let f7: u64 = value.b48;
+    let mut w0 = (f0 | (f1 << 7) | (f2 << 20)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 12) | (f3 << 11) | (f4 << 14)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f4 >> 18) | (f5 << 14) | (f6 << 25)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f6 >> 7) | (f7 << 12)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = (f7 >> 20) as u32;
+    stream.serialize_bits(&mut w4, 28)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_bench_bits(stream: &mut ReadStream<'_>, value: &mut BenchBits) -> Result {
-    stream.serialize_bits(&mut value.b7, 7)?;
-    stream.serialize_bits(&mut value.b13, 13)?;
-    stream.serialize_bits(&mut value.b23, 23)?;
-    stream.serialize_bits(&mut value.b3, 3)?;
-    stream.serialize_bits(&mut value.b32, 32)?;
-    stream.serialize_bits(&mut value.b11, 11)?;
-    stream.serialize_bits(&mut value.b19, 19)?;
-    stream.serialize_bits64(&mut value.b48, 48)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 28)?;
+    let c4 = u64::from(c);
+    let v0: u64 = c0 & 0x7f;
+    value.b7 = v0 as u32;
+    let v1: u64 = (c0 >> 7) & 0x1fff;
+    value.b13 = v1 as u32;
+    let v2: u64 = ((c0 >> 20) | (c1 << 12)) & 0x7fffff;
+    value.b23 = v2 as u32;
+    let v3: u64 = (c1 >> 11) & 0x7;
+    value.b3 = v3 as u32;
+    let v4: u64 = ((c1 >> 14) | (c2 << 18)) & 0xffffffff;
+    value.b32 = v4 as u32;
+    let v5: u64 = (c2 >> 14) & 0x7ff;
+    value.b11 = v5 as u32;
+    let v6: u64 = ((c2 >> 25) | (c3 << 7)) & 0x7ffff;
+    value.b19 = v6 as u32;
+    let v7: u64 = ((c3 >> 12) | (c4 << 20)) & 0xffffffffffff;
+    value.b48 = v7;
     Ok(())
 }
 
@@ -445,87 +482,90 @@ pub fn write_bench_mixed(stream: &mut WriteStream<'_>, value: &BenchMixed) -> Re
     if value.sequence < 0 || value.sequence > 65535 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.sequence as u32;
-        stream.serialize_bits(&mut offset_value, 16)?;
-    }
-    {
-        let mut raw_value = value.ack_bits;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
     if value.entity_id >= 1 << 12 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.entity_id;
-        stream.serialize_bits(&mut raw_value, 12)?;
     }
     if value.pos_x < -16384 || value.pos_x > 16383 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.pos_x as u32).wrapping_sub((-16384_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 15)?;
-    }
     if value.pos_y < -16384 || value.pos_y > 16383 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.pos_y as u32).wrapping_sub((-16384_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 15)?;
     }
     if value.pos_z < -16384 || value.pos_z > 16383 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.pos_z as u32).wrapping_sub((-16384_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 15)?;
-    }
     if value.yaw >= 1 << 9 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.yaw;
-        stream.serialize_bits(&mut raw_value, 9)?;
-    }
-    {
-        let mut bool_value = value.moving;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.firing;
-        stream.serialize_bool(&mut bool_value)?;
     }
     if value.timestamp >= 1 << 48 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.timestamp;
-        stream.serialize_bits64(&mut raw_value, 48)?;
-    }
     if value.weapon < 0 || value.weapon > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.weapon as u32;
-        stream.serialize_bits(&mut offset_value, 4)?;
-    }
+    let f0: u64 = u64::from(value.sequence as u32);
+    let f1: u64 = u64::from(value.ack_bits);
+    let f2: u64 = u64::from(value.entity_id);
+    let f3: u64 = u64::from((value.pos_x as u32).wrapping_sub((-16384_i32) as u32));
+    let f4: u64 = u64::from((value.pos_y as u32).wrapping_sub((-16384_i32) as u32));
+    let f5: u64 = u64::from((value.pos_z as u32).wrapping_sub((-16384_i32) as u32));
+    let f6: u64 = u64::from(value.yaw);
+    let f7: u64 = u64::from(value.moving);
+    let f8: u64 = u64::from(value.firing);
+    let f9: u64 = value.timestamp;
+    let f10: u64 = u64::from(value.weapon as u32);
+    let mut w0 = (f0 | (f1 << 16)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 16) | (f2 << 16) | (f3 << 28)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f3 >> 4) | (f4 << 11) | (f5 << 26)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f5 >> 6) | (f6 << 9) | (f7 << 18) | (f8 << 19) | (f9 << 20)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = (f9 >> 12) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = ((f9 >> 44) | (f10 << 4)) as u32;
+    stream.serialize_bits(&mut w5, 8)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_bench_mixed(stream: &mut ReadStream<'_>, value: &mut BenchMixed) -> Result {
-    stream.serialize_int(&mut value.sequence, 0, 65535)?;
-    stream.serialize_bits(&mut value.ack_bits, 32)?;
-    stream.serialize_bits(&mut value.entity_id, 12)?;
-    stream.serialize_int(&mut value.pos_x, -16384, 16383)?;
-    stream.serialize_int(&mut value.pos_y, -16384, 16383)?;
-    stream.serialize_int(&mut value.pos_z, -16384, 16383)?;
-    stream.serialize_bits(&mut value.yaw, 9)?;
-    stream.serialize_bool(&mut value.moving)?;
-    stream.serialize_bool(&mut value.firing)?;
-    stream.serialize_bits64(&mut value.timestamp, 48)?;
-    stream.serialize_int(&mut value.weapon, 0, 15)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 8)?;
+    let c5 = u64::from(c);
+    let v0: u64 = c0 & 0xffff;
+    value.sequence = v0 as i32;
+    let v1: u64 = ((c0 >> 16) | (c1 << 16)) & 0xffffffff;
+    value.ack_bits = v1 as u32;
+    let v2: u64 = (c1 >> 16) & 0xfff;
+    value.entity_id = v2 as u32;
+    let v3: u64 = ((c1 >> 28) | (c2 << 4)) & 0x7fff;
+    value.pos_x = (v3 as u32).wrapping_add((-16384_i32) as u32) as i32;
+    let v4: u64 = (c2 >> 11) & 0x7fff;
+    value.pos_y = (v4 as u32).wrapping_add((-16384_i32) as u32) as i32;
+    let v5: u64 = ((c2 >> 26) | (c3 << 6)) & 0x7fff;
+    value.pos_z = (v5 as u32).wrapping_add((-16384_i32) as u32) as i32;
+    let v6: u64 = (c3 >> 9) & 0x1ff;
+    value.yaw = v6 as u32;
+    let v7: u64 = (c3 >> 18) & 0x1;
+    value.moving = v7 != 0;
+    let v8: u64 = (c3 >> 19) & 0x1;
+    value.firing = v8 != 0;
+    let v9: u64 = ((c3 >> 20) | (c4 << 12) | (c5 << 44)) & 0xffffffffffff;
+    value.timestamp = v9;
+    let v10: u64 = (c5 >> 4) & 0xf;
+    value.weapon = v10 as i32;
     Ok(())
 }
 

--- a/generated/rust/src/render.rs
+++ b/generated/rust/src/render.rs
@@ -40,47 +40,53 @@ pub const RENDER_SPRITE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_render_sprite(stream: &mut WriteStream<'_>, value: &RenderSprite) -> Result {
-    {
-        let mut raw_value = value.sort_key;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.mesh_id;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.material_id;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.layer as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
     if value.team.0 > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.team.0 as u32;
-        stream.serialize_bits(&mut offset_value, 2)?;
-    }
+    let f0: u64 = value.sort_key;
+    let f1: u64 = u64::from(value.mesh_id);
+    let f2: u64 = u64::from(value.material_id);
+    let f3: u64 = u64::from(value.layer);
+    let f4: u64 = u64::from(value.team.0);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = f2 as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = (f3 | (f4 << 8)) as u32;
+    stream.serialize_bits(&mut w4, 10)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_render_sprite(stream: &mut ReadStream<'_>, value: &mut RenderSprite) -> Result {
-    stream.serialize_bits64(&mut value.sort_key, 64)?;
-    stream.serialize_bits(&mut value.mesh_id, 32)?;
-    stream.serialize_bits(&mut value.material_id, 32)?;
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.layer = raw_value as u8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 10)?;
+    let c4 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.sort_key = v0;
+    let v1: u64 = c2 & 0xffffffff;
+    value.mesh_id = v1 as u32;
+    let v2: u64 = c3 & 0xffffffff;
+    value.material_id = v2 as u32;
+    let v3: u64 = c4 & 0xff;
+    value.layer = v3 as u8;
+    let v4: u64 = (c4 >> 8) & 0x3;
+    if v4 > 2 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 2)?;
-        value.team = Team(enum_value as u8);
-    }
+    value.team = Team(v4 as u8);
     Ok(())
 }
 
@@ -113,14 +119,12 @@ pub const RENDER_BLOCK_MAX_BYTES: usize = 1120;
 
 #[inline(always)]
 pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> Result {
-    {
-        let mut raw_value = value.worker_index;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.sprite_count_hint;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
+    let f0: u64 = u64::from(value.worker_index);
+    let f1: u64 = u64::from(value.sprite_count_hint);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 32)?;
     if value.sprites_count < 0 || value.sprites_count > 64 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -136,8 +140,15 @@ pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> 
 
 #[inline]
 pub fn read_render_block(stream: &mut ReadStream<'_>, value: &mut RenderBlock) -> Result {
-    stream.serialize_bits(&mut value.worker_index, 32)?;
-    stream.serialize_bits(&mut value.sprite_count_hint, 32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.worker_index = v0 as u32;
+    let v1: u64 = c1 & 0xffffffff;
+    value.sprite_count_hint = v1 as u32;
     stream.serialize_int(&mut value.sprites_count, 0, RENDER_BLOCK_MAX_SPRITES as i32)?; // the count guards the loop (§6.3)
     for i in 0..value.sprites_count as usize {
         read_render_sprite(stream, &mut value.sprites[i])?;

--- a/generated/rust/src/types.rs
+++ b/generated/rust/src/types.rs
@@ -34,26 +34,45 @@ pub const VEC3_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_vec3(stream: &mut WriteStream<'_>, value: &Vec3) -> Result {
-    {
-        let mut float_value = value.x;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.y;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.z;
-        stream.serialize_f64(&mut float_value)?;
-    }
+    let f0: u64 = value.x.to_bits();
+    let f1: u64 = value.y.to_bits();
+    let f2: u64 = value.z.to_bits();
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_vec3(stream: &mut ReadStream<'_>, value: &mut Vec3) -> Result {
-    stream.serialize_f64(&mut value.x)?;
-    stream.serialize_f64(&mut value.y)?;
-    stream.serialize_f64(&mut value.z)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.x = f64::from_bits(v0);
+    let v1: u64 = c2 | (c3 << 32);
+    value.y = f64::from_bits(v1);
+    let v2: u64 = c4 | (c5 << 32);
+    value.z = f64::from_bits(v2);
     Ok(())
 }
 
@@ -86,31 +105,56 @@ pub const QUAT_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_quat(stream: &mut WriteStream<'_>, value: &Quat) -> Result {
-    {
-        let mut float_value = value.x;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.y;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.z;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.w;
-        stream.serialize_f64(&mut float_value)?;
-    }
+    let f0: u64 = value.x.to_bits();
+    let f1: u64 = value.y.to_bits();
+    let f2: u64 = value.z.to_bits();
+    let f3: u64 = value.w.to_bits();
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = f3 as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = (f3 >> 32) as u32;
+    stream.serialize_bits(&mut w7, 32)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quat(stream: &mut ReadStream<'_>, value: &mut Quat) -> Result {
-    stream.serialize_f64(&mut value.x)?;
-    stream.serialize_f64(&mut value.y)?;
-    stream.serialize_f64(&mut value.z)?;
-    stream.serialize_f64(&mut value.w)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.x = f64::from_bits(v0);
+    let v1: u64 = c2 | (c3 << 32);
+    value.y = f64::from_bits(v1);
+    let v2: u64 = c4 | (c5 << 32);
+    value.z = f64::from_bits(v2);
+    let v3: u64 = c6 | (c7 << 32);
+    value.w = f64::from_bits(v3);
     Ok(())
 }
 
@@ -142,25 +186,25 @@ pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
     if value.object_id < 0 || value.object_id > 9999 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.object_id as u32;
-        stream.serialize_bits(&mut offset_value, 14)?;
-    }
-    {
-        let mut raw_value = value.object_sequence as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
+    let f0: u64 = u64::from(value.object_id as u32);
+    let f1: u64 = u64::from(value.object_sequence);
+    let mut w0 = (f0 | (f1 << 14)) as u32;
+    stream.serialize_bits(&mut w0, 22)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_handle(stream: &mut ReadStream<'_>, value: &mut Handle) -> Result {
-    stream.serialize_int(&mut value.object_id, 0, (MAX_OBJECTS - 1) as i32)?;
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.object_sequence = raw_value as u8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 22)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x3fff;
+    if v0 > 9999 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.object_id = v0 as i32;
+    let v1: u64 = (c0 >> 14) & 0xff;
+    value.object_sequence = v1 as u8;
     Ok(())
 }
 
@@ -194,32 +238,48 @@ pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedP
     if value.x < -8388608 || value.x > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 25)?;
-    }
     if value.y < -8388608 || value.y > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 25)?;
     }
     if value.z < -8388608 || value.z > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.z as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 25)?;
-    }
+    let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
+    let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
+    let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 25)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 7) | (f2 << 18)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f2 >> 14) as u32;
+    stream.serialize_bits(&mut w2, 11)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quantized_position(stream: &mut ReadStream<'_>, value: &mut QuantizedPosition) -> Result {
-    stream.serialize_int(&mut value.x, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
-    stream.serialize_int(&mut value.y, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
-    stream.serialize_int(&mut value.z, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 11)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0x1ffffff;
+    if v0 > 16777216 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.x = (v0 as u32).wrapping_add(((-MAX_POSITION_UNITS) as i32) as u32) as i32;
+    let v1: u64 = ((c0 >> 25) | (c1 << 7)) & 0x1ffffff;
+    if v1 > 16777216 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.y = (v1 as u32).wrapping_add(((-MAX_POSITION_UNITS) as i32) as u32) as i32;
+    let v2: u64 = ((c1 >> 18) | (c2 << 14)) & 0x1ffffff;
+    if v2 > 16777216 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.z = (v2 as u32).wrapping_add(((-MAX_POSITION_UNITS) as i32) as u32) as i32;
     Ok(())
 }
 
@@ -253,32 +313,48 @@ pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedV
     if value.x < -2097152 || value.x > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 23)?;
-    }
     if value.y < -2097152 || value.y > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 23)?;
     }
     if value.z < -2097152 || value.z > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.z as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 23)?;
-    }
+    let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
+    let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
+    let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 23)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 9) | (f2 << 14)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f2 >> 18) as u32;
+    stream.serialize_bits(&mut w2, 5)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quantized_velocity(stream: &mut ReadStream<'_>, value: &mut QuantizedVelocity) -> Result {
-    stream.serialize_int(&mut value.x, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
-    stream.serialize_int(&mut value.y, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
-    stream.serialize_int(&mut value.z, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 5)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0x7fffff;
+    if v0 > 4194304 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.x = (v0 as u32).wrapping_add(((-MAX_VELOCITY_UNITS) as i32) as u32) as i32;
+    let v1: u64 = ((c0 >> 23) | (c1 << 9)) & 0x7fffff;
+    if v1 > 4194304 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.y = (v1 as u32).wrapping_add(((-MAX_VELOCITY_UNITS) as i32) as u32) as i32;
+    let v2: u64 = ((c1 >> 14) | (c2 << 18)) & 0x7fffff;
+    if v2 > 4194304 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.z = (v2 as u32).wrapping_add(((-MAX_VELOCITY_UNITS) as i32) as u32) as i32;
     Ok(())
 }
 
@@ -314,56 +390,53 @@ pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedR
     if value.x < -1024 || value.x > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
     if value.y < -1024 || value.y > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
     }
     if value.z < -1024 || value.z > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
     if value.w < -1024 || value.w > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.w as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
+    let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let f3: u64 = u64::from((value.w as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 12) | (f2 << 24)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 8) | (f3 << 4)) as u32;
+    stream.serialize_bits(&mut w1, 16)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quantized_rotation(stream: &mut ReadStream<'_>, value: &mut QuantizedRotation) -> Result {
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.x = range_value as i16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 16)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xfff;
+    if v0 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.y = range_value as i16;
+    value.x = ((v0 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
+    let v1: u64 = (c0 >> 12) & 0xfff;
+    if v1 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.z = range_value as i16;
+    value.y = ((v1 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
+    let v2: u64 = ((c0 >> 24) | (c1 << 8)) & 0xfff;
+    if v2 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.w = range_value as i16;
+    value.z = ((v2 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
+    let v3: u64 = (c1 >> 4) & 0xfff;
+    if v3 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.w = ((v3 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
     Ok(())
 }
 
@@ -476,76 +549,75 @@ pub const INPUT_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_input(stream: &mut WriteStream<'_>, value: &Input) -> Result {
-    {
-        let mut float_value = value.stick_x;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.stick_y;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.throttle;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.yaw;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.pitch;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut bool_value = value.fire;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.alt_fire;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.boost;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.brake;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.aim;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.lock_on;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.zoom;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.ping;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from(value.stick_x.to_bits());
+    let f1: u64 = u64::from(value.stick_y.to_bits());
+    let f2: u64 = u64::from(value.throttle.to_bits());
+    let f3: u64 = u64::from(value.yaw.to_bits());
+    let f4: u64 = u64::from(value.pitch.to_bits());
+    let f5: u64 = u64::from(value.fire);
+    let f6: u64 = u64::from(value.alt_fire);
+    let f7: u64 = u64::from(value.boost);
+    let f8: u64 = u64::from(value.brake);
+    let f9: u64 = u64::from(value.aim);
+    let f10: u64 = u64::from(value.lock_on);
+    let f11: u64 = u64::from(value.zoom);
+    let f12: u64 = u64::from(value.ping);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f2 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = f3 as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f4 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f5 | (f6 << 1) | (f7 << 2) | (f8 << 3) | (f9 << 4) | (f10 << 5) | (f11 << 6) | (f12 << 7)) as u32;
+    stream.serialize_bits(&mut w5, 8)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_input(stream: &mut ReadStream<'_>, value: &mut Input) -> Result {
-    stream.serialize_f32(&mut value.stick_x)?;
-    stream.serialize_f32(&mut value.stick_y)?;
-    stream.serialize_f32(&mut value.throttle)?;
-    stream.serialize_f32(&mut value.yaw)?;
-    stream.serialize_f32(&mut value.pitch)?;
-    stream.serialize_bool(&mut value.fire)?;
-    stream.serialize_bool(&mut value.alt_fire)?;
-    stream.serialize_bool(&mut value.boost)?;
-    stream.serialize_bool(&mut value.brake)?;
-    stream.serialize_bool(&mut value.aim)?;
-    stream.serialize_bool(&mut value.lock_on)?;
-    stream.serialize_bool(&mut value.zoom)?;
-    stream.serialize_bool(&mut value.ping)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 8)?;
+    let c5 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.stick_x = f32::from_bits(v0 as u32);
+    let v1: u64 = c1 & 0xffffffff;
+    value.stick_y = f32::from_bits(v1 as u32);
+    let v2: u64 = c2 & 0xffffffff;
+    value.throttle = f32::from_bits(v2 as u32);
+    let v3: u64 = c3 & 0xffffffff;
+    value.yaw = f32::from_bits(v3 as u32);
+    let v4: u64 = c4 & 0xffffffff;
+    value.pitch = f32::from_bits(v4 as u32);
+    let v5: u64 = c5 & 0x1;
+    value.fire = v5 != 0;
+    let v6: u64 = (c5 >> 1) & 0x1;
+    value.alt_fire = v6 != 0;
+    let v7: u64 = (c5 >> 2) & 0x1;
+    value.boost = v7 != 0;
+    let v8: u64 = (c5 >> 3) & 0x1;
+    value.brake = v8 != 0;
+    let v9: u64 = (c5 >> 4) & 0x1;
+    value.aim = v9 != 0;
+    let v10: u64 = (c5 >> 5) & 0x1;
+    value.lock_on = v10 != 0;
+    let v11: u64 = (c5 >> 6) & 0x1;
+    value.zoom = v11 != 0;
+    let v12: u64 = (c5 >> 7) & 0x1;
+    value.ping = v12 != 0;
     Ok(())
 }
 
@@ -580,18 +652,19 @@ pub const INPUT_PACKET_MAX_BYTES: usize = 360;
 
 #[inline(always)]
 pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> Result {
-    {
-        let mut raw_value = value.synchronize_sequence as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
-    {
-        let mut raw_value = value.current_frame;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.start_frame;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = u64::from(value.synchronize_sequence);
+    let f1: u64 = value.current_frame;
+    let f2: u64 = value.start_frame;
+    let mut w0 = (f0 | (f1 << 16)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f1 >> 16) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f1 >> 48) | (f2 << 16)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f2 >> 16) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = (f2 >> 48) as u32;
+    stream.serialize_bits(&mut w4, 16)?;
     if value.inputs_count < 0 || value.inputs_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -607,13 +680,23 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
 
 #[inline]
 pub fn read_input_packet(stream: &mut ReadStream<'_>, value: &mut InputPacket) -> Result {
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.synchronize_sequence = raw_value as u16;
-    }
-    stream.serialize_bits64(&mut value.current_frame, 64)?;
-    stream.serialize_bits64(&mut value.start_frame, 64)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 16)?;
+    let c4 = u64::from(c);
+    let v0: u64 = c0 & 0xffff;
+    value.synchronize_sequence = v0 as u16;
+    let v1: u64 = (c0 >> 16) | (c1 << 16) | (c2 << 48);
+    value.current_frame = v1;
+    let v2: u64 = (c2 >> 16) | (c3 << 16) | (c4 << 48);
+    value.start_frame = v2;
     stream.serialize_int(&mut value.inputs_count, 0, MAX_INPUTS_PER_PACKET as i32)?; // the count guards the loop (§6.3)
     for i in 0..value.inputs_count as usize {
         read_input(stream, &mut value.inputs[i])?;
@@ -693,27 +776,20 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
     if value.team.0 > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.team.0 as u32;
-        stream.serialize_bits(&mut offset_value, 2)?;
-    }
     if value.health < 0 || value.health > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.health as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
     }
     if value.thrust < 0 || value.thrust > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.thrust as u32;
-        stream.serialize_bits(&mut offset_value, 7)?;
-    }
     if value.pending.0 > 0 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    let f0: u64 = u64::from(value.team.0);
+    let f1: u64 = u64::from(value.health as u32);
+    let f2: u64 = u64::from(value.thrust as u32);
+    let mut w0 = (f0 | (f1 << 2) | (f2 << 12)) as u32;
+    stream.serialize_bits(&mut w0, 19)?;
     Ok(())
 }
 
@@ -737,26 +813,25 @@ pub fn read_ship_create(stream: &mut ReadStream<'_>, value: &mut ShipCreate) -> 
     } else {
         value.flags = 0;
     }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 2)?;
-        value.team = Team(enum_value as u8);
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 19)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x3;
+    if v0 > 2 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, MAX_HEALTH as i32)?;
-        value.health = range_value as i16;
+    value.team = Team(v0 as u8);
+    let v1: u64 = (c0 >> 2) & 0x3ff;
+    if v1 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 100)?;
-        value.thrust = range_value as i8;
+    value.health = (v1 as i32) as i16;
+    let v2: u64 = (c0 >> 12) & 0x7f;
+    if v2 > 100 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 0)?;
-        value.pending = Pending(enum_value as u8);
-    }
+    value.thrust = (v2 as i32) as i8;
+    value.pending = Pending(0 as u8);
     Ok(())
 }
 
@@ -788,24 +863,28 @@ pub fn write_expression_probe(stream: &mut WriteStream<'_>, value: &ExpressionPr
     if value.hardpoint_index < 0 || value.hardpoint_index > 31 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.hardpoint_index as u32;
-        stream.serialize_bits(&mut offset_value, 5)?;
-    }
     if value.spin_rate < 1024 || value.spin_rate > 2048 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 11)?;
-    }
+    let f0: u64 = u64::from(value.hardpoint_index as u32);
+    let f1: u64 = u64::from((value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 5)) as u32;
+    stream.serialize_bits(&mut w0, 16)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_expression_probe(stream: &mut ReadStream<'_>, value: &mut ExpressionProbe) -> Result {
-    stream.serialize_int(&mut value.hardpoint_index, 0, ((SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1) as i32)?;
-    stream.serialize_int(&mut value.spin_rate, (-(-ROTATION_UNITS)) as i32, (ROTATION_UNITS * 2) as i32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 16)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x1f;
+    value.hardpoint_index = v0 as i32;
+    let v1: u64 = (c0 >> 5) & 0x7ff;
+    if v1 > 1024 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.spin_rate = (v1 as u32).wrapping_add(((-(-ROTATION_UNITS)) as i32) as u32) as i32;
     Ok(())
 }
 
@@ -859,28 +938,32 @@ pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -
     if value.floor_bound > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
     if value.doubled_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 64)?;
     }
     if value.ceiling_range < 1 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.ceiling_range - 1;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
-    {
-        let mut raw_value = value.floor_default as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
+    let f1: u64 = (value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
+    let f2: u64 = value.ceiling_range - 1;
+    let f3: u64 = value.floor_default as u64;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = f3 as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = (f3 >> 32) as u32;
+    stream.serialize_bits(&mut w7, 32)?;
     {
         let mut raw_value = value.ceiling_default;
         stream.serialize_bits64(&mut raw_value, 64)?;
@@ -890,22 +973,41 @@ pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -
 
 #[inline]
 pub fn read_extreme_probe(stream: &mut ReadStream<'_>, value: &mut ExtremeProbe) -> Result {
-    stream.serialize_int64(&mut value.floor_bound, -9223372036854775808, 100)?;
-    stream.serialize_int64(&mut value.doubled_floor, -9223372036854775808, 100)?;
-    {
-        let mut offset_value: u64 = 0;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-        if offset_value > 18446744073709551614 {
-            // a read rejects out-of-range (SPEC §5)
-            return Err(Error::Validation);
-        }
-        value.ceiling_range = offset_value + 1;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    if v0 > 9223372036854775908 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.floor_default = raw_value as i64;
+    value.floor_bound = v0.wrapping_add((-9223372036854775808_i64) as u64) as i64;
+    let v1: u64 = c2 | (c3 << 32);
+    if v1 > 9223372036854775908 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.doubled_floor = v1.wrapping_add((-9223372036854775808_i64) as u64) as i64;
+    let v2: u64 = c4 | (c5 << 32);
+    if v2 > 18446744073709551614 {
+        // a read rejects out-of-range (SPEC §5)
+        return Err(Error::Validation);
+    }
+    value.ceiling_range = v2 + 1;
+    let v3: u64 = c6 | (c7 << 32);
+    value.floor_default = v3 as i64;
     stream.serialize_bits64(&mut value.ceiling_default, 64)?;
     Ok(())
 }
@@ -954,46 +1056,66 @@ pub fn write_extreme_row(stream: &mut WriteStream<'_>, value: &ExtremeRow) -> Re
     if value.clamped_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.clamped_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
     if value.clamped_ceiling < 1 || value.clamped_ceiling > 18446744073709551614 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.clamped_ceiling - 1;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
-    {
-        let mut raw_value = value.floor_def as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.ceiling_def;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = (value.clamped_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
+    let f1: u64 = value.clamped_ceiling - 1;
+    let f2: u64 = value.floor_def as u64;
+    let f3: u64 = value.ceiling_def;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = f3 as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = (f3 >> 32) as u32;
+    stream.serialize_bits(&mut w7, 32)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_extreme_row(stream: &mut ReadStream<'_>, value: &mut ExtremeRow) -> Result {
-    stream.serialize_int64(&mut value.clamped_floor, -9223372036854775808, 100)?;
-    {
-        let mut offset_value: u64 = 0;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-        if offset_value > 18446744073709551613 {
-            // a read rejects out-of-range (SPEC §5)
-            return Err(Error::Validation);
-        }
-        value.clamped_ceiling = offset_value + 1;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    if v0 > 9223372036854775908 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.floor_def = raw_value as i64;
+    value.clamped_floor = v0.wrapping_add((-9223372036854775808_i64) as u64) as i64;
+    let v1: u64 = c2 | (c3 << 32);
+    if v1 > 18446744073709551613 {
+        // a read rejects out-of-range (SPEC §5)
+        return Err(Error::Validation);
     }
-    stream.serialize_bits64(&mut value.ceiling_def, 64)?;
+    value.clamped_ceiling = v1 + 1;
+    let v2: u64 = c4 | (c5 << 32);
+    value.floor_def = v2 as i64;
+    let v3: u64 = c6 | (c7 << 32);
+    value.ceiling_def = v3;
     Ok(())
 }
 

--- a/generated/rust/src/wire.rs
+++ b/generated/rust/src/wire.rs
@@ -118,21 +118,14 @@ pub const PROBE_HEADER_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> Result {
-    {
-        let mut const_value: u32 = 171;
-        stream.serialize_bits(&mut const_value, 8)?; // const(171, 8) — SPEC §4.3
-    }
     if value.version >= 1 << 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.version;
-        stream.serialize_bits(&mut raw_value, 3)?;
-    }
-    {
-        let mut reserved_value: u32 = 0;
-        stream.serialize_bits(&mut reserved_value, 5)?; // reserved(5) — zeros on the wire
-    }
+    let f0: u64 = 171_u64; // const(171, 8) — SPEC §4.3
+    let f1: u64 = u64::from(value.version);
+    let f2: u64 = 0; // reserved(5) — zeros on the wire
+    let mut w0 = (f0 | (f1 << 8) | (f2 << 11)) as u32;
+    stream.serialize_bits(&mut w0, 16)?;
     stream.serialize_align()?;
     {
         let mut raw_value = value.probe_id;
@@ -143,22 +136,20 @@ pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> 
 
 #[inline]
 pub fn read_probe_header(stream: &mut ReadStream<'_>, value: &mut ProbeHeader) -> Result {
-    {
-        let mut const_value: u32 = 0;
-        stream.serialize_bits(&mut const_value, 8)?;
-        if const_value != 171 {
-            // const(171, 8): a read rejects any other value (SPEC §4.3)
-            return Err(Error::Validation);
-        }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 16)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0xff;
+    if v0 != 171 {
+        // const(171, 8): a read rejects any other value (SPEC §4.3)
+        return Err(Error::Validation);
     }
-    stream.serialize_bits(&mut value.version, 3)?;
-    {
-        let mut reserved_value: u32 = 0;
-        stream.serialize_bits(&mut reserved_value, 5)?;
-        if reserved_value != 0 {
-            // reserved(5): a read rejects nonzero (SPEC §4.3)
-            return Err(Error::Validation);
-        }
+    let v1: u64 = (c0 >> 8) & 0x7;
+    value.version = v1 as u32;
+    let v2: u64 = (c0 >> 11) & 0x1f;
+    if v2 != 0 {
+        // reserved(5): a read rejects nonzero (SPEC §4.3)
+        return Err(Error::Validation);
     }
     stream.serialize_align()?; // rejects nonzero padding (SPEC §4.3)
     stream.serialize_bits64(&mut value.probe_id, 64)?;
@@ -199,47 +190,58 @@ pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Resu
     if value.small >= 1 << 9 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.small;
-        stream.serialize_bits(&mut raw_value, 9)?;
-    }
     if value.boundary >= 1 << 33 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.boundary;
-        stream.serialize_bits64(&mut raw_value, 33)?;
-    }
-    {
-        let mut raw_value = value.wide;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut offset_value = value.sensor;
-        stream.serialize_bits(&mut offset_value, 32)?;
-    }
-    {
-        let mut offset_value = value.nonce;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
+    let f0: u64 = u64::from(value.small);
+    let f1: u64 = value.boundary;
+    let f2: u64 = value.wide;
+    let f3: u64 = value.sensor as u64;
+    let f4: u64 = value.nonce;
+    let mut w0 = (f0 | (f1 << 9)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 23) | (f2 << 10)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f2 >> 22) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f2 >> 54) | (f3 << 10)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f3 >> 22) | (f4 << 10)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f4 >> 22) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = (f4 >> 54) as u32;
+    stream.serialize_bits(&mut w6, 10)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_probe_bits(stream: &mut ReadStream<'_>, value: &mut ProbeBits) -> Result {
-    stream.serialize_bits(&mut value.small, 9)?;
-    stream.serialize_bits64(&mut value.boundary, 33)?;
-    stream.serialize_bits64(&mut value.wide, 64)?;
-    {
-        let mut range_value: i64 = 0;
-        stream.serialize_int64(&mut range_value, 0, 4294967295)?;
-        value.sensor = range_value as u32;
-    }
-    {
-        let mut offset_value: u64 = 0;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-        value.nonce = offset_value;
-    }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 10)?;
+    let c6 = u64::from(c);
+    let v0: u64 = c0 & 0x1ff;
+    value.small = v0 as u32;
+    let v1: u64 = ((c0 >> 9) | (c1 << 23)) & 0x1ffffffff;
+    value.boundary = v1;
+    let v2: u64 = (c1 >> 10) | (c2 << 22) | (c3 << 54);
+    value.wide = v2;
+    let v3: u64 = ((c3 >> 10) | (c4 << 22)) & 0xffffffff;
+    value.sensor = (v3 as i64) as u32;
+    let v4: u64 = (c4 >> 10) | (c5 << 22) | (c6 << 54);
+    value.nonce = v4;
     Ok(())
 }
 
@@ -313,26 +315,22 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
         let mut compressed_value = value.orientation;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
     }
-    {
-        let mut raw_value = value.raw_delta as u32;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.big_delta as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = u64::from(value.raw_delta as u32);
+    let f1: u64 = value.big_delta as u64;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
     if value.active {
         if value.weapon.0 > 15 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = value.weapon.0 as u32;
-            stream.serialize_bits(&mut offset_value, 4)?;
-        }
-        {
-            let mut bool_value = value.has_target;
-            stream.serialize_bool(&mut bool_value)?;
-        }
+        let f0: u64 = u64::from(value.weapon.0);
+        let f1: u64 = u64::from(value.has_target);
+        let mut w0 = (f0 | (f1 << 4)) as u32;
+        stream.serialize_bits(&mut w0, 5)?;
         if value.has_target {
             {
                 let mut raw_value = value.target_id as u32;
@@ -365,23 +363,25 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
 pub fn read_probe_sample(stream: &mut ReadStream<'_>, value: &mut ProbeSample) -> Result {
     stream.serialize_bool(&mut value.active)?;
     stream.serialize_compressed_float_precomputed(&mut value.orientation, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 32)?;
-        value.raw_delta = raw_value as i32;
-    }
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.big_delta = raw_value as i64;
-    }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.raw_delta = v0 as i32;
+    let v1: u64 = c1 | (c2 << 32);
+    value.big_delta = v1 as i64;
     if value.active {
-        {
-            let mut enum_value: i32 = 0;
-            stream.serialize_int(&mut enum_value, 0, 15)?;
-            value.weapon = Weapon(enum_value as u8);
-        }
-        stream.serialize_bool(&mut value.has_target)?;
+        let mut c: u32 = 0;
+        stream.serialize_bits(&mut c, 5)?;
+        let c0 = u64::from(c);
+        let v0: u64 = c0 & 0xf;
+        value.weapon = Weapon(v0 as u8);
+        let v1: u64 = (c0 >> 4) & 0x1;
+        value.has_target = v1 != 0;
         if value.has_target {
             {
                 let mut raw_value: u32 = 0;
@@ -477,29 +477,25 @@ pub fn write_probe_slab(stream: &mut WriteStream<'_>, value: &ProbeSlab) -> Resu
     if value.width > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.width as u32;
-        stream.serialize_bits(&mut offset_value, 7)?;
-    }
-    {
-        let mut raw_value = value.height as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
+    let f0: u64 = u64::from(value.width as u32);
+    let f1: u64 = u64::from(value.height);
+    let mut w0 = (f0 | (f1 << 7)) as u32;
+    stream.serialize_bits(&mut w0, 15)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_probe_slab(stream: &mut ReadStream<'_>, value: &mut ProbeSlab) -> Result {
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 100)?;
-        value.width = range_value as u8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 15)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x7f;
+    if v0 > 100 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.height = raw_value as u8;
-    }
+    value.width = (v0 as i32) as u8;
+    let v1: u64 = (c0 >> 7) & 0xff;
+    value.height = v1 as u8;
     Ok(())
 }
 
@@ -672,32 +668,29 @@ pub const PROBE_CONFIG_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> Result {
-    {
-        let mut raw_value = value.retries as u32;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
     if value.preferred.0 > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.preferred.0 as u32;
-        stream.serialize_bits(&mut offset_value, 4)?;
-    }
+    let f0: u64 = u64::from(value.retries as u32);
+    let f1: u64 = u64::from(value.preferred.0);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 4)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_probe_config(stream: &mut ReadStream<'_>, value: &mut ProbeConfig) -> Result {
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 32)?;
-        value.retries = raw_value as i32;
-    }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 15)?;
-        value.preferred = Weapon(enum_value as u8);
-    }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 4)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.retries = v0 as i32;
+    let v1: u64 = c1 & 0xf;
+    value.preferred = Weapon(v1 as u8);
     Ok(())
 }
 
@@ -814,56 +807,50 @@ pub const TEST_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
-    {
-        let mut raw_value = value.test_a as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
     if value.test_b < 0 || value.test_b > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.test_b as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
     }
     if value.test_c < 0 || value.test_c > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.test_c as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
-    }
     if value.test_d < 0 || value.test_d > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.test_d as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
-    }
+    let f0: u64 = u64::from(value.test_a);
+    let f1: u64 = u64::from(value.test_b as u32);
+    let f2: u64 = u64::from(value.test_c as u32);
+    let f3: u64 = u64::from(value.test_d as u32);
+    let mut w0 = (f0 | (f1 << 16) | (f2 << 26)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 6) | (f3 << 4)) as u32;
+    stream.serialize_bits(&mut w1, 14)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_test(stream: &mut ReadStream<'_>, value: &mut Test) -> Result {
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.test_a = raw_value as u16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 14)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xffff;
+    value.test_a = v0 as u16;
+    let v1: u64 = (c0 >> 16) & 0x3ff;
+    if v1 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 1000)?;
-        value.test_b = range_value as i16;
+    value.test_b = (v1 as i32) as i16;
+    let v2: u64 = ((c0 >> 26) | (c1 << 6)) & 0x3ff;
+    if v2 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 1000)?;
-        value.test_c = range_value as i16;
+    value.test_c = (v2 as i32) as i16;
+    let v3: u64 = (c1 >> 4) & 0x3ff;
+    if v3 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 1000)?;
-        value.test_d = range_value as i16;
-    }
+    value.test_d = (v3 as i32) as i16;
     Ok(())
 }
 
@@ -1084,49 +1071,32 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     if value.a < -100 || value.a > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.a as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
-    }
     if value.b < -100 || value.b > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.b as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
     }
     if value.c < -100 || value.c > 150 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.c as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
-    }
     if value.d >= 1 << 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.d;
-        stream.serialize_bits(&mut raw_value, 8)?;
     }
     if value.e >= 1 << 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.e;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
     if value.f >= 1 << 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
-    {
-        let mut bool_value = value.g;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from((value.a as u32).wrapping_sub((-100_i32) as u32));
+    let f1: u64 = u64::from((value.b as u32).wrapping_sub((-100_i32) as u32));
+    let f2: u64 = u64::from((value.c as u32).wrapping_sub((-100_i32) as u32));
+    let f3: u64 = u64::from(value.d);
+    let f4: u64 = u64::from(value.e);
+    let f5: u64 = u64::from(value.f);
+    let f6: u64 = u64::from(value.g);
+    let mut w0 = (f0 | (f1 << 8) | (f2 << 16) | (f3 << 24)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f4 | (f5 << 8) | (f6 << 16)) as u32;
+    stream.serialize_bits(&mut w1, 17)?;
     if value.items_count < 0 || value.items_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -1151,45 +1121,40 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut compressed_value = value.compressed_float_value;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     }
-    {
-        let mut float_value = value.double_value;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut raw_value = (value.int8_value as u8) as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
-    {
-        let mut raw_value = (value.int16_value as u16) as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
-    {
-        let mut raw_value = value.uint8_value as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
-    {
-        let mut raw_value = value.uint16_value as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
-    {
-        let mut raw_value = value.uint32_value;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.uint64_value;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.int64_full as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = value.double_value.to_bits();
+    let f1: u64 = u64::from(value.int8_value as u8);
+    let f2: u64 = u64::from(value.int16_value as u16);
+    let f3: u64 = u64::from(value.uint8_value);
+    let f4: u64 = u64::from(value.uint16_value);
+    let f5: u64 = u64::from(value.uint32_value);
+    let f6: u64 = value.uint64_value;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f1 | (f2 << 8) | (f3 << 24)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f4 | (f5 << 16)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f5 >> 16) | (f6 << 16)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f6 >> 16) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = (f6 >> 48) as u32;
+    stream.serialize_bits(&mut w6, 16)?;
     if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.int64_range as u64).wrapping_sub((-1000000000000_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 41)?;
-    }
+    let f0: u64 = value.int64_full as u64;
+    let f1: u64 = (value.int64_range as u64).wrapping_sub((-1000000000000_i64) as u64);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 9)?;
     stream.serialize_align()?;
     stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
     if value.text_length < 0 || value.text_length > 255 {
@@ -1209,48 +1174,85 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
 
 #[inline]
 pub fn read_test_data(stream: &mut ReadStream<'_>, value: &mut TestData) -> Result {
-    stream.serialize_int(&mut value.a, -100, 100)?;
-    stream.serialize_int(&mut value.b, -100, 100)?;
-    stream.serialize_int(&mut value.c, -100, 150)?;
-    stream.serialize_bits(&mut value.d, 8)?;
-    stream.serialize_bits(&mut value.e, 8)?;
-    stream.serialize_bits(&mut value.f, 8)?;
-    stream.serialize_bool(&mut value.g)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 17)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xff;
+    if v0 > 200 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.a = (v0 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v1: u64 = (c0 >> 8) & 0xff;
+    if v1 > 200 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.b = (v1 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v2: u64 = (c0 >> 16) & 0xff;
+    if v2 > 250 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.c = (v2 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v3: u64 = (c0 >> 24) & 0xff;
+    value.d = v3 as u32;
+    let v4: u64 = c1 & 0xff;
+    value.e = v4 as u32;
+    let v5: u64 = (c1 >> 8) & 0xff;
+    value.f = v5 as u32;
+    let v6: u64 = (c1 >> 16) & 0x1;
+    value.g = v6 != 0;
     stream.serialize_int(&mut value.items_count, 0, 16)?; // the count guards the loop (§6.3)
     for i in 0..value.items_count as usize {
         stream.serialize_int(&mut value.items[i], 0, 255)?;
     }
     stream.serialize_f32(&mut value.float_value)?;
     stream.serialize_compressed_float_precomputed(&mut value.compressed_float_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
-    stream.serialize_f64(&mut value.double_value)?;
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.int8_value = raw_value as u8 as i8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 16)?;
+    let c6 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.double_value = f64::from_bits(v0);
+    let v1: u64 = c2 & 0xff;
+    value.int8_value = v1 as u8 as i8;
+    let v2: u64 = (c2 >> 8) & 0xffff;
+    value.int16_value = v2 as u16 as i16;
+    let v3: u64 = (c2 >> 24) & 0xff;
+    value.uint8_value = v3 as u8;
+    let v4: u64 = c3 & 0xffff;
+    value.uint16_value = v4 as u16;
+    let v5: u64 = ((c3 >> 16) | (c4 << 16)) & 0xffffffff;
+    value.uint32_value = v5 as u32;
+    let v6: u64 = (c4 >> 16) | (c5 << 16) | (c6 << 48);
+    value.uint64_value = v6;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 9)?;
+    let c3 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.int64_full = v0 as i64;
+    let v1: u64 = (c2 | (c3 << 32)) & 0x1ffffffffff;
+    if v1 > 2000000000000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.int16_value = raw_value as u16 as i16;
-    }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.uint8_value = raw_value as u8;
-    }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.uint16_value = raw_value as u16;
-    }
-    stream.serialize_bits(&mut value.uint32_value, 32)?;
-    stream.serialize_bits64(&mut value.uint64_value, 64)?;
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.int64_full = raw_value as i64;
-    }
-    stream.serialize_int64(&mut value.int64_range, -1000000000000, 1000000000000)?;
+    value.int64_range = v1.wrapping_add((-1000000000000_i64) as u64) as i64;
     stream.serialize_align()?; // rejects nonzero padding (SPEC §4.3)
     stream.serialize_bytes(&mut value.fixed_bytes)?; // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop
     stream.serialize_int(&mut value.text_length, 0, 255)?; // the length guards the slice (§6.3)

--- a/internal/codegen/rust/flat.go
+++ b/internal/codegen/rust/flat.go
@@ -1,0 +1,598 @@
+// The flat word codec: the Rust target's self-contained wire form.
+//
+// The per-field form this replaces asked the runtime to place one field at a
+// time. That is free when the spine lands inlined in a caller whose stream was
+// just constructed — every scratch offset is then a compile-time constant and
+// the whole sequence folds — and it is expensive whenever it does not: entered
+// with an unknown bit position, each serialize_bits reloads the packer's
+// scratch, shifts by a runtime amount, tests a runtime carry and stores the
+// state back, so an eleven-field write pays eleven memory round trips through
+// the stream.
+//
+// The flat form removes that dependence. Every bit offset INSIDE a message is
+// a generation-time constant regardless of where the message starts, so the
+// emitter folds the field placement itself: field values are computed into
+// locals, OR'd into 32-bit chunk locals at literal shifts, and handed to the
+// stream one whole chunk at a time. A run of B bits costs ceil(B/32) stream
+// calls instead of one per field, and the packing that remains is register
+// arithmetic with literal shifts and literal masks — the same shape the Java
+// and C-family backends emit, spelled against the one buffer interface
+// serialize.rs exposes.
+//
+// Chunk widths sum to B EXACTLY (the last chunk carries B mod 32, or 32), so
+// the flat form reads and writes precisely the bits the per-field form did:
+// same wire, byte for byte, proven by the goldens and the cross-language
+// conformance suite.
+//
+// Runs break at every construct whose width or content is not a
+// generation-time constant — align, string/bytes, arrays, branches, nested
+// struct and union calls — and at the fixed-point, compressed-float and
+// 128-bit families, whose value arithmetic lives in the runtime. Those items
+// keep the per-field form and start a fresh run after themselves.
+//
+// The read side fuses its bounds checks the same way, which is the technique
+// the Java, Dart and JS-flat backends already carry ("bounds checks fused per
+// maximal static run"): one check per chunk instead of one per field. The
+// consequence that fusion always has is worth naming — a stream that is BOTH
+// truncated inside a run AND carries an out-of-range value before the
+// truncation now surfaces Overflow where the per-field form surfaced the range
+// refusal. Both refuse the packet; the set of accepted streams is unchanged,
+// which is the property that matters at the trust boundary.
+package rust
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// maxRunBits caps one flat run. Past it the run closes and a fresh one opens
+// at the next field boundary: a run holds every one of its field values live
+// across its chunk assembly, and an unbounded run on a hundred-field message
+// spills them to the stack, which is the cost the form exists to avoid. 256
+// bits is eight chunks — well inside the register file on every target this
+// family builds for, and long enough that every corpus shape's straight-line
+// stretches flatten whole.
+const maxRunBits = 256
+
+// flatPiece is one statically-sized contribution to a flat run: a scalar
+// field, a const item or a reserved item.
+type flatPiece struct {
+	item ir.Item
+	bits int64 // wire width; 0 for a degenerate range, which rides no bits
+
+	// guard emits the write-side range refusal. Never nil; it may emit
+	// nothing when both halves are vacuous.
+	guard func(ind string)
+
+	// value is the u64-valued write expression for the piece. Empty when
+	// bits is 0.
+	value string
+
+	// note is a trailing comment for the value's let binding.
+	note string
+
+	// read emits the read-side validation and field store. src names the u64
+	// local holding the extracted bits; a zero-bit piece is handed the literal
+	// "0", the only value its range can carry (SPEC §4.6).
+	read func(ind, src string)
+}
+
+// flatRun accumulates consecutive flat pieces and the items they came from,
+// so a run too short to be worth flattening can fall back item by item.
+type flatRun struct {
+	pieces []flatPiece
+	bits   int64
+}
+
+// worthFlattening is the policy: two or more bit-carrying pieces. One piece
+// packs and unpacks to exactly what the per-field form already emits, so
+// flattening it would churn the goldens for nothing.
+func (r *flatRun) worthFlattening() bool {
+	n := 0
+	for _, p := range r.pieces {
+		if p.bits > 0 {
+			n++
+		}
+	}
+	return n >= 2
+}
+
+// chunkWidths splits a run of `bits` wire bits into the 32-bit chunks the
+// stream sees. The widths sum to `bits` exactly.
+func chunkWidths(bits int64) []int64 {
+	var out []int64
+	for left := bits; left > 0; left -= 32 {
+		if left >= 32 {
+			out = append(out, 32)
+		} else {
+			out = append(out, left)
+		}
+	}
+	return out
+}
+
+// mask64 renders the low-`bits` mask as a u64 literal, or "" at 64 bits where
+// no mask is needed.
+func mask64(bits int64) string {
+	if bits >= 64 {
+		return ""
+	}
+	m := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))
+	return fmt.Sprintf("0x%x", m)
+}
+
+// ---- write ----------------------------------------------------------------
+
+// emitFlatWriteRun packs the run's fields into 32-bit chunks with literal
+// shifts and hands each whole chunk to the stream.
+func (g *gen) emitFlatWriteRun(r *flatRun, ind string) {
+	g.needsStreamTrait = true
+
+	// Refusals first, in declaration order: the set of refused values and the
+	// error each raises are exactly the per-field form's. What moves is how
+	// many bits reached the stream before the refusal — a refused write leaves
+	// a partial message either way, and the run has not started packing yet.
+	for _, p := range r.pieces {
+		p.guard(ind)
+	}
+
+	// one local per bit-carrying field, then the chunks
+	offsets := make([]int64, len(r.pieces))
+	var at int64
+	for i, p := range r.pieces {
+		offsets[i] = at
+		if p.bits > 0 {
+			g.pf("%slet f%d: u64 = %s;%s\n", ind, i, p.value, p.note)
+			at += p.bits
+		}
+	}
+
+	for j, width := range chunkWidths(r.bits) {
+		lo := int64(j) * 32
+		hi := lo + width
+		var terms []string
+		for i, p := range r.pieces {
+			if p.bits == 0 {
+				continue
+			}
+			o := offsets[i]
+			if o >= hi || o+p.bits <= lo {
+				continue
+			}
+			switch {
+			case o >= lo:
+				terms = append(terms, shiftLeft(fmt.Sprintf("f%d", i), o-lo))
+			default:
+				terms = append(terms, fmt.Sprintf("(f%d >> %d)", i, lo-o))
+			}
+		}
+		packed := strings.Join(terms, " | ")
+		if len(terms) > 1 {
+			packed = "(" + packed + ")"
+		}
+		g.pf("%slet mut w%d = %s as u32;\n", ind, j, packed)
+		g.pf("%sstream.serialize_bits(&mut w%d, %d)?;\n", ind, j, width)
+	}
+}
+
+// shiftLeft renders `expr << n`, dropping the shift at zero.
+func shiftLeft(expr string, n int64) string {
+	if n == 0 {
+		return expr
+	}
+	return fmt.Sprintf("(%s << %d)", expr, n)
+}
+
+// ---- read -----------------------------------------------------------------
+
+// emitFlatReadRun reads the run's chunks — one bounds check per chunk instead
+// of one per field — then unpacks, validates and stores each field with
+// literal shifts and masks.
+func (g *gen) emitFlatReadRun(r *flatRun, ind string) {
+	g.needsStreamTrait = true
+
+	widths := chunkWidths(r.bits)
+	g.pf("%slet mut c: u32 = 0;\n", ind)
+	for j, width := range widths {
+		g.pf("%sstream.serialize_bits(&mut c, %d)?;\n", ind, width)
+		g.pf("%slet c%d = u64::from(c);\n", ind, j)
+	}
+
+	var at int64
+	for i, p := range r.pieces {
+		if p.bits == 0 {
+			p.read(ind, "0")
+			continue
+		}
+		o := at
+		at += p.bits
+		first := o / 32
+		last := (o + p.bits - 1) / 32
+		var terms []string
+		for j := first; j <= last; j++ {
+			lo := j * 32
+			if lo <= o {
+				terms = append(terms, shiftRight(fmt.Sprintf("c%d", j), o-lo))
+			} else {
+				terms = append(terms, fmt.Sprintf("(c%d << %d)", j, lo-o))
+			}
+		}
+		expr := strings.Join(terms, " | ")
+		if m := mask64(p.bits); m != "" {
+			if len(terms) > 1 {
+				expr = fmt.Sprintf("(%s) & %s", expr, m)
+			} else {
+				expr = fmt.Sprintf("%s & %s", expr, m)
+			}
+		}
+		g.pf("%slet v%d: u64 = %s;\n", ind, i, expr)
+		p.read(ind, fmt.Sprintf("v%d", i))
+	}
+}
+
+// shiftRight renders `expr >> n`, dropping the shift at zero.
+func shiftRight(expr string, n int64) string {
+	if n == 0 {
+		return expr
+	}
+	return fmt.Sprintf("(%s >> %d)", expr, n)
+}
+
+// ---- classification -------------------------------------------------------
+
+// flatPieceOf classifies one item. The second result is false for every
+// construct whose width or content is not a generation-time constant; those
+// break the run and keep the per-field form.
+func (g *gen) flatPieceOf(item ir.Item) (flatPiece, bool) {
+	switch it := item.(type) {
+	case *ir.ConstItem:
+		return g.flatConstPiece(it), true
+	case *ir.ReservedItem:
+		return g.flatReservedPiece(it), true
+	case *ir.FieldItem:
+		if it.F.Array != ir.ArrayNone {
+			return flatPiece{}, false
+		}
+		return g.flatFieldPiece(item, it.F)
+	}
+	return flatPiece{}, false
+}
+
+func (g *gen) flatConstPiece(it *ir.ConstItem) flatPiece {
+	return flatPiece{
+		item:  it,
+		bits:  it.Bits,
+		guard: func(string) {},
+		value: fmt.Sprintf("%s_u64", it.Value.String()),
+		note:  fmt.Sprintf(" // const(%s, %d) — SPEC §4.3", it.Value.String(), it.Bits),
+		read: func(ind, src string) {
+			g.pf("%sif %s != %s {\n", ind, src, it.Value.String())
+			g.pf("%s    // const(%s, %d): a read rejects any other value (SPEC §4.3)\n", ind, it.Value.String(), it.Bits)
+			g.pf("%s    return Err(Error::Validation);\n%s}\n", ind, ind)
+		},
+	}
+}
+
+func (g *gen) flatReservedPiece(it *ir.ReservedItem) flatPiece {
+	return flatPiece{
+		item:  it,
+		bits:  it.Bits,
+		guard: func(string) {},
+		value: "0",
+		note:  fmt.Sprintf(" // reserved(%d) — zeros on the wire", it.Bits),
+		read: func(ind, src string) {
+			g.pf("%sif %s != 0 {\n", ind, src)
+			g.pf("%s    // reserved(%d): a read rejects nonzero (SPEC §4.3)\n", ind, it.Bits)
+			g.pf("%s    return Err(Error::Validation);\n%s}\n", ind, ind)
+		},
+	}
+}
+
+// flatFieldPiece classifies a scalar field. Everything whose value arithmetic
+// lives in the runtime — fixed point, compressed float, the 128-bit family —
+// stays on the per-field path and breaks the run.
+func (g *gen) flatFieldPiece(item ir.Item, f *ir.Field) (flatPiece, bool) {
+	name := "value." + f.Name
+	noGuard := func(string) {}
+
+	switch f.Type.Kind {
+	case ir.TBool:
+		return flatPiece{
+			item: item, bits: 1, guard: noGuard,
+			value: fmt.Sprintf("u64::from(%s)", name),
+			read: func(ind, src string) {
+				g.pf("%s%s = %s != 0;\n", ind, name, src)
+			},
+		}, true
+
+	case ir.TBits:
+		w := int64(f.Type.Width)
+		guard := noGuard
+		if f.Type.Width != 32 && f.Type.Width != 64 {
+			// storage is the wider unsigned type: bits above the wire width
+			// are refused, not wrapped (the runtime's write side only
+			// debug_asserts)
+			guard = func(ind string) {
+				g.pf("%sif %s >= 1 << %d {\n", ind, name, f.Type.Width)
+				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+			}
+		}
+		storage := g.rustFieldType(f.Type)
+		value := fmt.Sprintf("u64::from(%s)", name)
+		if storage == "u64" {
+			value = name
+		}
+		return flatPiece{
+			item: item, bits: w, guard: guard,
+			value: value,
+			read: func(ind, src string) {
+				if storage == "u64" {
+					g.pf("%s%s = %s;\n", ind, name, src)
+					return
+				}
+				g.pf("%s%s = %s as %s;\n", ind, name, src, storage)
+			},
+		}, true
+
+	case ir.TFloat32:
+		if f.HasFloatRange {
+			return flatPiece{}, false // the quantization lives in the runtime
+		}
+		return flatPiece{
+			item: item, bits: 32, guard: noGuard,
+			value: fmt.Sprintf("u64::from(%s.to_bits())", name),
+			read: func(ind, src string) {
+				g.pf("%s%s = f32::from_bits(%s as u32);\n", ind, name, src)
+			},
+		}, true
+
+	case ir.TFloat64:
+		return flatPiece{
+			item: item, bits: 64, guard: noGuard,
+			value: fmt.Sprintf("%s.to_bits()", name),
+			read: func(ind, src string) {
+				g.pf("%s%s = f64::from_bits(%s);\n", ind, name, src)
+			},
+		}, true
+
+	case ir.TNamed:
+		switch ref := f.Type.Ref.(type) {
+		case *ir.Enum:
+			bits := ir.BitsRequired(big.NewInt(0), big.NewInt(ref.Max))
+			guard := noGuard
+			if ref.Max < (int64(1)<<uint(ref.StorageBits))-1 {
+				// headroom storage can exceed the wire range: refused, not
+				// wrapped (the runtime's write side only debug_asserts)
+				guard = func(ind string) {
+					g.pf("%sif %s.0 > %d {\n", ind, name, ref.Max)
+					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				}
+			}
+			storage := rustUint(ref.StorageBits)
+			typeName := f.Type.Name
+			max := ref.Max
+			return flatPiece{
+				item: item, bits: bits, guard: guard,
+				value: fmt.Sprintf("u64::from(%s.0)", name),
+				read: func(ind, src string) {
+					// serialize_int's own refusal: a tag above the exported
+					// extent reaches the storage's bit headroom, and a read
+					// rejects it rather than admitting it (SPEC §4.2)
+					if !rangeIsFull(big.NewInt(0), big.NewInt(max), bits) {
+						g.pf("%sif %s > %d {\n", ind, src, max)
+						g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+					}
+					g.pf("%s%s = %s(%s as %s);\n", ind, name, typeName, src, storage)
+				},
+			}, true
+
+		case *ir.Flags:
+			wire := int64(ref.WireBits)
+			guard := noGuard
+			if ref.WireBits < 64 {
+				guard = func(ind string) {
+					g.pf("%sif %s >= 1 << %d {\n", ind, name, ref.WireBits)
+					g.pf("%s    // a mask bit above the wire width cannot ride\n", ind)
+					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				}
+			}
+			return flatPiece{
+				item: item, bits: wire, guard: guard,
+				value: name, // the flags alias IS u64 storage (SPEC §4.2)
+				read: func(ind, src string) {
+					g.pf("%s%s = %s;\n", ind, name, src)
+				},
+			}, true
+		}
+		return flatPiece{}, false // nested struct or union: its own call
+
+	case ir.TInt:
+		return g.flatIntPiece(item, f)
+	}
+	return flatPiece{}, false
+}
+
+// rangeIsFull reports whether [min,max] covers every value the wire's bit
+// count can carry, which makes the read-side range refusal provably vacuous.
+func rangeIsFull(min, max *big.Int, bits int64) bool {
+	if bits >= 64 {
+		return new(big.Int).Sub(max, min).Cmp(maxUint64) == 0
+	}
+	span := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))
+	return new(big.Int).Sub(max, min).Cmp(span) == 0
+}
+
+// flatIntPiece classifies an integer field across the four wire paths the
+// per-field form uses, so the folded offsets and the refusals are the same
+// arithmetic in the same order.
+func (g *gen) flatIntPiece(item ir.Item, f *ir.Field) (flatPiece, bool) {
+	name := "value." + f.Name
+	if f.Type.Width == 128 {
+		return flatPiece{}, false // the 128-bit family stays on the runtime path
+	}
+	storage := g.rustFieldType(f.Type)
+
+	if !f.HasIntRange {
+		w := int64(f.Type.Width)
+		var value string
+		switch {
+		case f.Type.Width == 64 && f.Type.Signed:
+			value = name + " as u64"
+		case f.Type.Width == 64:
+			value = name
+		case !f.Type.Signed:
+			value = fmt.Sprintf("u64::from(%s)", name)
+		case f.Type.Width == 32:
+			value = fmt.Sprintf("u64::from(%s as u32)", name)
+		default:
+			// through the same-width unsigned so the sign bit cannot extend
+			value = fmt.Sprintf("u64::from(%s as u%d)", name, f.Type.Width)
+		}
+		signed, width := f.Type.Signed, f.Type.Width
+		return flatPiece{
+			item: item, bits: w, guard: func(string) {},
+			value: value,
+			read: func(ind, src string) {
+				switch {
+				case width == 64 && signed:
+					g.pf("%s%s = %s as i64;\n", ind, name, src)
+				case width == 64:
+					g.pf("%s%s = %s;\n", ind, name, src)
+				case signed && width < 32:
+					// back through the same-width unsigned so the sign bit lands right
+					g.pf("%s%s = %s as u%d as i%d;\n", ind, name, src, width, width)
+				default:
+					g.pf("%s%s = %s as %s;\n", ind, name, src, storage)
+				}
+			},
+		}, true
+	}
+
+	// degenerate range: ZERO BITS — the value is known from the range alone
+	// (SPEC §4.6). The write keeps its refusal; the read materializes.
+	if f.IntMin.Cmp(f.IntMax) == 0 {
+		return flatPiece{
+			item: item, bits: 0,
+			guard: func(ind string) { g.emitWriteRangeGuard(name, f, ind) },
+			read: func(ind, _ string) {
+				g.pf("%s%s = %s;\n", ind, name, rustIntLitStorage(f.IntMin, f.Type.Signed, f.Type.Width))
+			},
+		}, true
+	}
+
+	bits := ir.BitsRequired(f.IntMin, f.IntMax)
+	switch intRangePath(f.IntMin, f.IntMax) {
+	case "int32":
+		lo := g.foldArg32(f.IntMinExpr, f.IntMin)
+		loZero := f.IntMin.Sign() == 0
+		exprIsU32 := !f.Type.Signed && f.Type.Width == 32
+		readLo := g.foldArg32(f.IntMinExpr, f.IntMin)
+		full := rangeIsFull(f.IntMin, f.IntMax, bits)
+		diff := new(big.Int).Sub(f.IntMax, f.IntMin)
+		return flatPiece{
+			item: item, bits: bits,
+			guard: func(ind string) { g.emitWriteRangeGuard(name, f, ind) },
+			value: fmt.Sprintf("u64::from(%s)", foldOffset32(name, exprIsU32, lo, loZero)),
+			read: func(ind, src string) {
+				if !full {
+					// a malicious packet can smuggle an out-of-range value
+					// into the encoding's bit headroom (SPEC §4.3)
+					g.pf("%sif %s > %s {\n", ind, src, diff.String())
+					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				}
+				decoded := fmt.Sprintf("(%s as u32).wrapping_add((%s) as u32) as i32", src, readLo)
+				if loZero {
+					decoded = fmt.Sprintf("%s as i32", src)
+				}
+				if f.Type.Signed && f.Type.Width == 32 {
+					g.pf("%s%s = %s;\n", ind, name, decoded)
+					return
+				}
+				g.pf("%s%s = (%s) as %s;\n", ind, name, decoded, storage)
+			},
+		}, true
+
+	case "int64":
+		lo := g.foldArg64(f.IntMinExpr, f.IntMin)
+		loZero := f.IntMin.Sign() == 0
+		exprIsU64 := !f.Type.Signed && f.Type.Width == 64
+		readLo := g.foldArg64(f.IntMinExpr, f.IntMin)
+		full := rangeIsFull(f.IntMin, f.IntMax, bits)
+		diff := new(big.Int).Sub(f.IntMax, f.IntMin)
+		cast := name + " as u64"
+		if exprIsU64 {
+			cast = name
+		}
+		value := cast
+		if !loZero {
+			value = fmt.Sprintf("(%s).wrapping_sub((%s) as u64)", cast, lo)
+		}
+		return flatPiece{
+			item: item, bits: bits,
+			guard: func(ind string) { g.emitWriteRangeGuard(name, f, ind) },
+			value: value,
+			read: func(ind, src string) {
+				if !full {
+					g.pf("%sif %s > %s {\n", ind, src, diff.String())
+					g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+				}
+				decoded := fmt.Sprintf("%s.wrapping_add((%s) as u64) as i64", src, readLo)
+				if loZero {
+					decoded = fmt.Sprintf("%s as i64", src)
+				}
+				if f.Type.Signed && f.Type.Width == 64 {
+					g.pf("%s%s = %s;\n", ind, name, decoded)
+					return
+				}
+				g.pf("%s%s = (%s) as %s;\n", ind, name, decoded, storage)
+			},
+		}, true
+	}
+
+	// full-range unsigned: raw offset bits over u64 storage
+	lo, _ := g.rangeArgs(f, "u64")
+	loVacuous := f.IntMin.Sign() == 0
+	hiVacuous := f.IntMax.Cmp(maxUint64) == 0
+	diff := new(big.Int).Sub(f.IntMax, f.IntMin)
+	value := name
+	if !loVacuous {
+		value = fmt.Sprintf("%s - %s", name, lo)
+	}
+	return flatPiece{
+		item: item, bits: bits,
+		guard: func(ind string) {
+			// Like every bounded write path in this target, the range refusal
+			// is generated: serialize.rs's write side only debug_asserts, so a
+			// misuse value must be refused here or it wraps into valid-looking
+			// wire; vacuous halves are elided.
+			switch {
+			case !loVacuous && !hiVacuous:
+				g.pf("%sif %s < %s || %s > %s {\n", ind, name, lo, name, f.IntMax.String())
+				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+			case !loVacuous:
+				g.pf("%sif %s < %s {\n", ind, name, lo)
+				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+			case !hiVacuous:
+				g.pf("%sif %s > %s {\n", ind, name, f.IntMax.String())
+				g.pf("%s    return Err(Error::Stream(serialize::Error::ValueOutOfRange));\n%s}\n", ind, ind)
+			}
+		},
+		value: value,
+		read: func(ind, src string) {
+			if diff.Cmp(maxUint64) != 0 {
+				// a full-width diff cannot overflow its own read — elided
+				g.pf("%sif %s > %s {\n", ind, src, diff.String())
+				g.pf("%s    // a read rejects out-of-range (SPEC §5)\n", ind)
+				g.pf("%s    return Err(Error::Validation);\n%s}\n", ind, ind)
+			}
+			if loVacuous {
+				g.pf("%s%s = %s;\n", ind, name, src)
+				return
+			}
+			g.pf("%s%s = %s + %s;\n", ind, name, src, lo)
+		},
+	}, true
+}

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -114,62 +114,128 @@ func (g *gen) emitStructFunctions(st *ir.Struct) {
 	g.pf("    Ok(())\n}\n\n")
 }
 
+// emitWriteItems walks the item list, gathering maximal runs of
+// statically-sized pieces into the flat word codec (flat.go) and emitting
+// everything else — align, arrays, strings, branches, nested calls, the
+// runtime-arithmetic families — one item at a time, per-field.
 func (g *gen) emitWriteItems(items []ir.Item, ind string) {
-	for _, item := range items {
-		switch item := item.(type) {
-		case *ir.FieldItem:
-			g.emitWriteField(item.F, ind)
-		case *ir.ConstItem:
-			g.emitConstItem(item, ind, true)
-		case *ir.ReservedItem:
-			g.emitReservedItem(item, ind, true)
-		case *ir.AlignItem:
-			g.needsStreamTrait = true
-			g.pf("%sstream.serialize_align()?;\n", ind)
-		case *ir.Branch:
-			neg := ""
-			if item.Neg {
-				neg = "!"
-			}
-			g.pf("%sif %svalue.%s {\n", ind, neg, item.Cond)
-			g.emitWriteItems(item.Then, ind+"    ")
-			if item.Else != nil {
-				g.pf("%s} else {\n", ind)
-				g.emitWriteItems(item.Else, ind+"    ")
-			}
-			g.pf("%s}\n", ind)
+	var run flatRun
+	flush := func() {
+		if len(run.pieces) == 0 {
+			return
 		}
+		if run.worthFlattening() {
+			g.emitFlatWriteRun(&run, ind)
+		} else {
+			for _, p := range run.pieces {
+				g.emitWriteItem(p.item, ind)
+			}
+		}
+		run = flatRun{}
+	}
+	for _, item := range items {
+		p, ok := g.flatPieceOf(item)
+		if !ok {
+			flush()
+			g.emitWriteItem(item, ind)
+			continue
+		}
+		if run.bits+p.bits > maxRunBits {
+			flush()
+		}
+		run.pieces = append(run.pieces, p)
+		run.bits += p.bits
+	}
+	flush()
+}
+
+// emitWriteItem is the per-field form: one item, one runtime call family.
+func (g *gen) emitWriteItem(item ir.Item, ind string) {
+	switch item := item.(type) {
+	case *ir.FieldItem:
+		g.emitWriteField(item.F, ind)
+	case *ir.ConstItem:
+		g.emitConstItem(item, ind, true)
+	case *ir.ReservedItem:
+		g.emitReservedItem(item, ind, true)
+	case *ir.AlignItem:
+		g.needsStreamTrait = true
+		g.pf("%sstream.serialize_align()?;\n", ind)
+	case *ir.Branch:
+		neg := ""
+		if item.Neg {
+			neg = "!"
+		}
+		g.pf("%sif %svalue.%s {\n", ind, neg, item.Cond)
+		g.emitWriteItems(item.Then, ind+"    ")
+		if item.Else != nil {
+			g.pf("%s} else {\n", ind)
+			g.emitWriteItems(item.Else, ind+"    ")
+		}
+		g.pf("%s}\n", ind)
 	}
 }
 
+// emitReadItems is emitWriteItems' twin: the same maximal runs take the flat
+// word codec, with one bounds check per 32-bit chunk instead of one per field.
 func (g *gen) emitReadItems(items []ir.Item, ind string) {
-	for _, item := range items {
-		switch item := item.(type) {
-		case *ir.FieldItem:
-			g.emitReadField(item.F, ind)
-		case *ir.ConstItem:
-			g.emitConstItem(item, ind, false)
-		case *ir.ReservedItem:
-			g.emitReservedItem(item, ind, false)
-		case *ir.AlignItem:
-			g.needsStreamTrait = true
-			g.pf("%sstream.serialize_align()?; // rejects nonzero padding (SPEC §4.3)\n", ind)
-		case *ir.Branch:
-			neg := ""
-			if item.Neg {
-				neg = "!"
-			}
-			g.pf("%sif %svalue.%s {\n", ind, neg, item.Cond)
-			g.emitReadItems(item.Then, ind+"    ")
-			// the untaken side reads as zero values (SPEC §5)
-			g.emitZeroItems(item.Else, ind+"    ")
-			g.pf("%s} else {\n", ind)
-			if item.Else != nil {
-				g.emitReadItems(item.Else, ind+"    ")
-			}
-			g.emitZeroItems(item.Then, ind+"    ")
-			g.pf("%s}\n", ind)
+	var run flatRun
+	flush := func() {
+		if len(run.pieces) == 0 {
+			return
 		}
+		if run.worthFlattening() {
+			g.emitFlatReadRun(&run, ind)
+		} else {
+			for _, p := range run.pieces {
+				g.emitReadItem(p.item, ind)
+			}
+		}
+		run = flatRun{}
+	}
+	for _, item := range items {
+		p, ok := g.flatPieceOf(item)
+		if !ok {
+			flush()
+			g.emitReadItem(item, ind)
+			continue
+		}
+		if run.bits+p.bits > maxRunBits {
+			flush()
+		}
+		run.pieces = append(run.pieces, p)
+		run.bits += p.bits
+	}
+	flush()
+}
+
+// emitReadItem is the per-field form: one item, one runtime call family.
+func (g *gen) emitReadItem(item ir.Item, ind string) {
+	switch item := item.(type) {
+	case *ir.FieldItem:
+		g.emitReadField(item.F, ind)
+	case *ir.ConstItem:
+		g.emitConstItem(item, ind, false)
+	case *ir.ReservedItem:
+		g.emitReservedItem(item, ind, false)
+	case *ir.AlignItem:
+		g.needsStreamTrait = true
+		g.pf("%sstream.serialize_align()?; // rejects nonzero padding (SPEC §4.3)\n", ind)
+	case *ir.Branch:
+		neg := ""
+		if item.Neg {
+			neg = "!"
+		}
+		g.pf("%sif %svalue.%s {\n", ind, neg, item.Cond)
+		g.emitReadItems(item.Then, ind+"    ")
+		// the untaken side reads as zero values (SPEC §5)
+		g.emitZeroItems(item.Else, ind+"    ")
+		g.pf("%s} else {\n", ind)
+		if item.Else != nil {
+			g.emitReadItems(item.Else, ind+"    ")
+		}
+		g.emitZeroItems(item.Then, ind+"    ")
+		g.pf("%s}\n", ind)
 	}
 }
 

--- a/internal/codegen/rust/functions.go
+++ b/internal/codegen/rust/functions.go
@@ -6,6 +6,14 @@
 // functions take &T, so every write goes through a mutable temp — the runtime
 // takes &mut for every value, reads and writes alike. The wire is
 // byte-identical to the C++ target's, construct by construct.
+//
+// Two forms share the emission. Maximal runs of statically-sized pieces take
+// the flat word codec (flat.go): the emitter folds the bit placement itself
+// and the stream sees whole 32-bit chunks. Everything else — align,
+// string/bytes, arrays, branches, nested struct and union calls, and the
+// fixed-point, compressed-float and 128-bit families, whose value arithmetic
+// lives in the runtime — keeps the per-field form below, one item per
+// runtime call family. Both spell the same wire.
 package rust
 
 import (

--- a/internal/codegen/rust/inline.go
+++ b/internal/codegen/rust/inline.go
@@ -54,6 +54,16 @@ package rust
 // Do NOT reach for branch-weight hints instead. Measured across this family
 // (the C++ tournament passes), cold hints activate the machine outliner and
 // shred the hot bodies; the C++ emitter carries the same standing warning.
+//
+// What either attribute buys depends entirely on what stands between the
+// spine and its caller, and in bench/rust nothing does: the driver reaches
+// the spine through a Fn::call shim, #[inline(always)] is honoured INTO that
+// shim, and LLVM then prices the shim against the driver and refuses it.
+// Flipping the read half to the demand there moves the bench_mixed rows by
+// less than half a percent — the attribute never reaches the timed loop.
+// Which is why the flat word codec (flat.go) is what closes the gap in that
+// regime: it makes the out-of-line body itself cheap, rather than betting on
+// an inlining decision the emitter does not control.
 
 // writeSpineInline is the inlining DEMAND every generated write wire function
 // is spelled with.

--- a/internal/codegen/rust/rust_test.go
+++ b/internal/codegen/rust/rust_test.go
@@ -68,21 +68,20 @@ func generateExtremesCorpus(t *testing.T) string {
 }
 
 // TestDoubledMinusAtExtremeFolds pins both sites that render the
-// doubled-minus bound: the write-side fold offset and the read-side
-// serialize_int64 arguments. At the extreme they must fold to the proven
-// plain-INT64_MIN spellings; in range the doubled minus keeps its symbolic,
-// parenthesized form (the pinned rule — a fold here would be a silent
-// retreat from symbolic rendering).
+// doubled-minus bound: the flat run's write offset and its read decode. At
+// the extreme they must fold to the proven plain-INT64_MIN spellings; in
+// range the doubled minus keeps its symbolic, parenthesized form (the pinned
+// rule — a fold here would be a silent retreat from symbolic rendering).
 func TestDoubledMinusAtExtremeFolds(t *testing.T) {
 	rs := generateExtremesCorpus(t)
 	for _, want := range []string{
 		// the write-side fold offset: same spelling as the plain floor_bound
-		"let mut offset_value = (value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);",
-		// the read-side runtime call: same spelling as the plain floor_bound
-		"stream.serialize_int64(&mut value.doubled_floor, -9223372036854775808, 100)?;",
+		"(value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);",
+		// the read-side decode: same spelling as the plain floor_bound
+		"value.doubled_floor = v1.wrapping_add((-9223372036854775808_i64) as u64) as i64;",
 		// the in-range doubled minus stays symbolic and parenthesized, both sides
-		"let mut offset_value = (value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32);",
-		"stream.serialize_int(&mut value.spin_rate, (-(-ROTATION_UNITS)) as i32, (ROTATION_UNITS * 2) as i32)?;",
+		"u64::from((value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32));",
+		"value.spin_rate = (v2 as u32).wrapping_add(((-(-ROTATION_UNITS)) as i32) as u32) as i32;",
 	} {
 		if !strings.Contains(rs, want) {
 			t.Errorf("generated Rust must contain %q:\n%s", want, rs)

--- a/testdata/golden/rust/render.rs
+++ b/testdata/golden/rust/render.rs
@@ -40,47 +40,53 @@ pub const RENDER_SPRITE_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_render_sprite(stream: &mut WriteStream<'_>, value: &RenderSprite) -> Result {
-    {
-        let mut raw_value = value.sort_key;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.mesh_id;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.material_id;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.layer as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
     if value.team.0 > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.team.0 as u32;
-        stream.serialize_bits(&mut offset_value, 2)?;
-    }
+    let f0: u64 = value.sort_key;
+    let f1: u64 = u64::from(value.mesh_id);
+    let f2: u64 = u64::from(value.material_id);
+    let f3: u64 = u64::from(value.layer);
+    let f4: u64 = u64::from(value.team.0);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = f2 as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = (f3 | (f4 << 8)) as u32;
+    stream.serialize_bits(&mut w4, 10)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_render_sprite(stream: &mut ReadStream<'_>, value: &mut RenderSprite) -> Result {
-    stream.serialize_bits64(&mut value.sort_key, 64)?;
-    stream.serialize_bits(&mut value.mesh_id, 32)?;
-    stream.serialize_bits(&mut value.material_id, 32)?;
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.layer = raw_value as u8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 10)?;
+    let c4 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.sort_key = v0;
+    let v1: u64 = c2 & 0xffffffff;
+    value.mesh_id = v1 as u32;
+    let v2: u64 = c3 & 0xffffffff;
+    value.material_id = v2 as u32;
+    let v3: u64 = c4 & 0xff;
+    value.layer = v3 as u8;
+    let v4: u64 = (c4 >> 8) & 0x3;
+    if v4 > 2 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 2)?;
-        value.team = Team(enum_value as u8);
-    }
+    value.team = Team(v4 as u8);
     Ok(())
 }
 
@@ -113,14 +119,12 @@ pub const RENDER_BLOCK_MAX_BYTES: usize = 1120;
 
 #[inline(always)]
 pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> Result {
-    {
-        let mut raw_value = value.worker_index;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.sprite_count_hint;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
+    let f0: u64 = u64::from(value.worker_index);
+    let f1: u64 = u64::from(value.sprite_count_hint);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 32)?;
     if value.sprites_count < 0 || value.sprites_count > 64 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -136,8 +140,15 @@ pub fn write_render_block(stream: &mut WriteStream<'_>, value: &RenderBlock) -> 
 
 #[inline]
 pub fn read_render_block(stream: &mut ReadStream<'_>, value: &mut RenderBlock) -> Result {
-    stream.serialize_bits(&mut value.worker_index, 32)?;
-    stream.serialize_bits(&mut value.sprite_count_hint, 32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.worker_index = v0 as u32;
+    let v1: u64 = c1 & 0xffffffff;
+    value.sprite_count_hint = v1 as u32;
     stream.serialize_int(&mut value.sprites_count, 0, RENDER_BLOCK_MAX_SPRITES as i32)?; // the count guards the loop (§6.3)
     for i in 0..value.sprites_count as usize {
         read_render_sprite(stream, &mut value.sprites[i])?;

--- a/testdata/golden/rust/types.rs
+++ b/testdata/golden/rust/types.rs
@@ -34,26 +34,45 @@ pub const VEC3_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_vec3(stream: &mut WriteStream<'_>, value: &Vec3) -> Result {
-    {
-        let mut float_value = value.x;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.y;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.z;
-        stream.serialize_f64(&mut float_value)?;
-    }
+    let f0: u64 = value.x.to_bits();
+    let f1: u64 = value.y.to_bits();
+    let f2: u64 = value.z.to_bits();
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_vec3(stream: &mut ReadStream<'_>, value: &mut Vec3) -> Result {
-    stream.serialize_f64(&mut value.x)?;
-    stream.serialize_f64(&mut value.y)?;
-    stream.serialize_f64(&mut value.z)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.x = f64::from_bits(v0);
+    let v1: u64 = c2 | (c3 << 32);
+    value.y = f64::from_bits(v1);
+    let v2: u64 = c4 | (c5 << 32);
+    value.z = f64::from_bits(v2);
     Ok(())
 }
 
@@ -86,31 +105,56 @@ pub const QUAT_MAX_BYTES: usize = 32;
 
 #[inline(always)]
 pub fn write_quat(stream: &mut WriteStream<'_>, value: &Quat) -> Result {
-    {
-        let mut float_value = value.x;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.y;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.z;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.w;
-        stream.serialize_f64(&mut float_value)?;
-    }
+    let f0: u64 = value.x.to_bits();
+    let f1: u64 = value.y.to_bits();
+    let f2: u64 = value.z.to_bits();
+    let f3: u64 = value.w.to_bits();
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = f3 as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = (f3 >> 32) as u32;
+    stream.serialize_bits(&mut w7, 32)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quat(stream: &mut ReadStream<'_>, value: &mut Quat) -> Result {
-    stream.serialize_f64(&mut value.x)?;
-    stream.serialize_f64(&mut value.y)?;
-    stream.serialize_f64(&mut value.z)?;
-    stream.serialize_f64(&mut value.w)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.x = f64::from_bits(v0);
+    let v1: u64 = c2 | (c3 << 32);
+    value.y = f64::from_bits(v1);
+    let v2: u64 = c4 | (c5 << 32);
+    value.z = f64::from_bits(v2);
+    let v3: u64 = c6 | (c7 << 32);
+    value.w = f64::from_bits(v3);
     Ok(())
 }
 
@@ -142,25 +186,25 @@ pub fn write_handle(stream: &mut WriteStream<'_>, value: &Handle) -> Result {
     if value.object_id < 0 || value.object_id > 9999 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.object_id as u32;
-        stream.serialize_bits(&mut offset_value, 14)?;
-    }
-    {
-        let mut raw_value = value.object_sequence as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
+    let f0: u64 = u64::from(value.object_id as u32);
+    let f1: u64 = u64::from(value.object_sequence);
+    let mut w0 = (f0 | (f1 << 14)) as u32;
+    stream.serialize_bits(&mut w0, 22)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_handle(stream: &mut ReadStream<'_>, value: &mut Handle) -> Result {
-    stream.serialize_int(&mut value.object_id, 0, (MAX_OBJECTS - 1) as i32)?;
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.object_sequence = raw_value as u8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 22)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x3fff;
+    if v0 > 9999 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.object_id = v0 as i32;
+    let v1: u64 = (c0 >> 14) & 0xff;
+    value.object_sequence = v1 as u8;
     Ok(())
 }
 
@@ -194,32 +238,48 @@ pub fn write_quantized_position(stream: &mut WriteStream<'_>, value: &QuantizedP
     if value.x < -8388608 || value.x > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 25)?;
-    }
     if value.y < -8388608 || value.y > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 25)?;
     }
     if value.z < -8388608 || value.z > 8388608 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.z as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 25)?;
-    }
+    let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
+    let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
+    let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_POSITION_UNITS) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 25)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 7) | (f2 << 18)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f2 >> 14) as u32;
+    stream.serialize_bits(&mut w2, 11)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quantized_position(stream: &mut ReadStream<'_>, value: &mut QuantizedPosition) -> Result {
-    stream.serialize_int(&mut value.x, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
-    stream.serialize_int(&mut value.y, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
-    stream.serialize_int(&mut value.z, (-MAX_POSITION_UNITS) as i32, MAX_POSITION_UNITS as i32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 11)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0x1ffffff;
+    if v0 > 16777216 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.x = (v0 as u32).wrapping_add(((-MAX_POSITION_UNITS) as i32) as u32) as i32;
+    let v1: u64 = ((c0 >> 25) | (c1 << 7)) & 0x1ffffff;
+    if v1 > 16777216 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.y = (v1 as u32).wrapping_add(((-MAX_POSITION_UNITS) as i32) as u32) as i32;
+    let v2: u64 = ((c1 >> 18) | (c2 << 14)) & 0x1ffffff;
+    if v2 > 16777216 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.z = (v2 as u32).wrapping_add(((-MAX_POSITION_UNITS) as i32) as u32) as i32;
     Ok(())
 }
 
@@ -253,32 +313,48 @@ pub fn write_quantized_velocity(stream: &mut WriteStream<'_>, value: &QuantizedV
     if value.x < -2097152 || value.x > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 23)?;
-    }
     if value.y < -2097152 || value.y > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 23)?;
     }
     if value.z < -2097152 || value.z > 2097152 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.z as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 23)?;
-    }
+    let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
+    let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
+    let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-MAX_VELOCITY_UNITS) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 23)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 9) | (f2 << 14)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f2 >> 18) as u32;
+    stream.serialize_bits(&mut w2, 5)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quantized_velocity(stream: &mut ReadStream<'_>, value: &mut QuantizedVelocity) -> Result {
-    stream.serialize_int(&mut value.x, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
-    stream.serialize_int(&mut value.y, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
-    stream.serialize_int(&mut value.z, (-MAX_VELOCITY_UNITS) as i32, MAX_VELOCITY_UNITS as i32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 5)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0x7fffff;
+    if v0 > 4194304 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.x = (v0 as u32).wrapping_add(((-MAX_VELOCITY_UNITS) as i32) as u32) as i32;
+    let v1: u64 = ((c0 >> 23) | (c1 << 9)) & 0x7fffff;
+    if v1 > 4194304 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.y = (v1 as u32).wrapping_add(((-MAX_VELOCITY_UNITS) as i32) as u32) as i32;
+    let v2: u64 = ((c1 >> 14) | (c2 << 18)) & 0x7fffff;
+    if v2 > 4194304 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.z = (v2 as u32).wrapping_add(((-MAX_VELOCITY_UNITS) as i32) as u32) as i32;
     Ok(())
 }
 
@@ -314,56 +390,53 @@ pub fn write_quantized_rotation(stream: &mut WriteStream<'_>, value: &QuantizedR
     if value.x < -1024 || value.x > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
     if value.y < -1024 || value.y > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
     }
     if value.z < -1024 || value.z > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
     if value.w < -1024 || value.w > 1024 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.w as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 12)?;
-    }
+    let f0: u64 = u64::from((value.x as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let f1: u64 = u64::from((value.y as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let f2: u64 = u64::from((value.z as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let f3: u64 = u64::from((value.w as u32).wrapping_sub(((-ROTATION_UNITS) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 12) | (f2 << 24)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 8) | (f3 << 4)) as u32;
+    stream.serialize_bits(&mut w1, 16)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_quantized_rotation(stream: &mut ReadStream<'_>, value: &mut QuantizedRotation) -> Result {
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.x = range_value as i16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 16)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xfff;
+    if v0 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.y = range_value as i16;
+    value.x = ((v0 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
+    let v1: u64 = (c0 >> 12) & 0xfff;
+    if v1 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.z = range_value as i16;
+    value.y = ((v1 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
+    let v2: u64 = ((c0 >> 24) | (c1 << 8)) & 0xfff;
+    if v2 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, (-ROTATION_UNITS) as i32, ROTATION_UNITS as i32)?;
-        value.w = range_value as i16;
+    value.z = ((v2 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
+    let v3: u64 = (c1 >> 4) & 0xfff;
+    if v3 > 2048 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.w = ((v3 as u32).wrapping_add(((-ROTATION_UNITS) as i32) as u32) as i32) as i16;
     Ok(())
 }
 
@@ -476,76 +549,75 @@ pub const INPUT_MAX_BYTES: usize = 24;
 
 #[inline(always)]
 pub fn write_input(stream: &mut WriteStream<'_>, value: &Input) -> Result {
-    {
-        let mut float_value = value.stick_x;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.stick_y;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.throttle;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.yaw;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut float_value = value.pitch;
-        stream.serialize_f32(&mut float_value)?;
-    }
-    {
-        let mut bool_value = value.fire;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.alt_fire;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.boost;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.brake;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.aim;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.lock_on;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.zoom;
-        stream.serialize_bool(&mut bool_value)?;
-    }
-    {
-        let mut bool_value = value.ping;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from(value.stick_x.to_bits());
+    let f1: u64 = u64::from(value.stick_y.to_bits());
+    let f2: u64 = u64::from(value.throttle.to_bits());
+    let f3: u64 = u64::from(value.yaw.to_bits());
+    let f4: u64 = u64::from(value.pitch.to_bits());
+    let f5: u64 = u64::from(value.fire);
+    let f6: u64 = u64::from(value.alt_fire);
+    let f7: u64 = u64::from(value.boost);
+    let f8: u64 = u64::from(value.brake);
+    let f9: u64 = u64::from(value.aim);
+    let f10: u64 = u64::from(value.lock_on);
+    let f11: u64 = u64::from(value.zoom);
+    let f12: u64 = u64::from(value.ping);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f2 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = f3 as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f4 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f5 | (f6 << 1) | (f7 << 2) | (f8 << 3) | (f9 << 4) | (f10 << 5) | (f11 << 6) | (f12 << 7)) as u32;
+    stream.serialize_bits(&mut w5, 8)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_input(stream: &mut ReadStream<'_>, value: &mut Input) -> Result {
-    stream.serialize_f32(&mut value.stick_x)?;
-    stream.serialize_f32(&mut value.stick_y)?;
-    stream.serialize_f32(&mut value.throttle)?;
-    stream.serialize_f32(&mut value.yaw)?;
-    stream.serialize_f32(&mut value.pitch)?;
-    stream.serialize_bool(&mut value.fire)?;
-    stream.serialize_bool(&mut value.alt_fire)?;
-    stream.serialize_bool(&mut value.boost)?;
-    stream.serialize_bool(&mut value.brake)?;
-    stream.serialize_bool(&mut value.aim)?;
-    stream.serialize_bool(&mut value.lock_on)?;
-    stream.serialize_bool(&mut value.zoom)?;
-    stream.serialize_bool(&mut value.ping)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 8)?;
+    let c5 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.stick_x = f32::from_bits(v0 as u32);
+    let v1: u64 = c1 & 0xffffffff;
+    value.stick_y = f32::from_bits(v1 as u32);
+    let v2: u64 = c2 & 0xffffffff;
+    value.throttle = f32::from_bits(v2 as u32);
+    let v3: u64 = c3 & 0xffffffff;
+    value.yaw = f32::from_bits(v3 as u32);
+    let v4: u64 = c4 & 0xffffffff;
+    value.pitch = f32::from_bits(v4 as u32);
+    let v5: u64 = c5 & 0x1;
+    value.fire = v5 != 0;
+    let v6: u64 = (c5 >> 1) & 0x1;
+    value.alt_fire = v6 != 0;
+    let v7: u64 = (c5 >> 2) & 0x1;
+    value.boost = v7 != 0;
+    let v8: u64 = (c5 >> 3) & 0x1;
+    value.brake = v8 != 0;
+    let v9: u64 = (c5 >> 4) & 0x1;
+    value.aim = v9 != 0;
+    let v10: u64 = (c5 >> 5) & 0x1;
+    value.lock_on = v10 != 0;
+    let v11: u64 = (c5 >> 6) & 0x1;
+    value.zoom = v11 != 0;
+    let v12: u64 = (c5 >> 7) & 0x1;
+    value.ping = v12 != 0;
     Ok(())
 }
 
@@ -580,18 +652,19 @@ pub const INPUT_PACKET_MAX_BYTES: usize = 360;
 
 #[inline(always)]
 pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> Result {
-    {
-        let mut raw_value = value.synchronize_sequence as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
-    {
-        let mut raw_value = value.current_frame;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.start_frame;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = u64::from(value.synchronize_sequence);
+    let f1: u64 = value.current_frame;
+    let f2: u64 = value.start_frame;
+    let mut w0 = (f0 | (f1 << 16)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f1 >> 16) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = ((f1 >> 48) | (f2 << 16)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f2 >> 16) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = (f2 >> 48) as u32;
+    stream.serialize_bits(&mut w4, 16)?;
     if value.inputs_count < 0 || value.inputs_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -607,13 +680,23 @@ pub fn write_input_packet(stream: &mut WriteStream<'_>, value: &InputPacket) -> 
 
 #[inline]
 pub fn read_input_packet(stream: &mut ReadStream<'_>, value: &mut InputPacket) -> Result {
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.synchronize_sequence = raw_value as u16;
-    }
-    stream.serialize_bits64(&mut value.current_frame, 64)?;
-    stream.serialize_bits64(&mut value.start_frame, 64)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 16)?;
+    let c4 = u64::from(c);
+    let v0: u64 = c0 & 0xffff;
+    value.synchronize_sequence = v0 as u16;
+    let v1: u64 = (c0 >> 16) | (c1 << 16) | (c2 << 48);
+    value.current_frame = v1;
+    let v2: u64 = (c2 >> 16) | (c3 << 16) | (c4 << 48);
+    value.start_frame = v2;
     stream.serialize_int(&mut value.inputs_count, 0, MAX_INPUTS_PER_PACKET as i32)?; // the count guards the loop (§6.3)
     for i in 0..value.inputs_count as usize {
         read_input(stream, &mut value.inputs[i])?;
@@ -693,27 +776,20 @@ pub fn write_ship_create(stream: &mut WriteStream<'_>, value: &ShipCreate) -> Re
     if value.team.0 > 2 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.team.0 as u32;
-        stream.serialize_bits(&mut offset_value, 2)?;
-    }
     if value.health < 0 || value.health > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.health as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
     }
     if value.thrust < 0 || value.thrust > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.thrust as u32;
-        stream.serialize_bits(&mut offset_value, 7)?;
-    }
     if value.pending.0 > 0 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    let f0: u64 = u64::from(value.team.0);
+    let f1: u64 = u64::from(value.health as u32);
+    let f2: u64 = u64::from(value.thrust as u32);
+    let mut w0 = (f0 | (f1 << 2) | (f2 << 12)) as u32;
+    stream.serialize_bits(&mut w0, 19)?;
     Ok(())
 }
 
@@ -737,26 +813,25 @@ pub fn read_ship_create(stream: &mut ReadStream<'_>, value: &mut ShipCreate) -> 
     } else {
         value.flags = 0;
     }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 2)?;
-        value.team = Team(enum_value as u8);
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 19)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x3;
+    if v0 > 2 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, MAX_HEALTH as i32)?;
-        value.health = range_value as i16;
+    value.team = Team(v0 as u8);
+    let v1: u64 = (c0 >> 2) & 0x3ff;
+    if v1 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 100)?;
-        value.thrust = range_value as i8;
+    value.health = (v1 as i32) as i16;
+    let v2: u64 = (c0 >> 12) & 0x7f;
+    if v2 > 100 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 0)?;
-        value.pending = Pending(enum_value as u8);
-    }
+    value.thrust = (v2 as i32) as i8;
+    value.pending = Pending(0 as u8);
     Ok(())
 }
 
@@ -788,24 +863,28 @@ pub fn write_expression_probe(stream: &mut WriteStream<'_>, value: &ExpressionPr
     if value.hardpoint_index < 0 || value.hardpoint_index > 31 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.hardpoint_index as u32;
-        stream.serialize_bits(&mut offset_value, 5)?;
-    }
     if value.spin_rate < 1024 || value.spin_rate > 2048 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32);
-        stream.serialize_bits(&mut offset_value, 11)?;
-    }
+    let f0: u64 = u64::from(value.hardpoint_index as u32);
+    let f1: u64 = u64::from((value.spin_rate as u32).wrapping_sub(((-(-ROTATION_UNITS)) as i32) as u32));
+    let mut w0 = (f0 | (f1 << 5)) as u32;
+    stream.serialize_bits(&mut w0, 16)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_expression_probe(stream: &mut ReadStream<'_>, value: &mut ExpressionProbe) -> Result {
-    stream.serialize_int(&mut value.hardpoint_index, 0, ((SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1) as i32)?;
-    stream.serialize_int(&mut value.spin_rate, (-(-ROTATION_UNITS)) as i32, (ROTATION_UNITS * 2) as i32)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 16)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x1f;
+    value.hardpoint_index = v0 as i32;
+    let v1: u64 = (c0 >> 5) & 0x7ff;
+    if v1 > 1024 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.spin_rate = (v1 as u32).wrapping_add(((-(-ROTATION_UNITS)) as i32) as u32) as i32;
     Ok(())
 }
 
@@ -859,28 +938,32 @@ pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -
     if value.floor_bound > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
     if value.doubled_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 64)?;
     }
     if value.ceiling_range < 1 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.ceiling_range - 1;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
-    {
-        let mut raw_value = value.floor_default as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = (value.floor_bound as u64).wrapping_sub((-9223372036854775808_i64) as u64);
+    let f1: u64 = (value.doubled_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
+    let f2: u64 = value.ceiling_range - 1;
+    let f3: u64 = value.floor_default as u64;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = f3 as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = (f3 >> 32) as u32;
+    stream.serialize_bits(&mut w7, 32)?;
     {
         let mut raw_value = value.ceiling_default;
         stream.serialize_bits64(&mut raw_value, 64)?;
@@ -890,22 +973,41 @@ pub fn write_extreme_probe(stream: &mut WriteStream<'_>, value: &ExtremeProbe) -
 
 #[inline]
 pub fn read_extreme_probe(stream: &mut ReadStream<'_>, value: &mut ExtremeProbe) -> Result {
-    stream.serialize_int64(&mut value.floor_bound, -9223372036854775808, 100)?;
-    stream.serialize_int64(&mut value.doubled_floor, -9223372036854775808, 100)?;
-    {
-        let mut offset_value: u64 = 0;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-        if offset_value > 18446744073709551614 {
-            // a read rejects out-of-range (SPEC §5)
-            return Err(Error::Validation);
-        }
-        value.ceiling_range = offset_value + 1;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    if v0 > 9223372036854775908 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.floor_default = raw_value as i64;
+    value.floor_bound = v0.wrapping_add((-9223372036854775808_i64) as u64) as i64;
+    let v1: u64 = c2 | (c3 << 32);
+    if v1 > 9223372036854775908 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
+    value.doubled_floor = v1.wrapping_add((-9223372036854775808_i64) as u64) as i64;
+    let v2: u64 = c4 | (c5 << 32);
+    if v2 > 18446744073709551614 {
+        // a read rejects out-of-range (SPEC §5)
+        return Err(Error::Validation);
+    }
+    value.ceiling_range = v2 + 1;
+    let v3: u64 = c6 | (c7 << 32);
+    value.floor_default = v3 as i64;
     stream.serialize_bits64(&mut value.ceiling_default, 64)?;
     Ok(())
 }
@@ -954,46 +1056,66 @@ pub fn write_extreme_row(stream: &mut WriteStream<'_>, value: &ExtremeRow) -> Re
     if value.clamped_floor > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.clamped_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
     if value.clamped_ceiling < 1 || value.clamped_ceiling > 18446744073709551614 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.clamped_ceiling - 1;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
-    {
-        let mut raw_value = value.floor_def as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.ceiling_def;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = (value.clamped_floor as u64).wrapping_sub((-9223372036854775808_i64) as u64);
+    let f1: u64 = value.clamped_ceiling - 1;
+    let f2: u64 = value.floor_def as u64;
+    let f3: u64 = value.ceiling_def;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = f2 as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f2 >> 32) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = f3 as u32;
+    stream.serialize_bits(&mut w6, 32)?;
+    let mut w7 = (f3 >> 32) as u32;
+    stream.serialize_bits(&mut w7, 32)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_extreme_row(stream: &mut ReadStream<'_>, value: &mut ExtremeRow) -> Result {
-    stream.serialize_int64(&mut value.clamped_floor, -9223372036854775808, 100)?;
-    {
-        let mut offset_value: u64 = 0;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-        if offset_value > 18446744073709551613 {
-            // a read rejects out-of-range (SPEC §5)
-            return Err(Error::Validation);
-        }
-        value.clamped_ceiling = offset_value + 1;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c6 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c7 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    if v0 > 9223372036854775908 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.floor_def = raw_value as i64;
+    value.clamped_floor = v0.wrapping_add((-9223372036854775808_i64) as u64) as i64;
+    let v1: u64 = c2 | (c3 << 32);
+    if v1 > 18446744073709551613 {
+        // a read rejects out-of-range (SPEC §5)
+        return Err(Error::Validation);
     }
-    stream.serialize_bits64(&mut value.ceiling_def, 64)?;
+    value.clamped_ceiling = v1 + 1;
+    let v2: u64 = c4 | (c5 << 32);
+    value.floor_def = v2 as i64;
+    let v3: u64 = c6 | (c7 << 32);
+    value.ceiling_def = v3;
     Ok(())
 }
 

--- a/testdata/golden/rust/wire.rs
+++ b/testdata/golden/rust/wire.rs
@@ -118,21 +118,14 @@ pub const PROBE_HEADER_MAX_BYTES: usize = 16;
 
 #[inline(always)]
 pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> Result {
-    {
-        let mut const_value: u32 = 171;
-        stream.serialize_bits(&mut const_value, 8)?; // const(171, 8) — SPEC §4.3
-    }
     if value.version >= 1 << 3 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.version;
-        stream.serialize_bits(&mut raw_value, 3)?;
-    }
-    {
-        let mut reserved_value: u32 = 0;
-        stream.serialize_bits(&mut reserved_value, 5)?; // reserved(5) — zeros on the wire
-    }
+    let f0: u64 = 171_u64; // const(171, 8) — SPEC §4.3
+    let f1: u64 = u64::from(value.version);
+    let f2: u64 = 0; // reserved(5) — zeros on the wire
+    let mut w0 = (f0 | (f1 << 8) | (f2 << 11)) as u32;
+    stream.serialize_bits(&mut w0, 16)?;
     stream.serialize_align()?;
     {
         let mut raw_value = value.probe_id;
@@ -143,22 +136,20 @@ pub fn write_probe_header(stream: &mut WriteStream<'_>, value: &ProbeHeader) -> 
 
 #[inline]
 pub fn read_probe_header(stream: &mut ReadStream<'_>, value: &mut ProbeHeader) -> Result {
-    {
-        let mut const_value: u32 = 0;
-        stream.serialize_bits(&mut const_value, 8)?;
-        if const_value != 171 {
-            // const(171, 8): a read rejects any other value (SPEC §4.3)
-            return Err(Error::Validation);
-        }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 16)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0xff;
+    if v0 != 171 {
+        // const(171, 8): a read rejects any other value (SPEC §4.3)
+        return Err(Error::Validation);
     }
-    stream.serialize_bits(&mut value.version, 3)?;
-    {
-        let mut reserved_value: u32 = 0;
-        stream.serialize_bits(&mut reserved_value, 5)?;
-        if reserved_value != 0 {
-            // reserved(5): a read rejects nonzero (SPEC §4.3)
-            return Err(Error::Validation);
-        }
+    let v1: u64 = (c0 >> 8) & 0x7;
+    value.version = v1 as u32;
+    let v2: u64 = (c0 >> 11) & 0x1f;
+    if v2 != 0 {
+        // reserved(5): a read rejects nonzero (SPEC §4.3)
+        return Err(Error::Validation);
     }
     stream.serialize_align()?; // rejects nonzero padding (SPEC §4.3)
     stream.serialize_bits64(&mut value.probe_id, 64)?;
@@ -199,47 +190,58 @@ pub fn write_probe_bits(stream: &mut WriteStream<'_>, value: &ProbeBits) -> Resu
     if value.small >= 1 << 9 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.small;
-        stream.serialize_bits(&mut raw_value, 9)?;
-    }
     if value.boundary >= 1 << 33 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.boundary;
-        stream.serialize_bits64(&mut raw_value, 33)?;
-    }
-    {
-        let mut raw_value = value.wide;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut offset_value = value.sensor;
-        stream.serialize_bits(&mut offset_value, 32)?;
-    }
-    {
-        let mut offset_value = value.nonce;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-    }
+    let f0: u64 = u64::from(value.small);
+    let f1: u64 = value.boundary;
+    let f2: u64 = value.wide;
+    let f3: u64 = value.sensor as u64;
+    let f4: u64 = value.nonce;
+    let mut w0 = (f0 | (f1 << 9)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f1 >> 23) | (f2 << 10)) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f2 >> 22) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = ((f2 >> 54) | (f3 << 10)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f3 >> 22) | (f4 << 10)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f4 >> 22) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = (f4 >> 54) as u32;
+    stream.serialize_bits(&mut w6, 10)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_probe_bits(stream: &mut ReadStream<'_>, value: &mut ProbeBits) -> Result {
-    stream.serialize_bits(&mut value.small, 9)?;
-    stream.serialize_bits64(&mut value.boundary, 33)?;
-    stream.serialize_bits64(&mut value.wide, 64)?;
-    {
-        let mut range_value: i64 = 0;
-        stream.serialize_int64(&mut range_value, 0, 4294967295)?;
-        value.sensor = range_value as u32;
-    }
-    {
-        let mut offset_value: u64 = 0;
-        stream.serialize_bits64(&mut offset_value, 64)?;
-        value.nonce = offset_value;
-    }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 10)?;
+    let c6 = u64::from(c);
+    let v0: u64 = c0 & 0x1ff;
+    value.small = v0 as u32;
+    let v1: u64 = ((c0 >> 9) | (c1 << 23)) & 0x1ffffffff;
+    value.boundary = v1;
+    let v2: u64 = (c1 >> 10) | (c2 << 22) | (c3 << 54);
+    value.wide = v2;
+    let v3: u64 = ((c3 >> 10) | (c4 << 22)) & 0xffffffff;
+    value.sensor = (v3 as i64) as u32;
+    let v4: u64 = (c4 >> 10) | (c5 << 22) | (c6 << 54);
+    value.nonce = v4;
     Ok(())
 }
 
@@ -313,26 +315,22 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
         let mut compressed_value = value.orientation;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
     }
-    {
-        let mut raw_value = value.raw_delta as u32;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.big_delta as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = u64::from(value.raw_delta as u32);
+    let f1: u64 = value.big_delta as u64;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
     if value.active {
         if value.weapon.0 > 15 {
             return Err(Error::Stream(serialize::Error::ValueOutOfRange));
         }
-        {
-            let mut offset_value = value.weapon.0 as u32;
-            stream.serialize_bits(&mut offset_value, 4)?;
-        }
-        {
-            let mut bool_value = value.has_target;
-            stream.serialize_bool(&mut bool_value)?;
-        }
+        let f0: u64 = u64::from(value.weapon.0);
+        let f1: u64 = u64::from(value.has_target);
+        let mut w0 = (f0 | (f1 << 4)) as u32;
+        stream.serialize_bits(&mut w0, 5)?;
         if value.has_target {
             {
                 let mut raw_value = value.target_id as u32;
@@ -365,23 +363,25 @@ pub fn write_probe_sample(stream: &mut WriteStream<'_>, value: &ProbeSample) -> 
 pub fn read_probe_sample(stream: &mut ReadStream<'_>, value: &mut ProbeSample) -> Result {
     stream.serialize_bool(&mut value.active)?;
     stream.serialize_compressed_float_precomputed(&mut value.orientation, 36000, 16, 360.0_f32, -180.0_f32)?; // compressed float [-180.0, 180.0] @ 0.01, constants folded at generation
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 32)?;
-        value.raw_delta = raw_value as i32;
-    }
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.big_delta = raw_value as i64;
-    }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.raw_delta = v0 as i32;
+    let v1: u64 = c1 | (c2 << 32);
+    value.big_delta = v1 as i64;
     if value.active {
-        {
-            let mut enum_value: i32 = 0;
-            stream.serialize_int(&mut enum_value, 0, 15)?;
-            value.weapon = Weapon(enum_value as u8);
-        }
-        stream.serialize_bool(&mut value.has_target)?;
+        let mut c: u32 = 0;
+        stream.serialize_bits(&mut c, 5)?;
+        let c0 = u64::from(c);
+        let v0: u64 = c0 & 0xf;
+        value.weapon = Weapon(v0 as u8);
+        let v1: u64 = (c0 >> 4) & 0x1;
+        value.has_target = v1 != 0;
         if value.has_target {
             {
                 let mut raw_value: u32 = 0;
@@ -477,29 +477,25 @@ pub fn write_probe_slab(stream: &mut WriteStream<'_>, value: &ProbeSlab) -> Resu
     if value.width > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.width as u32;
-        stream.serialize_bits(&mut offset_value, 7)?;
-    }
-    {
-        let mut raw_value = value.height as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
+    let f0: u64 = u64::from(value.width as u32);
+    let f1: u64 = u64::from(value.height);
+    let mut w0 = (f0 | (f1 << 7)) as u32;
+    stream.serialize_bits(&mut w0, 15)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_probe_slab(stream: &mut ReadStream<'_>, value: &mut ProbeSlab) -> Result {
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 100)?;
-        value.width = range_value as u8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 15)?;
+    let c0 = u64::from(c);
+    let v0: u64 = c0 & 0x7f;
+    if v0 > 100 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.height = raw_value as u8;
-    }
+    value.width = (v0 as i32) as u8;
+    let v1: u64 = (c0 >> 7) & 0xff;
+    value.height = v1 as u8;
     Ok(())
 }
 
@@ -672,32 +668,29 @@ pub const PROBE_CONFIG_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_probe_config(stream: &mut WriteStream<'_>, value: &ProbeConfig) -> Result {
-    {
-        let mut raw_value = value.retries as u32;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
     if value.preferred.0 > 15 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.preferred.0 as u32;
-        stream.serialize_bits(&mut offset_value, 4)?;
-    }
+    let f0: u64 = u64::from(value.retries as u32);
+    let f1: u64 = u64::from(value.preferred.0);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = f1 as u32;
+    stream.serialize_bits(&mut w1, 4)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_probe_config(stream: &mut ReadStream<'_>, value: &mut ProbeConfig) -> Result {
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 32)?;
-        value.retries = raw_value as i32;
-    }
-    {
-        let mut enum_value: i32 = 0;
-        stream.serialize_int(&mut enum_value, 0, 15)?;
-        value.preferred = Weapon(enum_value as u8);
-    }
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 4)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xffffffff;
+    value.retries = v0 as i32;
+    let v1: u64 = c1 & 0xf;
+    value.preferred = Weapon(v1 as u8);
     Ok(())
 }
 
@@ -814,56 +807,50 @@ pub const TEST_MAX_BYTES: usize = 8;
 
 #[inline(always)]
 pub fn write_test(stream: &mut WriteStream<'_>, value: &Test) -> Result {
-    {
-        let mut raw_value = value.test_a as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
     if value.test_b < 0 || value.test_b > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = value.test_b as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
     }
     if value.test_c < 0 || value.test_c > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.test_c as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
-    }
     if value.test_d < 0 || value.test_d > 1000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = value.test_d as u32;
-        stream.serialize_bits(&mut offset_value, 10)?;
-    }
+    let f0: u64 = u64::from(value.test_a);
+    let f1: u64 = u64::from(value.test_b as u32);
+    let f2: u64 = u64::from(value.test_c as u32);
+    let f3: u64 = u64::from(value.test_d as u32);
+    let mut w0 = (f0 | (f1 << 16) | (f2 << 26)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = ((f2 >> 6) | (f3 << 4)) as u32;
+    stream.serialize_bits(&mut w1, 14)?;
     Ok(())
 }
 
 #[inline]
 pub fn read_test(stream: &mut ReadStream<'_>, value: &mut Test) -> Result {
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.test_a = raw_value as u16;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 14)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xffff;
+    value.test_a = v0 as u16;
+    let v1: u64 = (c0 >> 16) & 0x3ff;
+    if v1 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 1000)?;
-        value.test_b = range_value as i16;
+    value.test_b = (v1 as i32) as i16;
+    let v2: u64 = ((c0 >> 26) | (c1 << 6)) & 0x3ff;
+    if v2 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 1000)?;
-        value.test_c = range_value as i16;
+    value.test_c = (v2 as i32) as i16;
+    let v3: u64 = (c1 >> 4) & 0x3ff;
+    if v3 > 1000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut range_value: i32 = 0;
-        stream.serialize_int(&mut range_value, 0, 1000)?;
-        value.test_d = range_value as i16;
-    }
+    value.test_d = (v3 as i32) as i16;
     Ok(())
 }
 
@@ -1084,49 +1071,32 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
     if value.a < -100 || value.a > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.a as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
-    }
     if value.b < -100 || value.b > 100 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut offset_value = (value.b as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
     }
     if value.c < -100 || value.c > 150 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.c as u32).wrapping_sub((-100_i32) as u32);
-        stream.serialize_bits(&mut offset_value, 8)?;
-    }
     if value.d >= 1 << 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
-    }
-    {
-        let mut raw_value = value.d;
-        stream.serialize_bits(&mut raw_value, 8)?;
     }
     if value.e >= 1 << 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.e;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
     if value.f >= 1 << 8 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value = value.f;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
-    {
-        let mut bool_value = value.g;
-        stream.serialize_bool(&mut bool_value)?;
-    }
+    let f0: u64 = u64::from((value.a as u32).wrapping_sub((-100_i32) as u32));
+    let f1: u64 = u64::from((value.b as u32).wrapping_sub((-100_i32) as u32));
+    let f2: u64 = u64::from((value.c as u32).wrapping_sub((-100_i32) as u32));
+    let f3: u64 = u64::from(value.d);
+    let f4: u64 = u64::from(value.e);
+    let f5: u64 = u64::from(value.f);
+    let f6: u64 = u64::from(value.g);
+    let mut w0 = (f0 | (f1 << 8) | (f2 << 16) | (f3 << 24)) as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f4 | (f5 << 8) | (f6 << 16)) as u32;
+    stream.serialize_bits(&mut w1, 17)?;
     if value.items_count < 0 || value.items_count > 16 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
@@ -1151,45 +1121,40 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
         let mut compressed_value = value.compressed_float_value;
         stream.serialize_compressed_float_precomputed(&mut compressed_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
     }
-    {
-        let mut float_value = value.double_value;
-        stream.serialize_f64(&mut float_value)?;
-    }
-    {
-        let mut raw_value = (value.int8_value as u8) as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
-    {
-        let mut raw_value = (value.int16_value as u16) as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
-    {
-        let mut raw_value = value.uint8_value as u32;
-        stream.serialize_bits(&mut raw_value, 8)?;
-    }
-    {
-        let mut raw_value = value.uint16_value as u32;
-        stream.serialize_bits(&mut raw_value, 16)?;
-    }
-    {
-        let mut raw_value = value.uint32_value;
-        stream.serialize_bits(&mut raw_value, 32)?;
-    }
-    {
-        let mut raw_value = value.uint64_value;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
-    {
-        let mut raw_value = value.int64_full as u64;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-    }
+    let f0: u64 = value.double_value.to_bits();
+    let f1: u64 = u64::from(value.int8_value as u8);
+    let f2: u64 = u64::from(value.int16_value as u16);
+    let f3: u64 = u64::from(value.uint8_value);
+    let f4: u64 = u64::from(value.uint16_value);
+    let f5: u64 = u64::from(value.uint32_value);
+    let f6: u64 = value.uint64_value;
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = (f1 | (f2 << 8) | (f3 << 24)) as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f4 | (f5 << 16)) as u32;
+    stream.serialize_bits(&mut w3, 32)?;
+    let mut w4 = ((f5 >> 16) | (f6 << 16)) as u32;
+    stream.serialize_bits(&mut w4, 32)?;
+    let mut w5 = (f6 >> 16) as u32;
+    stream.serialize_bits(&mut w5, 32)?;
+    let mut w6 = (f6 >> 48) as u32;
+    stream.serialize_bits(&mut w6, 16)?;
     if value.int64_range < -1000000000000 || value.int64_range > 1000000000000 {
         return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut offset_value = (value.int64_range as u64).wrapping_sub((-1000000000000_i64) as u64);
-        stream.serialize_bits64(&mut offset_value, 41)?;
-    }
+    let f0: u64 = value.int64_full as u64;
+    let f1: u64 = (value.int64_range as u64).wrapping_sub((-1000000000000_i64) as u64);
+    let mut w0 = f0 as u32;
+    stream.serialize_bits(&mut w0, 32)?;
+    let mut w1 = (f0 >> 32) as u32;
+    stream.serialize_bits(&mut w1, 32)?;
+    let mut w2 = f1 as u32;
+    stream.serialize_bits(&mut w2, 32)?;
+    let mut w3 = (f1 >> 32) as u32;
+    stream.serialize_bits(&mut w3, 9)?;
     stream.serialize_align()?;
     stream.write_bytes(&value.fixed_bytes); // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop (infallible: returns () in serialize.rs 2.0.0)
     if value.text_length < 0 || value.text_length > 255 {
@@ -1209,48 +1174,85 @@ pub fn write_test_data(stream: &mut WriteStream<'_>, value: &TestData) -> Result
 
 #[inline]
 pub fn read_test_data(stream: &mut ReadStream<'_>, value: &mut TestData) -> Result {
-    stream.serialize_int(&mut value.a, -100, 100)?;
-    stream.serialize_int(&mut value.b, -100, 100)?;
-    stream.serialize_int(&mut value.c, -100, 150)?;
-    stream.serialize_bits(&mut value.d, 8)?;
-    stream.serialize_bits(&mut value.e, 8)?;
-    stream.serialize_bits(&mut value.f, 8)?;
-    stream.serialize_bool(&mut value.g)?;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 17)?;
+    let c1 = u64::from(c);
+    let v0: u64 = c0 & 0xff;
+    if v0 > 200 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.a = (v0 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v1: u64 = (c0 >> 8) & 0xff;
+    if v1 > 200 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.b = (v1 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v2: u64 = (c0 >> 16) & 0xff;
+    if v2 > 250 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
+    }
+    value.c = (v2 as u32).wrapping_add((-100_i32) as u32) as i32;
+    let v3: u64 = (c0 >> 24) & 0xff;
+    value.d = v3 as u32;
+    let v4: u64 = c1 & 0xff;
+    value.e = v4 as u32;
+    let v5: u64 = (c1 >> 8) & 0xff;
+    value.f = v5 as u32;
+    let v6: u64 = (c1 >> 16) & 0x1;
+    value.g = v6 != 0;
     stream.serialize_int(&mut value.items_count, 0, 16)?; // the count guards the loop (§6.3)
     for i in 0..value.items_count as usize {
         stream.serialize_int(&mut value.items[i], 0, 255)?;
     }
     stream.serialize_f32(&mut value.float_value)?;
     stream.serialize_compressed_float_precomputed(&mut value.compressed_float_value, 1000, 10, 10.0_f32, 0.0_f32)?; // compressed float [0.0, 10.0] @ 0.01, constants folded at generation
-    stream.serialize_f64(&mut value.double_value)?;
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.int8_value = raw_value as u8 as i8;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c3 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c4 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c5 = u64::from(c);
+    stream.serialize_bits(&mut c, 16)?;
+    let c6 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.double_value = f64::from_bits(v0);
+    let v1: u64 = c2 & 0xff;
+    value.int8_value = v1 as u8 as i8;
+    let v2: u64 = (c2 >> 8) & 0xffff;
+    value.int16_value = v2 as u16 as i16;
+    let v3: u64 = (c2 >> 24) & 0xff;
+    value.uint8_value = v3 as u8;
+    let v4: u64 = c3 & 0xffff;
+    value.uint16_value = v4 as u16;
+    let v5: u64 = ((c3 >> 16) | (c4 << 16)) & 0xffffffff;
+    value.uint32_value = v5 as u32;
+    let v6: u64 = (c4 >> 16) | (c5 << 16) | (c6 << 48);
+    value.uint64_value = v6;
+    let mut c: u32 = 0;
+    stream.serialize_bits(&mut c, 32)?;
+    let c0 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c1 = u64::from(c);
+    stream.serialize_bits(&mut c, 32)?;
+    let c2 = u64::from(c);
+    stream.serialize_bits(&mut c, 9)?;
+    let c3 = u64::from(c);
+    let v0: u64 = c0 | (c1 << 32);
+    value.int64_full = v0 as i64;
+    let v1: u64 = (c2 | (c3 << 32)) & 0x1ffffffffff;
+    if v1 > 2000000000000 {
+        return Err(Error::Stream(serialize::Error::ValueOutOfRange));
     }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.int16_value = raw_value as u16 as i16;
-    }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 8)?;
-        value.uint8_value = raw_value as u8;
-    }
-    {
-        let mut raw_value: u32 = 0;
-        stream.serialize_bits(&mut raw_value, 16)?;
-        value.uint16_value = raw_value as u16;
-    }
-    stream.serialize_bits(&mut value.uint32_value, 32)?;
-    stream.serialize_bits64(&mut value.uint64_value, 64)?;
-    {
-        let mut raw_value: u64 = 0;
-        stream.serialize_bits64(&mut raw_value, 64)?;
-        value.int64_full = raw_value as i64;
-    }
-    stream.serialize_int64(&mut value.int64_range, -1000000000000, 1000000000000)?;
+    value.int64_range = v1.wrapping_add((-1000000000000_i64) as u64) as i64;
     stream.serialize_align()?; // rejects nonzero padding (SPEC §4.3)
     stream.serialize_bytes(&mut value.fixed_bytes)?; // byte-aligned [N]u8 — bulk copy, wire-identical to the per-byte loop
     stream.serialize_int(&mut value.text_length, 0, 255)?; // the length guards the slice (§6.3)


### PR DESCRIPTION
Campaign item 1 of the laggard round (#170): the Rust emitter learns the self-contained flat word-codec form. Wire bytes never move; `checks=always` is preserved exactly; nothing under `bench/LOCK`'s prefixes is touched.

## The move

**Blended nine-language quick table, one caffeinated sitting, M2, generated subject:**

| lang | family | checks | before ns/msg | after ns/msg | before % | after % |
|---|---|---|---:|---:|---:|---:|
| cpp | gen | removed | 1.72 | 1.70 | 100% | 100% |
| c | gen | removed | 1.85 | 1.86 | 107% | 109% |
| java | gen | contract | 6.49 | 6.50 | 377% | 383% |
| **rust** | **gen** | **always** | **10.22** | **7.53** | **594%** | **444%** |
| cs | gen | always | 13.59 | 13.53 | 790% | 797% |
| dart | gen | contract | 16.37 | 16.09 | 952% | 949% |
| go | gen | always | 26.93 | 26.55 | 1566% | 1565% |
| js | gen | contract | 75.53 | 74.69 | 4391% | 4402% |
| elixir | gen | contract | 288.68 | 287.10 | 16782% | 16922% |

Before column: the equalized sitting (`bench/results/2026-08-31-equalized-quick-*`). After: `bench/results/2026-08-31-rustcodec-quick-*`. **The frozen reference re-ran unchanged** — cpp gen within 2.4% write / 0.5% read, c within 0.2% / 0.7% — and every leg I did not touch landed within 2% of its equalized number, so the sitting is comparable and the movement is the emitter's. Rust is now the second-fastest generated leg.

**Full rust leg, per shape (family `gen`, median msgs/s, M2):**

| shape | write before | write after | | read before | read after | |
|---|---:|---:|---:|---:|---:|---:|
| rigidbody_moving | 50.1 | 50.8 | **1.01x** | 42.6 | 44.5 | **1.04x** |
| rigidbody_at_rest | 81.3 | 81.7 | **1.01x** | 75.1 | 78.5 | **1.05x** |
| chat | 67.1 | 68.8 | **1.03x** | 102.2 | 103.3 | **1.01x** |
| test | 224.7 | 876.4 | **3.90x** | 234.5 | 278.5 | **1.19x** |
| inputpacket | 47.0 | 70.7 | **1.51x** | 40.4 | 73.0 | **1.81x** |
| shipcreate | 77.3 | 84.9 | **1.10x** | 42.2 | 91.4 | **2.17x** |
| probe_header | 214.4 | 249.3 | **1.16x** | 153.5 | 182.8 | **1.19x** |
| probebits | 122.0 | 134.7 | **1.10x** | 134.0 | 149.7 | **1.12x** |
| probearray | 53.2 | 62.6 | **1.18x** | 63.0 | 66.1 | **1.05x** |
| testdata | 25.1 | 26.5 | **1.06x** | 21.7 | 24.3 | **1.12x** |
| real_packet | 8.6 | 10.0 | **1.16x** | 7.3 | 9.8 | **1.35x** |
| bench_packet | 65.9 | 70.8 | **1.07x** | 76.3 | 87.6 | **1.15x** |
| bench_ints | 108.2 | 132.8 | **1.23x** | 115.7 | 146.3 | **1.26x** |
| bench_bits | 117.0 | 148.4 | **1.27x** | 108.1 | 159.2 | **1.47x** |
| bench_mixed | 96.5 | 126.1 | **1.31x** | 102.1 | 136.0 | **1.33x** |
| **geomean** | | | **1.25x** | | | **1.26x** |

The hand-written `rt`/`bits` control rows — the same source before and after — moved **1.014x** across ten rows. That is the negative control on the sitting: the generated rows moved because the generated code changed.

## What the form is

Every bit offset **inside** a message is a generation-time constant no matter where the message starts. The old form did not use that: it handed the runtime one field at a time, which folds to nothing unless the spine lands inlined in a caller whose stream was just constructed. Entered with an unknown bit position — the regime every generated Rust call actually runs in — each `serialize_bits` reloads the packer's scratch, shifts by a runtime amount, tests a runtime carry and stores the state back. An eleven-field write paid eleven memory round trips through the stream.

`internal/codegen/rust/flat.go` folds the placement itself: field values into locals, OR'd into 32-bit chunk locals at literal shifts, one whole chunk per stream call. Reads fuse their bounds checks the same way — one per chunk instead of one per field — the technique the Java, Dart and JS-flat backends already carry.

```rust
let f0: u64 = u64::from(value.sequence as u32);
let f1: u64 = u64::from(value.ack_bits);
...
let mut w0 = (f0 | (f1 << 16)) as u32;
stream.serialize_bits(&mut w0, 32)?;
let mut w1 = ((f1 >> 16) | (f2 << 16) | (f3 << 28)) as u32;
stream.serialize_bits(&mut w1, 32)?;
```

Runs break at align, string/bytes, arrays, branches, nested struct and union calls, and the fixed-point / compressed-float / 128-bit families, whose value arithmetic lives in the runtime. Those keep the per-field form and start a fresh run after themselves. Runs also close at 256 bits so a hundred-field message does not hold every field value live at once. Chunk widths sum to the run's bit count **exactly** — the last chunk carries `B mod 32` — so the flat form touches precisely the bits the per-field form did.

The public surface is unchanged: same function names, same `(&mut WriteStream, &T) -> Result` signatures, same types.

## Wire and semantics

- Every wire golden **unmoved** (`git status testdata/wire` clean across the change).
- `make test` green: the full cross-language conformance suite, `test/rust` and `test/rust-ludicrous` included, plus the hostile-stream cases that pin specific error kinds (nonzero reserved → `Validation`, truncation → the stream's own error, out-of-range count → `Error::Stream`).
- `corpus_id` unchanged in every bench run: `457b96dfc5a0ffcd` quick, `bc776c004485e408` full.
- `checks=always` preserved: the same values are refused, with the same error, on every path. The checks-mode ruling stays the owner's.

**Negative control**, run and pasted:

```
$ printf '\xff' | dd of=testdata/wire/bench_mixed.bin bs=1 seek=3 count=1 conv=notrunc
$ cargo run --release -- --quick
WIRE GOLDEN MISMATCH: bench_mixed (21 golden vs 21 actual bytes) — refusing to bench code that does not match the corpus
BENCH FAILED (corpus_id 762ddd88ac9c941f)
$ # restore
$ cargo run --release -- --quick
bench_mixed        write     120.08 M msg/s ...
OK (corpus_id 457b96dfc5a0ffcd)
```

Two behaviours move, both named rather than smoothed:

1. **Refusal timing on write.** A run's refusals all run before the run packs, so a refused write has emitted fewer bits than before. Which values are refused, and with which error, is identical.
2. **Error kind on a doubly-bad read.** Fused bounds checks read a whole chunk at a time, so a stream that is *both* truncated inside a run *and* carries an out-of-range value before the truncation now surfaces `Overflow` where the per-field form surfaced the range refusal. Both refuse the packet; the set of *accepted* streams is unchanged, which is the property that matters at the trust boundary. This is the same consequence the Java/Dart/JS-flat fusion already carries.

## Where the remaining 4.4x lives — and it is not the codec

Honest account: 444% is not C-tier, and I can name the whole residue.

**The generated Rust spine is never inlined into the timed loop, and the emitter cannot fix that.** `#[inline(always)]` on the spine *is* honoured — into the `Fn::call` shim standing between the bench driver and the spine. LLVM then prices that shim against its caller and refuses it. clang honours `always_inline` unconditionally, so the C and C++ legs never see this regime. Three measurements pin it:

- Flipping the read spine to `#[inline(always)]` in this harness moves `bench_mixed` by **less than half a percent** (97.16/102.97 vs 97.11/103.12). The attribute never reaches the loop.
- Extracting the timed loops into their own small functions, and passing closures instead of fn items, changed **nothing**. It is the cost model, not the call shape.
- Rebuilding the **same binary** with `RUSTFLAGS="-C llvm-args=--inline-threshold=5000"` — a diagnostic, not a shipped flag — moves the generated rows a further **2.28x geomean** and the hand-written `rt` rows **4.54x**. `bench_mixed` goes to 367 M/s write and **~444 M/s read** ; `rigidbody_moving` read 10.0x; `probe_header` write 1034 M/s. Against generated C++'s 610/547 on the same sitting, that is **60% and ~81%** — read approaches within ~1.23x and write is within 1.7x. *(CORRECTED at review: this bullet originally claimed 606 M/s read and "read reaches parity" — the 606 was the hand-written `rt` row misattributed as the generated row; the reviewer's two independent runs measured gen read 444.5/437.8 M/s at 0.13% spread, and this PR's own later "450 M/s flat" sentence agrees. Read does NOT reach parity under the diagnostic.)*

So the ceiling this form approaches, once the inlining discipline matches the reference legs, is near-C-tier on reads (~1.2x). The residue is **LLVM's inliner cost model at the harness boundary**, not language physics — and, per the reviewer's own measurement, not linkage in the LTO sense: plain idiomatic `lto = "fat"` + `codegen-units = 1` (never measured by this PR; the repo has no `[profile.release]` at all) buys **~7% on read and nothing on write**, nowhere near the threshold diagnostic's ~3x. That strengthens the cost-model diagnosis and retires the "linkage asymmetry" framing this paragraph first used. I did not equalize it here: it changes the measured leg's build or driver mid-round for one language only, and that is the owner's call, not a worker's. `bench/rust/README.md` claimed the driver "inlines like the C++ template reference"; that claim is now corrected to what is measured, with the diagnostic named.

The flat form is what makes the *out-of-line* regime cheap, which is why it lands regardless of how the inlining item is ruled — and it wins in the inlined regime too on reads (`bench_mixed` read 450 M/s flat vs 573 M/s per-field is the one row where the per-field form is ahead once inlined; write is 346 vs 300 the other way).

**Aside, not shipped, as invited by the brief:** stripping only the write-side range refusals — what a `contract` checks mode would do — buys **+13.2%** on `bench_mixed` write (126.1 → 142.7 M/s), reads unaffected. That is roughly 6% blended: 444% → ~420%. It does not change the picture, and the mode stays `always`.

## Coverage gaps, named as follow-ons

- **Compressed floats and fixed-point break every run** — which is why `rigidbody_*` moved only 1.01–1.05x and `examples128`'s generated Rust is byte-identical before and after. Both are pure functions of the value plus generation-time constants; folding their arithmetic into the run is the obvious next pass, gated on a differential against the runtime's own quantization.
- **Arrays break runs.** A fixed array of scalars is a static run of `N * w` bits; unrolling small ones into the enclosing run is a bounded, measurable next step (`probearray` 1.18x/1.05x is the row that would move).
- **Nested struct and union calls break runs**, so a message built from small structs flattens per struct rather than whole.

Land and expand: each is a separate measured pass, not a reason to hold this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

