### PR TITLE
bench/results: cross-architecture verification on x86-64 (EPYC 9124)

### DIFF
--- a/bench/results/2026-09-01-x86_64-spacegame-clang-c.csv
+++ b/bench/results/2026-09-01-x86_64-spacegame-clang-c.csv
@@ -1,0 +1,28 @@
+# schema bench results
+# date: 2026-09-01T00:51:37Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: Ubuntu clang version 18.1.3 (1ubuntu1)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Ubuntu clang version 18.1.3 (1ubuntu1)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05); rustc 1.98.0 (88d9e12ae 2026-08-18) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "linux_x64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: taskset -c 15
+# noise: clang-18 control leg, same window/pinning as the primary sweep
+# schema commit: d398ec4
+# serialize commit: cebaed2 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize]
+# serialize.c commit: 37db942 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.c]
+# serialize.go commit: ae730d5 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.go]
+# serialize.rs commit: 6b52aa6 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.rs]
+# serialize.cs commit: f08327e (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.cs]
+# serialize.js commit: e391f1e (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,3,4728307,4706096,4762113,1975.06,1.18,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,3,2321910,2309433,2331745,969.88,0.96,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown

--- a/bench/results/2026-09-01-x86_64-spacegame-clang-cpp.csv
+++ b/bench/results/2026-09-01-x86_64-spacegame-clang-cpp.csv
@@ -1,0 +1,28 @@
+# schema bench results
+# date: 2026-09-01T00:51:25Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: Ubuntu clang version 18.1.3 (1ubuntu1)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Ubuntu clang version 18.1.3 (1ubuntu1)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05); rustc 1.98.0 (88d9e12ae 2026-08-18) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "linux_x64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: taskset -c 15
+# noise: clang-18 control leg, same window/pinning as the primary sweep
+# schema commit: d398ec4
+# serialize commit: cebaed2 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize]
+# serialize.c commit: 37db942 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.c]
+# serialize.go commit: ae730d5 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.go]
+# serialize.rs commit: 6b52aa6 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.rs]
+# serialize.cs commit: f08327e (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.cs]
+# serialize.js commit: e391f1e (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,3,5351509,5345023,5367058,2235.38,0.41,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,3,2496032,2488479,2500231,1042.62,0.47,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown

--- a/bench/results/2026-09-01-x86_64-spacegame.csv
+++ b/bench/results/2026-09-01-x86_64-spacegame.csv
@@ -1,0 +1,49 @@
+# schema bench results
+# date: 2026-09-01T00:47:17Z
+# host: spacegame  arch: x86_64  os: Linux 6.8.0-90-generic
+# cpu: AMD EPYC 9124 16-Core Processor
+# build: Release
+# cpp compiler: c++ (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: cc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 linux/amd64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05); rustc 1.98.0 (88d9e12ae 2026-08-18) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "linux_x64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: taskset -c 15
+# noise: NOISY: server.service resident (pre-release, no players, owner-confirmed) — one pinned game worker thread per isolated core at ~18% CPU including bench core 15; soak_sim/soak confined to core 0
+# schema commit: d398ec4
+# serialize commit: cebaed2 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize]
+# serialize.c commit: 37db942 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.c]
+# serialize.go commit: ae730d5 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.go]
+# serialize.rs commit: 6b52aa6 (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.rs]
+# serialize.cs commit: f08327e (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.cs]
+# serialize.js commit: e391f1e (HEAD) [build-verified: /home/ubuntu/rowan-bench-schema/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,3,4487822,4461541,4500026,1874.61,0.86,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,3,2071369,2069646,2073985,865.23,0.21,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,3,3781572,3762327,3789127,1579.60,0.71,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,3,1862029,1854252,1862788,777.79,0.46,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,3,1874651,1873571,1875369,783.06,0.10,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,3,888233,886066,889077,371.02,0.34,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,3,3202904,3197921,3211915,1337.88,0.44,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,3,1644370,1640863,1647143,686.87,0.38,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+cs,bench_mixed,write,4000000,438,3,1691805,1686145,1692835,706.68,0.40,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,3,712742,709610,712824,297.72,0.45,6b213fbfa1a03a99,gen,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,3,856478,848335,860964,357.76,1.47,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,3,401299,398652,401812,167.63,0.79,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,3,3871943,3870032,3873164,1617.35,0.08,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,3,1692438,1603139,1713729,706.95,6.53,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,3,1318589,1316797,1321619,550.79,0.37,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,3,614275,613513,615234,256.59,0.28,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,400000,438,3,213192,212556,213828,89.05,0.60,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,400000,438,3,127691,127324,127753,53.34,0.34,6b213fbfa1a03a99,gen,beam,contract,default,unknown


