### PR TITLE
elixir #174: lever M — one binary construction per barrier

### DIFF
--- a/bench/results/2026-09-01-elixirleverm-after-quick-arm64-macbook.csv
+++ b/bench/results/2026-09-01-elixirleverm-after-quick-arm64-macbook.csv
@@ -1,0 +1,49 @@
+# schema bench results
+# date: 2026-08-31T23:42:31Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: SHARED fanless M2 Air, a sibling Claude session (the C# round) live in the estate; load avg recorded per half in the PR. --quick is the iteration instrument, never certification (BENCH-STANDARD §2.8). AFTER half of a paired same-sitting A/B for lever M on branch elixir-lever-m: this branch's Elixir emitter output in generated/bench/elixir; every other leg is the in-sitting control. The lever's own figure comes from the ten-pass INTERLEAVED elixir A/B recorded on the PR, not from this pair — a shared box moves an unpaired half.
+# schema commit: f96d749
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ae730d5 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,3,7502917,7500031,7511501,3134.04,0.15,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,3,3576671,3569319,3580272,1494.01,0.31,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,3,7342521,7340837,7343735,3067.04,0.04,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,3,3649925,3647013,3657136,1524.61,0.28,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,3,2837055,2836037,2837121,1185.06,0.04,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,3,1501184,1498078,1501671,627.06,0.24,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,3,6095022,6093721,6096016,2545.95,0.04,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,3,2331443,2331424,2331786,973.87,0.02,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+cs,bench_mixed,write,4000000,438,3,2108226,2106467,2108546,880.63,0.10,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,3,992966,992760,993827,414.77,0.11,6b213fbfa1a03a99,gen,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,3,1348725,1342674,1351654,563.37,0.67,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,3,764235,761233,764344,319.23,0.41,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,3,5783650,5776137,5790303,2415.88,0.24,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,3,2286995,2239786,2301047,955.30,2.68,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,3,1886882,1883410,1887782,788.17,0.23,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,3,971323,970347,971849,405.73,0.15,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,400000,438,3,433833,433225,434318,181.22,0.25,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,400000,438,3,254139,252878,254142,106.16,0.50,6b213fbfa1a03a99,gen,beam,contract,default,unknown

--- a/bench/results/2026-09-01-elixirleverm-before-quick-arm64-macbook.csv
+++ b/bench/results/2026-09-01-elixirleverm-before-quick-arm64-macbook.csv
@@ -1,0 +1,49 @@
+# schema bench results
+# date: 2026-08-31T23:39:52Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: SHARED fanless M2 Air, a sibling Claude session (the C# round) live in the estate; load avg 4.57 at this half's start. --quick is the iteration instrument, never certification (BENCH-STANDARD §2.8). BEFORE half of a paired same-sitting A/B for lever M on branch elixir-lever-m: main's Elixir emitter output in generated/bench/elixir; every other leg is the in-sitting control. The lever's own figure comes from the ten-pass INTERLEAVED elixir A/B recorded on the PR, not from this pair — a shared box moves an unpaired half.
+# schema commit: d398ec4
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ae730d5 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,3,7409331,7402938,7410440,3094.95,0.10,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,3,3510302,3504147,3514152,1466.29,0.29,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,3,7187768,7184631,7226948,3002.40,0.59,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,3,3519733,3519144,3525437,1470.23,0.18,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,3,2724100,2722843,2725281,1137.88,0.09,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,3,1473753,1469639,1475552,615.60,0.40,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,3,5990326,5986240,5997313,2502.22,0.18,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,3,2289942,2263189,2291520,956.53,1.24,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+cs,bench_mixed,write,4000000,438,3,2050186,1994951,2060694,856.38,3.21,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,3,992472,960247,994998,414.56,3.50,6b213fbfa1a03a99,gen,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,3,1306696,1305404,1312216,545.82,0.52,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,3,748477,746410,748820,312.65,0.32,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,3,5646205,5643302,5647681,2358.47,0.08,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,3,2225496,2210740,2234639,929.61,1.07,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,3,1887711,1885689,1888227,788.51,0.13,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,3,974069,970901,974303,406.88,0.35,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,400000,438,3,382871,382554,383329,159.93,0.20,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,400000,438,3,248137,247261,248616,103.65,0.55,6b213fbfa1a03a99,gen,beam,contract,default,unknown

--- a/generated/bench/elixir/Bench.ex
+++ b/generated/bench/elixir/Bench.ex
@@ -307,7 +307,7 @@ defmodule Bench.Bench do
     v = value_bits7 &&& 0x7F
     scratch = scratch ||| v <<< 45
     v = value_bits13 &&& 0x1FFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 4
     v = value_bits23 &&& 0x7FFFFF
@@ -315,26 +315,31 @@ defmodule Bench.Bench do
     v = if value_flag, do: 1, else: 0
     scratch = scratch ||| v <<< 40
     v = f32_bits(value_x)
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 1
     v = f32_bits(value_y)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = f32_bits(value_z)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = value_big &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = value_big >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(6)-unit(8), sc1::little-size(5)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     # align: zero-pad to the byte boundary (SPEC §4.3)
     data = <<data::binary, scratch>>
@@ -552,7 +557,7 @@ defmodule Bench.Bench do
     end
 
     v = value_f5
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 4
 
@@ -598,10 +603,14 @@ defmodule Bench.Bench do
     end
 
     v = value_f9
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 7
-    data = <<data::binary, scratch::little-size(1)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(6)-unit(8), sc1::little-size(6)-unit(8),
+        scratch::little-size(1)-unit(8)>>
+
     scratch = scratch >>> 8
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -727,22 +736,26 @@ defmodule Bench.Bench do
     v = value_b3 &&& 0x7
     scratch = scratch ||| v <<< 43
     v = value_b32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 6
     v = value_b11 &&& 0x7FF
     scratch = scratch ||| v <<< 38
     v = value_b19 &&& 0x7FFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 1
     v = value_b48 &&& 0xFFFFFFFF
     scratch = scratch ||| v <<< 20
     v = value_b48 >>> 32 &&& 0xFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 4
-    data = <<data::binary, scratch::little-size(2)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(5)-unit(8), sc1::little-size(6)-unit(8),
+        sc2::little-size(6)-unit(8), scratch::little-size(2)-unit(8)>>
+
     scratch = scratch >>> 16
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -971,7 +984,7 @@ defmodule Bench.Bench do
     end
 
     v = value_pos_z + 16383
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 2
     v = value_yaw &&& 0x1FF
@@ -999,7 +1012,7 @@ defmodule Bench.Bench do
     end
 
     v = value_vel_y + 2048
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 7
 
@@ -1046,7 +1059,11 @@ defmodule Bench.Bench do
     scratch = scratch ||| v <<< 53
     v = if value_firing, do: 1, else: 0
     scratch = scratch ||| v <<< 54
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(5)-unit(8), sc1::little-size(5)-unit(8),
+        scratch::little-size(6)-unit(8)>>
+
     scratch = scratch >>> 48
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -1761,16 +1778,16 @@ defmodule Bench.Bench do
     v = value_ack_sequence
     scratch = scratch ||| v <<< 32
     v = value_ack_bits &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_session_id &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_session_id >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = value_client_id &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
 
     if value_nonce < 0 do
@@ -1782,10 +1799,10 @@ defmodule Bench.Bench do
     end
 
     v = value_nonce &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     v = value_nonce >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
 
     if value_world_time < -1_000_000_000_000 do
@@ -1798,12 +1815,12 @@ defmodule Bench.Bench do
 
     w = value_world_time + 1_000_000_000_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
     v = w >>> 32
     scratch = scratch ||| v <<< 32
     v = value_frame_tick &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc7 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 1
     v = value_frame_tick >>> 32 &&& 0xFFFF
@@ -1818,7 +1835,7 @@ defmodule Bench.Bench do
     end
 
     v = value_server_time
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc8 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 1
     n = length(value_entities)
@@ -1833,7 +1850,13 @@ defmodule Bench.Bench do
 
     v = n - 1
     scratch = scratch ||| v <<< 25
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(6)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(5)-unit(8),
+        sc8::little-size(6)-unit(8), scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
     scratch_bits = 4
 
@@ -2015,26 +2038,26 @@ defmodule Bench.Bench do
     v = cf_quantize(value_aim_z, -1.0, 2.0, 200, 200.0)
     scratch = scratch ||| v <<< 16
     v = f32_bits(value_recoil)
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc9 = scratch
     scratch = v
     w = f64_bits(value_drift)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc10 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc11 = scratch
     scratch = v
     v = value_wide_key &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc12 = scratch
     scratch = v
     v = value_wide_key >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc13 = scratch
     scratch = v
     v = value_wide_key >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc14 = scratch
     scratch = v
     v = value_wide_key >>> 96 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc15 = scratch
     scratch = v
 
     if value_flux < -1_267_650_600_228_229_401_496_703_205_376 do
@@ -2047,13 +2070,13 @@ defmodule Bench.Bench do
 
     w = value_flux + 1_267_650_600_228_229_401_496_703_205_376
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc16 = scratch
     scratch = v
     v = w >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc17 = scratch
     scratch = v
     v = w >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc18 = scratch
     scratch = v
     v = w >>> 96
     scratch = scratch ||| v <<< 32
@@ -2067,13 +2090,20 @@ defmodule Bench.Bench do
     end
 
     v = value_ping
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc19 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 6
     # reserved bits ride as zeros (SPEC §4.3)
     v = 0
     scratch = scratch ||| v <<< 22
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+
+    data =
+      <<data::binary, sc9::little-size(3)-unit(8), sc10::little-size(4)-unit(8),
+        sc11::little-size(4)-unit(8), sc12::little-size(4)-unit(8), sc13::little-size(4)-unit(8),
+        sc14::little-size(4)-unit(8), sc15::little-size(4)-unit(8), sc16::little-size(4)-unit(8),
+        sc17::little-size(4)-unit(8), sc18::little-size(4)-unit(8), sc19::little-size(4)-unit(8),
+        scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
     # align: zero-pad to the byte boundary (SPEC §4.3)
     data = <<data::binary, scratch>>
