### PR TITLE
The shape gate: a CI refusal that keeps hand-coded shape measurement out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,9 +344,6 @@ jobs:
       - run: go vet ./...
       - run: go build ./...
 
-  # The C/C++ reference lock (owner ruling 2026-08-31, issue #170): while
-  # bench/LOCK exists, a PR touching any locked prefix refuses. The lift is
-  # a PR whose whole diff is bench/LOCK itself — visible by construction.
   # The one-benchmark rule, made mechanical. The estate has exactly one
   # sanctioned benchmark — this repo's data-driven bench — and shape knowledge
   # belongs in bench/corpus and the generated code. This job refuses a commit
@@ -366,6 +363,9 @@ jobs:
       - name: refuse hand-coded shape measurement
         run: go run ./bench/tools/shapegate
 
+  # The C/C++ reference lock (owner ruling 2026-08-31, issue #170): while
+  # bench/LOCK exists, a PR touching any locked prefix refuses. The lift is
+  # a PR whose whole diff is bench/LOCK itself — visible by construction.
   cpp-lock:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,25 @@ jobs:
   # The C/C++ reference lock (owner ruling 2026-08-31, issue #170): while
   # bench/LOCK exists, a PR touching any locked prefix refuses. The lift is
   # a PR whose whole diff is bench/LOCK itself — visible by construction.
+  # The one-benchmark rule, made mechanical. The estate has exactly one
+  # sanctioned benchmark — this repo's data-driven bench — and shape knowledge
+  # belongs in bench/corpus and the generated code. This job refuses a commit
+  # that hand-codes measurement of a schema shape anywhere else. Every current
+  # exception is named in bench/SHAPE-GATE.allow with an exact count that can
+  # only shrink. Runs on push AND pull_request: unlike the cpp-lock this is a
+  # standing property of the tree, not a review-window freeze.
+  shape-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+      - name: refuse hand-coded shape measurement
+        run: go run ./bench/tools/shapegate
+
   cpp-lock:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,12 @@ fmt: bin/schema
 	./bin/schema fmt bench/corpus/Bench.schema
 	./bin/schema fmt bench/corpus/RealWorld.schema
 
+# The one-benchmark rule, made mechanical: no hand-coded measurement of a
+# schema shape anywhere in this repo except what bench/SHAPE-GATE.allow names.
+shape-gate:
+	go run ./bench/tools/shapegate
+
 clean:
 	rm -rf bin build generated
 
-.PHONY: all test check id fmt clean update-goldens bench bench-variants generated-current
+.PHONY: all test check id fmt clean update-goldens bench bench-variants generated-current shape-gate

--- a/bench/README.md
+++ b/bench/README.md
@@ -294,3 +294,23 @@ A runner is a standalone program in `bench/<lang>/` that:
 
 If a runner or its toolchain is missing, `run.sh` prints `SKIP <lang>`
 with the reason.
+
+## The shape gate
+
+`make shape-gate` (CI job `shape-gate`, `bench/tools/shapegate`) enforces the
+one-benchmark rule mechanically. The estate has exactly one sanctioned
+benchmark — this bench — and shape knowledge belongs in `bench/corpus/*.schema`
+and the code the compiler generates from it. Hand-written RUNNERS are fine and
+are the design; hand-written MEASUREMENT of a schema shape is not, anywhere.
+
+The gate extracts the shape vocabulary from the corpus itself, so it tracks a
+rename in the same commit, and refuses: a corpus identifier named under
+`bench/`, a timing primitive anywhere outside the runner and tool directories,
+a bench-shaped source path outside them, or a shape's wire size written down as
+a literal.
+
+Every place that does not yet comply is named in `bench/SHAPE-GATE.allow` with
+an exact count. The count is a ratchet: growing it fails, and so does leaving it
+too high once the debt is paid. `go run ./bench/tools/shapegate -ledger`
+regenerates the lines. What the gate cannot see is stated at the top of
+`bench/tools/shapegate/main.go` — read it before trusting it.

--- a/bench/SHAPE-GATE.allow
+++ b/bench/SHAPE-GATE.allow
@@ -23,38 +23,49 @@
 #     go run ./bench/tools/shapegate -ledger
 #
 # ---------------------------------------------------------------------------
-# THE NINE RUNNER LEGS — the debt this gate exists to retire.
+# THE DEBT IS PAID. Read this before reading the lines.
 #
-# The runners are hand-written, which is fine and stays. What is NOT fine is
-# that they currently hand-write the SHAPES too: a pinned initializer, an LCG
-# vary mapping and a sink fold per shape per language. That is nine hand-
-# written approximations of one benchmark, and it is the drift the owner named
-# on 2026-08-31.
+# When this gate was first written on main@6e1002b the register carried 2080
+# name hits across twelve runner files, because every one of the nine legs
+# hand-wrote the four corpus shapes: a family `rt` transcription against the
+# runtime API, and a family `gen` pinned initializer plus LCG vary mapping per
+# shape per language. That was the drift the owner named on 2026-08-31.
 #
-# Two open PRs retire it. #199 deletes family `rt` — the hand-written runtime-
-# API shape code — from every leg. #195 emits the family `gen` pin/vary/sink
-# from the corpus, so the legs stop transcribing it. As each lands, these
-# counts fall and the gate demands the smaller number; when a leg reaches zero
-# its line is deleted. The bench_mixed row is already there: it runs through
-# the committed variant corpus and names nothing.
+# #199 deleted family rt and the §1.3 hand-coded shapes. #204 retired the §1.2
+# example-corpus rows from every runner. #201 deleted the decomp.cpp scratch
+# harness. What is left is 29 name hits, and NOT ONE OF THEM IS HAND-CODED
+# SHAPE MEASUREMENT. Every remaining line below is one of exactly three kinds,
+# and each line says which:
+#
+#   (comment) the shape's NAME written in a prose comment. The gate is lexical
+#             and does not strip comments — deliberately, since a comment is
+#             where a hand-coded bench announces itself.
+#   (callsite) the GENERATED type or symbol named at the point the shape-blind
+#             driver instantiates it and hands it to generated Write/Read. The
+#             driver has to name the generated symbol to call it; it writes no
+#             field and pins no value. This is the design, not the debt.
+#   (prose)   an ENGLISH word that is also a corpus field name — `extra`,
+#             `sequence` — caught in a comment about something else. A known
+#             false-positive class, named in the package doc's stoplist note.
+#
+# The nine legs are shape-blind. The gate now guards a clean tree, and the
+# ratchet holds it there: any leg that grows one hand-written field, pin or
+# wire size fails this gate on the next push.
 # ---------------------------------------------------------------------------
 