### PR DESCRIPTION
Cross-architecture verification of the canonical nine-language table. **Do not merge yet** — this is a findings PR; the c/cpp tie ruling is affected and that is the owner's call.

## The two tables

`round_trip`, best-of-3 max rate, cpp = 100% denominator (run.sh's own blender). Higher = slower.

| rank | Air (arm64, Apple M2) | | x86-64 (EPYC 9124) | | |
|---|---|---|---|---|---|
| 1 | c | 98% | **cpp** | 100% | reshuffle |
| 2 | cpp | 100% | **c** | 111% | reshuffle |
| 3 | rust | 154% | **java** | 121% | reshuffle |
| 4 | java | 157% | **rust** | 126% | reshuffle |
| 5 | go | 239% | go | 233% | holds |
| 6 | cs | 361% | cs | 291% | holds |
| 7 | dart | 381% | dart | 337% | holds |
| 8 | js | 486% | js | 516% | holds |
| 9 | elixir | 1498% | elixir | 1623% | holds |

`corpus_id 6b213fbfa1a03a99` on all nine legs, **identical to the Air** — the wire is byte-identical across architectures. That gate passed before any timing was trusted.

## Finding 1 — the c/cpp tie does not survive the crossing

The tie ruling predicts c and cpp stay inside noise. On x86 they do not:

| build | c as % of cpp | spread |
|---|---|---|
| Air, arm64, Apple clang 21 | **97.9%** (tie, c marginally ahead) | 0.5-1.2% |
| x86, clang 18.1.3 (control leg) | **107.2%** | 0.5-1.0% |
| x86, gcc 13.3.0 (primary) | **111.3%** | 0.2-0.5% |

c is slower than cpp on x86 under **both** compilers, at 15-50x the measured spread. I ran the clang-18 control specifically so this could not be dismissed as a gcc artifact — architecture is the primary term, the compiler adds roughly 4 points on top. Both control CSVs are committed.

Side result: on this box clang beats gcc by **+20.6%** (cpp) and **+25.2%** (c) on round_trip. The primary sweep uses the box default (gcc), which is the conservative choice.

## Finding 2 — rust/java swap

Air `rust 154 < java 157`; x86 `java 121 < rust 126`. Both compress hard toward cpp on x86 (rust -28, java -36 points). Reproduced in two independent sweeps. Caveat: java carries the highest spread in the run (6.53% round_trip, JIT warmup) — still well inside the 15% NOISY threshold, and its max rate was stable across both sweeps.

## Finding 3 — go is the stability result

239% → 233%. A 6-point move across an architecture change, a different compiler backend and a different inliner. The 239% figure is a property of the emitted code, not of the M2.

js (+30) and elixir (+125) are the only legs that lose ground on x86.

## Ratios and magnitude

Magnitude belongs to the machine, as expected — the EPYC runs every leg slower in absolute terms (cpp 3.476M → 2.074M msg/s, 60%). The per-language x86/Air rate ratios spread from 52% (c) to 77% (java), and that spread *is* the reshuffle.

## Method

- schema pinned at `d398ec4` (the Air's canonical commit). Main has since advanced to `f95a683` (elixir #207 lever M), which changes generated elixir — **the elixir row here is the d398ec4 elixir**, deliberately, so the comparison is apples-to-apples.
- Every serialize runtime checked out to the exact commit the Air run used (`cebaed2`/`37db942`/`ae730d5`/`6b52aa6`/`f08327e`/`e391f1e`).
- All nine toolchains version-matched to the Air's CSV preamble and installed dist-local, nothing system-wide: go 1.27.0, rustc/cargo 1.98.0, dotnet 10.0.400, node v26.7.0, Temurin JDK 21.0.12.1, Dart 3.13.2, Elixir 1.20.4 on OTP 29.0.5. **No leg is ABSENT.**
- OTP 29.0.5 has no linux x86-64 upstream build, so it was built from pinned source against a pinned OpenSSL 3.0.13, also from source — no system packages were installed on the box.
- Pinned `taskset -c 15`, builds on cores 3-14, nice 10. Core 0 never touched.
- Two independent full sweeps agree within 1 point on every leg except elixir (13).

## Measurement conditions, stated plainly

The game service was resident throughout (pre-release, no players, owner-confirmed), with one pinned worker thread per isolated core at ~18% CPU **including bench core 15**. This is recorded in each CSV's `noise` line. The load is uniform across all nine legs, which is what an ordering/ratio comparison tolerates; absolute rates are correspondingly conservative. I did not stop the service.

## Harness bug spotted

`bench/run.sh:79` sets `OUT=""` unconditionally, which clobbers an inherited `OUT` env var — so `OUT=... bench/run.sh` silently writes to the default path instead. Only the `--out` flag works. It cost me one overwritten sweep. Worth either honouring the env var or documenting that it is flag-only.