@@ -2652,9 +2682,9 @@ defmodule Bench.Bench do
     end
 
     v = e_pos_z + 16383
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 15
@@ -2686,9 +2716,9 @@ defmodule Bench.Bench do
     end
 
     v = e_vel_y + 2048
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 12
@@ -2743,7 +2773,11 @@ defmodule Bench.Bench do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 1
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_bench_mixed_entities(rest, data, scratch, scratch_bits)
@@ -2751,7 +2785,7 @@ defmodule Bench.Bench do
 
   defp w_bench_mixed_stats([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_bench_mixed_stats([e1, e2 | rest], data, scratch, scratch_bits) do
+  defp w_bench_mixed_stats([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     %{stat_id: e1_stat_id, delta: e1_delta} = e1
     v = e1_stat_id &&& 0xFF
     scratch = scratch ||| v <<< scratch_bits
@@ -2784,8 +2818,44 @@ defmodule Bench.Bench do
     v = e2_delta + 512
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 10
+    %{stat_id: e3_stat_id, delta: e3_delta} = e3
+    v = e3_stat_id &&& 0xFF
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 8
+
+    if e3_delta < -512 do
+      raise ArgumentError, "e.delta is below the wire minimum"
+    end
+
+    if e3_delta > 511 do
+      raise ArgumentError, "e.delta is above the wire maximum"
+    end
+
+    v = e3_delta + 512
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 10
+    %{stat_id: e4_stat_id, delta: e4_delta} = e4
+    v = e4_stat_id &&& 0xFF
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 8
+
+    if e4_delta < -512 do
+      raise ArgumentError, "e.delta is below the wire minimum"
+    end
+
+    if e4_delta > 511 do
+      raise ArgumentError, "e.delta is above the wire maximum"
+    end
+
+    v = e4_delta + 512
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 10
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_bench_mixed_stats(rest, data, scratch, scratch_bits)

--- a/generated/bench/elixir/realworld/RealWorld.ex
+++ b/generated/bench/elixir/realworld/RealWorld.ex
@@ -477,11 +477,11 @@ defmodule Realworld.RealWorld do
     scratch = v
     w = f64_bits(value_f002f64)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(2)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 16
     scratch = scratch ||| v <<< 5
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 5
 
@@ -494,7 +494,7 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f003_int + 835_897
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 5
     v = cf_quantize(value_f004_cf32, 0.0, 2000.0, 20000, 20000.0)
@@ -520,17 +520,17 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f006_int + 1513
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 6
     v = f32_bits(value_f007f32)
     scratch = scratch ||| v <<< 18
     v = value_f008u64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc4 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 2
     v = value_f008u64 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
 
@@ -545,13 +545,19 @@ defmodule Realworld.RealWorld do
     v = value_f009_int + 22
     scratch = scratch ||| v <<< 34
     v = f32_bits(value_f010f32)
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc6 = scratch
     scratch = v
     v = value_f011_bits &&& 0x3FF
     scratch = scratch ||| v <<< 32
     v = if value_f012_bool, do: 1, else: 0
     scratch = scratch ||| v <<< 42
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(2)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(6)-unit(8), sc4::little-size(6)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(5)-unit(8),
+        scratch::little-size(5)-unit(8)>>
+
     scratch = scratch >>> 40
 
     {data, scratch} =
@@ -598,7 +604,7 @@ defmodule Realworld.RealWorld do
         end
 
         v = value_f016_fixed + 37_748_736
-        data = <<data::binary, scratch::little-size(6)-unit(8)>>
+        sc7 = scratch
         scratch = scratch >>> 48
         scratch = scratch ||| v <<< 3
 
@@ -612,7 +618,7 @@ defmodule Realworld.RealWorld do
 
         v = value_f017_uint
         scratch = scratch ||| v <<< 30
-        data = <<data::binary, scratch::little-size(5)-unit(8)>>
+        data = <<data::binary, sc7::little-size(6)-unit(8), scratch::little-size(5)-unit(8)>>
         scratch = scratch >>> 40
         {data, scratch}
       else
@@ -633,11 +639,11 @@ defmodule Realworld.RealWorld do
     v = w &&& 0xFFFFFFFF
     scratch = scratch ||| v <<< 14
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc7 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 6
     v = f32_bits(value_f020f32)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 6
 
@@ -650,19 +656,19 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f021_ufixed
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc9 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 6
     v = f32_bits(value_f022f32)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc10 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = value_f023_bits &&& 0x1FFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc11 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = f32_bits(value_f024f32)
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc12 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 2
 
@@ -677,7 +683,7 @@ defmodule Realworld.RealWorld do
     v = value_f025_fixed + 30464
     scratch = scratch ||| v <<< 34
     v = value_f026_bits &&& 0x1FF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc13 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 2
     v = cf_quantize(value_f027_cf32, -2.0, 4.0, 16, 16.0)
@@ -687,11 +693,11 @@ defmodule Realworld.RealWorld do
     v = value_f029i64 &&& 0xFFFFFFFF
     scratch = scratch ||| v <<< 20
     v = value_f029i64 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc14 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 4
     v = f32_bits(value_f030f32)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc15 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 4
     v = value_f031_bits &&& 0x1
@@ -717,7 +723,7 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f033_uint
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc16 = scratch
     scratch = v
 
     if value_f034_uint < 0 do
@@ -748,7 +754,7 @@ defmodule Realworld.RealWorld do
     v = if value_f038_bool, do: 1, else: 0
     scratch = scratch ||| v <<< 45
     v = value_f039_bits &&& 0x7FFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc17 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 6
 
@@ -774,11 +780,18 @@ defmodule Realworld.RealWorld do
     v = value_f041_int + 55
     scratch = scratch ||| v <<< 41
     v = value_f042_bits &&& 0x3FFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc18 = scratch
     scratch = v
     v = if value_f043_bool, do: 1, else: 0
     scratch = scratch ||| v <<< 30
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+
+    data =
+      <<data::binary, sc7::little-size(5)-unit(8), sc8::little-size(4)-unit(8),
+        sc9::little-size(4)-unit(8), sc10::little-size(4)-unit(8), sc11::little-size(4)-unit(8),
+        sc12::little-size(3)-unit(8), sc13::little-size(6)-unit(8), sc14::little-size(6)-unit(8),
+        sc15::little-size(4)-unit(8), sc16::little-size(5)-unit(8), sc17::little-size(5)-unit(8),
+        sc18::little-size(6)-unit(8), scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
 
     {data, scratch, scratch_bits} =
@@ -804,7 +817,7 @@ defmodule Realworld.RealWorld do
         end
 
         v = value_f046_uint
-        data = <<data::binary, scratch::little-size(6)-unit(8)>>
+        sc19 = scratch
         scratch = scratch >>> 48
         scratch = scratch ||| v <<< 3
 
@@ -818,7 +831,7 @@ defmodule Realworld.RealWorld do
 
         v = value_f047_int + 430_976
         scratch = scratch ||| v <<< 20
-        data = <<data::binary, scratch::little-size(5)-unit(8)>>
+        data = <<data::binary, sc19::little-size(6)-unit(8), scratch::little-size(5)-unit(8)>>
         scratch_bits = 0
         scratch = 0
         {data, scratch, scratch_bits}
@@ -832,9 +845,9 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc19 = scratch
+    fl19 = scratch_bits >>> 3
+    scratch = scratch >>> (fl19 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -854,7 +867,7 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 1
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc19::little-size(fl19)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
 
@@ -938,16 +951,16 @@ defmodule Realworld.RealWorld do
     scratch_bits = scratch_bits + 32
     w = f64_bits(value_f059f64)
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc20 = scratch
+    fl20 = scratch_bits >>> 3
+    scratch = scratch >>> (fl20 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc21 = scratch
+    fl21 = scratch_bits >>> 3
+    scratch = scratch >>> (fl21 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -967,9 +980,9 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f062_uint
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc22 = scratch
+    fl22 = scratch_bits >>> 3
+    scratch = scratch >>> (fl22 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 9
@@ -977,9 +990,9 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_f063i64 >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc23 = scratch
+    fl23 = scratch_bits >>> 3
+    scratch = scratch >>> (fl23 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -1008,9 +1021,9 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f066_ufixed
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc24 = scratch
+    fl24 = scratch_bits >>> 3
+    scratch = scratch >>> (fl24 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
@@ -1036,9 +1049,9 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 2
     v = cf_quantize(value_f071_cf32, 0.0, 10.0, 500, 500.0)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc25 = scratch
+    fl25 = scratch_bits >>> 3
+    scratch = scratch >>> (fl25 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 9
@@ -1061,7 +1074,13 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 1
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc20::little-size(fl20)-unit(8), sc21::little-size(fl21)-unit(8),
+        sc22::little-size(fl22)-unit(8), sc23::little-size(fl23)-unit(8),
+        sc24::little-size(fl24)-unit(8), sc25::little-size(fl25)-unit(8),
+        scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
 
@@ -1079,9 +1098,9 @@ defmodule Realworld.RealWorld do
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         v = value_f075u64 >>> 32 &&& 0xFFFFFFFF
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc26 = scratch
+        fl26 = scratch_bits >>> 3
+        scratch = scratch >>> (fl26 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
@@ -1107,9 +1126,9 @@ defmodule Realworld.RealWorld do
         end
 
         v = value_f077_int + 17
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc27 = scratch
+        fl27 = scratch_bits >>> 3
+        scratch = scratch >>> (fl27 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 6
@@ -1129,7 +1148,11 @@ defmodule Realworld.RealWorld do
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 5
         flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+        data =
+          <<data::binary, sc26::little-size(fl26)-unit(8), sc27::little-size(fl27)-unit(8),
+            scratch::little-size(flush)-unit(8)>>
+
         scratch = scratch >>> (flush <<< 3)
         scratch_bits = scratch_bits &&& 7
         {data, scratch, scratch_bits}
@@ -1144,9 +1167,9 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 29
     v = value_f082_bits &&& 0x1FFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc26 = scratch
+    fl26 = scratch_bits >>> 3
+    scratch = scratch >>> (fl26 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 25
@@ -1175,9 +1198,9 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 8
     v = value_f085_bits &&& 0x1FFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc27 = scratch
+    fl27 = scratch_bits >>> 3
+    scratch = scratch >>> (fl27 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 21
@@ -1195,16 +1218,16 @@ defmodule Realworld.RealWorld do
     scratch_bits = scratch_bits + 9
     w = f64_bits(value_f087f64)
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc28 = scratch
+    fl28 = scratch_bits >>> 3
+    scratch = scratch >>> (fl28 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc29 = scratch
+    fl29 = scratch_bits >>> 3
+    scratch = scratch >>> (fl29 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -1221,9 +1244,9 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 11
     v = value_f089_bits &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc30 = scratch
+    fl30 = scratch_bits >>> 3
+    scratch = scratch >>> (fl30 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -1240,9 +1263,9 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f090_uint
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc31 = scratch
+    fl31 = scratch_bits >>> 3
+    scratch = scratch >>> (fl31 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 8
@@ -1261,9 +1284,9 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_f093_bits >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc32 = scratch
+    fl32 = scratch_bits >>> 3
+    scratch = scratch >>> (fl32 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -1280,9 +1303,9 @@ defmodule Realworld.RealWorld do
     end
 
     v = value_f095_fixed + 103_350_272
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc33 = scratch
+    fl33 = scratch_bits >>> 3
+    scratch = scratch >>> (fl33 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 28
@@ -1290,14 +1313,21 @@ defmodule Realworld.RealWorld do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 18
     v = value_f097_bits &&& 0xFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc34 = scratch
+    fl34 = scratch_bits >>> 3
+    scratch = scratch >>> (fl34 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 12
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc26::little-size(fl26)-unit(8), sc27::little-size(fl27)-unit(8),
+        sc28::little-size(fl28)-unit(8), sc29::little-size(fl29)-unit(8),
+        sc30::little-size(fl30)-unit(8), sc31::little-size(fl31)-unit(8),
+        sc32::little-size(fl32)-unit(8), sc33::little-size(fl33)-unit(8),
+        sc34::little-size(fl34)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     if scratch_bits != 0, do: <<data::binary, scratch>>, else: data

--- a/generated/elixir-ludicrous/Ludicrous.ex
+++ b/generated/elixir-ludicrous/Ludicrous.ex
@@ -193,7 +193,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_position + 1_966_080_000
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 1
 
@@ -207,7 +207,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_reach + 65_536_000_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = w >>> 32
@@ -222,7 +222,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_ticks
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 6
 
@@ -230,7 +230,10 @@ defmodule Ludicrous.Ludicrous do
       raise ArgumentError, "value.samples must hold exactly 2 elements"
     end
 
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
     scratch_bits = 2
 
@@ -357,11 +360,11 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_span &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 1
     v = value_span >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
 
@@ -374,7 +377,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_reach &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = value_reach >>> 32
@@ -389,7 +392,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_ticks
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 6
 
@@ -397,7 +400,11 @@ defmodule Ludicrous.Ludicrous do
       raise ArgumentError, "value.samples must hold exactly 2 elements"
     end
 
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8),
+        scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
     scratch_bits = 2
 
@@ -520,13 +527,13 @@ defmodule Ludicrous.Ludicrous do
     v = value_entity_id &&& 0xFFFFFFFF
     scratch = v
     v = value_entity_id >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_entity_id >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_entity_id >>> 96 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
 
     if value_energy < -5_000_000_000 do
@@ -539,7 +546,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_energy + 5_000_000_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
     scratch = scratch ||| v <<< 32
@@ -554,15 +561,15 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_flux + 1_267_650_600_228_229_401_496_703_205_376
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 96
@@ -579,22 +586,29 @@ defmodule Ludicrous.Ludicrous do
     v = value_bias + 1000
     scratch = scratch ||| v <<< 40
     v = value_seed &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc7 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 3
     v = value_seed >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
     v = value_seed >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc9 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
     v = value_seed >>> 96 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc10 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(6)-unit(8),
+        sc8::little-size(4)-unit(8), sc9::little-size(4)-unit(8), sc10::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -771,7 +785,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_probe_position + 1_966_080_000
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 3
 
@@ -785,7 +799,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_probe_reach + 65_536_000_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
     v = w >>> 32
@@ -800,14 +814,17 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_probe_ticks
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc2 = scratch
     scratch = v
 
     if length(value_probe_samples) != 2 do
       raise ArgumentError, "value.probe.samples must hold exactly 2 elements"
     end
 
-    data = <<data::binary, scratch::little-size(2)-unit(8)>>
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(5)-unit(8), scratch::little-size(2)-unit(8)>>
+
     scratch = scratch >>> 16
     scratch_bits = 4
 
@@ -826,23 +843,23 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_entity_id >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc3 = scratch
+    fl3 = scratch_bits >>> 3
+    scratch = scratch >>> (fl3 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_entity_id >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc4 = scratch
+    fl4 = scratch_bits >>> 3
+    scratch = scratch >>> (fl4 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_entity_id >>> 96 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc5 = scratch
+    fl5 = scratch_bits >>> 3
+    scratch = scratch >>> (fl5 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -857,9 +874,9 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_wide_energy + 5_000_000_000
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc6 = scratch
+    fl6 = scratch_bits >>> 3
+    scratch = scratch >>> (fl6 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -877,23 +894,23 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_wide_flux + 1_267_650_600_228_229_401_496_703_205_376
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc7 = scratch
+    fl7 = scratch_bits >>> 3
+    scratch = scratch >>> (fl7 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc8 = scratch
+    fl8 = scratch_bits >>> 3
+    scratch = scratch >>> (fl8 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc9 = scratch
+    fl9 = scratch_bits >>> 3
+    scratch = scratch >>> (fl9 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -913,30 +930,30 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 11
     v = value_wide_seed &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc10 = scratch
+    fl10 = scratch_bits >>> 3
+    scratch = scratch >>> (fl10 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_seed >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc11 = scratch
+    fl11 = scratch_bits >>> 3
+    scratch = scratch >>> (fl11 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_seed >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc12 = scratch
+    fl12 = scratch_bits >>> 3
+    scratch = scratch >>> (fl12 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_seed >>> 96 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc13 = scratch
+    fl13 = scratch_bits >>> 3
+    scratch = scratch >>> (fl13 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -950,7 +967,15 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 3
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc3::little-size(fl3)-unit(8), sc4::little-size(fl4)-unit(8),
+        sc5::little-size(fl5)-unit(8), sc6::little-size(fl6)-unit(8),
+        sc7::little-size(fl7)-unit(8), sc8::little-size(fl8)-unit(8),
+        sc9::little-size(fl9)-unit(8), sc10::little-size(fl10)-unit(8),
+        sc11::little-size(fl11)-unit(8), sc12::little-size(fl12)-unit(8),
+        sc13::little-size(fl13)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
 
@@ -971,28 +996,32 @@ defmodule Ludicrous.Ludicrous do
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         v = value.target_id >>> 32 &&& 0xFFFFFFFF
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc14 = scratch
+        fl14 = scratch_bits >>> 3
+        scratch = scratch >>> (fl14 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         v = value.target_id >>> 64 &&& 0xFFFFFFFF
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc15 = scratch
+        fl15 = scratch_bits >>> 3
+        scratch = scratch >>> (fl15 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         v = value.target_id >>> 96 &&& 0xFFFFFFFF
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc16 = scratch
+        fl16 = scratch_bits >>> 3
+        scratch = scratch >>> (fl16 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+        data =
+          <<data::binary, sc14::little-size(fl14)-unit(8), sc15::little-size(fl15)-unit(8),
+            sc16::little-size(fl16)-unit(8), scratch::little-size(flush)-unit(8)>>
+
         scratch = scratch >>> (flush <<< 3)
         scratch_bits = scratch_bits &&& 7
         {data, scratch, scratch_bits}
@@ -1330,7 +1359,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_y + 6_553_600_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 32
@@ -1346,12 +1375,16 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_z + 6_553_600_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 4
     v = w >>> 32
     scratch = scratch ||| v <<< 36
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -1448,7 +1481,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_y + 1_073_741_824
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_z < -1_073_741_824 do
@@ -1460,7 +1493,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_z + 1_073_741_824
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
 
     if value_w < -1_073_741_824 do
@@ -1472,9 +1505,13 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_w + 1_073_741_824
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -1529,7 +1566,7 @@ defmodule Ludicrous.Ludicrous do
 
   defp w_fixed_probe_samples([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_fixed_probe_samples([e1, e2 | rest], data, scratch, scratch_bits) do
+  defp w_fixed_probe_samples([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < -524_288 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1553,8 +1590,36 @@ defmodule Ludicrous.Ludicrous do
     v = e2 + 524_288
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 21
+
+    if e3 < -524_288 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 524_288 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3 + 524_288
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
+
+    if e4 < -524_288 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 524_288 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4 + 524_288
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_fixed_probe_samples(rest, data, scratch, scratch_bits)
@@ -1611,7 +1676,7 @@ defmodule Ludicrous.Ludicrous do
   defp w_unsigned_probe_samples([], data, scratch, scratch_bits),
     do: {data, scratch, scratch_bits}
 
-  defp w_unsigned_probe_samples([e1, e2 | rest], data, scratch, scratch_bits) do
+  defp w_unsigned_probe_samples([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < 0 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1635,8 +1700,36 @@ defmodule Ludicrous.Ludicrous do
     v = e2
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 21
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 1_048_576 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 1_048_576 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_unsigned_probe_samples(rest, data, scratch, scratch_bits)
@@ -1697,28 +1790,32 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 96 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_ludicrous_state_keys(rest, data, scratch, scratch_bits)

--- a/generated/elixir/Clauses.ex
+++ b/generated/elixir/Clauses.ex
@@ -1506,7 +1506,7 @@ defmodule Example.Clauses do
 
   defp w_w17_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_w17_items([e1, e2, e3 | rest], data, scratch, scratch_bits) do
+  defp w_w17_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < 0 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1542,8 +1542,24 @@ defmodule Example.Clauses do
     v = e3
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 17
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 131_071 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 17
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_w17_items(rest, data, scratch, scratch_bits)
@@ -1592,7 +1608,7 @@ defmodule Example.Clauses do
 
   defp w_w26_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_w26_items([e1, e2 | rest], data, scratch, scratch_bits) do
+  defp w_w26_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < 0 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1616,8 +1632,36 @@ defmodule Example.Clauses do
     v = e2
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 26
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 67_108_863 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 26
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 67_108_863 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 26
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_w26_items(rest, data, scratch, scratch_bits)
@@ -1758,6 +1802,89 @@ defmodule Example.Clauses do
 
   defp w_w52_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
+  defp w_w52_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
+    if e1 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e1 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e1 &&& 0xFFFFFFFF
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e1 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+
+    if e2 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e2 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e2 &&& 0xFFFFFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e2 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3 &&& 0xFFFFFFFF
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e3 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4 &&& 0xFFFFFFFF
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e4 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+    flush = scratch_bits >>> 3
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
+    scratch = scratch >>> (flush <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    w_w52_items(rest, data, scratch, scratch_bits)
+  end
+
   defp w_w52_items([e | rest], data, scratch, scratch_bits) do
     if e < 0 do
       raise ArgumentError, "e is below the wire minimum"
@@ -1796,6 +1923,89 @@ defmodule Example.Clauses do
   end
 
   defp w_w50_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
+
+  defp w_w50_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
+    if e1 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e1 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e1 &&& 0xFFFFFFFF
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e1 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+
+    if e2 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e2 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e2 &&& 0xFFFFFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e2 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3 &&& 0xFFFFFFFF
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e3 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4 &&& 0xFFFFFFFF
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e4 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+    flush = scratch_bits >>> 3
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
+    scratch = scratch >>> (flush <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    w_w50_items(rest, data, scratch, scratch_bits)
+  end
 
   defp w_w50_items([e | rest], data, scratch, scratch_bits) do
     if e < 0 do

--- a/generated/elixir/Degenerate.ex
+++ b/generated/elixir/Degenerate.ex
@@ -92,16 +92,20 @@ defmodule Example.Degenerate do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -547,9 +551,9 @@ defmodule Example.Degenerate do
     v = value_b &&& 0xFFFFF
     scratch = scratch ||| v <<< 20
     v = value_c &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(3)-unit(8)>>
     data
   end
 
@@ -609,9 +613,9 @@ defmodule Example.Degenerate do
     v = value_inner_b &&& 0xFFFFF
     scratch = scratch ||| v <<< 20
     v = value_inner_c &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(3)-unit(8)>>
     data
   end
 
@@ -673,11 +677,11 @@ defmodule Example.Degenerate do
     v = value_inner_b &&& 0xFFFFF
     scratch = scratch ||| v <<< 20
     v = value_inner_c &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_trailer &&& 0xFFFF
     scratch = scratch ||| v <<< 24
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(5)-unit(8)>>
     data
   end
 
@@ -759,45 +763,52 @@ defmodule Example.Degenerate do
     v = value_pad0 &&& 0xFFFFFFFF
     scratch = v
     v = value_pad0 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_pad1 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_pad1 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = value_pad2 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = value_pad2 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     v = value_pad3 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = value_pad3 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
     v = value_pad4 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc7 = scratch
     scratch = v
     v = value_pad4 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = v
     v = value_pad5 &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc9 = scratch
     scratch = v
     %{a: value_inner_a, b: value_inner_b, c: value_inner_c} = value_inner
     v = value_inner_a &&& 0xFFFFF
     scratch = scratch ||| v <<< 24
     v = value_inner_b &&& 0xFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc10 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 4
     v = value_inner_c &&& 0xFFFFFF
     scratch = scratch ||| v <<< 24
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(4)-unit(8),
+        sc8::little-size(4)-unit(8), sc9::little-size(4)-unit(8), sc10::little-size(5)-unit(8),
+        scratch::little-size(6)-unit(8)>>
+
     data
   end
 
@@ -904,14 +915,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_f64_values(rest, data, scratch, scratch_bits)
@@ -939,14 +950,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_u64_values(rest, data, scratch, scratch_bits)
@@ -974,14 +985,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_i64_values(rest, data, scratch, scratch_bits)
@@ -1009,14 +1020,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_one_values(rest, data, scratch, scratch_bits)
@@ -1039,7 +1050,7 @@ defmodule Example.Degenerate do
 
   defp w_span_chunk_values([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_span_chunk_values([e1, e2, e3 | rest], data, scratch, scratch_bits) do
+  defp w_span_chunk_values([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     v = e1 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
@@ -1049,8 +1060,15 @@ defmodule Example.Degenerate do
     v = e3 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
+    v = e4 &&& 0xFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 16
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_chunk_values(rest, data, scratch, scratch_bits)
@@ -1101,14 +1119,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_tail_values(rest, data, scratch, scratch_bits)
@@ -1137,14 +1155,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_twice_a(rest, data, scratch, scratch_bits)
@@ -1158,14 +1176,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_twice_b(rest, data, scratch, scratch_bits)

--- a/generated/elixir/Joins.ex
+++ b/generated/elixir/Joins.ex
@@ -1397,13 +1397,13 @@ defmodule Example.Joins do
     v = value_p &&& 0xFFFFFFFF
     scratch = v
     v = value_q &&& 0x1FFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_r &&& 0x7FFFF
     scratch = scratch ||| v <<< 29
     v = value_tail &&& 0xF
     scratch = scratch ||| v <<< 48
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    data = <<data::binary, sc0::little-size(4)-unit(8), scratch::little-size(6)-unit(8)>>
     scratch = scratch >>> 48
     # the residual byte, statically known to be there
     <<data::binary, scratch>>

--- a/generated/elixir/Render.ex
+++ b/generated/elixir/Render.ex
@@ -54,13 +54,13 @@ defmodule Example.Render do
     v = value_sort_key &&& 0xFFFFFFFF
     scratch = v
     v = value_sort_key >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_mesh_id &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_material_id &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = value_layer &&& 0xFF
     scratch = scratch ||| v <<< 32
@@ -75,7 +75,11 @@ defmodule Example.Render do
 
     v = value_team
     scratch = scratch ||| v <<< 40
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(5)-unit(8)>>
+
     scratch = scratch >>> 40
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -165,7 +169,7 @@ defmodule Example.Render do
     v = value_worker_index &&& 0xFFFFFFFF
     scratch = v
     v = value_sprite_count_hint &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     n = length(value_sprites)
 
@@ -175,7 +179,7 @@ defmodule Example.Render do
 
     v = n
     scratch = scratch ||| v <<< 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    data = <<data::binary, sc0::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
     scratch = scratch >>> 32
     scratch_bits = 7
 
@@ -253,23 +257,23 @@ defmodule Example.Render do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_sort_key >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_mesh_id &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_material_id &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -289,7 +293,11 @@ defmodule Example.Render do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 2
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_render_block_sprites(rest, data, scratch, scratch_bits)

--- a/generated/elixir/Types.ex
+++ b/generated/elixir/Types.ex
@@ -157,23 +157,28 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     w = f64_bits(value_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -248,30 +253,36 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     w = f64_bits(value_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     w = f64_bits(value_w)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -451,10 +462,10 @@ defmodule Example.Types do
     end
 
     v = value_z + 8_388_608
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 2
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(6)-unit(8), scratch::little-size(3)-unit(8)>>
     scratch = scratch >>> 24
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -550,10 +561,10 @@ defmodule Example.Types do
     end
 
     v = value_z + 2_097_152
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 6
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(3)-unit(8)>>
     scratch = scratch >>> 24
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -738,21 +749,21 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_position_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     w = f64_bits(value_position_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
 
     %{
@@ -764,35 +775,43 @@ defmodule Example.Types do
 
     w = f64_bits(value_orientation_x)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
     w = f64_bits(value_orientation_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc7 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = v
     w = f64_bits(value_orientation_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc9 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc10 = scratch
     scratch = v
     w = f64_bits(value_orientation_w)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc11 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc12 = scratch
     scratch = v
     v = if value_at_rest, do: 1, else: 0
     scratch = scratch ||| v <<< 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(4)-unit(8),
+        sc8::little-size(4)-unit(8), sc9::little-size(4)-unit(8), sc10::little-size(4)-unit(8),
+        sc11::little-size(4)-unit(8), sc12::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
 
     {data, scratch} =
@@ -812,25 +831,25 @@ defmodule Example.Types do
         v = w &&& 0xFFFFFFFF
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc13 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_linear_velocity_y)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc14 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc15 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_linear_velocity_z)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc16 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc17 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
 
@@ -842,32 +861,40 @@ defmodule Example.Types do
 
         w = f64_bits(value_angular_velocity_x)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc18 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc19 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_angular_velocity_y)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc20 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc21 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_angular_velocity_z)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc22 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc23 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+        data =
+          <<data::binary, sc13::little-size(4)-unit(8), sc14::little-size(4)-unit(8),
+            sc15::little-size(4)-unit(8), sc16::little-size(4)-unit(8),
+            sc17::little-size(4)-unit(8), sc18::little-size(4)-unit(8),
+            sc19::little-size(4)-unit(8), sc20::little-size(4)-unit(8),
+            sc21::little-size(4)-unit(8), sc22::little-size(4)-unit(8),
+            sc23::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
         scratch = scratch >>> 32
         {data, scratch}
       else
@@ -1127,16 +1154,16 @@ defmodule Example.Types do
     v = f32_bits(value_stick_x)
     scratch = v
     v = f32_bits(value_stick_y)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = f32_bits(value_throttle)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = f32_bits(value_yaw)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = f32_bits(value_pitch)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = if value_fire, do: 1, else: 0
     scratch = scratch ||| v <<< 32
@@ -1154,7 +1181,12 @@ defmodule Example.Types do
     scratch = scratch ||| v <<< 38
     v = if value_ping, do: 1, else: 0
     scratch = scratch ||| v <<< 39
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8),
+        scratch::little-size(5)-unit(8)>>
+
     data
   end
 
@@ -1272,13 +1304,13 @@ defmodule Example.Types do
     v = value_current_frame &&& 0xFFFFFFFF
     scratch = scratch ||| v <<< 16
     v = value_current_frame >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_start_frame &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_start_frame >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     n = length(value_inputs)
 
@@ -1288,7 +1320,11 @@ defmodule Example.Types do
 
     v = n
     scratch = scratch ||| v <<< 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(6)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     scratch_bits = 5
 
@@ -1437,7 +1473,7 @@ defmodule Example.Types do
     end
 
     v = value_position_y + 8_388_608
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 4
 
@@ -1468,7 +1504,7 @@ defmodule Example.Types do
     end
 
     v = value_rotation_x + 1024
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 6
 
@@ -1520,7 +1556,7 @@ defmodule Example.Types do
     end
 
     v = value_linear_velocity_x + 2_097_152
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 6
 
@@ -1544,12 +1580,17 @@ defmodule Example.Types do
     end
 
     v = value_linear_velocity_z + 2_097_152
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 4
     v = if value_has_flags, do: 1, else: 0
     scratch = scratch ||| v <<< 27
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(6)-unit(8),
+        sc2::little-size(6)-unit(8), sc3::little-size(6)-unit(8),
+        scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
 
     {data, scratch, scratch_bits} =
@@ -1903,7 +1944,7 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_doubled_floor < -9_223_372_036_854_775_808 do
@@ -1916,10 +1957,10 @@ defmodule Example.Types do
 
     w = value_doubled_floor + 9_223_372_036_854_775_808
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
 
     if value_ceiling_range < 1 do
@@ -1932,24 +1973,30 @@ defmodule Example.Types do
 
     w = value_ceiling_range - 1
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     v = value_floor_default &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = value_floor_default >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
     v = value_ceiling_default &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc7 = scratch
     scratch = v
     v = value_ceiling_default >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(4)-unit(8),
+        sc8::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -2080,7 +2127,7 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_clamped_ceiling < 1 do
@@ -2093,24 +2140,30 @@ defmodule Example.Types do
 
     w = value_clamped_ceiling - 1
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = value_floor_def &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = value_floor_def >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     v = value_ceiling_def &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = value_ceiling_def >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -2209,30 +2262,30 @@ defmodule Example.Types do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_stick_y)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_throttle)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_yaw)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_pitch)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc3 = scratch
+    fl3 = scratch_bits >>> 3
+    scratch = scratch >>> (fl3 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2261,7 +2314,12 @@ defmodule Example.Types do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 1
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), sc3::little-size(fl3)-unit(8),
+        scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_input_packet_inputs(rest, data, scratch, scratch_bits)

--- a/generated/elixir/Wire.ex
+++ b/generated/elixir/Wire.ex
@@ -261,9 +261,9 @@ defmodule Example.Wire do
     v = value_probe_id &&& 0xFFFFFFFF
     scratch = v
     v = value_probe_id >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    data = <<data::binary, sc0::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
     data
   end
 
@@ -363,11 +363,11 @@ defmodule Example.Wire do
     v = value_boundary >>> 32 &&& 0x1
     scratch = scratch ||| v <<< 41
     v = value_wide &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 2
     v = value_wide >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
 
@@ -380,7 +380,7 @@ defmodule Example.Wire do
     end
 
     v = value_sensor
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
 
@@ -393,14 +393,19 @@ defmodule Example.Wire do
     end
 
     v = value_nonce &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = value_nonce >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(5)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -514,14 +519,18 @@ defmodule Example.Wire do
     v = value_raw_delta &&& 0xFFFFFFFF
     scratch = scratch ||| v <<< 17
     v = value_big_delta &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 1
     v = value_big_delta >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(6)-unit(8), sc1::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
 
     {data, scratch, scratch_bits} =
@@ -1810,7 +1819,7 @@ defmodule Example.Wire do
     v = value_header_probe_id &&& 0xFFFFFFFF
     scratch = v
     v = value_header_probe_id >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_flags >>> 8 != 0 do
@@ -1828,7 +1837,7 @@ defmodule Example.Wire do
     } = value_echo
 
     v = value_echo_test_a &&& 0xFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc1 = scratch
     scratch = v
 
     if value_echo_test_b < 0 do
@@ -1863,7 +1872,11 @@ defmodule Example.Wire do
 
     v = value_echo_test_d
     scratch = scratch ||| v <<< 36
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(5)-unit(8),
+        scratch::little-size(5)-unit(8)>>
+
     scratch = scratch >>> 40
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -2078,9 +2091,10 @@ defmodule Example.Wire do
     end
 
     v = n
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 1
+    data = <<data::binary, sc0::little-size(6)-unit(8)>>
     scratch_bits = 6
     {data, scratch, scratch_bits} = w_test_data_items(value_items, data, scratch, scratch_bits)
     v = f32_bits(value_float_value)
@@ -2091,16 +2105,16 @@ defmodule Example.Wire do
     scratch_bits = scratch_bits + 10
     w = f64_bits(value_double_value)
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2108,9 +2122,9 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 8
     v = value_int16_value &&& 0xFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc3 = scratch
+    fl3 = scratch_bits >>> 3
+    scratch = scratch >>> (fl3 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
@@ -2121,37 +2135,37 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
     v = value_uint32_value &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc4 = scratch
+    fl4 = scratch_bits >>> 3
+    scratch = scratch >>> (fl4 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_uint64_value &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc5 = scratch
+    fl5 = scratch_bits >>> 3
+    scratch = scratch >>> (fl5 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_uint64_value >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc6 = scratch
+    fl6 = scratch_bits >>> 3
+    scratch = scratch >>> (fl6 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_int64_full &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc7 = scratch
+    fl7 = scratch_bits >>> 3
+    scratch = scratch >>> (fl7 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_int64_full >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc8 = scratch
+    fl8 = scratch_bits >>> 3
+    scratch = scratch >>> (fl8 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2166,9 +2180,9 @@ defmodule Example.Wire do
 
     w = value_int64_range + 1_000_000_000_000
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc9 = scratch
+    fl9 = scratch_bits >>> 3
+    scratch = scratch >>> (fl9 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2176,7 +2190,14 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 9
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc1::little-size(fl1)-unit(8), sc2::little-size(fl2)-unit(8),
+        sc3::little-size(fl3)-unit(8), sc4::little-size(fl4)-unit(8),
+        sc5::little-size(fl5)-unit(8), sc6::little-size(fl6)-unit(8),
+        sc7::little-size(fl7)-unit(8), sc8::little-size(fl8)-unit(8),
+        sc9::little-size(fl9)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     # align: zero-pad to the byte boundary (SPEC §4.3)
@@ -2478,7 +2499,7 @@ defmodule Example.Wire do
 
   defp w_probe_sample_samples([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_probe_sample_samples([e1, e2, e3 | rest], data, scratch, scratch_bits) do
+  defp w_probe_sample_samples([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     v = e1 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
@@ -2488,8 +2509,15 @@ defmodule Example.Wire do
     v = e3 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
+    v = e4 &&& 0xFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 16
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_probe_sample_samples(rest, data, scratch, scratch_bits)
@@ -2682,21 +2710,25 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_big_delta &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_big_delta >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
 

--- a/internal/codegen/elixir/elixir.go
+++ b/internal/codegen/elixir/elixir.go
@@ -182,9 +182,16 @@ type gen struct {
 	fn strings.Builder
 
 	// pendW is the merge group open at this point of write emission: the
-	// static bits merged into the scratch since the last flush. Barriers
-	// close it; mergeW closes it when the next field would pass the budget.
+	// static bits merged into the scratch since the last spill. Barriers
+	// close it; mergeW spills when the next field would pass the budget.
 	pendW int64
+
+	// segW is the barrier's pending binary construction: the registers the
+	// full-group spills emptied the scratch into, waiting to ride ONE append
+	// as several segments. segN names the next one. A barrier drains them,
+	// so both are empty across every emission boundary.
+	segW []wseg
+	segN int
 
 	// the scratch's STATIC state, where the emitter knows it. A write
 	// function starts at a known zero and stays known until a value the

--- a/internal/codegen/elixir/functions.go
+++ b/internal/codegen/elixir/functions.go
@@ -47,7 +47,7 @@ const writeGroupBits = 52
 
 // mergeW merges v (already inside bits) into the scratch. The whole bytes do
 // NOT leave on every field: the generator knows every width statically, so it
-// carries a group of up to writeGroupBits and flushes once for the group,
+// carries a group of up to writeGroupBits and spills once for the group,
 // which is one bs_append BIF call for the group instead of one per field.
 // Every statement rebinds ONE variable (an Elixir conditional cannot rebind
 // several without a tuple, and the merge must allocate none). bits in [1, 32];
@@ -55,7 +55,7 @@ const writeGroupBits = 52
 // 2^59.
 func (g *gen) mergeW(bits int64, ind string) {
 	if g.pendW+bits > writeGroupBits {
-		g.flushW(ind)
+		g.spillW(ind)
 	}
 	switch {
 	case !g.sbKnown:
@@ -76,23 +76,92 @@ func (g *gen) mergeW(bits int64, ind string) {
 	g.pendW += bits
 }
 
-// flushW sends the group's whole bytes to the output binary and leaves the
-// scratch invariant the group model rests on: scratch_bits in [0, 7] and
-// scratch below 2^scratch_bits. It is a no-op when no group is open, which is
-// what makes a barrier free where one is already closed.
+// wseg is one segment waiting to ride the barrier's binary construction: the
+// register holding the bytes, and their width — a literal byte count where the
+// offset is static, otherwise the name of the local that computed it.
+type wseg struct {
+	reg   string
+	whole int64
+	width string
+}
+
+// text renders the segment. A literal width is the form the BEAM's binary
+// construction is built for; a dynamic one costs the same (measured: twelve
+// appends of a dynamic-width segment cost 103.7 ns against 103.6 for literal
+// widths — the append is the expense, not the arithmetic around it).
+func (s wseg) text() string {
+	if s.width != "" {
+		return fmt.Sprintf("%s::little-size(%s)-unit(8)", s.reg, s.width)
+	}
+	return fmt.Sprintf("%s::little-size(%d)-unit(8)", s.reg, s.whole)
+}
+
+// spillW empties the scratch's whole bytes into a fresh register because the
+// merge group is FULL, not because anything is about to observe data. The
+// bytes are recorded as a pending segment and the append is deferred to the
+// barrier, where one binary construction carries every register that spilled
+// since the last one.
+//
+// The statement count is what it was — a bind and a shift where there was an
+// append and a shift — and the fixnum envelope is untouched: a register is
+// filled by exactly the spill that used to append it, so it holds what the
+// scratch held, below 2^59. Registers stay live to the barrier; the BEAM has
+// 1024 of them and the deepest run in the tree spends nine.
+func (g *gen) spillW(ind string) {
+	if g.pendW == 0 {
+		return
+	}
+	g.pendW = 0
+	reg := fmt.Sprintf("sc%d", g.segN)
+	if !g.sbKnown {
+		width := fmt.Sprintf("fl%d", g.segN)
+		g.segN++
+		g.pf("%s%s = scratch\n", ind, reg)
+		g.pf("%s%s = scratch_bits >>> 3\n", ind, width)
+		g.pf("%sscratch = scratch >>> (%s <<< 3)\n", ind, width)
+		g.pf("%sscratch_bits = scratch_bits &&& 7\n", ind)
+		g.segW = append(g.segW, wseg{reg: reg, width: width})
+		return
+	}
+	whole, rest := g.sbVal>>3, g.sbVal&7
+	g.sbVal = rest
+	if whole == 0 {
+		return // under a byte: the group carries, nothing leaves
+	}
+	g.segN++
+	// the segment takes the low whole bytes, so the residual bits riding
+	// above them are simply not in the segment and need no masking here
+	g.pf("%s%s = scratch\n", ind, reg)
+	g.segW = append(g.segW, wseg{reg: reg, whole: whole})
+	if rest == 0 {
+		g.scZero, g.scBound = true, false
+		return
+	}
+	g.pf("%sscratch = scratch >>> %d\n", ind, whole<<3)
+}
+
+// flushW closes the group at a barrier: every register that spilled since the
+// last barrier, plus the scratch's own whole bytes, ride ONE binary
+// construction. It leaves the scratch invariant the group model rests on —
+// scratch_bits in [0, 7] and scratch below 2^scratch_bits — and is a no-op
+// when no group is open, which is what makes a barrier free where one is
+// already closed.
 //
 // EVERY point that observes data or scratch_bits outside the merge — the
 // function tail, an align, the bytes of a string, a loop helper's call and its
 // own tail, and the joins of a branch or a union case — is a barrier and calls
 // this first.
 func (g *gen) flushW(ind string) {
-	if g.pendW == 0 {
+	if g.pendW == 0 && len(g.segW) == 0 {
 		return
 	}
 	g.pendW = 0
+	segs := g.segW
+	g.segW = nil
 	if !g.sbKnown {
 		g.pf("%sflush = scratch_bits >>> 3\n", ind)
-		g.pf("%sdata = <<data::binary, scratch::little-size(flush)-unit(8)>>\n", ind)
+		segs = append(segs, wseg{reg: "scratch", width: "flush"})
+		g.segAppend(segs, ind)
 		g.pf("%sscratch = scratch >>> (flush <<< 3)\n", ind)
 		g.pf("%sscratch_bits = scratch_bits &&& 7\n", ind)
 		return
@@ -101,11 +170,17 @@ func (g *gen) flushW(ind string) {
 	// three bookkeeping statements are not emitted at all
 	whole, rest := g.sbVal>>3, g.sbVal&7
 	g.sbVal = rest
-	if whole == 0 {
-		return // under a byte: the group carries, nothing leaves
+	if whole > 0 {
+		g.scBound = true
+		segs = append(segs, wseg{reg: "scratch", whole: whole})
 	}
-	g.scBound = true
-	g.pf("%sdata = <<data::binary, scratch::little-size(%d)-unit(8)>>\n", ind, whole)
+	if len(segs) == 0 {
+		return // under a byte and nothing spilled: the group carries
+	}
+	g.segAppend(segs, ind)
+	if whole == 0 {
+		return // the scratch kept every bit it had; only registers left
+	}
 	if rest == 0 {
 		// the scratch held exactly the bytes that left, so its value is now
 		// zero — and it is not WRITTEN here, because the next merge of an
@@ -115,6 +190,38 @@ func (g *gen) flushW(ind string) {
 		return
 	}
 	g.pf("%sscratch = scratch >>> %d\n", ind, whole<<3)
+}
+
+// segAppend prints the barrier's one binary construction. Where the one-line
+// form outgrows the formatter's width the statement breaks after the `=` and
+// the segments fill greedily, which is mix format's own shape for a long
+// bitstring: `<<` at ind+2, continuations at ind+4, and each segment measured
+// with the comma or the closing `>>` that will follow it.
+func (g *gen) segAppend(segs []wseg, ind string) {
+	parts := make([]string, 0, len(segs)+1)
+	parts = append(parts, "data::binary")
+	for _, s := range segs {
+		parts = append(parts, s.text())
+	}
+	if one := ind + "data = <<" + strings.Join(parts, ", ") + ">>"; len(one) <= formatWidth {
+		g.pf("%s\n", one)
+		return
+	}
+	g.pf("\n%sdata =\n", ind)
+	line := ind + "  <<" + parts[0]
+	for i := 1; i < len(parts); i++ {
+		tail := 1 // the comma that follows this segment
+		if i == len(parts)-1 {
+			tail = 2 // the closing >> instead
+		}
+		if len(line)+1+1+len(parts[i])+tail > formatWidth {
+			g.pf("%s,\n", line)
+			line = ind + "    " + parts[i]
+			continue
+		}
+		line += ", " + parts[i]
+	}
+	g.pf("%s>>\n\n", line)
 }
 
 // syncSB materializes scratch_bits where the emitted code is about to read it
@@ -153,10 +260,12 @@ type sbState struct {
 	pend    int64
 	scBound bool
 	sbBound bool
+	segs    []wseg
+	segN    int
 }
 
 func (g *gen) sbSave() sbState {
-	return sbState{g.sbKnown, g.sbVal, g.scZero, g.pendW, g.scBound, g.sbBound}
+	return sbState{g.sbKnown, g.sbVal, g.scZero, g.pendW, g.scBound, g.sbBound, g.segW, g.segN}
 }
 
 // captureArm emits one arm of a branch or a union case into a detached
@@ -191,6 +300,7 @@ func sbAgree(arms []sbState) (int64, bool) {
 func (g *gen) sbRestore(s sbState) {
 	g.sbKnown, g.sbVal, g.scZero, g.pendW = s.known, s.val, s.zero, s.pend
 	g.scBound, g.sbBound = s.scBound, s.sbBound
+	g.segW, g.segN = s.segs, s.segN
 }
 
 // joinArm is one captured emission path of a branch or a union case: the
@@ -584,7 +694,7 @@ func (g *gen) emitWriteFunction(name string, items []ir.Item) {
 	g.usesImport = true
 	snake := ir.RustSnake(name)
 	g.fn.Reset()
-	g.pendW = 0
+	g.pendW, g.segW, g.segN = 0, nil, 0
 	// the surface starts at a known empty scratch: everything up to the
 	// first length the message's own data decides packs at literal offsets
 	g.sbKnown, g.sbVal, g.scZero = true, 0, true
@@ -929,7 +1039,7 @@ func (g *gen) writeHelper(f *ir.Field) string {
 	savedSB := g.sbSave()
 	savedBind, savedDisp, savedUsed := g.bindW, g.bindDisp, g.bindUsed
 	g.fn = strings.Builder{}
-	g.pendW = 0 // the helper is entered with the caller's group closed
+	g.pendW, g.segW, g.segN = 0, nil, 0 // entered with the caller's group closed
 	// and at an offset the caller's element count decides, so the helper's
 	// body maintains scratch_bits the way it did before the static pass
 	g.sbKnown, g.scZero = false, false
@@ -962,18 +1072,23 @@ func (g *gen) writeHelper(f *ir.Field) string {
 // share and the clause body is a bigger and bigger one.
 const writeUnrollMax = 4
 
-// writeUnroll is how many elements one clause of the loop writes. Elements
-// of a statically known width share a merge group — and so ONE append —
-// while the group's budget holds; measured, cutting appends is worth about a
-// quarter of a static run, and nothing else about the element changes. An
-// element whose width the wire decides gets one clause per element, as
-// before.
+// writeUnroll is how many elements one clause of the loop writes. What the
+// clause shares is ONE APPEND, and the append is the barrier's, not the merge
+// group's: a clause that outgrows the 52-bit group spills into a register and
+// keeps merging, and every register it spilled rides the tail's single binary
+// construction as its own segment. So the group budget no longer bounds k —
+// only the unroll cap does, and a stats clause of 18-bit elements takes four
+// (72 bits, two segments, one append) where the group alone allowed two.
+//
+// An element whose width the wire decides still gets one clause per element:
+// the clause's own tail is where it would have to be measured, and there is
+// nothing static to add up.
 func (g *gen) writeUnroll(f *ir.Field) int64 {
 	eb, ok := g.staticBitsScalar(f)
 	if !ok || eb <= 0 || eb > writeGroupBits {
 		return 1
 	}
-	return min(writeGroupBits/eb, writeUnrollMax)
+	return writeUnrollMax
 }
 
 // writeClause emits one clause of a write loop, taking k elements off the
@@ -994,7 +1109,7 @@ func (g *gen) writeClause(f *ir.Field, name string, k int64) {
 		// the raise text names the ELEMENT, never the clause's slot for it
 		g.bindDisp[ev] = "e"
 	}
-	g.pendW = 0
+	g.pendW, g.segW, g.segN = 0, nil, 0
 	g.sbKnown, g.scZero = false, false
 	g.scBound, g.sbBound = true, true
 	g.pf("  defp %s([%s | rest], data, scratch, scratch_bits) do\n", name, strings.Join(evs, ", "))

--- a/internal/codegen/elixir/functions.go
+++ b/internal/codegen/elixir/functions.go
@@ -350,6 +350,14 @@ func (g *gen) emitWriteJoin(ind, open, close string, arms []joinArm) {
 	g.pf("%s%s", ind, close)
 	g.pf("\n")
 	g.pendW, g.scZero = 0, false
+	// segW must not survive a join: registers spilled BEFORE the join would
+	// re-emit at the next barrier (silently — the wire-corruption class),
+	// and registers spilled INSIDE an arm would fail to compile outside it.
+	// Today every arm ends in a flush so this is always nil already; the
+	// reset guards the shape a future emitter change could produce. segN
+	// stays monotonic on purpose — resetting it renumbers registers after
+	// every join, churning the generated text for no safety.
+	g.segW = nil
 	g.sbKnown, g.sbVal = agree, val
 	g.scBound = true
 	g.sbBound = entrySB || !agree

--- a/testdata/golden/elixir/Clauses.ex
+++ b/testdata/golden/elixir/Clauses.ex
@@ -1506,7 +1506,7 @@ defmodule Example.Clauses do
 
   defp w_w17_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_w17_items([e1, e2, e3 | rest], data, scratch, scratch_bits) do
+  defp w_w17_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < 0 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1542,8 +1542,24 @@ defmodule Example.Clauses do
     v = e3
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 17
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 131_071 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 17
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_w17_items(rest, data, scratch, scratch_bits)
@@ -1592,7 +1608,7 @@ defmodule Example.Clauses do
 
   defp w_w26_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_w26_items([e1, e2 | rest], data, scratch, scratch_bits) do
+  defp w_w26_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < 0 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1616,8 +1632,36 @@ defmodule Example.Clauses do
     v = e2
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 26
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 67_108_863 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 26
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 67_108_863 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 26
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_w26_items(rest, data, scratch, scratch_bits)
@@ -1758,6 +1802,89 @@ defmodule Example.Clauses do
 
   defp w_w52_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
+  defp w_w52_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
+    if e1 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e1 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e1 &&& 0xFFFFFFFF
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e1 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+
+    if e2 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e2 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e2 &&& 0xFFFFFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e2 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3 &&& 0xFFFFFFFF
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e3 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 4_503_599_627_370_495 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4 &&& 0xFFFFFFFF
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e4 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 20
+    flush = scratch_bits >>> 3
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
+    scratch = scratch >>> (flush <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    w_w52_items(rest, data, scratch, scratch_bits)
+  end
+
   defp w_w52_items([e | rest], data, scratch, scratch_bits) do
     if e < 0 do
       raise ArgumentError, "e is below the wire minimum"
@@ -1796,6 +1923,89 @@ defmodule Example.Clauses do
   end
 
   defp w_w50_items([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
+
+  defp w_w50_items([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
+    if e1 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e1 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e1 &&& 0xFFFFFFFF
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e1 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+
+    if e2 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e2 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e2 &&& 0xFFFFFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e2 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3 &&& 0xFFFFFFFF
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e3 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 1_125_899_906_842_623 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4 &&& 0xFFFFFFFF
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 32
+    v = e4 >>> 32
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 18
+    flush = scratch_bits >>> 3
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
+    scratch = scratch >>> (flush <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    w_w50_items(rest, data, scratch, scratch_bits)
+  end
 
   defp w_w50_items([e | rest], data, scratch, scratch_bits) do
     if e < 0 do

--- a/testdata/golden/elixir/Degenerate.ex
+++ b/testdata/golden/elixir/Degenerate.ex
@@ -92,16 +92,20 @@ defmodule Example.Degenerate do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -547,9 +551,9 @@ defmodule Example.Degenerate do
     v = value_b &&& 0xFFFFF
     scratch = scratch ||| v <<< 20
     v = value_c &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(3)-unit(8)>>
     data
   end
 
@@ -609,9 +613,9 @@ defmodule Example.Degenerate do
     v = value_inner_b &&& 0xFFFFF
     scratch = scratch ||| v <<< 20
     v = value_inner_c &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(3)-unit(8)>>
     data
   end
 
@@ -673,11 +677,11 @@ defmodule Example.Degenerate do
     v = value_inner_b &&& 0xFFFFF
     scratch = scratch ||| v <<< 20
     v = value_inner_c &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_trailer &&& 0xFFFF
     scratch = scratch ||| v <<< 24
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(5)-unit(8)>>
     data
   end
 
@@ -759,45 +763,52 @@ defmodule Example.Degenerate do
     v = value_pad0 &&& 0xFFFFFFFF
     scratch = v
     v = value_pad0 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_pad1 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_pad1 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = value_pad2 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = value_pad2 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     v = value_pad3 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = value_pad3 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
     v = value_pad4 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc7 = scratch
     scratch = v
     v = value_pad4 >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = v
     v = value_pad5 &&& 0xFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc9 = scratch
     scratch = v
     %{a: value_inner_a, b: value_inner_b, c: value_inner_c} = value_inner
     v = value_inner_a &&& 0xFFFFF
     scratch = scratch ||| v <<< 24
     v = value_inner_b &&& 0xFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc10 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 4
     v = value_inner_c &&& 0xFFFFFF
     scratch = scratch ||| v <<< 24
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(4)-unit(8),
+        sc8::little-size(4)-unit(8), sc9::little-size(4)-unit(8), sc10::little-size(5)-unit(8),
+        scratch::little-size(6)-unit(8)>>
+
     data
   end
 
@@ -904,14 +915,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_f64_values(rest, data, scratch, scratch_bits)
@@ -939,14 +950,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_u64_values(rest, data, scratch, scratch_bits)
@@ -974,14 +985,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_i64_values(rest, data, scratch, scratch_bits)
@@ -1009,14 +1020,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_one_values(rest, data, scratch, scratch_bits)
@@ -1039,7 +1050,7 @@ defmodule Example.Degenerate do
 
   defp w_span_chunk_values([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_span_chunk_values([e1, e2, e3 | rest], data, scratch, scratch_bits) do
+  defp w_span_chunk_values([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     v = e1 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
@@ -1049,8 +1060,15 @@ defmodule Example.Degenerate do
     v = e3 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
+    v = e4 &&& 0xFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 16
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_chunk_values(rest, data, scratch, scratch_bits)
@@ -1101,14 +1119,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_tail_values(rest, data, scratch, scratch_bits)
@@ -1137,14 +1155,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_twice_a(rest, data, scratch, scratch_bits)
@@ -1158,14 +1176,14 @@ defmodule Example.Degenerate do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_span_twice_b(rest, data, scratch, scratch_bits)

--- a/testdata/golden/elixir/Joins.ex
+++ b/testdata/golden/elixir/Joins.ex
@@ -1397,13 +1397,13 @@ defmodule Example.Joins do
     v = value_p &&& 0xFFFFFFFF
     scratch = v
     v = value_q &&& 0x1FFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_r &&& 0x7FFFF
     scratch = scratch ||| v <<< 29
     v = value_tail &&& 0xF
     scratch = scratch ||| v <<< 48
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    data = <<data::binary, sc0::little-size(4)-unit(8), scratch::little-size(6)-unit(8)>>
     scratch = scratch >>> 48
     # the residual byte, statically known to be there
     <<data::binary, scratch>>

--- a/testdata/golden/elixir/Render.ex
+++ b/testdata/golden/elixir/Render.ex
@@ -54,13 +54,13 @@ defmodule Example.Render do
     v = value_sort_key &&& 0xFFFFFFFF
     scratch = v
     v = value_sort_key >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_mesh_id &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_material_id &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = value_layer &&& 0xFF
     scratch = scratch ||| v <<< 32
@@ -75,7 +75,11 @@ defmodule Example.Render do
 
     v = value_team
     scratch = scratch ||| v <<< 40
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(5)-unit(8)>>
+
     scratch = scratch >>> 40
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -165,7 +169,7 @@ defmodule Example.Render do
     v = value_worker_index &&& 0xFFFFFFFF
     scratch = v
     v = value_sprite_count_hint &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     n = length(value_sprites)
 
@@ -175,7 +179,7 @@ defmodule Example.Render do
 
     v = n
     scratch = scratch ||| v <<< 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    data = <<data::binary, sc0::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
     scratch = scratch >>> 32
     scratch_bits = 7
 
@@ -253,23 +257,23 @@ defmodule Example.Render do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_sort_key >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_mesh_id &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_material_id &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -289,7 +293,11 @@ defmodule Example.Render do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 2
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_render_block_sprites(rest, data, scratch, scratch_bits)

--- a/testdata/golden/elixir/Types.ex
+++ b/testdata/golden/elixir/Types.ex
@@ -157,23 +157,28 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     w = f64_bits(value_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -248,30 +253,36 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     w = f64_bits(value_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     w = f64_bits(value_w)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -451,10 +462,10 @@ defmodule Example.Types do
     end
 
     v = value_z + 8_388_608
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 2
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(6)-unit(8), scratch::little-size(3)-unit(8)>>
     scratch = scratch >>> 24
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -550,10 +561,10 @@ defmodule Example.Types do
     end
 
     v = value_z + 2_097_152
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 6
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data = <<data::binary, sc0::little-size(5)-unit(8), scratch::little-size(3)-unit(8)>>
     scratch = scratch >>> 24
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -738,21 +749,21 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     w = f64_bits(value_position_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     w = f64_bits(value_position_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
 
     %{
@@ -764,35 +775,43 @@ defmodule Example.Types do
 
     w = f64_bits(value_orientation_x)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
     w = f64_bits(value_orientation_y)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc7 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = v
     w = f64_bits(value_orientation_z)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc9 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc10 = scratch
     scratch = v
     w = f64_bits(value_orientation_w)
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc11 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc12 = scratch
     scratch = v
     v = if value_at_rest, do: 1, else: 0
     scratch = scratch ||| v <<< 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(4)-unit(8),
+        sc8::little-size(4)-unit(8), sc9::little-size(4)-unit(8), sc10::little-size(4)-unit(8),
+        sc11::little-size(4)-unit(8), sc12::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
 
     {data, scratch} =
@@ -812,25 +831,25 @@ defmodule Example.Types do
         v = w &&& 0xFFFFFFFF
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc13 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_linear_velocity_y)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc14 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc15 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_linear_velocity_z)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc16 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc17 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
 
@@ -842,32 +861,40 @@ defmodule Example.Types do
 
         w = f64_bits(value_angular_velocity_x)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc18 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc19 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_angular_velocity_y)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc20 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc21 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         w = f64_bits(value_angular_velocity_z)
         v = w &&& 0xFFFFFFFF
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc22 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
         v = w >>> 32
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+        sc23 = scratch
         scratch = scratch >>> 32
         scratch = scratch ||| v <<< 1
-        data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+        data =
+          <<data::binary, sc13::little-size(4)-unit(8), sc14::little-size(4)-unit(8),
+            sc15::little-size(4)-unit(8), sc16::little-size(4)-unit(8),
+            sc17::little-size(4)-unit(8), sc18::little-size(4)-unit(8),
+            sc19::little-size(4)-unit(8), sc20::little-size(4)-unit(8),
+            sc21::little-size(4)-unit(8), sc22::little-size(4)-unit(8),
+            sc23::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
         scratch = scratch >>> 32
         {data, scratch}
       else
@@ -1127,16 +1154,16 @@ defmodule Example.Types do
     v = f32_bits(value_stick_x)
     scratch = v
     v = f32_bits(value_stick_y)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = f32_bits(value_throttle)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = f32_bits(value_yaw)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = f32_bits(value_pitch)
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = if value_fire, do: 1, else: 0
     scratch = scratch ||| v <<< 32
@@ -1154,7 +1181,12 @@ defmodule Example.Types do
     scratch = scratch ||| v <<< 38
     v = if value_ping, do: 1, else: 0
     scratch = scratch ||| v <<< 39
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8),
+        scratch::little-size(5)-unit(8)>>
+
     data
   end
 
@@ -1272,13 +1304,13 @@ defmodule Example.Types do
     v = value_current_frame &&& 0xFFFFFFFF
     scratch = scratch ||| v <<< 16
     v = value_current_frame >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_start_frame &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_start_frame >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     n = length(value_inputs)
 
@@ -1288,7 +1320,11 @@ defmodule Example.Types do
 
     v = n
     scratch = scratch ||| v <<< 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(6)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     scratch_bits = 5
 
@@ -1437,7 +1473,7 @@ defmodule Example.Types do
     end
 
     v = value_position_y + 8_388_608
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 4
 
@@ -1468,7 +1504,7 @@ defmodule Example.Types do
     end
 
     v = value_rotation_x + 1024
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 6
 
@@ -1520,7 +1556,7 @@ defmodule Example.Types do
     end
 
     v = value_linear_velocity_x + 2_097_152
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 6
 
@@ -1544,12 +1580,17 @@ defmodule Example.Types do
     end
 
     v = value_linear_velocity_z + 2_097_152
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 4
     v = if value_has_flags, do: 1, else: 0
     scratch = scratch ||| v <<< 27
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(6)-unit(8),
+        sc2::little-size(6)-unit(8), sc3::little-size(6)-unit(8),
+        scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
 
     {data, scratch, scratch_bits} =
@@ -1903,7 +1944,7 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_doubled_floor < -9_223_372_036_854_775_808 do
@@ -1916,10 +1957,10 @@ defmodule Example.Types do
 
     w = value_doubled_floor + 9_223_372_036_854_775_808
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
 
     if value_ceiling_range < 1 do
@@ -1932,24 +1973,30 @@ defmodule Example.Types do
 
     w = value_ceiling_range - 1
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     v = value_floor_default &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = value_floor_default >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
     v = value_ceiling_default &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc7 = scratch
     scratch = v
     v = value_ceiling_default >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(4)-unit(8),
+        sc8::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -2080,7 +2127,7 @@ defmodule Example.Types do
     v = w &&& 0xFFFFFFFF
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_clamped_ceiling < 1 do
@@ -2093,24 +2140,30 @@ defmodule Example.Types do
 
     w = value_clamped_ceiling - 1
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = w >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
     v = value_floor_def &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = value_floor_def >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = v
     v = value_ceiling_def &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = v
     v = value_ceiling_def >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -2209,30 +2262,30 @@ defmodule Example.Types do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_stick_y)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_throttle)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_yaw)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = f32_bits(e_pitch)
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc3 = scratch
+    fl3 = scratch_bits >>> 3
+    scratch = scratch >>> (fl3 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2261,7 +2314,12 @@ defmodule Example.Types do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 1
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), sc3::little-size(fl3)-unit(8),
+        scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_input_packet_inputs(rest, data, scratch, scratch_bits)

--- a/testdata/golden/elixir/Wire.ex
+++ b/testdata/golden/elixir/Wire.ex
@@ -261,9 +261,9 @@ defmodule Example.Wire do
     v = value_probe_id &&& 0xFFFFFFFF
     scratch = v
     v = value_probe_id >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    data = <<data::binary, sc0::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
     data
   end
 
@@ -363,11 +363,11 @@ defmodule Example.Wire do
     v = value_boundary >>> 32 &&& 0x1
     scratch = scratch ||| v <<< 41
     v = value_wide &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 40
     scratch = scratch ||| v <<< 2
     v = value_wide >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
 
@@ -380,7 +380,7 @@ defmodule Example.Wire do
     end
 
     v = value_sensor
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
 
@@ -393,14 +393,19 @@ defmodule Example.Wire do
     end
 
     v = value_nonce &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = value_nonce >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(5)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -514,14 +519,18 @@ defmodule Example.Wire do
     v = value_raw_delta &&& 0xFFFFFFFF
     scratch = scratch ||| v <<< 17
     v = value_big_delta &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 1
     v = value_big_delta >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(6)-unit(8), sc1::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
 
     {data, scratch, scratch_bits} =
@@ -1810,7 +1819,7 @@ defmodule Example.Wire do
     v = value_header_probe_id &&& 0xFFFFFFFF
     scratch = v
     v = value_header_probe_id >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_flags >>> 8 != 0 do
@@ -1828,7 +1837,7 @@ defmodule Example.Wire do
     } = value_echo
 
     v = value_echo_test_a &&& 0xFFFF
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc1 = scratch
     scratch = v
 
     if value_echo_test_b < 0 do
@@ -1863,7 +1872,11 @@ defmodule Example.Wire do
 
     v = value_echo_test_d
     scratch = scratch ||| v <<< 36
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(5)-unit(8),
+        scratch::little-size(5)-unit(8)>>
+
     scratch = scratch >>> 40
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -2078,9 +2091,10 @@ defmodule Example.Wire do
     end
 
     v = n
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 1
+    data = <<data::binary, sc0::little-size(6)-unit(8)>>
     scratch_bits = 6
     {data, scratch, scratch_bits} = w_test_data_items(value_items, data, scratch, scratch_bits)
     v = f32_bits(value_float_value)
@@ -2091,16 +2105,16 @@ defmodule Example.Wire do
     scratch_bits = scratch_bits + 10
     w = f64_bits(value_double_value)
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2108,9 +2122,9 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 8
     v = value_int16_value &&& 0xFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc3 = scratch
+    fl3 = scratch_bits >>> 3
+    scratch = scratch >>> (fl3 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
@@ -2121,37 +2135,37 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
     v = value_uint32_value &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc4 = scratch
+    fl4 = scratch_bits >>> 3
+    scratch = scratch >>> (fl4 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_uint64_value &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc5 = scratch
+    fl5 = scratch_bits >>> 3
+    scratch = scratch >>> (fl5 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_uint64_value >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc6 = scratch
+    fl6 = scratch_bits >>> 3
+    scratch = scratch >>> (fl6 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_int64_full &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc7 = scratch
+    fl7 = scratch_bits >>> 3
+    scratch = scratch >>> (fl7 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_int64_full >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc8 = scratch
+    fl8 = scratch_bits >>> 3
+    scratch = scratch >>> (fl8 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2166,9 +2180,9 @@ defmodule Example.Wire do
 
     w = value_int64_range + 1_000_000_000_000
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc9 = scratch
+    fl9 = scratch_bits >>> 3
+    scratch = scratch >>> (fl9 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -2176,7 +2190,14 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 9
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc1::little-size(fl1)-unit(8), sc2::little-size(fl2)-unit(8),
+        sc3::little-size(fl3)-unit(8), sc4::little-size(fl4)-unit(8),
+        sc5::little-size(fl5)-unit(8), sc6::little-size(fl6)-unit(8),
+        sc7::little-size(fl7)-unit(8), sc8::little-size(fl8)-unit(8),
+        sc9::little-size(fl9)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     # align: zero-pad to the byte boundary (SPEC §4.3)
@@ -2478,7 +2499,7 @@ defmodule Example.Wire do
 
   defp w_probe_sample_samples([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_probe_sample_samples([e1, e2, e3 | rest], data, scratch, scratch_bits) do
+  defp w_probe_sample_samples([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     v = e1 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
@@ -2488,8 +2509,15 @@ defmodule Example.Wire do
     v = e3 &&& 0xFFFF
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 16
+    v = e4 &&& 0xFFFF
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 16
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_probe_sample_samples(rest, data, scratch, scratch_bits)
@@ -2682,21 +2710,25 @@ defmodule Example.Wire do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_big_delta &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e_big_delta >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
 

--- a/testdata/golden/ludicrous/elixir/Ludicrous.ex
+++ b/testdata/golden/ludicrous/elixir/Ludicrous.ex
@@ -193,7 +193,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_position + 1_966_080_000
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 1
 
@@ -207,7 +207,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_reach + 65_536_000_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = w >>> 32
@@ -222,7 +222,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_ticks
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 6
 
@@ -230,7 +230,10 @@ defmodule Ludicrous.Ludicrous do
       raise ArgumentError, "value.samples must hold exactly 2 elements"
     end
 
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
     scratch_bits = 2
 
@@ -357,11 +360,11 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_span &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 1
     v = value_span >>> 32
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
 
@@ -374,7 +377,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_reach &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 1
     v = value_reach >>> 32
@@ -389,7 +392,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_ticks
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 6
 
@@ -397,7 +400,11 @@ defmodule Ludicrous.Ludicrous do
       raise ArgumentError, "value.samples must hold exactly 2 elements"
     end
 
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8),
+        scratch::little-size(3)-unit(8)>>
+
     scratch = scratch >>> 24
     scratch_bits = 2
 
@@ -520,13 +527,13 @@ defmodule Ludicrous.Ludicrous do
     v = value_entity_id &&& 0xFFFFFFFF
     scratch = v
     v = value_entity_id >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
     v = value_entity_id >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
     v = value_entity_id >>> 96 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
 
     if value_energy < -5_000_000_000 do
@@ -539,7 +546,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_energy + 5_000_000_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc3 = scratch
     scratch = v
     v = w >>> 32
     scratch = scratch ||| v <<< 32
@@ -554,15 +561,15 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_flux + 1_267_650_600_228_229_401_496_703_205_376
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc4 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc5 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc6 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 96
@@ -579,22 +586,29 @@ defmodule Ludicrous.Ludicrous do
     v = value_bias + 1000
     scratch = scratch ||| v <<< 40
     v = value_seed &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(6)-unit(8)>>
+    sc7 = scratch
     scratch = scratch >>> 48
     scratch = scratch ||| v <<< 3
     v = value_seed >>> 32 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc8 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
     v = value_seed >>> 64 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc9 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
     v = value_seed >>> 96 &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc10 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), sc3::little-size(4)-unit(8), sc4::little-size(4)-unit(8),
+        sc5::little-size(4)-unit(8), sc6::little-size(4)-unit(8), sc7::little-size(6)-unit(8),
+        sc8::little-size(4)-unit(8), sc9::little-size(4)-unit(8), sc10::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -771,7 +785,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_probe_position + 1_966_080_000
-    data = <<data::binary, scratch::little-size(3)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 24
     scratch = scratch ||| v <<< 3
 
@@ -785,7 +799,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_probe_reach + 65_536_000_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 3
     v = w >>> 32
@@ -800,14 +814,17 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_probe_ticks
-    data = <<data::binary, scratch::little-size(5)-unit(8)>>
+    sc2 = scratch
     scratch = v
 
     if length(value_probe_samples) != 2 do
       raise ArgumentError, "value.probe.samples must hold exactly 2 elements"
     end
 
-    data = <<data::binary, scratch::little-size(2)-unit(8)>>
+    data =
+      <<data::binary, sc0::little-size(3)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(5)-unit(8), scratch::little-size(2)-unit(8)>>
+
     scratch = scratch >>> 16
     scratch_bits = 4
 
@@ -826,23 +843,23 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_entity_id >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc3 = scratch
+    fl3 = scratch_bits >>> 3
+    scratch = scratch >>> (fl3 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_entity_id >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc4 = scratch
+    fl4 = scratch_bits >>> 3
+    scratch = scratch >>> (fl4 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_entity_id >>> 96 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc5 = scratch
+    fl5 = scratch_bits >>> 3
+    scratch = scratch >>> (fl5 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -857,9 +874,9 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_wide_energy + 5_000_000_000
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc6 = scratch
+    fl6 = scratch_bits >>> 3
+    scratch = scratch >>> (fl6 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -877,23 +894,23 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_wide_flux + 1_267_650_600_228_229_401_496_703_205_376
     v = w &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc7 = scratch
+    fl7 = scratch_bits >>> 3
+    scratch = scratch >>> (fl7 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc8 = scratch
+    fl8 = scratch_bits >>> 3
+    scratch = scratch >>> (fl8 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = w >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc9 = scratch
+    fl9 = scratch_bits >>> 3
+    scratch = scratch >>> (fl9 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -913,30 +930,30 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 11
     v = value_wide_seed &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc10 = scratch
+    fl10 = scratch_bits >>> 3
+    scratch = scratch >>> (fl10 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_seed >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc11 = scratch
+    fl11 = scratch_bits >>> 3
+    scratch = scratch >>> (fl11 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_seed >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc12 = scratch
+    fl12 = scratch_bits >>> 3
+    scratch = scratch >>> (fl12 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = value_wide_seed >>> 96 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc13 = scratch
+    fl13 = scratch_bits >>> 3
+    scratch = scratch >>> (fl13 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
@@ -950,7 +967,15 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 3
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc3::little-size(fl3)-unit(8), sc4::little-size(fl4)-unit(8),
+        sc5::little-size(fl5)-unit(8), sc6::little-size(fl6)-unit(8),
+        sc7::little-size(fl7)-unit(8), sc8::little-size(fl8)-unit(8),
+        sc9::little-size(fl9)-unit(8), sc10::little-size(fl10)-unit(8),
+        sc11::little-size(fl11)-unit(8), sc12::little-size(fl12)-unit(8),
+        sc13::little-size(fl13)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
 
@@ -971,28 +996,32 @@ defmodule Ludicrous.Ludicrous do
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         v = value.target_id >>> 32 &&& 0xFFFFFFFF
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc14 = scratch
+        fl14 = scratch_bits >>> 3
+        scratch = scratch >>> (fl14 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         v = value.target_id >>> 64 &&& 0xFFFFFFFF
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc15 = scratch
+        fl15 = scratch_bits >>> 3
+        scratch = scratch >>> (fl15 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         v = value.target_id >>> 96 &&& 0xFFFFFFFF
-        flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-        scratch = scratch >>> (flush <<< 3)
+        sc16 = scratch
+        fl16 = scratch_bits >>> 3
+        scratch = scratch >>> (fl16 <<< 3)
         scratch_bits = scratch_bits &&& 7
         scratch = scratch ||| v <<< scratch_bits
         scratch_bits = scratch_bits + 32
         flush = scratch_bits >>> 3
-        data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+        data =
+          <<data::binary, sc14::little-size(fl14)-unit(8), sc15::little-size(fl15)-unit(8),
+            sc16::little-size(fl16)-unit(8), scratch::little-size(flush)-unit(8)>>
+
         scratch = scratch >>> (flush <<< 3)
         scratch_bits = scratch_bits &&& 7
         {data, scratch, scratch_bits}
@@ -1330,7 +1359,7 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_y + 6_553_600_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 2
     v = w >>> 32
@@ -1346,12 +1375,16 @@ defmodule Ludicrous.Ludicrous do
 
     w = value_z + 6_553_600_000
     v = w &&& 0xFFFFFFFF
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = scratch >>> 32
     scratch = scratch ||| v <<< 4
     v = w >>> 32
     scratch = scratch ||| v <<< 36
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        scratch::little-size(4)-unit(8)>>
+
     scratch = scratch >>> 32
     # the residual byte, statically known to be there
     <<data::binary, scratch>>
@@ -1448,7 +1481,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_y + 1_073_741_824
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc0 = scratch
     scratch = v
 
     if value_z < -1_073_741_824 do
@@ -1460,7 +1493,7 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_z + 1_073_741_824
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc1 = scratch
     scratch = v
 
     if value_w < -1_073_741_824 do
@@ -1472,9 +1505,13 @@ defmodule Ludicrous.Ludicrous do
     end
 
     v = value_w + 1_073_741_824
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+    sc2 = scratch
     scratch = v
-    data = <<data::binary, scratch::little-size(4)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(4)-unit(8), sc1::little-size(4)-unit(8),
+        sc2::little-size(4)-unit(8), scratch::little-size(4)-unit(8)>>
+
     data
   end
 
@@ -1529,7 +1566,7 @@ defmodule Ludicrous.Ludicrous do
 
   defp w_fixed_probe_samples([], data, scratch, scratch_bits), do: {data, scratch, scratch_bits}
 
-  defp w_fixed_probe_samples([e1, e2 | rest], data, scratch, scratch_bits) do
+  defp w_fixed_probe_samples([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < -524_288 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1553,8 +1590,36 @@ defmodule Ludicrous.Ludicrous do
     v = e2 + 524_288
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 21
+
+    if e3 < -524_288 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 524_288 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3 + 524_288
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
+
+    if e4 < -524_288 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 524_288 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4 + 524_288
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_fixed_probe_samples(rest, data, scratch, scratch_bits)
@@ -1611,7 +1676,7 @@ defmodule Ludicrous.Ludicrous do
   defp w_unsigned_probe_samples([], data, scratch, scratch_bits),
     do: {data, scratch, scratch_bits}
 
-  defp w_unsigned_probe_samples([e1, e2 | rest], data, scratch, scratch_bits) do
+  defp w_unsigned_probe_samples([e1, e2, e3, e4 | rest], data, scratch, scratch_bits) do
     if e1 < 0 do
       raise ArgumentError, "e is below the wire minimum"
     end
@@ -1635,8 +1700,36 @@ defmodule Ludicrous.Ludicrous do
     v = e2
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 21
+
+    if e3 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e3 > 1_048_576 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e3
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
+    scratch_bits = scratch_bits &&& 7
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
+
+    if e4 < 0 do
+      raise ArgumentError, "e is below the wire minimum"
+    end
+
+    if e4 > 1_048_576 do
+      raise ArgumentError, "e is above the wire maximum"
+    end
+
+    v = e4
+    scratch = scratch ||| v <<< scratch_bits
+    scratch_bits = scratch_bits + 21
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+    data = <<data::binary, sc0::little-size(fl0)-unit(8), scratch::little-size(flush)-unit(8)>>
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_unsigned_probe_samples(rest, data, scratch, scratch_bits)
@@ -1697,28 +1790,32 @@ defmodule Ludicrous.Ludicrous do
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 32 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc0 = scratch
+    fl0 = scratch_bits >>> 3
+    scratch = scratch >>> (fl0 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 64 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc1 = scratch
+    fl1 = scratch_bits >>> 3
+    scratch = scratch >>> (fl1 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     v = e >>> 96 &&& 0xFFFFFFFF
-    flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
-    scratch = scratch >>> (flush <<< 3)
+    sc2 = scratch
+    fl2 = scratch_bits >>> 3
+    scratch = scratch >>> (fl2 <<< 3)
     scratch_bits = scratch_bits &&& 7
     scratch = scratch ||| v <<< scratch_bits
     scratch_bits = scratch_bits + 32
     flush = scratch_bits >>> 3
-    data = <<data::binary, scratch::little-size(flush)-unit(8)>>
+
+    data =
+      <<data::binary, sc0::little-size(fl0)-unit(8), sc1::little-size(fl1)-unit(8),
+        sc2::little-size(fl2)-unit(8), scratch::little-size(flush)-unit(8)>>
+
     scratch = scratch >>> (flush <<< 3)
     scratch_bits = scratch_bits &&& 7
     w_ludicrous_state_keys(rest, data, scratch, scratch_bits)


### PR DESCRIPTION
Issue #174. **Lever M** — the one lever #202 named, prototyped and did not
land. With the NIF backend ruled out, it is the last planned Elixir lever, so
the number it lands is **the BEAM's published floor for now**.

**Headline, and it is below the estimate.** M makes the write path
**1.17x** faster and moves the §2.9 blend somewhere between **0% and 6%**,
against the ~12% #202 estimated. The write half is unambiguous and measured
by two instruments; the blend half is small, and the certification pair could
not resolve it at all. Both are reported as measured, neither is smoothed.

## What M is

Lever A closed the merge group across the fields of a scope and K closed it
across the elements of a clause, but neither could close it across the
GROUP's own budget: a barrier-free run wider than 52 bits had to empty the
scratch to keep merging, and every emptying was its own `bs_append`. A
`bench_mixed` header is 82 static bytes and paid ten of them; an entity
element paid three.

The emptying and the append were never the same thing. A full group now
**spills** — the scratch's whole bytes bind to a fresh register and the
scratch keeps merging — and the append is deferred to the **barrier**, where
every register that spilled since the last one rides ONE binary construction
as its own segment. A spill is a bind and a shift where it was an append and
a shift, so the statement count is unchanged and only the BIF calls move.
The dynamic-offset path (a loop helper's body) defers identically, each spill
naming the width local it computed — #174's own micro says that costs
nothing: twelve appends of a DYNAMIC-width segment measured 103.7 ns against
103.6 for literal widths.

The write clause's `k` follows from it. What a clause shares is one APPEND,
and the append is now the barrier's rather than the group's, so the 52-bit
budget no longer bounds `k` — only the unroll cap of four does.

| | before | after |
|---|---|---|
| static append sites in `generated/bench/elixir` | 79 | **44** |
| `bench_mixed` header | 10 appends | **1** (ten segments) |
| entity element | 3 appends | **1** |
| stats clause | 2 elements, 40 appends | **4 elements, 20 appends** |

## Measured

The lever's own figure comes from the **interleaved** instrument levers K and
L used: both arms in the same window, order rotated per pass, so a spike hits
both. Two sittings, `bench/elixir` under the pinned BEAM toolchain, the same
runner and the same corpus over two generated `Bench.ex` texts, max statistic,
median of per-pass ratios.

**Ten passes, main vs M** — M won 9 of 10 on write:

| | main | lever M | ratio |
|---|---:|---:|---:|
| write | 361,140 | 424,619 | **1.17x** |
| round_trip | 235,207 | 249,436 | **1.05x** |

**Nine passes, three-way**, separating M's two halves — C is the deferred
appends alone, with the clause `k` left where K had it:

| | B/A (full M) | C/A (appends only) | B/C (the clause widening) |
|---|---:|---:|---:|
| write | **1.168** | 1.099 | **1.070** |
| round_trip | **1.072** | 1.054 | 1.016 |

Both halves earn their place: deferring the appends is 1.10x on write on its
own, and widening the clause adds a further 1.07x. Neither is scaffolding.

## The certification pair, and what it could not show

`bench/run.sh --quick`, both halves 2m39s apart, corpus_id `6b213fbfa1a03a99`
on every row, **both committed**:
`bench/results/2026-09-01-elixirleverm-{before,after}-quick-arm64-macbook.csv`.
BEFORE stamps main at `d398ec4`, AFTER stamps this branch at `f96d749`.

| | before | after | ratio |
|---|---:|---:|---:|
| elixir write | 383,329 | 434,318 | 1.133x |
| elixir round_trip | 248,616 | 254,142 | 1.022x |
| **blend (§2.9)** | **1413%** | **1409%** | — |

**The controls say to read that second row as nothing.** The AFTER half was
globally the faster of the two — but not uniformly, and the original text of
this paragraph overstated it (CORRECTED at review, and commit 894414a's
message carries the old claim): the sixteen non-elixir rows actually ranged
**-0.25% to +4.10%** (cs round_trip -0.12%, dart round_trip -0.25%, dart
write -0.02% came in DOWN; cpp round_trip +1.9%). The wider, mixed-sign
control band strengthens the conclusion rather than weakening it: elixir
write at +13.3% is well clear of that drift; elixir round_trip at +2.2% is
inside it, and net of cpp the blend moves 0.3%.

That is not evidence the lever does nothing. It is evidence **this instrument
cannot resolve this question.** One sweep is ONE sample per arm, and elixir's
round_trip rate varies far more between runs in a sitting than within one:
across the nine interleaved passes of the same main-branch code it ran
219,874 to 247,320, a **12.5% range**, against the 0.55% spread inside a
single run. A 6% effect does not survive that. The sitting is labelled SHARED
in both preambles, which it was — a sibling session's C# round was live on the
same box.

So what a sweep actually recorded is **1413% -> 1409%**. The interleaved
round_trip ratio would imply roughly 1330%, and I am **not** publishing that
number: no sweep measured it, and the §2.9 blend is a sweep statistic. The
honest position is that this lever's effect on the blend is smaller than the
sweep's own between-run variance, and a quiet box would be needed to put a
figure on it.

## Why it is below the ~12% estimate — the mechanism, not a smoothing

The estimate came from #174's micro: one append of twelve segments at 73.3 ns
against twelve appends of one at 103.6, **1.41x**. That is the cost of appends
*in isolation*. In the codec they are one term of write, and write is ~65% of
round_trip on this shape — so a 1.17x write is at most a 1.10x round_trip
before anything else is counted, and the blend statistic is round_trip.

**The "slower derived read" is an arithmetic artifact, not a measurement**
(REWRITTEN at review — the original paragraph here presented a 6-15% derived-
read slowdown as an unexplained reproducible effect). Derived read is
round_trip MINUS write, never a measured row (§2.9 says exactly this and why).
Any lever that improves write more than round_trip drives that derived number
backwards BY CONSTRUCTION, and its error band is enormous: read-time is ~35%
of round_trip here, so a 1% error in round_trip moves derived read ~2.9%, and
round_trip's own between-run range on unchanged code is 12.5% — a ±30%+ band
on the derived figure. The three "instruments" shared one round_trip number,
so they were never independent replicates. **M is neutral on real read
traffic by construction**: the read emission is byte-identical (all 1,232
lines diffed), and read-heavy workloads decode binaries that arrived from a
socket — already plain non-writable refc binaries, unreachable by anything a
writer-side lever changes. The one true residue: the round-trip loop pays an
emasculation copy when the reader touches the still-writable binary the same
process just built — a loop artifact, identical in size on both branches, and
the reason round_trip cannot capture the whole write gain.

## Constraints held

- **The Elixir wire is byte-identical to the C++ pin.** The gate that
  actually carries an Elixir-only change is `test/elixir/main.exs`
  byte-comparing generated output against `testdata/wire/*.bin` — green, and
  the review proved it discriminating (a reversed barrier segment order goes
  red on six checks). ("No wire golden moved" is true but near-vacuous for
  this diff: goldens are produced by the C++ leg, which an Elixir emitter
  change cannot touch.) corpus_id `6b213fbfa1a03a99`.
- **The fixnum envelope is untouched**, which is what this whole round rests
  on. `mergeW`'s guard is unchanged, so a group is still at most 52 bits and
  the scratch at most 7 + 52 = 59; a register is filled by exactly the spill
  that used to append it, so it holds what the scratch held and nothing is
  grown. Registers stay live to the barrier instead of dying at the append —
  the deepest run in the tree spends 13 of the BEAM's 1024 (write_rigid_body, sc0..sc12 plus scratch — the review counted; the argument is unchanged).
- **Clauses.schema and Joins.schema pass**, which is the point of them: their
  mid-byte clause boundaries are exactly where a grouped write can disagree
  with a grouped read, and this lever changes how many elements a write clause
  takes. All nine legs byte-compare against the C++ pin.
- **Raise text and refusal semantics identical.** The diff ADDS 34 raise sites
  — the new clause slots — and removes none; the display map resolves every
  slot back to the element, so a message still reads `"e.delta is above the
  wire maximum"`. Every range, count, mask and length check is where it was.
- The barrier's construction is emitted in `mix format`'s own shape for a long
  bitstring, so `--check-formatted` passes on the emitted text.
- Nine-backend `make test` green; regeneration zero-diff; every generated
  module compiles under `--warnings-as-errors`; shape-gate clean with no new
  ledger entries; `mix format`, modernize, gofmt and `go vet` clean. The seven
  SOURCE goldens the emitter moved are re-pinned in the lever's own commit.
- `serialize.elixir` untouched — generated Elixir has no runtime dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

