### PR TITLE
cs: the codec pass — union batch cores, scoped batches, and the flat word codec (write 1.59x, round_trip 1.60x; 361% -> 219% of generated C++)

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -987,6 +987,13 @@ benchmarks two different versions of the same C++ library and publishes both.
 > `msbuild -getItem:Compile`) before it is printed — **and a leg that cannot
 > prove its runtime path REFUSES (no rows) rather than reporting.**
 
+**The schema commit records its BRANCH too** (added 2026-09-01, alongside the
+runtime lines that already did). The failure it closes is the twin of the one
+below: a sweep that silently measured the wrong tree, and a CSV that could not
+have said so. A bare SHA also stops resolving the moment it is rebased away,
+which is how a published result came to carry a dead SHA; the branch name
+survives the rebase and says which tree was on the bench.
+
 This clause was earned on **2026-08-15**: `bench/rust/Cargo.toml`,
 `bench/go/go.mod` and `bench/cs/schemabench.csproj` hardcoded their runtime
 paths while `run.sh` recorded `$SERIALIZE_RS`/`GO`/`CS` in the preamble — so a

--- a/bench/results/2026-09-01-cscodec-after-arm64-macbook.csv
+++ b/bench/results/2026-09-01-cscodec-after-arm64-macbook.csv
@@ -1,0 +1,84 @@
+# ---------------------------------------------------------------------------
+# PR #208 (cs-word-codec) — the C# codec pass, AFTER (cs-word-codec, 28b771d) half.
+#
+# ONE LEG ONLY (--only cs): nothing else in the tree changed, so the eight
+# other legs would have re-measured main against main. The cpp/c reference
+# rows this pair is read against are the quiet-box sweep at
+# bench/results/2026-09-01-arm64-macbook.csv, same corpus_id
+# 6b213fbfa1a03a99, same box, same day.
+#
+# TWO SITTINGS, both committed, taken back to back in the same window with the
+# other half. The box was shared with another worker's timed elixir runs
+# (PR #207) for part of the session; the pair is reported as max AND median
+# per BENCH-STANDARD.md rather than as a single number.
+#
+# THE `bits` FAMILY ROWS ARE NOT ATTRIBUTABLE TO THIS CHANGE, said out loud
+# rather than left for a reader to trip over. bench/cs/src/BitsBench.cs
+# exercises serialize.cs's raw BitWriter/BitReader and NO generated code at
+# all; neither the emitter nor the runtime moved under it. Its rows still
+# differ across the halves (bitpacker write 1222 -> 1087 MB/s at 0.6-3% spread
+# in sitting 2), which can only be process-level: JIT method placement and
+# cache/branch state after a differently shaped bench_mixed pass in the same
+# process. Read the `gen` rows; the `bits` rows here are an open question, not
+# a result.
+# ---------------------------------------------------------------------------
+# ---- sitting 1 ----
+# schema bench results
+# date: 2026-08-31T23:47:21Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: cs-only before/after pair for PR #208; quiet window, load ~1.5 at start
+# schema commit: 28b771d (cs-word-codec)
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ae730d5 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+cs,bench_mixed,write,4000000,438,7,3197126,3101121,3212822,1335.47,3.49,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,1525347,1502809,1538237,637.15,2.32,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,15830,13414,16568,989.08,19.92,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,15847,15481,16651,990.18,7.39,6b213fbfa1a03a99,bits,asm,always,default,unknown
+# ---- sitting 2 ----
+# schema bench results
+# date: 2026-09-01T00:00:24Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: cs-only before/after pair, sitting 2, for PR #208; box shared with another worker's timed runs — see the pair's own note
+# schema commit: 28b771d (cs-word-codec)
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ae730d5 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+cs,bench_mixed,write,4000000,438,7,3334630,3323773,3342814,1392.91,0.57,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,1586844,1568182,1594245,662.84,1.64,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,17400,17309,17407,1087.20,0.56,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,18496,18143,18549,1155.70,2.19,6b213fbfa1a03a99,bits,asm,always,default,unknown

--- a/bench/results/2026-09-01-cscodec-before-arm64-macbook.csv
+++ b/bench/results/2026-09-01-cscodec-before-arm64-macbook.csv
@@ -1,0 +1,88 @@
+# ---------------------------------------------------------------------------
+# PR #208 (cs-word-codec) — the C# codec pass, BEFORE (main, d398ec4) half.
+#
+# ONE LEG ONLY (--only cs): nothing else in the tree changed, so the eight
+# other legs would have re-measured main against main. The cpp/c reference
+# rows this pair is read against are the quiet-box sweep at
+# bench/results/2026-09-01-arm64-macbook.csv, same corpus_id
+# 6b213fbfa1a03a99, same box, same day.
+#
+# TWO SITTINGS, both committed, taken back to back in the same window with the
+# other half. The box was shared with another worker's timed elixir runs
+# (PR #207) for part of the session; the pair is reported as max AND median
+# per BENCH-STANDARD.md rather than as a single number.
+#
+# THE `bits` FAMILY ROWS ARE NOT ATTRIBUTABLE TO THIS CHANGE, said out loud
+# rather than left for a reader to trip over. bench/cs/src/BitsBench.cs
+# exercises serialize.cs's raw BitWriter/BitReader and NO generated code at
+# all; neither the emitter nor the runtime moved under it. Its rows still
+# differ across the halves (bitpacker write 1222 -> 1087 MB/s at 0.6-3% spread
+# in sitting 2), which can only be process-level: JIT method placement and
+# cache/branch state after a differently shaped bench_mixed pass in the same
+# process. Read the `gen` rows; the `bits` rows here are an open question, not
+# a result.
+# The `schema commit` line below carries no branch: the before half runs
+# main's own run.sh, which predates the branch-carrying line this PR adds
+# to it. The tree is main at d398ec4, and d398ec4 resolves on origin.
+#
+# ---------------------------------------------------------------------------
+# ---- sitting 1 ----
+# schema bench results
+# date: 2026-08-31T23:45:56Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: cs-only before/after pair for PR #208; quiet window, load ~1.5 at start
+# schema commit: d398ec4
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ae730d5 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+cs,bench_mixed,write,4000000,438,7,2103454,2082706,2104563,878.63,1.04,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,990865,958833,992155,413.89,3.36,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,19566,19077,19835,1222.55,3.87,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,17780,16342,18179,1110.96,10.33,6b213fbfa1a03a99,bits,asm,always,default,unknown
+# ---- sitting 2 ----
+# schema bench results
+# date: 2026-08-31T23:59:12Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: cs-only before/after pair, sitting 2, for PR #208; box shared with another worker's timed runs — see the pair's own note
+# schema commit: d398ec4
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: ae730d5 (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: f08327e (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+cs,bench_mixed,write,4000000,438,7,2068027,2014340,2072323,863.83,2.80,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,967119,890536,979294,403.97,9.18,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,19561,19156,19768,1222.24,3.13,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,18496,18395,18533,1155.68,0.74,6b213fbfa1a03a99,bits,asm,always,default,unknown

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -249,7 +249,11 @@ emit_preamble() {
         echo "# elixir: ${ELIXIR_VERSION:-not present} (generated codecs, zero runtime dependency; pinned BEAM toolchain)"
         echo "# pinning: $PIN_DESC"
         echo "# noise: ${BENCH_NOISE:-unlabelled}"
-        echo "# schema commit: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+        # the schema commit carries its BRANCH, exactly as every runtime line
+        # below does. A sweep that silently measured the wrong tree is a
+        # failure mode this repo has already had, and a CSV that records only
+        # a SHA cannot say which tree produced it once the SHA is rebased away.
+        echo "# schema commit: $(commit_of .)"
         # §3.5 / §5.2: the runtime commit for EVERY language, with its branch —
         # the serialize checkouts ride PR branches during review, and a number
         # measured against a branch must say so. Each line carries its

--- a/generated/bench/cs/Bench.cs
+++ b/generated/bench/cs/Bench.cs
@@ -244,54 +244,37 @@ namespace Bench
 
         public static bool WriteBenchPacket(WriteStream stream, BenchPacket value)
         {
-            if (value.A < -100 || value.A > 100)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.A) - unchecked((uint)(-100));
-                if (!stream.SerializeBits(ref offsetValue, 8))
+                // flat run: 89 bits in 2 chunk(s) — the field placement is folded
+                if (value.A < -100 || value.A > 100)
                 {
                     return false;
                 }
-            }
-            if (value.B < 0 || value.B > 65535)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.B);
-                if (!stream.SerializeBits(ref offsetValue, 16))
+                if (value.B < 0 || value.B > 65535)
                 {
                     return false;
                 }
-            }
-            if (value.C < -1000000 || value.C > 1000000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.C) - unchecked((uint)(-1000000));
-                if (!stream.SerializeBits(ref offsetValue, 21))
+                if (value.C < -1000000 || value.C > 1000000)
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.Bits7, 7))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Bits13, 13))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Bits23, 23))
-            {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.Flag))
-            {
-                return false;
+                ulong f0 = ((ulong)((uint)(value.A) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f1 = ((ulong)((uint)(value.B))) & 0xffffUL;
+                ulong f2 = ((ulong)((uint)(value.C) - unchecked((uint)(-1000000)))) & 0x1fffffUL;
+                ulong f3 = ((ulong)value.Bits7) & 0x7fUL;
+                ulong f4 = ((ulong)value.Bits13) & 0x1fffUL;
+                ulong f5 = ((ulong)value.Bits23) & 0x7fffffUL;
+                ulong f6 = value.Flag ? 1UL : 0UL;
+                ulong w0 = f0 | (f1 << 8) | (f2 << 24) | (f3 << 45) | (f4 << 52);
+                if (!stream.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f4 >> 12) | (f5 << 1) | (f6 << 24));
+                if (!stream.SerializeBits(ref w1, 25))
+                {
+                    return false;
+                }
             }
             if (!stream.SerializeFloat(ref value.X))
             {
@@ -411,112 +394,65 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBenchIntsBatch(ref WriteBatch batch, BenchInts value)
         {
-            if (value.F0 < -100 || value.F0 > 100)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F0) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                // flat run: 110 bits in 2 chunk(s) — the field placement is folded
+                if (value.F0 < -100 || value.F0 > 100)
                 {
                     return false;
                 }
-            }
-            if (value.F1 < 0 || value.F1 > 65535)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F1);
-                if (!batch.SerializeBits(ref offsetValue, 16))
+                if (value.F1 < 0 || value.F1 > 65535)
                 {
                     return false;
                 }
-            }
-            if (value.F2 < -1000000 || value.F2 > 1000000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F2) - unchecked((uint)(-1000000));
-                if (!batch.SerializeBits(ref offsetValue, 21))
+                if (value.F2 < -1000000 || value.F2 > 1000000)
                 {
                     return false;
                 }
-            }
-            if (value.F3 < 0 || value.F3 > 3)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F3);
-                if (!batch.SerializeBits(ref offsetValue, 2))
+                if (value.F3 < 0 || value.F3 > 3)
                 {
                     return false;
                 }
-            }
-            if (value.F4 < -15 || value.F4 > 15)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F4) - unchecked((uint)(-15));
-                if (!batch.SerializeBits(ref offsetValue, 5))
+                if (value.F4 < -15 || value.F4 > 15)
                 {
                     return false;
                 }
-            }
-            if (value.F5 < 0 || value.F5 > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F5);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.F5 < 0 || value.F5 > 1000)
                 {
                     return false;
                 }
-            }
-            if (value.F6 < -2048 || value.F6 > 2047)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F6) - unchecked((uint)(-2048));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.F6 < -2048 || value.F6 > 2047)
                 {
                     return false;
                 }
-            }
-            if (value.F7 < 0 || value.F7 > 255)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F7);
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (value.F7 < 0 || value.F7 > 255)
                 {
                     return false;
                 }
-            }
-            if (value.F8 < -600000 || value.F8 > 600000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F8) - unchecked((uint)(-600000));
-                if (!batch.SerializeBits(ref offsetValue, 21))
+                if (value.F8 < -600000 || value.F8 > 600000)
                 {
                     return false;
                 }
-            }
-            if (value.F9 < 0 || value.F9 > 100)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F9);
-                if (!batch.SerializeBits(ref offsetValue, 7))
+                if (value.F9 < 0 || value.F9 > 100)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.F0) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f1 = ((ulong)((uint)(value.F1))) & 0xffffUL;
+                ulong f2 = ((ulong)((uint)(value.F2) - unchecked((uint)(-1000000)))) & 0x1fffffUL;
+                ulong f3 = ((ulong)((uint)(value.F3))) & 0x3UL;
+                ulong f4 = ((ulong)((uint)(value.F4) - unchecked((uint)(-15)))) & 0x1fUL;
+                ulong f5 = ((ulong)((uint)(value.F5))) & 0x3ffUL;
+                ulong f6 = ((ulong)((uint)(value.F6) - unchecked((uint)(-2048)))) & 0xfffUL;
+                ulong f7 = ((ulong)((uint)(value.F7))) & 0xffUL;
+                ulong f8 = ((ulong)((uint)(value.F8) - unchecked((uint)(-600000)))) & 0x1fffffUL;
+                ulong f9 = ((ulong)((uint)(value.F9))) & 0x7fUL;
+                ulong w0 = f0 | (f1 << 8) | (f2 << 24) | (f3 << 45) | (f4 << 47) | (f5 << 52) | (f6 << 62);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                ulong w1 = (f6 >> 2) | (f7 << 10) | (f8 << 18) | (f9 << 39);
+                if (!batch.SerializeBits64(ref w1, 46))
                 {
                     return false;
                 }
@@ -611,37 +547,31 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteBenchBitsBatch(ref WriteBatch batch, BenchBits value)
         {
-            if (!batch.SerializeBits(ref value.B7, 7))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B13, 13))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B23, 23))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B3, 3))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B32, 32))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B11, 11))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B19, 19))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.B48, 48))
-            {
-                return false;
+                // flat run: 156 bits in 3 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.B7) & 0x7fUL;
+                ulong f1 = ((ulong)value.B13) & 0x1fffUL;
+                ulong f2 = ((ulong)value.B23) & 0x7fffffUL;
+                ulong f3 = ((ulong)value.B3) & 0x7UL;
+                ulong f4 = ((ulong)value.B32) & 0xffffffffUL;
+                ulong f5 = ((ulong)value.B11) & 0x7ffUL;
+                ulong f6 = ((ulong)value.B19) & 0x7ffffUL;
+                ulong f7 = ((ulong)value.B48) & 0xffffffffffffUL;
+                ulong w0 = f0 | (f1 << 7) | (f2 << 20) | (f3 << 43) | (f4 << 46);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                ulong w1 = (f4 >> 18) | (f5 << 14) | (f6 << 25) | (f7 << 44);
+                if (!batch.SerializeBits64(ref w1, 64))
+                {
+                    return false;
+                }
+                uint w2 = (uint)((f7 >> 20));
+                if (!batch.SerializeBits(ref w2, 28))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -849,124 +779,73 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMixedEntityBatch(ref WriteBatch batch, MixedEntity value)
         {
-            if (!batch.SerializeBits(ref value.EntityId, 12))
             {
-                return false;
-            }
-            if (value.PosX < -16383 || value.PosX > 16383)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.PosX) - unchecked((uint)(-16383));
-                if (!batch.SerializeBits(ref offsetValue, 15))
+                // flat run: 135 bits in 3 chunk(s) — the field placement is folded
+                if (value.PosX < -16383 || value.PosX > 16383)
                 {
                     return false;
                 }
-            }
-            if (value.PosY < -16383 || value.PosY > 16383)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.PosY) - unchecked((uint)(-16383));
-                if (!batch.SerializeBits(ref offsetValue, 15))
+                if (value.PosY < -16383 || value.PosY > 16383)
                 {
                     return false;
                 }
-            }
-            if (value.PosZ < -16383 || value.PosZ > 16383)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.PosZ) - unchecked((uint)(-16383));
-                if (!batch.SerializeBits(ref offsetValue, 15))
+                if (value.PosZ < -16383 || value.PosZ > 16383)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBits(ref value.Yaw, 9))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.Pitch, 9))
-            {
-                return false;
-            }
-            if (value.VelX < -2048 || value.VelX > 2047)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.VelX) - unchecked((uint)(-2048));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.VelX < -2048 || value.VelX > 2047)
                 {
                     return false;
                 }
-            }
-            if (value.VelY < -2048 || value.VelY > 2047)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.VelY) - unchecked((uint)(-2048));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.VelY < -2048 || value.VelY > 2047)
                 {
                     return false;
                 }
-            }
-            if (value.VelZ < -2048 || value.VelZ > 2047)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.VelZ) - unchecked((uint)(-2048));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.VelZ < -2048 || value.VelZ > 2047)
                 {
                     return false;
                 }
-            }
-            if (value.Health < 0 || value.Health > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Health);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.Health < 0 || value.Health > 1000)
                 {
                     return false;
                 }
-            }
-            {
-                uint enumValue = (uint)value.Weapon;
-                if (enumValue > 15) // headroom above the wire range cannot ride
+                if ((uint)value.Weapon > 15) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref enumValue, 4))
+                if (value.Damage >= 1ul << 8) // a mask bit above the wire width cannot ride
                 {
                     return false;
                 }
-            }
-            if (value.Damage >= 1ul << 8) // a mask bit above the wire width cannot ride
-            {
-                return false;
-            }
-            {
-                uint flagsValue = (uint)value.Damage;
-                if (!batch.SerializeBits(ref flagsValue, 8))
+                ulong f0 = ((ulong)value.EntityId) & 0xfffUL;
+                ulong f1 = ((ulong)((uint)(value.PosX) - unchecked((uint)(-16383)))) & 0x7fffUL;
+                ulong f2 = ((ulong)((uint)(value.PosY) - unchecked((uint)(-16383)))) & 0x7fffUL;
+                ulong f3 = ((ulong)((uint)(value.PosZ) - unchecked((uint)(-16383)))) & 0x7fffUL;
+                ulong f4 = ((ulong)value.Yaw) & 0x1ffUL;
+                ulong f5 = ((ulong)value.Pitch) & 0x1ffUL;
+                ulong f6 = ((ulong)((uint)(value.VelX) - unchecked((uint)(-2048)))) & 0xfffUL;
+                ulong f7 = ((ulong)((uint)(value.VelY) - unchecked((uint)(-2048)))) & 0xfffUL;
+                ulong f8 = ((ulong)((uint)(value.VelZ) - unchecked((uint)(-2048)))) & 0xfffUL;
+                ulong f9 = ((ulong)((uint)(value.Health))) & 0x3ffUL;
+                ulong f10 = ((ulong)(uint)value.Weapon) & 0xfUL;
+                ulong f11 = (value.Damage) & 0xffUL;
+                ulong f12 = value.Moving ? 1UL : 0UL;
+                ulong f13 = value.Firing ? 1UL : 0UL;
+                ulong w0 = f0 | (f1 << 12) | (f2 << 27) | (f3 << 42) | (f4 << 57);
+                if (!batch.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBool(ref value.Moving))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Firing))
-            {
-                return false;
+                ulong w1 = (f4 >> 7) | (f5 << 2) | (f6 << 11) | (f7 << 23) | (f8 << 35) | (f9 << 47) | (f10 << 57) | (f11 << 61);
+                if (!batch.SerializeBits64(ref w1, 64))
+                {
+                    return false;
+                }
+                uint w2 = (uint)((f11 >> 3) | (f12 << 5) | (f13 << 6));
+                if (!batch.SerializeBits(ref w2, 7))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -1076,17 +955,16 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMixedStatBatch(ref WriteBatch batch, MixedStat value)
         {
-            if (!batch.SerializeBits(ref value.StatId, 8))
             {
-                return false;
-            }
-            if (value.Delta < -512 || value.Delta > 511)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Delta) - unchecked((uint)(-512));
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                // flat run: 18 bits in 1 chunk(s) — the field placement is folded
+                if (value.Delta < -512 || value.Delta > 511)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)value.StatId) & 0xffUL;
+                ulong f1 = ((ulong)((uint)(value.Delta) - unchecked((uint)(-512)))) & 0x3ffUL;
+                uint w0 = (uint)(f0 | (f1 << 8));
+                if (!batch.SerializeBits(ref w0, 18))
                 {
                     return false;
                 }
@@ -1145,35 +1023,25 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMixedHitEventBatch(ref WriteBatch batch, MixedHitEvent value)
         {
-            if (!batch.SerializeBits(ref value.TargetId, 12))
             {
-                return false;
-            }
-            if (value.Damage < 0 || value.Damage > 4095)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Damage);
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                // flat run: 28 bits in 1 chunk(s) — the field placement is folded
+                if (value.Damage < 0 || value.Damage > 4095)
                 {
                     return false;
                 }
-            }
-            if (value.HitKind < 0 || value.HitKind > 7)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.HitKind);
-                if (!batch.SerializeBits(ref offsetValue, 3))
+                if (value.HitKind < 0 || value.HitKind > 7)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBool(ref value.Crit))
-            {
-                return false;
+                ulong f0 = ((ulong)value.TargetId) & 0xfffUL;
+                ulong f1 = ((ulong)((uint)(value.Damage))) & 0xfffUL;
+                ulong f2 = ((ulong)((uint)(value.HitKind))) & 0x7UL;
+                ulong f3 = value.Crit ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 12) | (f2 << 24) | (f3 << 27));
+                if (!batch.SerializeBits(ref w0, 28))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -1235,20 +1103,19 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMixedChatEventBatch(ref WriteBatch batch, MixedChatEvent value)
         {
-            if (value.Channel < 0 || value.Channel > 3)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Channel);
-                if (!batch.SerializeBits(ref offsetValue, 2))
+                // flat run: 14 bits in 1 chunk(s) — the field placement is folded
+                if (value.Channel < 0 || value.Channel > 3)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBits(ref value.Speaker, 12))
-            {
-                return false;
+                ulong f0 = ((ulong)((uint)(value.Channel))) & 0x3UL;
+                ulong f1 = ((ulong)value.Speaker) & 0xfffUL;
+                uint w0 = (uint)(f0 | (f1 << 2));
+                if (!batch.SerializeBits(ref w0, 14))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -1302,17 +1169,16 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteMixedPickupEventBatch(ref WriteBatch batch, MixedPickupEvent value)
         {
-            if (!batch.SerializeBits(ref value.ItemId, 10))
             {
-                return false;
-            }
-            if (value.Amount < 0 || value.Amount > 255)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Amount);
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                // flat run: 18 bits in 1 chunk(s) — the field placement is folded
+                if (value.Amount < 0 || value.Amount > 255)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)value.ItemId) & 0x3ffUL;
+                ulong f1 = ((ulong)((uint)(value.Amount))) & 0xffUL;
+                uint w0 = (uint)(f0 | (f1 << 10));
+                if (!batch.SerializeBits(ref w0, 18))
                 {
                     return false;
                 }
@@ -1474,60 +1340,54 @@ namespace Bench
         public static bool WriteBenchMixed(WriteStream stream, BenchMixed value)
         {
             {
-                uint constValue = 49374;
-                if (!stream.SerializeBits(ref constValue, 16)) // const(49374, 16) — SPEC §4.3
+                // flat run: 329 bits in 6 chunk(s) — the field placement is folded
+                if (value.AckSequence < 0 || value.AckSequence > 65535)
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.Sequence, 16))
-            {
-                return false;
-            }
-            if (value.AckSequence < 0 || value.AckSequence > 65535)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.AckSequence);
-                if (!stream.SerializeBits(ref offsetValue, 16))
+                if (value.WorldTime < -1000000000000 || value.WorldTime > 1000000000000)
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.AckBits, 32))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits64(ref value.SessionId, 64))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.ClientId, 32))
-            {
-                return false;
-            }
-            {
-                ulong offsetValue = value.Nonce;
-                if (!stream.SerializeBits64(ref offsetValue, 64))
+                ulong f0 = (49374UL) & 0xffffUL;
+                ulong f1 = ((ulong)value.Sequence) & 0xffffUL;
+                ulong f2 = ((ulong)((uint)(value.AckSequence))) & 0xffffUL;
+                ulong f3 = ((ulong)value.AckBits) & 0xffffffffUL;
+                ulong f4 = (ulong)value.SessionId;
+                ulong f5 = ((ulong)(value.ClientId)) & 0xffffffffUL;
+                ulong f6 = (ulong)((ulong)(value.Nonce));
+                ulong f7 = ((ulong)((ulong)(value.WorldTime) - unchecked((ulong)(-1000000000000)))) & 0x1ffffffffffUL;
+                ulong f8 = ((ulong)value.FrameTick) & 0xffffffffffffUL;
+                ulong w0 = f0 | (f1 << 16) | (f2 << 32) | (f3 << 48);
+                if (!stream.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-            }
-            if (value.WorldTime < -1000000000000 || value.WorldTime > 1000000000000)
-            {
-                return false;
-            }
-            {
-                ulong offsetValue = (ulong)(value.WorldTime) - unchecked((ulong)(-1000000000000));
-                if (!stream.SerializeBits64(ref offsetValue, 41))
+                ulong w1 = (f3 >> 16) | (f4 << 16);
+                if (!stream.SerializeBits64(ref w1, 64))
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits64(ref value.FrameTick, 48))
-            {
-                return false;
+                ulong w2 = (f4 >> 48) | (f5 << 16) | (f6 << 48);
+                if (!stream.SerializeBits64(ref w2, 64))
+                {
+                    return false;
+                }
+                ulong w3 = (f6 >> 16) | (f7 << 48);
+                if (!stream.SerializeBits64(ref w3, 64))
+                {
+                    return false;
+                }
+                ulong w4 = (f7 >> 16) | (f8 << 25);
+                if (!stream.SerializeBits64(ref w4, 64))
+                {
+                    return false;
+                }
+                uint w5 = (uint)((f8 >> 39));
+                if (!stream.SerializeBits(ref w5, 9))
+                {
+                    return false;
+                }
             }
             if (!stream.SerializeFixed(ref value.ServerTime, 24, 8, 0, 65535))
             {
@@ -1693,13 +1553,15 @@ namespace Bench
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.CrcHint, 24))
             {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.HasExtra))
-            {
-                return false;
+                // flat run: 25 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.CrcHint) & 0xffffffUL;
+                ulong f1 = value.HasExtra ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 24));
+                if (!stream.SerializeBits(ref w0, 25))
+                {
+                    return false;
+                }
             }
             if (value.HasExtra)
             {

--- a/generated/bench/cs/Bench.cs
+++ b/generated/bench/cs/Bench.cs
@@ -317,21 +317,23 @@ namespace Bench
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Bits7, 7))
             {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Bits13, 13))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Bits23, 23))
-            {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 44 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 44);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x7fUL;
+                value.Bits7 = (uint)v0;
+                ulong v1 = (c0 >> 7) & 0x1fffUL;
+                value.Bits13 = (uint)v1;
+                ulong v2 = (c0 >> 20) & 0x7fffffUL;
+                value.Bits23 = (uint)v2;
+                ulong v3 = (c0 >> 43) & 0x1UL;
+                value.Flag = v3 != 0UL;
             }
             if (!stream.SerializeFloat(ref value.X))
             {
@@ -496,13 +498,19 @@ namespace Bench
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.F6, -2048, 2047))
             {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.F7, 0, 255))
-            {
-                return false;
+                // flat run: 20 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 20);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xfffUL;
+                value.F6 = (int)((int)((uint)v0 + unchecked((uint)(-2048))));
+                ulong v1 = (c0 >> 12) & 0xffUL;
+                value.F7 = (int)((int)(uint)v1);
             }
             if (!batch.SerializeInt(ref value.F8, -600000, 600000))
             {
@@ -588,37 +596,35 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadBenchBitsBatch(ref ReadBatch batch, BenchBits value)
         {
-            if (!batch.SerializeBits(ref value.B7, 7))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B13, 13))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B23, 23))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B3, 3))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B32, 32))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B11, 11))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B19, 19))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.B48, 48))
-            {
-                return false;
+                // flat run: 156 bits in 3 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                batch.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                batch.SerializeBits64(ref c2, 28);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x7fUL;
+                value.B7 = (uint)v0;
+                ulong v1 = (c0 >> 7) & 0x1fffUL;
+                value.B13 = (uint)v1;
+                ulong v2 = (c0 >> 20) & 0x7fffffUL;
+                value.B23 = (uint)v2;
+                ulong v3 = (c0 >> 43) & 0x7UL;
+                value.B3 = (uint)v3;
+                ulong v4 = ((c0 >> 46) | (c1 << 18)) & 0xffffffffUL;
+                value.B32 = (uint)v4;
+                ulong v5 = (c1 >> 14) & 0x7ffUL;
+                value.B11 = (uint)v5;
+                ulong v6 = (c1 >> 25) & 0x7ffffUL;
+                value.B19 = (uint)v6;
+                ulong v7 = ((c1 >> 44) | (c2 << 20)) & 0xffffffffffffUL;
+                value.B48 = v7;
             }
             return true;
         }
@@ -878,53 +884,47 @@ namespace Bench
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Yaw, 9))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.Pitch, 9))
-            {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.VelX, -2048, 2047))
-            {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.VelY, -2048, 2047))
-            {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.VelZ, -2048, 2047))
-            {
-                return false;
+                // flat run: 54 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 54);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1ffUL;
+                value.Yaw = (uint)v0;
+                ulong v1 = (c0 >> 9) & 0x1ffUL;
+                value.Pitch = (uint)v1;
+                ulong v2 = (c0 >> 18) & 0xfffUL;
+                value.VelX = (int)((int)((uint)v2 + unchecked((uint)(-2048))));
+                ulong v3 = (c0 >> 30) & 0xfffUL;
+                value.VelY = (int)((int)((uint)v3 + unchecked((uint)(-2048))));
+                ulong v4 = (c0 >> 42) & 0xfffUL;
+                value.VelZ = (int)((int)((uint)v4 + unchecked((uint)(-2048))));
             }
             if (!batch.SerializeInt(ref value.Health, 0, 1000))
             {
                 return false;
             }
             {
-                int enumValue = 0;
-                if (!batch.SerializeInt(ref enumValue, 0, 15))
+                // flat run: 14 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 14);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.Weapon = (MixedWeapon)enumValue;
-            }
-            {
-                uint flagsValue = 0;
-                if (!batch.SerializeBits(ref flagsValue, 8))
-                {
-                    return false;
-                }
-                value.Damage = flagsValue;
-            }
-            if (!batch.SerializeBool(ref value.Moving))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Firing))
-            {
-                return false;
+                ulong v0 = c0 & 0xfUL;
+                value.Weapon = (MixedWeapon)(int)v0;
+                ulong v1 = (c0 >> 4) & 0xffUL;
+                value.Damage = v1;
+                ulong v2 = (c0 >> 12) & 0x1UL;
+                value.Moving = v2 != 0UL;
+                ulong v3 = (c0 >> 13) & 0x1UL;
+                value.Firing = v3 != 0UL;
             }
             return true;
         }
@@ -984,13 +984,19 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMixedStatBatch(ref ReadBatch batch, MixedStat value)
         {
-            if (!batch.SerializeBits(ref value.StatId, 8))
             {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.Delta, -512, 511))
-            {
-                return false;
+                // flat run: 18 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 18);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffUL;
+                value.StatId = (uint)v0;
+                ulong v1 = (c0 >> 8) & 0x3ffUL;
+                value.Delta = (int)((int)((uint)v1 + unchecked((uint)(-512))));
             }
             return true;
         }
@@ -1058,21 +1064,23 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMixedHitEventBatch(ref ReadBatch batch, MixedHitEvent value)
         {
-            if (!batch.SerializeBits(ref value.TargetId, 12))
             {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.Damage, 0, 4095))
