### PR TITLE
dart: fixed defaults emit DefInt verbatim, ending the double-scale (#168)

### DIFF
--- a/generated/dart-ludicrous/Ludicrous.dart
+++ b/generated/dart-ludicrous/Ludicrous.dart
@@ -2120,7 +2120,7 @@ final class FixedQuat {
   // wire [-1, 1]
   int z = 0;
   // specified default at construction; zero* gives the §5 zero form; wire [-1, 1]
-  int w = 1152921504606846976;
+  int w = 1073741824;
 }
 
 // fixedQuatMaxBits is the longest wire path; align pads at worst case (SPEC §6.1).

--- a/internal/codegen/dart/dart.go
+++ b/internal/codegen/dart/dart.go
@@ -657,11 +657,10 @@ func (g *gen) scalarStorage(f *ir.Field) (typ, init string) {
 		return "double", "0.0"
 	case is128(t):
 		if t.Kind == ir.TFixed {
-			// fixed defaults are whole units scaled by F at generation time;
-			// fixed storage is the raw scaled integer (STANDARD.md, fixed)
+			// ir.Field.DefInt is ALREADY the raw scaled integer for fixed
+			// fields (the C++ golden pins it) — emit it verbatim
 			if f.HasDefault {
-				raw := shiftedRaw(f.DefInt, uint(t.FracBits))
-				return g.pair128Type(t), g.render128(t.Signed, raw)
+				return g.pair128Type(t), g.render128(t.Signed, f.DefInt)
 			}
 			return g.pair128Type(t), g.pair128Type(t) + ".zero"
 		}
@@ -671,8 +670,7 @@ func (g *gen) scalarStorage(f *ir.Field) (typ, init string) {
 		return g.pair128Type(t), g.pair128Type(t) + ".zero"
 	case t.Kind == ir.TFixed:
 		if f.HasDefault {
-			raw := shiftedRaw(f.DefInt, uint(t.FracBits))
-			return "int", dartIntLit(raw)
+			return "int", dartIntLit(f.DefInt)
 		}
 		return "int", "0"
 	case t.Kind == ir.TNamed:
@@ -708,7 +706,9 @@ func (g *gen) pair128Type(t ir.FieldType) string {
 
 // shiftedRaw is a fixed-point whole-unit value scaled to raw storage:
 // v << F, with negative values negated around the shift so the arithmetic is
-// exact (the same derivation the wire bounds use).
+// exact (the same derivation the wire bounds use). For BOUNDS only:
+// ir.Field.IntMin/IntMax are whole units, but ir.Field.DefInt is ALREADY the
+// raw scaled integer — a default through this helper double-scales (#168).
 func shiftedRaw(v *big.Int, fracBits uint) *big.Int {
 	if v.Sign() < 0 {
 		return new(big.Int).Neg(new(big.Int).Lsh(new(big.Int).Neg(v), fracBits))

--- a/internal/codegen/dart/dart_test.go
+++ b/internal/codegen/dart/dart_test.go
@@ -1,0 +1,59 @@
+package dart
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+)
+
+// TestFixedDefaultIsRawNotDoubleScaled pins #168: ir.Field.DefInt for a
+// fixed-point default is ALREADY the raw scaled integer (the C++ golden pins
+// 2^30 for a Q2.30 default of 1.0), and the storage emitter must render it
+// verbatim. The old emitter pushed DefInt through the whole-unit bounds
+// scaler and emitted 2^60. Both storage branches are covered: the 64-bit
+// int path and the 128-bit pair path.
+func TestFixedDefaultIsRawNotDoubleScaled(t *testing.T) {
+	src := "package t\n\n" +
+		"type P\n{\n" +
+		"    w fixed(2, 30)   = 1.0 | min = -1, max = 1\n" +
+		"    r fixed(112, 16) = 2.0 | min = -1000, max = 1000\n" +
+		"}\n"
+	f, perrs := parser.Parse("Fixed.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "Fixed.schema", Name: "Fixed.schema", Base: "Fixed",
+		Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+
+	files, err := Generate(u)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var all strings.Builder
+	for _, b := range files {
+		all.Write(b)
+	}
+	out := all.String()
+
+	// Q2.30, 1.0 -> raw 1 << 30
+	if !strings.Contains(out, "int w = 1073741824;") {
+		t.Errorf("64-bit fixed default: want the raw literal 1073741824 (1.0 in Q2.30), not found")
+	}
+	if strings.Contains(out, "1152921504606846976") {
+		t.Errorf("64-bit fixed default double-scaled: 2^60 appears in the output")
+	}
+	// Q112.16, 2.0 -> raw 2 << 16 = 131072, rendered through the 128 pair
+	if !strings.Contains(out, "131072") {
+		t.Errorf("128-bit fixed default: want the raw literal 131072 (2.0 in Q112.16), not found")
+	}
+	if strings.Contains(out, "8589934592") { // 2 << 32 — the double-scale for F=16
+		t.Errorf("128-bit fixed default double-scaled: 2<<32 appears in the output")
+	}
+}

--- a/testdata/golden/ludicrous/dart/Ludicrous.dart
+++ b/testdata/golden/ludicrous/dart/Ludicrous.dart
@@ -2120,7 +2120,7 @@ final class FixedQuat {
   // wire [-1, 1]
   int z = 0;
   // specified default at construction; zero* gives the §5 zero form; wire [-1, 1]
-  int w = 1152921504606846976;
+  int w = 1073741824;
 }
 
 // fixedQuatMaxBits is the longest wire path; align pads at worst case (SPEC §6.1).


### PR DESCRIPTION
Fixes #168, exactly as filed: `DefInt` is already raw; the Dart emitter scaled it again in both storage branches. Fix uses `DefInt` verbatim; `shiftedRaw` remains for the wire bounds (which are whole units) and its comment now names the asymmetry that caused this. The generated tree and golden move by ONE literal (2^60 → 2^30 on `FixedQuat.w`); no wire golden moves — storage text only.

New `TestFixedDefaultIsRawNotDoubleScaled` covers both branches with a 64-bit and a 128-bit defaulted fixed field: proven red on the old emitter (both double-scales detected), green on the fix. Goldens, build, vet, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)