### PR TITLE
dart: reserved-word refusal reaches declaration names (#162)

### DIFF
--- a/internal/codegen/dart/dart.go
+++ b/internal/codegen/dart/dart.go
@@ -155,6 +155,29 @@ func checkNames(u *ir.Unit) error {
 			return err
 		}
 	}
+	// declaration names emit verbatim as class/extension names, so they are
+	// exactly the surface the shadow-hazard entries (String, List, Object,
+	// Endian, ByteData) exist for — a `type List` would shadow dart:core
+	for _, e := range u.Enums {
+		if err := check("enum", "", e.Name, e.Name); err != nil {
+			return err
+		}
+	}
+	for _, fl := range u.Flags {
+		if err := check("flags", "", fl.Name, fl.Name); err != nil {
+			return err
+		}
+	}
+	for _, st := range u.Structs {
+		if err := check("type", "", st.Name, st.Name); err != nil {
+			return err
+		}
+	}
+	for _, un := range u.Unions {
+		if err := check("union", "", un.Name, un.Name); err != nil {
+			return err
+		}
+	}
 	for _, e := range u.Enums {
 		for _, v := range e.Variants {
 			if err := check("variant", e.Name, v, dartName(v)); err != nil {

--- a/internal/codegen/dart/dart_test.go
+++ b/internal/codegen/dart/dart_test.go
@@ -57,3 +57,42 @@ func TestFixedDefaultIsRawNotDoubleScaled(t *testing.T) {
 		t.Errorf("128-bit fixed default double-scaled: 2<<32 appears in the output")
 	}
 }
+
+// TestReservedDeclarationNamesRefused pins #162: the shadow-hazard entries
+// (String, List, Object, Endian, ByteData) exist for DECLARATION names, which
+// emit verbatim as Dart class names — a `type List` would shadow dart:core.
+// The old checkNames walked consts, variants and fields but never the
+// declarations themselves, leaving those entries unreachable.
+func TestReservedDeclarationNamesRefused(t *testing.T) {
+	cases := []struct {
+		src    string
+		needle string
+	}{
+		{"package t\n\ntype List { x uint8 }\n", "List"},
+		{"package t\n\nenum Endian { Little, Big }\n\ntype P { e Endian }\n", "Endian"},
+		{"package t\n\nflags Object { A }\n\ntype P { o Object }\n", "Object"},
+		{"package t\n\ntype Blob { x uint8 }\n\nunion String { blob Blob }\n", "String"},
+		{"package t\n\ntype ByteData { x uint8 }\n", "ByteData"},
+	}
+	for _, c := range cases {
+		f, perrs := parser.Parse("Res.schema", []byte(c.src))
+		if len(perrs) > 0 {
+			t.Fatalf("parse: %v", perrs[0])
+		}
+		u, cerrs := check.Unit([]check.SourceFile{{
+			Path: "Res.schema", Name: "Res.schema", Base: "Res",
+			Bytes: []byte(c.src), AST: f,
+		}})
+		if len(cerrs) > 0 {
+			t.Fatalf("check: %v", cerrs[0])
+		}
+		_, err := Generate(u)
+		if err == nil {
+			t.Errorf("declaration %q: want a reserved-identifier refusal, got success", c.needle)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.needle) || !strings.Contains(err.Error(), "rename it") {
+			t.Errorf("declaration %q: refusal does not name the identifier: %v", c.needle, err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #162. `checkNames` walked consts, variants and fields but never declaration names — so the shadow-hazard entries its own `dartReserved` map documents (String, List, Object, Endian, ByteData), which exist exactly for declarations emitted verbatim as class names, were unreachable. `type List` emitted `final class List` and broke `dart analyze` in the user project. Declarations (enum, flags, type, union) now refuse through the same path, naming the identifier.

`TestReservedDeclarationNamesRefused` pins all five entries: proven red on the old code (4 silent-success cases), green on the fix. Goldens untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)