-            {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.HitKind, 0, 7))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Crit))
-            {
-                return false;
+                // flat run: 28 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 28);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xfffUL;
+                value.TargetId = (uint)v0;
+                ulong v1 = (c0 >> 12) & 0xfffUL;
+                value.Damage = (int)((int)(uint)v1);
+                ulong v2 = (c0 >> 24) & 0x7UL;
+                value.HitKind = (int)((int)(uint)v2);
+                ulong v3 = (c0 >> 27) & 0x1UL;
+                value.Crit = v3 != 0UL;
             }
             return true;
         }
@@ -1132,13 +1140,19 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMixedChatEventBatch(ref ReadBatch batch, MixedChatEvent value)
         {
-            if (!batch.SerializeInt(ref value.Channel, 0, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.Speaker, 12))
-            {
-                return false;
+                // flat run: 14 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 14);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x3UL;
+                value.Channel = (int)((int)(uint)v0);
+                ulong v1 = (c0 >> 2) & 0xfffUL;
+                value.Speaker = (uint)v1;
             }
             return true;
         }
@@ -1198,13 +1212,19 @@ namespace Bench
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadMixedPickupEventBatch(ref ReadBatch batch, MixedPickupEvent value)
         {
-            if (!batch.SerializeBits(ref value.ItemId, 10))
             {
-                return false;
-            }
-            if (!batch.SerializeInt(ref value.Amount, 0, 255))
-            {
-                return false;
+                // flat run: 18 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 18);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x3ffUL;
+                value.ItemId = (uint)v0;
+                ulong v1 = (c0 >> 10) & 0xffUL;
+                value.Amount = (int)((int)(uint)v1);
             }
             return true;
         }
@@ -1597,43 +1617,37 @@ namespace Bench
         public static bool ReadBenchMixed(ReadStream stream, BenchMixed value)
         {
             {
-                uint constValue = 0;
-                if (!stream.SerializeBits(ref constValue, 16))
+                // flat run: 240 bits in 4 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                stream.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                stream.SerializeBits64(ref c2, 64);
+                ulong c3 = 0;
+                stream.SerializeBits64(ref c3, 48);
+                if (!stream.Ok)
                 {
                     return false;
                 }
-                if (constValue != 49374) // const(49374, 16): a read rejects any other value (SPEC §4.3)
+                ulong v0 = c0 & 0xffffUL;
+                if (v0 != 49374UL) // const(49374, 16): a read rejects any other value (SPEC §4.3)
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.Sequence, 16))
-            {
-                return false;
-            }
-            if (!stream.SerializeInt(ref value.AckSequence, 0, 65535))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.AckBits, 32))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits64(ref value.SessionId, 64))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.ClientId, 32))
-            {
-                return false;
-            }
-            {
-                ulong offsetValue = 0;
-                if (!stream.SerializeBits64(ref offsetValue, 64))
-                {
-                    return false;
-                }
-                value.Nonce = offsetValue;
+                ulong v1 = (c0 >> 16) & 0xffffUL;
+                value.Sequence = (uint)v1;
+                ulong v2 = (c0 >> 32) & 0xffffUL;
+                value.AckSequence = (int)((int)(uint)v2);
+                ulong v3 = ((c0 >> 48) | (c1 << 16)) & 0xffffffffUL;
+                value.AckBits = (uint)v3;
+                ulong v4 = ((c1 >> 16) | (c2 << 48));
+                value.SessionId = v4;
+                ulong v5 = (c2 >> 16) & 0xffffffffUL;
+                value.ClientId = (uint)(uint)v5;
+                ulong v6 = ((c2 >> 48) | (c3 << 16));
+                value.Nonce = v6;
             }
             if (!stream.SerializeInt64(ref value.WorldTime, -1000000000000, 1000000000000))
             {
@@ -1782,13 +1796,19 @@ namespace Bench
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.CrcHint, 24))
             {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.HasExtra))
-            {
-                return false;
+                // flat run: 25 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 25);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffffffUL;
+                value.CrcHint = (uint)v0;
+                ulong v1 = (c0 >> 24) & 0x1UL;
+                value.HasExtra = v1 != 0UL;
             }
             if (value.HasExtra)
             {

--- a/generated/bench/cs/Bench.cs
+++ b/generated/bench/cs/Bench.cs
@@ -242,19 +242,7 @@ namespace Bench
             Array.Clear(value.Blob, 0, 17);
         }
 
-        // batch form: stream state stays in registers across the body and End
-        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteBenchPacket(WriteStream stream, BenchPacket value)
-        {
-            WriteBatch batch = stream.BeginBatch();
-            bool result = WriteBenchPacketBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool WriteBenchPacketBatch(ref WriteBatch batch, BenchPacket value)
         {
             if (value.A < -100 || value.A > 100)
             {
@@ -262,7 +250,7 @@ namespace Bench
             }
             {
                 uint offsetValue = (uint)(value.A) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
@@ -273,7 +261,7 @@ namespace Bench
             }
             {
                 uint offsetValue = (uint)(value.B);
-                if (!batch.SerializeBits(ref offsetValue, 16))
+                if (!stream.SerializeBits(ref offsetValue, 16))
                 {
                     return false;
                 }
@@ -284,48 +272,48 @@ namespace Bench
             }
             {
                 uint offsetValue = (uint)(value.C) - unchecked((uint)(-1000000));
-                if (!batch.SerializeBits(ref offsetValue, 21))
+                if (!stream.SerializeBits(ref offsetValue, 21))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.Bits7, 7))
+            if (!stream.SerializeBits(ref value.Bits7, 7))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Bits13, 13))
+            if (!stream.SerializeBits(ref value.Bits13, 13))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Bits23, 23))
+            if (!stream.SerializeBits(ref value.Bits23, 23))
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.Flag))
+            if (!stream.SerializeBool(ref value.Flag))
             {
                 return false;
             }
-            if (!batch.SerializeFloat(ref value.X))
+            if (!stream.SerializeFloat(ref value.X))
             {
                 return false;
             }
-            if (!batch.SerializeFloat(ref value.Y))
+            if (!stream.SerializeFloat(ref value.Y))
             {
                 return false;
             }
-            if (!batch.SerializeFloat(ref value.Z))
+            if (!stream.SerializeFloat(ref value.Z))
             {
                 return false;
             }
-            if (!batch.SerializeBits64(ref value.Big, 64))
+            if (!stream.SerializeBits64(ref value.Big, 64))
             {
                 return false;
             }
-            if (!batch.SerializeAlign())
+            if (!stream.SerializeAlign())
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.Blob.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+            if (!stream.SerializeBytes(value.Blob.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
             {
                 return false;
             }
@@ -334,65 +322,55 @@ namespace Bench
 
         public static bool ReadBenchPacket(ReadStream stream, BenchPacket value)
         {
-            ReadBatch batch = stream.BeginBatch();
-            bool result = ReadBenchPacketBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ReadBenchPacketBatch(ref ReadBatch batch, BenchPacket value)
-        {
-            if (!batch.SerializeInt(ref value.A, -100, 100))
+            if (!stream.SerializeInt(ref value.A, -100, 100))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.B, 0, 65535))
+            if (!stream.SerializeInt(ref value.B, 0, 65535))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.C, -1000000, 1000000))
+            if (!stream.SerializeInt(ref value.C, -1000000, 1000000))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Bits7, 7))
+            if (!stream.SerializeBits(ref value.Bits7, 7))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Bits13, 13))
+            if (!stream.SerializeBits(ref value.Bits13, 13))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Bits23, 23))
+            if (!stream.SerializeBits(ref value.Bits23, 23))
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.Flag))
+            if (!stream.SerializeBool(ref value.Flag))
             {
                 return false;
             }
-            if (!batch.SerializeFloat(ref value.X))
+            if (!stream.SerializeFloat(ref value.X))
             {
                 return false;
             }
-            if (!batch.SerializeFloat(ref value.Y))
+            if (!stream.SerializeFloat(ref value.Y))
             {
                 return false;
             }
-            if (!batch.SerializeFloat(ref value.Z))
+            if (!stream.SerializeFloat(ref value.Z))
             {
                 return false;
             }
-            if (!batch.SerializeBits64(ref value.Big, 64))
+            if (!stream.SerializeBits64(ref value.Big, 64))
             {
                 return false;
             }
-            if (!batch.SerializeAlign()) // rejects nonzero padding (SPEC §4.3)
+            if (!stream.SerializeAlign()) // rejects nonzero padding (SPEC §4.3)
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.Blob.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+            if (!stream.SerializeBytes(value.Blob.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
             {
                 return false;
             }
@@ -1378,33 +1356,55 @@ namespace Bench
             value.Type = MixedEventType.None;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteMixedEvent(WriteStream stream, MixedEvent value)
+        {
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteMixedEventBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteMixedEventBatch(ref WriteBatch batch, MixedEvent value)
         {
             uint tagValue = (uint)value.Type;
             if (tagValue > 3) // the tag validates BEFORE it rides (SPEC §4.8)
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref tagValue, 2))
+            if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
             }
             switch (value.Type)
             {
                 case MixedEventType.Hit:
-                    return WriteMixedHitEvent(stream, value.Hit);
+                    return WriteMixedHitEventBatch(ref batch, value.Hit);
                 case MixedEventType.Chat:
-                    return WriteMixedChatEvent(stream, value.Chat);
+                    return WriteMixedChatEventBatch(ref batch, value.Chat);
                 case MixedEventType.Pickup:
-                    return WriteMixedPickupEvent(stream, value.Pickup);
+                    return WriteMixedPickupEventBatch(ref batch, value.Pickup);
             }
             return true; // None — the tag is the whole wire (SPEC §4.8)
         }
 
         public static bool ReadMixedEvent(ReadStream stream, MixedEvent value)
         {
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadMixedEventBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadMixedEventBatch(ref ReadBatch batch, MixedEvent value)
+        {
             int tagValue = 0;
-            if (!stream.SerializeInt(ref tagValue, 0, 3)) // rejects a tag above the count (SPEC §4.8)
+            if (!batch.SerializeInt(ref tagValue, 0, 3)) // rejects a tag above the count (SPEC §4.8)
             {
                 return false;
             }
@@ -1413,13 +1413,13 @@ namespace Bench
             {
                 case MixedEventType.Hit:
                     ZeroMixedHitEvent(value.Hit); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadMixedHitEvent(stream, value.Hit);
+                    return ReadMixedHitEventBatch(ref batch, value.Hit);
                 case MixedEventType.Chat:
                     ZeroMixedChatEvent(value.Chat); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadMixedChatEvent(stream, value.Chat);
+                    return ReadMixedChatEventBatch(ref batch, value.Chat);
                 case MixedEventType.Pickup:
                     ZeroMixedPickupEvent(value.Pickup); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadMixedPickupEvent(stream, value.Pickup);
+                    return ReadMixedPickupEventBatch(ref batch, value.Pickup);
             }
             return true; // None
         }
@@ -1544,9 +1544,20 @@ namespace Bench
                     return false;
                 }
             }
-            for (int i = 0; i < value.EntitiesCount; i++)
             {
-                if (!WriteMixedEntity(stream, value.Entities[i]))
+                // scoped batch: one capture and one restore for the whole site
+                WriteBatch batch = stream.BeginBatch();
+                bool batchOk = true;
+                for (int i = 0; i < value.EntitiesCount; i++)
+                {
+                    if (!WriteMixedEntityBatch(ref batch, value.Entities[i]))
+                    {
+                        batchOk = false;
+                        break;
+                    }
+                }
+                batch.End();
+                if (!batchOk)
                 {
                     return false;
                 }
@@ -1562,16 +1573,33 @@ namespace Bench
                     return false;
                 }
             }
-            for (int i = 0; i < value.StatsCount; i++)
             {
-                if (!WriteMixedStat(stream, value.Stats[i]))
+                // scoped batch: one capture and one restore for the whole site
+                WriteBatch batch = stream.BeginBatch();
+                bool batchOk = true;
+                for (int i = 0; i < value.StatsCount; i++)
+                {
+                    if (!WriteMixedStatBatch(ref batch, value.Stats[i]))
+                    {
+                        batchOk = false;
+                        break;
+                    }
+                }
+                batch.End();
+                if (!batchOk)
                 {
                     return false;
                 }
             }
-            if (!WriteMixedEvent(stream, value.GameEvent))
             {
-                return false;
+                // scoped batch: one capture and one restore for the whole site
+                WriteBatch batch = stream.BeginBatch();
+                bool batchOk = WriteMixedEventBatch(ref batch, value.GameEvent);
+                batch.End();
+                if (!batchOk)
+                {
+                    return false;
+                }
             }
             for (int i = 0; i < 4; i++)
             {
@@ -1761,9 +1789,20 @@ namespace Bench
             {
                 return false;
             }
-            for (int i = 0; i < value.EntitiesCount; i++)
             {
-                if (!ReadMixedEntity(stream, value.Entities[i]))
+                // scoped batch: one capture and one restore for the whole site
+                ReadBatch batch = stream.BeginBatch();
+                bool batchOk = true;
+                for (int i = 0; i < value.EntitiesCount; i++)
+                {
+                    if (!ReadMixedEntityBatch(ref batch, value.Entities[i]))
+                    {
+                        batchOk = false;
+                        break;
+                    }
+                }
+                batch.End();
+                if (!batchOk)
                 {
                     return false;
                 }
@@ -1772,16 +1811,33 @@ namespace Bench
             {
                 return false;
             }
-            for (int i = 0; i < value.StatsCount; i++)
             {
-                if (!ReadMixedStat(stream, value.Stats[i]))
+                // scoped batch: one capture and one restore for the whole site
+                ReadBatch batch = stream.BeginBatch();
+                bool batchOk = true;
+                for (int i = 0; i < value.StatsCount; i++)
+                {
+                    if (!ReadMixedStatBatch(ref batch, value.Stats[i]))
+                    {
+                        batchOk = false;
+                        break;
+                    }
+                }
+                batch.End();
+                if (!batchOk)
                 {
                     return false;
                 }
             }
-            if (!ReadMixedEvent(stream, value.GameEvent))
             {
-                return false;
+                // scoped batch: one capture and one restore for the whole site
+                ReadBatch batch = stream.BeginBatch();
+                bool batchOk = ReadMixedEventBatch(ref batch, value.GameEvent);
+                batch.End();
+                if (!batchOk)
+                {
+                    return false;
+                }
             }
             for (int i = 0; i < 4; i++)
             {

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -391,24 +391,20 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F005Uint > 7316)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F005Uint);
-                if (!batch.SerializeBits(ref offsetValue, 13))
+                // flat run: 25 bits in 1 chunk(s) — the field placement is folded
+                if (value.F005Uint > 7316)
                 {
                     return false;
                 }
-            }
-            if (value.F006Int < -1513 || value.F006Int > 1513)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F006Int) - unchecked((uint)(-1513));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.F006Int < -1513 || value.F006Int > 1513)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.F005Uint))) & 0x1fffUL;
+                ulong f1 = ((ulong)((uint)(value.F006Int) - unchecked((uint)(-1513)))) & 0xfffUL;
+                uint w0 = (uint)(f0 | (f1 << 13));
+                if (!batch.SerializeBits(ref w0, 25))
                 {
                     return false;
                 }
@@ -436,13 +432,15 @@ namespace Realworld
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F011Bits, 10))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F012Bool))
-            {
-                return false;
+                // flat run: 11 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.F011Bits) & 0x3ffUL;
+                ulong f1 = value.F012Bool ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 10));
+                if (!batch.SerializeBits(ref w0, 11))
+                {
+                    return false;
+                }
             }
             if (value.F012Bool)
             {
@@ -450,24 +448,20 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (value.F014Uint > 775)
                 {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F014Uint);
-                    if (!batch.SerializeBits(ref offsetValue, 10))
+                    // flat run: 16 bits in 1 chunk(s) — the field placement is folded
+                    if (value.F014Uint > 775)
                     {
                         return false;
                     }
-                }
-                if (value.F015Int < -21 || value.F015Int > 21)
-                {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F015Int) - unchecked((uint)(-21));
-                    if (!batch.SerializeBits(ref offsetValue, 6))
+                    if (value.F015Int < -21 || value.F015Int > 21)
+                    {
+                        return false;
+                    }
+                    ulong f0 = ((ulong)((uint)(value.F014Uint))) & 0x3ffUL;
+                    ulong f1 = ((ulong)((uint)(value.F015Int) - unchecked((uint)(-21)))) & 0x3fUL;
+                    uint w0 = (uint)(f0 | (f1 << 10));
+                    if (!batch.SerializeBits(ref w0, 16))
                     {
                         return false;
                     }
@@ -553,92 +547,62 @@ namespace Realworld
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F031Bits, 1))
             {
-                return false;
-            }
-            if (value.F032Int < -3 || value.F032Int > 3)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F032Int) - unchecked((uint)(-3));
-                if (!batch.SerializeBits(ref offsetValue, 3))
+                // flat run: 69 bits in 2 chunk(s) — the field placement is folded
+                if (value.F032Int < -3 || value.F032Int > 3)
                 {
                     return false;
                 }
-            }
-            if (value.F033Uint > 142780)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F033Uint);
-                if (!batch.SerializeBits(ref offsetValue, 18))
+                if (value.F033Uint > 142780)
                 {
                     return false;
                 }
-            }
-            if (value.F034Uint > 14149)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F034Uint);
-                if (!batch.SerializeBits(ref offsetValue, 14))
+                if (value.F034Uint > 14149)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBits(ref value.F035Bits, 9))
-            {
-                return false;
-            }
-            {
-                uint enumValue = (uint)value.F036Enum;
-                if (enumValue > 5) // headroom above the wire range cannot ride
+                if ((uint)value.F036Enum > 5) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref enumValue, 3))
+                ulong f0 = ((ulong)value.F031Bits) & 0x1UL;
+                ulong f1 = ((ulong)((uint)(value.F032Int) - unchecked((uint)(-3)))) & 0x7UL;
+                ulong f2 = ((ulong)((uint)(value.F033Uint))) & 0x3ffffUL;
+                ulong f3 = ((ulong)((uint)(value.F034Uint))) & 0x3fffUL;
+                ulong f4 = ((ulong)value.F035Bits) & 0x1ffUL;
+                ulong f5 = ((ulong)(uint)value.F036Enum) & 0x7UL;
+                ulong f6 = value.F037Bool ? 1UL : 0UL;
+                ulong f7 = value.F038Bool ? 1UL : 0UL;
+                ulong f8 = ((ulong)value.F039Bits) & 0x7ffffUL;
+                ulong w0 = f0 | (f1 << 1) | (f2 << 4) | (f3 << 22) | (f4 << 36) | (f5 << 45) | (f6 << 48) | (f7 << 49) | (f8 << 50);
+                if (!batch.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBool(ref value.F037Bool))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F038Bool))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F039Bits, 19))
-            {
-                return false;
+                uint w1 = (uint)((f8 >> 14));
+                if (!batch.SerializeBits(ref w1, 5))
+                {
+                    return false;
+                }
             }
             if (!batch.SerializeFixed(ref value.F040Fixed, 4, 12, -5, 5))
             {
                 return false;
             }
-            if (value.F041Int < -55 || value.F041Int > 55)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F041Int) - unchecked((uint)(-55));
-                if (!batch.SerializeBits(ref offsetValue, 7))
+                // flat run: 38 bits in 1 chunk(s) — the field placement is folded
+                if (value.F041Int < -55 || value.F041Int > 55)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBits(ref value.F042Bits, 30))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F043Bool))
-            {
-                return false;
+                ulong f0 = ((ulong)((uint)(value.F041Int) - unchecked((uint)(-55)))) & 0x7fUL;
+                ulong f1 = ((ulong)value.F042Bits) & 0x3fffffffUL;
+                ulong f2 = value.F043Bool ? 1UL : 0UL;
+                ulong w0 = f0 | (f1 << 7) | (f2 << 37);
+                if (!batch.SerializeBits64(ref w0, 38))
+                {
+                    return false;
+                }
             }
             if (value.F043Bool)
             {
@@ -646,28 +610,21 @@ namespace Realworld
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref value.F045Bits, 12))
                 {
-                    return false;
-                }
-                if (value.F046Uint > 76063)
-                {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F046Uint);
-                    if (!batch.SerializeBits(ref offsetValue, 17))
+                    // flat run: 49 bits in 1 chunk(s) — the field placement is folded
+                    if (value.F046Uint > 76063)
                     {
                         return false;
                     }
-                }
-                if (value.F047Int < -430976 || value.F047Int > 430976)
-                {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F047Int) - unchecked((uint)(-430976));
-                    if (!batch.SerializeBits(ref offsetValue, 20))
+                    if (value.F047Int < -430976 || value.F047Int > 430976)
+                    {
+                        return false;
+                    }
+                    ulong f0 = ((ulong)value.F045Bits) & 0xfffUL;
+                    ulong f1 = ((ulong)((uint)(value.F046Uint))) & 0x1ffffUL;
+                    ulong f2 = ((ulong)((uint)(value.F047Int) - unchecked((uint)(-430976)))) & 0xfffffUL;
+                    ulong w0 = f0 | (f1 << 12) | (f2 << 29);
+                    if (!batch.SerializeBits64(ref w0, 49))
                     {
                         return false;
                     }
@@ -687,17 +644,16 @@ namespace Realworld
             }
             if (value.F050Bool)
             {
-                if (!batch.SerializeBool(ref value.F051Bool))
                 {
-                    return false;
-                }
-                if (value.F052Int < -57 || value.F052Int > 57)
-                {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F052Int) - unchecked((uint)(-57));
-                    if (!batch.SerializeBits(ref offsetValue, 7))
+                    // flat run: 8 bits in 1 chunk(s) — the field placement is folded
+                    if (value.F052Int < -57 || value.F052Int > 57)
+                    {
+                        return false;
+                    }
+                    ulong f0 = value.F051Bool ? 1UL : 0UL;
+                    ulong f1 = ((ulong)((uint)(value.F052Int) - unchecked((uint)(-57)))) & 0x7fUL;
+                    uint w0 = (uint)(f0 | (f1 << 1));
+                    if (!batch.SerializeBits(ref w0, 8))
                     {
                         return false;
                     }
@@ -718,28 +674,21 @@ namespace Realworld
                     }
                 }
             }
-            if (!batch.SerializeBool(ref value.F055Bool))
             {
-                return false;
-            }
-            if (value.F056Int < -13 || value.F056Int > 13)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F056Int) - unchecked((uint)(-13));
-                if (!batch.SerializeBits(ref offsetValue, 5))
+                // flat run: 11 bits in 1 chunk(s) — the field placement is folded
+                if (value.F056Int < -13 || value.F056Int > 13)
                 {
                     return false;
                 }
-            }
-            if (value.F057Int < -15 || value.F057Int > 15)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F057Int) - unchecked((uint)(-15));
-                if (!batch.SerializeBits(ref offsetValue, 5))
+                if (value.F057Int < -15 || value.F057Int > 15)
+                {
+                    return false;
+                }
+                ulong f0 = value.F055Bool ? 1UL : 0UL;
+                ulong f1 = ((ulong)((uint)(value.F056Int) - unchecked((uint)(-13)))) & 0x1fUL;
+                ulong f2 = ((ulong)((uint)(value.F057Int) - unchecked((uint)(-15)))) & 0x1fUL;
+                uint w0 = (uint)(f0 | (f1 << 1) | (f2 << 6));
+                if (!batch.SerializeBits(ref w0, 11))
                 {
                     return false;
                 }
@@ -763,31 +712,26 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F062Uint > 503)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F062Uint);
-                if (!batch.SerializeBits(ref offsetValue, 9))
+                // flat run: 82 bits in 2 chunk(s) — the field placement is folded
+                if (value.F062Uint > 503)
                 {
                     return false;
                 }
-            }
-            {
-                ulong rawValue = (ulong)value.F063I64;
-                if (!batch.SerializeBits64(ref rawValue, 64))
+                if (value.F064Uint > 299)
                 {
                     return false;
                 }
-            }
-            if (value.F064Uint > 299)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F064Uint);
-                if (!batch.SerializeBits(ref offsetValue, 9))
+                ulong f0 = ((ulong)((uint)(value.F062Uint))) & 0x1ffUL;
+                ulong f1 = (ulong)value.F063I64;
+                ulong f2 = ((ulong)((uint)(value.F064Uint))) & 0x1ffUL;
+                ulong w0 = f0 | (f1 << 9);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f1 >> 55) | (f2 << 9));
+                if (!batch.SerializeBits(ref w1, 18))
                 {
                     return false;
                 }
@@ -817,17 +761,16 @@ namespace Realworld
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.F069Bits, 11))
             {
-                return false;
-            }
-            if (value.F070Uint > 2)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F070Uint);
-                if (!batch.SerializeBits(ref offsetValue, 2))
+                // flat run: 13 bits in 1 chunk(s) — the field placement is folded
+                if (value.F070Uint > 2)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)value.F069Bits) & 0x7ffUL;
+                ulong f1 = ((ulong)((uint)(value.F070Uint))) & 0x3UL;
+                uint w0 = (uint)(f0 | (f1 << 11));
+                if (!batch.SerializeBits(ref w0, 13))
                 {
                     return false;
                 }
@@ -846,84 +789,65 @@ namespace Realworld
                     return false;
                 }
             }
-            if (value.F073Int < -4 || value.F073Int > 4)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F073Int) - unchecked((uint)(-4));
-                if (!batch.SerializeBits(ref offsetValue, 4))
+                // flat run: 5 bits in 1 chunk(s) — the field placement is folded
+                if (value.F073Int < -4 || value.F073Int > 4)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBool(ref value.F074Bool))
-            {
-                return false;
+                ulong f0 = ((ulong)((uint)(value.F073Int) - unchecked((uint)(-4)))) & 0xfUL;
+                ulong f1 = value.F074Bool ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 4));
+                if (!batch.SerializeBits(ref w0, 5))
+                {
+                    return false;
+                }
             }
             if (value.F074Bool)
             {
-                if (!batch.SerializeBits64(ref value.F075U64, 64))
                 {
-                    return false;
-                }
-                if (value.F076Int < -26218 || value.F076Int > 26218)
-                {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F076Int) - unchecked((uint)(-26218));
-                    if (!batch.SerializeBits(ref offsetValue, 16))
+                    // flat run: 100 bits in 2 chunk(s) — the field placement is folded
+                    if (value.F076Int < -26218 || value.F076Int > 26218)
                     {
                         return false;
                     }
-                }
-                if (value.F077Int < -17 || value.F077Int > 17)
-                {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F077Int) - unchecked((uint)(-17));
-                    if (!batch.SerializeBits(ref offsetValue, 6))
+                    if (value.F077Int < -17 || value.F077Int > 17)
                     {
                         return false;
                     }
-                }
-                if (!batch.SerializeBits(ref value.F078Bits, 9))
-                {
-                    return false;
-                }
-                if (value.F079Uint > 17)
-                {
-                    return false;
-                }
-                {
-                    uint offsetValue = (uint)(value.F079Uint);
-                    if (!batch.SerializeBits(ref offsetValue, 5))
+                    if (value.F079Uint > 17)
+                    {
+                        return false;
+                    }
+                    ulong f0 = (ulong)value.F075U64;
+                    ulong f1 = ((ulong)((uint)(value.F076Int) - unchecked((uint)(-26218)))) & 0xffffUL;
+                    ulong f2 = ((ulong)((uint)(value.F077Int) - unchecked((uint)(-17)))) & 0x3fUL;
+                    ulong f3 = ((ulong)value.F078Bits) & 0x1ffUL;
+                    ulong f4 = ((ulong)((uint)(value.F079Uint))) & 0x1fUL;
+                    ulong w0 = f0;
+                    if (!batch.SerializeBits64(ref w0, 64))
+                    {
+                        return false;
+                    }
+                    ulong w1 = f1 | (f2 << 16) | (f3 << 22) | (f4 << 31);
+                    if (!batch.SerializeBits64(ref w1, 36))
                     {
                         return false;
                     }
                 }
             }
-            if (!batch.SerializeBool(ref value.F080Bool))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F081Bits, 29))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F082Bits, 25))
-            {
-                return false;
-            }
-            {
-                uint enumValue = (uint)value.F083Enum;
-                if (enumValue > 5) // headroom above the wire range cannot ride
+                // flat run: 58 bits in 1 chunk(s) — the field placement is folded
+                if ((uint)value.F083Enum > 5) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref enumValue, 3))
+                ulong f0 = value.F080Bool ? 1UL : 0UL;
+                ulong f1 = ((ulong)value.F081Bits) & 0x1fffffffUL;
+                ulong f2 = ((ulong)value.F082Bits) & 0x1ffffffUL;
+                ulong f3 = ((ulong)(uint)value.F083Enum) & 0x7UL;
+                ulong w0 = f0 | (f1 << 1) | (f2 << 30) | (f3 << 55);
+                if (!batch.SerializeBits64(ref w0, 58))
                 {
                     return false;
                 }
@@ -935,17 +859,16 @@ namespace Realworld
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.F085Bits, 21))
             {
-                return false;
-            }
-            if (value.F086Uint > 399)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F086Uint);
-                if (!batch.SerializeBits(ref offsetValue, 9))
+                // flat run: 30 bits in 1 chunk(s) — the field placement is folded
+                if (value.F086Uint > 399)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)value.F085Bits) & 0x1fffffUL;
+                ulong f1 = ((ulong)((uint)(value.F086Uint))) & 0x1ffUL;
+                uint w0 = (uint)(f0 | (f1 << 21));
+                if (!batch.SerializeBits(ref w0, 30))
                 {
                     return false;
                 }
@@ -954,66 +877,56 @@ namespace Realworld
             {
                 return false;
             }
-            if (value.F088Int < -694 || value.F088Int > 694)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F088Int) - unchecked((uint)(-694));
-                if (!batch.SerializeBits(ref offsetValue, 11))
+                // flat run: 138 bits in 3 chunk(s) — the field placement is folded
+                if (value.F088Int < -694 || value.F088Int > 694)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBits64(ref value.F089Bits, 48))
-            {
-                return false;
-            }
-            if (value.F090Uint > 214)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.F090Uint);
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (value.F090Uint > 214)
                 {
                     return false;
                 }
-            }
-            if (value.F091Flags >= 1ul << 5) // a mask bit above the wire width cannot ride
-            {
-                return false;
-            }
-            {
-                uint flagsValue = (uint)value.F091Flags;
-                if (!batch.SerializeBits(ref flagsValue, 5))
+                if (value.F091Flags >= 1ul << 5) // a mask bit above the wire width cannot ride
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBool(ref value.F092Bool))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.F093Bits, 64))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F094Bool))
-            {
-                return false;
+                ulong f0 = ((ulong)((uint)(value.F088Int) - unchecked((uint)(-694)))) & 0x7ffUL;
+                ulong f1 = ((ulong)value.F089Bits) & 0xffffffffffffUL;
+                ulong f2 = ((ulong)((uint)(value.F090Uint))) & 0xffUL;
+                ulong f3 = (value.F091Flags) & 0x1fUL;
+                ulong f4 = value.F092Bool ? 1UL : 0UL;
+                ulong f5 = (ulong)value.F093Bits;
+                ulong f6 = value.F094Bool ? 1UL : 0UL;
+                ulong w0 = f0 | (f1 << 11) | (f2 << 59);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                ulong w1 = (f2 >> 5) | (f3 << 3) | (f4 << 8) | (f5 << 9);
+                if (!batch.SerializeBits64(ref w1, 64))
+                {
+                    return false;
+                }
+                uint w2 = (uint)((f5 >> 55) | (f6 << 9));
+                if (!batch.SerializeBits(ref w2, 10))
+                {
+                    return false;
+                }
             }
             if (!batch.SerializeFixed(ref value.F095Fixed, 16, 16, -1577, 1577))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F096Bits, 18))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F097Bits, 12))
