### PR TITLE
bench/LOCK: control 2 names the rows that exist

### DIFF
--- a/bench/LOCK
+++ b/bench/LOCK
@@ -13,9 +13,17 @@
 # those; any change there means an emitter or example moved). The harness
 # legs and generated/bench/{c,cpp} leave the mechanical lock under TWO
 # procedural controls, enforced at review: (1) emitters byte-unchanged in
-# any PR touching them (git shows it), and (2) the unchanged shapes'
-# c/cpp rows (bench_packet/ints/bits) must reproduce in-sitting in any PR
-# that touches the c/cpp legs.
+# any PR touching them (git shows it), and (2) the c/cpp rows must reproduce
+# in-sitting in any PR that touches the c/cpp legs.
+#
+# AMENDED 2026-08-31: control 2 named bench_packet / bench_ints / bench_bits
+# as the reproduction rows. Those rows no longer exist — the ruling on #196
+# left ONE bench corpus and #199 retired the three hand-coded shapes with it,
+# so a control naming them is a control that cannot be run. **The
+# reproduction rows are bench_mixed (family gen: write and round_trip) and
+# bitpacker (family bits).** bitpacker earns its place by being the negative
+# control: its source is byte-identical across every harness change, so
+# whatever it does is what the translation unit's layout did.
 #
 # While this file exists, CI's cpp-lock job REFUSES any pull request that
 # modifies a path under the prefixes below. Lifting or amending the lock is


### PR DESCRIPTION
bench/LOCK's procedural control 2 requires *"the unchanged shapes' c/cpp
rows (`bench_packet`/`ints`/`bits`)"* to reproduce in-sitting in any PR that
touches the c/cpp legs.

Those three rows no longer exist. The owner's one-bench ruling (#196) left
`Bench.schema` as the only bench corpus, and #199 retired the three
hand-coded shapes with it — their type declarations and goldens survive as
conformance fixtures, but no runner measures them. A control that names rows
nobody can produce is a control that cannot be run, and the very next PR
touching the c/cpp legs (#204) hits it.

**Amended to name `bench_mixed` (family `gen`: `write` and `round_trip`) and
`bitpacker` (family `bits`).**

`bitpacker` is the load-bearing half. Its source is byte-identical across
every harness change — the diffs move only its call site's position in the
file — so any movement it shows is the translation unit's layout and nothing
else. That is exactly what control 2 exists to catch, and it is what both
#199 and #204 found: frozen code moving several percent in one language
because the TU around it shrank.

Per the lock's own amendment protocol, this PR's diff touches **only**
`bench/LOCK`. The mechanical prefix list is untouched (it is currently
suspended under the #189 one-shot carve), and the full lift condition —
the round closing on the owner's word, issue #170 — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
