### PR TITLE
cpp emitter: string-helper guards scoped per package (#189, PR B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,20 @@ build/schema_test: generated/cpp/.stamp test/main.cpp test/second.cpp
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) -Igenerated/cpp -Itest test/main.cpp test/second.cpp -o $@
 
+# The two-unit guard regression (issue #189): two packages, both with
+# string(N) fields, included into ONE translation unit. Its corpus is
+# test-only — generated at build time into build/, never part of the
+# committed generated/ tree (one package per generate call, SPEC §3.2).
+build/guard-generated/.stamp: bin/schema test/guard/Alpha.schema test/guard/Beta.schema
+	@mkdir -p build/guard-generated
+	./bin/schema generate --lang cpp --out build/guard-generated test/guard/Alpha.schema
+	./bin/schema generate --lang cpp --out build/guard-generated test/guard/Beta.schema
+	@touch $@
+
+build/schema_test_guard: build/guard-generated/.stamp test/guard/main.cpp
+	@mkdir -p build
+	$(CXX) $(CXXFLAGS) -Ibuild/guard-generated test/guard/main.cpp -o $@
+
 build/schema_test_random: generated/cpp/.stamp test/random_main.cpp
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) -Igenerated/cpp -Itest test/random_main.cpp -o $@
@@ -326,8 +340,9 @@ build/schema_test_c_ludicrous: generated/c-ludicrous/.stamp test/c-ludicrous/mai
 		-O2 -ffp-contract=off -Igenerated/c-ludicrous -I$(SERIALIZE_C) \
 		test/c-ludicrous/main.c $(SERIALIZE_C)/serialize.c -o $@ -lm
 
-test: build/schema_test build/schema_test_random build/schema_test_ludicrous build/schema_test_c build/schema_test_c_ludicrous build/schema_test_bench build/schema_test_bench_c generated/go/.stamp generated/rust/.stamp generated/cs/.stamp generated/js/.stamp generated/dart/.stamp generated/java/.stamp generated/elixir/.stamp generated/go-ludicrous/.stamp generated/rust-ludicrous/.stamp generated/cs-ludicrous/.stamp generated/js-ludicrous/.stamp generated/dart-ludicrous/.stamp generated/java-ludicrous/.stamp generated/elixir-ludicrous/.stamp generated/bench/go/.stamp generated/bench/rust/.stamp generated/bench/cs/.stamp generated/bench/js/.stamp generated/bench/dart/.stamp generated/bench/java/.stamp generated/bench/elixir/.stamp build/java-test/.stamp build/java-test-ludicrous/.stamp build/java-bench/.stamp
+test: build/schema_test build/schema_test_guard build/schema_test_random build/schema_test_ludicrous build/schema_test_c build/schema_test_c_ludicrous build/schema_test_bench build/schema_test_bench_c generated/go/.stamp generated/rust/.stamp generated/cs/.stamp generated/js/.stamp generated/dart/.stamp generated/java/.stamp generated/elixir/.stamp generated/go-ludicrous/.stamp generated/rust-ludicrous/.stamp generated/cs-ludicrous/.stamp generated/js-ludicrous/.stamp generated/dart-ludicrous/.stamp generated/java-ludicrous/.stamp generated/elixir-ludicrous/.stamp generated/bench/go/.stamp generated/bench/rust/.stamp generated/bench/cs/.stamp generated/bench/js/.stamp generated/bench/dart/.stamp generated/bench/java/.stamp generated/bench/elixir/.stamp build/java-test/.stamp build/java-test-ludicrous/.stamp build/java-bench/.stamp
 	./build/schema_test
+	./build/schema_test_guard
 	./build/schema_test_random
 	./build/schema_test_ludicrous
 	cd test/c && ../../build/schema_test_c