-            {
-                return false;
+                // flat run: 30 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.F096Bits) & 0x3ffffUL;
+                ulong f1 = ((ulong)value.F097Bits) & 0xfffUL;
+                uint w0 = (uint)(f0 | (f1 << 18));
+                if (!batch.SerializeBits(ref w0, 30))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/generated/bench/cs/realworld/RealWorld.cs
+++ b/generated/bench/cs/realworld/RealWorld.cs
@@ -995,13 +995,19 @@ namespace Realworld
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F011Bits, 10))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F012Bool))
-            {
-                return false;
+                // flat run: 11 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 11);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x3ffUL;
+                value.F011Bits = (uint)v0;
+                ulong v1 = (c0 >> 10) & 0x1UL;
+                value.F012Bool = v1 != 0UL;
             }
             if (value.F012Bool)
             {
@@ -1146,17 +1152,21 @@ namespace Realworld
                 }
                 value.F036Enum = (PacketMode)enumValue;
             }
-            if (!batch.SerializeBool(ref value.F037Bool))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F038Bool))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F039Bits, 19))
-            {
-                return false;
+                // flat run: 21 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 21);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1UL;
+                value.F037Bool = v0 != 0UL;
+                ulong v1 = (c0 >> 1) & 0x1UL;
+                value.F038Bool = v1 != 0UL;
+                ulong v2 = (c0 >> 2) & 0x7ffffUL;
+                value.F039Bits = (uint)v2;
             }
             if (!batch.SerializeFixed(ref value.F040Fixed, 4, 12, -5, 5))
             {
@@ -1170,13 +1180,19 @@ namespace Realworld
                 }
                 value.F041Int = (sbyte)rangeValue;
             }
-            if (!batch.SerializeBits(ref value.F042Bits, 30))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F043Bool))
-            {
-                return false;
+                // flat run: 31 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 31);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x3fffffffUL;
+                value.F042Bits = (uint)v0;
+                ulong v1 = (c0 >> 30) & 0x1UL;
+                value.F043Bool = v1 != 0UL;
             }
             if (value.F043Bool)
             {
@@ -1405,17 +1421,21 @@ namespace Realworld
                 value.F078Bits = 0;
                 value.F079Uint = 0;
             }
-            if (!batch.SerializeBool(ref value.F080Bool))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F081Bits, 29))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F082Bits, 25))
-            {
-                return false;
+                // flat run: 55 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 55);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1UL;
+                value.F080Bool = v0 != 0UL;
+                ulong v1 = (c0 >> 1) & 0x1fffffffUL;
+                value.F081Bits = (uint)v1;
+                ulong v2 = (c0 >> 30) & 0x1ffffffUL;
+                value.F082Bits = (uint)v2;
             }
             {
                 int enumValue = 0;
@@ -1470,36 +1490,42 @@ namespace Realworld
                 value.F090Uint = (byte)rangeValue;
             }
             {
-                uint flagsValue = 0;
-                if (!batch.SerializeBits(ref flagsValue, 5))
+                // flat run: 71 bits in 2 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                batch.SerializeBits64(ref c1, 7);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.F091Flags = flagsValue;
-            }
-            if (!batch.SerializeBool(ref value.F092Bool))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.F093Bits, 64))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.F094Bool))
-            {
-                return false;
+                ulong v0 = c0 & 0x1fUL;
+                value.F091Flags = v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.F092Bool = v1 != 0UL;
+                ulong v2 = ((c0 >> 6) | (c1 << 58));
+                value.F093Bits = v2;
+                ulong v3 = (c1 >> 6) & 0x1UL;
+                value.F094Bool = v3 != 0UL;
             }
             if (!batch.SerializeFixed(ref value.F095Fixed, 16, 16, -1577, 1577))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F096Bits, 18))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.F097Bits, 12))
-            {
-                return false;
+                // flat run: 30 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 30);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x3ffffUL;
+                value.F096Bits = (uint)v0;
+                ulong v1 = (c0 >> 18) & 0xfffUL;
+                value.F097Bits = (uint)v1;
             }
             return true;
         }

--- a/generated/cs/Clauses.cs
+++ b/generated/cs/Clauses.cs
@@ -1024,7 +1024,22 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteEmptyABatch(ref WriteBatch batch, EmptyA value)
+        {
+            // empty body — presence is the payload (SPEC §4.6)
+            return true;
+        }
+
         public static bool ReadEmptyA(ReadStream stream, EmptyA value)
+        {
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadEmptyABatch(ref ReadBatch batch, EmptyA value)
         {
             return true;
         }
@@ -1046,7 +1061,22 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteEmptyBBatch(ref WriteBatch batch, EmptyB value)
+        {
+            // empty body — presence is the payload (SPEC §4.6)
+            return true;
+        }
+
         public static bool ReadEmptyB(ReadStream stream, EmptyB value)
+        {
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadEmptyBBatch(ref ReadBatch batch, EmptyB value)
         {
             return true;
         }
@@ -1085,6 +1115,29 @@ namespace Example
             return true; // None — the tag is the whole wire (SPEC §4.8)
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteEmptyUnionBatch(ref WriteBatch batch, EmptyUnion value)
+        {
+            uint tagValue = (uint)value.Type;
+            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
+            {
+                return false;
+            }
+            if (!batch.SerializeBits(ref tagValue, 2))
+            {
+                return false;
+            }
+            switch (value.Type)
+            {
+                case EmptyUnionType.A:
+                    return WriteEmptyABatch(ref batch, value.A);
+                case EmptyUnionType.B:
+                    return WriteEmptyBBatch(ref batch, value.B);
+            }
+            return true; // None — the tag is the whole wire (SPEC §4.8)
+        }
+
         public static bool ReadEmptyUnion(ReadStream stream, EmptyUnion value)
         {
             int tagValue = 0;
@@ -1105,6 +1158,28 @@ namespace Example
             return true; // None
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadEmptyUnionBatch(ref ReadBatch batch, EmptyUnion value)
+        {
+            int tagValue = 0;
+            if (!batch.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
+            {
+                return false;
+            }
+            value.Type = (EmptyUnionType)tagValue;
+            switch (value.Type)
+            {
+                case EmptyUnionType.A:
+                    ZeroEmptyA(value.A); // the selected arm starts from the zero form (SPEC §5)
+                    return ReadEmptyABatch(ref batch, value.A);
+                case EmptyUnionType.B:
+                    ZeroEmptyB(value.B); // the selected arm starts from the zero form (SPEC §5)
+                    return ReadEmptyBBatch(ref batch, value.B);
+            }
+            return true; // None
+        }
+
         // HoldsEmptyUnionMaxBits is the longest wire path; align pads at worst case (SPEC §6.1).
         // HoldsEmptyUnionMaxBytes is rounded up to the 8-byte write-buffer granularity.
         public const long HoldsEmptyUnionMaxBits = 14;
@@ -1118,17 +1193,29 @@ namespace Example
             value.Tail = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteHoldsEmptyUnion(WriteStream stream, HoldsEmptyUnion value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteHoldsEmptyUnionBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteHoldsEmptyUnionBatch(ref WriteBatch batch, HoldsEmptyUnion value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!WriteEmptyUnion(stream, value.U))
+            if (!WriteEmptyUnionBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 7))
+            if (!batch.SerializeBits(ref value.Tail, 7))
             {
                 return false;
             }
@@ -1137,15 +1224,25 @@ namespace Example
 
         public static bool ReadHoldsEmptyUnion(ReadStream stream, HoldsEmptyUnion value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadHoldsEmptyUnionBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadHoldsEmptyUnionBatch(ref ReadBatch batch, HoldsEmptyUnion value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!ReadEmptyUnion(stream, value.U))
+            if (!ReadEmptyUnionBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 7))
+            if (!batch.SerializeBits(ref value.Tail, 7))
             {
                 return false;
             }

--- a/generated/cs/Clauses.cs
+++ b/generated/cs/Clauses.cs
@@ -777,13 +777,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTri3Batch(ref WriteBatch batch, Tri3 value)
         {
-            if (!batch.SerializeBits(ref value.A, 1))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 2))
-            {
-                return false;
+                // flat run: 3 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.A) & 0x1UL;
+                ulong f1 = ((ulong)value.B) & 0x3UL;
+                uint w0 = (uint)(f0 | (f1 << 1));
+                if (!batch.SerializeBits(ref w0, 3))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -913,13 +915,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteElevenBatch(ref WriteBatch batch, Eleven value)
         {
-            if (!batch.SerializeBits(ref value.A, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 8))
-            {
-                return false;
+                // flat run: 11 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.A) & 0x7UL;
+                ulong f1 = ((ulong)value.B) & 0xffUL;
+                uint w0 = (uint)(f0 | (f1 << 3));
+                if (!batch.SerializeBits(ref w0, 11))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/generated/cs/Clauses.cs
+++ b/generated/cs/Clauses.cs
@@ -802,13 +802,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTri3Batch(ref ReadBatch batch, Tri3 value)
         {
-            if (!batch.SerializeBits(ref value.A, 1))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 2))
-            {
-                return false;
+                // flat run: 3 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 3);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1UL;
+                value.A = (uint)v0;
+                ulong v1 = (c0 >> 1) & 0x3UL;
+                value.B = (uint)v1;
             }
             return true;
         }
@@ -940,13 +946,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadElevenBatch(ref ReadBatch batch, Eleven value)
         {
-            if (!batch.SerializeBits(ref value.A, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 8))
-            {
-                return false;
+                // flat run: 11 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 11);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x7UL;
+                value.A = (uint)v0;
+                ulong v1 = (c0 >> 3) & 0xffUL;
+                value.B = (uint)v1;
             }
             return true;
         }

--- a/generated/cs/Degenerate.cs
+++ b/generated/cs/Degenerate.cs
@@ -628,17 +628,21 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTrioBatch(ref ReadBatch batch, Trio value)
         {
-            if (!batch.SerializeBits(ref value.A, 20))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 20))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.C, 24))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xfffffUL;
+                value.A = (uint)v0;
+                ulong v1 = (c0 >> 20) & 0xfffffUL;
+                value.B = (uint)v1;
+                ulong v2 = (c0 >> 40) & 0xffffffUL;
+                value.C = (uint)v2;
             }
             return true;
         }

--- a/generated/cs/Degenerate.cs
+++ b/generated/cs/Degenerate.cs
@@ -602,17 +602,16 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTrioBatch(ref WriteBatch batch, Trio value)
         {
-            if (!batch.SerializeBits(ref value.A, 20))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 20))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.C, 24))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.A) & 0xfffffUL;
+                ulong f1 = ((ulong)value.B) & 0xfffffUL;
+                ulong f2 = ((ulong)value.C) & 0xffffffUL;
+                ulong w0 = f0 | (f1 << 20) | (f2 << 40);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/generated/cs/Joins.cs
+++ b/generated/cs/Joins.cs
@@ -267,13 +267,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmsAgreeBatch(ref ReadBatch batch, ArmsAgree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -370,13 +376,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmsDisagreeBatch(ref ReadBatch batch, ArmsDisagree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -465,13 +477,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmEmptyBatch(ref ReadBatch batch, ArmEmpty value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -579,13 +597,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmsNestedBatch(ref ReadBatch batch, ArmsNested value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Outer))
-            {
-                return false;
+                // flat run: 4 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 4);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x7UL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 3) & 0x1UL;
+                value.Outer = v1 != 0UL;
             }
             if (value.Outer)
             {
@@ -690,13 +714,19 @@ namespace Example
 
         public static bool ReadArmAlign(ReadStream stream, ArmAlign value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 6);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -827,13 +857,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmArrayBatch(ref ReadBatch batch, ArmArray value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -1332,21 +1368,25 @@ namespace Example
                     return false;
                 }
             }
-            if (!stream.SerializeBits(ref value.P, 32))
             {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Q, 29))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.R, 19))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Tail, 4))
-            {
-                return false;
+                // flat run: 84 bits in 2 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                stream.SerializeBits64(ref c1, 20);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffffffffUL;
+                value.P = (uint)v0;
+                ulong v1 = (c0 >> 32) & 0x1fffffffUL;
+                value.Q = (uint)v1;
+                ulong v2 = ((c0 >> 61) | (c1 << 3)) & 0x7ffffUL;
+                value.R = (uint)v2;
+                ulong v3 = (c1 >> 16) & 0xfUL;
+                value.Tail = (uint)v3;
             }
             return true;
         }

--- a/generated/cs/Joins.cs
+++ b/generated/cs/Joins.cs
@@ -224,13 +224,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmsAgreeBatch(ref WriteBatch batch, ArmsAgree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -325,13 +327,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmsDisagreeBatch(ref WriteBatch batch, ArmsDisagree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -425,13 +429,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmEmptyBatch(ref WriteBatch batch, ArmEmpty value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -516,13 +522,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmsNestedBatch(ref WriteBatch batch, ArmsNested value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Outer))
-            {
-                return false;
+                // flat run: 4 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x7UL;
+                ulong f1 = value.Outer ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 3));
+                if (!batch.SerializeBits(ref w0, 4))
+                {
+                    return false;
+                }
             }
             if (value.Outer)
             {
@@ -638,13 +646,15 @@ namespace Example
 
         public static bool WriteArmAlign(WriteStream stream, ArmAlign value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!stream.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -753,13 +763,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmArrayBatch(ref WriteBatch batch, ArmArray value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -1264,21 +1276,22 @@ namespace Example
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.P, 32))
             {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Q, 29))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.R, 19))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Tail, 4))
-            {
-                return false;
+                // flat run: 84 bits in 2 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.P) & 0xffffffffUL;
+                ulong f1 = ((ulong)value.Q) & 0x1fffffffUL;
+                ulong f2 = ((ulong)value.R) & 0x7ffffUL;
+                ulong f3 = ((ulong)value.Tail) & 0xfUL;
+                ulong w0 = f0 | (f1 << 32) | (f2 << 61);
+                if (!stream.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f2 >> 3) | (f3 << 16));
+                if (!stream.SerializeBits(ref w1, 20))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/generated/cs/Joins.cs
+++ b/generated/cs/Joins.cs
@@ -878,9 +878,31 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteNarrowBatch(ref WriteBatch batch, Narrow value)
+        {
+            if (!batch.SerializeBits(ref value.N, 3))
+            {
+                return false;
+            }
+            return true;
+        }
+
         public static bool ReadNarrow(ReadStream stream, Narrow value)
         {
             if (!stream.SerializeBits(ref value.N, 3))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadNarrowBatch(ref ReadBatch batch, Narrow value)
+        {
+            if (!batch.SerializeBits(ref value.N, 3))
             {
                 return false;
             }
@@ -907,9 +929,31 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteWideBatch(ref WriteBatch batch, Wide value)
+        {
+            if (!batch.SerializeBits64(ref value.W, 37))
+            {
+                return false;
+            }
+            return true;
+        }
+
         public static bool ReadWide(ReadStream stream, Wide value)
         {
             if (!stream.SerializeBits64(ref value.W, 37))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadWideBatch(ref ReadBatch batch, Wide value)
+        {
+            if (!batch.SerializeBits64(ref value.W, 37))
             {
                 return false;
             }
@@ -929,31 +973,53 @@ namespace Example
             value.Type = UnevenType.None;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteUneven(WriteStream stream, Uneven value)
+        {
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteUnevenBatch(ref WriteBatch batch, Uneven value)
         {
             uint tagValue = (uint)value.Type;
             if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref tagValue, 2))
+            if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
             }
             switch (value.Type)
             {
                 case UnevenType.Narrow:
-                    return WriteNarrow(stream, value.Narrow);
+                    return WriteNarrowBatch(ref batch, value.Narrow);
                 case UnevenType.Wide:
-                    return WriteWide(stream, value.Wide);
+                    return WriteWideBatch(ref batch, value.Wide);
             }
             return true; // None — the tag is the whole wire (SPEC §4.8)
         }
 
         public static bool ReadUneven(ReadStream stream, Uneven value)
         {
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadUnevenBatch(ref ReadBatch batch, Uneven value)
+        {
             int tagValue = 0;
-            if (!stream.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
+            if (!batch.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
             {
                 return false;
             }
@@ -962,10 +1028,10 @@ namespace Example
             {
                 case UnevenType.Narrow:
                     ZeroNarrow(value.Narrow); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadNarrow(stream, value.Narrow);
+                    return ReadNarrowBatch(ref batch, value.Narrow);
                 case UnevenType.Wide:
                     ZeroWide(value.Wide); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadWide(stream, value.Wide);
+                    return ReadWideBatch(ref batch, value.Wide);
             }
             return true; // None
         }
@@ -983,17 +1049,29 @@ namespace Example
             value.Tail = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteHoldsUneven(WriteStream stream, HoldsUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteHoldsUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteHoldsUnevenBatch(ref WriteBatch batch, HoldsUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!WriteUneven(stream, value.U))
+            if (!WriteUnevenBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 11))
+            if (!batch.SerializeBits(ref value.Tail, 11))
             {
                 return false;
             }
@@ -1002,15 +1080,25 @@ namespace Example
 
         public static bool ReadHoldsUneven(ReadStream stream, HoldsUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadHoldsUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadHoldsUnevenBatch(ref ReadBatch batch, HoldsUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!ReadUneven(stream, value.U))
+            if (!ReadUnevenBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 11))
+            if (!batch.SerializeBits(ref value.Tail, 11))
             {
                 return false;
             }
@@ -1034,9 +1122,21 @@ namespace Example
             value.Tail = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteArrUneven(WriteStream stream, ArrUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteArrUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteArrUnevenBatch(ref WriteBatch batch, ArrUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
@@ -1046,19 +1146,19 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ItemsCount);
-                if (!stream.SerializeBits(ref offsetValue, 2))
+                if (!batch.SerializeBits(ref offsetValue, 2))
                 {
                     return false;
                 }
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (!WriteUneven(stream, value.Items[i]))
+                if (!WriteUnevenBatch(ref batch, value.Items[i]))
                 {
                     return false;
                 }
             }
-            if (!stream.SerializeBits(ref value.Tail, 3))
+            if (!batch.SerializeBits(ref value.Tail, 3))
             {
                 return false;
             }
@@ -1067,22 +1167,32 @@ namespace Example
 
         public static bool ReadArrUneven(ReadStream stream, ArrUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadArrUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadArrUnevenBatch(ref ReadBatch batch, ArrUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!stream.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
+            if (!batch.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
             {
                 return false;
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (!ReadUneven(stream, value.Items[i]))
+                if (!ReadUnevenBatch(ref batch, value.Items[i]))
                 {
                     return false;
                 }
             }
-            if (!stream.SerializeBits(ref value.Tail, 3))
+            if (!batch.SerializeBits(ref value.Tail, 3))
             {
                 return false;
             }
@@ -1108,21 +1218,9 @@ namespace Example
             value.Tail = 0;
         }
 
-        // batch form: stream state stays in registers across the body and End
-        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRegainAfterAlign(WriteStream stream, RegainAfterAlign value)
         {
-            WriteBatch batch = stream.BeginBatch();
-            bool result = WriteRegainAfterAlignBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool WriteRegainAfterAlignBatch(ref WriteBatch batch, RegainAfterAlign value)
-        {
-            if (!batch.SerializeBits(ref value.Lead, 5))
+            if (!stream.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
@@ -1132,7 +1230,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ItemsCount);
-                if (!batch.SerializeBits(ref offsetValue, 2))
+                if (!stream.SerializeBits(ref offsetValue, 2))
                 {
                     return false;
                 }
@@ -1145,7 +1243,7 @@ namespace Example
                 }
                 {
                     uint offsetValue = (uint)(value.Items[i]);
-                    if (!batch.SerializeBits(ref offsetValue, 13))
+                    if (!stream.SerializeBits(ref offsetValue, 13))
                     {
                         return false;
                     }
@@ -1157,28 +1255,28 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.SLength);
-                if (!batch.SerializeBits(ref offsetValue, 3))
+                if (!stream.SerializeBits(ref offsetValue, 3))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBytes(value.S.AsSpan(0, value.SLength)))
+            if (!stream.SerializeBytes(value.S.AsSpan(0, value.SLength)))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.P, 32))
+            if (!stream.SerializeBits(ref value.P, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Q, 29))
+            if (!stream.SerializeBits(ref value.Q, 29))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.R, 19))
+            if (!stream.SerializeBits(ref value.R, 19))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Tail, 4))
+            if (!stream.SerializeBits(ref value.Tail, 4))
             {
                 return false;
             }
@@ -1187,21 +1285,11 @@ namespace Example
 
         public static bool ReadRegainAfterAlign(ReadStream stream, RegainAfterAlign value)
         {
-            ReadBatch batch = stream.BeginBatch();
-            bool result = ReadRegainAfterAlignBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ReadRegainAfterAlignBatch(ref ReadBatch batch, RegainAfterAlign value)
-        {
-            if (!batch.SerializeBits(ref value.Lead, 5))
+            if (!stream.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
+            if (!stream.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
             {
                 return false;
             }
@@ -1209,18 +1297,18 @@ namespace Example
             {
                 {
                     int rangeValue = 0;
-                    if (!batch.SerializeInt(ref rangeValue, 0, 8191))
+                    if (!stream.SerializeInt(ref rangeValue, 0, 8191))
                     {
                         return false;
                     }
                     value.Items[i] = (ushort)rangeValue;
                 }
             }
-            if (!batch.SerializeInt(ref value.SLength, 0, 4)) // the length guards the slice (§6.3)
+            if (!stream.SerializeInt(ref value.SLength, 0, 4)) // the length guards the slice (§6.3)
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.S.AsSpan(0, value.SLength)))
+            if (!stream.SerializeBytes(value.S.AsSpan(0, value.SLength)))
             {
                 return false;
             }
@@ -1231,19 +1319,19 @@ namespace Example
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.P, 32))
+            if (!stream.SerializeBits(ref value.P, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Q, 29))
+            if (!stream.SerializeBits(ref value.Q, 29))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.R, 19))
+            if (!stream.SerializeBits(ref value.R, 19))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Tail, 4))
+            if (!stream.SerializeBits(ref value.Tail, 4))
             {
                 return false;
             }

--- a/generated/cs/Render.cs
+++ b/generated/cs/Render.cs
@@ -73,32 +73,29 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderSpriteBatch(ref WriteBatch batch, RenderSprite value)
         {
-            if (!batch.SerializeBits64(ref value.SortKey, 64))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MeshId, 32))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MaterialId, 32))
-            {
-                return false;
-            }
-            {
-                uint rawValue = value.Layer;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                // flat run: 138 bits in 3 chunk(s) — the field placement is folded
+                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-            }
-            {
-                uint enumValue = (uint)value.Team;
-                if (enumValue > 2) // headroom above the wire range cannot ride
+                ulong f0 = (ulong)value.SortKey;
+                ulong f1 = ((ulong)(value.MeshId)) & 0xffffffffUL;
+                ulong f2 = ((ulong)(value.MaterialId)) & 0xffffffffUL;
+                ulong f3 = ((ulong)(value.Layer)) & 0xffUL;
+                ulong f4 = ((ulong)(uint)value.Team) & 0x3UL;
+                ulong w0 = f0;
+                if (!batch.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref enumValue, 2))
+                ulong w1 = f1 | (f2 << 32);
+                if (!batch.SerializeBits64(ref w1, 64))
+                {
+                    return false;
+                }
+                uint w2 = (uint)(f3 | (f4 << 8));
+                if (!batch.SerializeBits(ref w2, 10))
                 {
                     return false;
                 }
@@ -180,13 +177,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderBlockBatch(ref WriteBatch batch, RenderBlock value)
         {
-            if (!batch.SerializeBits(ref value.WorkerIndex, 32))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.SpriteCountHint, 32))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)(value.WorkerIndex)) & 0xffffffffUL;
+                ulong f1 = ((ulong)(value.SpriteCountHint)) & 0xffffffffUL;
+                ulong w0 = f0 | (f1 << 32);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
             }
             if (value.SpritesCount < 0 || value.SpritesCount > (int)RenderBlockMaxSprites) // the count guards the loop (§6.3); out-of-contract writes are refused
             {

--- a/generated/cs/Render.cs
+++ b/generated/cs/Render.cs
@@ -115,25 +115,27 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderSpriteBatch(ref ReadBatch batch, RenderSprite value)
         {
-            if (!batch.SerializeBits64(ref value.SortKey, 64))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MeshId, 32))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MaterialId, 32))
-            {
-                return false;
-            }
-            {
-                uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                // flat run: 136 bits in 3 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                batch.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                batch.SerializeBits64(ref c2, 8);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.Layer = (byte)rawValue;
+                ulong v0 = c0;
+                value.SortKey = v0;
+                ulong v1 = c1 & 0xffffffffUL;
+                value.MeshId = (uint)(uint)v1;
+                ulong v2 = (c1 >> 32) & 0xffffffffUL;
+                value.MaterialId = (uint)(uint)v2;
+                ulong v3 = c2 & 0xffUL;
+                value.Layer = (byte)(uint)v3;
             }
             {
                 int enumValue = 0;
@@ -220,13 +222,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderBlockBatch(ref ReadBatch batch, RenderBlock value)
         {
-            if (!batch.SerializeBits(ref value.WorkerIndex, 32))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.SpriteCountHint, 32))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffffffffUL;
+                value.WorkerIndex = (uint)(uint)v0;
+                ulong v1 = (c0 >> 32) & 0xffffffffUL;
+                value.SpriteCountHint = (uint)(uint)v1;
             }
             if (!batch.SerializeInt(ref value.SpritesCount, 0, (int)RenderBlockMaxSprites)) // the count guards the loop (§6.3)
             {

--- a/generated/cs/Types.cs
+++ b/generated/cs/Types.cs
@@ -857,37 +857,31 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.Fire))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.AltFire))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Boost))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Brake))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Aim))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.LockOn))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Zoom))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Ping))
-            {
-                return false;
+                // flat run: 8 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 8);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1UL;
+                value.Fire = v0 != 0UL;
+                ulong v1 = (c0 >> 1) & 0x1UL;
+                value.AltFire = v1 != 0UL;
+                ulong v2 = (c0 >> 2) & 0x1UL;
+                value.Boost = v2 != 0UL;
+                ulong v3 = (c0 >> 3) & 0x1UL;
+                value.Brake = v3 != 0UL;
+                ulong v4 = (c0 >> 4) & 0x1UL;
+                value.Aim = v4 != 0UL;
+                ulong v5 = (c0 >> 5) & 0x1UL;
+                value.LockOn = v5 != 0UL;
+                ulong v6 = (c0 >> 6) & 0x1UL;
+                value.Zoom = v6 != 0UL;
+                ulong v7 = (c0 >> 7) & 0x1UL;
+                value.Ping = v7 != 0UL;
             }
             return true;
         }

--- a/generated/cs/Types.cs
+++ b/generated/cs/Types.cs
@@ -331,20 +331,16 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteHandleBatch(ref WriteBatch batch, Handle value)
         {
-            if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.ObjectId);
-                if (!batch.SerializeBits(ref offsetValue, 14))
+                // flat run: 22 bits in 1 chunk(s) — the field placement is folded
+                if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.ObjectSequence;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                ulong f0 = ((ulong)((uint)(value.ObjectId))) & 0x3fffUL;
+                ulong f1 = ((ulong)(value.ObjectSequence)) & 0xffUL;
+                uint w0 = (uint)(f0 | (f1 << 14));
+                if (!batch.SerializeBits(ref w0, 22))
                 {
                     return false;
                 }
@@ -406,35 +402,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedPositionBatch(ref WriteBatch batch, QuantizedPosition value)
         {
-            if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.X) - unchecked((uint)((int)(-MaxPositionUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 25))
+                // flat run: 75 bits in 2 chunk(s) — the field placement is folded
+                if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Y) - unchecked((uint)((int)(-MaxPositionUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 25))
+                if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Z) - unchecked((uint)((int)(-MaxPositionUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 25))
+                if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
+                ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
+                ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
+                ulong w0 = f0 | (f1 << 25) | (f2 << 50);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f2 >> 14));
+                if (!batch.SerializeBits(ref w1, 11))
                 {
                     return false;
                 }
@@ -496,35 +487,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedVelocityBatch(ref WriteBatch batch, QuantizedVelocity value)
         {
-            if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.X) - unchecked((uint)((int)(-MaxVelocityUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 23))
+                // flat run: 69 bits in 2 chunk(s) — the field placement is folded
+                if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Y) - unchecked((uint)((int)(-MaxVelocityUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 23))
+                if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Z) - unchecked((uint)((int)(-MaxVelocityUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 23))
+                if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
+                ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
+                ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
+                ulong w0 = f0 | (f1 << 23) | (f2 << 46);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f2 >> 18));
+                if (!batch.SerializeBits(ref w1, 5))
                 {
                     return false;
                 }
@@ -587,46 +573,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedRotationBatch(ref WriteBatch batch, QuantizedRotation value)
         {
-            if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.X) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                // flat run: 48 bits in 1 chunk(s) — the field placement is folded
+                if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Y) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Z) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
                 {
                     return false;
                 }
-            }
-            if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.W) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong f3 = ((ulong)((uint)(value.W) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong w0 = f0 | (f1 << 12) | (f2 << 24) | (f3 << 36);
+                if (!batch.SerializeBits64(ref w0, 48))
                 {
                     return false;
                 }
@@ -836,37 +806,21 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.Fire))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.AltFire))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Boost))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Brake))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Aim))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.LockOn))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Zoom))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Ping))
-            {
-                return false;
+                // flat run: 8 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = value.Fire ? 1UL : 0UL;
+                ulong f1 = value.AltFire ? 1UL : 0UL;
+                ulong f2 = value.Boost ? 1UL : 0UL;
+                ulong f3 = value.Brake ? 1UL : 0UL;
+                ulong f4 = value.Aim ? 1UL : 0UL;
+                ulong f5 = value.LockOn ? 1UL : 0UL;
+                ulong f6 = value.Zoom ? 1UL : 0UL;
+                ulong f7 = value.Ping ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 1) | (f2 << 2) | (f3 << 3) | (f4 << 4) | (f5 << 5) | (f6 << 6) | (f7 << 7));
+                if (!batch.SerializeBits(ref w0, 8))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -1124,41 +1078,28 @@ namespace Example
                 }
             }
             {
-                uint enumValue = (uint)value.Team;
-                if (enumValue > 2) // headroom above the wire range cannot ride
+                // flat run: 19 bits in 1 chunk(s) — the field placement is folded
+                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref enumValue, 2))
+                if (value.Health < 0 || value.Health > (int)MaxHealth)
                 {
                     return false;
                 }
-            }
-            if (value.Health < 0 || value.Health > (int)MaxHealth)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Health);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.Thrust < 0 || value.Thrust > 100)
                 {
                     return false;
                 }
