### PR TITLE
bench/LOCK: the #189 carve is spent — prefixes restored (PR C)

### DIFF
--- a/bench/LOCK
+++ b/bench/LOCK
@@ -30,13 +30,14 @@
 # a PR whose diff touches ONLY this file. The full lift condition is the
 # round closing, on the owner's word (issue #170).
 #
-# ONE-SHOT CARVE, owner ruling 2026-08-31 (issue #189): the emitter prefixes
-# are SUSPENDED for exactly one licensed change — the string-helper guard
-# scoping fix (#189, PR B of its protocol) — under the reproduction control
-# (frozen shapes' c/cpp rows re-run in-sitting). The prefixes are restored by
-# the protocol's PR C immediately after the fix merges. Any other emitter
-# change during the suspension is a review-block on sight.
+# The #189 one-shot carve (owner ruling 2026-08-31) is SPENT: its single
+# licensed change — the string-helper guard scoping fix, PR B of the #189
+# protocol — merged under the reproduction control, and this edit is the
+# protocol's PR C restoring the prefixes.
 #
 # Locked prefixes, one per line (matched against changed paths):
-# (emitter and generated c/cpp prefixes temporarily suspended per the carve
-#  above — restored by #189 PR C)
+internal/codegen/c/
+internal/codegen/cpp/
+generated/c/
+generated/cpp/
+generated/c-ludicrous/


### PR DESCRIPTION
Single-file edit per the lock's own protocol. PR B (#220) merged under the reproduction control; this restores the locked prefixes. The pre-carve list is restored verbatim except `generated/cpp-ludicrous/`, which matches nothing in today's tree (cpp ludicrous lives under `generated/cpp/ludicrous/`, already covered by the `generated/cpp/` prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)