--- a/generated/bench/cpp/BenchWire.h
+++ b/generated/bench/cpp/BenchWire.h
@@ -52,8 +52,8 @@ namespace bench {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-#ifndef SCHEMA_UTF8_VALID_DEFINED
-#define SCHEMA_UTF8_VALID_DEFINED
+#ifndef SCHEMA_BENCH_UTF8_VALID_DEFINED
+#define SCHEMA_BENCH_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
 // write path debug-asserts with this validator and the release path costs
 // nothing. Rejects truncated sequences, bare continuations, overlongs,
@@ -118,10 +118,10 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
     }
     return true;
 }
-#endif // SCHEMA_UTF8_VALID_DEFINED
+#endif // SCHEMA_BENCH_UTF8_VALID_DEFINED
 
-#ifndef SCHEMA_INTERIOR_NULL_DEFINED
-#define SCHEMA_INTERIOR_NULL_DEFINED
+#ifndef SCHEMA_BENCH_INTERIOR_NULL_DEFINED
+#define SCHEMA_BENCH_INTERIOR_NULL_DEFINED
 // string(N) carries bytes excluding 0x00: an interior null is content every
 // generated reader refuses (SPEC §4.7) — generated-code validation; no
 // serialize primitive performs it. The scan is word-wise: eight bytes per
@@ -161,7 +161,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     }
     return false;
 }
-#endif // SCHEMA_INTERIOR_NULL_DEFINED
+#endif // SCHEMA_BENCH_INTERIOR_NULL_DEFINED
 
 SCHEMA_WRITE_INLINE bool WriteBenchPacket( serialize::WriteStream & stream, const BenchPacket & value )
 {

--- a/generated/cpp/ClausesWire.h
+++ b/generated/cpp/ClausesWire.h
@@ -52,8 +52,8 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-#ifndef SCHEMA_UTF8_VALID_DEFINED
-#define SCHEMA_UTF8_VALID_DEFINED
+#ifndef SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
+#define SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
 // write path debug-asserts with this validator and the release path costs
 // nothing. Rejects truncated sequences, bare continuations, overlongs,
@@ -118,10 +118,10 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
     }
     return true;
 }
-#endif // SCHEMA_UTF8_VALID_DEFINED
+#endif // SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 
-#ifndef SCHEMA_INTERIOR_NULL_DEFINED
-#define SCHEMA_INTERIOR_NULL_DEFINED
+#ifndef SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
+#define SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 // string(N) carries bytes excluding 0x00: an interior null is content every
 // generated reader refuses (SPEC §4.7) — generated-code validation; no
 // serialize primitive performs it. The scan is word-wise: eight bytes per
@@ -161,7 +161,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     }
     return false;
 }
-#endif // SCHEMA_INTERIOR_NULL_DEFINED
+#endif // SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 
 SCHEMA_WRITE_INLINE bool WriteW13( serialize::WriteStream & stream, const W13 & value )
 {

--- a/generated/cpp/JoinsWire.h
+++ b/generated/cpp/JoinsWire.h
@@ -53,8 +53,8 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-#ifndef SCHEMA_UTF8_VALID_DEFINED
-#define SCHEMA_UTF8_VALID_DEFINED
+#ifndef SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
+#define SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
 // write path debug-asserts with this validator and the release path costs
 // nothing. Rejects truncated sequences, bare continuations, overlongs,
@@ -119,10 +119,10 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
     }
     return true;
 }
-#endif // SCHEMA_UTF8_VALID_DEFINED
+#endif // SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 
-#ifndef SCHEMA_INTERIOR_NULL_DEFINED
-#define SCHEMA_INTERIOR_NULL_DEFINED
+#ifndef SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
+#define SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 // string(N) carries bytes excluding 0x00: an interior null is content every
 // generated reader refuses (SPEC §4.7) — generated-code validation; no
 // serialize primitive performs it. The scan is word-wise: eight bytes per
@@ -162,7 +162,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     }
     return false;
 }