-            }
-            if (value.Thrust < 0 || value.Thrust > 100)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Thrust);
-                if (!batch.SerializeBits(ref offsetValue, 7))
+                if ((uint)value.Pending > 0) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-            }
-            {
-                uint enumValue = (uint)value.Pending;
-                if (enumValue > 0) // headroom above the wire range cannot ride
+                ulong f0 = ((ulong)(uint)value.Team) & 0x3UL;
+                ulong f1 = ((ulong)((uint)(value.Health))) & 0x3ffUL;
+                ulong f2 = ((ulong)((uint)(value.Thrust))) & 0x7fUL;
+                uint w0 = (uint)(f0 | (f1 << 2) | (f2 << 12));
+                if (!batch.SerializeBits(ref w0, 19))
                 {
                     return false;
                 }
@@ -1278,24 +1219,20 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExpressionProbeBatch(ref WriteBatch batch, ExpressionProbe value)
         {
-            if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.HardpointIndex);
-                if (!batch.SerializeBits(ref offsetValue, 5))
+                // flat run: 16 bits in 1 chunk(s) — the field placement is folded
+                if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
                 {
                     return false;
                 }
-            }
-            if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.SpinRate) - (uint)((int)(-(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 11))
+                if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.HardpointIndex))) & 0x1fUL;
+                ulong f1 = ((ulong)((uint)(value.SpinRate) - (uint)((int)(-(-RotationUnits))))) & 0x7ffUL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 16))
                 {
                     return false;
                 }

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -727,11 +727,40 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteProbeRingBatch(ref WriteBatch batch, ProbeRing value)
+        {
+            {
+                uint rawValue = value.Radius;
+                if (!batch.SerializeBits(ref rawValue, 16))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public static bool ReadProbeRing(ReadStream stream, ProbeRing value)
         {
             {
                 uint rawValue = 0;
                 if (!stream.SerializeBits(ref rawValue, 16))
+                {
+                    return false;
+                }
+                value.Radius = (ushort)rawValue;
+            }
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadProbeRingBatch(ref ReadBatch batch, ProbeRing value)
+        {
+            {
+                uint rawValue = 0;
+                if (!batch.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
@@ -831,31 +860,53 @@ namespace Example
             value.Type = ProbeShapeType.None;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeShape(WriteStream stream, ProbeShape value)
+        {
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteProbeShapeBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteProbeShapeBatch(ref WriteBatch batch, ProbeShape value)
         {
             uint tagValue = (uint)value.Type;
             if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref tagValue, 2))
+            if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
             }
             switch (value.Type)
             {
                 case ProbeShapeType.Ring:
-                    return WriteProbeRing(stream, value.Ring);
+                    return WriteProbeRingBatch(ref batch, value.Ring);
                 case ProbeShapeType.Slab:
-                    return WriteProbeSlab(stream, value.Slab);
+                    return WriteProbeSlabBatch(ref batch, value.Slab);
             }
             return true; // None — the tag is the whole wire (SPEC §4.8)
         }
 
         public static bool ReadProbeShape(ReadStream stream, ProbeShape value)
         {
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadProbeShapeBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadProbeShapeBatch(ref ReadBatch batch, ProbeShape value)
+        {
             int tagValue = 0;
-            if (!stream.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
+            if (!batch.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
             {
                 return false;
             }
@@ -864,10 +915,10 @@ namespace Example
             {
                 case ProbeShapeType.Ring:
                     ZeroProbeRing(value.Ring); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadProbeRing(stream, value.Ring);
+                    return ReadProbeRingBatch(ref batch, value.Ring);
                 case ProbeShapeType.Slab:
                     ZeroProbeSlab(value.Slab); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadProbeSlab(stream, value.Slab);
+                    return ReadProbeSlabBatch(ref batch, value.Slab);
             }
             return true; // None
         }
@@ -890,20 +941,32 @@ namespace Example
             value.ExtrasCount = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeCollider(WriteStream stream, ProbeCollider value)
+        {
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteProbeColliderBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteProbeColliderBatch(ref WriteBatch batch, ProbeCollider value)
         {
             {
                 uint rawValue = value.Armor;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                if (!batch.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
             }
-            if (!WriteProbeShape(stream, value.Shape))
+            if (!WriteProbeShapeBatch(ref batch, value.Shape))
             {
                 return false;
             }
-            if (!WriteProbeShape(stream, value.Backup))
+            if (!WriteProbeShapeBatch(ref batch, value.Backup))
             {
                 return false;
             }
@@ -913,14 +976,14 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ExtrasCount);
-                if (!stream.SerializeBits(ref offsetValue, 2))
+                if (!batch.SerializeBits(ref offsetValue, 2))
                 {
                     return false;
                 }
             }
             for (int i = 0; i < value.ExtrasCount; i++)
             {
-                if (!WriteProbeShape(stream, value.Extras[i]))
+                if (!WriteProbeShapeBatch(ref batch, value.Extras[i]))
                 {
                     return false;
                 }
@@ -930,29 +993,39 @@ namespace Example
 
         public static bool ReadProbeCollider(ReadStream stream, ProbeCollider value)
         {
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadProbeColliderBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadProbeColliderBatch(ref ReadBatch batch, ProbeCollider value)
+        {
             {
                 uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                if (!batch.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
                 value.Armor = (byte)rawValue;
             }
-            if (!ReadProbeShape(stream, value.Shape))
+            if (!ReadProbeShapeBatch(ref batch, value.Shape))
             {
                 return false;
             }
-            if (!ReadProbeShape(stream, value.Backup))
+            if (!ReadProbeShapeBatch(ref batch, value.Backup))
             {
                 return false;
             }
-            if (!stream.SerializeInt(ref value.ExtrasCount, 0, 2)) // the count guards the loop (§6.3)
+            if (!batch.SerializeInt(ref value.ExtrasCount, 0, 2)) // the count guards the loop (§6.3)
             {
                 return false;
             }
             for (int i = 0; i < value.ExtrasCount; i++)
             {
-                if (!ReadProbeShape(stream, value.Extras[i]))
+                if (!ReadProbeShapeBatch(ref batch, value.Extras[i]))
                 {
                     return false;
                 }
@@ -1457,19 +1530,7 @@ namespace Example
             value.TextLength = 0;
         }
 
-        // batch form: stream state stays in registers across the body and End
-        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTestData(WriteStream stream, TestData value)
-        {
-            WriteBatch batch = stream.BeginBatch();
-            bool result = WriteTestDataBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool WriteTestDataBatch(ref WriteBatch batch, TestData value)
         {
             if (value.A < -100 || value.A > 100)
             {
@@ -1477,7 +1538,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.A) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
@@ -1488,7 +1549,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.B) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
@@ -1499,24 +1560,24 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.C) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.D, 8))
+            if (!stream.SerializeBits(ref value.D, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.E, 8))
+            if (!stream.SerializeBits(ref value.E, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F, 8))
+            if (!stream.SerializeBits(ref value.F, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.G))
+            if (!stream.SerializeBool(ref value.G))
             {
                 return false;
             }
@@ -1526,7 +1587,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ItemsCount);
-                if (!batch.SerializeBits(ref offsetValue, 5))
+                if (!stream.SerializeBits(ref offsetValue, 5))
                 {
                     return false;
                 }
@@ -1539,66 +1600,66 @@ namespace Example
                 }
                 {
                     uint offsetValue = (uint)(value.Items[i]);
-                    if (!batch.SerializeBits(ref offsetValue, 8))
+                    if (!stream.SerializeBits(ref offsetValue, 8))
                     {
                         return false;
                     }
                 }
             }
-            if (!batch.SerializeFloat(ref value.FloatValue))
+            if (!stream.SerializeFloat(ref value.FloatValue))
             {
                 return false;
             }
             {
                 float compressedValue = value.CompressedFloatValue;
-                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
+                if (!stream.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeDouble(ref value.DoubleValue))
+            if (!stream.SerializeDouble(ref value.DoubleValue))
             {
                 return false;
             }
             {
                 uint rawValue = (byte)value.Int8Value;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
             }
             {
                 uint rawValue = (ushort)value.Int16Value;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
             }
             {
                 uint rawValue = value.Uint8Value;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
             }
             {
                 uint rawValue = value.Uint16Value;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.Uint32Value, 32))
+            if (!stream.SerializeBits(ref value.Uint32Value, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits64(ref value.Uint64Value, 64))
+            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
             {
                 return false;
             }
             {
                 ulong rawValue = (ulong)value.Int64Full;
-                if (!batch.SerializeBits64(ref rawValue, 64))
+                if (!stream.SerializeBits64(ref rawValue, 64))
                 {
                     return false;
                 }
@@ -1609,16 +1670,16 @@ namespace Example
             }
             {
                 ulong offsetValue = (ulong)(value.Int64Range) - unchecked((ulong)(-1000000000000));
-                if (!batch.SerializeBits64(ref offsetValue, 41))
+                if (!stream.SerializeBits64(ref offsetValue, 41))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeAlign())
+            if (!stream.SerializeAlign())
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+            if (!stream.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
             {
                 return false;
             }
@@ -1628,12 +1689,12 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.TextLength);
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
+            if (!stream.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
             {
                 return false;
             }
@@ -1642,70 +1703,60 @@ namespace Example
 
         public static bool ReadTestData(ReadStream stream, TestData value)
         {
-            ReadBatch batch = stream.BeginBatch();
-            bool result = ReadTestDataBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ReadTestDataBatch(ref ReadBatch batch, TestData value)
-        {
-            if (!batch.SerializeInt(ref value.A, -100, 100))
+            if (!stream.SerializeInt(ref value.A, -100, 100))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.B, -100, 100))
+            if (!stream.SerializeInt(ref value.B, -100, 100))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.C, -100, 150))
+            if (!stream.SerializeInt(ref value.C, -100, 150))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.D, 8))
+            if (!stream.SerializeBits(ref value.D, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.E, 8))
+            if (!stream.SerializeBits(ref value.E, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F, 8))
+            if (!stream.SerializeBits(ref value.F, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.G))
+            if (!stream.SerializeBool(ref value.G))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.ItemsCount, 0, 16)) // the count guards the loop (§6.3)
+            if (!stream.SerializeInt(ref value.ItemsCount, 0, 16)) // the count guards the loop (§6.3)
             {
                 return false;
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (!batch.SerializeInt(ref value.Items[i], 0, 255))
+                if (!stream.SerializeInt(ref value.Items[i], 0, 255))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeFloat(ref value.FloatValue))
+            if (!stream.SerializeFloat(ref value.FloatValue))
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloatPrecomputed(ref value.CompressedFloatValue, 1000u, 10, 10.0f, 0.0f))
+            if (!stream.SerializeCompressedFloatPrecomputed(ref value.CompressedFloatValue, 1000u, 10, 10.0f, 0.0f))
             {
                 return false;
             }
-            if (!batch.SerializeDouble(ref value.DoubleValue))
+            if (!stream.SerializeDouble(ref value.DoubleValue))
             {
                 return false;
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
@@ -1713,7 +1764,7 @@ namespace Example
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
@@ -1721,7 +1772,7 @@ namespace Example
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
@@ -1729,45 +1780,45 @@ namespace Example
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
                 value.Uint16Value = (ushort)rawValue;
             }
-            if (!batch.SerializeBits(ref value.Uint32Value, 32))
+            if (!stream.SerializeBits(ref value.Uint32Value, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits64(ref value.Uint64Value, 64))
+            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
             {
                 return false;
             }
             {
                 ulong rawValue = 0;
-                if (!batch.SerializeBits64(ref rawValue, 64))
+                if (!stream.SerializeBits64(ref rawValue, 64))
                 {
                     return false;
                 }
                 value.Int64Full = (long)rawValue;
             }
-            if (!batch.SerializeInt64(ref value.Int64Range, -1000000000000, 1000000000000))
+            if (!stream.SerializeInt64(ref value.Int64Range, -1000000000000, 1000000000000))
             {
                 return false;
             }
-            if (!batch.SerializeAlign()) // rejects nonzero padding (SPEC §4.3)
+            if (!stream.SerializeAlign()) // rejects nonzero padding (SPEC §4.3)
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+            if (!stream.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.TextLength, 0, 255)) // the length guards the slice (§6.3)
+            if (!stream.SerializeInt(ref value.TextLength, 0, 255)) // the length guards the slice (§6.3)
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
+            if (!stream.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
             {
                 return false;
             }

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -313,19 +313,12 @@ namespace Example
         private static bool WriteProbeHeaderBatch(ref WriteBatch batch, ProbeHeader value)
         {
             {
-                uint constValue = 171;
-                if (!batch.SerializeBits(ref constValue, 8)) // const(171, 8) — SPEC §4.3
-                {
-                    return false;
-                }
-            }
-            if (!batch.SerializeBits(ref value.Version, 3))
-            {
-                return false;
-            }
-            {
-                uint reservedValue = 0;
-                if (!batch.SerializeBits(ref reservedValue, 5)) // reserved(5) — zeros on the wire
+                // flat run: 16 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = (171UL) & 0xffUL;
+                ulong f1 = ((ulong)value.Version) & 0x7UL;
+                ulong f2 = 0UL;
+                uint w0 = (uint)(f0 | (f1 << 8) | (f2 << 11));
+                if (!batch.SerializeBits(ref w0, 16))
                 {
                     return false;
                 }
@@ -419,28 +412,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeBitsBatch(ref WriteBatch batch, ProbeBits value)
         {
-            if (!batch.SerializeBits(ref value.Small, 9))
             {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Boundary, 33))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Wide, 64))
-            {
-                return false;
-            }
-            {
-                ulong offsetValue = (ulong)(value.Sensor);
-                if (!batch.SerializeBits64(ref offsetValue, 32))
+                // flat run: 202 bits in 4 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Small) & 0x1ffUL;
+                ulong f1 = ((ulong)value.Boundary) & 0x1ffffffffUL;
+                ulong f2 = (ulong)value.Wide;
+                ulong f3 = ((ulong)((ulong)(value.Sensor))) & 0xffffffffUL;
+                ulong f4 = (ulong)((ulong)(value.Nonce));
+                ulong w0 = f0 | (f1 << 9) | (f2 << 42);
+                if (!batch.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-            }
-            {
-                ulong offsetValue = value.Nonce;
-                if (!batch.SerializeBits64(ref offsetValue, 64))
+                ulong w1 = (f2 >> 22) | (f3 << 42);
+                if (!batch.SerializeBits64(ref w1, 64))
+                {
+                    return false;
+                }
+                ulong w2 = (f3 >> 22) | (f4 << 10);
+                if (!batch.SerializeBits64(ref w2, 64))
+                {
+                    return false;
+                }
+                uint w3 = (uint)((f4 >> 54));
+                if (!batch.SerializeBits(ref w3, 10))
                 {
                     return false;
                 }
@@ -553,19 +548,18 @@ namespace Example
             if (value.Active)
             {
                 {
-                    uint enumValue = (uint)value.Weapon;
-                    if (enumValue > 15) // headroom above the wire range cannot ride
+                    // flat run: 5 bits in 1 chunk(s) — the field placement is folded
+                    if ((uint)value.Weapon > 15) // headroom above the wire range cannot ride
                     {
                         return false;
                     }
-                    if (!batch.SerializeBits(ref enumValue, 4))
+                    ulong f0 = ((ulong)(uint)value.Weapon) & 0xfUL;
+                    ulong f1 = value.HasTarget ? 1UL : 0UL;
+                    uint w0 = (uint)(f0 | (f1 << 4));
+                    if (!batch.SerializeBits(ref w0, 5))
                     {
                         return false;
                     }
-                }
-                if (!batch.SerializeBool(ref value.HasTarget))
-                {
-                    return false;
                 }
                 if (value.HasTarget)
                 {
@@ -795,20 +789,16 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeSlabBatch(ref WriteBatch batch, ProbeSlab value)
         {
-            if (value.Width > 100)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Width);
-                if (!batch.SerializeBits(ref offsetValue, 7))
+                // flat run: 15 bits in 1 chunk(s) — the field placement is folded
+                if (value.Width > 100)
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.Height;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                ulong f0 = ((ulong)((uint)(value.Width))) & 0x7fUL;
+                ulong f1 = ((ulong)(value.Height)) & 0xffUL;
+                uint w0 = (uint)(f0 | (f1 << 7));
+                if (!batch.SerializeBits(ref w0, 15))
                 {
                     return false;
                 }
@@ -1060,19 +1050,15 @@ namespace Example
         private static bool WriteProbeConfigBatch(ref WriteBatch batch, ProbeConfig value)
         {
             {
-                uint rawValue = (uint)value.Retries;
-                if (!batch.SerializeBits(ref rawValue, 32))
+                // flat run: 36 bits in 1 chunk(s) — the field placement is folded
+                if ((uint)value.Preferred > 15) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-            }
-            {
-                uint enumValue = (uint)value.Preferred;
-                if (enumValue > 15) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
-                if (!batch.SerializeBits(ref enumValue, 4))
+                ulong f0 = ((ulong)((uint)value.Retries)) & 0xffffffffUL;
+                ulong f1 = ((ulong)(uint)value.Preferred) & 0xfUL;
+                ulong w0 = f0 | (f1 << 32);
+                if (!batch.SerializeBits64(ref w0, 36))
                 {
                     return false;
                 }
@@ -1231,41 +1217,25 @@ namespace Example
         private static bool WriteTestBatch(ref WriteBatch batch, Test value)
         {
             {
-                uint rawValue = value.TestA;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                // flat run: 46 bits in 1 chunk(s) — the field placement is folded
+                if (value.TestB < 0 || value.TestB > 1000)
                 {
                     return false;
                 }
-            }
-            if (value.TestB < 0 || value.TestB > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.TestB);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.TestC < 0 || value.TestC > 1000)
                 {
                     return false;
                 }
-            }
-            if (value.TestC < 0 || value.TestC > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.TestC);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.TestD < 0 || value.TestD > 1000)
                 {
                     return false;
                 }
-            }
-            if (value.TestD < 0 || value.TestD > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.TestD);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                ulong f0 = ((ulong)(value.TestA)) & 0xffffUL;
+                ulong f1 = ((ulong)((uint)(value.TestB))) & 0x3ffUL;
+                ulong f2 = ((ulong)((uint)(value.TestC))) & 0x3ffUL;
+                ulong f3 = ((ulong)((uint)(value.TestD))) & 0x3ffUL;
+                ulong w0 = f0 | (f1 << 16) | (f2 << 26) | (f3 << 36);
+                if (!batch.SerializeBits64(ref w0, 46))
                 {
                     return false;
                 }
@@ -1532,54 +1502,32 @@ namespace Example
 
         public static bool WriteTestData(WriteStream stream, TestData value)
         {
-            if (value.A < -100 || value.A > 100)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.A) - unchecked((uint)(-100));
-                if (!stream.SerializeBits(ref offsetValue, 8))
+                // flat run: 49 bits in 1 chunk(s) — the field placement is folded
+                if (value.A < -100 || value.A > 100)
                 {
                     return false;
                 }
-            }
-            if (value.B < -100 || value.B > 100)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.B) - unchecked((uint)(-100));
-                if (!stream.SerializeBits(ref offsetValue, 8))
+                if (value.B < -100 || value.B > 100)
                 {
                     return false;
                 }
-            }
-            if (value.C < -100 || value.C > 150)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.C) - unchecked((uint)(-100));
-                if (!stream.SerializeBits(ref offsetValue, 8))
+                if (value.C < -100 || value.C > 150)
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.D, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.E, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.F, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.G))
-            {
-                return false;
+                ulong f0 = ((ulong)((uint)(value.A) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f1 = ((ulong)((uint)(value.B) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f2 = ((ulong)((uint)(value.C) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f3 = ((ulong)value.D) & 0xffUL;
+                ulong f4 = ((ulong)value.E) & 0xffUL;
+                ulong f5 = ((ulong)value.F) & 0xffUL;
+                ulong f6 = value.G ? 1UL : 0UL;
+                ulong w0 = f0 | (f1 << 8) | (f2 << 16) | (f3 << 24) | (f4 << 32) | (f5 << 40) | (f6 << 48);
+                if (!stream.SerializeBits64(ref w0, 49))
+                {
+                    return false;
+                }
             }
             if (value.ItemsCount < 0 || value.ItemsCount > 16) // the count guards the loop (§6.3); out-of-contract writes are refused
             {
@@ -1622,55 +1570,36 @@ namespace Example
                 return false;
             }
             {
-                uint rawValue = (byte)value.Int8Value;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                // flat run: 249 bits in 4 chunk(s) — the field placement is folded
+                if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = (ushort)value.Int16Value;
-                if (!stream.SerializeBits(ref rawValue, 16))
+                ulong f0 = ((ulong)((byte)value.Int8Value)) & 0xffUL;
+                ulong f1 = ((ulong)((ushort)value.Int16Value)) & 0xffffUL;
+                ulong f2 = ((ulong)(value.Uint8Value)) & 0xffUL;
+                ulong f3 = ((ulong)(value.Uint16Value)) & 0xffffUL;
+                ulong f4 = ((ulong)(value.Uint32Value)) & 0xffffffffUL;
+                ulong f5 = (ulong)value.Uint64Value;
+                ulong f6 = (ulong)value.Int64Full;
+                ulong f7 = ((ulong)((ulong)(value.Int64Range) - unchecked((ulong)(-1000000000000)))) & 0x1ffffffffffUL;
+                ulong w0 = f0 | (f1 << 8) | (f2 << 24) | (f3 << 32) | (f4 << 48);
+                if (!stream.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.Uint8Value;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                ulong w1 = (f4 >> 16) | (f5 << 16);
+                if (!stream.SerializeBits64(ref w1, 64))
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.Uint16Value;
-                if (!stream.SerializeBits(ref rawValue, 16))
+                ulong w2 = (f5 >> 48) | (f6 << 16);
+                if (!stream.SerializeBits64(ref w2, 64))
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.Uint32Value, 32))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
-            {
-                return false;
-            }
-            {
-                ulong rawValue = (ulong)value.Int64Full;
-                if (!stream.SerializeBits64(ref rawValue, 64))
-                {
-                    return false;
-                }
-            }
-            if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
-            {
-                return false;
-            }
-            {
-                ulong offsetValue = (ulong)(value.Int64Range) - unchecked((ulong)(-1000000000000));
-                if (!stream.SerializeBits64(ref offsetValue, 41))
+                ulong w3 = (f6 >> 48) | (f7 << 16);
+                if (!stream.SerializeBits64(ref w3, 57))
                 {
                     return false;
                 }

--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -347,27 +347,23 @@ namespace Example
         private static bool ReadProbeHeaderBatch(ref ReadBatch batch, ProbeHeader value)
         {
             {
-                uint constValue = 0;
-                if (!batch.SerializeBits(ref constValue, 8))
+                // flat run: 16 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 16);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                if (constValue != 171) // const(171, 8): a read rejects any other value (SPEC §4.3)
+                ulong v0 = c0 & 0xffUL;
+                if (v0 != 171UL) // const(171, 8): a read rejects any other value (SPEC §4.3)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBits(ref value.Version, 3))
-            {
-                return false;
-            }
-            {
-                uint reservedValue = 0;
-                if (!batch.SerializeBits(ref reservedValue, 5))
-                {
-                    return false;
-                }
-                if (reservedValue != 0) // reserved(5): a read rejects nonzero (SPEC §4.3)
+                ulong v1 = (c0 >> 8) & 0x7UL;
+                value.Version = (uint)v1;
+                ulong v2 = (c0 >> 11) & 0x1fUL;
+                if (v2 != 0UL) // reserved(5): a read rejects nonzero
                 {
                     return false;
                 }
@@ -455,33 +451,31 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeBitsBatch(ref ReadBatch batch, ProbeBits value)
         {
-            if (!batch.SerializeBits(ref value.Small, 9))
             {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Boundary, 33))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Wide, 64))
-            {
-                return false;
-            }
-            {
-                long rangeValue = 0;
-                if (!batch.SerializeInt64(ref rangeValue, 0, 4294967295))
+                // flat run: 202 bits in 4 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                batch.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                batch.SerializeBits64(ref c2, 64);
+                ulong c3 = 0;
+                batch.SerializeBits64(ref c3, 10);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.Sensor = (uint)rangeValue;
-            }
-            {
-                ulong offsetValue = 0;
-                if (!batch.SerializeBits64(ref offsetValue, 64))
-                {
-                    return false;
-                }
-                value.Nonce = offsetValue;
+                ulong v0 = c0 & 0x1ffUL;
+                value.Small = (uint)v0;
+                ulong v1 = (c0 >> 9) & 0x1ffffffffUL;
+                value.Boundary = v1;
+                ulong v2 = ((c0 >> 42) | (c1 << 22));
+                value.Wide = v2;
+                ulong v3 = ((c1 >> 42) | (c2 << 22)) & 0xffffffffUL;
+                value.Sensor = (uint)((long)v3);
+                ulong v4 = ((c2 >> 10) | (c3 << 54));
+                value.Nonce = v4;
             }
             return true;
         }
@@ -642,16 +636,18 @@ namespace Example
             if (value.Active)
             {
                 {
-                    int enumValue = 0;
-                    if (!batch.SerializeInt(ref enumValue, 0, 15))
+                    // flat run: 5 bits in 1 chunk(s) — one bounds check per chunk,
+                    // one sticky-error test for the whole run
+                    ulong c0 = 0;
+                    batch.SerializeBits64(ref c0, 5);
+                    if (!batch.Ok)
                     {
                         return false;
                     }
-                    value.Weapon = (Weapon)enumValue;
-                }
-                if (!batch.SerializeBool(ref value.HasTarget))
-                {
-                    return false;
+                    ulong v0 = c0 & 0xfUL;
+                    value.Weapon = (Weapon)(int)v0;
+                    ulong v1 = (c0 >> 4) & 0x1UL;
+                    value.HasTarget = v1 != 0UL;
                 }
                 if (value.HasTarget)
                 {
@@ -1079,20 +1075,18 @@ namespace Example
         private static bool ReadProbeConfigBatch(ref ReadBatch batch, ProbeConfig value)
         {
             {
-                uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 32))
+                // flat run: 36 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 36);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.Retries = (int)rawValue;
-            }
-            {
-                int enumValue = 0;
-                if (!batch.SerializeInt(ref enumValue, 0, 15))
-                {
-                    return false;
-                }
-                value.Preferred = (Weapon)enumValue;
+                ulong v0 = c0 & 0xffffffffUL;
+                value.Retries = (int)(uint)v0;
+                ulong v1 = (c0 >> 32) & 0xfUL;
+                value.Preferred = (Weapon)(int)v1;
             }
             return true;
         }
@@ -1644,21 +1638,23 @@ namespace Example
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.D, 8))
             {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.E, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.F, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.G))
-            {
-                return false;
+                // flat run: 25 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 25);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffUL;
+                value.D = (uint)v0;
+                ulong v1 = (c0 >> 8) & 0xffUL;
+                value.E = (uint)v1;
+                ulong v2 = (c0 >> 16) & 0xffUL;
+                value.F = (uint)v2;
+                ulong v3 = (c0 >> 24) & 0x1UL;
+                value.G = v3 != 0UL;
             }
             if (!stream.SerializeInt(ref value.ItemsCount, 0, 16)) // the count guards the loop (§6.3)
             {
@@ -1684,52 +1680,34 @@ namespace Example
                 return false;
             }
             {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                // flat run: 208 bits in 4 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                stream.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                stream.SerializeBits64(ref c2, 64);
+                ulong c3 = 0;
+                stream.SerializeBits64(ref c3, 16);
+                if (!stream.Ok)
                 {
                     return false;
                 }
-                value.Int8Value = (sbyte)(byte)rawValue;
-            }
-            {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 16))
-                {
-                    return false;
-                }
-                value.Int16Value = (short)(ushort)rawValue;
-            }
-            {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 8))
-                {
-                    return false;
-                }
-                value.Uint8Value = (byte)rawValue;
-            }
-            {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 16))
-                {
-                    return false;
-                }
-                value.Uint16Value = (ushort)rawValue;
-            }
-            if (!stream.SerializeBits(ref value.Uint32Value, 32))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
-            {
-                return false;
-            }
-            {
-                ulong rawValue = 0;
-                if (!stream.SerializeBits64(ref rawValue, 64))
-                {
-                    return false;
-                }
-                value.Int64Full = (long)rawValue;
+                ulong v0 = c0 & 0xffUL;
+                value.Int8Value = (sbyte)(byte)(uint)v0;
+                ulong v1 = (c0 >> 8) & 0xffffUL;
+                value.Int16Value = (short)(ushort)(uint)v1;
+                ulong v2 = (c0 >> 24) & 0xffUL;
+                value.Uint8Value = (byte)(uint)v2;
+                ulong v3 = (c0 >> 32) & 0xffffUL;
+                value.Uint16Value = (ushort)(uint)v3;
+                ulong v4 = ((c0 >> 48) | (c1 << 16)) & 0xffffffffUL;
+                value.Uint32Value = (uint)(uint)v4;
+                ulong v5 = ((c1 >> 16) | (c2 << 48));
+                value.Uint64Value = v5;
+                ulong v6 = ((c2 >> 16) | (c3 << 48));
+                value.Int64Full = (long)v6;
             }
             if (!stream.SerializeInt64(ref value.Int64Range, -1000000000000, 1000000000000))
             {

--- a/internal/codegen/csharp/batch.go
+++ b/internal/codegen/csharp/batch.go
@@ -35,8 +35,18 @@
 //
 // A type composed under a batched parent needs a core whatever its own
 // density (rule 1: the parent must reach it by ref, inline), so cores are
-// emitted for the closure of batched pairs over struct composition; the
-// entry-form decision stays per-pair.
+// emitted for the closure of batched pairs over composition — struct fields
+// AND union arms; the entry-form decision stays per-pair.
+//
+// UNIONS CARRY CORES TOO. They did not until the C# profile of BenchMixed
+// convicted the plain path: one union field anywhere in a message put the
+// WHOLE message back on the stream, and on the bench shape that meant the
+// 8-element entity array and the 80-element stat array each paid a full
+// BeginBatch capture / End restore AND a real call PER ELEMENT — 88 of them
+// on a 438-byte message. A union's arm dispatch is a switch over calls, and
+// a core makes those calls core-to-core by ref like any other composition,
+// so nothing about rule 1 stood in the way; only the missing emitter half
+// did.
 package csharp
 
 import (
@@ -48,37 +58,35 @@ func batchWorthwhile(s, b int64) bool {
 	return s >= 2+4*b
 }
 
-// reachesUnion reports whether a struct's wire body reaches a union through
-// any field, transitively. Such a pair stays on the stream: a union's arm
-// dispatch calls the arms' plain stream entries, and composing that under a
-// ref-struct batch core would address-expose the batch (rule 1's measured
-// 0.71x). Union batch cores are a follow-on if a profile ever convicts the
-// plain path — land-simple, not a ruling against.
-func reachesUnion(st *ir.Struct, visiting map[string]bool) bool {
-	if visiting[st.Name] {
-		return false
-	}
-	visiting[st.Name] = true
-	defer delete(visiting, st.Name)
-	for _, f := range st.Fields {
-		if f.Type.Kind != ir.TNamed {
-			continue
-		}
-		switch ref := f.Type.Ref.(type) {
-		case *ir.Union:
-			return true
-		case *ir.Struct:
-			if reachesUnion(ref, visiting) {
-				return true
-			}
-		}
-	}
-	return false
+// batchEntry decides whether a pair's own ENTRY runs its whole body on a
+// batch. Density is necessary and not sufficient: a body with ANY delegated
+// site must Sync the batch state down and Recapture it around that site, and
+// between the two it hands the register allocator a ref struct that has to
+// survive the whole body. See batch.go's header for the measurement.
+func batchEntry(s, b int64) bool {
+	return b == 0 && batchWorthwhile(s, b)
 }
 
 // densityStruct is the (scalar, bulk) site weight of a struct's wire body.
 func densityStruct(st *ir.Struct) (int64, int64) {
 	return densityItems(st.Items, ir.AlignedFixedByteArrays(st))
+}
+
+// densityUnion is the (scalar, bulk) site weight of a union's wire body: the
+// tag site, plus the heaviest arm — a batch spans whichever arm runs, and the
+// worst case is the one that has to earn the capture/restore.
+func densityUnion(u *ir.Union) (int64, int64) {
+	var s, b int64
+	for _, v := range u.Variants {
+		if v.Ref == nil {
+			continue
+		}
+		as, ab := densityStruct(v.Ref)
+		if as+ab > s+b {
+			s, b = as, ab
+		}
+	}
+	return 1 + s, b // the tag rides on the batch like any other scalar
 }
 
 func densityItems(items []ir.Item, bulk map[*ir.Field]bool) (s, b int64) {
@@ -109,9 +117,12 @@ func densityField(f *ir.Field, isBulkByteArray bool) (s, b int64) {
 	case ir.TString, ir.TBytes:
 		es, eb = 1, 1 // the length site, then the delegated byte run
 	case ir.TNamed:
-		if st, ok := f.Type.Ref.(*ir.Struct); ok {
-			es, eb = densityStruct(st)
-		} else {
+		switch ref := f.Type.Ref.(type) {
+		case *ir.Struct:
+			es, eb = densityStruct(ref)
+		case *ir.Union:
+			es, eb = densityUnion(ref)
+		default:
 			es = 1 // enum or flags
 		}
 	default:
@@ -128,50 +139,84 @@ func densityField(f *ir.Field, isBulkByteArray bool) (s, b int64) {
 
 // batchPlan decides, per Write/Read pair name, whether the entry runs a batch
 // (batched) and whether a *Batch core is emitted (needCore: the closure of
-// batched pairs over struct composition — rule 1 requires every composed type
-// to be reachable by ref core-to-core).
+// batched pairs over composition — rule 1 requires every composed type, struct
+// field or union arm, to be reachable by ref core-to-core).
 func batchPlan(u *ir.Unit) (batched, needCore map[string]bool) {
 	batched = map[string]bool{}
 	needCore = map[string]bool{}
-	var pending []*ir.Struct
+	var pending []composite
+	open := func(name string, c composite) {
+		if needCore[name] {
+			return
+		}
+		needCore[name] = true
+		pending = append(pending, c)
+	}
 	for _, f := range u.Files {
 		for _, d := range f.Decls {
-			if d, ok := d.(*ir.Struct); ok {
-				if reachesUnion(d, map[string]bool{}) {
-					continue // stays on the stream — see reachesUnion
-				}
-				if s, b := densityStruct(d); batchWorthwhile(s, b) {
+			switch d := d.(type) {
+			case *ir.Struct:
+				if s, b := densityStruct(d); batchEntry(s, b) {
 					batched[d.Name] = true
-					needCore[d.Name] = true
-					pending = append(pending, d)
+					open(d.Name, composite{st: d})
+				}
+			case *ir.Union:
+				if s, b := densityUnion(d); batchEntry(s, b) {
+					batched[d.Name] = true
+					open(d.Name, composite{un: d})
 				}
 			}
 		}
 	}
-	// close over composition: every struct type a core's body calls needs its
-	// own core, whatever its density
+	// close over composition: every type a core's body calls needs its own
+	// core, whatever its density
 	for len(pending) > 0 {
-		st := pending[0]
+		c := pending[0]
 		pending = pending[1:]
-		for _, child := range childStructs(st) {
-			if !needCore[child.Name] {
-				needCore[child.Name] = true
-				pending = append(pending, child)
-			}
+		for _, child := range c.children() {
+			open(child.name(), child)
 		}
 	}
 	return
 }
 
-// childStructs lists the struct types st's wire body calls into. A synthetic
-// view wrapper (Items empty, Fields set) walks its fields directly.
-func childStructs(st *ir.Struct) []*ir.Struct {
-	var out []*ir.Struct
-	note := func(f *ir.Field) {
-		if f.Type.Kind == ir.TNamed {
-			if child, ok := f.Type.Ref.(*ir.Struct); ok {
-				out = append(out, child)
+// composite is one node of the composition graph the core closure walks: a
+// struct's wire body, or a union's arm dispatch. Exactly one field is set.
+type composite struct {
+	st *ir.Struct
+	un *ir.Union
+}
+
+func (c composite) name() string {
+	if c.st != nil {
+		return c.st.Name
+	}
+	return c.un.Name
+}
+
+// children lists the composite types this one's wire body calls into. A
+// synthetic struct view wrapper (Items empty, Fields set) walks its fields
+// directly; a union walks its arms.
+func (c composite) children() []composite {
+	var out []composite
+	if c.un != nil {
+		for _, v := range c.un.Variants {
+			if v.Ref != nil {
+				out = append(out, composite{st: v.Ref})
 			}
+		}
+		return out
+	}
+	st := c.st
+	note := func(f *ir.Field) {
+		if f.Type.Kind != ir.TNamed {
+			return
+		}
+		switch child := f.Type.Ref.(type) {
+		case *ir.Struct:
+			out = append(out, composite{st: child})
+		case *ir.Union:
+			out = append(out, composite{un: child})
 		}
 	}
 	if len(st.Items) == 0 && len(st.Fields) > 0 {

--- a/internal/codegen/csharp/flat.go
+++ b/internal/codegen/csharp/flat.go
@@ -1,4 +1,4 @@
-// The flat word codec, write half: the C# target's chunked wire form.
+// The flat word codec: the C# target's chunked wire form.
 //
 // The per-field form asks the stream to place one field at a time. In C# the
 // call itself is free — the JitDisasm audit of the bench shape found ZERO
@@ -56,14 +56,9 @@
 // it has fields, so flattening would add a materialized local per field and
 // remove nothing.
 //
-// THE READ HALF IS NOT HERE. Folding a ranged read means replacing
-// SerializeInt with a generated comparison, and serialize.cs's ranged read
-// LATCHES SerializeError.ValueOutOfRange on refusal where a generated guard
-// returns false without latching. serialize.cs publishes checks=always and
-// test/cs pins that latch, so the read fold waits on a public refusal-latch
-// on ReadStream/ReadBatch — a serialize.cs change, tracked separately. The
-// write path has no such dependence: its folded range refusals already
-// return false without latching (see emitWriteFoldedRange).
+// The read half follows the write half in this file, with its own header:
+// what it fuses, the two consequences that fusion always has, and the one
+// class of item it will NOT absorb.
 package csharp
 
 import (
@@ -100,6 +95,11 @@ type flatPiece struct {
 	bits  int64
 	guard func(ind string) // write-side refusals and headroom guards; may be nil
 	expr  string           // ulong-valued, already masked to bits; "" when bits == 0
+
+	// read emits the read-side validation and field store. src names the ulong
+	// local holding the extracted bits; a zero-bit piece is handed the literal
+	// "0UL", the only value its range can carry (SPEC §4.6).
+	read func(ind, src string)
 }
 
 // flatChunkWidths splits a run of `bits` wire bits into the chunks the stream
@@ -395,4 +395,270 @@ func (g *gen) flatWriteEnumPiece(item *ir.FieldItem, ref *ir.Enum, name string) 
 	}
 	return flatPiece{item: item, bits: bits, guard: guard,
 		expr: flatMasked(fmt.Sprintf("(ulong)(%s)%s", typ, name), bits)}, true
+}
+
+// ---- the read half ---------------------------------------------------------
+//
+// The read run fuses what the per-field form paid per field: ONE bounds check
+// per chunk instead of one per field, and ONE sticky-error test for the whole
+// run. Reading every chunk before the error test is safe and is the point — a
+// failed chunk latches the stream's error and every later chunk read returns
+// on it immediately, leaving its destination at zero.
+//
+// TWO CONSEQUENCES, both named rather than discovered later:
+//
+//   - A stream that is BOTH truncated inside a run AND carries an
+//     out-of-range value before the truncation now surfaces the stream's
+//     overflow error where the per-field form surfaced the range refusal.
+//     Both refuse the packet; the set of ACCEPTED streams is unchanged, which
+//     is the property that matters at the trust boundary. Java, Dart, JS-flat,
+//     Rust and Go already carry this consequence.
+//
+//   - A failed run leaves the destination object untouched where the
+//     per-field form left the fields before the failure updated. Both are
+//     partial states a failed read gives no contract over (SPEC §5).
+//
+// WHAT A READ RUN WILL NOT ABSORB, and why. A ranged read whose range check
+// can actually fire goes through serialize.cs's SerializeInt/SerializeInt64,
+// which LATCH SerializeError.ValueOutOfRange; a generated comparison returns
+// false without latching, and cs publishes checks=always with test/cs pinning
+// that latch. So a ranged piece joins a read run only where its check is
+// VACUOUS — max - min is exactly 2^bits - 1, so no value the bits can hold is
+// out of range — or where the emitter's own read path ALREADY refuses without
+// latching (the full-range unsigned bits64 path, which has always carried a
+// generated refusal). Everything else closes the run and keeps the runtime
+// call. Folding the rest waits on a public refusal-latch on
+// ReadStream/ReadBatch — a serialize.cs change.
+
+// flatVacuousRange reports whether a ranged read's refusal can never fire:
+// the offset domain [0, max-min] fills the bit width exactly.
+func flatVacuousRange(min, max *big.Int) bool {
+	bits := ir.BitsRequired(min, max)
+	if bits == 0 {
+		return true // a degenerate range rides no bits and reads no value
+	}
+	diff := new(big.Int).Sub(max, min)
+	full := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))
+	return diff.Cmp(full) == 0
+}
+
+// emitFlatReadRun reads the run's chunks, tests the latch once, then unpacks,
+// validates and stores each value with literal shifts and masks.
+func (g *gen) emitFlatReadRun(pieces []flatPiece, bits int64, ind string) {
+	g.sf("%s{\n", ind)
+	inner := ind + "    "
+	widths := flatChunkWidths(bits)
+	g.sf("%s// flat run: %d bits in %d chunk(s) — one bounds check per chunk,\n", inner, bits, len(widths))
+	g.sf("%s// one sticky-error test for the whole run\n", inner)
+	for j, width := range widths {
+		g.sf("%sulong c%d = 0;\n", inner, j)
+		g.sf("%s%s.SerializeBits64(ref c%d, %d);\n", inner, g.rv(), j, width)
+	}
+	g.sf("%sif (!%s.Ok)\n%s{\n%s    return false;\n%s}\n", inner, g.rv(), inner, inner, inner)
+
+	var at int64
+	for i, p := range pieces {
+		if p.bits == 0 {
+			p.read(inner, "0UL")
+			continue
+		}
+		o := at
+		at += p.bits
+		first := o / flatChunkBits
+		last := (o + p.bits - 1) / flatChunkBits
+		var terms []string
+		for j := first; j <= last; j++ {
+			lo := j * flatChunkBits
+			if lo <= o {
+				terms = append(terms, flatShiftRight(fmt.Sprintf("c%d", j), o-lo))
+			} else {
+				terms = append(terms, fmt.Sprintf("(c%d << %d)", j, lo-o))
+			}
+		}
+		expr := strings.Join(terms, " | ")
+		if len(terms) > 1 {
+			expr = "(" + expr + ")"
+		}
+		if m := flatMaskLit(p.bits); m != "" {
+			expr = expr + " & " + m
+		}
+		g.sf("%sulong v%d = %s;\n", inner, i, expr)
+		p.read(inner, fmt.Sprintf("v%d", i))
+	}
+	g.sf("%s}\n", ind)
+}
+
+// flatReadPieceOf classifies one item into its contribution to a read run, or
+// reports false — which closes the run and sends the item down the per-field
+// path.
+func (g *gen) flatReadPieceOf(item ir.Item) (flatPiece, bool) {
+	switch item := item.(type) {
+	case *ir.ConstItem:
+		if item.Bits < 1 || item.Bits > 64 {
+			return flatPiece{}, false
+		}
+		lit := item.Value.String() + "UL"
+		return flatPiece{item: item, bits: item.Bits, read: func(ind, src string) {
+			g.sf("%sif (%s != %s) // const(%s, %d): a read rejects any other value (SPEC §4.3)\n",
+				ind, src, lit, item.Value.String(), item.Bits)
+			g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+		}}, true
+	case *ir.ReservedItem:
+		if item.Bits < 1 || item.Bits > 64 {
+			return flatPiece{}, false
+		}
+		return flatPiece{item: item, bits: item.Bits, read: func(ind, src string) {
+			g.sf("%sif (%s != 0UL) // reserved(%d): a read rejects nonzero\n", ind, src, item.Bits)
+			g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+		}}, true
+	case *ir.FieldItem:
+		return g.flatReadFieldPiece(item)
+	}
+	return flatPiece{}, false
+}
+
+func (g *gen) flatReadFieldPiece(item *ir.FieldItem) (flatPiece, bool) {
+	f := item.F
+	if f.Array != ir.ArrayNone {
+		return flatPiece{}, false
+	}
+	name := "value." + g.fieldBase(f)
+	switch f.Type.Kind {
+	case ir.TBool:
+		return flatPiece{item: item, bits: 1, read: func(ind, src string) {
+			g.sf("%s%s = %s != 0UL;\n", ind, name, src)
+		}}, true
+
+	case ir.TBits:
+		w := int64(f.Type.Width)
+		if w < 1 || w > 64 {
+			return flatPiece{}, false
+		}
+		return flatPiece{item: item, bits: w, read: func(ind, src string) {
+			if w <= 32 {
+				g.sf("%s%s = (uint)%s;\n", ind, name, src)
+				return
+			}
+			g.sf("%s%s = %s;\n", ind, name, src)
+		}}, true
+
+	case ir.TInt:
+		if f.Type.Width > 64 {
+			return flatPiece{}, false
+		}
+		if !f.HasIntRange {
+			return g.flatReadBarePiece(item, name)
+		}
+		return g.flatReadRangedPiece(item, name)
+
+	case ir.TNamed:
+		switch ref := f.Type.Ref.(type) {
+		case *ir.Enum:
+			bits := ir.BitsRequired(big.NewInt(0), big.NewInt(ref.Max))
+			// the runtime's ranged read is the refuser for a non-vacuous enum
+			// range, and it latches; leave those on the call
+			if bits < 1 || bits > 64 ||
+				big.NewInt(ref.Max).Cmp(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))) != 0 {
+				return flatPiece{}, false
+			}
+			return flatPiece{item: item, bits: bits, read: func(ind, src string) {
+				g.sf("%s%s = (%s)(int)%s;\n", ind, name, f.Type.Name, src)
+			}}, true
+		case *ir.Flags:
+			w := int64(ref.WireBits)
+			if w < 1 || w > 64 {
+				return flatPiece{}, false
+			}
+			return flatPiece{item: item, bits: w, read: func(ind, src string) {
+				g.sf("%s%s = %s;\n", ind, name, src)
+			}}, true
+		}
+	}
+	return flatPiece{}, false
+}
+
+func (g *gen) flatReadBarePiece(item *ir.FieldItem, name string) (flatPiece, bool) {
+	f := item.F
+	w := int64(f.Type.Width)
+	if w < 1 || w > 64 {
+		return flatPiece{}, false
+	}
+	typ := g.csFieldType(f.Type)
+	return flatPiece{item: item, bits: w, read: func(ind, src string) {
+		switch {
+		case w == 64 && f.Type.Signed:
+			g.sf("%s%s = (long)%s;\n", ind, name, src)
+		case w == 64:
+			g.sf("%s%s = %s;\n", ind, name, src)
+		case f.Type.Signed && w < 32:
+			// back through the same-width unsigned so the sign bit lands right
+			g.sf("%s%s = (%s)(%s)(uint)%s;\n", ind, name, csInt(f.Type.Width), csUint(f.Type.Width), src)
+		default:
+			g.sf("%s%s = (%s)(uint)%s;\n", ind, name, typ, src)
+		}
+	}}, true
+}
+
+// flatReadRangedPiece folds a ranged read into the run only where the refusal
+// cannot fire, or where the emitter's own read path already refuses without
+// latching — see the read half's header.
+func (g *gen) flatReadRangedPiece(item *ir.FieldItem, name string) (flatPiece, bool) {
+	f := item.F
+	bits := ir.BitsRequired(f.IntMin, f.IntMax)
+	if bits > 64 {
+		return flatPiece{}, false
+	}
+	typ := g.csFieldType(f.Type)
+	if f.IntMin.Cmp(f.IntMax) == 0 {
+		// degenerate range: zero bits — the value is the range (SPEC §4.6)
+		lit := f.IntMin.String() + "L"
+		if !f.Type.Signed && !f.IntMin.IsInt64() {
+			lit = f.IntMin.String() + "UL"
+		}
+		return flatPiece{item: item, bits: 0, read: func(ind, src string) {
+			g.sf("%s%s = unchecked((%s)(%s));\n", ind, name, typ, lit)
+		}}, true
+	}
+	switch intRangePath(f.IntMin, f.IntMax) {
+	case "int32":
+		if !flatVacuousRange(f.IntMin, f.IntMax) {
+			return flatPiece{}, false // the runtime is the refuser, and it latches
+		}
+		lo, _ := g.rangeArgs(f, "int")
+		return flatPiece{item: item, bits: bits, read: func(ind, src string) {
+			expr := fmt.Sprintf("(int)(uint)%s", src)
+			if f.IntMin.Sign() != 0 {
+				expr = fmt.Sprintf("(int)((uint)%s + unchecked((uint)(%s)))", src, lo)
+			}
+			g.sf("%s%s = (%s)(%s);\n", ind, name, typ, expr)
+		}}, true
+	case "int64":
+		if !flatVacuousRange(f.IntMin, f.IntMax) {
+			return flatPiece{}, false
+		}
+		lo, _ := g.rangeArgs(f, "long")
+		return flatPiece{item: item, bits: bits, read: func(ind, src string) {
+			expr := fmt.Sprintf("(long)%s", src)
+			if f.IntMin.Sign() != 0 {
+				expr = fmt.Sprintf("(long)(%s + unchecked((ulong)(%s)))", src, lo)
+			}
+			g.sf("%s%s = (%s)(%s);\n", ind, name, typ, expr)
+		}}, true
+	default:
+		// full-range unsigned: the emitter's own read path already refuses
+		// out-of-range WITHOUT latching, so the fold changes nothing
+		lo, _ := g.rangeArgs(f, "ulong")
+		diff := new(big.Int).Sub(f.IntMax, f.IntMin)
+		return flatPiece{item: item, bits: bits, read: func(ind, src string) {
+			if diff.Cmp(maxUint64) != 0 {
+				g.sf("%sif (%s > %s) // a read rejects out-of-range (SPEC §5) — not latched\n", ind, src, diff.String())
+				g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+			}
+			if f.IntMin.Sign() == 0 {
+				g.sf("%s%s = %s;\n", ind, name, src)
+				return
+			}
+			g.sf("%s%s = %s + %s;\n", ind, name, src, lo)
+		}}, true
+	}
 }

--- a/internal/codegen/csharp/flat.go
+++ b/internal/codegen/csharp/flat.go
@@ -303,12 +303,11 @@ func (g *gen) flatWriteBarePiece(item *ir.FieldItem, name string) (flatPiece, bo
 	if w < 1 || w > 64 {
 		return flatPiece{}, false
 	}
-	var expr string
-	switch {
-	case w == 64:
+	// at 64 the storage IS the chunk word's type, so no narrowing cast and no
+	// mask; below it the value narrows through fmt32Cast and masks to width
+	expr := flatMasked("(ulong)("+fmt32Cast(f, name)+")", w)
+	if w == 64 {
 		expr = "(ulong)" + name
-	default:
-		expr = flatMasked("(ulong)("+fmt32Cast(f, name)+")", w)
 	}
 	return flatPiece{item: item, bits: w, expr: expr}, true
 }

--- a/internal/codegen/csharp/flat.go
+++ b/internal/codegen/csharp/flat.go
@@ -1,0 +1,398 @@
+// The flat word codec, write half: the C# target's chunked wire form.
+//
+// The per-field form asks the stream to place one field at a time. In C# the
+// call itself is free — the JitDisasm audit of the bench shape found ZERO
+// direct calls into serialize.cs from any generated method; every entry point
+// the generated code touches inlines. What is not free is what each of those
+// inlined bodies does: BitWriter's packer step masks, shifts, ORs into the
+// scratch word, tests `newScratchBits >= 64`, conditionally stores a qword and
+// recovers the spill — a data-dependent branch and a store PER FIELD, against
+// state the JIT can only keep in registers inside a batch.
+//
+// The flat form removes the per-field dependence the same way the Rust (#183)
+// and Go (#198) ports did. Every bit offset INSIDE a message is a
+// generation-time constant regardless of where the message starts, so the
+// emitter folds the field placement itself: field values are computed into
+// ulong locals, OR'd into word-sized chunk locals at literal shifts, and
+// handed to the stream one whole chunk at a time. A run of B bits costs
+// ceil(B/64) packer steps instead of one per field, and what remains is
+// register arithmetic with literal shifts and literal masks.
+//
+// THREE INVARIANTS, RE-DERIVED FOR C# RATHER THAN INHERITED. #198's review
+// record is the reason this list is spelled out: the Go port shipped silent
+// wire corruption by carrying a Rust fallback across without re-deriving what
+// made it safe.
+//
+//  1. CHUNKS ARE 64 BITS. serialize.cs's SerializeBits64 splits a wide value
+//     low-dword-first-then-remainder, which IS the 32-bit chunk order, so a
+//     64-bit chunk lands exactly where two 32-bit chunks would have. It costs
+//     one bounds check (Debug.Assert on the write path) and two packer steps
+//     where two SerializeBits calls cost two of each. A chunk of 32 bits or
+//     fewer goes through SerializeBits.
+//
+//  2. EVERY PIECE IS MASKED TO ITS WIDTH. BitWriter.WriteBitsUnchecked opens
+//     with `value &= (uint)((1UL << bits) - 1)` — the per-field form TRUNCATES
+//     a too-wide value rather than refusing it. The flat form must mask too,
+//     or a value with bits above its field width would corrupt its neighbours
+//     in the chunk instead of being truncated. This is the invariant #198
+//     lost; it is enforced here at the single place a piece's value
+//     expression is built (flatMasked), never at the call sites.
+//
+//  3. WRITE REFUSALS COME FIRST, IN DECLARATION ORDER. The set of refused
+//     values and the verdict each produces are exactly the per-field form's —
+//     a generated guard returning false without latching, the family's own
+//     form. What moves is how many bits reached the stream before the
+//     refusal: a refused write leaves a partial message either way, and the
+//     run has simply not started packing yet.
+//
+// A run breaks at every construct whose width or content is not a
+// generation-time constant — align, string/bytes, arrays, branches, nested
+// struct and union calls — and at the float, fixed-point, compressed-float
+// and 128-bit families, whose value arithmetic lives in the runtime. Those
+// items keep the per-field form and a fresh run opens after them.
+//
+// A run that would not REDUCE the packer-step count is not flattened
+// (flatWorthwhile): a body of whole-chunk fields packs into as many chunks as
+// it has fields, so flattening would add a materialized local per field and
+// remove nothing.
+//
+// THE READ HALF IS NOT HERE. Folding a ranged read means replacing
+// SerializeInt with a generated comparison, and serialize.cs's ranged read
+// LATCHES SerializeError.ValueOutOfRange on refusal where a generated guard
+// returns false without latching. serialize.cs publishes checks=always and
+// test/cs pins that latch, so the read fold waits on a public refusal-latch
+// on ReadStream/ReadBatch — a serialize.cs change, tracked separately. The
+// write path has no such dependence: its folded range refusals already
+// return false without latching (see emitWriteFoldedRange).
+package csharp
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// flatChunkBits is the word the stream sees — see invariant 1.
+const flatChunkBits = 64
+
+// flatMaxRunBits caps one flat run. Past it the run closes and a fresh one
+// opens at the next item boundary: a run holds every one of its field values
+// live across its chunk assembly, and an unbounded run on a hundred-field
+// message spills them to the stack, which is the cost the form exists to
+// avoid.
+//
+// 384 is the Go port's measured peak, carried here UNMEASURED-BY-EVIDENCE:
+// swept on the bench shape at 128 / 256 / 512 the C# numbers are flat
+// (write 3.30 / 3.32 / 3.30, round_trip 1.18 / 1.18 / 1.19 M msg/s), because
+// this corpus's longest run is MixedEntity's 135 bits and no cap in that
+// range binds it. The value is a placeholder for a corpus that does reach
+// it — a schema with a 400-bit scalar body is what would move it, and the
+// number here is Go's answer to that question, not C#'s.
+const flatMaxRunBits = 384
+
+// flatPiece is one item's contribution to a run. The item rides along so a
+// run that does not pay can be re-emitted through the per-field path ITEM by
+// item — the property #198 lost when it fell back over pieces instead.
+type flatPiece struct {
+	item  ir.Item
+	bits  int64
+	guard func(ind string) // write-side refusals and headroom guards; may be nil
+	expr  string           // ulong-valued, already masked to bits; "" when bits == 0
+}
+
+// flatChunkWidths splits a run of `bits` wire bits into the chunks the stream
+// sees. The widths sum to `bits` EXACTLY, which is what makes the flat form
+// write precisely the bits the per-field form wrote.
+func flatChunkWidths(bits int64) []int64 {
+	var out []int64
+	for left := bits; left > 0; left -= flatChunkBits {
+		if left >= flatChunkBits {
+			out = append(out, flatChunkBits)
+			continue
+		}
+		out = append(out, left)
+	}
+	return out
+}
+
+// flatMaskLit renders the low-`bits` mask as a C# ulong literal, or "" at 64
+// bits where no mask is needed.
+func flatMaskLit(bits int64) string {
+	if bits >= 64 {
+		return ""
+	}
+	m := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1))
+	return fmt.Sprintf("0x%xUL", m)
+}
+
+// flatMasked wraps a ulong-valued expression in its width mask — invariant 2,
+// enforced in one place.
+func flatMasked(expr string, bits int64) string {
+	m := flatMaskLit(bits)
+	if m == "" {
+		return expr
+	}
+	return "(" + expr + ") & " + m
+}
+
+func flatShiftLeft(expr string, n int64) string {
+	if n == 0 {
+		return expr
+	}
+	return fmt.Sprintf("(%s << %d)", expr, n)
+}
+
+func flatShiftRight(expr string, n int64) string {
+	if n == 0 {
+		return expr
+	}
+	return fmt.Sprintf("(%s >> %d)", expr, n)
+}
+
+// flatWorthwhile is the policy: flatten only where it REDUCES the number of
+// packer steps, which is the entire cost the form exists to remove.
+func flatWorthwhile(pieces []flatPiece, bits int64) bool {
+	n := 0
+	for _, p := range pieces {
+		if p.bits > 0 {
+			n++
+		}
+	}
+	if n < 2 {
+		return false
+	}
+	return len(flatChunkWidths(bits)) < n
+}
+
+// emitFlatWriteRun packs the run's values into chunk words at literal shifts
+// and hands each whole chunk to the stream. The whole run lives in a block so
+// its locals are scoped to it and sibling runs may reuse the names.
+func (g *gen) emitFlatWriteRun(pieces []flatPiece, bits int64, ind string) {
+	g.sf("%s{\n", ind)
+	inner := ind + "    "
+	g.sf("%s// flat run: %d bits in %d chunk(s) — the field placement is folded\n",
+		inner, bits, len(flatChunkWidths(bits)))
+
+	// invariant 3: every refusal first, in declaration order
+	for _, p := range pieces {
+		if p.guard != nil {
+			p.guard(inner)
+		}
+	}
+
+	offsets := make([]int64, len(pieces))
+	var at int64
+	for i, p := range pieces {
+		offsets[i] = at
+		if p.bits == 0 {
+			continue
+		}
+		g.sf("%sulong f%d = %s;\n", inner, i, p.expr)
+		at += p.bits
+	}
+
+	for j, width := range flatChunkWidths(bits) {
+		lo := int64(j) * flatChunkBits
+		hi := lo + width
+		var terms []string
+		for i, p := range pieces {
+			if p.bits == 0 {
+				continue
+			}
+			o := offsets[i]
+			if o >= hi || o+p.bits <= lo {
+				continue
+			}
+			if o >= lo {
+				terms = append(terms, flatShiftLeft(fmt.Sprintf("f%d", i), o-lo))
+			} else {
+				terms = append(terms, flatShiftRight(fmt.Sprintf("f%d", i), lo-o))
+			}
+		}
+		packed := strings.Join(terms, " | ")
+		if width <= 32 {
+			g.sf("%suint w%d = (uint)(%s);\n", inner, j, packed)
+			g.call(inner, fmt.Sprintf("%s.SerializeBits(ref w%d, %d)", g.rv(), j, width), "")
+			continue
+		}
+		g.sf("%sulong w%d = %s;\n", inner, j, packed)
+		g.call(inner, fmt.Sprintf("%s.SerializeBits64(ref w%d, %d)", g.rv(), j, width), "")
+	}
+	g.sf("%s}\n", ind)
+}
+
+// ---- classification --------------------------------------------------------
+
+// flatWritePieceOf classifies one item into its contribution to a write run,
+// or reports false — which closes the run and sends the item down the
+// per-field path.
+func (g *gen) flatWritePieceOf(item ir.Item) (flatPiece, bool) {
+	switch item := item.(type) {
+	case *ir.ConstItem:
+		if item.Bits < 1 || item.Bits > 64 {
+			return flatPiece{}, false
+		}
+		return flatPiece{item: item, bits: item.Bits,
+			expr: flatMasked(item.Value.String()+"UL", item.Bits)}, true
+	case *ir.ReservedItem:
+		if item.Bits < 1 || item.Bits > 64 {
+			return flatPiece{}, false
+		}
+		return flatPiece{item: item, bits: item.Bits, expr: "0UL"}, true
+	case *ir.FieldItem:
+		return g.flatWriteFieldPiece(item)
+	}
+	return flatPiece{}, false // align, branch: not statically sized here
+}
+
+func (g *gen) flatWriteFieldPiece(item *ir.FieldItem) (flatPiece, bool) {
+	f := item.F
+	if f.Array != ir.ArrayNone {
+		return flatPiece{}, false // arrays keep their loop (v1)
+	}
+	name := "value." + g.fieldBase(f)
+	switch f.Type.Kind {
+	case ir.TBool:
+		return flatPiece{item: item, bits: 1, expr: fmt.Sprintf("%s ? 1UL : 0UL", name)}, true
+
+	case ir.TBits:
+		w := int64(f.Type.Width)
+		if w < 1 || w > 64 {
+			return flatPiece{}, false
+		}
+		return flatPiece{item: item, bits: w,
+			expr: flatMasked("(ulong)"+name, w)}, true
+
+	case ir.TInt:
+		if f.Type.Width > 64 {
+			return flatPiece{}, false // the 128-bit family lives in the runtime
+		}
+		if !f.HasIntRange {
+			return g.flatWriteBarePiece(item, name)
+		}
+		return g.flatWriteRangedPiece(item, name)
+
+	case ir.TNamed:
+		switch ref := f.Type.Ref.(type) {
+		case *ir.Enum:
+			return g.flatWriteEnumPiece(item, ref, name)
+		case *ir.Flags:
+			w := int64(ref.WireBits)
+			if w < 1 || w > 64 {
+				return flatPiece{}, false
+			}
+			return flatPiece{item: item, bits: w,
+				guard: func(ind string) {
+					g.sf("%sif (%s >= 1ul << %d) // a mask bit above the wire width cannot ride\n", ind, name, w)
+					g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+				},
+				expr: flatMasked(name, w)}, true
+		}
+	}
+	return flatPiece{}, false
+}
+
+// flatWriteBarePiece is a bare integer at its storage width. Signed values
+// cast through the same-width unsigned first — a sign extension into the
+// chunk word would corrupt its neighbours, exactly as it would in C++.
+func (g *gen) flatWriteBarePiece(item *ir.FieldItem, name string) (flatPiece, bool) {
+	f := item.F
+	w := int64(f.Type.Width)
+	if w < 1 || w > 64 {
+		return flatPiece{}, false
+	}
+	var expr string
+	switch {
+	case w == 64:
+		expr = "(ulong)" + name
+	default:
+		expr = flatMasked("(ulong)("+fmt32Cast(f, name)+")", w)
+	}
+	return flatPiece{item: item, bits: w, expr: expr}, true
+}
+
+// flatWriteRangedPiece is a ranged integer: the offset from min in a
+// generation-time bit count, with the same refusal emitWriteFoldedRange
+// emits — the same guard, the same vacuous halves elided, the same
+// non-latching false.
+func (g *gen) flatWriteRangedPiece(item *ir.FieldItem, name string) (flatPiece, bool) {
+	f := item.F
+	bits := ir.BitsRequired(f.IntMin, f.IntMax)
+	if bits > 64 {
+		return flatPiece{}, false
+	}
+	path := intRangePath(f.IntMin, f.IntMax)
+	var guardLo, guardHi bool
+	var lo, hi, cast string
+	if path == "bits64" {
+		// full-range unsigned: ulong storage only, bounds in the ulong domain
+		guardLo = f.IntMin.Sign() != 0
+		guardHi = f.IntMax.Cmp(maxUint64) != 0
+		lo, hi = g.rangeArgs(f, "ulong")
+		cast = "ulong"
+	} else {
+		sMin, sMax := storageBounds(f.Type)
+		guardLo = f.IntMin.Cmp(sMin) > 0
+		guardHi = f.IntMax.Cmp(sMax) < 0
+		typ := "int"
+		cast = "uint"
+		if path != "int32" {
+			typ, cast = "long", "ulong"
+			if !f.Type.Signed && f.Type.Width == 64 {
+				typ = "ulong"
+			}
+		}
+		lo, hi = g.rangeArgs(f, typ)
+	}
+	guard := func(ind string) {
+		switch {
+		case guardLo && guardHi:
+			g.sf("%sif (%s < %s || %s > %s)\n%s{\n%s    return false;\n%s}\n", ind, name, lo, name, hi, ind, ind, ind)
+		case guardLo:
+			g.sf("%sif (%s < %s)\n%s{\n%s    return false;\n%s}\n", ind, name, lo, ind, ind, ind)
+		case guardHi:
+			g.sf("%sif (%s > %s)\n%s{\n%s    return false;\n%s}\n", ind, name, hi, ind, ind, ind)
+		}
+	}
+	if bits == 0 {
+		// a degenerate range costs ZERO BITS — the refusal is the whole write
+		return flatPiece{item: item, bits: 0, guard: guard}, true
+	}
+	loCast := fmt.Sprintf("(%s)(%s)", cast, lo)
+	if f.IntMin.Sign() < 0 {
+		loCast = fmt.Sprintf("unchecked((%s)(%s))", cast, lo)
+	}
+	offset := fmt.Sprintf("(%s)(%s)", cast, name)
+	if f.IntMin.Sign() != 0 {
+		offset = fmt.Sprintf("(%s)(%s) - %s", cast, name, loCast)
+	}
+	return flatPiece{item: item, bits: bits, guard: guard,
+		expr: flatMasked("(ulong)("+offset+")", bits)}, true
+}
+
+// flatWriteEnumPiece is an enum in [0, Max] with a generation-time bit count,
+// carrying the headroom guard the per-field form carries.
+func (g *gen) flatWriteEnumPiece(item *ir.FieldItem, ref *ir.Enum, name string) (flatPiece, bool) {
+	bits := ir.BitsRequired(big.NewInt(0), big.NewInt(ref.Max))
+	if bits > 64 {
+		return flatPiece{}, false
+	}
+	typ := "uint"
+	if ref.StorageBits > 32 {
+		typ = "ulong"
+	}
+	var guard func(ind string)
+	if big.NewInt(ref.Max).Cmp(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(ref.StorageBits)), big.NewInt(1))) < 0 {
+		guard = func(ind string) {
+			g.sf("%sif ((%s)%s > %d) // headroom above the wire range cannot ride\n", ind, typ, name, ref.Max)
+			g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
+		}
+	}
+	if bits == 0 {
+		return flatPiece{item: item, bits: 0, guard: guard}, true
+	}
+	return flatPiece{item: item, bits: bits, guard: guard,
+		expr: flatMasked(fmt.Sprintf("(ulong)(%s)%s", typ, name), bits)}, true
+}

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -206,30 +206,69 @@ func (g *gen) emitZeroFunction(st *ir.Struct) {
 	g.sf("}\n\n")
 }
 
+// emitWriteItems walks a body, accumulating maximal FLAT RUNS of statically
+// sized items (flat.go) and emitting everything else through the per-field
+// path. A run that does not reduce the packer-step count, or that a
+// non-flattenable item interrupts, falls back ITEM BY ITEM — never piece by
+// piece: the item is the only unit the per-field path can re-emit.
 func (g *gen) emitWriteItems(items []ir.Item, ind string) {
+	var run []flatPiece
+	var runBits int64
+	flush := func() {
+		if len(run) == 0 {
+			return
+		}
+		pieces, bits := run, runBits
+		run, runBits = nil, 0
+		if flatWorthwhile(pieces, bits) {
+			g.emitFlatWriteRun(pieces, bits, ind)
+			return
+		}
+		for _, p := range pieces {
+			g.emitWriteItem(p.item, ind)
+		}
+	}
 	for _, item := range items {
-		switch item := item.(type) {
-		case *ir.FieldItem:
-			g.emitWriteField(item.F, ind)
-		case *ir.ConstItem:
-			g.emitConstItem(item, ind, true)
-		case *ir.ReservedItem:
-			g.emitReservedItem(item, ind, true)
-		case *ir.AlignItem:
-			g.call(ind, g.rv()+".SerializeAlign()", "")
-		case *ir.Branch:
-			neg := ""
-			if item.Neg {
-				neg = "!"
-			}
-			g.sf("%sif (%svalue.%s)\n%s{\n", ind, neg, g.m(ir.GoExportName(item.Cond)), ind)
-			g.emitWriteItems(item.Then, ind+"    ")
+		p, ok := g.flatWritePieceOf(item)
+		if ok && runBits+p.bits <= flatMaxRunBits {
+			run = append(run, p)
+			runBits += p.bits
+			continue
+		}
+		flush()
+		if ok {
+			run, runBits = []flatPiece{p}, p.bits
+			continue
+		}
+		g.emitWriteItem(item, ind)
+	}
+	flush()
+}
+
+// emitWriteItem is the per-field path for one item — the run's fallback and
+// the emitter for everything a run cannot hold.
+func (g *gen) emitWriteItem(item ir.Item, ind string) {
+	switch item := item.(type) {
+	case *ir.FieldItem:
+		g.emitWriteField(item.F, ind)
+	case *ir.ConstItem:
+		g.emitConstItem(item, ind, true)
+	case *ir.ReservedItem:
+		g.emitReservedItem(item, ind, true)
+	case *ir.AlignItem:
+		g.call(ind, g.rv()+".SerializeAlign()", "")
+	case *ir.Branch:
+		neg := ""
+		if item.Neg {
+			neg = "!"
+		}
+		g.sf("%sif (%svalue.%s)\n%s{\n", ind, neg, g.m(ir.GoExportName(item.Cond)), ind)
+		g.emitWriteItems(item.Then, ind+"    ")
+		g.sf("%s}\n", ind)
+		if item.Else != nil {
+			g.sf("%selse\n%s{\n", ind, ind)
+			g.emitWriteItems(item.Else, ind+"    ")
 			g.sf("%s}\n", ind)
-			if item.Else != nil {
-				g.sf("%selse\n%s{\n", ind, ind)
-				g.emitWriteItems(item.Else, ind+"    ")
-				g.sf("%s}\n", ind)
-			}
 		}
 	}
 }

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -273,33 +273,70 @@ func (g *gen) emitWriteItem(item ir.Item, ind string) {
 	}
 }
 
+// emitReadItems is emitWriteItems' twin over read runs — same accumulation,
+// same item-by-item fallback, a stricter classifier (flat.go's read half
+// names what it will not absorb and why).
 func (g *gen) emitReadItems(items []ir.Item, ind string) {
-	for _, item := range items {
-		switch item := item.(type) {
-		case *ir.FieldItem:
-			g.emitReadField(item.F, ind)
-		case *ir.ConstItem:
-			g.emitConstItem(item, ind, false)
-		case *ir.ReservedItem:
-			g.emitReservedItem(item, ind, false)
-		case *ir.AlignItem:
-			g.call(ind, g.rv()+".SerializeAlign()", " // rejects nonzero padding (SPEC §4.3)")
-		case *ir.Branch:
-			neg := ""
-			if item.Neg {
-				neg = "!"
-			}
-			g.sf("%sif (%svalue.%s)\n%s{\n", ind, neg, g.m(ir.GoExportName(item.Cond)), ind)
-			g.emitReadItems(item.Then, ind+"    ")
-			// the untaken side reads as zero values (SPEC §5)
-			g.emitZeroItems(item.Else, ind+"    ")
-			g.sf("%s}\n%selse\n%s{\n", ind, ind, ind)
-			if item.Else != nil {
-				g.emitReadItems(item.Else, ind+"    ")
-			}
-			g.emitZeroItems(item.Then, ind+"    ")
-			g.sf("%s}\n", ind)
+	var run []flatPiece
+	var runBits int64
+	flush := func() {
+		if len(run) == 0 {
+			return
 		}
+		pieces, bits := run, runBits
+		run, runBits = nil, 0
+		if flatWorthwhile(pieces, bits) {
+			g.emitFlatReadRun(pieces, bits, ind)
+			return
+		}
+		for _, p := range pieces {
+			g.emitReadItem(p.item, ind)
+		}
+	}
+	for _, item := range items {
+		p, ok := g.flatReadPieceOf(item)
+		if ok && runBits+p.bits <= flatMaxRunBits {
+			run = append(run, p)
+			runBits += p.bits
+			continue
+		}
+		flush()
+		if ok {
+			run, runBits = []flatPiece{p}, p.bits
+			continue
+		}
+		g.emitReadItem(item, ind)
+	}
+	flush()
+}
+
+// emitReadItem is the per-field path for one item — the run's fallback and
+// the emitter for everything a run cannot hold.
+func (g *gen) emitReadItem(item ir.Item, ind string) {
+	switch item := item.(type) {
+	case *ir.FieldItem:
+		g.emitReadField(item.F, ind)
+	case *ir.ConstItem:
+		g.emitConstItem(item, ind, false)
+	case *ir.ReservedItem:
+		g.emitReservedItem(item, ind, false)
+	case *ir.AlignItem:
+		g.call(ind, g.rv()+".SerializeAlign()", " // rejects nonzero padding (SPEC §4.3)")
+	case *ir.Branch:
+		neg := ""
+		if item.Neg {
+			neg = "!"
+		}
+		g.sf("%sif (%svalue.%s)\n%s{\n", ind, neg, g.m(ir.GoExportName(item.Cond)), ind)
+		g.emitReadItems(item.Then, ind+"    ")
+		// the untaken side reads as zero values (SPEC §5)
+		g.emitZeroItems(item.Else, ind+"    ")
+		g.sf("%s}\n%selse\n%s{\n", ind, ind, ind)
+		if item.Else != nil {
+			g.emitReadItems(item.Else, ind+"    ")
+		}
+		g.emitZeroItems(item.Then, ind+"    ")
+		g.sf("%s}\n", ind)
 	}
 }
 

--- a/internal/codegen/csharp/functions.go
+++ b/internal/codegen/csharp/functions.go
@@ -118,6 +118,77 @@ func (g *gen) emitCoreAttr() {
 	g.sf("[MethodImpl(MethodImplOptions.AggressiveInlining)]\n")
 }
 
+// batchScopeChild names the nested pair a composition site calls into when
+// that call earns a SCOPED BATCH — a batch opened and ended around the
+// composition site alone, inside a body that is otherwise on the stream.
+// Returns "" when the site does not earn one.
+//
+// The site earns one when the child carries a core AND passed the density
+// rule as a pair of its own: reaching that core by ref costs one capture and
+// one restore for the WHOLE site — an array's entire loop included — where
+// the child's stream entry costs one capture and one restore PER ELEMENT,
+// plus a real call the JIT will not inline through. On the bench shape that
+// is 88 capture/restore round trips (8 entities + 80 stats) traded for 3.
+//
+// A body already inside a core needs no scope: it reaches its children
+// core-to-core by ref already.
+func (g *gen) batchScopeChild(f *ir.Field) string {
+	if g.inBatch || f.Type.Kind != ir.TNamed {
+		return ""
+	}
+	switch f.Type.Ref.(type) {
+	case *ir.Struct, *ir.Union:
+	default:
+		return "" // enums and flags are scalars, not composition
+	}
+	name := f.Type.Name
+	if !g.needCore[name] || !g.batched[name] {
+		return ""
+	}
+	return name
+}
+
+// emitBatchScope emits one scoped batch around a composition site. ONLY the
+// composition call — or the loop of them — rides inside the scope: an array's
+// count site stays on the stream ahead of it, so the scope's body has exactly
+// one way to fail and End always runs before the refusal leaves the function.
+func (g *gen) emitBatchScope(writing bool, f *ir.Field, child, ind string) {
+	base := g.fieldBase(f)
+	name := "value." + base
+	dir, batchType := "Read", "ReadBatch"
+	if writing {
+		dir, batchType = "Write", "WriteBatch"
+	}
+	bound := g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "int", false)
+	count := bound
+	if f.Array == ir.ArrayCounted {
+		count = "value." + g.m(base+"Count")
+		if writing {
+			g.emitWriteFoldedRange(count, fmt.Sprintf("%d", f.ArrayMin), bound,
+				big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), false, true, true,
+				" // the count guards the loop (§6.3); out-of-contract writes are refused", ind)
+		} else {
+			g.call(ind, fmt.Sprintf("stream.SerializeInt(ref %s, %d, %s)", count, f.ArrayMin, bound),
+				" // the count guards the loop (§6.3)")
+		}
+	}
+	g.sf("%s{\n", ind)
+	g.sf("%s    // scoped batch: one capture and one restore for the whole site\n", ind)
+	g.sf("%s    %s batch = stream.BeginBatch();\n", ind, batchType)
+	if f.Array == ir.ArrayNone {
+		g.sf("%s    bool batchOk = %s%sBatch(ref batch, %s);\n", ind, dir, child, name)
+	} else {
+		g.sf("%s    bool batchOk = true;\n", ind)
+		g.sf("%s    for (int i = 0; i < %s; i++)\n%s    {\n", ind, count, ind)
+		g.sf("%s        if (!%s%sBatch(ref batch, %s[i]))\n%s        {\n", ind, dir, child, name, ind)
+		g.sf("%s            batchOk = false;\n%s            break;\n%s        }\n", ind, ind, ind)
+		g.sf("%s    }\n", ind)
+	}
+	g.sf("%s    batch.End();\n", ind)
+	g.sf("%s    if (!batchOk)\n%s    {\n%s        return false;\n%s    }\n", ind, ind, ind, ind)
+	g.sf("%s}\n", ind)
+}
+
 // emitZeroFunction emits the §5 ZERO form for a class — all-zero storage,
 // specified defaults NOT reapplied (those live in construction only; the wire
 // contract stays a pure function of the encodings). It is the C# twin of the
@@ -195,11 +266,12 @@ func (g *gen) emitReadItems(items []ir.Item, ind string) {
 
 // call emits the C++-style bool early-out around one serialize call; comment
 // (leading " // ...") rides the if line.
-// emitUnionFunctions emits the union's bounds and wire pair (SPEC §4.8):
-// plain stream functions — a union never batches (batchPlan excludes any
-// type that reaches one), so no *Batch core exists. The write validates the
-// tag BEFORE it rides; the read rejects a tag above
-// the count and zero-establishes exactly the selected arm.
+// emitUnionFunctions emits the union's bounds and wire pair (SPEC §4.8),
+// under the same batch plan every other pair obeys: the entry keeps its
+// stream signature, and a *Batch core is emitted whenever the union is
+// batched or composed under something that is. The write validates the tag
+// BEFORE it rides; the read rejects a tag above the count and
+// zero-establishes exactly the selected arm.
 func (g *gen) emitUnionFunctions(d *ir.Union) {
 	g.needsSerialize = true
 	g.owner = d.Name
@@ -216,40 +288,52 @@ func (g *gen) emitUnionFunctions(d *ir.Union) {
 	g.sf("    value.Type = %sType.None;\n}\n\n", d.Name)
 
 	bits := ir.BitsRequired(big.NewInt(0), big.NewInt(d.Max))
-	g.sf("public static bool Write%s(WriteStream stream, %s value)\n{\n", d.Name, d.Name)
-	if d.Max == 0 {
-		g.sf("    // an empty union holds only None; its degenerate tag range [0, 0]\n")
-		g.sf("    // costs zero bits (SPEC §4.8)\n")
-		g.sf("    return value.Type == %sType.None;\n}\n\n", d.Name)
-	} else {
-		g.sf("    uint tagValue = (uint)value.Type;\n")
-		g.sf("    if (tagValue > %d) // the tag validates BEFORE it rides (SPEC §4.8)\n", d.Max)
-		g.sf("    {\n        return false;\n    }\n")
-		g.call("    ", fmt.Sprintf("stream.SerializeBits(ref tagValue, %d)", bits), "")
-		g.sf("    switch (value.Type)\n    {\n")
-		for _, v := range d.Variants {
-			g.sf("        case %sType.%s:\n            return Write%s(stream, value.%s);\n",
-				d.Name, ir.GoExportName(v.Name), v.Type, ir.GoExportName(v.Name))
-		}
-		g.sf("    }\n    return true; // None — the tag is the whole wire (SPEC §4.8)\n}\n\n")
-	}
+	g.emitPair(d.Name, d.Name,
+		func() {
+			if d.Max == 0 {
+				g.sf("    // an empty union holds only None; its degenerate tag range [0, 0]\n")
+				g.sf("    // costs zero bits (SPEC §4.8)\n")
+				g.sf("    return value.Type == %sType.None;\n", d.Name)
+				return
+			}
+			g.sf("    uint tagValue = (uint)value.Type;\n")
+			g.sf("    if (tagValue > %d) // the tag validates BEFORE it rides (SPEC §4.8)\n", d.Max)
+			g.sf("    {\n        return false;\n    }\n")
+			g.call("    ", fmt.Sprintf("%s.SerializeBits(ref tagValue, %d)", g.rv(), bits), "")
+			g.sf("    switch (value.Type)\n    {\n")
+			for _, v := range d.Variants {
+				g.sf("        case %sType.%s:\n            return %s;\n",
+					d.Name, ir.GoExportName(v.Name), g.armCall("Write", v))
+			}
+			g.sf("    }\n    return true; // None — the tag is the whole wire (SPEC §4.8)\n")
+		},
+		func() {
+			if d.Max == 0 {
+				g.sf("    value.Type = %sType.None; // zero wire bits — only None exists (SPEC §4.8)\n", d.Name)
+				g.sf("    return true;\n")
+				return
+			}
+			g.sf("    int tagValue = 0;\n")
+			g.call("    ", fmt.Sprintf("%s.SerializeInt(ref tagValue, 0, %d)", g.rv(), d.Max), " // rejects a tag above the count (SPEC §4.8)")
+			g.sf("    value.Type = (%sType)tagValue;\n", d.Name)
+			g.sf("    switch (value.Type)\n    {\n")
+			for _, v := range d.Variants {
+				g.sf("        case %sType.%s:\n", d.Name, ir.GoExportName(v.Name))
+				g.sf("            Zero%s(value.%s); // the selected arm starts from the zero form (SPEC §5)\n", v.Type, ir.GoExportName(v.Name))
+				g.sf("            return %s;\n", g.armCall("Read", v))
+			}
+			g.sf("    }\n    return true; // None\n")
+		})
+}
 
-	g.sf("public static bool Read%s(ReadStream stream, %s value)\n{\n", d.Name, d.Name)
-	if d.Max == 0 {
-		g.sf("    value.Type = %sType.None; // zero wire bits — only None exists (SPEC §4.8)\n", d.Name)
-		g.sf("    return true;\n}\n\n")
-		return
+// armCall renders the call to one union arm's wire function: core-to-core by
+// ref inside a batch core (rule 1 — the arm dispatch composes exactly like a
+// nested struct field), the plain stream entry otherwise.
+func (g *gen) armCall(dir string, v ir.UnionVariant) string {
+	if g.inBatch {
+		return fmt.Sprintf("%s%sBatch(ref batch, value.%s)", dir, v.Type, ir.GoExportName(v.Name))
 	}
-	g.sf("    int tagValue = 0;\n")
-	g.call("    ", fmt.Sprintf("stream.SerializeInt(ref tagValue, 0, %d)", d.Max), " // rejects a tag above the count (SPEC §4.8)")
-	g.sf("    value.Type = (%sType)tagValue;\n", d.Name)
-	g.sf("    switch (value.Type)\n    {\n")
-	for _, v := range d.Variants {
-		g.sf("        case %sType.%s:\n", d.Name, ir.GoExportName(v.Name))
-		g.sf("            Zero%s(value.%s); // the selected arm starts from the zero form (SPEC §5)\n", v.Type, ir.GoExportName(v.Name))
-		g.sf("            return Read%s(stream, value.%s);\n", v.Type, ir.GoExportName(v.Name))
-	}
-	g.sf("    }\n    return true; // None\n}\n\n")
+	return fmt.Sprintf("%s%s(stream, value.%s)", dir, v.Type, ir.GoExportName(v.Name))
 }
 
 func (g *gen) call(ind, expr, comment string) {
@@ -482,6 +566,10 @@ func intRangePath(min, max *big.Int) string {
 func (g *gen) emitWriteField(f *ir.Field, ind string) {
 	base := g.fieldBase(f)
 	name := "value." + base
+	if child := g.batchScopeChild(f); child != "" {
+		g.emitBatchScope(true, f, child, ind)
+		return
+	}
 	if f.Array != ir.ArrayNone {
 		bound := g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "int", false)
 		if g.bulkBytes[f] {
@@ -657,9 +745,11 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 				g.call(ind, fmt.Sprintf("Write%s(stream, %s)", f.Type.Name, name), "")
 			}
 		case *ir.Union:
-			// never inside a batch core: batchPlan excludes any pair that
-			// reaches a union (batch.go, reachesUnion)
-			g.call(ind, fmt.Sprintf("Write%s(stream, %s)", f.Type.Name, name), "")
+			if g.inBatch {
+				g.call(ind, fmt.Sprintf("Write%sBatch(ref batch, %s)", f.Type.Name, name), "")
+			} else {
+				g.call(ind, fmt.Sprintf("Write%s(stream, %s)", f.Type.Name, name), "")
+			}
 		}
 	}
 }
@@ -738,6 +828,10 @@ func csFixed8Temp(f *ir.Field) string {
 func (g *gen) emitReadField(f *ir.Field, ind string) {
 	base := g.fieldBase(f)
 	name := "value." + base
+	if child := g.batchScopeChild(f); child != "" {
+		g.emitBatchScope(false, f, child, ind)
+		return
+	}
 	if f.Array != ir.ArrayNone {
 		bound := g.renderArg(f.ArrayExpr, big.NewInt(f.ArrayBound), "int", false)
 		if g.bulkBytes[f] {
@@ -916,9 +1010,11 @@ func (g *gen) emitReadScalar(f *ir.Field, name, ind string) {
 				g.call(ind, fmt.Sprintf("Read%s(stream, %s)", f.Type.Name, name), "")
 			}
 		case *ir.Union:
-			// never inside a batch core: batchPlan excludes any pair that
-			// reaches a union (batch.go, reachesUnion)
-			g.call(ind, fmt.Sprintf("Read%s(stream, %s)", f.Type.Name, name), "")
+			if g.inBatch {
+				g.call(ind, fmt.Sprintf("Read%sBatch(ref batch, %s)", f.Type.Name, name), "")
+			} else {
+				g.call(ind, fmt.Sprintf("Read%s(stream, %s)", f.Type.Name, name), "")
+			}
 		}
 	}
 }

--- a/testdata/golden/cs/Clauses.cs
+++ b/testdata/golden/cs/Clauses.cs
@@ -1024,7 +1024,22 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteEmptyABatch(ref WriteBatch batch, EmptyA value)
+        {
+            // empty body — presence is the payload (SPEC §4.6)
+            return true;
+        }
+
         public static bool ReadEmptyA(ReadStream stream, EmptyA value)
+        {
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadEmptyABatch(ref ReadBatch batch, EmptyA value)
         {
             return true;
         }
@@ -1046,7 +1061,22 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteEmptyBBatch(ref WriteBatch batch, EmptyB value)
+        {
+            // empty body — presence is the payload (SPEC §4.6)
+            return true;
+        }
+
         public static bool ReadEmptyB(ReadStream stream, EmptyB value)
+        {
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadEmptyBBatch(ref ReadBatch batch, EmptyB value)
         {
             return true;
         }
@@ -1085,6 +1115,29 @@ namespace Example
             return true; // None — the tag is the whole wire (SPEC §4.8)
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteEmptyUnionBatch(ref WriteBatch batch, EmptyUnion value)
+        {
+            uint tagValue = (uint)value.Type;
+            if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
+            {
+                return false;
+            }
+            if (!batch.SerializeBits(ref tagValue, 2))
+            {
+                return false;
+            }
+            switch (value.Type)
+            {
+                case EmptyUnionType.A:
+                    return WriteEmptyABatch(ref batch, value.A);
+                case EmptyUnionType.B:
+                    return WriteEmptyBBatch(ref batch, value.B);
+            }
+            return true; // None — the tag is the whole wire (SPEC §4.8)
+        }
+
         public static bool ReadEmptyUnion(ReadStream stream, EmptyUnion value)
         {
             int tagValue = 0;
@@ -1105,6 +1158,28 @@ namespace Example
             return true; // None
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadEmptyUnionBatch(ref ReadBatch batch, EmptyUnion value)
+        {
+            int tagValue = 0;
+            if (!batch.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
+            {
+                return false;
+            }
+            value.Type = (EmptyUnionType)tagValue;
+            switch (value.Type)
+            {
+                case EmptyUnionType.A:
+                    ZeroEmptyA(value.A); // the selected arm starts from the zero form (SPEC §5)
+                    return ReadEmptyABatch(ref batch, value.A);
+                case EmptyUnionType.B:
+                    ZeroEmptyB(value.B); // the selected arm starts from the zero form (SPEC §5)
+                    return ReadEmptyBBatch(ref batch, value.B);
+            }
+            return true; // None
+        }
+
         // HoldsEmptyUnionMaxBits is the longest wire path; align pads at worst case (SPEC §6.1).
         // HoldsEmptyUnionMaxBytes is rounded up to the 8-byte write-buffer granularity.
         public const long HoldsEmptyUnionMaxBits = 14;
@@ -1118,17 +1193,29 @@ namespace Example
             value.Tail = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteHoldsEmptyUnion(WriteStream stream, HoldsEmptyUnion value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteHoldsEmptyUnionBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteHoldsEmptyUnionBatch(ref WriteBatch batch, HoldsEmptyUnion value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!WriteEmptyUnion(stream, value.U))
+            if (!WriteEmptyUnionBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 7))
+            if (!batch.SerializeBits(ref value.Tail, 7))
             {
                 return false;
             }
@@ -1137,15 +1224,25 @@ namespace Example
 
         public static bool ReadHoldsEmptyUnion(ReadStream stream, HoldsEmptyUnion value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadHoldsEmptyUnionBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadHoldsEmptyUnionBatch(ref ReadBatch batch, HoldsEmptyUnion value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!ReadEmptyUnion(stream, value.U))
+            if (!ReadEmptyUnionBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 7))
+            if (!batch.SerializeBits(ref value.Tail, 7))
             {
                 return false;
             }

--- a/testdata/golden/cs/Clauses.cs
+++ b/testdata/golden/cs/Clauses.cs
@@ -777,13 +777,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTri3Batch(ref WriteBatch batch, Tri3 value)
         {
-            if (!batch.SerializeBits(ref value.A, 1))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 2))
-            {
-                return false;
+                // flat run: 3 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.A) & 0x1UL;
+                ulong f1 = ((ulong)value.B) & 0x3UL;
+                uint w0 = (uint)(f0 | (f1 << 1));
+                if (!batch.SerializeBits(ref w0, 3))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -913,13 +915,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteElevenBatch(ref WriteBatch batch, Eleven value)
         {
-            if (!batch.SerializeBits(ref value.A, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 8))
-            {
-                return false;
+                // flat run: 11 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.A) & 0x7UL;
+                ulong f1 = ((ulong)value.B) & 0xffUL;
+                uint w0 = (uint)(f0 | (f1 << 3));
+                if (!batch.SerializeBits(ref w0, 11))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/testdata/golden/cs/Clauses.cs
+++ b/testdata/golden/cs/Clauses.cs
@@ -802,13 +802,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTri3Batch(ref ReadBatch batch, Tri3 value)
         {
-            if (!batch.SerializeBits(ref value.A, 1))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 2))
-            {
-                return false;
+                // flat run: 3 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 3);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1UL;
+                value.A = (uint)v0;
+                ulong v1 = (c0 >> 1) & 0x3UL;
+                value.B = (uint)v1;
             }
             return true;
         }
@@ -940,13 +946,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadElevenBatch(ref ReadBatch batch, Eleven value)
         {
-            if (!batch.SerializeBits(ref value.A, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 8))
-            {
-                return false;
+                // flat run: 11 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 11);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x7UL;
+                value.A = (uint)v0;
+                ulong v1 = (c0 >> 3) & 0xffUL;
+                value.B = (uint)v1;
             }
             return true;
         }

--- a/testdata/golden/cs/Degenerate.cs
+++ b/testdata/golden/cs/Degenerate.cs
@@ -628,17 +628,21 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadTrioBatch(ref ReadBatch batch, Trio value)
         {
-            if (!batch.SerializeBits(ref value.A, 20))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 20))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.C, 24))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xfffffUL;
+                value.A = (uint)v0;
+                ulong v1 = (c0 >> 20) & 0xfffffUL;
+                value.B = (uint)v1;
+                ulong v2 = (c0 >> 40) & 0xffffffUL;
+                value.C = (uint)v2;
             }
             return true;
         }

--- a/testdata/golden/cs/Degenerate.cs
+++ b/testdata/golden/cs/Degenerate.cs
@@ -602,17 +602,16 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteTrioBatch(ref WriteBatch batch, Trio value)
         {
-            if (!batch.SerializeBits(ref value.A, 20))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.B, 20))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.C, 24))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.A) & 0xfffffUL;
+                ulong f1 = ((ulong)value.B) & 0xfffffUL;
+                ulong f2 = ((ulong)value.C) & 0xffffffUL;
+                ulong w0 = f0 | (f1 << 20) | (f2 << 40);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/testdata/golden/cs/Joins.cs
+++ b/testdata/golden/cs/Joins.cs
@@ -267,13 +267,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmsAgreeBatch(ref ReadBatch batch, ArmsAgree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -370,13 +376,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmsDisagreeBatch(ref ReadBatch batch, ArmsDisagree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -465,13 +477,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmEmptyBatch(ref ReadBatch batch, ArmEmpty value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -579,13 +597,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmsNestedBatch(ref ReadBatch batch, ArmsNested value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Outer))
-            {
-                return false;
+                // flat run: 4 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 4);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x7UL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 3) & 0x1UL;
+                value.Outer = v1 != 0UL;
             }
             if (value.Outer)
             {
@@ -690,13 +714,19 @@ namespace Example
 
         public static bool ReadArmAlign(ReadStream stream, ArmAlign value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 6);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -827,13 +857,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadArmArrayBatch(ref ReadBatch batch, ArmArray value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 6);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1fUL;
+                value.Lead = (uint)v0;
+                ulong v1 = (c0 >> 5) & 0x1UL;
+                value.Flag = v1 != 0UL;
             }
             if (value.Flag)
             {
@@ -1332,21 +1368,25 @@ namespace Example
                     return false;
                 }
             }
-            if (!stream.SerializeBits(ref value.P, 32))
             {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Q, 29))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.R, 19))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Tail, 4))
-            {
-                return false;
+                // flat run: 84 bits in 2 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                stream.SerializeBits64(ref c1, 20);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffffffffUL;
+                value.P = (uint)v0;
+                ulong v1 = (c0 >> 32) & 0x1fffffffUL;
+                value.Q = (uint)v1;
+                ulong v2 = ((c0 >> 61) | (c1 << 3)) & 0x7ffffUL;
+                value.R = (uint)v2;
+                ulong v3 = (c1 >> 16) & 0xfUL;
+                value.Tail = (uint)v3;
             }
             return true;
         }

--- a/testdata/golden/cs/Joins.cs
+++ b/testdata/golden/cs/Joins.cs
@@ -224,13 +224,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmsAgreeBatch(ref WriteBatch batch, ArmsAgree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -325,13 +327,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmsDisagreeBatch(ref WriteBatch batch, ArmsDisagree value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -425,13 +429,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmEmptyBatch(ref WriteBatch batch, ArmEmpty value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -516,13 +522,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmsNestedBatch(ref WriteBatch batch, ArmsNested value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 3))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Outer))
-            {
-                return false;
+                // flat run: 4 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x7UL;
+                ulong f1 = value.Outer ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 3));
+                if (!batch.SerializeBits(ref w0, 4))
+                {
+                    return false;
+                }
             }
             if (value.Outer)
             {
@@ -638,13 +646,15 @@ namespace Example
 
         public static bool WriteArmAlign(WriteStream stream, ArmAlign value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!stream.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -753,13 +763,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteArmArrayBatch(ref WriteBatch batch, ArmArray value)
         {
-            if (!batch.SerializeBits(ref value.Lead, 5))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Flag))
-            {
-                return false;
+                // flat run: 6 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Lead) & 0x1fUL;
+                ulong f1 = value.Flag ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 6))
+                {
+                    return false;
+                }
             }
             if (value.Flag)
             {
@@ -1264,21 +1276,22 @@ namespace Example
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.P, 32))
             {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Q, 29))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.R, 19))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.Tail, 4))
