### PR TITLE
make builds the compiler and nothing else

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-# schema — build the compiler, generate the C++ headers from the corpus, and
-# prove they compile and link (prints OK). `make` runs the whole chain.
+# schema — `make` builds the compiler (bin/schema) and nothing else: no
+# serialize checkouts, no language toolchains, no generation. The full
+# nine-language conformance chain is `make test`, and it needs the sibling
+# runtime checkouts and toolchains documented below.
 
 CXX      ?= c++
 CXXFLAGS ?= -std=c++17 -Wall -Wextra -Werror -ffp-contract=off
@@ -67,7 +69,7 @@ SCHEMAS      := $(wildcard examples/*.schema)
 SCHEMAS128   := $(wildcard examples128/*.schema)
 SCHEMAS_BENCH := $(wildcard bench/corpus/*.schema)
 
-all: test
+all: bin/schema
 
 # The version the built binary reports. `git describe` gives the exact tag on a
 # release build and tag-commits-hash elsewhere; when this is not a git checkout

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ would have hand-written, not an interpreter walking a schema at runtime.
 ## How do I use it?
 
 ```
-go build -o /usr/local/bin/schema ./cmd/schema
+make            # builds the compiler at bin/schema — needs only Go
 
 schema check    <dir of .schema files>
 schema generate --lang c|cpp|cs|dart|elixir|go|java|js|rust --out <outdir> <dir>


### PR DESCRIPTION
Owner ruling on the fresh-clone report: `make` now builds `bin/schema` only — no serialize checkouts, no language toolchains, no generation. The full nine-language conformance chain remains `make test`, which is what every CI job already calls (no job used the bare default, verified).

Reproduced the break in a sibling-free fresh clone (`fatal error: 'serialize.h' file not found`); with this change the same clone builds the compiler with only Go installed. README's How-do-I-use-it now leads with `make`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)