-names bench/c/bench_main.c 332 nine-leg shape debt: family rt (deleted by #199) plus the gen pin/vary for the three non-mixed shapes (emitted by #195)
-names bench/cpp/bench_main.cpp 263 nine-leg shape debt: family rt (#199) plus gen pin/vary (#195)
-names bench/cs/src/Program.cs 88 nine-leg shape debt: gen pin/vary for the three non-mixed shapes (#195)
-names bench/cs/src/RtBench.cs 203 family rt, hand-written runtime-API shape code — deleted whole by #199
-names bench/dart/main.dart 39 nine-leg shape debt: gen pin/vary (#195)
-names bench/elixir/runner.exs 17 nine-leg shape debt: gen pin/vary (#195)
-names bench/go/main.go 81 nine-leg shape debt: gen pin/vary (#195); the go leg is the first on the emitter
-names bench/go/rt.go 204 family rt, hand-written runtime-API shape code — deleted whole by #199
-names bench/java/Main.java 47 nine-leg shape debt: gen pin/vary (#195)
-names bench/js/main.mjs 384 nine-leg shape debt: family rt (#199) plus gen pin/vary (#195)
-names bench/rust/src/main.rs 83 nine-leg shape debt: gen pin/vary (#195)
-names bench/rust/src/rt.rs 205 family rt, hand-written runtime-API shape code — deleted whole by #199
+names bench/c/bench_main.c 4 shape-blind leg: 3 comments naming the shape + `#define BM_TYPE BenchMixed`, the generated type handed to the data-driven driver (callsite)
+names bench/cpp/bench_main.cpp 3 shape-blind leg: 2 comments + `bench::BenchMixed` as the template argument to bench_datadriven (callsite)
+names bench/cs/src/Program.cs 3 shape-blind leg: 1 comment + `Bench.BenchMixed` as the BenchDataDriven type argument (callsite), + `extra` in "one extra untimed pass" (prose)
+names bench/dart/main.dart 3 shape-blind leg: 1 comment + `BenchMixed` as the gateDataDriven type argument and `BenchMixed.new` constructor tear-off (callsite)
+names bench/elixir/main.exs 1 shape-blind leg: the header comment naming the shape this leg measures (comment)
+names bench/elixir/runner.exs 2 shape-blind leg: 1 header comment (comment) + `sequence` in "replaying one sequence the branch predictor could memorize" (prose)
+names bench/go/main.go 3 shape-blind leg: 1 comment + `bench.BenchMixed` as the benchDataDriven type argument (callsite), + `extra` in "one extra untimed pass" (prose)
+names bench/java/Main.java 6 shape-blind leg: 1 comment + 5 `Bench.BenchMixed` callsites — the instance array, the decode target, and the generated read/write calls. Java has no generics over the generated type, so the driver names it inline instead of once (callsite)
+names bench/js/main.mjs 2 shape-blind leg: 1 comment + `bench.BenchMixed` passed to benchDataDrivenFlat (callsite)
+names bench/rust/src/main.rs 2 shape-blind leg: 1 comment + `benchgen::BenchMixed` as the bench_datadriven type parameter (callsite)
 
-consts bench/c/bench_main.c 1 a shape wire size written down, inside the rt/gen shape code above
-consts bench/cpp/bench_main.cpp 1 a shape wire size written down, inside the rt/gen shape code above
-consts bench/java/Main.java 3 shape wire sizes written down, inside the gen shape code above
+consts bench/c/bench_main.c 1 a comment stating the variant file is 64 x 438 bytes; no 438 in code (comment)
+consts bench/java/Main.java 3 three references to GitHub issue #156, which collides with the declared 156-bit total of a corpus shape. A pure false positive of the numeric check, kept visible rather than special-cased (prose)
 
 # ---------------------------------------------------------------------------
 # THE CORPUS TOOLING — shape knowledge in ONE place, deliberately.
@@ -66,16 +77,15 @@ consts bench/java/Main.java 3 shape wire sizes written down, inside the gen shap
 # than remembered. #195's emitter supersedes it.
 #
 # realpacket-gen is the same bargain for the §1.7 RealWorld snapshot.
-# inline-gate and inline-verdict name shapes only as ROW LABELS in their
-# symbol maps and test fixtures — no serialization, no timing.
+# inline-gate names shapes only as SYMBOL NAMES in its budget symbol map and
+# its test fixtures — no serialization, no timing.
 # ---------------------------------------------------------------------------
 
 names bench/tools/variantgen/main.go 94 the single deliberate copy of BenchMixed shape code; emits the corpus the nine legs read blind (superseded by #195)
 names bench/tools/realpacket-gen/main.go 11 the single deliberate copy of the RealWorld snapshot shape code (§1.7)
 names bench/tools/realpacket-gen/pin_test.go 3 pins the generator above against its golden
-names bench/tools/inline-gate.sh 9 shape names as row labels in the inline-budget symbol map and its test fixtures
-names bench/tools/inline-verdict.sh 2 shape names as row labels in the symbol map
-consts bench/tools/variantgen/main.go 3 the variant corpus stride and record size, which this tool is the authority for
+names bench/tools/inline-gate.sh 9 shape names inside the inline-budget symbol map and its disassembly test fixtures — row labels, no serialization, no clock
+consts bench/tools/variantgen/main.go 3 three comments stating the 438-byte golden size this tool is the authority for (comment)
 
 # ---------------------------------------------------------------------------
 # THE §1.5 GOLDEN PINNER — correctness, not measurement.
@@ -89,25 +99,3 @@ consts bench/tools/variantgen/main.go 3 the variant corpus stride and record siz
 
 paths test/bench/c_main.c 1 the §1.5 golden pinner: correctness code, no timing
 paths test/bench/main.cpp 1 the §1.5 golden pinner: correctness code, no timing
-
-# ---------------------------------------------------------------------------
-# A DELETION CANDIDATE, held here so it cannot be forgotten.
-#
-# bench/results/harness-contract-air/decomp.cpp is a 294-line hand-coded
-# benchmark committed into the results tree on 2026-08-30 as #170 forensics.
-# It hand-codes a shape and its wire size, embeds the hand-written runtime-API
-# subject verbatim, and reads a clock. It is a live harness parked where live
-# harnesses are not supposed to exist, and nothing regenerates or re-verifies
-# it — run it after a corpus change and it will report confidently on a shape
-# that no longer exists.
-#
-# Its findings are already written up next to it in
-# 2026-08-30-harness-contract-decomposition.md, which is the durable record.
-# RECOMMENDED: delete the .cpp, keep the .md. Owner's call; until then it sits
-# here under all three checks so it stays visible.
-# ---------------------------------------------------------------------------
-
-names bench/results/harness-contract-air/decomp.cpp 15 DELETION CANDIDATE — hand-coded shape measurement committed to the results tree (#170 forensics)
-timing bench/results/harness-contract-air/decomp.cpp 1 DELETION CANDIDATE — a live timed loop outside every sanctioned runner directory
-consts bench/results/harness-contract-air/decomp.cpp 1 DELETION CANDIDATE — a shape wire size written down by hand
-paths bench/results/harness-contract-air/decomp.cpp 1 DELETION CANDIDATE — benchmark source in the results tree

--- a/bench/SHAPE-GATE.allow
+++ b/bench/SHAPE-GATE.allow
@@ -1,0 +1,113 @@
+# SHAPE-GATE.allow — the complete register of hand-coded shape knowledge.
+#
+# The estate has ONE benchmark: this repo's data-driven bench. Shape knowledge
+# belongs in bench/corpus/*.schema and in the code the compiler generates from
+# it — nowhere else. bench/tools/shapegate enforces that mechanically, and
+# every place that does not yet comply is listed HERE, by name, with a count
+# and a reason. Nothing is exempt silently.
+#
+# FORMAT, one per line:
+#
+#     <check> <path> <count> <reason>
+#
+#     check   names | timing | paths | consts
+#     count   the EXACT number of hits the gate finds today
+#
+# THE COUNT IS A RATCHET. More hits than the count is a refusal: the debt grew.
+# FEWER hits is also a refusal, and the gate prints the new number to write:
+# the debt shrank and the ledger has to say so. An entry matching no file is a
+# refusal too. So the register cannot rot, and it only moves one way.
+#
+# Regenerate the lines after paying debt down:
+#
+#     go run ./bench/tools/shapegate -ledger
+#
+# ---------------------------------------------------------------------------
+# THE NINE RUNNER LEGS — the debt this gate exists to retire.
+#
+# The runners are hand-written, which is fine and stays. What is NOT fine is
+# that they currently hand-write the SHAPES too: a pinned initializer, an LCG
+# vary mapping and a sink fold per shape per language. That is nine hand-
+# written approximations of one benchmark, and it is the drift the owner named
+# on 2026-08-31.
+#
+# Two open PRs retire it. #199 deletes family `rt` — the hand-written runtime-
+# API shape code — from every leg. #195 emits the family `gen` pin/vary/sink
+# from the corpus, so the legs stop transcribing it. As each lands, these
+# counts fall and the gate demands the smaller number; when a leg reaches zero
+# its line is deleted. The bench_mixed row is already there: it runs through
+# the committed variant corpus and names nothing.
+# ---------------------------------------------------------------------------
+
+names bench/c/bench_main.c 332 nine-leg shape debt: family rt (deleted by #199) plus the gen pin/vary for the three non-mixed shapes (emitted by #195)
+names bench/cpp/bench_main.cpp 263 nine-leg shape debt: family rt (#199) plus gen pin/vary (#195)
+names bench/cs/src/Program.cs 88 nine-leg shape debt: gen pin/vary for the three non-mixed shapes (#195)
+names bench/cs/src/RtBench.cs 203 family rt, hand-written runtime-API shape code — deleted whole by #199
+names bench/dart/main.dart 39 nine-leg shape debt: gen pin/vary (#195)
+names bench/elixir/runner.exs 17 nine-leg shape debt: gen pin/vary (#195)
+names bench/go/main.go 81 nine-leg shape debt: gen pin/vary (#195); the go leg is the first on the emitter
+names bench/go/rt.go 204 family rt, hand-written runtime-API shape code — deleted whole by #199
+names bench/java/Main.java 47 nine-leg shape debt: gen pin/vary (#195)
+names bench/js/main.mjs 384 nine-leg shape debt: family rt (#199) plus gen pin/vary (#195)
+names bench/rust/src/main.rs 83 nine-leg shape debt: gen pin/vary (#195)
+names bench/rust/src/rt.rs 205 family rt, hand-written runtime-API shape code — deleted whole by #199
+
+consts bench/c/bench_main.c 1 a shape wire size written down, inside the rt/gen shape code above
+consts bench/cpp/bench_main.cpp 1 a shape wire size written down, inside the rt/gen shape code above
+consts bench/java/Main.java 3 shape wire sizes written down, inside the gen shape code above
+
+# ---------------------------------------------------------------------------
+# THE CORPUS TOOLING — shape knowledge in ONE place, deliberately.
+#
+# variantgen holds the BenchMixed pin and vary mapping so the nine legs do not
+# have to: it commits the variant corpus every leg then reads blind. That is
+# the design, not the debt — one copy replacing nine. It is listed anyway,
+# because "one deliberate copy" is a claim that should be checkable rather
+# than remembered. #195's emitter supersedes it.
+#
+# realpacket-gen is the same bargain for the §1.7 RealWorld snapshot.
+# inline-gate and inline-verdict name shapes only as ROW LABELS in their
+# symbol maps and test fixtures — no serialization, no timing.
+# ---------------------------------------------------------------------------
+
+names bench/tools/variantgen/main.go 94 the single deliberate copy of BenchMixed shape code; emits the corpus the nine legs read blind (superseded by #195)
+names bench/tools/realpacket-gen/main.go 11 the single deliberate copy of the RealWorld snapshot shape code (§1.7)
+names bench/tools/realpacket-gen/pin_test.go 3 pins the generator above against its golden
+names bench/tools/inline-gate.sh 9 shape names as row labels in the inline-budget symbol map and its test fixtures
+names bench/tools/inline-verdict.sh 2 shape names as row labels in the symbol map
+consts bench/tools/variantgen/main.go 3 the variant corpus stride and record size, which this tool is the authority for
+
+# ---------------------------------------------------------------------------
+# THE §1.5 GOLDEN PINNER — correctness, not measurement.
+#
+# test/bench/ writes the pinned instances through the GENERATED code and
+# byte-checks them against testdata/wire/. It is the oracle every runner is
+# gated against before it is allowed to report a number. It names shapes, as a
+# conformance suite must, and it contains no clock — which is exactly the line
+# this gate draws. Only its bench-shaped PATH trips a check.
+# ---------------------------------------------------------------------------
+
+paths test/bench/c_main.c 1 the §1.5 golden pinner: correctness code, no timing
+paths test/bench/main.cpp 1 the §1.5 golden pinner: correctness code, no timing
+
+# ---------------------------------------------------------------------------
+# A DELETION CANDIDATE, held here so it cannot be forgotten.
+#
+# bench/results/harness-contract-air/decomp.cpp is a 294-line hand-coded
+# benchmark committed into the results tree on 2026-08-30 as #170 forensics.
+# It hand-codes a shape and its wire size, embeds the hand-written runtime-API
+# subject verbatim, and reads a clock. It is a live harness parked where live
+# harnesses are not supposed to exist, and nothing regenerates or re-verifies
+# it — run it after a corpus change and it will report confidently on a shape
+# that no longer exists.
+#
+# Its findings are already written up next to it in
+# 2026-08-30-harness-contract-decomposition.md, which is the durable record.
+# RECOMMENDED: delete the .cpp, keep the .md. Owner's call; until then it sits
+# here under all three checks so it stays visible.
+# ---------------------------------------------------------------------------
+
+names bench/results/harness-contract-air/decomp.cpp 15 DELETION CANDIDATE — hand-coded shape measurement committed to the results tree (#170 forensics)
+timing bench/results/harness-contract-air/decomp.cpp 1 DELETION CANDIDATE — a live timed loop outside every sanctioned runner directory
+consts bench/results/harness-contract-air/decomp.cpp 1 DELETION CANDIDATE — a shape wire size written down by hand
+paths bench/results/harness-contract-air/decomp.cpp 1 DELETION CANDIDATE — benchmark source in the results tree

--- a/bench/tools/shapegate/main.go
+++ b/bench/tools/shapegate/main.go
@@ -60,6 +60,19 @@
 //   - It is a lexical check. Code that computes a field name or a size at run
 //     time to evade it passes, and nothing short of a human reading the diff
 //     would catch that.
+//   - It guards MEASUREMENT, not CORRECTNESS. A shape-blind runner driving a
+//     defective emitter is still shape-blind and still passes here. #198 is
+//     the worked example: the Go emitter wrote a fixed scalar array twice, 32
+//     wire bytes where the other eight languages write 16, and Go-to-Go
+//     round-trips passed clean because both ends shared the defect. Nothing in
+//     this gate can see that. Cross-language wire agreement is the conformance
+//     suite's job, and issue #203 records the corpus blind spot that let it
+//     through.
+//   - It does not read comments differently from code. A shape NAME in a prose
+//     comment counts as a hit, which is why several ledger entries below are
+//     comments and say so. That is deliberate: a hand-coded bench announces
+//     itself in its own header comment, and teaching the gate to skip comments
+//     would teach it to skip the announcement.
 package main
 
 import (
@@ -111,11 +124,20 @@ var sourceExts = map[string]bool{
 	".kt": true, ".swift": true, ".zig": true,
 }
 
-// skipDirs — machine-written or vendored trees. Generated code names shapes
-// because that is its whole job; scanning it would flag the correct design.
+// skipDirs — machine-written, vendored or downloaded trees. Generated code
+// names shapes because that is its whole job; scanning it would flag the
+// correct design.
+//
+// `dist` is the Makefile's pinned toolchain drop (the Dart SDK, the JDK, OTP,
+// Elixir — see the DART/JAVA/BEAM_PATH comments at the top of the Makefile).
+// It is gitignored and absent on CI, which uses setup-dart/setup-java instead,
+// so the gate only ever meets it on a fully provisioned developer machine. The
+// Dart SDK alone ships `lib/core/stopwatch.dart`; without this line `make
+// shape-gate` refuses on exactly the trees that can run the whole bench.
 var skipDirs = map[string]bool{
 	".git": true, "generated": true, "testdata": true, "build": true,
 	"bin": true, "vendor": true, "node_modules": true, "target": true,
+	"dist": true,
 }
 
 // ------------------------------------------------------------------------------------------

--- a/bench/tools/shapegate/main.go
+++ b/bench/tools/shapegate/main.go
@@ -1,0 +1,649 @@
+// shapegate — the mechanical guarantee behind the one-benchmark rule.
+//
+//	go run ./bench/tools/shapegate        # or: make shape-gate
+//
+// THE RULE IT ENFORCES. The estate has exactly one sanctioned benchmark: this
+// repo's data-driven bench. Shape knowledge lives in two places and nowhere
+// else — bench/corpus/*.schema (the definition) and the code the compiler
+// GENERATES from it. The nine language runners are hand-written and stay that
+// way, but they are SHAPE-BLIND: timing, buffers, CSV and loops only. A runner
+// that names a field, hardcodes a wire size, or grows its own timed loop over a
+// hand-serialized struct is the divergence class the owner named — nine
+// hand-written approximations of one benchmark, drifting apart silently.
+//
+// Prose cannot hold that line. This does.
+//
+// WHAT IT CHECKS.
+//
+//	names     No shape identifier from bench/corpus/*.schema — type, enum,
+//	          union, flags or field name, in any case form — appears anywhere
+//	          under bench/. The vocabulary is EXTRACTED from the corpus, so it
+//	          tracks the corpus automatically: rename a field and the gate
+//	          starts guarding the new name in the same commit. Scoped to the
+//	          measurement tier on purpose — naming a shape is not a benchmark,
+//	          and test/ names them constantly and correctly.
+//
+//	timing    No timing primitive appears anywhere in the repository outside
+//	          the sanctioned runner and tool directories. This is what catches
+//	          a scratch harness parked in bench/results/, an ad-hoc timer added
+//	          to a test, or a perf example under cmd/.
+//
+//	paths     No SOURCE file whose path says "benchmark" (bench, perf, profile,
+//	          timing, throughput, criterion, jmh) appears outside the
+//	          sanctioned prefixes. Result data and documentation under bench/
+//	          are not source and are not scanned.
+//
+//	consts    No distinctive wire constant of a corpus shape — its byte size,
+//	          its bit count — appears as a literal in a runner. A shape-blind
+//	          runner derives sizes from the committed corpus at run time; a
+//	          hand-coded one has to write the shape's size down somewhere.
+//
+//	ledger    Every exemption in bench/SHAPE-GATE.allow still matches a real
+//	          file at exactly its recorded count. An entry whose file is gone
+//	          FAILS. An entry whose count DROPPED fails too, and prints the new
+//	          number to write. The debt can only shrink.
+//
+// WHAT IT CANNOT SEE. Stated plainly, because a gate that oversells itself is
+// worse than none:
+//
+//   - It runs in THIS repository's CI. A hand-coded serialize benchmark in
+//     another repository is outside its reach entirely.
+//   - Markdown is not scanned. A benchmark pasted into a fenced code block in a
+//     .md file passes.
+//   - The name vocabulary drops identifiers shorter than 4 characters and a
+//     stoplist of ordinary programming words, because `x`, `if` and `delta` are
+//     corpus field names and grepping for them would fire on everything. A
+//     hand-coded bench written using ONLY those names would pass — it would
+//     also be unreadable.
+//   - Wire constants below 32 are not distinctive enough to guard, so the 14
+//     and 20 byte shapes are guarded by name only.
+//   - It is a lexical check. Code that computes a field name or a size at run
+//     time to evade it passes, and nothing short of a human reading the diff
+//     would catch that.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ------------------------------------------------------------------------------------------
+// where the sanctioned machinery lives
+// ------------------------------------------------------------------------------------------
+
+// runnerDirs — the nine language legs and the bench tooling. Timing primitives
+// and bench-shaped paths are legal here and illegal everywhere else.
+var runnerDirs = []string{
+	"bench/c/",
+	"bench/cpp/",
+	"bench/cs/",
+	"bench/dart/",
+	"bench/elixir/",
+	"bench/go/",
+	"bench/java/",
+	"bench/js/",
+	"bench/rust/",
+	"bench/tools/",
+	"bench/run.sh",
+}
+
+// corpusDir — the shape definition and its committed data. Shape names are
+// legal here by definition; this is the one place they are supposed to be.
+const corpusDir = "bench/corpus/"
+
+// goldenGlob — the committed wire goldens. Their FILE SIZES are the shapes'
+// wire sizes, so the constant vocabulary needs no parsing to be authoritative.
+const goldenGlob = "testdata/wire/bench_*.bin"
+
+const ledgerPath = "bench/SHAPE-GATE.allow"
+
+// sourceExts — the file kinds a benchmark can be written in.
+var sourceExts = map[string]bool{
+	".c": true, ".h": true, ".inc": true, ".cpp": true, ".hpp": true, ".cc": true,
+	".cs": true, ".go": true, ".rs": true, ".java": true, ".js": true, ".mjs": true,
+	".dart": true, ".ex": true, ".exs": true, ".sh": true, ".py": true, ".rb": true,
+	".kt": true, ".swift": true, ".zig": true,
+}
+
+// skipDirs — machine-written or vendored trees. Generated code names shapes
+// because that is its whole job; scanning it would flag the correct design.
+var skipDirs = map[string]bool{
+	".git": true, "generated": true, "testdata": true, "build": true,
+	"bin": true, "vendor": true, "node_modules": true, "target": true,
+}
+
+// ------------------------------------------------------------------------------------------
+// check 1 — the shape vocabulary, extracted from the corpus
+// ------------------------------------------------------------------------------------------
+
+// minNameLen — shorter identifiers are not distinctive. `a`, `b`, `c`, `x`,
+// `y`, `z`, `f0`..`f9`, `b7`..`b48` are all real corpus field names and all
+// unguardable. Named in the package doc as a known blind spot.
+const minNameLen = 4
+
+// nameStoplist — corpus field names that are also ordinary programming words.
+// Guarding them would fire on every runner's own variables.
+var nameStoplist = map[string]bool{
+	"align": true, "flag": true, "bits": true, "blob": true, "delta": true,
+	"stats": true, "hits": true, "type": true, "size": true, "data": true,
+	"item": true, "kind": true, "next": true, "byte": true, "word": true,
+	"read": true, "write": true, "name": true, "value": true, "count": true,
+	"index": true, "hash": true, "seed": true, "mask": true, "base": true,
+	// English words that happen to be corpus field names. They collide with
+	// ordinary prose ("a clean bill of health", "cannot drift from") and would
+	// make the gate cry wolf in comments, which is how gates get switched off.
+	"chat": true, "drift": true, "health": true,
+}
+
+var (
+	declRe  = regexp.MustCompile(`^\s*(?:type|enum|union|flags)\s+([A-Za-z_][A-Za-z0-9_]*)`)
+	fieldRe = regexp.MustCompile(`^\s+([a-z_][a-z0-9_]*)\s`)
+	bitsRe  = regexp.MustCompile(`=\s*(\d+)\s*bits`)
+)
+
+// vocabulary reads every .schema under bench/corpus and returns the guarded
+// identifiers, in every case form a port would spell them.
+func vocabulary(root string) (map[string]string, []string, error) {
+	files, err := filepath.Glob(filepath.Join(root, corpusDir, "*.schema"))
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(files) == 0 {
+		return nil, nil, fmt.Errorf("no .schema files under %s — the gate refuses to run with an empty vocabulary", corpusDir)
+	}
+
+	// guarded maps a spelling to the corpus identifier it came from, so a
+	// refusal can say WHICH field was named rather than just "a field was".
+	guarded := map[string]string{}
+	var roots []string
+
+	for _, f := range files {
+		fh, err := os.Open(f)
+		if err != nil {
+			return nil, nil, err
+		}
+		sc := bufio.NewScanner(fh)
+		sc.Buffer(make([]byte, 1<<20), 1<<20)
+		for sc.Scan() {
+			line := sc.Text()
+			if i := strings.Index(line, "//"); i >= 0 {
+				line = line[:i]
+			}
+			var ident string
+			if m := declRe.FindStringSubmatch(line); m != nil {
+				ident = m[1]
+			} else if m := fieldRe.FindStringSubmatch(line); m != nil {
+				ident = m[1]
+			}
+			if ident == "" {
+				continue
+			}
+			if len(ident) < minNameLen || nameStoplist[strings.ToLower(ident)] {
+				continue
+			}
+			roots = append(roots, ident)
+			for _, form := range caseForms(ident) {
+				if len(form) >= minNameLen && !nameStoplist[strings.ToLower(form)] {
+					guarded[form] = ident
+				}
+			}
+		}
+		fh.Close()
+		if err := sc.Err(); err != nil {
+			return nil, nil, err
+		}
+	}
+	if len(guarded) == 0 {
+		return nil, nil, fmt.Errorf("corpus parsed but yielded no guardable identifiers — the gate refuses to run blind")
+	}
+	sort.Strings(roots)
+	return guarded, dedupe(roots), nil
+}
+
+// caseForms — the spellings one identifier takes across nine languages:
+// snake_case as written, lowerCamel, UpperCamel, UPPER_SNAKE, and the
+// underscore-free flattening some ports use.
+func caseForms(ident string) []string {
+	parts := strings.Split(ident, "_")
+	var camel, pascal, flat strings.Builder
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		t := strings.ToUpper(p[:1]) + p[1:]
+		pascal.WriteString(t)
+		flat.WriteString(strings.ToLower(p))
+		if i == 0 {
+			camel.WriteString(strings.ToLower(p))
+		} else {
+			camel.WriteString(t)
+		}
+	}
+	return dedupe([]string{
+		ident,
+		camel.String(),
+		pascal.String(),
+		strings.ToUpper(ident),
+		flat.String(),
+	})
+}
+
+// ------------------------------------------------------------------------------------------
+// check 2 — timing primitives, in every language the estate writes
+// ------------------------------------------------------------------------------------------
+
+var timingRe = regexp.MustCompile(strings.Join([]string{
+	`clock_gettime`, `std::chrono`, `chrono::`, `QueryPerformanceCounter`,
+	`mach_absolute_time`, `__rdtsc`, `\bStopwatch\b`, `\bnanoTime\b`,
+	`System\.monotonic_time`, `:timer\.tc`, `process\.hrtime`,
+	`performance\.now`, `Instant::now`, `time\.Now\(\)`, `criterion::`,
+	`BenchmarkDotNet`, `\*testing\.B\b`, `DateTime\.[Nn]ow`,
+	`\bhrtime\b`, `getrusage`, `\bperf_event_open\b`,
+}, "|"))
+
+// ------------------------------------------------------------------------------------------
+// check 3 — bench-shaped paths
+// ------------------------------------------------------------------------------------------
+
+var benchPathRe = regexp.MustCompile(`(?i)(^|/|[._-])(bench|benches|benchmark|benchmarks|perf|profile|profiling|timing|throughput|criterion|jmh)([._-]|/|$)`)
+
+// ------------------------------------------------------------------------------------------
+// check 4 — distinctive wire constants
+// ------------------------------------------------------------------------------------------
+
+// minConst — below this a number is not distinctive enough to accuse anyone of.
+// The two smallest corpus shapes' wire sizes fall out here; those shapes are
+// guarded by name only. Named in the package doc.
+const minConst = 32
+
+// wireConstants — the byte size of every committed golden, and its bit count.
+// Derived from the goldens themselves, which are the corpus's own authority,
+// so no comment format or emitter behaviour has to hold for this to be right.
+// The exact bit total is additionally read from the schema's `= N bits` trailer
+// where the corpus states one.
+func wireConstants(root string) (map[int]string, error) {
+	out := map[int]string{}
+
+	goldens, err := filepath.Glob(filepath.Join(root, goldenGlob))
+	if err != nil {
+		return nil, err
+	}
+	for _, g := range goldens {
+		st, err := os.Stat(g)
+		if err != nil {
+			continue
+		}
+		shape := strings.TrimSuffix(filepath.Base(g), ".bin")
+		n := int(st.Size())
+		if n >= minConst {
+			out[n] = shape + " wire bytes"
+		}
+		if n*8 >= minConst {
+			out[n*8] = shape + " wire bits"
+		}
+	}
+
+	schemas, _ := filepath.Glob(filepath.Join(root, corpusDir, "*.schema"))
+	for _, s := range schemas {
+		b, err := os.ReadFile(s)
+		if err != nil {
+			continue
+		}
+		for _, m := range bitsRe.FindAllStringSubmatch(string(b), -1) {
+			if n, err := strconv.Atoi(m[1]); err == nil && n >= minConst {
+				if _, seen := out[n]; !seen {
+					out[n] = "declared bit total in " + filepath.Base(s)
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no wire constants derived from %s or %s — the gate refuses to run blind", goldenGlob, corpusDir)
+	}
+	return out, nil
+}
+
+// ------------------------------------------------------------------------------------------
+// the ledger
+// ------------------------------------------------------------------------------------------
+
+// ledgerEntry — one named, capped, dated exemption. The count is EXACT: the
+// debt cannot grow, and when it shrinks the gate says so and makes you write
+// the smaller number down. When it reaches zero the entry is deleted.
+type ledgerEntry struct {
+	check string
+	path  string
+	count int
+	line  int
+	why   string
+}
+
+func readLedger(root string) ([]ledgerEntry, error) {
+	f, err := os.Open(filepath.Join(root, ledgerPath))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []ledgerEntry
+	sc := bufio.NewScanner(f)
+	n := 0
+	for sc.Scan() {
+		n++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 4)
+		if len(parts) < 4 {
+			return nil, fmt.Errorf("%s:%d: want `<check> <path> <count> <reason>`, got %q", ledgerPath, n, line)
+		}
+		c, err := strconv.Atoi(parts[2])
+		if err != nil {
+			return nil, fmt.Errorf("%s:%d: count %q is not a number", ledgerPath, n, parts[2])
+		}
+		switch parts[0] {
+		case "names", "timing", "paths", "consts":
+		default:
+			return nil, fmt.Errorf("%s:%d: unknown check %q (want names|timing|paths|consts)", ledgerPath, n, parts[0])
+		}
+		out = append(out, ledgerEntry{check: parts[0], path: parts[1], count: c, line: n, why: parts[3]})
+	}
+	return out, sc.Err()
+}
+
+// ------------------------------------------------------------------------------------------
+// the scan
+// ------------------------------------------------------------------------------------------
+
+type finding struct {
+	check  string
+	path   string
+	count  int
+	detail []string
+}
+
+// emitLedger — `-ledger` prints the ledger lines the current tree would need,
+// so paying debt down is `go run ./bench/tools/shapegate -ledger`, paste, and
+// write the reason for anything that survives. Never run in CI.
+var emitLedger bool
+
+func main() {
+	root := "."
+	for _, a := range os.Args[1:] {
+		if a == "-ledger" || a == "--ledger" {
+			emitLedger = true
+			continue
+		}
+		root = a
+	}
+	if err := run(root); err != nil {
+		fmt.Fprintf(os.Stderr, "\nSHAPE GATE REFUSAL\n\n%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(root string) error {
+	guarded, roots, err := vocabulary(root)
+	if err != nil {
+		return err
+	}
+	consts, err := wireConstants(root)
+	if err != nil {
+		return err
+	}
+	ledger, err := readLedger(root)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("shape gate\n")
+	fmt.Printf("  corpus vocabulary : %d identifiers, %d spellings guarded\n", len(roots), len(guarded))
+	fmt.Printf("  wire constants    : %s\n", formatConsts(consts))
+	fmt.Printf("  ledger            : %d exemption(s)\n\n", len(ledger))
+
+	found := map[string]map[string]*finding{
+		"names": {}, "timing": {}, "paths": {}, "consts": {},
+	}
+	add := func(check, path string, n int, detail []string) {
+		if n == 0 {
+			return
+		}
+		found[check][path] = &finding{check: check, path: path, count: n, detail: detail}
+	}
+
+	err = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(root, p)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+		if info.IsDir() {
+			if rel != "." && skipDirs[info.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if rel == ledgerPath {
+			return nil
+		}
+
+		if !sourceExts[strings.ToLower(filepath.Ext(rel))] {
+			return nil
+		}
+
+		// paths — a bench-shaped SOURCE file outside the sanctioned prefixes.
+		// Results and docs under bench/ are data, not machinery, and are not
+		// source, so they never reach here.
+		if benchPathRe.MatchString(rel) && !underRunner(rel) && !strings.HasPrefix(rel, corpusDir) {
+			add("paths", rel, 1, []string{"a source file whose path names a benchmark, outside the sanctioned runner directories"})
+		}
+		b, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return rerr
+		}
+		text := string(b)
+
+		// timing — legal only in the runner and tool directories.
+		if !underRunner(rel) {
+			if hits := timingRe.FindAllString(text, -1); len(hits) > 0 {
+				add("timing", rel, len(hits), dedupe(hits))
+			}
+		}
+
+		// names and consts — the measurement tier only, and never the corpus,
+		// which is where shape knowledge is supposed to live.
+		//
+		// WHY NOT REPO-WIDE. Naming a shape is not a benchmark; TIMING a shape
+		// is. test/ names these shapes constantly and should — that is what a
+		// conformance suite does — and the compiler internals collide with
+		// ordinary field words. Scoping names to
+		// bench/ keeps the check precise, and the repo-wide timing check above
+		// is what actually catches a benchmark parked anywhere else: it cannot
+		// measure without reading a clock.
+		if !strings.HasPrefix(rel, "bench/") || strings.HasPrefix(rel, corpusDir) {
+			return nil
+		}
+		if n, which := countNames(text, guarded); n > 0 {
+			add("names", rel, n, which)
+		}
+		if n, which := countConsts(text, consts); n > 0 {
+			add("consts", rel, n, which)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if emitLedger {
+		for _, check := range []string{"names", "timing", "paths", "consts"} {
+			for _, path := range sortedFindingPaths(found[check]) {
+				fmt.Printf("%s %s %d REASON\n", check, path, found[check][path].count)
+			}
+		}
+		return nil
+	}
+	return reconcile(found, ledger)
+}
+
+func underRunner(rel string) bool {
+	for _, d := range runnerDirs {
+		if strings.HasPrefix(rel, d) {
+			return true
+		}
+	}
+	return false
+}
+
+var identRe = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_]*`)
+
+func countNames(text string, guarded map[string]string) (int, []string) {
+	n := 0
+	seen := map[string]bool{}
+	for _, tok := range identRe.FindAllString(text, -1) {
+		if root, ok := guarded[tok]; ok {
+			n++
+			seen[tok+" (corpus: "+root+")"] = true
+		}
+	}
+	return n, sortedKeys(seen)
+}
+
+var numRe = regexp.MustCompile(`\b\d+\b`)
+
+func countConsts(text string, consts map[int]string) (int, []string) {
+	n := 0
+	seen := map[string]bool{}
+	for _, tok := range numRe.FindAllString(text, -1) {
+		v, err := strconv.Atoi(tok)
+		if err != nil {
+			continue
+		}
+		if what, ok := consts[v]; ok {
+			n++
+			seen[tok+" ("+what+")"] = true
+		}
+	}
+	return n, sortedKeys(seen)
+}
+
+// ------------------------------------------------------------------------------------------
+// reconciliation — findings against the ledger, in both directions
+// ------------------------------------------------------------------------------------------
+
+func reconcile(found map[string]map[string]*finding, ledger []ledgerEntry) error {
+	var refusals []string
+
+	allowed := map[string]ledgerEntry{}
+	for _, e := range ledger {
+		allowed[e.check+" "+e.path] = e
+	}
+
+	// direction 1 — findings the ledger does not cover, or covers too thinly.
+	for _, check := range []string{"names", "timing", "paths", "consts"} {
+		for _, path := range sortedFindingPaths(found[check]) {
+			f := found[check][path]
+			e, ok := allowed[check+" "+path]
+			if !ok {
+				refusals = append(refusals, fmt.Sprintf(
+					"%s  %s\n    %d hit(s), no ledger entry\n    %s",
+					strings.ToUpper(check), path, f.count, strings.Join(f.detail, "\n    ")))
+				continue
+			}
+			if f.count > e.count {
+				refusals = append(refusals, fmt.Sprintf(
+					"%s  %s\n    %d hit(s), ledger allows %d — the exemption GREW\n    %s",
+					strings.ToUpper(check), path, f.count, e.count, strings.Join(f.detail, "\n    ")))
+			}
+		}
+	}
+
+	// direction 2 — ledger hygiene. A stale entry is a lie about the tree, and
+	// a shrunk one is debt that has been paid and must be written down.
+	for _, e := range ledger {
+		f, ok := found[e.check][e.path]
+		if !ok {
+			refusals = append(refusals, fmt.Sprintf(
+				"LEDGER  %s:%d\n    `%s %s %d` matches nothing — the file is gone or clean.\n    Delete this line.",
+				ledgerPath, e.line, e.check, e.path, e.count))
+			continue
+		}
+		if f.count < e.count {
+			refusals = append(refusals, fmt.Sprintf(
+				"LEDGER  %s:%d\n    `%s %s %d` is stale — the file now has %d.\n    Lower the count to %d. The ledger only shrinks.",
+				ledgerPath, e.line, e.check, e.path, e.count, f.count, f.count))
+		}
+	}
+
+	total := 0
+	for _, m := range found {
+		total += len(m)
+	}
+	if len(refusals) == 0 {
+		fmt.Printf("clean — %d file(s) carry shape knowledge, every one on the ledger\n", total)
+		return nil
+	}
+	return fmt.Errorf("%s\n\nThe estate has ONE benchmark: this repo's data-driven bench (bench/README.md).\nHand-written runners are fine. Hand-written MEASUREMENT of a schema shape is not.\nIf a refusal above is a deliberate, owner-ruled exception, add it to %s\nwith its exact count and the reason.",
+		strings.Join(refusals, "\n\n"), ledgerPath)
+}
+
+// ------------------------------------------------------------------------------------------
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string]bool) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	if len(out) > 8 {
+		out = append(out[:8], fmt.Sprintf("... and %d more", len(out)-8))
+	}
+	return out
+}
+
+func sortedFindingPaths(m map[string]*finding) []string {
+	var out []string
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatConsts(m map[int]string) string {
+	var ks []int
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Ints(ks)
+	var parts []string
+	for _, k := range ks {
+		parts = append(parts, strconv.Itoa(k))
+	}
+	return strings.Join(parts, " ")
+}

--- a/bench/tools/shapegate/main.go
+++ b/bench/tools/shapegate/main.go
@@ -194,9 +194,12 @@ func vocabulary(root string) (map[string]string, []string, error) {
 				}
 			}
 		}
-		fh.Close()
+		cerr := fh.Close()
 		if err := sc.Err(); err != nil {
 			return nil, nil, err
+		}
+		if cerr != nil {
+			return nil, nil, cerr
 		}
 	}
 	if len(guarded) == 0 {
@@ -332,7 +335,7 @@ func readLedger(root string) ([]ledgerEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var out []ledgerEntry
 	sc := bufio.NewScanner(f)
@@ -387,7 +390,7 @@ func main() {
 		root = a
 	}
 	if err := run(root); err != nil {
-		fmt.Fprintf(os.Stderr, "\nSHAPE GATE REFUSAL\n\n%v\n", err)
+		fmt.Fprintf(os.Stderr, "\nSHAPE GATE REFUSAL\n\n%v\n\n%s\n", err, theRule)
 		os.Exit(1)
 	}
 }
@@ -596,9 +599,15 @@ func reconcile(found map[string]map[string]*finding, ledger []ledgerEntry) error
 		fmt.Printf("clean — %d file(s) carry shape knowledge, every one on the ledger\n", total)
 		return nil
 	}
-	return fmt.Errorf("%s\n\nThe estate has ONE benchmark: this repo's data-driven bench (bench/README.md).\nHand-written runners are fine. Hand-written MEASUREMENT of a schema shape is not.\nIf a refusal above is a deliberate, owner-ruled exception, add it to %s\nwith its exact count and the reason.",
-		strings.Join(refusals, "\n\n"), ledgerPath)
+	return fmt.Errorf("%s", strings.Join(refusals, "\n\n"))
 }
+
+// theRule — printed under every refusal, so the reader does not have to go
+// find out what the gate is for before deciding what to do about it.
+const theRule = `The estate has ONE benchmark: this repo's data-driven bench (bench/README.md).
+Hand-written runners are fine. Hand-written MEASUREMENT of a schema shape is not.
+If a refusal above is a deliberate, owner-ruled exception, add it to ` + ledgerPath + `
+with its exact count and the reason.`
 
 // ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Owner concern, 2026-08-31, verbatim: *"My concern is if you have any other profiling per-language that is hand coded. I don't trust this and it will drift. We have to lock this in."*

This is the lock. An estate-wide audit ran alongside it; the findings are at the bottom.

> **Rebased 2026-08-31 onto `main@0514fc4`.** Everything below — every count, every pasted refusal — is from the rebased head, not the tree this PR was written on. What changed is the headline: **the debt is paid.**

## THE DEBT IS PAID — the gate now guards a clean tree

When this gate was written on `main@6e1002b` its register carried **2080 name hits across twelve runner files**, because every one of the nine legs hand-wrote the corpus shapes: a family `rt` transcription against the runtime API, plus a family `gen` pinned initializer and LCG vary mapping per shape per language. Nine hand-written approximations of one benchmark. That was the drift the owner named.

Three PRs landed since:

- **#199** deleted family `rt` and the §1.3 hand-coded shapes from every leg
- **#204** retired the §1.2 example-corpus rows from every runner
- **#201** deleted `bench/results/harness-contract-air/decomp.cpp`, the scratch harness this PR had flagged for the owner's ruling

**The ratchet caught all of it, in the direction that matters.** The rebased gate refused with nine stale counts and seven entries matching nothing — debt paid without the register saying so, which is a failure by design. The register is now rewritten to the true numbers.

Across the nine runner legs the count falls **from 1946 to 29**, and — the part worth saying loudly —

> **not one of those 29 is hand-coded shape measurement.**

Every remaining hit in the nine legs is one of exactly three kinds, and every ledger line says which:

| kind | what it is | example |
|---|---|---|
| **(comment)** | the shape's name in a prose comment. The gate does not strip comments, deliberately — a hand-coded bench announces itself in its own header | `// Java codecs over bench/corpus/Bench.schema's BenchMixed.` |
| **(callsite)** | the **generated** type named where the shape-blind driver instantiates it and hands it to generated `Write`/`Read`. It writes no field and pins no value | `bench_datadriven<bench::BenchMixed>( "bench_mixed", ... )` |
| **(prose)** | an English word that is also a corpus field name — a known false-positive class named in the package doc's stoplist note | `extra` in *"one extra untimed pass"* |

The nine legs are shape-blind. The estate has reached the owner's ruling — **there is only a single schema bench: `Bench.schema`** — and this gate's job changes from shrinking a debt to holding a clean tree. Any leg that grows one hand-written field, one pin, or one wire size fails on the next push.

What is left on the register is the corpus tooling (one deliberate copy, by design), the §1.5 golden pinner's bench-shaped path, and two numeric false positives. Nineteen entries, all named, all reasoned.

## The rule, made mechanical

The estate has exactly one sanctioned benchmark: this repo's data-driven bench. Shape knowledge belongs in `bench/corpus/*.schema` and in the code the compiler generates from it. Hand-written **runners** are fine and are the design. Hand-written **measurement of a schema shape** is not, anywhere.

`bench/tools/shapegate` refuses four things:

| check | what it refuses |
|---|---|
| `names` | a corpus identifier — type, enum, union, flags or field, in any case form — appearing under `bench/` |
| `timing` | a timing primitive anywhere in the repo outside the sanctioned runner and tool directories |
| `paths` | a bench-shaped **source** path outside those directories |
| `consts` | a shape's distinctive wire size or bit count written down as a literal under `bench/` |

The vocabulary is **extracted from the corpus**, not written into the checker, so renaming a field starts guarding the new name in the same commit. The wire constants come from the committed goldens' own file sizes, so no comment format or emitter behaviour has to hold for them to be right. If either extraction comes back empty the gate **refuses to run** rather than passing blind.

`bench/SHAPE-GATE.allow` is the complete register of everything that does not comply, each line with an exact count and a reason. The count is a **ratchet in both directions**: more hits fails because the debt grew; *fewer* hits also fails, printing the number to write, because the debt was paid and the register must say so; and an entry matching no file fails as rot. That is not a claim — it is what happened on this rebase, and it is what produced the numbers above.

`make shape-gate` locally. CI job `shape-gate`, on push and pull_request — unlike `cpp-lock` this is a standing property of the tree, not a review-window freeze.

## Negative control, re-proven on the rebased head

A gate proven on an older tree is proven on an older tree. All four plants were re-run against `main@0514fc4` + this branch, each reverted to green after. Pasted verbatim.

Controls **A** and **B** are the originals. Controls **C** and **D** needed new subjects — the originals planted into `bench/go/rt.go` and `bench/elixir/runner.exs`'s hand-written shape block, and #199 deleted both. Their replacements exercise the same two ledger directions on files that exist today, and are noted where they differ.

**A. A plausible hand-coded bench in `internal/perf/mixed_bench.c`** — `clock_gettime`, a 438-byte buffer:

```
SHAPE GATE REFUSAL

TIMING  internal/perf/mixed_bench.c
    2 hit(s), no ledger entry
    clock_gettime

PATHS  internal/perf/mixed_bench.c
    1 hit(s), no ledger entry
    a source file whose path names a benchmark, outside the sanctioned runner directories
exit status 1
```

**B. Shape code sneaked into a sanctioned runner** (`bench/dart/main.dart`, ledger cap now 3, not 39 — the cap fell with the debt, so the plant is caught by a much tighter fence than before):

```
NAMES  bench/dart/main.dart
    11 hit(s), ledger allows 3 — the exemption GREW
    BenchMixed (corpus: BenchMixed)
    ack_bits (corpus: ack_bits)
    ack_sequence (corpus: ack_sequence)
    aim_x (corpus: aim_x)
    aim_y (corpus: aim_y)
    aim_z (corpus: aim_z)
    client_id (corpus: client_id)
    crc_hint (corpus: crc_hint)
    ... and 1 more

CONSTS  bench/dart/main.dart
    2 hit(s), no ledger entry
    3504 (bench_mixed wire bits)
    438 (bench_mixed wire bytes)
exit status 1
```

**C. Ledger rot** — a ledgered file removed without touching the register. *Changed subject:* the original deleted `bench/go/rt.go` to simulate #199; #199 has landed and that file is gone, so the plant now deletes `bench/elixir/main.exs`.

```
LEDGER  bench/SHAPE-GATE.allow:60
    `names bench/elixir/main.exs 1` matches nothing — the file is gone or clean.
    Delete this line.
exit status 1
```

**D. Debt paid, register not lowered.** *Changed subject:* the original removed four hand-written field names from `bench/elixir/runner.exs`; there are no longer four hand-written field names in any leg to remove — which is the point of this whole rebase. The equivalent plant rewrites the one comment in `bench/java/Main.java` that names the shape, dropping its count from 6 to 5:

```
LEDGER  bench/SHAPE-GATE.allow:63
    `names bench/java/Main.java 6` is stale — the file now has 5.
    Lower the count to 5. The ledger only shrinks.
exit status 1
```

**The refuse-to-run-blind paths, also tested** — the gate must refuse rather than pass silently when an extraction comes back empty. Three runs against synthetic roots:

```
# corpus directory with no .schema files
no .schema files under bench/corpus/ — the gate refuses to run with an empty vocabulary

# a corpus that parses but yields nothing guardable
corpus parsed but yielded no guardable identifiers — the gate refuses to run blind

# no goldens and no declared bit total >= 32
no wire constants derived from testdata/wire/bench_*.bin or bench/corpus/ — the gate refuses to run blind
```

All three exit 1. On the real tree both extractions are non-empty: **161 corpus identifiers, 731 spellings**, and the wire constants **49 110 112 135 156 160 392 438 3504** read from the four committed goldens (`bench_ints` 14 B, `bench_bits` 20 B, `bench_packet` 49 B, `bench_mixed` 438 B) plus the schema's declared bit totals. The 14- and 20-byte shapes fall below the `minConst` floor and are guarded by name only, exactly as the package doc says.

**Green on the rebased head as committed:**

```
shape gate
  corpus vocabulary : 161 identifiers, 731 spellings guarded
  wire constants    : 49 110 112 135 156 160 392 438 3504
  ledger            : 19 exemption(s)

clean — 19 file(s) carry shape knowledge, every one on the ledger
```

`make test` passes locally on the rebased head with the full pinned toolchain. `gofmt`, `go vet ./...` and `go mod tidy -diff` clean.

## One defect the re-proof found: `dist/`

Worth recording, because it was invisible on CI and would have hit every developer.

`dist/` is the Makefile's pinned toolchain drop — the Dart SDK, the JDK, OTP, Elixir — gitignored, and **absent on CI**, which uses `setup-dart`/`setup-java` instead. So the `shape-gate` job never met it. On a machine that had followed the Makefile's own `dist/` instructions, `make shape-gate` refused with **42 findings, every one of them inside a downloaded toolchain**: the Dart SDK ships `lib/core/stopwatch.dart`, Mix ships `profile.fprof.ex`, OTP ships `clock_gettime`.

The gate was unusable on exactly the trees that can run the whole bench, and green CI could never have told anyone. `dist/` joins `skipDirs` alongside `generated`, `vendor` and `node_modules`, with a comment saying why. Found only because the re-proof ran on a fresh clone provisioned the way the Makefile documents.

## What this gate CANNOT see

Stated plainly, because a gate that oversells itself is worse than none. Also in the package doc, where the next reader will find it.

- **It guards MEASUREMENT, not CORRECTNESS.** A shape-blind runner driving a *defective emitter* is still shape-blind and still passes here. **#198 is the worked example**: the Go emitter wrote a fixed scalar array twice — 32 wire bytes where the other eight languages write 16 — and Go-to-Go round-trips passed clean because both ends shared the defect. Silent wire corruption, and nothing in this gate can see it. Cross-language wire agreement is the conformance suite's job; issue **#203** records the corpus blind spot that let it through. This gate makes the nine legs measure the *same shape*; it does not make the nine emitters agree on the *bytes*.
- **It runs in THIS repository's CI.** A hand-coded serialize benchmark in another repository is entirely outside its reach. See the recommendation below.
- **Markdown is not scanned.** A benchmark pasted into a fenced code block passes.
- **Short and ordinary names are not guarded.** The vocabulary drops identifiers under 4 characters and a stoplist of ordinary words, because `x`, `if`, `delta`, `chat` and `health` are all corpus field names and guarding them would fire on English prose. A bench written using only those names would pass — it would also be unreadable.
- **Small wire sizes are not guarded.** Constants below 32 are not distinctive, so the two smallest corpus shapes are guarded by name only.
- **Comments count as hits, and that is deliberate.** Several ledger entries are comments and say so. Teaching the gate to skip comments would teach it to skip the header a hand-coded bench announces itself in.
- **It is lexical.** Code that computes a field name or a size at run time to evade it passes, and only a human reading the diff would catch that.
- **Gitignored trees are skipped** — `dist/`, `generated/`, `vendor/`, `node_modules/`, `build/`, `target/`. Nothing there is committed, so nothing there can drift into the repo, but the gate is blind inside them by construction.

### Covering the other repos

Nine sibling repos are deleting their in-repo benches (`serialize` #105, `serialize.c` #57, `serialize.cs` #36, `serialize.dart` #3, `serialize.elixir` #2, `serialize.go` #54, `serialize.java` #2, `serialize.js` #9, `serialize.rs` #66). Nothing stops a tenth from appearing.

The cheap cover, **not built here**: lift the timing and paths checks — the two that need no corpus — into a reusable workflow in `mas-bandwidth/.github`, and have each family repo call it. Those two checks are the ones that generalise; `names` and `consts` need a corpus and belong only here. That is a separate PR in a separate repo and should be ruled on separately.

## The register today

Nineteen entries. Ten runner lines (comment / callsite / prose, as classified above), five corpus-tooling lines, two numeric false positives, two `paths` lines for the §1.5 golden pinner.

The register names, deliberately and permanently until superseded: `bench/tools/variantgen` and `realpacket-gen` (one copy of shape code each, which is the design — one copy replacing nine; #195's emitter supersedes variantgen), `bench/tools/inline-gate.sh` (shape names as symbol-map labels and disassembly fixtures — no serialization, no clock), and `test/bench/` (the §1.5 golden pinner: correctness code with no clock, which is exactly the line this gate draws).

Two numeric entries are honest false positives, kept visible rather than special-cased: `bench/java/Main.java` carries three references to GitHub issue **#156**, which collides with a corpus shape's declared 156-bit total, and `bench/c/bench_main.c` states the 438-byte golden size in a comment. Special-casing either would put a hole in the numeric check to buy tidiness.

**Resolved since the original PR:** `bench/results/harness-contract-air/decomp.cpp` — the 294-line hand-coded harness this PR flagged for the owner's ruling, held on the register under all four checks so it could not be forgotten. #201 deleted it and kept the `.md`, which was the recommendation. Its four ledger lines went stale on this rebase and the gate demanded their removal by name.

## Files touched

`bench/tools/shapegate/main.go`, `bench/SHAPE-GATE.allow`, `.github/workflows/ci.yml` (one job), `Makefile` (one target appended), `bench/README.md` (one section appended). Nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