-            {
-                return false;
+                // flat run: 84 bits in 2 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.P) & 0xffffffffUL;
+                ulong f1 = ((ulong)value.Q) & 0x1fffffffUL;
+                ulong f2 = ((ulong)value.R) & 0x7ffffUL;
+                ulong f3 = ((ulong)value.Tail) & 0xfUL;
+                ulong w0 = f0 | (f1 << 32) | (f2 << 61);
+                if (!stream.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f2 >> 3) | (f3 << 16));
+                if (!stream.SerializeBits(ref w1, 20))
+                {
+                    return false;
+                }
             }
             return true;
         }

--- a/testdata/golden/cs/Joins.cs
+++ b/testdata/golden/cs/Joins.cs
@@ -878,9 +878,31 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteNarrowBatch(ref WriteBatch batch, Narrow value)
+        {
+            if (!batch.SerializeBits(ref value.N, 3))
+            {
+                return false;
+            }
+            return true;
+        }
+
         public static bool ReadNarrow(ReadStream stream, Narrow value)
         {
             if (!stream.SerializeBits(ref value.N, 3))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadNarrowBatch(ref ReadBatch batch, Narrow value)
+        {
+            if (!batch.SerializeBits(ref value.N, 3))
             {
                 return false;
             }
@@ -907,9 +929,31 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteWideBatch(ref WriteBatch batch, Wide value)
+        {
+            if (!batch.SerializeBits64(ref value.W, 37))
+            {
+                return false;
+            }
+            return true;
+        }
+
         public static bool ReadWide(ReadStream stream, Wide value)
         {
             if (!stream.SerializeBits64(ref value.W, 37))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadWideBatch(ref ReadBatch batch, Wide value)
+        {
+            if (!batch.SerializeBits64(ref value.W, 37))
             {
                 return false;
             }
@@ -929,31 +973,53 @@ namespace Example
             value.Type = UnevenType.None;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteUneven(WriteStream stream, Uneven value)
+        {
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteUnevenBatch(ref WriteBatch batch, Uneven value)
         {
             uint tagValue = (uint)value.Type;
             if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref tagValue, 2))
+            if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
             }
             switch (value.Type)
             {
                 case UnevenType.Narrow:
-                    return WriteNarrow(stream, value.Narrow);
+                    return WriteNarrowBatch(ref batch, value.Narrow);
                 case UnevenType.Wide:
-                    return WriteWide(stream, value.Wide);
+                    return WriteWideBatch(ref batch, value.Wide);
             }
             return true; // None — the tag is the whole wire (SPEC §4.8)
         }
 
         public static bool ReadUneven(ReadStream stream, Uneven value)
         {
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadUnevenBatch(ref ReadBatch batch, Uneven value)
+        {
             int tagValue = 0;
-            if (!stream.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
+            if (!batch.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
             {
                 return false;
             }
@@ -962,10 +1028,10 @@ namespace Example
             {
                 case UnevenType.Narrow:
                     ZeroNarrow(value.Narrow); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadNarrow(stream, value.Narrow);
+                    return ReadNarrowBatch(ref batch, value.Narrow);
                 case UnevenType.Wide:
                     ZeroWide(value.Wide); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadWide(stream, value.Wide);
+                    return ReadWideBatch(ref batch, value.Wide);
             }
             return true; // None
         }
@@ -983,17 +1049,29 @@ namespace Example
             value.Tail = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteHoldsUneven(WriteStream stream, HoldsUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteHoldsUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteHoldsUnevenBatch(ref WriteBatch batch, HoldsUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!WriteUneven(stream, value.U))
+            if (!WriteUnevenBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 11))
+            if (!batch.SerializeBits(ref value.Tail, 11))
             {
                 return false;
             }
@@ -1002,15 +1080,25 @@ namespace Example
 
         public static bool ReadHoldsUneven(ReadStream stream, HoldsUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadHoldsUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadHoldsUnevenBatch(ref ReadBatch batch, HoldsUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!ReadUneven(stream, value.U))
+            if (!ReadUnevenBatch(ref batch, value.U))
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.Tail, 11))
+            if (!batch.SerializeBits(ref value.Tail, 11))
             {
                 return false;
             }
@@ -1034,9 +1122,21 @@ namespace Example
             value.Tail = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteArrUneven(WriteStream stream, ArrUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteArrUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteArrUnevenBatch(ref WriteBatch batch, ArrUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
@@ -1046,19 +1146,19 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ItemsCount);
-                if (!stream.SerializeBits(ref offsetValue, 2))
+                if (!batch.SerializeBits(ref offsetValue, 2))
                 {
                     return false;
                 }
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (!WriteUneven(stream, value.Items[i]))
+                if (!WriteUnevenBatch(ref batch, value.Items[i]))
                 {
                     return false;
                 }
             }
-            if (!stream.SerializeBits(ref value.Tail, 3))
+            if (!batch.SerializeBits(ref value.Tail, 3))
             {
                 return false;
             }
@@ -1067,22 +1167,32 @@ namespace Example
 
         public static bool ReadArrUneven(ReadStream stream, ArrUneven value)
         {
-            if (!stream.SerializeBits(ref value.Lead, 5))
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadArrUnevenBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadArrUnevenBatch(ref ReadBatch batch, ArrUneven value)
+        {
+            if (!batch.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!stream.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
+            if (!batch.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
             {
                 return false;
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (!ReadUneven(stream, value.Items[i]))
+                if (!ReadUnevenBatch(ref batch, value.Items[i]))
                 {
                     return false;
                 }
             }
-            if (!stream.SerializeBits(ref value.Tail, 3))
+            if (!batch.SerializeBits(ref value.Tail, 3))
             {
                 return false;
             }
@@ -1108,21 +1218,9 @@ namespace Example
             value.Tail = 0;
         }
 
-        // batch form: stream state stays in registers across the body and End
-        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteRegainAfterAlign(WriteStream stream, RegainAfterAlign value)
         {
-            WriteBatch batch = stream.BeginBatch();
-            bool result = WriteRegainAfterAlignBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool WriteRegainAfterAlignBatch(ref WriteBatch batch, RegainAfterAlign value)
-        {
-            if (!batch.SerializeBits(ref value.Lead, 5))
+            if (!stream.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
@@ -1132,7 +1230,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ItemsCount);
-                if (!batch.SerializeBits(ref offsetValue, 2))
+                if (!stream.SerializeBits(ref offsetValue, 2))
                 {
                     return false;
                 }
@@ -1145,7 +1243,7 @@ namespace Example
                 }
                 {
                     uint offsetValue = (uint)(value.Items[i]);
-                    if (!batch.SerializeBits(ref offsetValue, 13))
+                    if (!stream.SerializeBits(ref offsetValue, 13))
                     {
                         return false;
                     }
@@ -1157,28 +1255,28 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.SLength);
-                if (!batch.SerializeBits(ref offsetValue, 3))
+                if (!stream.SerializeBits(ref offsetValue, 3))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBytes(value.S.AsSpan(0, value.SLength)))
+            if (!stream.SerializeBytes(value.S.AsSpan(0, value.SLength)))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.P, 32))
+            if (!stream.SerializeBits(ref value.P, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Q, 29))
+            if (!stream.SerializeBits(ref value.Q, 29))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.R, 19))
+            if (!stream.SerializeBits(ref value.R, 19))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Tail, 4))
+            if (!stream.SerializeBits(ref value.Tail, 4))
             {
                 return false;
             }
@@ -1187,21 +1285,11 @@ namespace Example
 
         public static bool ReadRegainAfterAlign(ReadStream stream, RegainAfterAlign value)
         {
-            ReadBatch batch = stream.BeginBatch();
-            bool result = ReadRegainAfterAlignBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ReadRegainAfterAlignBatch(ref ReadBatch batch, RegainAfterAlign value)
-        {
-            if (!batch.SerializeBits(ref value.Lead, 5))
+            if (!stream.SerializeBits(ref value.Lead, 5))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
+            if (!stream.SerializeInt(ref value.ItemsCount, 0, 3)) // the count guards the loop (§6.3)
             {
                 return false;
             }
@@ -1209,18 +1297,18 @@ namespace Example
             {
                 {
                     int rangeValue = 0;
-                    if (!batch.SerializeInt(ref rangeValue, 0, 8191))
+                    if (!stream.SerializeInt(ref rangeValue, 0, 8191))
                     {
                         return false;
                     }
                     value.Items[i] = (ushort)rangeValue;
                 }
             }
-            if (!batch.SerializeInt(ref value.SLength, 0, 4)) // the length guards the slice (§6.3)
+            if (!stream.SerializeInt(ref value.SLength, 0, 4)) // the length guards the slice (§6.3)
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.S.AsSpan(0, value.SLength)))
+            if (!stream.SerializeBytes(value.S.AsSpan(0, value.SLength)))
             {
                 return false;
             }
@@ -1231,19 +1319,19 @@ namespace Example
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.P, 32))
+            if (!stream.SerializeBits(ref value.P, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Q, 29))
+            if (!stream.SerializeBits(ref value.Q, 29))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.R, 19))
+            if (!stream.SerializeBits(ref value.R, 19))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.Tail, 4))
+            if (!stream.SerializeBits(ref value.Tail, 4))
             {
                 return false;
             }