-#endif // SCHEMA_INTERIOR_NULL_DEFINED
+#endif // SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 
 SCHEMA_WRITE_INLINE bool WriteArmsAgree( serialize::WriteStream & stream, const ArmsAgree & value )
 {

--- a/generated/cpp/WireWire.h
+++ b/generated/cpp/WireWire.h
@@ -53,8 +53,8 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-#ifndef SCHEMA_UTF8_VALID_DEFINED
-#define SCHEMA_UTF8_VALID_DEFINED
+#ifndef SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
+#define SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
 // write path debug-asserts with this validator and the release path costs
 // nothing. Rejects truncated sequences, bare continuations, overlongs,
@@ -119,10 +119,10 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
     }
     return true;
 }
-#endif // SCHEMA_UTF8_VALID_DEFINED
+#endif // SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 
-#ifndef SCHEMA_INTERIOR_NULL_DEFINED
-#define SCHEMA_INTERIOR_NULL_DEFINED
+#ifndef SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
+#define SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 // string(N) carries bytes excluding 0x00: an interior null is content every
 // generated reader refuses (SPEC §4.7) — generated-code validation; no
 // serialize primitive performs it. The scan is word-wise: eight bytes per
@@ -162,7 +162,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     }
     return false;
 }
-#endif // SCHEMA_INTERIOR_NULL_DEFINED
+#endif // SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 
 SCHEMA_WRITE_INLINE bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {

--- a/internal/codegen/cpp/nullscan.go
+++ b/internal/codegen/cpp/nullscan.go
@@ -1,5 +1,7 @@
 package cpp
 
+import "strings"
+
 // emitInteriorNullScan emits the read-side interior-null refusal every
 // generated reader owes (SPEC §4.7): string(N) carries bytes excluding 0x00,
 // and a payload with a null anywhere in [0, length) is content the read
@@ -12,10 +14,13 @@ package cpp
 // buffer-slack dependence, no masking, and no endianness dependence (the
 // idiom reports a zero byte wherever it sits in the word). A shorter payload
 // takes a per-byte tail bounded at seven. SCHEMA_READ_INLINE: the read
-// spine's inlining demand covers the scan too. Guarded against redefinition
-// because several wire headers can land in one translation unit.
+// spine's inlining demand covers the scan too. Guarded per package: the scan
+// lives inside namespace <package>, so each unit in a translation unit needs
+// its own copy exactly once — several wire headers of one package can land
+// in one translation unit.
 func (g *gen) emitInteriorNullScan() {
-	g.pf("#ifndef SCHEMA_INTERIOR_NULL_DEFINED\n#define SCHEMA_INTERIOR_NULL_DEFINED\n")
+	guard := "SCHEMA_" + strings.ToUpper(g.unit.Package) + "_INTERIOR_NULL_DEFINED"
+	g.pf("#ifndef %s\n#define %s\n", guard, guard)
 	g.pf("// string(N) carries bytes excluding 0x00: an interior null is content every\n")
 	g.pf("// generated reader refuses (SPEC §4.7) — generated-code validation; no\n")
 	g.pf("// serialize primitive performs it. The scan is word-wise: eight bytes per\n")
@@ -38,5 +43,5 @@ func (g *gen) emitInteriorNullScan() {
 	g.pf("    for ( ; i < length; i++ )\n    {\n")
 	g.pf("        if ( bytes[i] == 0 )\n        {\n            return true;\n        }\n    }\n")
 	g.pf("    return false;\n}\n")
-	g.pf("#endif // SCHEMA_INTERIOR_NULL_DEFINED\n\n")
+	g.pf("#endif // %s\n\n", guard)
 }

--- a/internal/codegen/cpp/utf8.go
+++ b/internal/codegen/cpp/utf8.go
@@ -1,6 +1,10 @@
 package cpp
 
-import "github.com/mas-bandwidth/schema/v2/ir"
+import (
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
 
 // fileHasStrings reports whether any declaration in the file carries a
 // string(N) field — the trigger for emitting the UTF-8 validator the
@@ -23,10 +27,13 @@ func fileHasStrings(f *ir.File) bool {
 // emitUtf8Validator emits the well-formedness check behind the write-side
 // debug assert: string(N) payloads are well-formed UTF-8 BY CONTRACT,
 // writer-trusted (SPEC §4.7) — no release-path cost, no
-// read-path validation. Guarded against redefinition because several wire
-// headers can land in one translation unit.
+// read-path validation. Guarded per package: the validator lives inside
+// namespace <package>, so each unit in a translation unit needs its own copy
+// exactly once — several wire headers of one package can land in one
+// translation unit.
 func (g *gen) emitUtf8Validator() {
-	g.pf("#ifndef SCHEMA_UTF8_VALID_DEFINED\n#define SCHEMA_UTF8_VALID_DEFINED\n")
+	guard := "SCHEMA_" + strings.ToUpper(g.unit.Package) + "_UTF8_VALID_DEFINED"
+	g.pf("#ifndef %s\n#define %s\n", guard, guard)
 	g.pf("// string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the\n")
 	g.pf("// write path debug-asserts with this validator and the release path costs\n")
 	g.pf("// nothing. Rejects truncated sequences, bare continuations, overlongs,\n")
@@ -51,5 +58,5 @@ func (g *gen) emitUtf8Validator() {
 	g.pf("        if ( continuations == 3 && ( code_point < 0x10000 || code_point > 0x10FFFF ) )\n        {\n            return false;\n        }\n")
 	g.pf("        i += 1 + continuations;\n    }\n")
 	g.pf("    return true;\n}\n")
-	g.pf("#endif // SCHEMA_UTF8_VALID_DEFINED\n\n")
+	g.pf("#endif // %s\n\n", guard)
 }

--- a/test/guard/Alpha.schema
+++ b/test/guard/Alpha.schema
@@ -1,0 +1,13 @@
+// Two-unit guard regression, first unit (issue #189 shape): this package and
+// package beta (Beta.schema) both carry string(N) fields, and test/guard/
+// main.cpp includes both generated wire headers into ONE translation unit.
+// The generated string helpers are namespace-local, so their include guards
+// must be per-package — a TU-wide guard strips the helpers from whichever
+// unit is included second and its string wire functions do not compile.
+
+package alpha
+
+type AlphaMessage
+{
+    text string(15)
+}

--- a/test/guard/Beta.schema
+++ b/test/guard/Beta.schema
@@ -1,0 +1,11 @@
+// Two-unit guard regression, second unit (issue #189 shape): included AFTER
+// Alpha.schema's generated wire header in test/guard/main.cpp's translation
+// unit — the position where a TU-wide string-helper guard loses the helpers.
+// See Alpha.schema.
+
+package beta
+
+type BetaMessage
+{
+    note string(15)
+}

--- a/test/guard/main.cpp
+++ b/test/guard/main.cpp
@@ -1,0 +1,69 @@
+// The two-unit guard regression (issue #189): TWO schema units from TWO
+// packages, BOTH carrying string(N) fields, ride in this ONE translation
+// unit. The generated string helpers (schema_utf8_valid,
+// schema_interior_null) are namespace-local, so each package's wire header
+// must emit its own copy under a per-package guard — a TU-wide guard strips
+// them from the second unit included and this file does not compile.
+// Round-trips a string through each namespace and prints OK.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "AlphaWire.h" // first unit: defines namespace alpha's helpers
+#include "BetaWire.h"  // second unit: must define namespace beta's helpers too
+
+static void check_line( bool ok, int line )
+{
+    if ( !ok )
+    {
+        fprintf( stderr, "guard test FAILED at line %d\n", line );
+        exit( 1 );
+    }
+}
+
+#define check( expr ) check_line( (expr), __LINE__ )
+
+int main()
+{
+    alignas( 8 ) uint8_t buffer[256 + 8]; // + 8: the reader loads 64-bit windows
+
+    // namespace alpha: the first unit's string round-trip
+    {
+        alpha::AlphaMessage in;
+        std::memcpy( in.text, "hello", 5 );
+        in.text_length = 5;
+
+        serialize::WriteStream ws( buffer, 256 );
+        check( alpha::WriteAlphaMessage( ws, in ) );
+        ws.Flush();
+
+        alpha::AlphaMessage out;
+        serialize::ReadStream rs( buffer, ws.GetBytesProcessed() );
+        check( alpha::ReadAlphaMessage( rs, out ) );
+        check( out.text_length == 5 );
+        check( std::memcmp( out.text, "hello", 5 ) == 0 );
+    }
+
+    // namespace beta: the SECOND unit's string round-trip — the read path
+    // calls beta's own schema_interior_null, the helper a TU-wide guard
+    // would have stripped
+    {
+        beta::BetaMessage in;
+        std::memcpy( in.note, "world", 5 );
+        in.note_length = 5;
+
+        serialize::WriteStream ws( buffer, 256 );
+        check( beta::WriteBetaMessage( ws, in ) );
+        ws.Flush();
+
+        beta::BetaMessage out;
+        serialize::ReadStream rs( buffer, ws.GetBytesProcessed() );
+        check( beta::ReadBetaMessage( rs, out ) );
+        check( out.note_length == 5 );
+        check( std::memcmp( out.note, "world", 5 ) == 0 );
+    }
+
+    printf( "OK\n" );
+    return 0;
+}

--- a/testdata/golden/cpp/ClausesWire.h
+++ b/testdata/golden/cpp/ClausesWire.h
@@ -52,8 +52,8 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-#ifndef SCHEMA_UTF8_VALID_DEFINED
-#define SCHEMA_UTF8_VALID_DEFINED
+#ifndef SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
+#define SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
 // write path debug-asserts with this validator and the release path costs
 // nothing. Rejects truncated sequences, bare continuations, overlongs,
@@ -118,10 +118,10 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
     }
     return true;
 }
-#endif // SCHEMA_UTF8_VALID_DEFINED
+#endif // SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 
-#ifndef SCHEMA_INTERIOR_NULL_DEFINED
-#define SCHEMA_INTERIOR_NULL_DEFINED
+#ifndef SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
+#define SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 // string(N) carries bytes excluding 0x00: an interior null is content every
 // generated reader refuses (SPEC §4.7) — generated-code validation; no
 // serialize primitive performs it. The scan is word-wise: eight bytes per
@@ -161,7 +161,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     }
     return false;
 }
-#endif // SCHEMA_INTERIOR_NULL_DEFINED
+#endif // SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 
 SCHEMA_WRITE_INLINE bool WriteW13( serialize::WriteStream & stream, const W13 & value )
 {

--- a/testdata/golden/cpp/JoinsWire.h
+++ b/testdata/golden/cpp/JoinsWire.h
@@ -53,8 +53,8 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-#ifndef SCHEMA_UTF8_VALID_DEFINED
-#define SCHEMA_UTF8_VALID_DEFINED
+#ifndef SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
+#define SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
 // write path debug-asserts with this validator and the release path costs
 // nothing. Rejects truncated sequences, bare continuations, overlongs,
@@ -119,10 +119,10 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
     }
     return true;
 }
