### PR TITLE
The c/cpp statistical tie: both report 100% inside the noise band

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -712,6 +712,17 @@ stride clause was added 2026-08-15, with the measurement that demanded it):
 
 ### §2.8 Quick mode — PROPOSED
 
+**The c/cpp statistical tie (owner ruling, 2026-09-01).** The c and cpp legs
+compile the same word-codec shape with the same clang backend at the same
+flags, and across every sitting of the data-driven era their gap has stayed
+inside the pair's own spread (c has printed 97–100% of cpp while frozen code
+moved ±2% and TU layout alone has moved byte-identical code up to 10%). So
+the headline table reports them as a TIE: when c's percentage sits within the
+pair's combined spread of 100%, c prints 100% and a note names the measured
+figure. Display rule only — the CSV always carries the raw rates — and the
+ruling carries its own exit: a sitting that separates the pair beyond the
+combined spread prints the real figure, and that separation is a finding.
+
 `run.sh --quick` is the ITERATION instrument, never the certification
 instrument, and every leg's stderr says so. It exists so a nine-language
 comparison costs minutes, not an evening; nothing it prints publishes.

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -596,7 +596,27 @@ if [ "$QUICK" = 1 ]; then
                         printf "  %-10s %6s\n", lang, "—"
                         notes = notes sprintf("  §2.3 INVALID: %s spread %.1f%% > 40%% — the row does not publish as a number\n", lang, sp[lang])
                     } else if (ref > 0) {
-                        printf "  %-10s %5.0f%%\n", lang, ts[lang] / ref * 100.0
+                        # The c/cpp statistical tie (owner ruling 2026-09-01, §2.8):
+                        # the two legs are the same clang word codec, and their gap
+                        # has never left the pair's own spread — so when c sits
+                        # inside the pair's combined spread of cpp, both print 100%.
+                        # Display rule only: the CSV always carries the raw rates,
+                        # and a future sitting that separates them beyond the noise
+                        # prints the real figure, which is the ruling's own exit.
+                        pct = ts[lang] / ref * 100.0
+                        # tie threshold: the pair's combined within-sitting
+                        # spread, floored at 3.0 points — the measured
+                        # cross-sitting noise floor for this pair (c has
+                        # printed 97-100% across the era's sittings on
+                        # byte-frozen code; §2.8's tie paragraph carries the
+                        # derivation and the exit).
+                        tieband = sp["c"] + sp["cpp"]; if (tieband < 3.0) tieband = 3.0
+                        if (lang == "c" && ("cpp" in sp) && (pct - 100.0 <= tieband) && (100.0 - pct <= tieband)) {
+                            printf "  %-10s %5.0f%%\n", lang, 100.0
+                            notes = notes sprintf("  §2.8 TIE: c measured %.1f%% of cpp, inside the tie band (%.1f points) — reported as a statistical tie at 100%%\n", pct, tieband)
+                        } else {
+                            printf "  %-10s %5.0f%%\n", lang, pct
+                        }
                         if (sp[lang] > 15.0)
                             notes = notes sprintf("  §2.3 NOISY: %s spread %.1f%% > 15%% — judge this row against the noise, not the digit\n", lang, sp[lang])
                     } else {


### PR DESCRIPTION
Owner ruling 2026-09-01. Display rule in the quick headline only — CSV rates untouched, cpp stays the computational denominator; c prints 100% with a note naming the measured figure when the pair sits inside the tie band (combined spread floored at 3.0 points, the measured cross-sitting noise floor). The ruling's own exit: a real separation beyond the band prints the real figure and is a finding. Proven both directions against the ledger CSV (97.9% ties with note; a doctored 12% split prints 88%). §2.8 carries the derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)