--- a/testdata/golden/cs/Render.cs
+++ b/testdata/golden/cs/Render.cs
@@ -73,32 +73,29 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderSpriteBatch(ref WriteBatch batch, RenderSprite value)
         {
-            if (!batch.SerializeBits64(ref value.SortKey, 64))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MeshId, 32))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MaterialId, 32))
-            {
-                return false;
-            }
-            {
-                uint rawValue = value.Layer;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                // flat run: 138 bits in 3 chunk(s) — the field placement is folded
+                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-            }
-            {
-                uint enumValue = (uint)value.Team;
-                if (enumValue > 2) // headroom above the wire range cannot ride
+                ulong f0 = (ulong)value.SortKey;
+                ulong f1 = ((ulong)(value.MeshId)) & 0xffffffffUL;
+                ulong f2 = ((ulong)(value.MaterialId)) & 0xffffffffUL;
+                ulong f3 = ((ulong)(value.Layer)) & 0xffUL;
+                ulong f4 = ((ulong)(uint)value.Team) & 0x3UL;
+                ulong w0 = f0;
+                if (!batch.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref enumValue, 2))
+                ulong w1 = f1 | (f2 << 32);
+                if (!batch.SerializeBits64(ref w1, 64))
+                {
+                    return false;
+                }
+                uint w2 = (uint)(f3 | (f4 << 8));
+                if (!batch.SerializeBits(ref w2, 10))
                 {
                     return false;
                 }