-#endif // SCHEMA_UTF8_VALID_DEFINED
+#endif // SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 
-#ifndef SCHEMA_INTERIOR_NULL_DEFINED
-#define SCHEMA_INTERIOR_NULL_DEFINED
+#ifndef SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
+#define SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 // string(N) carries bytes excluding 0x00: an interior null is content every
 // generated reader refuses (SPEC §4.7) — generated-code validation; no
 // serialize primitive performs it. The scan is word-wise: eight bytes per
@@ -162,7 +162,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     }
     return false;
 }
-#endif // SCHEMA_INTERIOR_NULL_DEFINED
+#endif // SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 
 SCHEMA_WRITE_INLINE bool WriteArmsAgree( serialize::WriteStream & stream, const ArmsAgree & value )
 {

--- a/testdata/golden/cpp/WireWire.h
+++ b/testdata/golden/cpp/WireWire.h
@@ -53,8 +53,8 @@ namespace example {
 #endif
 #endif // SCHEMA_READ_INLINE_DEFINED
 
-#ifndef SCHEMA_UTF8_VALID_DEFINED
-#define SCHEMA_UTF8_VALID_DEFINED
+#ifndef SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
+#define SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 // string(N) payloads are well-formed UTF-8 BY CONTRACT (SPEC §4.7): the
 // write path debug-asserts with this validator and the release path costs
 // nothing. Rejects truncated sequences, bare continuations, overlongs,
@@ -119,10 +119,10 @@ inline bool schema_utf8_valid( const uint8_t * bytes, int32_t length )
     }
     return true;
 }
