### PR TITLE
bench/run.sh: honor inherited OUT, refuse overwriting an existing results CSV

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -12,7 +12,9 @@
 #   --debug       also build and run the Debug pair (matched-pair methodology;
 #                 only Release numbers are meaningful, Debug is recorded so
 #                 pathological debug regressions are visible)
-#   --out FILE    results CSV (default bench/results/<date>-<arch>-<host>.csv)
+#   --out FILE    results CSV (default bench/results/<date>-<arch>-<host>.csv;
+#                 an inherited OUT env var is honored the same way). A FILE
+#                 that already exists is REFUSED — never silently overwritten
 #   --compiler    C++ compiler (default: $CXX, else c++)
 #   --quick       the iteration instrument, never the certification
 #                 instrument: every leg runs bench_mixed ONLY (3 measured
@@ -79,7 +81,7 @@ set -e
 cd "$(dirname "$0")/.."     # repo root
 
 DEBUG=0
-OUT=""
+OUT="${OUT:-}"      # an inherited OUT env var is honored, same as --out
 ONLY=""
 ROUND=""
 BARE=0
@@ -157,6 +159,17 @@ skip_leg() {
 ARCH="$(uname -m)"
 HOST="$(hostname -s)"
 OUT="${OUT:-bench/results/$(date +%F)-$ARCH-$HOST.csv}"
+
+# Refuse to overwrite an existing results file. The dated default makes
+# same-day collisions silent, and a committed ledger CSV overwritten by a
+# later sitting is exactly how a ledger lies — both boxes hit this on
+# 2026-09-01 (#219). No override flag: pick a distinct --out, or remove
+# the file deliberately.
+if [ -e "$OUT" ]; then
+    echo "refusing to overwrite existing results file: $OUT" >&2
+    echo "pick a distinct --out (e.g. add a sitting tag), or remove the file first if the overwrite is deliberate" >&2
+    exit 1
+fi
 mkdir -p bench/results build/bench
 
 # cpu pinning: taskset where it exists (linux); none on macOS


### PR DESCRIPTION
Closes #219. Two fixes, one class: `OUT=file ./bench/run.sh` was silently ignored (cleared unconditionally — cost a sweep on the x86 box), and the dated default silently overwrites a same-day committed ledger CSV (cost a re-run on the Air the same day). The env var is now honored the same as `--out`, and any existing results file refuses loudly with the remedy in the message. The pass driver is unaffected — it always passes fresh per-round `--out` paths (verified). `--render` reads existing files before the refusal and is unaffected (verified locally: refusal fires on the committed sitting-2 CSV; render of the same file still works; `bash -n` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)