@@ -180,13 +177,15 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteRenderBlockBatch(ref WriteBatch batch, RenderBlock value)
         {
-            if (!batch.SerializeBits(ref value.WorkerIndex, 32))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.SpriteCountHint, 32))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)(value.WorkerIndex)) & 0xffffffffUL;
+                ulong f1 = ((ulong)(value.SpriteCountHint)) & 0xffffffffUL;
+                ulong w0 = f0 | (f1 << 32);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
             }
             if (value.SpritesCount < 0 || value.SpritesCount > (int)RenderBlockMaxSprites) // the count guards the loop (§6.3); out-of-contract writes are refused
             {

--- a/testdata/golden/cs/Render.cs
+++ b/testdata/golden/cs/Render.cs
@@ -115,25 +115,27 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderSpriteBatch(ref ReadBatch batch, RenderSprite value)
         {
-            if (!batch.SerializeBits64(ref value.SortKey, 64))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MeshId, 32))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.MaterialId, 32))
-            {
-                return false;
-            }
-            {
-                uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                // flat run: 136 bits in 3 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                batch.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                batch.SerializeBits64(ref c2, 8);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.Layer = (byte)rawValue;
+                ulong v0 = c0;
+                value.SortKey = v0;
+                ulong v1 = c1 & 0xffffffffUL;
+                value.MeshId = (uint)(uint)v1;
+                ulong v2 = (c1 >> 32) & 0xffffffffUL;
+                value.MaterialId = (uint)(uint)v2;
+                ulong v3 = c2 & 0xffUL;
+                value.Layer = (byte)(uint)v3;
             }
             {
                 int enumValue = 0;
@@ -220,13 +222,19 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadRenderBlockBatch(ref ReadBatch batch, RenderBlock value)
         {
-            if (!batch.SerializeBits(ref value.WorkerIndex, 32))
             {
-                return false;
-            }
-            if (!batch.SerializeBits(ref value.SpriteCountHint, 32))
-            {
-                return false;
+                // flat run: 64 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffffffffUL;
+                value.WorkerIndex = (uint)(uint)v0;
+                ulong v1 = (c0 >> 32) & 0xffffffffUL;
+                value.SpriteCountHint = (uint)(uint)v1;
             }
             if (!batch.SerializeInt(ref value.SpritesCount, 0, (int)RenderBlockMaxSprites)) // the count guards the loop (§6.3)
             {

--- a/testdata/golden/cs/Types.cs
+++ b/testdata/golden/cs/Types.cs
@@ -857,37 +857,31 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.Fire))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.AltFire))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Boost))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Brake))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Aim))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.LockOn))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Zoom))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Ping))
-            {
-                return false;
+                // flat run: 8 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 8);
+                if (!batch.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0x1UL;
+                value.Fire = v0 != 0UL;
+                ulong v1 = (c0 >> 1) & 0x1UL;
+                value.AltFire = v1 != 0UL;
+                ulong v2 = (c0 >> 2) & 0x1UL;
+                value.Boost = v2 != 0UL;
+                ulong v3 = (c0 >> 3) & 0x1UL;
+                value.Brake = v3 != 0UL;
+                ulong v4 = (c0 >> 4) & 0x1UL;
+                value.Aim = v4 != 0UL;
+                ulong v5 = (c0 >> 5) & 0x1UL;
+                value.LockOn = v5 != 0UL;
+                ulong v6 = (c0 >> 6) & 0x1UL;
+                value.Zoom = v6 != 0UL;
+                ulong v7 = (c0 >> 7) & 0x1UL;
+                value.Ping = v7 != 0UL;
             }
             return true;
         }

--- a/testdata/golden/cs/Types.cs
+++ b/testdata/golden/cs/Types.cs
@@ -331,20 +331,16 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteHandleBatch(ref WriteBatch batch, Handle value)
         {
-            if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.ObjectId);
-                if (!batch.SerializeBits(ref offsetValue, 14))
+                // flat run: 22 bits in 1 chunk(s) — the field placement is folded
+                if (value.ObjectId < 0 || value.ObjectId > (int)(MaxObjects - 1))
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.ObjectSequence;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                ulong f0 = ((ulong)((uint)(value.ObjectId))) & 0x3fffUL;
+                ulong f1 = ((ulong)(value.ObjectSequence)) & 0xffUL;
+                uint w0 = (uint)(f0 | (f1 << 14));
+                if (!batch.SerializeBits(ref w0, 22))
                 {
                     return false;
                 }
@@ -406,35 +402,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedPositionBatch(ref WriteBatch batch, QuantizedPosition value)
         {
-            if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.X) - unchecked((uint)((int)(-MaxPositionUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 25))
+                // flat run: 75 bits in 2 chunk(s) — the field placement is folded
+                if (value.X < (int)(-MaxPositionUnits) || value.X > (int)MaxPositionUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Y) - unchecked((uint)((int)(-MaxPositionUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 25))
+                if (value.Y < (int)(-MaxPositionUnits) || value.Y > (int)MaxPositionUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Z) - unchecked((uint)((int)(-MaxPositionUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 25))
+                if (value.Z < (int)(-MaxPositionUnits) || value.Z > (int)MaxPositionUnits)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
+                ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
+                ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxPositionUnits))))) & 0x1ffffffUL;
+                ulong w0 = f0 | (f1 << 25) | (f2 << 50);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f2 >> 14));
+                if (!batch.SerializeBits(ref w1, 11))
                 {
                     return false;
                 }
@@ -496,35 +487,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedVelocityBatch(ref WriteBatch batch, QuantizedVelocity value)
         {
-            if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.X) - unchecked((uint)((int)(-MaxVelocityUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 23))
+                // flat run: 69 bits in 2 chunk(s) — the field placement is folded
+                if (value.X < (int)(-MaxVelocityUnits) || value.X > (int)MaxVelocityUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Y) - unchecked((uint)((int)(-MaxVelocityUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 23))
+                if (value.Y < (int)(-MaxVelocityUnits) || value.Y > (int)MaxVelocityUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Z) - unchecked((uint)((int)(-MaxVelocityUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 23))
+                if (value.Z < (int)(-MaxVelocityUnits) || value.Z > (int)MaxVelocityUnits)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
+                ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
+                ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-MaxVelocityUnits))))) & 0x7fffffUL;
+                ulong w0 = f0 | (f1 << 23) | (f2 << 46);
+                if (!batch.SerializeBits64(ref w0, 64))
+                {
+                    return false;
+                }
+                uint w1 = (uint)((f2 >> 18));
+                if (!batch.SerializeBits(ref w1, 5))
                 {
                     return false;
                 }
@@ -587,46 +573,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteQuantizedRotationBatch(ref WriteBatch batch, QuantizedRotation value)
         {
-            if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.X) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                // flat run: 48 bits in 1 chunk(s) — the field placement is folded
+                if (value.X < (int)(-RotationUnits) || value.X > (int)RotationUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Y) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.Y < (int)(-RotationUnits) || value.Y > (int)RotationUnits)
                 {
                     return false;
                 }
-            }
-            if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Z) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.Z < (int)(-RotationUnits) || value.Z > (int)RotationUnits)
                 {
                     return false;
                 }
-            }
-            if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.W) - unchecked((uint)((int)(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 12))
+                if (value.W < (int)(-RotationUnits) || value.W > (int)RotationUnits)
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.X) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong f1 = ((ulong)((uint)(value.Y) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong f2 = ((ulong)((uint)(value.Z) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong f3 = ((ulong)((uint)(value.W) - unchecked((uint)((int)(-RotationUnits))))) & 0xfffUL;
+                ulong w0 = f0 | (f1 << 12) | (f2 << 24) | (f3 << 36);
+                if (!batch.SerializeBits64(ref w0, 48))
                 {
                     return false;
                 }
@@ -836,37 +806,21 @@ namespace Example
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.Fire))
             {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.AltFire))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Boost))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Brake))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Aim))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.LockOn))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Zoom))
-            {
-                return false;
-            }
-            if (!batch.SerializeBool(ref value.Ping))
-            {
-                return false;
+                // flat run: 8 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = value.Fire ? 1UL : 0UL;
+                ulong f1 = value.AltFire ? 1UL : 0UL;
+                ulong f2 = value.Boost ? 1UL : 0UL;
+                ulong f3 = value.Brake ? 1UL : 0UL;
+                ulong f4 = value.Aim ? 1UL : 0UL;
+                ulong f5 = value.LockOn ? 1UL : 0UL;
+                ulong f6 = value.Zoom ? 1UL : 0UL;
+                ulong f7 = value.Ping ? 1UL : 0UL;
+                uint w0 = (uint)(f0 | (f1 << 1) | (f2 << 2) | (f3 << 3) | (f4 << 4) | (f5 << 5) | (f6 << 6) | (f7 << 7));
+                if (!batch.SerializeBits(ref w0, 8))
+                {
+                    return false;
+                }
             }
             return true;
         }
@@ -1124,41 +1078,28 @@ namespace Example
                 }
             }
             {
-                uint enumValue = (uint)value.Team;
-                if (enumValue > 2) // headroom above the wire range cannot ride
+                // flat run: 19 bits in 1 chunk(s) — the field placement is folded
+                if ((uint)value.Team > 2) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-                if (!batch.SerializeBits(ref enumValue, 2))
+                if (value.Health < 0 || value.Health > (int)MaxHealth)
                 {
                     return false;
                 }
-            }
-            if (value.Health < 0 || value.Health > (int)MaxHealth)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Health);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.Thrust < 0 || value.Thrust > 100)
                 {
                     return false;
                 }
