### PR TITLE
cpp-lock: empty prefix list is a carve window, not a refusal of everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,10 @@ jobs:
           if [ "$changed" = "bench/LOCK" ]; then
             echo "diff touches only bench/LOCK — the lift act, allowed"; exit 0
           fi
-          prefixes="$(grep -v '^#' bench/LOCK | grep -v '^[[:space:]]*$')"
+          prefixes="$(grep -v '^#' bench/LOCK | grep -v '^[[:space:]]*$' || true)"
+          if [ -z "$prefixes" ]; then
+            echo "bench/LOCK carries no active prefixes (a carve window) — guard inactive"; exit 0
+          fi
           violations=""
           while IFS= read -r f; do
             while IFS= read -r p; do


### PR DESCRIPTION
Found by the #192 review: since the #189 carve emptied bench/LOCK's prefix list, the guard's grep exits 1 under bash -e and kills the step before any verdict — every PR refused, with neither the refusal nor the clean message printed. The exact gate-red-against-everything class. One-file fix: tolerate the empty list, name it a carve window, exit 0; the guard re-arms when PR C restores prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)