-#endif // SCHEMA_UTF8_VALID_DEFINED
+#endif // SCHEMA_EXAMPLE_UTF8_VALID_DEFINED
 
-#ifndef SCHEMA_INTERIOR_NULL_DEFINED
-#define SCHEMA_INTERIOR_NULL_DEFINED
+#ifndef SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
+#define SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 // string(N) carries bytes excluding 0x00: an interior null is content every
 // generated reader refuses (SPEC §4.7) — generated-code validation; no
 // serialize primitive performs it. The scan is word-wise: eight bytes per
@@ -162,7 +162,7 @@ SCHEMA_READ_INLINE bool schema_interior_null( const uint8_t * bytes, int32_t len
     }
     return false;
 }
-#endif // SCHEMA_INTERIOR_NULL_DEFINED
+#endif // SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED
 
 SCHEMA_WRITE_INLINE bool WriteProbeHeader( serialize::WriteStream & stream, const ProbeHeader & value )
 {


### PR DESCRIPTION
PR B of the #189 protocol, licensed by bench/LOCK's one-shot carve (owner ruling 2026-08-31).

## The defect

The C++ emitter's string helpers (`schema_utf8_valid`, `schema_interior_null`) are emitted **inside `namespace <package>`** but guarded by **TU-wide** include guards (`SCHEMA_UTF8_VALID_DEFINED`, `SCHEMA_INTERIOR_NULL_DEFINED`). Two generated units from two packages, both with `string(N)` fields, in one translation unit: the first unit sets the guard, the second unit's namespace never gets its helpers, and its string wire functions do not compile.

## The fix

`internal/codegen/cpp/utf8.go` and `internal/codegen/cpp/nullscan.go`: the guards now carry the package name — `SCHEMA_<PKG>_UTF8_VALID_DEFINED` / `SCHEMA_<PKG>_INTERIOR_NULL_DEFINED` — one copy per package per TU, following the `emitFlagAppendHelper` pattern that already did this correctly in the same emitter. Formatting conventions unchanged; the helper bodies are byte-identical.

**C-side verdict: NOT defective, left untouched.** The C emitter's helpers are file-scope `static` with trailing-underscore names, so the TU-wide guard is exactly right there — the second unit's functions call the first emission's definition (this is also what commit f1c0f8c recorded: "the C leg needs no guard workaround"). The `SCHEMA_WRITE_INLINE` / `SCHEMA_READ_INLINE` macro blocks in C++ are preprocessor macros, not namespace-local symbols — TU-wide guards are correct for them and they are untouched too.

## Regression test (red on main, green here)

`test/guard/`: two packages (`alpha`, `beta`), both with `string(15)` fields, generated **at build time into `build/guard-generated/`** (test-only corpus — never part of the committed `generated/` tree) and included into ONE translation unit (`test/guard/main.cpp`, new `make` leg `build/schema_test_guard`). Round-trips a string through each namespace.

**Red** — old emitter (this branch with the two emitter files stashed back to main's state), verbatim:

```
c++ -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -I../serialize -Ibuild/guard-generated test/guard/main.cpp -o build/schema_test_guard
build/guard-generated/BetaWire.h:172:23: error: use of undeclared identifier 'schema_utf8_valid'; did you mean 'alpha::schema_utf8_valid'?
build/guard-generated/BetaWire.h:183:10: error: use of undeclared identifier 'schema_interior_null'; did you mean 'alpha::schema_interior_null'?
2 errors generated.
make: *** [build/schema_test_guard] Error 1
```

**Green** — with the fix (`git stash pop`, regenerate, rebuild):

```
./bin/schema generate --lang cpp --out build/guard-generated test/guard/Alpha.schema
./bin/schema generate --lang cpp --out build/guard-generated test/guard/Beta.schema
c++ -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -I../serialize -Ibuild/guard-generated test/guard/main.cpp -o build/schema_test_guard
$ ./build/schema_test_guard
OK
```

## bench/cpp workaround

Already gone: the `#undef SCHEMA_UTF8_VALID_DEFINED` / `#undef SCHEMA_INTERIOR_NULL_DEFINED` workaround was removed by #204 (commit 3cf6b90) when the example units left the bench TU. `grep -rn "SCHEMA_UTF8_VALID_DEFINED\|SCHEMA_INTERIOR_NULL_DEFINED" bench/` matches nothing today; there is nothing left to remove.

## Generated-diff inventory

`make test` green (all nine legs); `make generated-current` prints `generated/ tree is current`. The regeneration diff is **exactly** the guard lines — 6 lines in each of 4 generated files (plus the same 6 in their 3 text-golden mirrors), nothing else:

- `generated/cpp/ClausesWire.h`, `generated/cpp/JoinsWire.h`, `generated/cpp/WireWire.h` (package `example`):
  - `#ifndef/#define/#endif // SCHEMA_UTF8_VALID_DEFINED` → `SCHEMA_EXAMPLE_UTF8_VALID_DEFINED`
  - `#ifndef/#define/#endif // SCHEMA_INTERIOR_NULL_DEFINED` → `SCHEMA_EXAMPLE_INTERIOR_NULL_DEFINED`
- `generated/bench/cpp/BenchWire.h` (package `bench`): same six lines → `SCHEMA_BENCH_*`
- `testdata/golden/cpp/{ClausesWire.h,JoinsWire.h,WireWire.h}`: text mirrors of the above
- **No C outputs changed. Nothing under `testdata/wire` changed** (`git diff main -- testdata/wire` is empty). Ludicrous corpora carry no strings, so no helper emissions there.

## Reproduction control (bench/LOCK control 2)

The frozen shapes' c/cpp rows re-run in-sitting on this branch (bench/run.sh --only cpp, --only c, Release O3, quiet box) against the sitting-2 reference `bench/results/2026-09-01-sitting2-arm64-macbook.csv` (medians, msgs/sec):

| row | reference | this branch | ratio |
|---|---|---|---|
| cpp bench_mixed write | 7,442,587 | 7,559,675 | +1.57% |
| cpp bench_mixed round_trip | 3,492,440 | 3,550,572 | +1.66% |
| cpp bitpacker write | 58,460 | 60,071 | +2.76% |
| cpp bitpacker read | 89,999 | 92,563 | +2.85% |
| c bench_mixed write | 7,220,881 | 7,299,110 | +1.08% |
| c bench_mixed round_trip | 3,584,859 | 3,575,579 | −0.26% |
| c bitpacker write | 60,022 | 59,778 | −0.41% |
| c bitpacker read | 56,751 | 56,098 | −1.15% |

All rows within ±2.9% of the reference — inside the ~5% band. The control CSVs went to scratch files; nothing under `bench/results/` is touched.

## Wire bytes

Byte-unchanged everywhere: the change is include-guard **text** in C++ headers only — zero effect on any emitted codec logic, and the wire goldens under `testdata/wire` are untouched, byte for byte.

PR C (the single-file bench/LOCK prefix restoration) follows once this merges, per the protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