-            }
-            if (value.Thrust < 0 || value.Thrust > 100)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Thrust);
-                if (!batch.SerializeBits(ref offsetValue, 7))
+                if ((uint)value.Pending > 0) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-            }
-            {
-                uint enumValue = (uint)value.Pending;
-                if (enumValue > 0) // headroom above the wire range cannot ride
+                ulong f0 = ((ulong)(uint)value.Team) & 0x3UL;
+                ulong f1 = ((ulong)((uint)(value.Health))) & 0x3ffUL;
+                ulong f2 = ((ulong)((uint)(value.Thrust))) & 0x7fUL;
+                uint w0 = (uint)(f0 | (f1 << 2) | (f2 << 12));
+                if (!batch.SerializeBits(ref w0, 19))
                 {
                     return false;
                 }
@@ -1278,24 +1219,20 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteExpressionProbeBatch(ref WriteBatch batch, ExpressionProbe value)
         {
-            if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.HardpointIndex);
-                if (!batch.SerializeBits(ref offsetValue, 5))
+                // flat run: 16 bits in 1 chunk(s) — the field placement is folded
+                if (value.HardpointIndex < 0 || value.HardpointIndex > (int)((ShipMaxLasers + ShipMaxMissiles) - 1))
                 {
                     return false;
                 }
-            }
-            if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.SpinRate) - (uint)((int)(-(-RotationUnits)));
-                if (!batch.SerializeBits(ref offsetValue, 11))
+                if (value.SpinRate < (int)(-(-RotationUnits)) || value.SpinRate > (int)(RotationUnits * 2))
+                {
+                    return false;
+                }
+                ulong f0 = ((ulong)((uint)(value.HardpointIndex))) & 0x1fUL;
+                ulong f1 = ((ulong)((uint)(value.SpinRate) - (uint)((int)(-(-RotationUnits))))) & 0x7ffUL;
+                uint w0 = (uint)(f0 | (f1 << 5));
+                if (!batch.SerializeBits(ref w0, 16))
                 {
                     return false;
                 }

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -727,11 +727,40 @@ namespace Example
             return true;
         }
 
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteProbeRingBatch(ref WriteBatch batch, ProbeRing value)
+        {
+            {
+                uint rawValue = value.Radius;
+                if (!batch.SerializeBits(ref rawValue, 16))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public static bool ReadProbeRing(ReadStream stream, ProbeRing value)
         {
             {
                 uint rawValue = 0;
                 if (!stream.SerializeBits(ref rawValue, 16))
+                {
+                    return false;
+                }
+                value.Radius = (ushort)rawValue;
+            }
+            return true;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadProbeRingBatch(ref ReadBatch batch, ProbeRing value)
+        {
+            {
+                uint rawValue = 0;
+                if (!batch.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
@@ -831,31 +860,53 @@ namespace Example
             value.Type = ProbeShapeType.None;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeShape(WriteStream stream, ProbeShape value)
+        {
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteProbeShapeBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteProbeShapeBatch(ref WriteBatch batch, ProbeShape value)
         {
             uint tagValue = (uint)value.Type;
             if (tagValue > 2) // the tag validates BEFORE it rides (SPEC §4.8)
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref tagValue, 2))
+            if (!batch.SerializeBits(ref tagValue, 2))
             {
                 return false;
             }
             switch (value.Type)
             {
                 case ProbeShapeType.Ring:
-                    return WriteProbeRing(stream, value.Ring);
+                    return WriteProbeRingBatch(ref batch, value.Ring);
                 case ProbeShapeType.Slab:
-                    return WriteProbeSlab(stream, value.Slab);
+                    return WriteProbeSlabBatch(ref batch, value.Slab);
             }
             return true; // None — the tag is the whole wire (SPEC §4.8)
         }
 
         public static bool ReadProbeShape(ReadStream stream, ProbeShape value)
         {
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadProbeShapeBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadProbeShapeBatch(ref ReadBatch batch, ProbeShape value)
+        {
             int tagValue = 0;
-            if (!stream.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
+            if (!batch.SerializeInt(ref tagValue, 0, 2)) // rejects a tag above the count (SPEC §4.8)
             {
                 return false;
             }
@@ -864,10 +915,10 @@ namespace Example
             {
                 case ProbeShapeType.Ring:
                     ZeroProbeRing(value.Ring); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadProbeRing(stream, value.Ring);
+                    return ReadProbeRingBatch(ref batch, value.Ring);
                 case ProbeShapeType.Slab:
                     ZeroProbeSlab(value.Slab); // the selected arm starts from the zero form (SPEC §5)
-                    return ReadProbeSlab(stream, value.Slab);
+                    return ReadProbeSlabBatch(ref batch, value.Slab);
             }
             return true; // None
         }
@@ -890,20 +941,32 @@ namespace Example
             value.ExtrasCount = 0;
         }
 
+        // batch form: stream state stays in registers across the body and End
+        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteProbeCollider(WriteStream stream, ProbeCollider value)
+        {
+            WriteBatch batch = stream.BeginBatch();
+            bool result = WriteProbeColliderBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool WriteProbeColliderBatch(ref WriteBatch batch, ProbeCollider value)
         {
             {
                 uint rawValue = value.Armor;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                if (!batch.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
             }
-            if (!WriteProbeShape(stream, value.Shape))
+            if (!WriteProbeShapeBatch(ref batch, value.Shape))
             {
                 return false;
             }
-            if (!WriteProbeShape(stream, value.Backup))
+            if (!WriteProbeShapeBatch(ref batch, value.Backup))
             {
                 return false;
             }
@@ -913,14 +976,14 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ExtrasCount);
-                if (!stream.SerializeBits(ref offsetValue, 2))
+                if (!batch.SerializeBits(ref offsetValue, 2))
                 {
                     return false;
                 }
             }
             for (int i = 0; i < value.ExtrasCount; i++)
             {
-                if (!WriteProbeShape(stream, value.Extras[i]))
+                if (!WriteProbeShapeBatch(ref batch, value.Extras[i]))
                 {
                     return false;
                 }
@@ -930,29 +993,39 @@ namespace Example
 
         public static bool ReadProbeCollider(ReadStream stream, ProbeCollider value)
         {
+            ReadBatch batch = stream.BeginBatch();
+            bool result = ReadProbeColliderBatch(ref batch, value);
+            batch.End();
+            return result;
+        }
+
+        // inline-only batch core — a real call would address-expose the batch
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ReadProbeColliderBatch(ref ReadBatch batch, ProbeCollider value)
+        {
             {
                 uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                if (!batch.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
                 value.Armor = (byte)rawValue;
             }
-            if (!ReadProbeShape(stream, value.Shape))
+            if (!ReadProbeShapeBatch(ref batch, value.Shape))
             {
                 return false;
             }
-            if (!ReadProbeShape(stream, value.Backup))
+            if (!ReadProbeShapeBatch(ref batch, value.Backup))
             {
                 return false;
             }
-            if (!stream.SerializeInt(ref value.ExtrasCount, 0, 2)) // the count guards the loop (§6.3)
+            if (!batch.SerializeInt(ref value.ExtrasCount, 0, 2)) // the count guards the loop (§6.3)
             {
                 return false;
             }
             for (int i = 0; i < value.ExtrasCount; i++)
             {
-                if (!ReadProbeShape(stream, value.Extras[i]))
+                if (!ReadProbeShapeBatch(ref batch, value.Extras[i]))
                 {
                     return false;
                 }
@@ -1457,19 +1530,7 @@ namespace Example
             value.TextLength = 0;
         }
 
-        // batch form: stream state stays in registers across the body and End
-        // publishes it — same wire bytes, same validation, same error model.
         public static bool WriteTestData(WriteStream stream, TestData value)
-        {
-            WriteBatch batch = stream.BeginBatch();
-            bool result = WriteTestDataBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool WriteTestDataBatch(ref WriteBatch batch, TestData value)
         {
             if (value.A < -100 || value.A > 100)
             {
@@ -1477,7 +1538,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.A) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
@@ -1488,7 +1549,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.B) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
@@ -1499,24 +1560,24 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.C) - unchecked((uint)(-100));
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.D, 8))
+            if (!stream.SerializeBits(ref value.D, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.E, 8))
+            if (!stream.SerializeBits(ref value.E, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F, 8))
+            if (!stream.SerializeBits(ref value.F, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.G))
+            if (!stream.SerializeBool(ref value.G))
             {
                 return false;
             }
@@ -1526,7 +1587,7 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.ItemsCount);
-                if (!batch.SerializeBits(ref offsetValue, 5))
+                if (!stream.SerializeBits(ref offsetValue, 5))
                 {
                     return false;
                 }
@@ -1539,66 +1600,66 @@ namespace Example
                 }
                 {
                     uint offsetValue = (uint)(value.Items[i]);
-                    if (!batch.SerializeBits(ref offsetValue, 8))
+                    if (!stream.SerializeBits(ref offsetValue, 8))
                     {
                         return false;
                     }
                 }
             }
-            if (!batch.SerializeFloat(ref value.FloatValue))
+            if (!stream.SerializeFloat(ref value.FloatValue))
             {
                 return false;
             }
             {
                 float compressedValue = value.CompressedFloatValue;
-                if (!batch.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
+                if (!stream.SerializeCompressedFloatPrecomputed(ref compressedValue, 1000u, 10, 10.0f, 0.0f))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeDouble(ref value.DoubleValue))
+            if (!stream.SerializeDouble(ref value.DoubleValue))
             {
                 return false;
             }
             {
                 uint rawValue = (byte)value.Int8Value;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
             }
             {
                 uint rawValue = (ushort)value.Int16Value;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
             }
             {
                 uint rawValue = value.Uint8Value;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
             }
             {
                 uint rawValue = value.Uint16Value;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBits(ref value.Uint32Value, 32))
+            if (!stream.SerializeBits(ref value.Uint32Value, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits64(ref value.Uint64Value, 64))
+            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
             {
                 return false;
             }
             {
                 ulong rawValue = (ulong)value.Int64Full;
-                if (!batch.SerializeBits64(ref rawValue, 64))
+                if (!stream.SerializeBits64(ref rawValue, 64))
                 {
                     return false;
                 }
@@ -1609,16 +1670,16 @@ namespace Example
             }
             {
                 ulong offsetValue = (ulong)(value.Int64Range) - unchecked((ulong)(-1000000000000));
-                if (!batch.SerializeBits64(ref offsetValue, 41))
+                if (!stream.SerializeBits64(ref offsetValue, 41))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeAlign())
+            if (!stream.SerializeAlign())
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+            if (!stream.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
             {
                 return false;
             }
@@ -1628,12 +1689,12 @@ namespace Example
             }
             {
                 uint offsetValue = (uint)(value.TextLength);
-                if (!batch.SerializeBits(ref offsetValue, 8))
+                if (!stream.SerializeBits(ref offsetValue, 8))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
+            if (!stream.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
             {
                 return false;
             }
@@ -1642,70 +1703,60 @@ namespace Example
 
         public static bool ReadTestData(ReadStream stream, TestData value)
         {
-            ReadBatch batch = stream.BeginBatch();
-            bool result = ReadTestDataBatch(ref batch, value);
-            batch.End();
-            return result;
-        }
-
-        // inline-only batch core — a real call would address-expose the batch
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool ReadTestDataBatch(ref ReadBatch batch, TestData value)
-        {
-            if (!batch.SerializeInt(ref value.A, -100, 100))
+            if (!stream.SerializeInt(ref value.A, -100, 100))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.B, -100, 100))
+            if (!stream.SerializeInt(ref value.B, -100, 100))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.C, -100, 150))
+            if (!stream.SerializeInt(ref value.C, -100, 150))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.D, 8))
+            if (!stream.SerializeBits(ref value.D, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.E, 8))
+            if (!stream.SerializeBits(ref value.E, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBits(ref value.F, 8))
+            if (!stream.SerializeBits(ref value.F, 8))
             {
                 return false;
             }
-            if (!batch.SerializeBool(ref value.G))
+            if (!stream.SerializeBool(ref value.G))
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.ItemsCount, 0, 16)) // the count guards the loop (§6.3)
+            if (!stream.SerializeInt(ref value.ItemsCount, 0, 16)) // the count guards the loop (§6.3)
             {
                 return false;
             }
             for (int i = 0; i < value.ItemsCount; i++)
             {
-                if (!batch.SerializeInt(ref value.Items[i], 0, 255))
+                if (!stream.SerializeInt(ref value.Items[i], 0, 255))
                 {
                     return false;
                 }
             }
-            if (!batch.SerializeFloat(ref value.FloatValue))
+            if (!stream.SerializeFloat(ref value.FloatValue))
             {
                 return false;
             }
-            if (!batch.SerializeCompressedFloatPrecomputed(ref value.CompressedFloatValue, 1000u, 10, 10.0f, 0.0f))
+            if (!stream.SerializeCompressedFloatPrecomputed(ref value.CompressedFloatValue, 1000u, 10, 10.0f, 0.0f))
             {
                 return false;
             }
-            if (!batch.SerializeDouble(ref value.DoubleValue))
+            if (!stream.SerializeDouble(ref value.DoubleValue))
             {
                 return false;
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
@@ -1713,7 +1764,7 @@ namespace Example
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
@@ -1721,7 +1772,7 @@ namespace Example
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                if (!stream.SerializeBits(ref rawValue, 8))
                 {
                     return false;
                 }
@@ -1729,45 +1780,45 @@ namespace Example
             }
             {
                 uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                if (!stream.SerializeBits(ref rawValue, 16))
                 {
                     return false;
                 }
                 value.Uint16Value = (ushort)rawValue;
             }
-            if (!batch.SerializeBits(ref value.Uint32Value, 32))
+            if (!stream.SerializeBits(ref value.Uint32Value, 32))
             {
                 return false;
             }
-            if (!batch.SerializeBits64(ref value.Uint64Value, 64))
+            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
             {
                 return false;
             }
             {
                 ulong rawValue = 0;
-                if (!batch.SerializeBits64(ref rawValue, 64))
+                if (!stream.SerializeBits64(ref rawValue, 64))
                 {
                     return false;
                 }
                 value.Int64Full = (long)rawValue;
             }
-            if (!batch.SerializeInt64(ref value.Int64Range, -1000000000000, 1000000000000))
+            if (!stream.SerializeInt64(ref value.Int64Range, -1000000000000, 1000000000000))
             {
                 return false;
             }
-            if (!batch.SerializeAlign()) // rejects nonzero padding (SPEC §4.3)
+            if (!stream.SerializeAlign()) // rejects nonzero padding (SPEC §4.3)
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
+            if (!stream.SerializeBytes(value.FixedBytes.AsSpan(0, 17))) // byte-aligned [N]uint8 — bulk copy, wire-identical to the per-byte loop
             {
                 return false;
             }
-            if (!batch.SerializeInt(ref value.TextLength, 0, 255)) // the length guards the slice (§6.3)
+            if (!stream.SerializeInt(ref value.TextLength, 0, 255)) // the length guards the slice (§6.3)
             {
                 return false;
             }
-            if (!batch.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
+            if (!stream.SerializeBytes(value.Text.AsSpan(0, value.TextLength)))
             {
                 return false;
             }

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -313,19 +313,12 @@ namespace Example
         private static bool WriteProbeHeaderBatch(ref WriteBatch batch, ProbeHeader value)
         {
             {
-                uint constValue = 171;
-                if (!batch.SerializeBits(ref constValue, 8)) // const(171, 8) — SPEC §4.3
-                {
-                    return false;
-                }
-            }
-            if (!batch.SerializeBits(ref value.Version, 3))
-            {
-                return false;
-            }
-            {
-                uint reservedValue = 0;
-                if (!batch.SerializeBits(ref reservedValue, 5)) // reserved(5) — zeros on the wire
+                // flat run: 16 bits in 1 chunk(s) — the field placement is folded
+                ulong f0 = (171UL) & 0xffUL;
+                ulong f1 = ((ulong)value.Version) & 0x7UL;
+                ulong f2 = 0UL;
+                uint w0 = (uint)(f0 | (f1 << 8) | (f2 << 11));
+                if (!batch.SerializeBits(ref w0, 16))
                 {
                     return false;
                 }
@@ -419,28 +412,30 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeBitsBatch(ref WriteBatch batch, ProbeBits value)
         {
-            if (!batch.SerializeBits(ref value.Small, 9))
             {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Boundary, 33))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Wide, 64))
-            {
-                return false;
-            }
-            {
-                ulong offsetValue = (ulong)(value.Sensor);
-                if (!batch.SerializeBits64(ref offsetValue, 32))
+                // flat run: 202 bits in 4 chunk(s) — the field placement is folded
+                ulong f0 = ((ulong)value.Small) & 0x1ffUL;
+                ulong f1 = ((ulong)value.Boundary) & 0x1ffffffffUL;
+                ulong f2 = (ulong)value.Wide;
+                ulong f3 = ((ulong)((ulong)(value.Sensor))) & 0xffffffffUL;
+                ulong f4 = (ulong)((ulong)(value.Nonce));
+                ulong w0 = f0 | (f1 << 9) | (f2 << 42);
+                if (!batch.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-            }
-            {
-                ulong offsetValue = value.Nonce;
-                if (!batch.SerializeBits64(ref offsetValue, 64))
+                ulong w1 = (f2 >> 22) | (f3 << 42);
+                if (!batch.SerializeBits64(ref w1, 64))
+                {
+                    return false;
+                }
+                ulong w2 = (f3 >> 22) | (f4 << 10);
+                if (!batch.SerializeBits64(ref w2, 64))
+                {
+                    return false;
+                }
+                uint w3 = (uint)((f4 >> 54));
+                if (!batch.SerializeBits(ref w3, 10))
                 {
                     return false;
                 }
@@ -553,19 +548,18 @@ namespace Example
             if (value.Active)
             {
                 {
-                    uint enumValue = (uint)value.Weapon;
-                    if (enumValue > 15) // headroom above the wire range cannot ride
+                    // flat run: 5 bits in 1 chunk(s) — the field placement is folded
+                    if ((uint)value.Weapon > 15) // headroom above the wire range cannot ride
                     {
                         return false;
                     }
-                    if (!batch.SerializeBits(ref enumValue, 4))
+                    ulong f0 = ((ulong)(uint)value.Weapon) & 0xfUL;
+                    ulong f1 = value.HasTarget ? 1UL : 0UL;
+                    uint w0 = (uint)(f0 | (f1 << 4));
+                    if (!batch.SerializeBits(ref w0, 5))
                     {
                         return false;
                     }
-                }
-                if (!batch.SerializeBool(ref value.HasTarget))
-                {
-                    return false;
                 }
                 if (value.HasTarget)
                 {
@@ -795,20 +789,16 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool WriteProbeSlabBatch(ref WriteBatch batch, ProbeSlab value)
         {
-            if (value.Width > 100)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.Width);
-                if (!batch.SerializeBits(ref offsetValue, 7))
+                // flat run: 15 bits in 1 chunk(s) — the field placement is folded
+                if (value.Width > 100)
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.Height;
-                if (!batch.SerializeBits(ref rawValue, 8))
+                ulong f0 = ((ulong)((uint)(value.Width))) & 0x7fUL;
+                ulong f1 = ((ulong)(value.Height)) & 0xffUL;
+                uint w0 = (uint)(f0 | (f1 << 7));
+                if (!batch.SerializeBits(ref w0, 15))
                 {
                     return false;
                 }
@@ -1060,19 +1050,15 @@ namespace Example
         private static bool WriteProbeConfigBatch(ref WriteBatch batch, ProbeConfig value)
         {
             {
-                uint rawValue = (uint)value.Retries;
-                if (!batch.SerializeBits(ref rawValue, 32))
+                // flat run: 36 bits in 1 chunk(s) — the field placement is folded
+                if ((uint)value.Preferred > 15) // headroom above the wire range cannot ride
                 {
                     return false;
                 }
-            }
-            {
-                uint enumValue = (uint)value.Preferred;
-                if (enumValue > 15) // headroom above the wire range cannot ride
-                {
-                    return false;
-                }
-                if (!batch.SerializeBits(ref enumValue, 4))
+                ulong f0 = ((ulong)((uint)value.Retries)) & 0xffffffffUL;
+                ulong f1 = ((ulong)(uint)value.Preferred) & 0xfUL;
+                ulong w0 = f0 | (f1 << 32);
+                if (!batch.SerializeBits64(ref w0, 36))
                 {
                     return false;
                 }
@@ -1231,41 +1217,25 @@ namespace Example
         private static bool WriteTestBatch(ref WriteBatch batch, Test value)
         {
             {
-                uint rawValue = value.TestA;
-                if (!batch.SerializeBits(ref rawValue, 16))
+                // flat run: 46 bits in 1 chunk(s) — the field placement is folded
+                if (value.TestB < 0 || value.TestB > 1000)
                 {
                     return false;
                 }
-            }
-            if (value.TestB < 0 || value.TestB > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.TestB);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.TestC < 0 || value.TestC > 1000)
                 {
                     return false;
                 }
-            }
-            if (value.TestC < 0 || value.TestC > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.TestC);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                if (value.TestD < 0 || value.TestD > 1000)
                 {
                     return false;
                 }
-            }
-            if (value.TestD < 0 || value.TestD > 1000)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.TestD);
-                if (!batch.SerializeBits(ref offsetValue, 10))
+                ulong f0 = ((ulong)(value.TestA)) & 0xffffUL;
+                ulong f1 = ((ulong)((uint)(value.TestB))) & 0x3ffUL;
+                ulong f2 = ((ulong)((uint)(value.TestC))) & 0x3ffUL;
+                ulong f3 = ((ulong)((uint)(value.TestD))) & 0x3ffUL;
+                ulong w0 = f0 | (f1 << 16) | (f2 << 26) | (f3 << 36);
+                if (!batch.SerializeBits64(ref w0, 46))
                 {
                     return false;
                 }
@@ -1532,54 +1502,32 @@ namespace Example
 
         public static bool WriteTestData(WriteStream stream, TestData value)
         {
-            if (value.A < -100 || value.A > 100)
             {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.A) - unchecked((uint)(-100));
-                if (!stream.SerializeBits(ref offsetValue, 8))
+                // flat run: 49 bits in 1 chunk(s) — the field placement is folded
+                if (value.A < -100 || value.A > 100)
                 {
                     return false;
                 }
-            }
-            if (value.B < -100 || value.B > 100)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.B) - unchecked((uint)(-100));
-                if (!stream.SerializeBits(ref offsetValue, 8))
+                if (value.B < -100 || value.B > 100)
                 {
                     return false;
                 }
-            }
-            if (value.C < -100 || value.C > 150)
-            {
-                return false;
-            }
-            {
-                uint offsetValue = (uint)(value.C) - unchecked((uint)(-100));
-                if (!stream.SerializeBits(ref offsetValue, 8))
+                if (value.C < -100 || value.C > 150)
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.D, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.E, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.F, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.G))
-            {
-                return false;
+                ulong f0 = ((ulong)((uint)(value.A) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f1 = ((ulong)((uint)(value.B) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f2 = ((ulong)((uint)(value.C) - unchecked((uint)(-100)))) & 0xffUL;
+                ulong f3 = ((ulong)value.D) & 0xffUL;
+                ulong f4 = ((ulong)value.E) & 0xffUL;
+                ulong f5 = ((ulong)value.F) & 0xffUL;
+                ulong f6 = value.G ? 1UL : 0UL;
+                ulong w0 = f0 | (f1 << 8) | (f2 << 16) | (f3 << 24) | (f4 << 32) | (f5 << 40) | (f6 << 48);
+                if (!stream.SerializeBits64(ref w0, 49))
+                {
+                    return false;
+                }
             }
             if (value.ItemsCount < 0 || value.ItemsCount > 16) // the count guards the loop (§6.3); out-of-contract writes are refused
             {
@@ -1622,55 +1570,36 @@ namespace Example
                 return false;
             }
             {
-                uint rawValue = (byte)value.Int8Value;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                // flat run: 249 bits in 4 chunk(s) — the field placement is folded
+                if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = (ushort)value.Int16Value;
-                if (!stream.SerializeBits(ref rawValue, 16))
+                ulong f0 = ((ulong)((byte)value.Int8Value)) & 0xffUL;
+                ulong f1 = ((ulong)((ushort)value.Int16Value)) & 0xffffUL;
+                ulong f2 = ((ulong)(value.Uint8Value)) & 0xffUL;
+                ulong f3 = ((ulong)(value.Uint16Value)) & 0xffffUL;
+                ulong f4 = ((ulong)(value.Uint32Value)) & 0xffffffffUL;
+                ulong f5 = (ulong)value.Uint64Value;
+                ulong f6 = (ulong)value.Int64Full;
+                ulong f7 = ((ulong)((ulong)(value.Int64Range) - unchecked((ulong)(-1000000000000)))) & 0x1ffffffffffUL;
+                ulong w0 = f0 | (f1 << 8) | (f2 << 24) | (f3 << 32) | (f4 << 48);
+                if (!stream.SerializeBits64(ref w0, 64))
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.Uint8Value;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                ulong w1 = (f4 >> 16) | (f5 << 16);
+                if (!stream.SerializeBits64(ref w1, 64))
                 {
                     return false;
                 }
-            }
-            {
-                uint rawValue = value.Uint16Value;
-                if (!stream.SerializeBits(ref rawValue, 16))
+                ulong w2 = (f5 >> 48) | (f6 << 16);
+                if (!stream.SerializeBits64(ref w2, 64))
                 {
                     return false;
                 }
-            }
-            if (!stream.SerializeBits(ref value.Uint32Value, 32))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
-            {
-                return false;
-            }
-            {
-                ulong rawValue = (ulong)value.Int64Full;
-                if (!stream.SerializeBits64(ref rawValue, 64))
-                {
-                    return false;
-                }
-            }
-            if (value.Int64Range < -1000000000000 || value.Int64Range > 1000000000000)
-            {
-                return false;
-            }
-            {
-                ulong offsetValue = (ulong)(value.Int64Range) - unchecked((ulong)(-1000000000000));
-                if (!stream.SerializeBits64(ref offsetValue, 41))
+                ulong w3 = (f6 >> 48) | (f7 << 16);
+                if (!stream.SerializeBits64(ref w3, 57))
                 {
                     return false;
                 }

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -347,27 +347,23 @@ namespace Example
         private static bool ReadProbeHeaderBatch(ref ReadBatch batch, ProbeHeader value)
         {
             {
-                uint constValue = 0;
-                if (!batch.SerializeBits(ref constValue, 8))
+                // flat run: 16 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 16);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                if (constValue != 171) // const(171, 8): a read rejects any other value (SPEC §4.3)
+                ulong v0 = c0 & 0xffUL;
+                if (v0 != 171UL) // const(171, 8): a read rejects any other value (SPEC §4.3)
                 {
                     return false;
                 }
-            }
-            if (!batch.SerializeBits(ref value.Version, 3))
-            {
-                return false;
-            }
-            {
-                uint reservedValue = 0;
-                if (!batch.SerializeBits(ref reservedValue, 5))
-                {
-                    return false;
-                }
-                if (reservedValue != 0) // reserved(5): a read rejects nonzero (SPEC §4.3)
+                ulong v1 = (c0 >> 8) & 0x7UL;
+                value.Version = (uint)v1;
+                ulong v2 = (c0 >> 11) & 0x1fUL;
+                if (v2 != 0UL) // reserved(5): a read rejects nonzero
                 {
                     return false;
                 }
@@ -455,33 +451,31 @@ namespace Example
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ReadProbeBitsBatch(ref ReadBatch batch, ProbeBits value)
         {
-            if (!batch.SerializeBits(ref value.Small, 9))
             {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Boundary, 33))
-            {
-                return false;
-            }
-            if (!batch.SerializeBits64(ref value.Wide, 64))
-            {
-                return false;
-            }
-            {
-                long rangeValue = 0;
-                if (!batch.SerializeInt64(ref rangeValue, 0, 4294967295))
+                // flat run: 202 bits in 4 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                batch.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                batch.SerializeBits64(ref c2, 64);
+                ulong c3 = 0;
+                batch.SerializeBits64(ref c3, 10);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.Sensor = (uint)rangeValue;
-            }
-            {
-                ulong offsetValue = 0;
-                if (!batch.SerializeBits64(ref offsetValue, 64))
-                {
-                    return false;
-                }
-                value.Nonce = offsetValue;
+                ulong v0 = c0 & 0x1ffUL;
+                value.Small = (uint)v0;
+                ulong v1 = (c0 >> 9) & 0x1ffffffffUL;
+                value.Boundary = v1;
+                ulong v2 = ((c0 >> 42) | (c1 << 22));
+                value.Wide = v2;
+                ulong v3 = ((c1 >> 42) | (c2 << 22)) & 0xffffffffUL;
+                value.Sensor = (uint)((long)v3);
+                ulong v4 = ((c2 >> 10) | (c3 << 54));
+                value.Nonce = v4;
             }
             return true;
         }
@@ -642,16 +636,18 @@ namespace Example
             if (value.Active)
             {
                 {
-                    int enumValue = 0;
-                    if (!batch.SerializeInt(ref enumValue, 0, 15))
+                    // flat run: 5 bits in 1 chunk(s) — one bounds check per chunk,
+                    // one sticky-error test for the whole run
+                    ulong c0 = 0;
+                    batch.SerializeBits64(ref c0, 5);
+                    if (!batch.Ok)
                     {
                         return false;
                     }
-                    value.Weapon = (Weapon)enumValue;
-                }
-                if (!batch.SerializeBool(ref value.HasTarget))
-                {
-                    return false;
+                    ulong v0 = c0 & 0xfUL;
+                    value.Weapon = (Weapon)(int)v0;
+                    ulong v1 = (c0 >> 4) & 0x1UL;
+                    value.HasTarget = v1 != 0UL;
                 }
                 if (value.HasTarget)
                 {
@@ -1079,20 +1075,18 @@ namespace Example
         private static bool ReadProbeConfigBatch(ref ReadBatch batch, ProbeConfig value)
         {
             {
-                uint rawValue = 0;
-                if (!batch.SerializeBits(ref rawValue, 32))
+                // flat run: 36 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                batch.SerializeBits64(ref c0, 36);
+                if (!batch.Ok)
                 {
                     return false;
                 }
-                value.Retries = (int)rawValue;
-            }
-            {
-                int enumValue = 0;
-                if (!batch.SerializeInt(ref enumValue, 0, 15))
-                {
-                    return false;
-                }
-                value.Preferred = (Weapon)enumValue;
+                ulong v0 = c0 & 0xffffffffUL;
+                value.Retries = (int)(uint)v0;
+                ulong v1 = (c0 >> 32) & 0xfUL;
+                value.Preferred = (Weapon)(int)v1;
             }
             return true;
         }
@@ -1644,21 +1638,23 @@ namespace Example
             {
                 return false;
             }
-            if (!stream.SerializeBits(ref value.D, 8))
             {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.E, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits(ref value.F, 8))
-            {
-                return false;
-            }
-            if (!stream.SerializeBool(ref value.G))
-            {
-                return false;
+                // flat run: 25 bits in 1 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 25);
+                if (!stream.Ok)
+                {
+                    return false;
+                }
+                ulong v0 = c0 & 0xffUL;
+                value.D = (uint)v0;
+                ulong v1 = (c0 >> 8) & 0xffUL;
+                value.E = (uint)v1;
+                ulong v2 = (c0 >> 16) & 0xffUL;
+                value.F = (uint)v2;
+                ulong v3 = (c0 >> 24) & 0x1UL;
+                value.G = v3 != 0UL;
             }
             if (!stream.SerializeInt(ref value.ItemsCount, 0, 16)) // the count guards the loop (§6.3)
             {
@@ -1684,52 +1680,34 @@ namespace Example
                 return false;
             }
             {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 8))
+                // flat run: 208 bits in 4 chunk(s) — one bounds check per chunk,
+                // one sticky-error test for the whole run
+                ulong c0 = 0;
+                stream.SerializeBits64(ref c0, 64);
+                ulong c1 = 0;
+                stream.SerializeBits64(ref c1, 64);
+                ulong c2 = 0;
+                stream.SerializeBits64(ref c2, 64);
+                ulong c3 = 0;
+                stream.SerializeBits64(ref c3, 16);
+                if (!stream.Ok)
                 {
                     return false;
                 }
-                value.Int8Value = (sbyte)(byte)rawValue;
-            }
-            {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 16))
-                {
-                    return false;
-                }
-                value.Int16Value = (short)(ushort)rawValue;
-            }
-            {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 8))
-                {
-                    return false;
-                }
-                value.Uint8Value = (byte)rawValue;
-            }
-            {
-                uint rawValue = 0;
-                if (!stream.SerializeBits(ref rawValue, 16))
-                {
-                    return false;
-                }
-                value.Uint16Value = (ushort)rawValue;
-            }
-            if (!stream.SerializeBits(ref value.Uint32Value, 32))
-            {
-                return false;
-            }
-            if (!stream.SerializeBits64(ref value.Uint64Value, 64))
-            {
-                return false;
-            }
-            {
-                ulong rawValue = 0;
-                if (!stream.SerializeBits64(ref rawValue, 64))
-                {
-                    return false;
-                }
-                value.Int64Full = (long)rawValue;
+                ulong v0 = c0 & 0xffUL;
+                value.Int8Value = (sbyte)(byte)(uint)v0;
+                ulong v1 = (c0 >> 8) & 0xffffUL;
+                value.Int16Value = (short)(ushort)(uint)v1;
+                ulong v2 = (c0 >> 24) & 0xffUL;
+                value.Uint8Value = (byte)(uint)v2;
+                ulong v3 = (c0 >> 32) & 0xffffUL;
+                value.Uint16Value = (ushort)(uint)v3;
+                ulong v4 = ((c0 >> 48) | (c1 << 16)) & 0xffffffffUL;
+                value.Uint32Value = (uint)(uint)v4;
+                ulong v5 = ((c1 >> 16) | (c2 << 48));
+                value.Uint64Value = v5;
+                ulong v6 = ((c2 >> 16) | (c3 << 48));
+                value.Int64Full = (long)v6;
             }
             if (!stream.SerializeInt64(ref value.Int64Range, -1000000000000, 1000000000000))
             {


### PR DESCRIPTION
The C# backend was the laggard on the current ledger — 361% of generated C/C++ on `bench/results/2026-09-01-arm64-macbook.csv` (main at d00cf49) — and the only backend never audited for generation quality (#170's matrix). This is that audit and the levers it found.

**Headline** (`--only cs`, both halves committed, two sittings back to back, `bench_mixed`, family `gen`, `checks=always`):

| path | before max | after max | before median | after median | |
|---|---|---|---|---|---|
| write | 2,104,563 | **3,342,814** | 2,103,454 | 3,334,630 | **1.59x** |
| round_trip | 992,155 | **1,594,245** | 990,865 | 1,586,844 | **1.60x** |

Against the same day's quiet-box reference at the same `corpus_id` (cpp round_trip median 3,467,551), on the round_trip statistic: **350% → 219% of generated C++**, and on write 347% → 219%. Zero allocations on the hot path throughout (the leg's own assert). Wire bytes never moved: full `make test` green across nine backends on every commit, degenerate corpus included.

---

## 1. MEASURE FIRST — where the time actually was

Instrument: `DOTNET_JitDisasm` + `DOTNET_JitDisasmSummary`, `DOTNET_TieredCompilation=0`, FullOpts, against the built `bench/cs` Release binary (BENCH-STANDARD.md §4.1's own recipe). Not dotnet-trace: every hot call inlines, so a sampled stack would attribute the whole codec to one frame and say nothing.

**Finding 1 — this is NOT Go's distribution.** #198 found ~86% of Go's time inside runtime calls the compiler would not inline. C# has no such wall: `ReadBenchMixed` and `WriteBenchMixed` contain ZERO direct `bl` into serialize.cs. Every entry point the generated code touches inlines. Anyone porting #198's conclusions here would have optimised the wrong thing.

**Finding 2 — the cost was the generated code's own composition.** `BenchMixed` reaches a union, and the batch plan excluded any type that reached one, so the whole message ran on the stream and reached its element types through their STREAM entries — each of which opens a batch and closes it again:

| site | elements | BeginBatch/End round trips | real calls |
|---|---|---|---|
| `entities` | 8 | 8 | 8 |
| `stats` | 80 | 80 | 80 |
| `game_event` | 1 | 1 | 1 + 1 arm |

89 capture/restore round trips per 438-byte message, on the two arrays carrying 72% of the wire bits.

**Finding 3 — what the inlined bodies do.** `BitWriter`'s packer step masks, shifts, ORs into scratch, tests `newScratchBits >= 64`, conditionally stores a qword and recovers the spill: a data-dependent branch and a conditional store PER FIELD. `MixedEntity` paid fourteen for 135 bits.

**Finding 4 — read-path code density.** `ReadBitsUnchecked`'s slack-free window-assembly fallback loop is inlined at EVERY field read site — a loop that never runs on a slack buffer. `ReadBenchMixed` was 8952 bytes of code for 869 bytes of IL.

## 2. THE LEVERS, ranked, and what each returned

| # | lever | where | status |
|---|---|---|---|
| A | **Union batch cores + a scoped batch per composition site** — 89 capture/restore round trips become 3 | emitter | **LANDED — write +34%, round_trip +11%** |
| A' | Whole-message batch, the obvious companion to A | emitter | **REFUSED BY MEASUREMENT** — write 2.10→2.04, round_trip 0.97→0.76 M msg/s. See §3. |
| B1 | **The flat word codec, write half** — values into locals, OR'd into 64-bit chunk words at literal shifts | emitter | **LANDED — write +17%, round_trip +9%** |
| B2 | **The flat word codec, read half** — one bounds check per chunk, one sticky-error test per run | emitter | **LANDED — round_trip +30%** |
| E | Public refusal-latch on `ReadStream`/`ReadBatch`, so B2 could fold the ranged reads it leaves on the runtime call | serialize.cs | **RANKED AND REFUSED — worth ~1%.** See §4. |
| C | Hoist the read slack-path out of line (`NoInlining` cold helper) so the fallback stops being pasted at every read site | serialize.cs | not taken — B2 cut the read sites from 14 to 3 per entity, which removes most of what made this attractive |
| D | Branch-free 64-bit chunk primitives on the batch (`value >> 1 >> (63 - sb)` handles `sb == 0` branchlessly) | serialize.cs | not taken — ranked behind C for the same reason |
| F | Group K array elements into one run (80 stats × 18 bits = 80 chunk touches today; K=8 would make it 30) | emitter | **the next real lever** — Go's `flatGroupRun`, not ported here (land-and-expand) |
| G | Unroll small fixed scalar arrays into runs (`loadout [4]uint8`) | emitter | small, not taken |
| H | The C# bench driver's write/read delegates (one indirect call per op cpp and rust do not pay) | bench/cs | **NOT TAKEN — harness, and cross-leg comparability is not mine to move** |

## 3. Lever A' — the measured refusal, stated

Once unions carry cores, nothing stops the whole message body running on one batch. It is slower, and materially. The JIT DID inline the 12.7 KB core (entry IL size 23), so this is not the address-exposure law from the original batch work firing. It is the delegated sites: `BenchMixed`'s body has six (`fixed`, two `bytes` runs, `ufixed`, `uint128`, `int128`), each a Sync down and a Recapture back, and between them a ref struct the register allocator must keep alive across 12.7 KB of code.

`batchEntry` now states it: density is necessary, `b == 0` is the rest.

## 4. Lever E — refused on evidence, not deferred

B2 folds a ranged read into a run only where the range check is VACUOUS (`max - min == 2^bits - 1`), or where this emitter's read path already refuses without latching (the full-range unsigned path). Everything else keeps the runtime call, because `SerializeInt` LATCHES `ValueOutOfRange` and a generated comparison would not — cs publishes `checks=always` and test/cs pins that latch.

The obvious follow-on was a public refusal-latch on `ReadStream`/`ReadBatch` so the rest could fold. **A hand-written prototype that folded every ranged read of the two hot cores, latch semantics and all, measured round_trip 1.55 M msg/s. The landed restriction measures 1.54.** The API addition is worth about 1%. Recorded as refused.

## 5. Discipline

- **Wire bytes never move.** Full `make test` green across nine backends on every commit — degenerate corpus, `test/cs` and `test/cs-ludicrous` (which pin the corrupt-wire refusals) included. The bench's own golden + per-variant round-trip gates pass at `corpus_id 6b213fbfa1a03a99`.
- **Negative control, run rather than assumed.** With `flatMaskLit` forced to emit no mask — the flat form's masking invariant deliberately broken — `make test` produces 65 failure lines. The gate that proves this form does see it.
- **Checks semantics preserved exactly.** Same inputs refused, same errors, on every path. The two consequences fusion always has (which error surfaces when a stream is both truncated and out of range; a failed run leaving the destination untouched) are named in `flat.go`, and are the ones Rust, Go, Java, Dart and JS-flat already carry.
- **Zero allocations on the hot path**, still 0 bytes/pass.
- **One commit per lever, one measurement per commit**, attribution never bundled.
- **Provenance**: `bench/run.sh`'s `schema commit` line now carries its branch, like every runtime line already did — a small fix for a failure mode this repo has had twice (a sweep that measured the wrong tree; a published result whose SHA was rebased away). Law-home in BENCH-STANDARD.md §3.5.
- The `bits` family rows in the committed pair are flagged in the CSVs themselves as NOT attributable to this change: `BitsBench.cs` touches no generated code, yet its rows move 11% across the halves at sub-3% spread. Process-level, an open question, not a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
