### PR TITLE
Tables: evolution-tolerant data declarations, C++ backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ GO_SOURCES   := $(shell find cmd internal -name '*.go') go.mod
 SCHEMAS      := $(wildcard examples/*.schema)
 SCHEMAS128   := $(wildcard examples128/*.schema)
 SCHEMAS_BENCH := $(wildcard bench/corpus/*.schema)
+SCHEMAS_TABLES := $(wildcard tables/examples/*.schema)
 
 all: bin/schema
 
@@ -193,6 +194,24 @@ build/guard-generated/.stamp: bin/schema test/guard/Alpha.schema test/guard/Beta
 build/schema_test_guard: build/guard-generated/.stamp test/guard/main.cpp
 	@mkdir -p build
 	$(CXX) $(CXXFLAGS) -Ibuild/guard-generated test/guard/main.cpp -o $@
+
+# The tables corpus (SPEC-TABLES.md): the tabledemo unit plus the
+# two-generation evolution pair (tblv1/tblv2), generated at build time into
+# build/ — test-only, never part of the committed generated/ tree.
+build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) test/tables/V1.schema test/tables/V2.schema
+	@mkdir -p build/tables-generated
+	./bin/schema generate --lang cpp --out build/tables-generated/examples tables/examples
+	./bin/schema generate --lang cpp --out build/tables-generated/v1 test/tables/V1.schema
+	./bin/schema generate --lang cpp --out build/tables-generated/v2 test/tables/V2.schema
+	@touch $@
+
+# Deliberately compiled WITHOUT -I$(SERIALIZE): the generated Table headers
+# carry no serialize dependency, and this build proves it stays that way.
+build/schema_test_tables: build/tables-generated/.stamp test/tables/main.cpp
+	@mkdir -p build
+	$(CXX) -std=c++17 -Wall -Wextra -Werror -ffp-contract=off \
+		-Ibuild/tables-generated/examples -Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
+		test/tables/main.cpp -o $@
 
 build/schema_test_random: generated/cpp/.stamp test/random_main.cpp
 	@mkdir -p build
@@ -342,9 +361,10 @@ build/schema_test_c_ludicrous: generated/c-ludicrous/.stamp test/c-ludicrous/mai
 		-O2 -ffp-contract=off -Igenerated/c-ludicrous -I$(SERIALIZE_C) \
 		test/c-ludicrous/main.c $(SERIALIZE_C)/serialize.c -o $@ -lm
 
-test: build/schema_test build/schema_test_guard build/schema_test_random build/schema_test_ludicrous build/schema_test_c build/schema_test_c_ludicrous build/schema_test_bench build/schema_test_bench_c generated/go/.stamp generated/rust/.stamp generated/cs/.stamp generated/js/.stamp generated/dart/.stamp generated/java/.stamp generated/elixir/.stamp generated/go-ludicrous/.stamp generated/rust-ludicrous/.stamp generated/cs-ludicrous/.stamp generated/js-ludicrous/.stamp generated/dart-ludicrous/.stamp generated/java-ludicrous/.stamp generated/elixir-ludicrous/.stamp generated/bench/go/.stamp generated/bench/rust/.stamp generated/bench/cs/.stamp generated/bench/js/.stamp generated/bench/dart/.stamp generated/bench/java/.stamp generated/bench/elixir/.stamp build/java-test/.stamp build/java-test-ludicrous/.stamp build/java-bench/.stamp
+test: build/schema_test build/schema_test_guard build/schema_test_tables build/schema_test_random build/schema_test_ludicrous build/schema_test_c build/schema_test_c_ludicrous build/schema_test_bench build/schema_test_bench_c generated/go/.stamp generated/rust/.stamp generated/cs/.stamp generated/js/.stamp generated/dart/.stamp generated/java/.stamp generated/elixir/.stamp generated/go-ludicrous/.stamp generated/rust-ludicrous/.stamp generated/cs-ludicrous/.stamp generated/js-ludicrous/.stamp generated/dart-ludicrous/.stamp generated/java-ludicrous/.stamp generated/elixir-ludicrous/.stamp generated/bench/go/.stamp generated/bench/rust/.stamp generated/bench/cs/.stamp generated/bench/js/.stamp generated/bench/dart/.stamp generated/bench/java/.stamp generated/bench/elixir/.stamp build/java-test/.stamp build/java-test-ludicrous/.stamp build/java-bench/.stamp
 	./build/schema_test
 	./build/schema_test_guard
+	./build/schema_test_tables
 	./build/schema_test_random
 	./build/schema_test_ludicrous
 	cd test/c && ../../build/schema_test_c
@@ -430,6 +450,9 @@ generated-current: test
 check: bin/schema
 	./bin/schema check examples
 	./bin/schema check examples128
+	./bin/schema check tables/examples
+	./bin/schema check test/tables/V1.schema
+	./bin/schema check test/tables/V2.schema
 	./bin/schema check bench/corpus/Bench.schema
 	./bin/schema check bench/corpus/RealWorld.schema
 
@@ -442,6 +465,9 @@ id: bin/schema
 fmt: bin/schema
 	./bin/schema fmt examples
 	./bin/schema fmt examples128
+	./bin/schema fmt tables/examples
+	./bin/schema fmt test/tables/V1.schema
+	./bin/schema fmt test/tables/V2.schema
 	./bin/schema fmt bench/corpus/Bench.schema
 	./bin/schema fmt bench/corpus/RealWorld.schema
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ would have hand-written, not an interpreter walking a schema at runtime.
   sibling `ufixed(48, 16)` are declared like any other field, and the compiler
   owns both the storage and the wire for them.
 - **128-bit integers**, ranged like any other, in every target language.
+- **Tables for data that outlives builds** — `table` declares save/load
+  structures on an evolution-tolerant wire (C++ today): unknown fields skip,
+  absent fields default, renames survive via `was = "old_name"`, and every
+  table ships with reflection descriptors for tools that walk fields by name.
+  Packets and tables version independently — a table never moves the
+  protocol id.
 - **Zero allocation, no runtime reflection** — straight-line code reading and
   writing your own buffers.
 - **Reads validate, always — in every language.** Out-of-range values are

--- a/SPEC.md
+++ b/SPEC.md
@@ -1108,8 +1108,6 @@ schema declares a pure data contract — hardcoded structs, one protocol id,
 same-or-refuse (§3) — and constructs outside that contract are refused BY
 NAME rather than falling into a generic parse error:
 
-- **`table`** — tables are not part of the language; content that outlives
-  builds is out of schema's scope entirely.
 - **`message`** — messages are not part of the language: a message set is a
   union of payload types plus your own framing (§4.8, and the pattern in
   §4.9's example).
@@ -1124,7 +1122,9 @@ The projection (§3.1) keeps FROZEN tokens — `table=false message=false` on
 every type line, `round=nearest` on every compressed-float field line — so
 each refusal was id-neutral for every unit that never declared the
 construct; changing a token is a `ProjectionVersion` bump, taken
-deliberately or not at all.
+deliberately or not at all. `table` declarations (SPEC-TABLES.md) never
+enter the projection at all — a `type` line's token is `table=false`
+forever, and packets and tables version independently.
 
 ## 5. Trust model — inherited
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -550,6 +550,171 @@ find out, once, at connect time, instead of paying for it on every packet.
 
 ---
 
+## Tables: data that outlives builds
+
+Packets are for the network: exact-match, bit-packed, same protocol id or
+refuse. **Tables are for data** — tools→game pipelines, editors that walk
+properties by name, save/load to memory or disk — where the writer and the
+reader are routinely DIFFERENT builds and both must cope. Declare one with
+`table`; the body grammar is the type body's:
+
+```
+table ShipConfig
+{
+    health      float32 = 100.0
+    speed       float32 = 500.0
+    armor_level int32 = 1 | min = 0, max = 10
+    name        string(32)
+}
+```
+
+A table lives on its own wire — evolution-tolerant TLV, C++ only today. Field
+identity is a hash of the field NAME, so any reader takes any data, both
+directions: unknown fields are skipped, absent fields take their declared
+defaults, a field whose type changed is skipped rather than misdecoded,
+out-of-range values are clamped. Every such event is counted in a report;
+only structural damage stops a load. Tables never touch the protocol id —
+add, edit or remove one and no packet byte and no id moves.
+
+### Save and load
+
+Generation produces `<Base>Table.h` beside the packet headers — plain byte
+code with **no serialize dependency**, includable from any translation unit.
+The encode surface is a measure/save split, and the caller owns every buffer
+(generated code allocates nothing):
+
+```cpp
+#include "ConfigTable.h"
+
+ShipConfig ship;
+ship.health = 250.0f;
+
+int64_t size = TableMeasureShipConfig( ship );     // exact, writes nothing
+std::vector<uint8_t> buffer( size );               // or any storage you own
+TableSaveShipConfig( ship, buffer.data(), size );  // returns size, or -1 if short
+
+TableReport report;
+ShipConfig loaded;
+if ( !TableReadShipConfig( buffer.data(), size, loaded, report ) )
+{
+    // framing damage: report.malformed is set, the good prefix is kept
+}
+if ( report.unknown || report.kind_mismatch || report.clamped )
+{
+    // the data came from a different schema generation — loaded is still
+    // fully usable; log the counts so drift is visible
+}
+```
+
+Values at their defaults stay off the wire entirely — an all-default table
+saves as 2 bytes and loads back complete.
+
+### Nesting: a root table IS a format
+
+A field whose type is another table nests it by value; bounded arrays of
+tables give you collections. That is the whole recipe for a config or asset
+bin — declare the root, and the file format falls out:
+
+```
+table WeaponConfig
+{
+    damage float32 = 21.0
+    homing bool
+}
+
+table GameConfig
+{
+    friendly_fire bool
+    weapons       [..MaxWeapons]WeaponConfig
+    level_name    string(64)
+}
+```
+
+Whatever envelope you want around it — a magic, a content hash, several roots
+in one file — is a few lines of your code on top of `TableSave`/`TableRead`.
+schema deliberately does not prescribe one. Tables may also reference plain
+`type`s, enums and flags; everything a table reaches gets table codecs too.
+A `type` cannot reference a table (packets stay exact-match), and a table
+cannot nest itself.
+
+### Renaming a field: `was`
+
+Wire identity is the name hash, so a rename would orphan stored data. `was`
+keeps the old identity through the rename:
+
+```
+table ShipConfig
+{
+    speed float32 = 500.0 | was = "velocity"
+}
+```
+
+Old files that carry `velocity` load into `speed`; new files keep writing the
+old id. The compiler refuses `was` naming the field's own current name, and
+refuses any two fields of one table whose effective ids collide.
+
+### Going wide
+
+Every nested table on the wire is length-prefixed, so building a large file
+parallelizes: measure the subtables on N workers, prefix-sum the offsets,
+and scatter-write disjoint ranges — no worker touches another's bytes.
+
+```cpp
+// one worker per profile; shown serially
+int64_t sizes[kProfiles], total = 0;
+for ( int i = 0; i < kProfiles; i++ )
+{
+    sizes[i] = TableMeasureProfileConfig( profiles[i] ); // parallel-safe: read-only
+    total += sizes[i];
+}
+uint8_t * buffer = arena_alloc( total );
+int64_t offsets[kProfiles], at = 0;
+for ( int i = 0; i < kProfiles; i++ ) { offsets[i] = at; at += sizes[i]; }
+for ( int i = 0; i < kProfiles; i++ ) // each iteration is an independent job
+{
+    TableSaveProfileConfig( profiles[i], buffer + offsets[i], sizes[i] );
+}
+```
+
+The same framing means a reader CAN fan nested decodes out to workers — each
+length-prefixed body is a self-contained decode.
+
+### Walking fields at runtime
+
+Every closure type gets a reflection descriptor — name, wire id and kind,
+storage offset, array bounds and count companions, declared ranges, enum
+name functions, branch guards — enough to write a generic editor, printer or
+differ with no RTTI and no schema files at runtime:
+
+```cpp
+const TableTypeInfo * type = TableTypeShipConfig();
+for ( int32_t i = 0; i < type->num_fields; i++ )
+{
+    const TableFieldInfo & field = type->fields[i];
+    printf( "%s %s @%u", field.name, field.type_name, field.offset );
+    if ( field.has_range )
+        printf( "  [%g, %g]", field.range_min, field.range_max );
+    if ( field.enum_name )
+        printf( "  (%s)", field.enum_name( 1 ) );
+    if ( field.table )
+        printf( "  -> %s", field.table->name );   // recurse for nested tables
+    printf( "\n" );
+}
+```
+
+Decoded tables are **relocatable**: trivially copyable, standard-layout,
+pointer-free, arrays inline with their `_count`/`_length` companions — so a
+value can be memcpy'd, mmap'd or shared across processes and still walked
+through descriptor offsets. Generated `static_assert`s enforce it.
+
+Tables are generated for `--lang cpp` only today; every other target refuses
+a unit that declares them, by name. What stays off the table wire: `fixed`,
+`int128`/`uint128` (no neutral table kind), `const`/`reserved`/`align`
+(bit-position constructs — the table wire has no bit positions), and
+string/bytes/array extents past 65535 (lengths and counts ride in uint16).
+
+---
+
 ## Embedding the compiler
 
 The compiler is a Go library as well as a binary. `cmd/schema` is a client of

--- a/USAGE.md
+++ b/USAGE.md
@@ -591,7 +591,10 @@ ship.health = 250.0f;
 
 int64_t size = TableMeasureShipConfig( ship );     // exact, writes nothing
 std::vector<uint8_t> buffer( size );               // or any storage you own
-TableSaveShipConfig( ship, buffer.data(), size );  // returns size, or -1 if short
+TableSaveShipConfig( ship, buffer.data(), size );  // returns size — a buffer
+// of exactly TableMeasure's answer always suffices; -1 means the buffer is
+// too small, or the value violates a storage bound (a _count or _length
+// outside its declared range — measure returns -1 for those too)
 
 TableReport report;
 ShipConfig loaded;

--- a/compiler/builtin.go
+++ b/compiler/builtin.go
@@ -1,8 +1,12 @@
 package compiler
 
 import (
+	"fmt"
+	"sort"
+
 	cgen "github.com/mas-bandwidth/schema/v2/internal/codegen/c"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/cpp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/cpptable"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/csharp"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/dart"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/elixir"
@@ -12,6 +16,23 @@ import (
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/rust"
 	"github.com/mas-bandwidth/schema/v2/ir"
 )
+
+// refuseTables is the named refusal every non-C++ target gives a unit that
+// declares tables (SPEC-TABLES.md): tables are C++-only today, and each
+// per-language table backend is a named follow-on — refused loudly here
+// rather than silently emitting a unit with the tables missing.
+func refuseTables(u *ir.Unit, target string) error {
+	if len(u.Tables) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(u.Tables))
+	for name := range u.Tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return fmt.Errorf("unit declares tables (%s) — tables are C++-only today, and the %s table backend is a named follow-on; generate with --lang cpp, or move the tables to their own unit (SPEC-TABLES.md)",
+		englishList(names), target)
+}
 
 // builtins is the set [New] registers. The per-language emitters stay
 // internal — they are implementations, not API, and freezing eight emitter
@@ -39,6 +60,9 @@ type dartTarget struct{}
 func (dartTarget) Names() []string { return []string{"dart"} }
 
 func (dartTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "dart"); err != nil {
+		return nil, err
+	}
 	return dart.Generate(u)
 }
 
@@ -48,6 +72,9 @@ type elixirTarget struct{}
 func (elixirTarget) Names() []string { return []string{"elixir"} }
 
 func (elixirTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "elixir"); err != nil {
+		return nil, err
+	}
 	return elixir.Generate(u)
 }
 
@@ -57,6 +84,9 @@ type cTarget struct{}
 func (cTarget) Names() []string { return []string{"c"} }
 
 func (cTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "c"); err != nil {
+		return nil, err
+	}
 	return cgen.Generate(u)
 }
 
@@ -66,7 +96,24 @@ type cppTarget struct{}
 func (cppTarget) Names() []string { return []string{"cpp"} }
 
 func (cppTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
-	return cpp.Generate(u)
+	files, err := cpp.Generate(u)
+	if err != nil {
+		return nil, err
+	}
+	// units that declare tables ALSO get <Base>Table.h per file — the
+	// TABLE-wire codecs (SPEC-TABLES.md); a table-free unit's output is
+	// byte-identical to what the packet emitter alone produces
+	tables, err := cpptable.Generate(u)
+	if err != nil {
+		return nil, err
+	}
+	for name, data := range tables {
+		if _, dup := files[name]; dup {
+			return nil, fmt.Errorf("generated file %s is claimed twice — a schema file named <X>.schema beside <X minus Table>.schema with tables collides on the Table header; rename one file (SPEC-TABLES.md)", name)
+		}
+		files[name] = data
+	}
+	return files, nil
 }
 
 // csTarget emits C#.
@@ -75,6 +122,9 @@ type csTarget struct{}
 func (csTarget) Names() []string { return []string{"cs", "csharp"} }
 
 func (csTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "cs"); err != nil {
+		return nil, err
+	}
 	return csharp.Generate(u)
 }
 
@@ -84,6 +134,9 @@ type goTarget struct{}
 func (goTarget) Names() []string { return []string{"go"} }
 
 func (goTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "go"); err != nil {
+		return nil, err
+	}
 	return golang.Generate(u)
 }
 
@@ -93,6 +146,9 @@ type javaTarget struct{}
 func (javaTarget) Names() []string { return []string{"java"} }
 
 func (javaTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "java"); err != nil {
+		return nil, err
+	}
 	return java.Generate(u)
 }
 
@@ -102,6 +158,9 @@ type jsTarget struct{}
 func (jsTarget) Names() []string { return []string{"js", "javascript"} }
 
 func (jsTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "js"); err != nil {
+		return nil, err
+	}
 	return js.Generate(u)
 }
 
@@ -111,5 +170,8 @@ type rustTarget struct{}
 func (rustTarget) Names() []string { return []string{"rust"} }
 
 func (rustTarget) Generate(u *ir.Unit, _ Options) (map[string][]byte, error) {
+	if err := refuseTables(u, "rust"); err != nil {
+		return nil, err
+	}
 	return rust.Generate(u)
 }

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -145,8 +145,8 @@ func TestGeneratedTableCodeAllocatesNothing(t *testing.T) {
 			t.Errorf("generated table code contains %q — generated codecs must not allocate", banned)
 		}
 	}
-	for _, line := range strings.Split(table, "\n") {
-		if idx := strings.Index(line, "new "); idx >= 0 && !strings.Contains(line, "new ( &") && !strings.Contains(line, "<new>") {
+	for line := range strings.SplitSeq(table, "\n") {
+		if found := strings.Contains(line, "new "); found && !strings.Contains(line, "new ( &") && !strings.Contains(line, "<new>") {
 			t.Errorf("generated table code contains a non-placement new: %q", line)
 		}
 	}

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -1,0 +1,171 @@
+// Tests for the tables generation surface (SPEC-TABLES.md): the C++ target
+// grows Table headers, every other target refuses BY NAME, non-table output
+// is byte-identical with or without tables, and the generated codecs
+// allocate nothing.
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+func unitFromSource(t *testing.T, src string) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse("Probe.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "Probe.schema", Name: "Probe.schema", Base: "Probe", Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	return u
+}
+
+const packetSrc = `package probe
+
+enum Kind { Alpha, Beta }
+
+type Point
+{
+    x float32
+    y float32
+}
+
+type Packet
+{
+    kind  Kind
+    items [..16]Point
+}
+`
+
+const tableSrc = packetSrc + `
+table Config
+{
+    scale  float32 = 1.0
+    label  string(24)
+    points [..8]Point
+}
+`
+
+// TestNonCppTargetsRefuseTables: a unit declaring tables is refused by name
+// under every target but cpp — loudly, never by silently dropping the tables.
+func TestNonCppTargetsRefuseTables(t *testing.T) {
+	c := New()
+	u := unitFromSource(t, tableSrc)
+	for _, target := range []string{"c", "cs", "dart", "elixir", "go", "java", "js", "rust"} {
+		if _, err := c.Generate(u, target, Options{}); err == nil {
+			t.Errorf("--lang %s accepted a unit with tables — it must refuse by name", target)
+		} else if !strings.Contains(err.Error(), "C++-only") || !strings.Contains(err.Error(), "Config") {
+			t.Errorf("--lang %s refusal does not name the rule and the tables: %v", target, err)
+		}
+	}
+	// the aliases refuse too
+	if _, err := c.Generate(u, "csharp", Options{}); err == nil {
+		t.Error("--lang csharp accepted a unit with tables")
+	}
+}
+
+// TestCppEmitsTableHeaders: the cpp target adds <Base>Table.h beside the
+// packet headers for a unit with tables, and adds NOTHING for one without.
+func TestCppEmitsTableHeaders(t *testing.T) {
+	c := New()
+
+	with, err := c.Generate(unitFromSource(t, tableSrc), "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := with["ProbeTable.h"]; !ok {
+		t.Fatalf("no ProbeTable.h emitted for a unit with tables; got %d files", len(with))
+	}
+
+	without, err := c.Generate(unitFromSource(t, packetSrc), "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name := range without {
+		if strings.HasSuffix(name, "Table.h") {
+			t.Fatalf("a table-free unit emitted %s", name)
+		}
+	}
+}
+
+// TestTablesMoveNoGeneratedPacketByte is the other half of the independence
+// proof: beyond the protocol id, adding a table changes not one byte of the
+// NON-TABLE generated output, in the C++ target and in every refusing
+// target's view of the world (they see identical units either way).
+func TestTablesMoveNoGeneratedPacketByte(t *testing.T) {
+	c := New()
+	with, err := c.Generate(unitFromSource(t, tableSrc), "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	without, err := c.Generate(unitFromSource(t, packetSrc), "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range without {
+		got, ok := with[name]
+		if !ok {
+			t.Errorf("file %s disappeared when a table was added", name)
+			continue
+		}
+		if string(got) != string(data) {
+			t.Errorf("file %s changed when a table was added — tables must move no packet byte", name)
+		}
+	}
+	for name := range with {
+		if _, ok := without[name]; !ok && !strings.HasSuffix(name, "Table.h") {
+			t.Errorf("adding a table grew unexpected non-table file %s", name)
+		}
+	}
+}
+
+// TestGeneratedTableCodeAllocatesNothing: the generated Table header must
+// hold zero allocation and zero standard-container usage — the caller owns
+// every buffer. The one `new` is the placement-new prefill.
+func TestGeneratedTableCodeAllocatesNothing(t *testing.T) {
+	c := New()
+	files, err := c.Generate(unitFromSource(t, tableSrc), "cpp", Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := string(files["ProbeTable.h"])
+	if table == "" {
+		t.Fatal("no ProbeTable.h")
+	}
+	for _, banned := range []string{"malloc", "std::vector", "std::string", "std::unique_ptr", "std::shared_ptr", "delete "} {
+		if strings.Contains(table, banned) {
+			t.Errorf("generated table code contains %q — generated codecs must not allocate", banned)
+		}
+	}
+	for _, line := range strings.Split(table, "\n") {
+		if idx := strings.Index(line, "new "); idx >= 0 && !strings.Contains(line, "new ( &") && !strings.Contains(line, "<new>") {
+			t.Errorf("generated table code contains a non-placement new: %q", line)
+		}
+	}
+	// the load-bearing surfaces are present
+	for _, want := range []string{
+		"TableMeasureConfig", "TableSaveConfig", "TableReadConfig", "TableWriteConfig",
+		"TableTypeConfig", "struct TableReport",
+		"static_assert( std::is_trivially_copyable<Config>::value",
+		"static_assert( std::is_standard_layout<Config>::value",
+	} {
+		if !strings.Contains(table, want) {
+			t.Errorf("generated table header is missing %q", want)
+		}
+	}
+	// no serialize dependency (the banner SAYS "no serialize dependency", so
+	// the probes are the load-bearing spellings: the include and the symbols)
+	for _, banned := range []string{"#include \"serialize", "serialize::", "serialize_"} {
+		if strings.Contains(table, banned) {
+			t.Errorf("generated table header contains %q — it must stand alone", banned)
+		}
+	}
+}

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -51,6 +51,15 @@ type TypeDecl struct {
 	Body  *Block
 }
 
+// TableDecl is a `table` declaration: a data type on the evolution-tolerant
+// TABLE wire (SPEC-TABLES.md) rather than the packet wire. The body grammar
+// is the type body's; a table declaration takes no qualification.
+type TableDecl struct {
+	Name string
+	Pos  Pos
+	Body *Block
+}
+
 // UnionDecl is a first-class one-of type (SPEC §4.8): an implicit None row,
 // then each variant naming its payload type. The tag enum <Name>Type is
 // generated, never declared.
@@ -71,12 +80,14 @@ func (d *ConstDecl) DeclName() string { return d.Name }
 func (d *EnumDecl) DeclName() string  { return d.Name }
 func (d *FlagsDecl) DeclName() string { return d.Name }
 func (d *TypeDecl) DeclName() string  { return d.Name }
+func (d *TableDecl) DeclName() string { return d.Name }
 func (d *UnionDecl) DeclName() string { return d.Name }
 
 func (d *ConstDecl) DeclPos() Pos { return d.Pos }
 func (d *EnumDecl) DeclPos() Pos  { return d.Pos }
 func (d *FlagsDecl) DeclPos() Pos { return d.Pos }
 func (d *TypeDecl) DeclPos() Pos  { return d.Pos }
+func (d *TableDecl) DeclPos() Pos { return d.Pos }
 func (d *UnionDecl) DeclPos() Pos { return d.Pos }
 
 type Name struct {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -40,6 +40,12 @@ type checker struct {
 	flagsD   map[string]*ir.Flags
 	structs  map[string]*ir.Struct
 	unions   map[string]*ir.Union
+	tables   map[string]*ir.Struct // `table` declarations (SPEC-TABLES.md)
+
+	// the table closure — tables plus every struct one reaches — computed by
+	// checkTables and consumed by checkClaimedNames (closure members grow
+	// generated Table* symbols)
+	tableClosure map[string]bool
 
 	// enums currently being resolved — the cycle guard for | max = E.Max
 	// chains (resolveEnum memoizes only on completion, so recursion needs
@@ -77,6 +83,7 @@ func Unit(files []SourceFile) (*ir.Unit, []error) {
 		flagsD:   map[string]*ir.Flags{},
 		structs:  map[string]*ir.Struct{},
 		unions:   map[string]*ir.Union{},
+		tables:   map[string]*ir.Struct{},
 		unit: &ir.Unit{
 			DeclFile: map[string]string{},
 			Consts:   map[string]*ir.Const{},
@@ -84,6 +91,7 @@ func Unit(files []SourceFile) (*ir.Unit, []error) {
 			Flags:    map[string]*ir.Flags{},
 			Structs:  map[string]*ir.Struct{},
 			Unions:   map[string]*ir.Union{},
+			Tables:   map[string]*ir.Struct{},
 		},
 	}
 
@@ -93,6 +101,7 @@ func Unit(files []SourceFile) (*ir.Unit, []error) {
 	c.resolveAllConsts()
 	c.resolveBodies()
 	c.checkCycles()
+	c.checkTables()
 	c.checkClaimedNames()
 	c.checkTargetNames()
 	c.assemble()
@@ -498,6 +507,7 @@ var valuedAttr = map[string]bool{
 	"min":        true,
 	"max":        true,
 	"resolution": true,
+	"was":        true,
 }
 
 func (c *checker) enumMax(e *ast.MaxExpr) (*big.Int, bool) {
@@ -761,6 +771,11 @@ func (c *checker) resolveBodies() {
 					c.errf(d.Pos, "cpp_native and cpp_include go together: the mapped name needs the header that declares it (SPEC §4.2 Native type mapping)")
 				}
 				c.structs[d.Name] = st
+			case *ast.TableDecl:
+				// tables share the struct shape but live beside the packet
+				// decls, never among them (SPEC-TABLES.md): the packet wire,
+				// the projection and the protocol id do not know they exist
+				c.tables[d.Name] = &ir.Struct{Name: d.Name, IsTable: true}
 			case *ast.UnionDecl:
 				// the shell first, so fields can reference the union in any
 				// order; variants resolve in the second pass below. Max and
@@ -779,7 +794,9 @@ func (c *checker) resolveBodies() {
 		for _, d := range f.AST.Decls {
 			switch d := d.(type) {
 			case *ast.TypeDecl:
-				c.structs[d.Name].Fields, c.structs[d.Name].Items = c.resolveBody(d.Name, d.Body)
+				c.structs[d.Name].Fields, c.structs[d.Name].Items = c.resolveBody(d.Name, d.Body, false)
+			case *ast.TableDecl:
+				c.tables[d.Name].Fields, c.tables[d.Name].Items = c.resolveBody(d.Name, d.Body, true)
 			case *ast.UnionDecl:
 				c.resolveUnion(d)
 			}
@@ -830,6 +847,8 @@ func (c *checker) resolveUnion(d *ast.UnionDecl) {
 		switch pd.(type) {
 		case *ast.TypeDecl:
 			un.Variants = append(un.Variants, ir.UnionVariant{Name: v.Name, Type: v.Type, Ref: c.structs[v.Type]})
+		case *ast.TableDecl:
+			c.errf(v.TypePos, "%s is a table, not a union payload — a payload is a declared `type`; tables nest in tables directly (SPEC-TABLES.md)", v.Type)
 		case *ast.EnumDecl, *ast.FlagsDecl:
 			c.errf(v.TypePos, "%s is not a union payload — a payload is a declared type; wrap the value in a type (SPEC §4.8)", v.Type)
 		case *ast.UnionDecl:
@@ -847,7 +866,7 @@ type scopeFrame struct {
 	fields map[string]*ir.Field
 }
 
-func (c *checker) resolveBody(owner string, body *ast.Block) ([]*ir.Field, []ir.Item) {
+func (c *checker) resolveBody(owner string, body *ast.Block, inTable bool) ([]*ir.Field, []ir.Item) {
 	var out []*ir.Field
 	names := map[string]ast.Pos{}
 	var walk func(b *ast.Block, guard string, scopes []*scopeFrame) []ir.Item
@@ -863,7 +882,7 @@ func (c *checker) resolveBody(owner string, body *ast.Block) ([]*ir.Field, []ir.
 					continue
 				}
 				names[item.Name] = item.Pos
-				f := c.resolveField(owner, item)
+				f := c.resolveField(owner, item, inTable)
 				if f == nil {
 					continue
 				}
@@ -893,6 +912,10 @@ func (c *checker) resolveBody(owner string, body *ast.Block) ([]*ir.Field, []ir.
 				}
 				items = append(items, br)
 			case *ast.ConstField:
+				if inTable {
+					c.errf(item.Pos, "const(value, bits) is a packet-wire construct — a table's wire is field-tagged TLV with no bit positions; remove it from table %s (SPEC-TABLES.md)", owner)
+					continue
+				}
 				bits, ok := c.evalWidth(item.Bits, "const width")
 				if !ok {
 					continue
@@ -907,10 +930,18 @@ func (c *checker) resolveBody(owner string, body *ast.Block) ([]*ir.Field, []ir.
 				}
 				items = append(items, &ir.ConstItem{Value: v, Bits: bits}) // wire-only: no storage
 			case *ast.ReservedItem:
+				if inTable {
+					c.errf(item.Pos, "reserved(bits) is a packet-wire construct — a table's wire is field-tagged TLV with no bit positions; remove it from table %s (SPEC-TABLES.md)", owner)
+					continue
+				}
 				if bits, ok := c.evalWidth(item.Bits, "reserved width"); ok {
 					items = append(items, &ir.ReservedItem{Bits: bits})
 				}
 			case *ast.AlignItem:
+				if inTable {
+					c.errf(item.Pos, "align is a packet-wire construct — a table's wire is field-tagged TLV with no bit positions; remove it from table %s (SPEC-TABLES.md)", owner)
+					continue
+				}
 				items = append(items, &ir.AlignItem{})
 			}
 		}
@@ -941,7 +972,7 @@ func (c *checker) evalWidth(e ast.Expr, what string) (int64, bool) {
 	return v.Int64(), true
 }
 
-func (c *checker) resolveField(owner string, f *ast.Field) *ir.Field {
+func (c *checker) resolveField(owner string, f *ast.Field, inTable bool) *ir.Field {
 	out := &ir.Field{Name: f.Name}
 
 	// scalar type
@@ -1028,6 +1059,12 @@ func (c *checker) resolveField(owner string, f *ast.Field) *ir.Field {
 		switch d.(type) {
 		case *ast.TypeDecl:
 			out.Type = ir.FieldType{Kind: ir.TNamed, Name: f.Type.Name, Ref: c.structs[f.Type.Name]}
+		case *ast.TableDecl:
+			if !inTable {
+				c.errf(f.Type.Pos, "%s is a table, not a wire type — tables live on the TABLE wire and cannot ride in a `type`; declare the field's type with `type`, or move the declaring type to a `table` (SPEC-TABLES.md)", f.Type.Name)
+				return nil
+			}
+			out.Type = ir.FieldType{Kind: ir.TNamed, Name: f.Type.Name, Ref: c.tables[f.Type.Name]}
 		case *ast.EnumDecl:
 			out.Type = ir.FieldType{Kind: ir.TNamed, Name: f.Type.Name, Ref: c.enums[f.Type.Name]}
 		case *ast.FlagsDecl:
@@ -1081,6 +1118,11 @@ func (c *checker) resolveField(owner string, f *ast.Field) *ir.Field {
 	}
 
 	c.resolveAttrs(f, out)
+
+	if out.WasName != "" && !inTable {
+		c.errf(f.Pos, "field %s: was is a table-wire concept — it aliases a renamed field's wire id, and only table fields have wire ids; a `type`'s wire is positional, so a rename there moves no bit (SPEC-TABLES.md)", f.Name)
+		return nil
+	}
 
 	// the fixed and 128-bit families mirror serialize's own surface exactly
 	// (SPEC §4.3, runtime-first): fixed(I, F) and int128 are RANGED — the
@@ -1250,6 +1292,25 @@ func (c *checker) resolveAttrs(f *ast.Field, out *ir.Field) {
 		switch a.Key {
 		case "min", "max", "resolution":
 			// validated below
+		case "was":
+			// rename aliasing (SPEC-TABLES.md): the field's TABLE-wire id
+			// stays the hash of the OLD name, so identity survives the
+			// rename. Table fields only — enforced by resolveField, which
+			// knows the owner's kind.
+			lit, ok := a.Value.(*ast.StringLit)
+			if !ok {
+				c.errf(a.Pos, `was takes the field's old name as a quoted string, e.g. was = "velocity" (SPEC-TABLES.md)`)
+				continue
+			}
+			if lit.Value == "" {
+				c.errf(a.Pos, "was = \"\" names nothing — was records the field's old name after a rename (SPEC-TABLES.md)")
+				continue
+			}
+			if lit.Value == f.Name {
+				c.errf(a.Pos, "field %s: was = %q names the field's own current name — was records the OLD name after a rename; drop the attribute until one happens (SPEC-TABLES.md)", f.Name, lit.Value)
+				continue
+			}
+			out.WasName = lit.Value
 		case "round":
 			// refused by name: rounding is not an attribute — it is the one
 			// fixed-point rule, half away from zero, everywhere (SPEC §4.3)
@@ -1490,6 +1551,21 @@ func (c *checker) checkCycles() {
 		}
 		color[name] = grey
 		path = append(path, name)
+		if st := c.tables[name]; st != nil {
+			// tables join the composition graph exactly as types do: nesting
+			// is by value, so a table holding itself — directly or through a
+			// chain — has infinite size (SPEC-TABLES.md, the §4.6 rule)
+			for _, f := range st.Fields {
+				if f.Type.Kind == ir.TNamed {
+					switch f.Type.Ref.(type) {
+					case *ir.Struct, *ir.Union:
+						if !visit(f.Type.Name) {
+							break
+						}
+					}
+				}
+			}
+		}
 		if st := c.structs[name]; st != nil {
 			for _, f := range st.Fields {
 				if f.Type.Kind == ir.TNamed {
@@ -1515,17 +1591,160 @@ func (c *checker) checkCycles() {
 		color[name] = black
 		return true
 	}
-	names := make([]string, 0, len(c.structs)+len(c.unions))
+	names := make([]string, 0, len(c.structs)+len(c.unions)+len(c.tables))
 	for n := range c.structs {
 		names = append(names, n)
 	}
 	for n := range c.unions {
 		names = append(names, n)
 	}
+	for n := range c.tables {
+		names = append(names, n)
+	}
 	sort.Strings(names)
 	for _, n := range names {
 		visit(n)
 	}
+}
+
+// ---- tables (SPEC-TABLES.md) ----
+
+// closureMember resolves a closure name to its resolved struct — a table or
+// a plain type.
+func (c *checker) closureMember(name string) *ir.Struct {
+	if st := c.tables[name]; st != nil {
+		return st
+	}
+	return c.structs[name]
+}
+
+// checkTables enforces the table closure's wire capability and the field-id
+// uniqueness the TABLE wire's identity scheme requires (SPEC-TABLES.md).
+//
+// Capability: a `table` and everything it references, transitively, must stay
+// on table-wire kinds — plain fixed-width scalars, length-prefixed
+// strings/bytes/tables, the neutral encoding a third party could implement
+// from a one-page description. int128/uint128 and fixed(I, F) have no
+// table-wire kind, string/bytes/array extents ride in uint16, and an array
+// of unions is a named follow-on — each is refused HERE, loudly, instead of
+// surprising a generated reader later.
+//
+// Identity: a field's wire id is fold16(fnv1a32(name)) — of the `was` alias
+// where one is declared — and two fields of one closure member whose
+// effective ids collide would be indistinguishable on the wire, so the
+// collision is a compile error.
+func (c *checker) checkTables() {
+	closure := map[string]bool{}
+	var walk func(name string)
+	walk = func(name string) {
+		if closure[name] {
+			return
+		}
+		st := c.closureMember(name)
+		if st == nil {
+			return
+		}
+		closure[name] = true
+		for _, f := range st.Fields {
+			if f.Type.Kind != ir.TNamed {
+				continue
+			}
+			switch ref := f.Type.Ref.(type) {
+			case *ir.Struct:
+				walk(ref.Name)
+			case *ir.Union:
+				for _, v := range ref.Variants {
+					walk(v.Type)
+				}
+			}
+		}
+	}
+	// SORTED: map iteration order must not shuffle the diagnostics run to run
+	roots := make([]string, 0, len(c.tables))
+	for name := range c.tables {
+		roots = append(roots, name)
+	}
+	sort.Strings(roots)
+	for _, name := range roots {
+		walk(name)
+	}
+	c.tableClosure = closure
+
+	names := make([]string, 0, len(closure))
+	for name := range closure {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		st := c.closureMember(name)
+		if st == nil {
+			continue
+		}
+		pos := ast.Pos{}
+		if d, ok := c.astDecls[name]; ok {
+			pos = d.DeclPos()
+		}
+		what := "type"
+		if st.IsTable {
+			what = "table"
+		}
+		seen := map[uint16]*ir.Field{}
+		for _, f := range st.Fields {
+			var bad string
+			switch {
+			case f.Type.Kind == ir.TInt && f.Type.Width == 128:
+				bad = "int128/uint128"
+			case f.Type.Kind == ir.TFixed:
+				bad = fixedSpelling(f.Type.Signed) + "(I, F)"
+			}
+			if bad != "" {
+				c.errf(pos, "%s.%s: %s has no table-wire kind, and %s %s is in a table's closure — a `table` and everything it references must stay on table-wire kinds (SPEC-TABLES.md)",
+					name, f.Name, bad, what, name)
+				continue
+			}
+			if (f.Type.Kind == ir.TString || f.Type.Kind == ir.TBytes) && f.Type.Size > 65535 {
+				spelling := "string"
+				if f.Type.Kind == ir.TBytes {
+					spelling = "bytes"
+				}
+				c.errf(pos, "%s.%s: %s(%d) exceeds 65535, and %s %s is in a table's closure — table-wire lengths ride in uint16 (SPEC-TABLES.md)",
+					name, f.Name, spelling, f.Type.Size, what, name)
+				continue
+			}
+			if f.Array != ir.ArrayNone && f.ArrayBound > 65535 {
+				c.errf(pos, "%s.%s: array bound %d exceeds 65535, and %s %s is in a table's closure — table-wire counts ride in uint16 (SPEC-TABLES.md)",
+					name, f.Name, f.ArrayBound, what, name)
+				continue
+			}
+			if f.Type.Kind == ir.TNamed {
+				if _, isUnion := f.Type.Ref.(*ir.Union); isUnion && f.Array != ir.ArrayNone {
+					// a SCALAR union field rides the table wire as kUnion:
+					// u8 tag, then the selected arm length-prefixed —
+					// skippable, elidable (None), kind-mismatch-safe. An
+					// ARRAY of unions is the remaining named follow-on.
+					c.errf(pos, "%s.%s: an array of unions may not sit on a table-closure path yet — wrap the union in a type, or ask for the pass (SPEC-TABLES.md)",
+						name, f.Name)
+					continue
+				}
+			}
+			id := ir.TableFieldId(f)
+			if prev, dup := seen[id]; dup {
+				c.errf(pos, "%s %s: fields %s and %s collide on table-wire id 0x%04x — rename one (SPEC-TABLES.md)",
+					what, name, describeTableField(prev), describeTableField(f), id)
+				continue
+			}
+			seen[id] = f
+		}
+	}
+}
+
+// describeTableField names a field for the id-collision diagnostic, showing
+// the was alias when that is where the colliding id comes from.
+func describeTableField(f *ir.Field) string {
+	if f.WasName != "" {
+		return fmt.Sprintf("%s (was %q)", f.Name, f.WasName)
+	}
+	return f.Name
 }
 
 // ---- target-name safety (SPEC §4.6) ----
@@ -1736,6 +1955,8 @@ func (c *checker) checkTargetNames() {
 			switch d := d.(type) {
 			case *ast.TypeDecl:
 				walkBlock(d.Body, d.Name, map[string]claim{})
+			case *ast.TableDecl:
+				walkBlock(d.Body, d.Name, map[string]claim{})
 			case *ast.EnumDecl:
 				for _, v := range d.Variants {
 					checkName(v.Text, v.Pos, "enum variant")
@@ -1790,6 +2011,16 @@ func (c *checker) checkClaimedNames() {
 	add("PROTOCOL_ID", "the unit's generated PROTOCOL_ID (Rust form)", unitPos)
 	add("Error", "the unit's generated Error type (Rust form)", unitPos)
 	add("Result", "the unit's generated Result alias (Rust form)", unitPos)
+	if len(c.tables) > 0 {
+		// the TABLE-wire runtime the generated Table headers define once per
+		// package (SPEC-TABLES.md) — claimed only when a unit declares a
+		// table, so table-free units keep their whole namespace
+		for _, gen := range []string{"TableReport", "TableWriter", "TableReader",
+			"TableTypeInfo", "TableFieldInfo", "table_bits_to_float",
+			"table_float_to_bits", "table_bits_to_double", "table_double_to_bits"} {
+			add(gen, "the generated TABLE-wire runtime (SPEC-TABLES.md)", unitPos)
+		}
+	}
 
 	declNames := make([]string, 0, len(c.astDecls))
 	for name := range c.astDecls {
@@ -1895,8 +2126,27 @@ func (c *checker) checkClaimedNames() {
 			}
 		case *ast.TypeDecl:
 			c.addStructSymbols(add, addRust, name, d.DeclPos())
+			if c.tableClosure[name] {
+				c.addTableSymbols(add, name, d.DeclPos())
+			}
+		case *ast.TableDecl:
+			// a table generates its storage struct plus the Table codec and
+			// descriptor family — no packet-wire symbols (SPEC-TABLES.md)
+			c.addTableSymbols(add, name, d.DeclPos())
 		}
 	}
+}
+
+// addTableSymbols registers the TABLE-wire generated names of one closure
+// member: the measure/write/save/read codecs and the reflection descriptor
+// (SPEC-TABLES.md). C++-only today, so only the CamelCase spellings claim.
+func (c *checker) addTableSymbols(add func(name, what string, pos ast.Pos), name string, pos ast.Pos) {
+	why := fmt.Sprintf("%s's generated TABLE-wire functions", name)
+	add("TableMeasure"+name, why, pos)
+	add("TableWrite"+name, why, pos)
+	add("TableSave"+name, why, pos)
+	add("TableRead"+name, why, pos)
+	add("TableType"+name, why, pos)
 }
 
 // addStructSymbols registers the per-type generated names: the split
@@ -1944,6 +2194,14 @@ func (c *checker) assemble() {
 				st := c.structs[d.Name]
 				irf.Decls = append(irf.Decls, st)
 				u.Structs[d.Name] = st
+			case *ast.TableDecl:
+				// tables assemble BESIDE the decl stream, never into it
+				// (SPEC-TABLES.md): File.Decls and Unit.Structs feed the
+				// packet backends and the wire projection, and a table must
+				// move neither a generated packet byte nor the protocol id
+				tbl := c.tables[d.Name]
+				irf.Tables = append(irf.Tables, tbl)
+				u.Tables[d.Name] = tbl
 			case *ast.UnionDecl:
 				un := c.unions[d.Name]
 				irf.Decls = append(irf.Decls, un)

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -166,8 +166,8 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\ntype T { x ufixed(64, 0) | min = 0, max = 18446744073709551615 }\n"},
 		{name: "ufixed default below its unsigned range", want: "outside its range",
 			src: "package t\ntype T { x ufixed(16, 16) = -1.0 | min = 0, max = 5 }\n"},
-		{name: "table is not part of the language", want: "tables are not part of the language",
-			src: "package t\ntable T { x int32 }\n"},
+		{name: "a table declaration takes no qualification", want: "takes no qualification",
+			src: "package t\ntable T | pinned\n{\n    x int32\n}\n"},
 		{name: "message is not part of the language", want: "messages are not part of the language",
 			src: "package t\nmessage M { x uint8 }\n"},
 		{name: "object is not part of the language", want: "objects are not part of the language",
@@ -250,6 +250,8 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\ntype T { n int32 | min = 0, max }\n"},
 		{name: "resolution written without a value", want: "requires a value",
 			src: "package t\ntype T { x float32 | min = 0, max = 1, resolution }\n"},
+		{name: "was written without a value", want: "requires a value",
+			src: "package t\ntable T { x int32 | was }\n"},
 
 		// cycle guards: every resolver that can re-enter itself must REJECT,
 		// not recurse. Before the enum guard these crashed the compiler with

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -1,0 +1,201 @@
+// Tests for the table frontend (SPEC-TABLES.md): the refusals that keep the
+// table wire sound, and the independence proof — tables move no protocol id.
+package check
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+func buildUnit(t *testing.T, src string) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse("T.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := Unit([]SourceFile{{
+		Path: "T.schema", Name: "T.schema", Base: "T", Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	return u
+}
+
+// TestTableRefusals is the tables extension of the break-the-language suite:
+// every way to misuse a table that the checker provably catches.
+func TestTableRefusals(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+		src  string
+	}{
+		{name: "a type field cannot reference a table", want: "is a table, not a wire type",
+			src: "package t\ntable Tab { x int32 }\ntype P { tab Tab }\n"},
+		{name: "was on a type field is refused by name", want: "was is a table-wire concept",
+			src: "package t\ntype P { speed float32 | was = \"velocity\" }\n"},
+		{name: "was naming the field's own current name", want: "names the field's own current name",
+			src: "package t\ntable Tab { speed float32 | was = \"speed\" }\n"},
+		{name: "was with an empty string", want: "names nothing",
+			src: "package t\ntable Tab { speed float32 | was = \"\" }\n"},
+		{name: "was takes a quoted string", want: "was takes the field's old name as a quoted string",
+			src: "package t\ntable Tab { speed float32 | was = velocity }\n"},
+		{name: "effective wire ids collide (was aliases a live sibling)", want: "collide on table-wire id",
+			src: "package t\ntable Tab {\n    a int32 | was = \"b\"\n    b int32\n}\n"},
+		{name: "a table nesting itself is a composition cycle", want: "type composition cycle",
+			src: "package t\ntable Tab { inner Tab }\n"},
+		{name: "a table cycle through a chain", want: "type composition cycle",
+			src: "package t\ntable Aaa { b Bbb }\ntable Bbb { a Aaa }\n"},
+		{name: "const(value, bits) in a table body", want: "const(value, bits) is a packet-wire construct",
+			src: "package t\ntable Tab {\n    const(7, 4)\n    x int32\n}\n"},
+		{name: "reserved(bits) in a table body", want: "reserved(bits) is a packet-wire construct",
+			src: "package t\ntable Tab {\n    reserved(4)\n    x int32\n}\n"},
+		{name: "align in a table body", want: "align is a packet-wire construct",
+			src: "package t\ntable Tab {\n    align\n    x int32\n}\n"},
+		{name: "a table is not a union payload", want: "not a union payload",
+			src: "package t\ntable Tab { x int32 }\nunion U\n{\n    tab Tab\n}\n"},
+		{name: "fixed(I, F) has no table-wire kind", want: "has no table-wire kind",
+			src: "package t\ntable Tab { x fixed(16, 16) | min = 0, max = 5 }\n"},
+		{name: "fixed in a type pulled into a closure", want: "has no table-wire kind",
+			src: "package t\ntype Inner { x fixed(16, 16) | min = 0, max = 5 }\ntable Tab { inner Inner }\n"},
+		{name: "uint128 has no table-wire kind", want: "has no table-wire kind",
+			src: "package t\ntable Tab { x uint128 }\n"},
+		{name: "string past the uint16 length", want: "table-wire lengths ride in uint16",
+			src: "package t\ntable Tab { s string(70000) }\n"},
+		{name: "array bound past the uint16 count", want: "table-wire counts ride in uint16",
+			src: "package t\ntable Tab { xs [..70000]int32 }\n"},
+		{name: "an array of unions in a closure", want: "an array of unions may not sit on a table-closure path",
+			src: "package t\ntype P { x int32 }\nunion U\n{\n    p P\n}\ntable Tab { us [..4]U }\n"},
+		{name: "a declaration colliding with the table runtime", want: "generated TABLE-wire runtime",
+			src: "package t\ntable Tab { x int32 }\ntype TableReport { y int32 }\n"},
+		{name: "a declaration colliding with generated table codecs", want: "generated TABLE-wire functions",
+			src: "package t\ntable Tab { x int32 }\ntype TableReadTab { y int32 }\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := runUnit(t, map[string]string{"T.schema": tc.src})
+			if len(errs) == 0 {
+				t.Fatalf("expected a diagnostic containing %q, got none", tc.want)
+			}
+			for _, e := range errs {
+				if strings.Contains(e.Error(), tc.want) {
+					return
+				}
+			}
+			t.Fatalf("no diagnostic contains %q; got: %v", tc.want, errs)
+		})
+	}
+}
+
+// TestTypeFreeOfTableSymbols: a table-free unit keeps its whole namespace —
+// the TableReport claim exists only when a table is declared.
+func TestTypeFreeOfTableSymbols(t *testing.T) {
+	if errs := runUnit(t, map[string]string{"T.schema": "package t\ntype TableReport { y int32 }\n"}); len(errs) > 0 {
+		t.Fatalf("a table-free unit must not claim the table runtime names: %v", errs)
+	}
+}
+
+const tablelessSrc = `package probe
+
+const MaxItems = 16
+
+enum Kind { Alpha, Beta }
+
+type Point
+{
+    x float32
+    y float32
+}
+
+type Packet
+{
+    kind  Kind
+    items [..MaxItems]Point
+}
+`
+
+// TestTablesMoveNoProtocolId is the independence requirement: packets and
+// tables version independently, so ADDING a table (and everything in its
+// closure that was already there) moves neither the projection nor the id —
+// and neither does EDITING one.
+func TestTablesMoveNoProtocolId(t *testing.T) {
+	withTable := tablelessSrc + `
+table Config
+{
+    scale  float32 = 1.0
+    points [..8]Point
+}
+`
+	editedTable := tablelessSrc + `
+table Config
+{
+    scale   float32 = 2.0
+    points  [..8]Point
+    comment string(32)
+}
+`
+	base := buildUnit(t, tablelessSrc)
+	added := buildUnit(t, withTable)
+	edited := buildUnit(t, editedTable)
+
+	if ir.WireProjection(base) != ir.WireProjection(added) {
+		t.Fatalf("adding a table changed the wire projection:\n--- without ---\n%s\n--- with ---\n%s",
+			ir.WireProjection(base), ir.WireProjection(added))
+	}
+	if base.ProtocolId != added.ProtocolId {
+		t.Fatalf("adding a table moved the protocol id %#x -> %#x", base.ProtocolId, added.ProtocolId)
+	}
+	if added.ProtocolId != edited.ProtocolId {
+		t.Fatalf("editing a table moved the protocol id %#x -> %#x", added.ProtocolId, edited.ProtocolId)
+	}
+}
+
+// TestTableFieldIds pins the id function and the was override.
+func TestTableFieldIds(t *testing.T) {
+	// frozen values: the id is WIRE FORMAT — a change here breaks every
+	// stored table on earth
+	pins := map[string]uint16{
+		"velocity": 0x2e46,
+		"damage":   0x15a9,
+		"name":     0x30df,
+	}
+	for name, want := range pins {
+		if got := ir.FieldId(name); got != want {
+			t.Errorf("FieldId(%q) = %#04x, want %#04x — the table-wire id function moved", name, got, want)
+		}
+	}
+
+	u := buildUnit(t, "package t\ntable Tab { speed float32 | was = \"velocity\" }\n")
+	f := u.Tables["Tab"].Fields[0]
+	if got := ir.TableFieldId(f); got != ir.FieldId("velocity") {
+		t.Errorf("was alias not honored: id %#04x, want hash of the old name %#04x", got, ir.FieldId("velocity"))
+	}
+	if ir.TableFieldId(f) == ir.FieldId("speed") {
+		t.Error("was alias ignored — the renamed field kept its new-name id")
+	}
+}
+
+// TestTablesInvisibleToPacketIR: tables live beside the decl stream, never in
+// it — Structs, File.Decls and the projection must not see them.
+func TestTablesInvisibleToPacketIR(t *testing.T) {
+	u := buildUnit(t, tablelessSrc+"\ntable Config { scale float32 = 1.0 }\n")
+	if _, leaked := u.Structs["Config"]; leaked {
+		t.Fatal("a table leaked into Unit.Structs — the packet backends would emit it")
+	}
+	if u.Tables["Config"] == nil {
+		t.Fatal("the table is missing from Unit.Tables")
+	}
+	for _, f := range u.Files {
+		for _, d := range f.Decls {
+			if st, ok := d.(*ir.Struct); ok && st.IsTable {
+				t.Fatal("a table leaked into File.Decls — the packet backends would emit it")
+			}
+		}
+	}
+	if strings.Contains(ir.WireProjection(u), "Config") {
+		t.Fatal("a table leaked into the wire projection — the protocol id depends on it")
+	}
+}

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -1,0 +1,716 @@
+// TABLE-wire storage, codec and descriptor emission (SPEC-TABLES.md).
+// Readers prefill declared defaults then overlay, skip unknown ids, skip
+// kind mismatches, clamp out-of-range values, and count every event.
+package cpptable
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// cppFieldType maps a field type to its C++ storage spelling, mirroring the
+// packet emitter's conventions so closure types from <Base>.h and table
+// structs from this header read as one family. The bool reports a
+// self-initializing type (a generated struct or union needs no initializer).
+func (g *tableGen) cppFieldType(t ir.FieldType) (string, bool) {
+	switch t.Kind {
+	case ir.TInt:
+		if t.Signed {
+			return fmt.Sprintf("int%d_t", t.Width), false
+		}
+		return fmt.Sprintf("uint%d_t", t.Width), false
+	case ir.TBits:
+		if t.Width <= 32 {
+			return "uint32_t", false
+		}
+		return "uint64_t", false
+	case ir.TBool:
+		return "bool", false
+	case ir.TFloat32:
+		return "float", false
+	case ir.TFloat64:
+		return "double", false
+	case ir.TNamed:
+		g.noteRef(t.Name)
+		if _, isUnion := t.Ref.(*ir.Union); isUnion {
+			return t.Name, true
+		}
+		st, isStruct := t.Ref.(*ir.Struct)
+		if isStruct && st.CppNative != "" && g.unit.DeclFile[t.Name] != g.file.Base {
+			// native type mapping (SPEC §4.2): storage speaks the hand type
+			// deriving from the generated basis — same layout, so the
+			// relocatability asserts and descriptor offsets still hold
+			g.nativeIncludes[st.CppInclude] = true
+			return "::" + st.CppNative, true
+		}
+		return t.Name, isStruct
+	}
+	return "/* ? */", false
+}
+
+// tableIntLit renders an integer literal safely at 64-bit width: unsigned
+// values past INT64_MAX need ull, and INT64_MIN has no single-literal form.
+func tableIntLit(v *big.Int, signed bool, widthBytes int) string {
+	s := v.String()
+	if widthBytes < 8 {
+		return s
+	}
+	if !signed {
+		return s + "ull"
+	}
+	if s == "-9223372036854775808" {
+		return "( -9223372036854775807ll - 1 )"
+	}
+	return s + "ll"
+}
+
+// fieldDefaultExpr renders the C++ expression a field's default compares
+// against on the write side (elision) — identical literals to the NSDMIs.
+func (g *tableGen) fieldDefaultExpr(f *ir.Field) string {
+	switch f.Type.Kind {
+	case ir.TBool:
+		if f.HasDefault && f.DefBool {
+			return "true"
+		}
+		return "false"
+	case ir.TFloat32:
+		if f.HasDefault {
+			return formatFloat(f.DefFloat, true)
+		}
+		return "0.0f"
+	case ir.TFloat64:
+		if f.HasDefault {
+			return formatFloat(f.DefFloat, false)
+		}
+		return "0.0"
+	case ir.TInt, ir.TBits:
+		if f.HasDefault && f.DefInt != nil {
+			signed := f.Type.Kind == ir.TInt && f.Type.Signed
+			width := 4
+			if f.Type.Width > 32 {
+				width = 8
+			}
+			return tableIntLit(f.DefInt, signed, width)
+		}
+		return "0"
+	case ir.TNamed:
+		switch f.Type.Ref.(type) {
+		case *ir.Enum:
+			if f.HasDefault && f.DefVariant != "" {
+				return f.Type.Name + "::" + f.DefVariant
+			}
+			return f.Type.Name + "::None"
+		case *ir.Flags:
+			return "0"
+		}
+	}
+	return "0"
+}
+
+// ---- storage (table declarations only; closure types come from <Base>.h) ----
+
+func (g *tableGen) emitTableStruct(st *ir.Struct) {
+	g.pf("// table %s — TABLE-wire storage: relocatable, bounded, defaults in the\n", st.Name)
+	g.pf("// member initializers (SPEC-TABLES.md)\n")
+	g.pf("struct %s {\n", st.Name)
+	prevGuard := ""
+	for _, f := range st.Fields {
+		if f.Guard != prevGuard {
+			if f.Guard != "" {
+				g.pf("\n    // %s — guarded fields stay off the wire when the guard says so;\n", f.Guard)
+				g.pf("    // a read's prefilled defaults stand in for the untaken side\n")
+			} else {
+				g.pf("\n")
+			}
+			prevGuard = f.Guard
+		}
+		g.emitTableStorageField(f)
+	}
+	g.pf("};\n\n")
+}
+
+func (g *tableGen) emitTableStorageField(f *ir.Field) {
+	typ, selfInit := g.cppFieldType(f.Type)
+	switch {
+	case f.Type.Kind == ir.TString:
+		g.pf("    char %s[%d + 1] = {}; // string(%d): max length, used length beside it\n", f.Name, f.Type.Size, f.Type.Size)
+		g.pf("    int32_t %s_length = 0;\n", f.Name)
+	case f.Type.Kind == ir.TBytes:
+		g.pf("    uint8_t %s[%d] = {}; // bytes(%d): fixed buffer, used length beside it\n", f.Name, f.Type.Size, f.Type.Size)
+		g.pf("    int32_t %s_length = 0;\n", f.Name)
+	case f.Array == ir.ArrayFixed:
+		g.pf("    %s %s[%d] = {};\n", typ, f.Name, f.ArrayBound)
+	case f.Array == ir.ArrayCounted:
+		g.pf("    %s %s[%d] = {}; // used count beside it; count in [0, %d]\n", typ, f.Name, f.ArrayBound, f.ArrayBound)
+		g.pf("    int32_t %s_count = 0;\n", f.Name)
+	default:
+		init := ""
+		if !selfInit {
+			init = " = " + g.fieldDefaultExpr(f)
+		}
+		g.pf("    %s %s%s;\n", typ, f.Name, init)
+	}
+}
+
+// ---- guards ----
+
+// tableGuardExprs composes each guarded field's branch condition from the
+// wire tree ("value.a && !value.b" for nesting) so the writer and measurer
+// keep untaken-branch fields off the wire — TLV's native optionality carries
+// the branch, and the reader's prefilled defaults stand in for the untaken
+// side.
+func tableGuardExprs(st *ir.Struct) map[string]string {
+	return guardWalk(st, "value.")
+}
+
+// tableGuardStrings is the value-free twin for the reflection descriptors
+// ("at_rest", "!at_rest", "active && has_target").
+func tableGuardStrings(st *ir.Struct) map[string]string {
+	return guardWalk(st, "")
+}
+
+func guardWalk(st *ir.Struct, prefix string) map[string]string {
+	guards := map[string]string{}
+	var walk func(items []ir.Item, cond string)
+	walk = func(items []ir.Item, cond string) {
+		for _, item := range items {
+			switch item := item.(type) {
+			case *ir.FieldItem:
+				if cond != "" {
+					guards[item.F.Name] = cond
+				}
+			case *ir.Branch:
+				pos, neg := prefix+item.Cond, "!"+prefix+item.Cond
+				if item.Neg {
+					pos, neg = neg, pos
+				}
+				and := func(a, b string) string {
+					if a == "" {
+						return b
+					}
+					return a + " && " + b
+				}
+				walk(item.Then, and(cond, pos))
+				walk(item.Else, and(cond, neg))
+			}
+		}
+	}
+	walk(st.Items, "")
+	return guards
+}
+
+// ---- measure ----
+
+// emitTableMeasure emits TableMeasure<X>: the EXACT encoded size of a value,
+// no writing — the parallel-generation lever. Every nested table on the wire
+// is length-prefixed, so a caller can measure subtables in parallel,
+// prefix-sum offsets, and scatter-write disjoint ranges from N workers.
+// Mirrors TableWrite's elision decisions branch for branch: for any value,
+// TableSave writes exactly this many bytes.
+func (g *tableGen) emitTableMeasure(st *ir.Struct) {
+	g.pf("inline int64_t TableMeasure%s( const %s & value )\n{\n", st.Name, st.Name)
+	if len(st.Fields) == 0 {
+		g.pf("    (void) value; // empty type: presence is the payload\n")
+	}
+	g.pf("    int64_t bytes = 2; // terminator\n")
+	guards := tableGuardExprs(st)
+	for _, f := range st.Fields {
+		if cond, guarded := guards[f.Name]; guarded {
+			g.pf("    if ( %s )\n    {\n", cond)
+			g.indent = "    "
+			g.emitTableMeasureField(f)
+			g.indent = ""
+			g.pf("    }\n")
+			continue
+		}
+		g.emitTableMeasureField(f)
+	}
+	g.pf("    return bytes;\n}\n\n")
+}
+
+func (g *tableGen) emitTableMeasureField(f *ir.Field) {
+	kind := tableScalarKind(f)
+	width := tableKindWidth(kind)
+	switch {
+	case f.Type.Kind == ir.TString:
+		g.pf("    if ( value.%s_length > 0 ) { bytes += 3 + 2 + value.%s_length; } // %s\n", f.Name, f.Name, f.Name)
+	case f.Type.Kind == ir.TBytes:
+		g.pf("    if ( value.%s_length > 0 ) { bytes += 3 + 4 + 3 + value.%s_length; } // %s\n", f.Name, f.Name, f.Name)
+	case f.Array == ir.ArrayCounted && kind == tkTable:
+		g.pf("    if ( value.%s_count > 0 )\n    {\n", f.Name)
+		g.pf("        bytes += 3 + 4 + 3; // %s\n", f.Name)
+		g.pf("        for ( int32_t i = 0; i < value.%s_count; i++ )\n        {\n", f.Name)
+		g.pf("            bytes += 4 + TableMeasure%s( value.%s[i] );\n", f.Type.Name, f.Name)
+		g.pf("        }\n    }\n")
+	case f.Array == ir.ArrayCounted:
+		g.pf("    if ( value.%s_count > 0 ) { bytes += 3 + 4 + 3 + int64_t( value.%s_count ) * %d; } // %s\n", f.Name, f.Name, width, f.Name)
+	case f.Array == ir.ArrayFixed && kind == tkTable:
+		g.pf("    {\n")
+		g.pf("        bytes += 3 + 4 + 3; // %s (fixed [%d])\n", f.Name, f.ArrayBound)
+		g.pf("        for ( int32_t i = 0; i < %d; i++ )\n        {\n", f.ArrayBound)
+		g.pf("            bytes += 4 + TableMeasure%s( value.%s[i] );\n", f.Type.Name, f.Name)
+		g.pf("        }\n    }\n")
+	case f.Array == ir.ArrayFixed:
+		g.pf("    {\n")
+		g.pf("        bool all_default_%s = true;\n", f.Name)
+		g.pf("        for ( int32_t i = 0; i < %d; i++ ) { if ( value.%s[i] != %s ) { all_default_%s = false; break; } }\n",
+			f.ArrayBound, f.Name, g.fieldDefaultExpr(f), f.Name)
+		g.pf("        if ( !all_default_%s ) { bytes += 3 + 4 + 3 + %d; } // %s\n", f.Name, f.ArrayBound*int64(width), f.Name)
+		g.pf("    }\n")
+	case kind == tkUnion:
+		un := f.Type.Ref.(*ir.Union)
+		g.pf("    switch ( value.%s.type ) // %s\n    {\n", f.Name, f.Name)
+		g.pf("        case %sType::None: break; // None elides — TLV absence is the None\n", un.Name)
+		for _, v := range un.Variants {
+			g.pf("        case %sType::%s: bytes += 3 + 1 + 4 + TableMeasure%s( value.%s.%s ); break;\n",
+				un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
+		}
+		g.pf("        default: break; // invalid tag: TableWrite refuses it before this measure could disagree\n")
+		g.pf("    }\n")
+	case kind == tkTable:
+		g.pf("    {\n")
+		g.pf("        int64_t body_%s = TableMeasure%s( value.%s );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("        if ( body_%s > 2 ) { bytes += 3 + 4 + body_%s; } // %s: all-default nested elides\n", f.Name, f.Name, f.Name)
+		g.pf("    }\n")
+	default:
+		g.pf("    if ( value.%s != %s ) { bytes += 3 + %d; } // %s\n", f.Name, g.fieldDefaultExpr(f), width, f.Name)
+	}
+}
+
+// ---- write / save ----
+
+func (g *tableGen) emitTableWrite(st *ir.Struct) {
+	g.pf("inline bool TableWrite%s( TableWriter & w, const %s & value )\n{\n", st.Name, st.Name)
+	if len(st.Fields) == 0 {
+		g.pf("    (void) value; // empty type: presence is the payload\n")
+	}
+	guards := tableGuardExprs(st)
+	for _, f := range st.Fields {
+		if cond, guarded := guards[f.Name]; guarded {
+			g.pf("    if ( %s )\n    {\n", cond)
+			g.indent = "    "
+			g.emitTableWriteField(f)
+			g.indent = ""
+			g.pf("    }\n")
+			continue
+		}
+		g.emitTableWriteField(f)
+	}
+	g.pf("    w.put16( 0 ); // terminator\n")
+	g.pf("    return !w.overflow;\n}\n\n")
+}
+
+// emitTableSave emits the buffer-level entry of the measure/save pair:
+// TableSave writes into a caller-provided buffer and returns the bytes
+// written — exactly TableMeasure's answer — or -1 when the buffer is too
+// small. No allocation anywhere: the caller owns the buffer.
+func (g *tableGen) emitTableSave(st *ir.Struct) {
+	g.pf("inline int64_t TableSave%s( const %s & value, uint8_t * buffer, int64_t capacity )\n{\n", st.Name, st.Name)
+	g.pf("    TableWriter w( buffer, capacity );\n")
+	g.pf("    if ( !TableWrite%s( w, value ) ) { return -1; }\n", st.Name)
+	g.pf("    return w.offset; // == TableMeasure%s( value )\n}\n\n", st.Name)
+}
+
+func (g *tableGen) emitTableWriteField(f *ir.Field) {
+	id := ir.TableFieldId(f)
+	kind := tableScalarKind(f)
+	if f.Type.Kind == ir.TNamed {
+		g.noteRef(f.Type.Name)
+	}
+	switch {
+	case f.Type.Kind == ir.TString:
+		g.pf("    if ( value.%s_length > 0 )\n    {\n", f.Name)
+		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkString, f.Name)
+		g.pf("        w.put16( uint16_t( value.%s_length ) );\n", f.Name)
+		g.pf("        w.raw( value.%s, value.%s_length );\n    }\n", f.Name, f.Name)
+	case f.Type.Kind == ir.TBytes:
+		g.pf("    if ( value.%s_length > 0 )\n    {\n", f.Name)
+		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkArray, f.Name)
+		g.pf("        w.put32( uint32_t( 3 + value.%s_length ) );\n", f.Name)
+		g.pf("        w.put8( %d ); w.put16( uint16_t( value.%s_length ) );\n", tkU8, f.Name)
+		g.pf("        w.raw( value.%s, value.%s_length );\n    }\n", f.Name, f.Name)
+	case f.Array == ir.ArrayCounted:
+		g.pf("    if ( value.%s_count > 0 )\n    {\n", f.Name)
+		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkArray, f.Name)
+		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
+		g.pf("        w.put8( %d ); w.put16( uint16_t( value.%s_count ) );\n", kind, f.Name)
+		g.pf("        for ( int32_t i = 0; i < value.%s_count; i++ )\n        {\n", f.Name)
+		g.emitTableWriteElement(f, kind, fmt.Sprintf("value.%s[i]", f.Name), "            ")
+		g.pf("        }\n")
+		g.pf("        w.patch32( len_at_%s, uint32_t( w.offset - len_at_%s - 4 ) );\n    }\n", f.Name, f.Name)
+	case f.Array == ir.ArrayFixed && kind == tkTable:
+		// fixed arrays of tables always ride — no cheap element-default
+		// compare in C++ (an all-default element costs 6 bytes)
+		g.pf("    {\n")
+		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s (fixed [%d])\n", id, tkArray, f.Name, f.ArrayBound)
+		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
+		g.pf("        w.put8( %d ); w.put16( %d );\n", kind, f.ArrayBound)
+		g.pf("        for ( int32_t i = 0; i < %d; i++ )\n        {\n", f.ArrayBound)
+		g.emitTableWriteElement(f, kind, fmt.Sprintf("value.%s[i]", f.Name), "            ")
+		g.pf("        }\n")
+		g.pf("        w.patch32( len_at_%s, uint32_t( w.offset - len_at_%s - 4 ) );\n    }\n", f.Name, f.Name)
+	case f.Array == ir.ArrayFixed:
+		// fixed arrays are positional; an all-default array elides entirely
+		// (parity with the reader's prefill)
+		g.pf("    {\n")
+		g.pf("        bool all_default_%s = true;\n", f.Name)
+		g.pf("        for ( int32_t i = 0; i < %d; i++ ) { if ( value.%s[i] != %s ) { all_default_%s = false; break; } }\n",
+			f.ArrayBound, f.Name, g.fieldDefaultExpr(f), f.Name)
+		g.pf("        if ( !all_default_%s )\n        {\n", f.Name)
+		g.pf("            w.put16( 0x%04x ); w.put8( %d ); // %s (fixed [%d])\n", id, tkArray, f.Name, f.ArrayBound)
+		g.pf("            int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
+		g.pf("            w.put8( %d ); w.put16( %d );\n", kind, f.ArrayBound)
+		g.pf("            for ( int32_t i = 0; i < %d; i++ )\n            {\n", f.ArrayBound)
+		g.emitTableWriteElement(f, kind, fmt.Sprintf("value.%s[i]", f.Name), "                ")
+		g.pf("            }\n")
+		g.pf("            w.patch32( len_at_%s, uint32_t( w.offset - len_at_%s - 4 ) );\n        }\n    }\n", f.Name, f.Name)
+	case kind == tkUnion:
+		un := f.Type.Ref.(*ir.Union)
+		for _, v := range un.Variants {
+			g.noteRef(v.Type)
+		}
+		g.pf("    if ( value.%s.type != %sType::None )\n    {\n", f.Name, un.Name)
+		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkUnion, f.Name)
+		g.pf("        w.put8( (uint8_t) value.%s.type );\n", f.Name)
+		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
+		g.pf("        switch ( value.%s.type )\n        {\n", f.Name)
+		for _, v := range un.Variants {
+			g.pf("            case %sType::%s: if ( !TableWrite%s( w, value.%s.%s ) ) return false; break;\n",
+				un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
+		}
+		g.pf("            default: return false; // write validates the tag before it rides\n")
+		g.pf("        }\n")
+		g.pf("        w.patch32( len_at_%s, uint32_t( w.offset - len_at_%s - 4 ) );\n    }\n", f.Name, f.Name)
+	case kind == tkTable:
+		g.pf("    {\n")
+		g.pf("        int64_t field_at_%s = w.offset;\n", f.Name)
+		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkTable, f.Name)
+		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
+		g.pf("        if ( !TableWrite%s( w, value.%s ) ) return false;\n", f.Type.Name, f.Name)
+		g.pf("        int64_t body_%s = w.offset - len_at_%s - 4;\n", f.Name, f.Name)
+		g.pf("        if ( body_%s <= 2 ) { w.offset = field_at_%s; } // all-default nested elides\n", f.Name, f.Name)
+		g.pf("        else { w.patch32( len_at_%s, uint32_t( body_%s ) ); }\n    }\n", f.Name, f.Name)
+	default:
+		g.pf("    if ( value.%s != %s )\n    {\n", f.Name, g.fieldDefaultExpr(f))
+		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, kind, f.Name)
+		g.emitTableWriteElement(f, kind, "value."+f.Name, "        ")
+		g.pf("    }\n")
+	}
+}
+
+func (g *tableGen) emitTableWriteElement(f *ir.Field, kind int, expr, ind string) {
+	switch kind {
+	case tkBool:
+		g.pf("%sw.put8( %s ? 1 : 0 );\n", ind, expr)
+	case tkF32:
+		g.pf("%sw.put32( table_float_to_bits( %s ) );\n", ind, expr)
+	case tkF64:
+		g.pf("%sw.put64( table_double_to_bits( %s ) );\n", ind, expr)
+	case tkTable:
+		g.pf("%s{\n%s    int64_t elem_len_at = w.offset; w.put32( 0 );\n", ind, ind)
+		g.pf("%s    if ( !TableWrite%s( w, %s ) ) return false;\n", ind, f.Type.Name, expr)
+		g.pf("%s    w.patch32( elem_len_at, uint32_t( w.offset - elem_len_at - 4 ) );\n%s}\n", ind, ind)
+	default:
+		width := tableKindWidth(kind)
+		cast := fmt.Sprintf("uint%d_t", width*8)
+		g.pf("%sw.%s( %s( %s ) );\n", ind, tablePut(width), cast, expr)
+	}
+}
+
+// ---- read ----
+
+func (g *tableGen) emitTableRead(st *ir.Struct) {
+	g.pf("inline bool TableRead%s( TableReader & r, %s & value )\n{\n", st.Name, st.Name)
+	// placement new, NOT `value = T{}`: assignment materializes a temporary,
+	// and generated types can be large — a stack bomb on worker threads.
+	// In-place value-init applies the same NSDMI defaults with no temporary.
+	g.pf("    new ( &value ) %s{}; // prefill declared defaults in place, then overlay\n", st.Name)
+	g.pf("    for ( ;; )\n    {\n")
+	g.pf("        if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }\n")
+	g.pf("        uint16_t field_id = r.get16();\n")
+	g.pf("        if ( field_id == 0 ) return true;\n")
+	g.pf("        if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }\n")
+	g.pf("        uint8_t kind = r.get8();\n")
+	if len(st.Fields) > 0 {
+		g.pf("        switch ( field_id )\n        {\n")
+		for _, f := range st.Fields {
+			id := ir.TableFieldId(f)
+			kind := tableScalarKind(f)
+			wireKind := kind
+			if f.Array != ir.ArrayNone || f.Type.Kind == ir.TBytes {
+				wireKind = tkArray
+			}
+			if f.Type.Kind == ir.TBytes {
+				kind = tkU8 // bytes travel as an array of u8 elements
+			}
+			g.pf("            case 0x%04x: // %s\n            {\n", id, f.Name)
+			g.pf("                if ( kind != %d )\n                {\n", wireKind)
+			g.pf("                    r.report->kind_mismatch++;\n")
+			g.pf("                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }\n")
+			g.pf("                    break;\n                }\n")
+			g.emitTableReadField(f, kind)
+			g.pf("                break;\n            }\n")
+		}
+		g.pf("            default:\n            {\n")
+		g.pf("                r.report->unknown++;\n")
+		g.pf("                if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }\n")
+		g.pf("                break;\n            }\n")
+		g.pf("        }\n    }\n}\n\n")
+	} else {
+		g.pf("        r.report->unknown++;\n")
+		g.pf("        if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }\n")
+		g.pf("    }\n}\n\n")
+	}
+
+	// buffer-level convenience entry
+	g.pf("inline bool TableRead%s( const uint8_t * buffer, int64_t bytes, %s & value, TableReport & report )\n{\n", st.Name, st.Name)
+	g.pf("    TableReader r( buffer, bytes, &report );\n")
+	g.pf("    return TableRead%s( r, value );\n}\n\n", st.Name)
+}
+
+func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
+	ind := "                "
+	switch {
+	case f.Type.Kind == ir.TString:
+		g.pf("%sif ( !r.has( 2 ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint16_t len = r.get16();\n", ind)
+		g.pf("%sif ( !r.has( len ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint16_t keep = len;\n", ind)
+		g.pf("%sif ( keep > %d ) { keep = %d; r.report->clamped++; }\n", ind, f.Type.Size, f.Type.Size)
+		g.pf("%smemcpy( value.%s, r.buffer + r.offset, keep );\n", ind, f.Name)
+		g.pf("%svalue.%s[keep] = 0;\n", ind, f.Name)
+		g.pf("%svalue.%s_length = keep;\n", ind, f.Name)
+		g.pf("%sr.offset += len;\n", ind)
+	case f.Array != ir.ArrayNone || f.Type.Kind == ir.TBytes:
+		bound := f.ArrayBound
+		if f.Type.Kind == ir.TBytes {
+			bound = f.Type.Size
+		}
+		g.pf("%sif ( !r.has( 4 ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint32_t body_len = r.get32();\n", ind)
+		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%sint64_t body_end = r.offset + body_len;\n", ind)
+		g.pf("%sif ( body_len >= 3 )\n%s{\n", ind, ind)
+		g.pf("%s    uint8_t elem_kind = r.get8();\n", ind)
+		g.pf("%s    uint16_t count = r.get16();\n", ind)
+		g.pf("%s    if ( elem_kind != %d ) { r.report->kind_mismatch++; r.offset = body_end; break; }\n", ind, kind)
+		g.pf("%s    uint16_t keep = count;\n", ind)
+		g.pf("%s    if ( keep > %d ) { keep = %d; r.report->clamped++; }\n", ind, bound, bound)
+		g.pf("%s    for ( uint16_t i = 0; i < keep; i++ )\n%s    {\n", ind, ind)
+		g.emitTableReadElement(f, kind, ind+"        ")
+		g.pf("%s    }\n", ind)
+		if f.Type.Kind == ir.TBytes {
+			g.pf("%s    value.%s_length = keep;\n", ind, f.Name)
+		} else if f.Array == ir.ArrayCounted {
+			g.pf("%s    value.%s_count = keep;\n", ind, f.Name)
+		}
+		g.pf("%s}\n", ind)
+		g.pf("%sr.offset = body_end; // excess elements and slack skip via the length\n", ind)
+	case kind == tkUnion:
+		un := f.Type.Ref.(*ir.Union)
+		g.pf("%sif ( !r.has( 1 ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint8_t tag = r.get8();\n", ind)
+		g.pf("%sif ( tag == 0 ) { value.%s.type = %sType::None; break; } // None: the tag is the whole payload\n", ind, f.Name, un.Name)
+		g.pf("%sif ( !r.has( 4 ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint32_t body_len = r.get32();\n", ind)
+		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%sif ( tag > %d ) { r.report->kind_mismatch++; r.offset += body_len; break; } // above the declared count: skipped and counted, the value stays None\n", ind, len(un.Variants))
+		g.pf("%svalue.%s.type = %sType( tag );\n", ind, f.Name, un.Name)
+		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind, ind)
+		g.pf("%s    switch ( value.%s.type )\n%s    {\n", ind, f.Name, ind)
+		for _, v := range un.Variants {
+			g.pf("%s        case %sType::%s: TableRead%s( sub, value.%s.%s ); break;\n",
+				ind, un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
+		}
+		g.pf("%s        default: break; // unreachable: the tag was ranged above\n", ind)
+		g.pf("%s    }\n%s}\n", ind, ind)
+		g.pf("%sr.offset += body_len;\n", ind)
+	case kind == tkTable:
+		g.pf("%sif ( !r.has( 4 ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint32_t body_len = r.get32();\n", ind)
+		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind, ind)
+		g.pf("%s    TableRead%s( sub, value.%s );\n", ind, f.Type.Name, f.Name)
+		g.pf("%s}\n", ind)
+		g.pf("%sr.offset += body_len;\n", ind)
+	default:
+		g.emitTableReadScalarInto(f, kind, "value."+f.Name, ind)
+	}
+}
+
+func (g *tableGen) emitTableReadElement(f *ir.Field, kind int, ind string) {
+	switch kind {
+	case tkTable:
+		g.pf("%sif ( !r.has( 4 ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint32_t elem_len = r.get32();\n", ind)
+		g.pf("%sif ( !r.has( elem_len ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, elem_len, r.report );\n", ind, ind)
+		g.pf("%s    TableRead%s( sub, value.%s[i] );\n", ind, f.Type.Name, f.Name)
+		g.pf("%s}\n", ind)
+		g.pf("%sr.offset += elem_len;\n", ind)
+	default:
+		g.emitTableReadScalarInto(f, kind, fmt.Sprintf("value.%s[i]", f.Name), ind)
+	}
+}
+
+// emitTableReadScalarInto decodes one fixed-width scalar into a storage
+// lvalue, with range clamps where the schema declares them.
+func (g *tableGen) emitTableReadScalarInto(f *ir.Field, kind int, lvalue, ind string) {
+	width := tableKindWidth(kind)
+	g.pf("%sif ( !r.has( %d ) ) { r.report->malformed = true; return false; }\n", ind, width)
+	switch kind {
+	case tkBool:
+		g.pf("%s%s = r.get8() != 0;\n", ind, lvalue)
+	case tkF32:
+		if f.HasFloatRange {
+			g.pf("%sfloat decoded = table_bits_to_float( r.get32() );\n", ind)
+			g.pf("%sif ( decoded < %s ) { decoded = %s; r.report->clamped++; }\n", ind, formatFloat(f.FMin, true), formatFloat(f.FMin, true))
+			g.pf("%selse if ( decoded > %s ) { decoded = %s; r.report->clamped++; }\n", ind, formatFloat(f.FMax, true), formatFloat(f.FMax, true))
+			g.pf("%s%s = decoded;\n", ind, lvalue)
+			return
+		}
+		g.pf("%s%s = table_bits_to_float( r.get32() );\n", ind, lvalue)
+	case tkF64:
+		g.pf("%s%s = table_bits_to_double( r.get64() );\n", ind, lvalue)
+	default:
+		if enum, isEnum := f.Type.Ref.(*ir.Enum); f.Type.Kind == ir.TNamed && isEnum {
+			g.pf("%suint%d_t raw = r.%s( );\n", ind, width*8, tableGet(width))
+			g.pf("%sif ( raw > %d ) { raw = 0; r.report->clamped++; } // out-of-set -> None\n", ind, enum.Max)
+			g.pf("%s%s = %s( raw );\n", ind, lvalue, f.Type.Name)
+			return
+		}
+		signed := f.Type.Kind == ir.TInt && f.Type.Signed
+		storage := fmt.Sprintf("uint%d_t", width*8)
+		if signed {
+			storage = fmt.Sprintf("int%d_t", width*8)
+		}
+		g.pf("%s%s decoded = %s( r.%s( ) );\n", ind, storage, storage, tableGet(width))
+		if f.HasIntRange {
+			lo := tableIntLit(f.IntMin, signed, width)
+			hi := tableIntLit(f.IntMax, signed, width)
+			g.pf("%sif ( decoded < %s ) { decoded = %s; r.report->clamped++; }\n", ind, lo, lo)
+			g.pf("%selse if ( decoded > %s ) { decoded = %s; r.report->clamped++; }\n", ind, hi, hi)
+		}
+		if f.Type.Kind == ir.TBits && f.Type.Width < width*8 {
+			maxv := (uint64(1) << f.Type.Width) - 1
+			g.pf("%sif ( decoded > %dull ) { decoded = %dull; r.report->clamped++; } // bits(%d) width clamp\n", ind, maxv, maxv, f.Type.Width)
+		}
+		g.pf("%s%s = decoded;\n", ind, lvalue)
+	}
+}
+
+// ---- reflection descriptors ----
+
+// tableFieldTypeName renders a field's schema-facing type name for the
+// descriptor ("float32", "bits(9)", "Grade", "GunnerSettings").
+func tableFieldTypeName(f *ir.Field) string {
+	switch f.Type.Kind {
+	case ir.TBool:
+		return "bool"
+	case ir.TInt:
+		prefix := "int"
+		if !f.Type.Signed {
+			prefix = "uint"
+		}
+		return fmt.Sprintf("%s%d", prefix, f.Type.Width)
+	case ir.TBits:
+		return fmt.Sprintf("bits(%d)", f.Type.Width)
+	case ir.TFloat32:
+		return "float32"
+	case ir.TFloat64:
+		return "float64"
+	case ir.TString:
+		return "string"
+	case ir.TBytes:
+		return "bytes"
+	case ir.TNamed:
+		return f.Type.Name
+	}
+	return "?"
+}
+
+// bigToDouble renders a big.Int as a C++ double literal for the descriptor's
+// range fields (precision past 2^53 is documented as lost).
+func bigToDouble(v *big.Int) string {
+	f, _ := new(big.Float).SetInt(v).Float64()
+	return formatFloat(f, false)
+}
+
+// emitTableDescriptor emits TableType<X>() — the reflection descriptor: a
+// function-local static (one instance per process, ODR-safe in inline
+// functions), built once on first use.
+func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
+	guards := tableGuardStrings(st)
+	g.pf("inline const TableTypeInfo * TableType%s()\n{\n", st.Name)
+	if len(st.Fields) > 0 {
+		g.pf("    static const TableFieldInfo fields[] = {\n")
+		for _, f := range st.Fields {
+			id := ir.TableFieldId(f)
+			kind := tableScalarKind(f)
+			if f.Type.Kind == ir.TBytes {
+				kind = tkU8
+			}
+			isArray := f.Array != ir.ArrayNone || f.Type.Kind == ir.TBytes
+			counted := f.Array == ir.ArrayCounted || f.Type.Kind == ir.TBytes || f.Type.Kind == ir.TString
+
+			bound := int64(0)
+			switch {
+			case f.Array != ir.ArrayNone:
+				bound = f.ArrayBound
+			case f.Type.Kind == ir.TBytes, f.Type.Kind == ir.TString:
+				bound = f.Type.Size
+			}
+
+			elemSize := fmt.Sprintf("(uint32_t) sizeof( %s{}.%s )", st.Name, f.Name)
+			if isArray {
+				elemSize = fmt.Sprintf("(uint32_t) sizeof( %s{}.%s[0] )", st.Name, f.Name)
+			}
+
+			countOffset := "0xffffffffu"
+			if counted {
+				companion := f.Name + "_count"
+				if f.Type.Kind == ir.TBytes || f.Type.Kind == ir.TString {
+					companion = f.Name + "_length"
+				}
+				countOffset = fmt.Sprintf("(uint32_t) offsetof( %s, %s )", st.Name, companion)
+			}
+
+			table := "NULL"
+			if _, isStruct := f.Type.Ref.(*ir.Struct); f.Type.Kind == ir.TNamed && isStruct {
+				table = fmt.Sprintf("TableType%s()", f.Type.Name)
+				g.noteRef(f.Type.Name)
+			}
+
+			hasRange := "false"
+			rangeMin, rangeMax := "0.0", "0.0"
+			if f.HasIntRange {
+				hasRange = "true"
+				rangeMin, rangeMax = bigToDouble(f.IntMin), bigToDouble(f.IntMax)
+			} else if f.HasFloatRange {
+				hasRange = "true"
+				rangeMin, rangeMax = formatFloat(f.FMin, false), formatFloat(f.FMax, false)
+			}
+
+			enumMax := "-1"
+			enumName := "NULL"
+			if enum, isEnum := f.Type.Ref.(*ir.Enum); f.Type.Kind == ir.TNamed && isEnum {
+				enumMax = fmt.Sprintf("%d", enum.Max)
+				enumName = fmt.Sprintf("+[]( uint64_t v ) { return EnumName( %s( v ) ); }", f.Type.Name)
+			}
+
+			g.pf("        { \"%s\", \"%s\", 0x%04x, %d, %v, %v, %d, (uint32_t) offsetof( %s, %s ), %s, %s, %s, %s, %s, %s, %s, %s, \"%s\" },\n",
+				f.Name, tableFieldTypeName(f), id, kind, isArray, counted, bound,
+				st.Name, f.Name, elemSize, countOffset, table,
+				hasRange, rangeMin, rangeMax, enumMax, enumName, guards[f.Name])
+		}
+		g.pf("    };\n")
+		g.pf("    static const TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), %d, fields };\n",
+			st.Name, st.Name, len(st.Fields))
+	} else {
+		g.pf("    static const TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL };\n",
+			st.Name, st.Name)
+	}
+	g.pf("    return &info;\n}\n\n")
+}

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -208,7 +208,10 @@ func guardWalk(st *ir.Struct, prefix string) map[string]string {
 // is length-prefixed, so a caller can measure subtables in parallel,
 // prefix-sum offsets, and scatter-write disjoint ranges from N workers.
 // Mirrors TableWrite's elision decisions branch for branch: for any value,
-// TableSave writes exactly this many bytes.
+// TableSave writes exactly this many bytes into a buffer of exactly this
+// size. A value violating its storage invariants (a count or length outside
+// its bound, an out-of-range union tag) measures as -1, exactly as the
+// write side refuses it.
 func (g *tableGen) emitTableMeasure(st *ir.Struct) {
 	g.pf("inline int64_t TableMeasure%s( const %s & value )\n{\n", st.Name, st.Name)
 	if len(st.Fields) == 0 {
@@ -235,22 +238,30 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 	width := tableKindWidth(kind)
 	switch {
 	case f.Type.Kind == ir.TString:
+		g.pf("    if ( value.%s_length < 0 || value.%s_length > %d ) { return -1; } // storage invariant\n", f.Name, f.Name, f.Type.Size)
 		g.pf("    if ( value.%s_length > 0 ) { bytes += 3 + 2 + value.%s_length; } // %s\n", f.Name, f.Name, f.Name)
 	case f.Type.Kind == ir.TBytes:
+		g.pf("    if ( value.%s_length < 0 || value.%s_length > %d ) { return -1; } // storage invariant\n", f.Name, f.Name, f.Type.Size)
 		g.pf("    if ( value.%s_length > 0 ) { bytes += 3 + 4 + 3 + value.%s_length; } // %s\n", f.Name, f.Name, f.Name)
 	case f.Array == ir.ArrayCounted && kind == tkTable:
+		g.pf("    if ( value.%s_count < 0 || value.%s_count > %d ) { return -1; } // storage invariant\n", f.Name, f.Name, f.ArrayBound)
 		g.pf("    if ( value.%s_count > 0 )\n    {\n", f.Name)
 		g.pf("        bytes += 3 + 4 + 3; // %s\n", f.Name)
 		g.pf("        for ( int32_t i = 0; i < value.%s_count; i++ )\n        {\n", f.Name)
-		g.pf("            bytes += 4 + TableMeasure%s( value.%s[i] );\n", f.Type.Name, f.Name)
+		g.pf("            int64_t elem_%s = TableMeasure%s( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
+		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
 	case f.Array == ir.ArrayCounted:
+		g.pf("    if ( value.%s_count < 0 || value.%s_count > %d ) { return -1; } // storage invariant\n", f.Name, f.Name, f.ArrayBound)
 		g.pf("    if ( value.%s_count > 0 ) { bytes += 3 + 4 + 3 + int64_t( value.%s_count ) * %d; } // %s\n", f.Name, f.Name, width, f.Name)
 	case f.Array == ir.ArrayFixed && kind == tkTable:
 		g.pf("    {\n")
 		g.pf("        bytes += 3 + 4 + 3; // %s (fixed [%d])\n", f.Name, f.ArrayBound)
 		g.pf("        for ( int32_t i = 0; i < %d; i++ )\n        {\n", f.ArrayBound)
-		g.pf("            bytes += 4 + TableMeasure%s( value.%s[i] );\n", f.Type.Name, f.Name)
+		g.pf("            int64_t elem_%s = TableMeasure%s( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
+		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
 	case f.Array == ir.ArrayFixed:
 		g.pf("    {\n")
@@ -264,14 +275,17 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    switch ( value.%s.type ) // %s\n    {\n", f.Name, f.Name)
 		g.pf("        case %sType::None: break; // None elides — TLV absence is the None\n", un.Name)
 		for _, v := range un.Variants {
-			g.pf("        case %sType::%s: bytes += 3 + 1 + 4 + TableMeasure%s( value.%s.%s ); break;\n",
-				un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
+			g.pf("        case %sType::%s:\n        {\n", un.Name, ir.GoExportName(v.Name))
+			g.pf("            int64_t arm_%s = TableMeasure%s( value.%s.%s );\n", f.Name, v.Type, f.Name, v.Name)
+			g.pf("            if ( arm_%s < 0 ) { return -1; }\n", f.Name)
+			g.pf("            bytes += 3 + 1 + 4 + arm_%s;\n            break;\n        }\n", f.Name)
 		}
-		g.pf("        default: break; // invalid tag: TableWrite refuses it before this measure could disagree\n")
+		g.pf("        default: return -1; // invalid tag — the write side refuses it too\n")
 		g.pf("    }\n")
 	case kind == tkTable:
 		g.pf("    {\n")
 		g.pf("        int64_t body_%s = TableMeasure%s( value.%s );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("        if ( body_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("        if ( body_%s > 2 ) { bytes += 3 + 4 + body_%s; } // %s: all-default nested elides\n", f.Name, f.Name, f.Name)
 		g.pf("    }\n")
 	default:
@@ -321,17 +335,20 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 	}
 	switch {
 	case f.Type.Kind == ir.TString:
+		g.pf("    if ( value.%s_length < 0 || value.%s_length > %d ) { return false; } // storage invariant\n", f.Name, f.Name, f.Type.Size)
 		g.pf("    if ( value.%s_length > 0 )\n    {\n", f.Name)
 		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkString, f.Name)
 		g.pf("        w.put16( uint16_t( value.%s_length ) );\n", f.Name)
 		g.pf("        w.raw( value.%s, value.%s_length );\n    }\n", f.Name, f.Name)
 	case f.Type.Kind == ir.TBytes:
+		g.pf("    if ( value.%s_length < 0 || value.%s_length > %d ) { return false; } // storage invariant\n", f.Name, f.Name, f.Type.Size)
 		g.pf("    if ( value.%s_length > 0 )\n    {\n", f.Name)
 		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkArray, f.Name)
 		g.pf("        w.put32( uint32_t( 3 + value.%s_length ) );\n", f.Name)
 		g.pf("        w.put8( %d ); w.put16( uint16_t( value.%s_length ) );\n", tkU8, f.Name)
 		g.pf("        w.raw( value.%s, value.%s_length );\n    }\n", f.Name, f.Name)
 	case f.Array == ir.ArrayCounted:
+		g.pf("    if ( value.%s_count < 0 || value.%s_count > %d ) { return false; } // storage invariant\n", f.Name, f.Name, f.ArrayBound)
 		g.pf("    if ( value.%s_count > 0 )\n    {\n", f.Name)
 		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkArray, f.Name)
 		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
@@ -384,14 +401,18 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		g.pf("        }\n")
 		g.pf("        w.patch32( len_at_%s, uint32_t( w.offset - len_at_%s - 4 ) );\n    }\n", f.Name, f.Name)
 	case kind == tkTable:
+		// elision is decided BEFORE any byte is emitted: measuring first
+		// keeps an all-default nested field from touching the buffer at all,
+		// so saving into a buffer of exactly TableMeasure's size never
+		// trips overflow on transient header bytes
 		g.pf("    {\n")
-		g.pf("        int64_t field_at_%s = w.offset;\n", f.Name)
-		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkTable, f.Name)
-		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
-		g.pf("        if ( !TableWrite%s( w, value.%s ) ) return false;\n", f.Type.Name, f.Name)
-		g.pf("        int64_t body_%s = w.offset - len_at_%s - 4;\n", f.Name, f.Name)
-		g.pf("        if ( body_%s <= 2 ) { w.offset = field_at_%s; } // all-default nested elides\n", f.Name, f.Name)
-		g.pf("        else { w.patch32( len_at_%s, uint32_t( body_%s ) ); }\n    }\n", f.Name, f.Name)
+		g.pf("        int64_t body_%s = TableMeasure%s( value.%s );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("        if ( body_%s < 0 ) return false; // storage invariant, refused as measure refuses it\n", f.Name)
+		g.pf("        if ( body_%s > 2 ) // all-default nested elides\n        {\n", f.Name)
+		g.pf("            w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkTable, f.Name)
+		g.pf("            w.put32( uint32_t( body_%s ) );\n", f.Name)
+		g.pf("            if ( !TableWrite%s( w, value.%s ) ) return false;\n", f.Type.Name, f.Name)
+		g.pf("        }\n    }\n")
 	default:
 		g.pf("    if ( value.%s != %s )\n    {\n", f.Name, g.fieldDefaultExpr(f))
 		g.pf("        w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, kind, f.Name)
@@ -488,6 +509,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		if f.Type.Kind == ir.TBytes {
 			bound = f.Type.Size
 		}
+		counted := f.Type.Kind == ir.TBytes || f.Array == ir.ArrayCounted
 		g.pf("%sif ( !r.has( 4 ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%suint32_t body_len = r.get32();\n", ind)
 		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
@@ -498,13 +520,24 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%s    if ( elem_kind != %d ) { r.report->kind_mismatch++; r.offset = body_end; break; }\n", ind, kind)
 		g.pf("%s    uint16_t keep = count;\n", ind)
 		g.pf("%s    if ( keep > %d ) { keep = %d; r.report->clamped++; }\n", ind, bound, bound)
+		g.pf("%s    // elements are BOUNDED by the field body: a count the length\n", ind)
+		g.pf("%s    // cannot cover keeps the decoded prefix, flags malformed, and\n", ind)
+		g.pf("%s    // the parent continues at the next field — following fields'\n", ind)
+		g.pf("%s    // bytes are never fabricated into elements\n", ind)
+		g.pf("%s    TableReader sub( r.buffer + r.offset, body_end - r.offset, r.report );\n", ind)
+		if counted {
+			g.pf("%s    uint16_t decoded = 0;\n", ind)
+		}
 		g.pf("%s    for ( uint16_t i = 0; i < keep; i++ )\n%s    {\n", ind, ind)
 		g.emitTableReadElement(f, kind, ind+"        ")
+		if counted {
+			g.pf("%s        decoded = uint16_t( i + 1 );\n", ind)
+		}
 		g.pf("%s    }\n", ind)
 		if f.Type.Kind == ir.TBytes {
-			g.pf("%s    value.%s_length = keep;\n", ind, f.Name)
+			g.pf("%s    value.%s_length = decoded;\n", ind, f.Name)
 		} else if f.Array == ir.ArrayCounted {
-			g.pf("%s    value.%s_count = keep;\n", ind, f.Name)
+			g.pf("%s    value.%s_count = decoded;\n", ind, f.Name)
 		}
 		g.pf("%s}\n", ind)
 		g.pf("%sr.offset = body_end; // excess elements and slack skip via the length\n", ind)
@@ -536,47 +569,54 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%s}\n", ind)
 		g.pf("%sr.offset += body_len;\n", ind)
 	default:
-		g.emitTableReadScalarInto(f, kind, "value."+f.Name, ind)
+		g.emitTableReadScalarFrom(f, kind, "value."+f.Name, ind,
+			"r", "r.report->malformed = true; return false;")
 	}
 }
 
+// emitTableReadElement decodes one array element from the field-body
+// sub-reader; truncation keeps the decoded prefix and flags malformed
+// without stopping the parent decode.
 func (g *tableGen) emitTableReadElement(f *ir.Field, kind int, ind string) {
 	switch kind {
 	case tkTable:
-		g.pf("%sif ( !r.has( 4 ) ) { r.report->malformed = true; return false; }\n", ind)
-		g.pf("%suint32_t elem_len = r.get32();\n", ind)
-		g.pf("%sif ( !r.has( elem_len ) ) { r.report->malformed = true; return false; }\n", ind)
-		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, elem_len, r.report );\n", ind, ind)
-		g.pf("%s    TableRead%s( sub, value.%s[i] );\n", ind, f.Type.Name, f.Name)
+		g.pf("%sif ( !sub.has( 4 ) ) { r.report->malformed = true; break; }\n", ind)
+		g.pf("%suint32_t elem_len = sub.get32();\n", ind)
+		g.pf("%sif ( !sub.has( elem_len ) ) { r.report->malformed = true; break; }\n", ind)
+		g.pf("%s{\n%s    TableReader elem( sub.buffer + sub.offset, elem_len, r.report );\n", ind, ind)
+		g.pf("%s    TableRead%s( elem, value.%s[i] );\n", ind, f.Type.Name, f.Name)
 		g.pf("%s}\n", ind)
-		g.pf("%sr.offset += elem_len;\n", ind)
+		g.pf("%ssub.offset += elem_len;\n", ind)
 	default:
-		g.emitTableReadScalarInto(f, kind, fmt.Sprintf("value.%s[i]", f.Name), ind)
+		g.emitTableReadScalarFrom(f, kind, fmt.Sprintf("value.%s[i]", f.Name), ind,
+			"sub", "r.report->malformed = true; break;")
 	}
 }
 
-// emitTableReadScalarInto decodes one fixed-width scalar into a storage
-// lvalue, with range clamps where the schema declares them.
-func (g *tableGen) emitTableReadScalarInto(f *ir.Field, kind int, lvalue, ind string) {
+// emitTableReadScalarFrom decodes one fixed-width scalar from the named
+// reader into a storage lvalue, with range clamps where the schema declares
+// them. onTrunc is the truncation action: a scalar FIELD stops the decode
+// (outer framing damage), an array ELEMENT keeps the prefix and breaks.
+func (g *tableGen) emitTableReadScalarFrom(f *ir.Field, kind int, lvalue, ind, rdr, onTrunc string) {
 	width := tableKindWidth(kind)
-	g.pf("%sif ( !r.has( %d ) ) { r.report->malformed = true; return false; }\n", ind, width)
+	g.pf("%sif ( !%s.has( %d ) ) { %s }\n", ind, rdr, width, onTrunc)
 	switch kind {
 	case tkBool:
-		g.pf("%s%s = r.get8() != 0;\n", ind, lvalue)
+		g.pf("%s%s = %s.get8() != 0;\n", ind, lvalue, rdr)
 	case tkF32:
 		if f.HasFloatRange {
-			g.pf("%sfloat decoded = table_bits_to_float( r.get32() );\n", ind)
-			g.pf("%sif ( decoded < %s ) { decoded = %s; r.report->clamped++; }\n", ind, formatFloat(f.FMin, true), formatFloat(f.FMin, true))
-			g.pf("%selse if ( decoded > %s ) { decoded = %s; r.report->clamped++; }\n", ind, formatFloat(f.FMax, true), formatFloat(f.FMax, true))
-			g.pf("%s%s = decoded;\n", ind, lvalue)
+			g.pf("%sfloat decoded_f = table_bits_to_float( %s.get32() );\n", ind, rdr)
+			g.pf("%sif ( decoded_f < %s ) { decoded_f = %s; r.report->clamped++; }\n", ind, formatFloat(f.FMin, true), formatFloat(f.FMin, true))
+			g.pf("%selse if ( decoded_f > %s ) { decoded_f = %s; r.report->clamped++; }\n", ind, formatFloat(f.FMax, true), formatFloat(f.FMax, true))
+			g.pf("%s%s = decoded_f;\n", ind, lvalue)
 			return
 		}
-		g.pf("%s%s = table_bits_to_float( r.get32() );\n", ind, lvalue)
+		g.pf("%s%s = table_bits_to_float( %s.get32() );\n", ind, lvalue, rdr)
 	case tkF64:
-		g.pf("%s%s = table_bits_to_double( r.get64() );\n", ind, lvalue)
+		g.pf("%s%s = table_bits_to_double( %s.get64() );\n", ind, lvalue, rdr)
 	default:
 		if enum, isEnum := f.Type.Ref.(*ir.Enum); f.Type.Kind == ir.TNamed && isEnum {
-			g.pf("%suint%d_t raw = r.%s( );\n", ind, width*8, tableGet(width))
+			g.pf("%suint%d_t raw = %s.%s( );\n", ind, width*8, rdr, tableGet(width))
 			g.pf("%sif ( raw > %d ) { raw = 0; r.report->clamped++; } // out-of-set -> None\n", ind, enum.Max)
 			g.pf("%s%s = %s( raw );\n", ind, lvalue, f.Type.Name)
 			return
@@ -586,18 +626,18 @@ func (g *tableGen) emitTableReadScalarInto(f *ir.Field, kind int, lvalue, ind st
 		if signed {
 			storage = fmt.Sprintf("int%d_t", width*8)
 		}
-		g.pf("%s%s decoded = %s( r.%s( ) );\n", ind, storage, storage, tableGet(width))
+		g.pf("%s%s decoded_v = %s( %s.%s( ) );\n", ind, storage, storage, rdr, tableGet(width))
 		if f.HasIntRange {
 			lo := tableIntLit(f.IntMin, signed, width)
 			hi := tableIntLit(f.IntMax, signed, width)
-			g.pf("%sif ( decoded < %s ) { decoded = %s; r.report->clamped++; }\n", ind, lo, lo)
-			g.pf("%selse if ( decoded > %s ) { decoded = %s; r.report->clamped++; }\n", ind, hi, hi)
+			g.pf("%sif ( decoded_v < %s ) { decoded_v = %s; r.report->clamped++; }\n", ind, lo, lo)
+			g.pf("%selse if ( decoded_v > %s ) { decoded_v = %s; r.report->clamped++; }\n", ind, hi, hi)
 		}
 		if f.Type.Kind == ir.TBits && f.Type.Width < width*8 {
 			maxv := (uint64(1) << f.Type.Width) - 1
-			g.pf("%sif ( decoded > %dull ) { decoded = %dull; r.report->clamped++; } // bits(%d) width clamp\n", ind, maxv, maxv, f.Type.Width)
+			g.pf("%sif ( decoded_v > %dull ) { decoded_v = %dull; r.report->clamped++; } // bits(%d) width clamp\n", ind, maxv, maxv, f.Type.Width)
 		}
-		g.pf("%s%s = decoded;\n", ind, lvalue)
+		g.pf("%s%s = decoded_v;\n", ind, lvalue)
 	}
 }
 

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -1,0 +1,550 @@
+// Package cpptable emits <Base>Table.h — the TABLE-wire C++ codecs
+// (SPEC-TABLES.md). One header per unit file, emitted only when the unit
+// declares tables: storage structs for the `table` declarations, then
+// measure/write/save/read codecs and reflection descriptors for the whole
+// TABLE CLOSURE (every table plus everything one references, transitively).
+//
+// The wire is neutral, evolution-tolerant TLV: field identity is the name
+// hash, unknown fields skip, absent fields default, changed kinds skip
+// (never misdecode), out-of-range values clamp, framing damage stops the
+// decode with a partial result — and every event lands in the TableReport.
+// Plain byte code with NO serialize dependency, so a Table header is
+// includable from any translation unit; the encode surface is a
+// measure/save split, so a caller can measure nested tables in parallel,
+// prefix-sum offsets, and scatter-write disjoint ranges from N workers.
+// Generated codecs allocate nothing: the caller owns every buffer.
+package cpptable
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// table-wire kinds (SPEC-TABLES.md) — the whole vocabulary of the neutral
+// wire: plain little-endian scalars, length-prefixed strings/bytes/tables.
+const (
+	tkBool   = 1
+	tkI8     = 2
+	tkI16    = 3
+	tkI32    = 4
+	tkI64    = 5
+	tkU8     = 6
+	tkU16    = 7
+	tkU32    = 8
+	tkU64    = 9
+	tkF32    = 10
+	tkF64    = 11
+	tkString = 12
+	tkTable  = 13
+	tkArray  = 14
+	tkUnion  = 15
+)
+
+func tableScalarKind(f *ir.Field) int {
+	switch f.Type.Kind {
+	case ir.TBool:
+		return tkBool
+	case ir.TInt:
+		if f.Type.Signed {
+			switch f.Type.Width {
+			case 8:
+				return tkI8
+			case 16:
+				return tkI16
+			case 32:
+				return tkI32
+			default:
+				return tkI64
+			}
+		}
+		switch f.Type.Width {
+		case 8:
+			return tkU8
+		case 16:
+			return tkU16
+		case 32:
+			return tkU32
+		default:
+			return tkU64
+		}
+	case ir.TBits:
+		switch {
+		case f.Type.Width <= 8:
+			return tkU8
+		case f.Type.Width <= 16:
+			return tkU16
+		case f.Type.Width <= 32:
+			return tkU32
+		default:
+			return tkU64
+		}
+	case ir.TFloat32:
+		return tkF32
+	case ir.TFloat64:
+		return tkF64
+	case ir.TString:
+		return tkString
+	case ir.TBytes:
+		return tkArray
+	case ir.TNamed:
+		switch ref := f.Type.Ref.(type) {
+		case *ir.Enum:
+			switch ref.StorageBits {
+			case 8:
+				return tkU8
+			case 16:
+				return tkU16
+			case 32:
+				return tkU32
+			default:
+				return tkU64
+			}
+		case *ir.Flags:
+			return tkU64
+		case *ir.Struct:
+			return tkTable
+		case *ir.Union:
+			return tkUnion
+		}
+	}
+	return 0
+}
+
+func tableKindWidth(kind int) int {
+	switch kind {
+	case tkBool, tkI8, tkU8:
+		return 1
+	case tkI16, tkU16:
+		return 2
+	case tkI32, tkU32, tkF32:
+		return 4
+	case tkI64, tkU64, tkF64:
+		return 8
+	}
+	return 0
+}
+
+func tablePut(width int) string { return fmt.Sprintf("put%d", width*8) }
+func tableGet(width int) string { return fmt.Sprintf("get%d", width*8) }
+
+type tableGen struct {
+	unit           *ir.Unit
+	file           *ir.File
+	body           strings.Builder
+	includes       map[string]bool // referenced files -> #include "<base>Table.h"
+	nativeIncludes map[string]bool // cpp_include headers of mapped types
+	indent         string          // extra per-line indent while emitting inside a branch guard
+}
+
+func (g *tableGen) pf(format string, args ...any) {
+	s := fmt.Sprintf(format, args...)
+	if g.indent != "" && s != "" {
+		trailing := strings.HasSuffix(s, "\n")
+		if trailing {
+			s = s[:len(s)-1]
+		}
+		s = g.indent + strings.ReplaceAll(s, "\n", "\n"+g.indent)
+		if trailing {
+			s += "\n"
+		}
+	}
+	g.body.WriteString(s)
+}
+
+func (g *tableGen) noteRef(name string) {
+	if base, ok := g.unit.DeclFile[name]; ok && base != g.file.Base {
+		g.includes[base] = true
+	}
+}
+
+// formatFloat renders a float literal; single-precision literals format at
+// FLOAT32 precision, so the emitted clamp bounds and defaults are exactly the
+// values the runtime compares against.
+func formatFloat(v float64, single bool) string {
+	bitSize := 64
+	if single {
+		bitSize = 32
+	}
+	s := strconv.FormatFloat(v, 'g', -1, bitSize)
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	if single {
+		s += "f"
+	}
+	return s
+}
+
+// tablePrimitives is the shared runtime, emitted into every Table.h behind a
+// per-package guard — one definition per TU whatever the include order, and a
+// lone Table.h works standalone.
+func tablePrimitives(pkg string) string {
+	guard := strings.ToUpper(pkg) + "_SCHEMA_TABLE_PRIMITIVES"
+	return `#ifndef ` + guard + `
+#define ` + guard + `
+
+namespace ` + pkg + ` {
+
+// The table-wire read report — the permissive contract's ledger. Silence
+// (all zero) means the data matched this reader's schema exactly.
+struct TableReport
+{
+    int32_t unknown = 0;       // unknown field ids skipped (newer data)
+    int32_t kind_mismatch = 0; // known id, changed type — skipped, never misdecoded
+    int32_t clamped = 0;       // out-of-range values clamped to declared bounds
+    bool malformed = false;    // framing damage; decode stopped, partial result kept
+};
+
+// ---- reflection (tables only, SPEC-TABLES.md) ----
+//
+// Static field descriptors for every type in the table closure: name, wire
+// id/kind, storage offset, bounds, ranges, enum names and branch guards —
+// enough to walk, print, diff, edit or bind any table value at runtime with
+// no RTTI and no schema files. TableType<X>() returns X's descriptor.
+
+struct TableTypeInfo;
+
+struct TableFieldInfo
+{
+    const char * name;      // schema field name, e.g. "health"
+    const char * type_name; // schema type name, e.g. "float32", "Grade"
+    uint16_t id;            // table-wire field id (name hash; the was alias's hash after a rename)
+    uint8_t kind;           // table-wire kind; for arrays/strings/bytes, the ELEMENT kind
+    bool is_array;          // fixed or counted array (bytes included)
+    bool counted;           // a _count/_length int32 companion exists (counted arrays, strings, bytes)
+    int32_t array_bound;    // array capacity / string max length; 0 for plain scalars
+    uint32_t offset;        // offsetof the storage member
+    uint32_t elem_size;     // sizeof the member (element size for arrays)
+    uint32_t count_offset;  // offsetof the _count/_length companion, or 0xffffffff
+    const TableTypeInfo * table; // nested table's descriptor, or NULL
+    bool has_range;         // a declared [min, max] (int or float)
+    double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
+    double range_max;
+    int64_t enum_max;       // enums: highest valid value (None = 0 always valid); else -1
+    const char * (*enum_name)( uint64_t value ); // enums: value -> name; else NULL
+    const char * guard;     // branch guard, e.g. "at_rest" or "!at_rest"; "" if unguarded
+};
+
+struct TableTypeInfo
+{
+    const char * name;   // schema type name
+    uint32_t size;       // sizeof the storage struct
+    int32_t num_fields;
+    const TableFieldInfo * fields;
+};
+
+struct TableWriter
+{
+    uint8_t * buffer;
+    int64_t capacity;
+    int64_t offset = 0;
+    bool overflow = false;
+
+    TableWriter( uint8_t * buffer, int64_t capacity ) : buffer( buffer ), capacity( capacity ) {}
+
+    void raw( const void * data, int64_t bytes )
+    {
+        if ( offset + bytes > capacity ) { overflow = true; return; }
+        memcpy( buffer + offset, data, (size_t) bytes );
+        offset += bytes;
+    }
+    void put8( uint8_t v )   { raw( &v, 1 ); }
+    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    void patch32( int64_t at, uint32_t v )
+    {
+        if ( at + 4 > capacity ) { overflow = true; return; }
+        buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
+        buffer[at+2] = uint8_t( v >> 16 ); buffer[at+3] = uint8_t( v >> 24 );
+    }
+};
+
+struct TableReader
+{
+    const uint8_t * buffer;
+    int64_t size;
+    int64_t offset = 0;
+    TableReport * report;
+
+    TableReader( const uint8_t * buffer, int64_t size, TableReport * report )
+        : buffer( buffer ), size( size ), report( report ) {}
+
+    bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    uint8_t get8()   { return buffer[offset++]; }
+    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+
+    // skip one payload by kind; false = framing damage
+    bool skip( uint8_t kind )
+    {
+        switch ( kind )
+        {
+            case 1: case 2: case 6: return has( 1 ) ? ( offset += 1, true ) : false;
+            case 3: case 7:         return has( 2 ) ? ( offset += 2, true ) : false;
+            case 4: case 8: case 10: return has( 4 ) ? ( offset += 4, true ) : false;
+            case 5: case 9: case 11: return has( 8 ) ? ( offset += 8, true ) : false;
+            case 12:
+            {
+                if ( !has( 2 ) ) return false;
+                uint16_t n = get16();
+                return has( n ) ? ( offset += n, true ) : false;
+            }
+            case 13: case 14:
+            {
+                if ( !has( 4 ) ) return false;
+                uint32_t n = get32();
+                return has( n ) ? ( offset += n, true ) : false;
+            }
+            case 15: // union: u8 tag, then the selected arm length-prefixed (tag 0 = None, no body)
+            {
+                if ( !has( 1 ) ) return false;
+                if ( get8() == 0 ) return true;
+                if ( !has( 4 ) ) return false;
+                uint32_t n = get32();
+                return has( n ) ? ( offset += n, true ) : false;
+            }
+        }
+        return false;
+    }
+};
+
+inline float table_bits_to_float( uint32_t bits ) { float f; memcpy( &f, &bits, 4 ); return f; }
+inline uint32_t table_float_to_bits( float f ) { uint32_t b; memcpy( &b, &f, 4 ); return b; }
+inline double table_bits_to_double( uint64_t bits ) { double d; memcpy( &d, &bits, 8 ); return d; }
+inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8 ); return b; }
+
+} // namespace ` + pkg + `
+
+#endif // ` + guard + `
+`
+}
+
+// Generate emits <Base>Table.h for every unit file when the unit declares
+// tables, and nothing when it does not — a table-free unit's generated tree
+// is byte-identical with or without this package.
+func Generate(u *ir.Unit) (map[string][]byte, error) {
+	if len(u.Tables) == 0 {
+		return map[string][]byte{}, nil
+	}
+	if err := checkIncludeCycle(u); err != nil {
+		return nil, err
+	}
+	closure := ir.TableClosure(u)
+	out := map[string][]byte{}
+	for _, f := range u.Files {
+		g := &tableGen{unit: u, file: f, includes: map[string]bool{}, nativeIncludes: map[string]bool{}}
+		var members []*ir.Struct
+		members = append(members, orderTables(f.Tables)...)
+		for _, d := range f.Decls {
+			if st, ok := d.(*ir.Struct); ok && closure[st.Name] {
+				members = append(members, st)
+			}
+		}
+		if len(members) > 0 {
+			for _, st := range members {
+				if st.IsTable {
+					g.emitTableStruct(st)
+				}
+			}
+			g.pf("// ---- codecs: measure/write/save/read per closure member ----\n\n")
+			for _, st := range members {
+				g.pf("inline int64_t TableMeasure%s( const %s & value );\n", st.Name, st.Name)
+				g.pf("inline bool TableWrite%s( TableWriter & w, const %s & value );\n", st.Name, st.Name)
+				g.pf("inline bool TableRead%s( TableReader & r, %s & value );\n", st.Name, st.Name)
+			}
+			g.pf("\n")
+			for _, st := range members {
+				g.emitTableMeasure(st)
+				g.emitTableWrite(st)
+				g.emitTableSave(st)
+				g.emitTableRead(st)
+			}
+			g.pf("// ---- relocatability, enforced: the wire is a pure length-prefixed\n")
+			g.pf("// stream AND the decoded storage is pointer-free — every closure type\n")
+			g.pf("// must stay trivially copyable and standard-layout, so instances can be\n")
+			g.pf("// memcpy'd, mmap'd, shared across processes, and walked through\n")
+			g.pf("// descriptor offsets. A failure here means a pointer, virtual or\n")
+			g.pf("// non-trivial member crept into generated storage.\n")
+			for _, st := range members {
+				g.pf("static_assert( std::is_trivially_copyable<%s>::value, \"%s must stay relocatable\" );\n", st.Name, st.Name)
+				g.pf("static_assert( std::is_standard_layout<%s>::value, \"%s must stay standard-layout for offsetof\" );\n", st.Name, st.Name)
+			}
+			g.pf("\n")
+			g.pf("// ---- reflection descriptors (tables only, SPEC-TABLES.md) ----\n\n")
+			for _, st := range members {
+				g.pf("inline const TableTypeInfo * TableType%s();\n", st.Name)
+			}
+			g.pf("\n")
+			for _, st := range members {
+				g.emitTableDescriptor(st)
+			}
+		} else {
+			g.pf("// no tables declared or referenced in this file — codecs are emitted\n")
+			g.pf("// for the table closure only (`table` declarations and what they reach)\n")
+		}
+		var h strings.Builder
+		fmt.Fprintf(&h, "// Code generated by the schema compiler from %s.schema. DO NOT EDIT.\n// SPDX-License-Identifier: NONE — this generated output is yours, under terms of\n// your choice. See the LICENSE exception in the schema compiler; the compiler is\n// AGPL-3.0, its output is not.\n", f.Base)
+		fmt.Fprintf(&h, "// package %s — protocol id 0x%016x (packets only: tables version by field id, not by protocol id)\n", u.Package, u.ProtocolId)
+		h.WriteString("// The TABLE wire (evolution-tolerant, SPEC-TABLES.md): no serialize\n")
+		h.WriteString("// dependency — includable from any TU.\n\n")
+		h.WriteString("#pragma once\n\n#include <cstdint>\n#include <cstring>\n#include <cstddef> // offsetof, for the reflection descriptors\n#include <new> // in-place prefill (placement new): no giant stack temporaries\n#include <type_traits> // the enforced relocatability asserts\n")
+		fmt.Fprintf(&h, "\n#include \"%s.h\"\n", f.Base)
+		names := make([]string, 0, len(g.includes))
+		for n := range g.includes {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			fmt.Fprintf(&h, "#include \"%sTable.h\"\n", n)
+		}
+		native := make([]string, 0, len(g.nativeIncludes))
+		for n := range g.nativeIncludes {
+			native = append(native, n)
+		}
+		sort.Strings(native)
+		for _, n := range native {
+			fmt.Fprintf(&h, "#include \"%s\"\n", n)
+		}
+		h.WriteString("\n")
+		h.WriteString(tablePrimitives(u.Package))
+		fmt.Fprintf(&h, "\nnamespace %s {\n\n", u.Package)
+		h.WriteString(g.body.String())
+		fmt.Fprintf(&h, "} // namespace %s\n", u.Package)
+		out[f.Base+"Table.h"] = []byte(h.String())
+	}
+	return out, nil
+}
+
+// checkIncludeCycle refuses cross-file reference cycles among the table
+// closure: <A>Table.h and <B>Table.h including each other cannot compile
+// (each needs the other's structs complete). Composition cycles are already
+// refused by the checker; this is the FILE-level shadow of the same rule.
+func checkIncludeCycle(u *ir.Unit) error {
+	closure := ir.TableClosure(u)
+	deps := map[string]map[string]bool{}
+	for _, f := range u.Files {
+		set := map[string]bool{}
+		note := func(name string) {
+			if base, ok := u.DeclFile[name]; ok && base != f.Base {
+				set[base] = true
+			}
+		}
+		var members []*ir.Struct
+		members = append(members, f.Tables...)
+		for _, d := range f.Decls {
+			if st, ok := d.(*ir.Struct); ok && closure[st.Name] {
+				members = append(members, st)
+			}
+		}
+		for _, st := range members {
+			for _, fld := range st.Fields {
+				if fld.Type.Kind != ir.TNamed {
+					continue
+				}
+				note(fld.Type.Name)
+				if un, isUnion := fld.Type.Ref.(*ir.Union); isUnion {
+					for _, v := range un.Variants {
+						note(v.Type)
+					}
+				}
+			}
+		}
+		deps[f.Base] = set
+	}
+	color := map[string]int{}
+	var path []string
+	var visit func(base string) error
+	visit = func(base string) error {
+		switch color[base] {
+		case 1:
+			return fmt.Errorf("table include cycle: %s -> %s — the generated Table headers would include each other; move a declaration so the cross-file reference graph is acyclic (SPEC-TABLES.md)",
+				strings.Join(path, " -> "), base)
+		case 2:
+			return nil
+		}
+		color[base] = 1
+		path = append(path, base)
+		targets := make([]string, 0, len(deps[base]))
+		for t := range deps[base] {
+			targets = append(targets, t)
+		}
+		sort.Strings(targets)
+		for _, t := range targets {
+			if err := visit(t); err != nil {
+				return err
+			}
+		}
+		path = path[:len(path)-1]
+		color[base] = 2
+		return nil
+	}
+	bases := make([]string, 0, len(deps))
+	for b := range deps {
+		bases = append(bases, b)
+	}
+	sort.Strings(bases)
+	for _, b := range bases {
+		if err := visit(b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// orderTables returns a file's tables with every same-file table preceding
+// its by-value users — schema references are order-free, C++ is not. Stable:
+// declaration order survives wherever no dependency forces otherwise.
+// (Cycles are refused by the checker; the fallback below is defensive.)
+func orderTables(tables []*ir.Struct) []*ir.Struct {
+	n := len(tables)
+	byName := map[string]int{}
+	for i, st := range tables {
+		byName[st.Name] = i
+	}
+	adj := make([][]int, n)
+	indeg := make([]int, n)
+	for i, st := range tables {
+		for _, f := range st.Fields {
+			if f.Type.Kind != ir.TNamed {
+				continue
+			}
+			if ref, ok := f.Type.Ref.(*ir.Struct); ok && ref.IsTable {
+				if j, ok := byName[ref.Name]; ok && j != i {
+					adj[j] = append(adj[j], i)
+					indeg[i]++
+				}
+			}
+		}
+	}
+	order := make([]*ir.Struct, 0, n)
+	done := make([]bool, n)
+	for len(order) < n {
+		pick := -1
+		for i := 0; i < n; i++ {
+			if !done[i] && indeg[i] == 0 {
+				pick = i
+				break
+			}
+		}
+		if pick == -1 {
+			for i := 0; i < n; i++ {
+				if !done[i] {
+					pick = i
+					break
+				}
+			}
+		}
+		done[pick] = true
+		order = append(order, tables[pick])
+		for _, t := range adj[pick] {
+			indeg[t]--
+		}
+	}
+	return order
+}

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -526,14 +526,14 @@ func orderTables(tables []*ir.Struct) []*ir.Struct {
 	done := make([]bool, n)
 	for len(order) < n {
 		pick := -1
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if !done[i] && indeg[i] == 0 {
 				pick = i
 				break
 			}
 		}
 		if pick == -1 {
-			for i := 0; i < n; i++ {
+			for i := range n {
 				if !done[i] {
 					pick = i
 					break

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -525,6 +525,9 @@ func fpDecl(b *strings.Builder, d ast.Decl) {
 	case *ast.TypeDecl:
 		fmt.Fprintf(b, "type %s %s\n", d.Name, fpAttrs(d.Attrs))
 		fpBlock(b, d.Body)
+	case *ast.TableDecl:
+		fmt.Fprintf(b, "table %s\n", d.Name)
+		fpBlock(b, d.Body)
 	case *ast.UnionDecl:
 		fmt.Fprintf(b, "union %s\n{\n", d.Name)
 		for _, v := range d.Variants {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -191,11 +191,20 @@ func (p *parser) parseDecl() {
 		p.file.Decls = append(p.file.Decls, d)
 
 	case scanner.KwTable:
-		// `table` is reserved and refused: tables are not part of the
-		// language. Realtime wire types are `type`; the id is exact-match
-		// and content that outlives builds is not this compiler's subject.
-		p.errf(t.Pos, "tables are not part of the language — declare a `type` (the id is exact-match: same protocol id or refuse, SPEC §3)")
-		p.skipDecl()
+		// `table` declares a data type on the evolution-tolerant TABLE wire
+		// (SPEC-TABLES.md): field identity by name hash, unknown fields
+		// skipped, absent fields defaulted. The body grammar is the type
+		// body's; a table declaration takes no qualification.
+		p.advance()
+		name := p.expect(scanner.Ident, "table name")
+		d := &ast.TableDecl{Name: name.Text, Pos: t.Pos}
+		if p.kind() == scanner.Pipe {
+			p.errf(p.tok().Pos, "a table declaration takes no qualification (SPEC-TABLES.md)")
+			p.skipToTerminator()
+		}
+		d.Body = p.parseBlock()
+		p.expectTerminator("table declaration")
+		p.file.Decls = append(p.file.Decls, d)
 
 	case scanner.KwMessage:
 		// `message` is reserved and refused: messages are not part of the

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -37,6 +37,13 @@ type Unit struct {
 	Flags    map[string]*Flags
 	Structs  map[string]*Struct
 	Unions   map[string]*Union
+
+	// Tables holds the unit's `table` declarations (SPEC-TABLES.md), keyed by
+	// name. Tables live on the evolution-tolerant TABLE wire, not the packet
+	// wire: they are deliberately absent from Structs, from File.Decls and
+	// from the wire projection, so the packet backends and the protocol id
+	// never see them — packets and tables version independently.
+	Tables map[string]*Struct
 }
 
 // File is one schema file's declarations, in declaration order.
@@ -44,6 +51,11 @@ type File struct {
 	Base  string // "Constants"
 	Path  string // as given, e.g. "examples/Constants.schema"
 	Decls []Decl
+
+	// Tables is the file's `table` declarations in declaration order — kept
+	// beside Decls, not inside, so the packet backends' traversals never
+	// meet one (SPEC-TABLES.md).
+	Tables []*Struct
 }
 
 // Decl is one top-level declaration.
@@ -95,10 +107,13 @@ type UnionVariant struct {
 	Ref  *Struct // the payload
 }
 
-// Struct is a `type` declaration.
+// Struct is a `type` declaration — or, when IsTable is set, a `table`
+// declaration (SPEC-TABLES.md), which shares the resolved body shape but
+// lives in Unit.Tables/File.Tables instead of the packet decl stream.
 type Struct struct {
-	Name string
-	Tags []string // inert in v1 (SPEC §4.2)
+	Name    string
+	IsTable bool     // declared with `table`: a table-wire root
+	Tags    []string // inert in v1 (SPEC §4.2)
 	// C++ native type mapping (SPEC §4.2, Native type mapping): when set,
 	// generated C++ declares fields of this type as ::CppNative (a hand type
 	// deriving from the generated basis struct — same layout, plus behavior)
@@ -172,6 +187,11 @@ const (
 type Field struct {
 	Name  string
 	Guard string // "" or "if !at_rest" — branch context, kept as a comment
+
+	// WasName is the `was = "old_name"` rename alias (SPEC-TABLES.md): the
+	// field's TABLE-wire id derives from this name instead of Name, so wire
+	// identity survives a rename. Table fields only; "" when unset.
+	WasName string
 
 	Array      ArrayKind
 	ArrayBound int64

--- a/ir/table.go
+++ b/ir/table.go
@@ -1,0 +1,75 @@
+// Table-wire field identity and the table closure (SPEC-TABLES.md).
+// Target-independent, so every backend and any generator outside this module
+// derives one id for one field name.
+package ir
+
+import "sort"
+
+// FieldId is the stable TABLE-wire identity of a field name:
+// fold16(fnv1a32(name)), rebounding 0 (the terminator) to 1.
+func FieldId(name string) uint16 {
+	h := uint32(0x811C9DC5)
+	for i := 0; i < len(name); i++ {
+		h ^= uint32(name[i])
+		h *= 0x01000193
+	}
+	id := uint16((h ^ (h >> 16)) & 0xFFFF)
+	if id == 0 {
+		id = 1
+	}
+	return id
+}
+
+// TableFieldId is a field's EFFECTIVE table-wire id: the hash of its
+// `was = "old_name"` alias when one is declared — so wire identity survives
+// the rename — and of its own name otherwise.
+func TableFieldId(f *Field) uint16 {
+	if f.WasName != "" {
+		return FieldId(f.WasName)
+	}
+	return FieldId(f.Name)
+}
+
+// TableClosure is the set of structs that carry table codecs and reflection
+// descriptors: every `table` declaration plus every struct reachable from one
+// through fields (nested tables and types, array elements, union payloads),
+// transitively. Plain types outside the closure stay packet-wire only.
+func TableClosure(u *Unit) map[string]bool {
+	closure := map[string]bool{}
+	var walk func(name string)
+	walk = func(name string) {
+		if closure[name] {
+			return
+		}
+		st := u.Tables[name]
+		if st == nil {
+			st = u.Structs[name]
+		}
+		if st == nil {
+			return
+		}
+		closure[name] = true
+		for _, f := range st.Fields {
+			if f.Type.Kind != TNamed {
+				continue
+			}
+			switch ref := f.Type.Ref.(type) {
+			case *Struct:
+				walk(ref.Name)
+			case *Union:
+				for _, v := range ref.Variants {
+					walk(v.Type)
+				}
+			}
+		}
+	}
+	names := make([]string, 0, len(u.Tables))
+	for name := range u.Tables {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		walk(name)
+	}
+	return closure
+}

--- a/tables/examples/Nested.schema
+++ b/tables/examples/Nested.schema
@@ -1,0 +1,9 @@
+// Nested.schema — a table referencing a table declared in another file:
+// the generated NestedTable.h includes TablesTable.h (SPEC-TABLES.md).
+package tabledemo
+
+table ArchiveConfig
+{
+    root  RootConfig
+    count int32 = 1  | min = 0, max = 100
+}

--- a/tables/examples/Tables.schema
+++ b/tables/examples/Tables.schema
@@ -1,0 +1,77 @@
+// Tables.schema — the tables corpus (SPEC-TABLES.md): a config-like root
+// table whose closure exercises every table-wire kind. A root table with
+// nested subtables IS a format: this file is the shape of a game's
+// config/assets bin, spelled with generic names. The envelope around it
+// (magic, content hash) stays a few lines of user code by design.
+package tabledemo
+
+const MaxLoadoutSlots = 8
+const MaxProfileName  = 32
+
+enum Grade { Bronze, Silver, Gold }
+
+flags Perks { Shielded, Cloaked, Turbo }
+
+// a plain type in the closure: it gets table codecs too
+type Attachment
+{
+    slot  int32 = 0     | min = 0, max = MaxLoadoutSlots - 1
+    power float32 = 1.0
+}
+
+type Buff
+{
+    multiplier float32 = 1.0
+}
+
+type Debuff
+{
+    amount int32 = 0 | min = 0, max = 100
+}
+
+union Effect
+{
+    buff   Buff
+    debuff Debuff
+}
+
+// declared FIRST, references tables declared below: schema references are
+// order-free, and the emitter orders the generated structs
+table RootConfig
+{
+    version_note string(16)
+    weapons      [..8]WeaponConfig
+    profiles     [..4]ProfileConfig
+}
+
+table WeaponConfig
+{
+    damage      float32 = 21.0
+    speed       float32 = 500.0 | was = "velocity"
+    penetration int32 = 1       | min = 0, max = 10
+    channel     bits(6)
+    homing      bool
+    effect      Effect
+}
+
+table LoadoutConfig
+{
+    grade       Grade = Silver
+    perks       Perks
+    primary     WeaponConfig
+    backups     [2]WeaponConfig
+    attachments [..MaxLoadoutSlots]Attachment
+}
+
+table ProfileConfig
+{
+    name        string(MaxProfileName)
+    icon        bytes(16)
+    experience  uint32 = 0
+    ratings     [4]float32
+    has_loadout bool
+    if has_loadout
+    {
+        loadout LoadoutConfig
+    }
+}

--- a/tables/examples/Tables.schema
+++ b/tables/examples/Tables.schema
@@ -68,6 +68,13 @@ table ProfileConfig
     name        string(MaxProfileName)
     icon        bytes(16)
     experience  uint32 = 0
+    tilt        int8
+    heading     int16
+    timestamp   int64
+    badge       uint8
+    port        uint16
+    epoch       uint64
+    precision   float64
     ratings     [4]float32
     has_loadout bool
     if has_loadout

--- a/test/tables/V1.schema
+++ b/test/tables/V1.schema
@@ -1,0 +1,23 @@
+// V1.schema — the OLD side of the both-directions evolution test
+// (SPEC-TABLES.md): V2 adds c, removes b, changes a's kind, renames name to
+// title (with was), and grows Inner. Distinct packages so both generations
+// compile into ONE test binary; the wire does not care — table identity is
+// the field-name hash, not the package or the protocol id.
+package tblv1
+
+enum Mode { Alpha, Beta }
+
+type Inner
+{
+    factor float32 = 2.5
+}
+
+table Cfg
+{
+    a     int32 = 5     | min = 0, max = 1000
+    b     float32 = 1.5
+    mode  Mode = Beta
+    name  string(32)
+    inner Inner
+    items [..8]int32    | min = 0, max = 255
+}

--- a/test/tables/V2.schema
+++ b/test/tables/V2.schema
@@ -1,0 +1,23 @@
+// V2.schema — the NEW side of the evolution test: relative to V1, `a`
+// changed kind (int32 -> float32), `c` was added, `b` was removed, `name`
+// was renamed to `title` (was = "name" keeps the wire id), and Inner gained
+// a field. Any reader x any data, both directions (SPEC-TABLES.md).
+package tblv2
+
+enum Mode { Alpha, Beta }
+
+type Inner
+{
+    factor float32 = 2.5
+    gain   float32 = 1.0
+}
+
+table Cfg
+{
+    a     float32 = 5.0
+    c     bool = true
+    mode  Mode = Beta
+    title string(32)    | was = "name"
+    inner Inner
+    items [..8]int32    | min = 0, max = 255
+}

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -1,0 +1,456 @@
+// The TABLE-wire conformance test (SPEC-TABLES.md). Three generated units in
+// one binary: the tables corpus (tabledemo), and the two-generation evolution
+// pair (tblv1/tblv2) whose schemas disagree on purpose. Compiled WITHOUT the
+// serialize include path — the Table headers must stand alone.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "TablesTable.h"
+#include "NestedTable.h"
+#include "V1Table.h"
+#include "V2Table.h"
+
+static int failures = 0;
+
+#define CHECK( condition )                                                    \
+    do                                                                        \
+    {                                                                         \
+        if ( !( condition ) )                                                 \
+        {                                                                     \
+            printf( "FAIL %s:%d: %s\n", __FILE__, __LINE__, #condition );     \
+            failures++;                                                       \
+        }                                                                     \
+    } while ( 0 )
+
+// an independent implementation of the table-wire field id —
+// fold16(fnv1a32(name)), 0 rebounds to 1 — pinning the compiler's hash
+// against a second implementation written from the spec alone
+static uint16_t field_id( const char * name )
+{
+    uint32_t h = 0x811C9DC5u;
+    for ( const char * p = name; *p; ++p )
+    {
+        h ^= (uint32_t) (uint8_t) *p;
+        h *= 0x01000193u;
+    }
+    uint16_t id = (uint16_t) ( ( h ^ ( h >> 16 ) ) & 0xFFFF );
+    return id == 0 ? 1 : id;
+}
+
+static const tabledemo::TableFieldInfo * demo_field( const tabledemo::TableTypeInfo * type, const char * name )
+{
+    for ( int32_t i = 0; i < type->num_fields; i++ )
+        if ( strcmp( type->fields[i].name, name ) == 0 )
+            return &type->fields[i];
+    return NULL;
+}
+
+static const tblv1::TableFieldInfo * v1_field( const tblv1::TableTypeInfo * type, const char * name )
+{
+    for ( int32_t i = 0; i < type->num_fields; i++ )
+        if ( strcmp( type->fields[i].name, name ) == 0 )
+            return &type->fields[i];
+    return NULL;
+}
+
+static void set_string( char * dest, int32_t & length, const char * s )
+{
+    length = (int32_t) strlen( s );
+    memcpy( dest, s, length + 1 );
+}
+
+// ---- round trip: the corpus root, every kind populated ----
+
+static void test_round_trip()
+{
+    tabledemo::RootConfig root;
+    set_string( root.version_note, root.version_note_length, "v-one" );
+
+    root.weapons_count = 2;
+    root.weapons[0].damage = 40.0f;           // non-default: rides
+    root.weapons[0].channel = 45;             // bits(6)
+    root.weapons[0].homing = true;
+    root.weapons[0].effect.type = tabledemo::EffectType::Buff;
+    root.weapons[0].effect.buff = tabledemo::Buff{};
+    root.weapons[0].effect.buff.multiplier = 3.0f;
+    // weapons[1] stays all-default: a counted element still rides (length-prefixed)
+
+    root.profiles_count = 1;
+    tabledemo::ProfileConfig & p = root.profiles[0];
+    set_string( p.name, p.name_length, "player one" );
+    p.icon[0] = 1; p.icon[1] = 2; p.icon[2] = 250; p.icon_length = 3;
+    p.experience = 777;
+    p.ratings[2] = 0.5f;
+    p.has_loadout = true;
+    p.loadout.grade = tabledemo::Grade::Gold;
+    p.loadout.perks = tabledemo::Perks_Cloaked;
+    p.loadout.primary.penetration = 7;
+    p.loadout.backups[0].damage = 1.0f;
+    p.loadout.attachments_count = 1;
+    p.loadout.attachments[0].slot = 3;
+    p.loadout.attachments[0].power = 2.0f;
+
+    uint8_t buffer[16384];
+    int64_t need = tabledemo::TableMeasureRootConfig( root );
+    int64_t wrote = tabledemo::TableSaveRootConfig( root, buffer, sizeof( buffer ) );
+    CHECK( wrote > 0 );
+    CHECK( need == wrote ); // measure/save split: measure is EXACT
+
+    tabledemo::TableReport report;
+    tabledemo::RootConfig out;
+    CHECK( tabledemo::TableReadRootConfig( buffer, wrote, out, report ) );
+    CHECK( report.unknown == 0 && report.kind_mismatch == 0 && report.clamped == 0 && !report.malformed );
+
+    CHECK( strcmp( out.version_note, "v-one" ) == 0 && out.version_note_length == 5 );
+    CHECK( out.weapons_count == 2 );
+    CHECK( out.weapons[0].damage == 40.0f );
+    CHECK( out.weapons[0].speed == 500.0f ); // default survived elision
+    CHECK( out.weapons[0].channel == 45 );
+    CHECK( out.weapons[0].homing == true );
+    CHECK( out.weapons[0].effect.type == tabledemo::EffectType::Buff );
+    CHECK( out.weapons[0].effect.buff.multiplier == 3.0f );
+    CHECK( out.weapons[1].damage == 21.0f && out.weapons[1].effect.type == tabledemo::EffectType::None );
+    CHECK( out.profiles_count == 1 );
+    CHECK( strcmp( out.profiles[0].name, "player one" ) == 0 );
+    CHECK( out.profiles[0].icon_length == 3 && out.profiles[0].icon[2] == 250 );
+    CHECK( out.profiles[0].experience == 777 );
+    CHECK( out.profiles[0].ratings[2] == 0.5f && out.profiles[0].ratings[0] == 0.0f );
+    CHECK( out.profiles[0].has_loadout == true );
+    CHECK( out.profiles[0].loadout.grade == tabledemo::Grade::Gold );
+    CHECK( out.profiles[0].loadout.perks == tabledemo::Perks_Cloaked );
+    CHECK( out.profiles[0].loadout.primary.penetration == 7 );
+    CHECK( out.profiles[0].loadout.backups[0].damage == 1.0f );
+    CHECK( out.profiles[0].loadout.backups[1].damage == 21.0f );
+    CHECK( out.profiles[0].loadout.attachments_count == 1 );
+    CHECK( out.profiles[0].loadout.attachments[0].slot == 3 );
+    CHECK( out.profiles[0].loadout.attachments[0].power == 2.0f );
+
+    // relocatable: memcpy the decoded value and read the copy
+    static tabledemo::RootConfig moved;
+    memcpy( (void *) &moved, (const void *) &out, sizeof( out ) );
+    CHECK( moved.profiles[0].experience == 777 );
+    CHECK( strcmp( moved.profiles[0].name, "player one" ) == 0 );
+
+    // a too-small buffer refuses instead of truncating
+    uint8_t tiny[8];
+    CHECK( tabledemo::TableSaveRootConfig( root, tiny, sizeof( tiny ) ) == -1 );
+}
+
+// ---- all-default: everything elides, decode restores every default ----
+
+static void test_all_default()
+{
+    tabledemo::WeaponConfig weapon;
+    uint8_t buffer[64];
+    int64_t wrote = tabledemo::TableSaveWeaponConfig( weapon, buffer, sizeof( buffer ) );
+    CHECK( wrote == 2 ); // bare terminator
+    CHECK( tabledemo::TableMeasureWeaponConfig( weapon ) == 2 );
+
+    tabledemo::TableReport report;
+    tabledemo::WeaponConfig out;
+    out.damage = -1.0f; // garbage that the prefill must erase
+    CHECK( tabledemo::TableReadWeaponConfig( buffer, wrote, out, report ) );
+    CHECK( out.damage == 21.0f && out.speed == 500.0f && out.penetration == 1 );
+    CHECK( !report.malformed && report.unknown == 0 );
+}
+
+// ---- guarded fields stay off the wire when the guard says so ----
+
+static void test_guard()
+{
+    tabledemo::ProfileConfig p;
+    p.has_loadout = false;
+    p.loadout.grade = tabledemo::Grade::Gold; // junk behind an untaken guard
+
+    uint8_t buffer[512];
+    int64_t wrote = tabledemo::TableSaveProfileConfig( p, buffer, sizeof( buffer ) );
+    CHECK( wrote == 2 ); // guard false + everything else default: all elides
+    CHECK( tabledemo::TableMeasureProfileConfig( p ) == wrote );
+
+    tabledemo::TableReport report;
+    tabledemo::ProfileConfig out;
+    CHECK( tabledemo::TableReadProfileConfig( buffer, wrote, out, report ) );
+    CHECK( out.loadout.grade == tabledemo::Grade::Silver ); // untaken side decodes to defaults
+}
+
+// ---- evolution, both directions (SPEC-TABLES.md: any reader x any data) ----
+
+static void test_evolution_old_reader_new_data()
+{
+    tblv2::Cfg v2;
+    v2.a = 7.5f;
+    v2.c = false; // non-default, rides
+    v2.mode = tblv2::Mode::Alpha;
+    set_string( v2.title, v2.title_length, "fresh" );
+    v2.inner.factor = 9.5f;
+    v2.inner.gain = 4.0f;
+    v2.items[0] = 10;
+    v2.items_count = 1;
+
+    uint8_t wire[1024];
+    int64_t bytes = tblv2::TableSaveCfg( v2, wire, sizeof( wire ) );
+    CHECK( bytes > 0 && bytes == tblv2::TableMeasureCfg( v2 ) );
+
+    tblv1::TableReport report;
+    tblv1::Cfg out;
+    CHECK( tblv1::TableReadCfg( wire, bytes, out, report ) );
+    CHECK( !report.malformed );
+    CHECK( report.unknown == 2 );       // c (top level) + gain (nested)
+    CHECK( report.kind_mismatch == 1 ); // a: f32 wire vs v1's i32 expectation
+    CHECK( out.a == 5 );                // a skipped -> v1 default, never misdecoded
+    CHECK( out.b == 1.5f );             // removed in v2 -> absent -> v1 default
+    CHECK( strcmp( out.name, "fresh" ) == 0 ); // v2 title carries was = "name": identity survived the rename
+    CHECK( out.mode == tblv1::Mode::Alpha );
+    CHECK( out.inner.factor == 9.5f );
+    CHECK( out.items_count == 1 && out.items[0] == 10 );
+}
+
+static void test_evolution_new_reader_old_data()
+{
+    tblv1::Cfg v1;
+    v1.a = 9;
+    v1.b = 8.5f;
+    set_string( v1.name, v1.name_length, "aged" );
+    v1.inner.factor = 1.25f;
+
+    uint8_t wire[1024];
+    int64_t bytes = tblv1::TableSaveCfg( v1, wire, sizeof( wire ) );
+    CHECK( bytes > 0 && bytes == tblv1::TableMeasureCfg( v1 ) );
+
+    tblv2::TableReport report;
+    tblv2::Cfg out;
+    CHECK( tblv2::TableReadCfg( wire, bytes, out, report ) );
+    CHECK( !report.malformed );
+    CHECK( report.unknown == 1 );       // b, removed in v2
+    CHECK( report.kind_mismatch == 1 ); // a: i32 wire vs v2's f32 expectation
+    CHECK( out.a == 5.0f );             // v2 default
+    CHECK( out.c == true );             // added in v2, absent in old data -> default
+    CHECK( strcmp( out.title, "aged" ) == 0 ); // old "name" data lands in the renamed field
+    CHECK( out.mode == tblv2::Mode::Beta );
+    CHECK( out.inner.factor == 1.25f );
+    CHECK( out.inner.gain == 1.0f );    // nested added field defaults
+}
+
+// ---- clamping: hostile or stale numerics clamp and count ----
+
+static void le16( uint8_t * p, uint16_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); }
+static void le32( uint8_t * p, uint32_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); p[2] = (uint8_t) ( v >> 16 ); p[3] = (uint8_t) ( v >> 24 ); }
+
+static void test_clamping()
+{
+    // a wider writer sent a = 2000; v1's a is [0, 1000] — crafted from the
+    // descriptor's own id so the bytes are exactly what such a writer emits
+    const tblv1::TableFieldInfo * a = v1_field( tblv1::TableTypeCfg(), "a" );
+    CHECK( a != NULL && a->kind == 4 && a->has_range && a->range_max == 1000.0 );
+
+    uint8_t wire[16];
+    int n = 0;
+    le16( wire + n, a->id ); n += 2;
+    wire[n++] = 4; // kI32
+    le32( wire + n, (uint32_t) 2000 ); n += 4;
+    le16( wire + n, 0 ); n += 2; // terminator
+
+    tblv1::TableReport report;
+    tblv1::Cfg out;
+    CHECK( tblv1::TableReadCfg( wire, n, out, report ) );
+    CHECK( report.clamped == 1 && out.a == 1000 );
+
+    // bits(6) width clamp: a u8 payload of 200 clamps to 63
+    const tabledemo::TableFieldInfo * ch = demo_field( tabledemo::TableTypeWeaponConfig(), "channel" );
+    CHECK( ch != NULL && ch->kind == 6 );
+    uint8_t wire2[8];
+    n = 0;
+    le16( wire2 + n, ch->id ); n += 2;
+    wire2[n++] = 6; // kU8
+    wire2[n++] = 200;
+    le16( wire2 + n, 0 ); n += 2;
+
+    tabledemo::TableReport report2;
+    tabledemo::WeaponConfig weapon;
+    CHECK( tabledemo::TableReadWeaponConfig( wire2, n, weapon, report2 ) );
+    CHECK( report2.clamped == 1 && weapon.channel == 63 );
+
+    // an over-long string — a future schema widened string(32) — clamps to
+    // capacity, stays NUL-terminated, and counts
+    const tblv1::TableFieldInfo * nameInfo = v1_field( tblv1::TableTypeCfg(), "name" );
+    uint8_t wire4[64];
+    n = 0;
+    le16( wire4 + n, nameInfo->id ); n += 2;
+    wire4[n++] = 12; // kString
+    le16( wire4 + n, 40 ); n += 2; // longer than string(32)
+    for ( int i = 0; i < 40; i++ ) wire4[n++] = 'y';
+    le16( wire4 + n, 0 ); n += 2;
+
+    tblv1::TableReport report4;
+    tblv1::Cfg out4;
+    CHECK( tblv1::TableReadCfg( wire4, n, out4, report4 ) );
+    CHECK( report4.clamped == 1 && out4.name_length == 32 && out4.name[32] == 0 );
+}
+
+// ---- malformed framing: decode stops, partial result kept, flag raised ----
+
+static void test_malformed()
+{
+    tblv1::TableReport report;
+    tblv1::Cfg out;
+
+    uint8_t one_byte[1] = { 0x34 };
+    CHECK( !tblv1::TableReadCfg( one_byte, 1, out, report ) );
+    CHECK( report.malformed );
+
+    // a valid field id whose payload is truncated mid-scalar
+    const tblv1::TableFieldInfo * a = v1_field( tblv1::TableTypeCfg(), "a" );
+    uint8_t truncated[5];
+    le16( truncated, a->id );
+    truncated[2] = 4;  // kI32 wants 4 payload bytes; only 2 follow
+    truncated[3] = 0;
+    truncated[4] = 0;
+    tblv1::TableReport report2;
+    CHECK( !tblv1::TableReadCfg( truncated, 5, out, report2 ) );
+    CHECK( report2.malformed );
+
+    // damage after good fields: the good prefix survives (partial result)
+    tblv1::Cfg src;
+    src.a = 42;
+    uint8_t wire[256];
+    int64_t bytes = tblv1::TableSaveCfg( src, wire, sizeof( wire ) );
+    CHECK( bytes > 0 );
+    tblv1::TableReport report3;
+    tblv1::Cfg out3;
+    CHECK( !tblv1::TableReadCfg( wire, bytes - 2, out3, report3 ) ); // terminator cut off
+    CHECK( report3.malformed && out3.a == 42 );
+}
+
+// ---- reflection: walk, identify, and read fields with no schema files ----
+
+static void test_reflection()
+{
+    const tabledemo::TableTypeInfo * weapon = tabledemo::TableTypeWeaponConfig();
+    CHECK( strcmp( weapon->name, "WeaponConfig" ) == 0 );
+    CHECK( weapon->size == sizeof( tabledemo::WeaponConfig ) );
+
+    // the was rename: speed's wire id is hash("velocity"), not hash("speed") —
+    // pinned against an independent C++ implementation of the id function
+    const tabledemo::TableFieldInfo * speed = demo_field( weapon, "speed" );
+    CHECK( speed != NULL );
+    CHECK( speed->id == field_id( "velocity" ) );
+    CHECK( speed->id != field_id( "speed" ) );
+    const tabledemo::TableFieldInfo * damage = demo_field( weapon, "damage" );
+    CHECK( damage != NULL && damage->id == field_id( "damage" ) );
+    CHECK( damage->kind == 10 ); // kF32
+
+    // ranges surface for editors
+    const tabledemo::TableFieldInfo * pen = demo_field( weapon, "penetration" );
+    CHECK( pen != NULL && pen->has_range && pen->range_min == 0.0 && pen->range_max == 10.0 );
+
+    // enum name function: value -> name, out-of-set included
+    const tabledemo::TableFieldInfo * grade = demo_field( tabledemo::TableTypeLoadoutConfig(), "grade" );
+    CHECK( grade != NULL && grade->enum_max == 3 && grade->enum_name != NULL );
+    CHECK( strcmp( grade->enum_name( 3 ), "Gold" ) == 0 );
+    CHECK( strcmp( grade->enum_name( 9 ), "???" ) == 0 );
+
+    // nested-table descriptors chain, arrays carry bounds and companions
+    const tabledemo::TableTypeInfo * rootType = tabledemo::TableTypeRootConfig();
+    const tabledemo::TableFieldInfo * profiles = demo_field( rootType, "profiles" );
+    CHECK( profiles != NULL && profiles->kind == 13 && profiles->is_array && profiles->counted );
+    CHECK( profiles->array_bound == 4 );
+    CHECK( profiles->table == tabledemo::TableTypeProfileConfig() );
+
+    // guards surface machine-usable
+    const tabledemo::TableFieldInfo * loadout = demo_field( tabledemo::TableTypeProfileConfig(), "loadout" );
+    CHECK( loadout != NULL && strcmp( loadout->guard, "has_loadout" ) == 0 );
+
+    // generic field access through offset — an editor walking properties
+    tabledemo::ProfileConfig p;
+    p.experience = 777;
+    const tabledemo::TableFieldInfo * exp = demo_field( tabledemo::TableTypeProfileConfig(), "experience" );
+    CHECK( exp != NULL );
+    uint32_t read_back;
+    memcpy( &read_back, (const uint8_t *) &p + exp->offset, sizeof( read_back ) );
+    CHECK( read_back == 777 );
+}
+
+// ---- cross-file nesting: ArchiveConfig (Nested.schema) holds RootConfig ----
+
+static void test_cross_file()
+{
+    static tabledemo::ArchiveConfig archive; // static: the value is large
+    set_string( archive.root.version_note, archive.root.version_note_length, "deep" );
+    archive.root.weapons_count = 1;
+    archive.root.weapons[0].homing = true;
+    archive.count = 5;
+
+    static uint8_t buffer[16384];
+    int64_t wrote = tabledemo::TableSaveArchiveConfig( archive, buffer, sizeof( buffer ) );
+    CHECK( wrote > 0 && wrote == tabledemo::TableMeasureArchiveConfig( archive ) );
+
+    tabledemo::TableReport report;
+    static tabledemo::ArchiveConfig out;
+    CHECK( tabledemo::TableReadArchiveConfig( buffer, wrote, out, report ) );
+    CHECK( strcmp( out.root.version_note, "deep" ) == 0 );
+    CHECK( out.root.weapons_count == 1 && out.root.weapons[0].homing );
+    CHECK( out.count == 5 );
+}
+
+// ---- parallel generation: measure subtables, prefix-sum, scatter-write ----
+
+static void test_parallel_shape()
+{
+    // the go-wide pattern from USAGE.md, single-threaded here for
+    // determinism: measure each profile, hand each a disjoint range, write
+    // independently, and the concatenation decodes as if written serially
+    tabledemo::ProfileConfig profiles[3];
+    for ( int i = 0; i < 3; i++ )
+    {
+        profiles[i].experience = 100 + i;
+    }
+    int64_t sizes[3];
+    int64_t total = 0;
+    for ( int i = 0; i < 3; i++ )
+    {
+        sizes[i] = tabledemo::TableMeasureProfileConfig( profiles[i] );
+        total += sizes[i];
+    }
+    static uint8_t buffer[4096];
+    int64_t offset = 0;
+    for ( int i = 0; i < 3; i++ ) // each iteration is independent: a worker
+    {
+        int64_t wrote = tabledemo::TableSaveProfileConfig( profiles[i], buffer + offset, sizes[i] );
+        CHECK( wrote == sizes[i] );
+        offset += wrote;
+    }
+    CHECK( offset == total );
+    offset = 0;
+    for ( int i = 0; i < 3; i++ )
+    {
+        tabledemo::TableReport report;
+        tabledemo::ProfileConfig out;
+        CHECK( tabledemo::TableReadProfileConfig( buffer + offset, sizes[i], out, report ) );
+        CHECK( out.experience == (uint32_t) ( 100 + i ) );
+        offset += sizes[i];
+    }
+}
+
+int main()
+{
+    test_round_trip();
+    test_all_default();
+    test_guard();
+    test_evolution_old_reader_new_data();
+    test_evolution_new_reader_old_data();
+    test_clamping();
+    test_malformed();
+    test_reflection();
+    test_cross_file();
+    test_parallel_shape();
+
+    if ( failures > 0 )
+    {
+        printf( "tables test: %d failure(s)\n", failures );
+        return 1;
+    }
+    printf( "tables test passed\n" );
+    return 0;
+}

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -61,6 +61,30 @@ static void set_string( char * dest, int32_t & length, const char * s )
     memcpy( dest, s, length + 1 );
 }
 
+static void le16( uint8_t * p, uint16_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); }
+static void le32( uint8_t * p, uint32_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); p[2] = (uint8_t) ( v >> 16 ); p[3] = (uint8_t) ( v >> 24 ); }
+
+// check_exact_capacity is the go-wide guarantee: TableSave into a buffer of
+// EXACTLY TableMeasure's size succeeds and byte-matches a roomy save — a
+// scatter-writing worker gets exactly sizes[i] and nothing more.
+template <typename T>
+static void check_exact_capacity( const T & value,
+                                  int64_t (*measure)( const T & ),
+                                  int64_t (*save)( const T &, uint8_t *, int64_t ) )
+{
+    static uint8_t roomy[65536];
+    static uint8_t exact[65536];
+    int64_t need = measure( value );
+    CHECK( need >= 2 && need <= (int64_t) sizeof( roomy ) );
+    CHECK( save( value, roomy, sizeof( roomy ) ) == need );
+    CHECK( save( value, exact, need ) == need ); // exactly measure's answer
+    CHECK( memcmp( roomy, exact, (size_t) need ) == 0 );
+    if ( need > 2 )
+    {
+        CHECK( save( value, exact, need - 1 ) == -1 ); // one byte short refuses
+    }
+}
+
 // ---- round trip: the corpus root, every kind populated ----
 
 static void test_round_trip()
@@ -82,6 +106,13 @@ static void test_round_trip()
     set_string( p.name, p.name_length, "player one" );
     p.icon[0] = 1; p.icon[1] = 2; p.icon[2] = 250; p.icon_length = 3;
     p.experience = 777;
+    p.tilt = -12;                 // i8
+    p.heading = -30000;           // i16
+    p.timestamp = -5000000000ll;  // i64
+    p.badge = 200;                // u8
+    p.port = 40000;               // u16
+    p.epoch = 0x1122334455667788ull; // u64
+    p.precision = 2.5;            // f64
     p.ratings[2] = 0.5f;
     p.has_loadout = true;
     p.loadout.grade = tabledemo::Grade::Gold;
@@ -116,6 +147,13 @@ static void test_round_trip()
     CHECK( strcmp( out.profiles[0].name, "player one" ) == 0 );
     CHECK( out.profiles[0].icon_length == 3 && out.profiles[0].icon[2] == 250 );
     CHECK( out.profiles[0].experience == 777 );
+    CHECK( out.profiles[0].tilt == -12 );
+    CHECK( out.profiles[0].heading == -30000 );
+    CHECK( out.profiles[0].timestamp == -5000000000ll );
+    CHECK( out.profiles[0].badge == 200 );
+    CHECK( out.profiles[0].port == 40000 );
+    CHECK( out.profiles[0].epoch == 0x1122334455667788ull );
+    CHECK( out.profiles[0].precision == 2.5 );
     CHECK( out.profiles[0].ratings[2] == 0.5f && out.profiles[0].ratings[0] == 0.0f );
     CHECK( out.profiles[0].has_loadout == true );
     CHECK( out.profiles[0].loadout.grade == tabledemo::Grade::Gold );
@@ -136,6 +174,144 @@ static void test_round_trip()
     // a too-small buffer refuses instead of truncating
     uint8_t tiny[8];
     CHECK( tabledemo::TableSaveRootConfig( root, tiny, sizeof( tiny ) ) == -1 );
+
+    // the exact-capacity guarantee holds for the fully-populated root
+    check_exact_capacity( root, tabledemo::TableMeasureRootConfig, tabledemo::TableSaveRootConfig );
+}
+
+// ---- exact capacity: measure's answer IS the buffer size, corpus-wide ----
+
+static void test_exact_capacity()
+{
+    // the reviewer's repro shape: non-default fields around an ALL-DEFAULT
+    // nested table — the elided field must not touch the buffer at all, so
+    // saving into exactly measure's size succeeds
+    tblv1::Cfg cfg;
+    cfg.a = 9;
+    cfg.b = 8.5f;
+    set_string( cfg.name, cfg.name_length, "exact" );
+    // cfg.inner stays all-default: elides
+    check_exact_capacity( cfg, tblv1::TableMeasureCfg, tblv1::TableSaveCfg );
+
+    // all-default everything (2 bytes)
+    tblv1::Cfg empty;
+    check_exact_capacity( empty, tblv1::TableMeasureCfg, tblv1::TableSaveCfg );
+    tabledemo::WeaponConfig weapon;
+    check_exact_capacity( weapon, tabledemo::TableMeasureWeaponConfig, tabledemo::TableSaveWeaponConfig );
+
+    // an elided nested table inside a GUARDED group
+    tabledemo::ProfileConfig profile;
+    profile.experience = 1;
+    profile.has_loadout = true; // loadout itself stays all-default: elides
+    check_exact_capacity( profile, tabledemo::TableMeasureProfileConfig, tabledemo::TableSaveProfileConfig );
+
+    // nested tables of nested tables, some elided, some riding
+    static tabledemo::ArchiveConfig archive;
+    archive.count = 9;
+    archive.root.weapons_count = 1; // weapons[0] all-default: rides as an element, its nested union elides
+    check_exact_capacity( archive, tabledemo::TableMeasureArchiveConfig, tabledemo::TableSaveArchiveConfig );
+
+    // loadout: fixed array of tables (always rides) around all-default elements
+    tabledemo::LoadoutConfig loadout;
+    loadout.grade = tabledemo::Grade::Gold;
+    check_exact_capacity( loadout, tabledemo::TableMeasureLoadoutConfig, tabledemo::TableSaveLoadoutConfig );
+
+    // the v2 evolution shape
+    tblv2::Cfg v2;
+    v2.a = 1.0f;
+    v2.inner.gain = 2.0f;
+    check_exact_capacity( v2, tblv2::TableMeasureCfg, tblv2::TableSaveCfg );
+}
+
+// ---- storage invariants: the write side validates what it reads ----
+
+static void test_storage_invariants()
+{
+    uint8_t buffer[4096];
+
+    // a count above the bound must not read out of the array into the wire
+    tabledemo::RootConfig root;
+    root.weapons_count = 9; // bound is 8
+    CHECK( tabledemo::TableMeasureRootConfig( root ) == -1 );
+    CHECK( tabledemo::TableSaveRootConfig( root, buffer, sizeof( buffer ) ) == -1 );
+
+    // a negative length must not memcpy a huge size_t
+    tblv1::Cfg cfg;
+    cfg.name_length = -1;
+    CHECK( tblv1::TableMeasureCfg( cfg ) == -1 );
+    CHECK( tblv1::TableSaveCfg( cfg, buffer, sizeof( buffer ) ) == -1 );
+
+    // a negative count refuses too
+    tblv1::Cfg cfg2;
+    cfg2.items_count = -3;
+    CHECK( tblv1::TableMeasureCfg( cfg2 ) == -1 );
+    CHECK( tblv1::TableSaveCfg( cfg2, buffer, sizeof( buffer ) ) == -1 );
+
+    // a violation deep inside a nested, guarded table propagates up
+    tabledemo::ProfileConfig profile;
+    profile.has_loadout = true;
+    profile.loadout.attachments_count = -5;
+    CHECK( tabledemo::TableMeasureProfileConfig( profile ) == -1 );
+    CHECK( tabledemo::TableSaveProfileConfig( profile, buffer, sizeof( buffer ) ) == -1 );
+
+    // an out-of-range union tag refuses in measure exactly as in write
+    tabledemo::WeaponConfig weapon;
+    weapon.effect.type = (tabledemo::EffectType) 9;
+    CHECK( tabledemo::TableMeasureWeaponConfig( weapon ) == -1 );
+    CHECK( tabledemo::TableSaveWeaponConfig( weapon, buffer, sizeof( buffer ) ) == -1 );
+}
+
+// ---- bounded elements: a count the body length cannot cover never reads
+// ---- the following fields' bytes (SPEC-TABLES.md: skipped, NEVER misdecoded)
+
+static void test_bounded_elements()
+{
+    const tblv1::TableFieldInfo * items = v1_field( tblv1::TableTypeCfg(), "items" );
+    const tblv1::TableFieldInfo * a = v1_field( tblv1::TableTypeCfg(), "a" );
+    CHECK( items != NULL && a != NULL );
+
+    // body_len = 3 covers only elem_kind + count; count claims 2 elements —
+    // the elements would have to come from the NEXT field's bytes. They must
+    // not: prefix kept (empty), malformed flagged, and a = 42 still decodes.
+    uint8_t wire[32];
+    int n = 0;
+    le16( wire + n, items->id ); n += 2;
+    wire[n++] = 14;              // kArray
+    le32( wire + n, 3 ); n += 4; // body_len: header only, no element bytes
+    wire[n++] = 4;               // elem_kind kI32
+    le16( wire + n, 2 ); n += 2; // count 2 — a lie
+    le16( wire + n, a->id ); n += 2;
+    wire[n++] = 4;               // kI32
+    le32( wire + n, 42 ); n += 4;
+    le16( wire + n, 0 ); n += 2; // terminator
+
+    tblv1::TableReport report;
+    tblv1::Cfg out;
+    CHECK( tblv1::TableReadCfg( wire, n, out, report ) );
+    CHECK( report.malformed );        // the lie is framing damage, flagged
+    CHECK( out.items_count == 0 );    // no fabricated elements
+    CHECK( out.a == 42 );             // the parent continued at the next field
+
+    // a body covering one full element plus slack: the decoded PREFIX is kept
+    n = 0;
+    le16( wire + n, items->id ); n += 2;
+    wire[n++] = 14;
+    le32( wire + n, 3 + 4 + 2 ); n += 4; // one i32 element + 2 slack bytes
+    wire[n++] = 4;
+    le16( wire + n, 2 ); n += 2;         // count 2, body holds 1.5
+    le32( wire + n, 10 ); n += 4;        // element 0
+    wire[n++] = 0; wire[n++] = 0;        // the half element
+    le16( wire + n, a->id ); n += 2;
+    wire[n++] = 4;
+    le32( wire + n, 42 ); n += 4;
+    le16( wire + n, 0 ); n += 2;
+
+    tblv1::TableReport report2;
+    tblv1::Cfg out2;
+    CHECK( tblv1::TableReadCfg( wire, n, out2, report2 ) );
+    CHECK( report2.malformed );
+    CHECK( out2.items_count == 1 && out2.items[0] == 10 ); // bounded prefix
+    CHECK( out2.a == 42 );
 }
 
 // ---- all-default: everything elides, decode restores every default ----
@@ -234,9 +410,6 @@ static void test_evolution_new_reader_old_data()
 }
 
 // ---- clamping: hostile or stale numerics clamp and count ----
-
-static void le16( uint8_t * p, uint16_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); }
-static void le32( uint8_t * p, uint32_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); p[2] = (uint8_t) ( v >> 16 ); p[3] = (uint8_t) ( v >> 24 ); }
 
 static void test_clamping()
 {
@@ -362,6 +535,33 @@ static void test_reflection()
     const tabledemo::TableFieldInfo * loadout = demo_field( tabledemo::TableTypeProfileConfig(), "loadout" );
     CHECK( loadout != NULL && strcmp( loadout->guard, "has_loadout" ) == 0 );
 
+    // every one of the 15 wire kinds rides somewhere in the corpus battery;
+    // the scalar kinds pin here by descriptor (containers pinned above and
+    // in the round trip: 12 string, 13 table, 14 array, 15 union; 1 bool on
+    // homing, 10 f32 on damage)
+    const tabledemo::TableTypeInfo * profileType = tabledemo::TableTypeProfileConfig();
+    struct { const char * field; uint8_t kind; } scalar_kinds[] = {
+        { "tilt", 2 },       // i8
+        { "heading", 3 },    // i16
+        { "timestamp", 5 },  // i64
+        { "badge", 6 },      // u8
+        { "port", 7 },       // u16
+        { "experience", 8 }, // u32
+        { "epoch", 9 },      // u64
+        { "precision", 11 }, // f64
+    };
+    for ( const auto & sk : scalar_kinds )
+    {
+        const tabledemo::TableFieldInfo * field = demo_field( profileType, sk.field );
+        CHECK( field != NULL && field->kind == sk.kind );
+    }
+    const tabledemo::TableFieldInfo * homing = demo_field( weapon, "homing" );
+    CHECK( homing != NULL && homing->kind == 1 ); // bool
+    const tabledemo::TableFieldInfo * effect = demo_field( weapon, "effect" );
+    CHECK( effect != NULL && effect->kind == 15 ); // union
+    const tabledemo::TableFieldInfo * nameF = demo_field( profileType, "name" );
+    CHECK( nameF != NULL && nameF->kind == 12 ); // string
+
     // generic field access through offset — an editor walking properties
     tabledemo::ProfileConfig p;
     p.experience = 777;
@@ -436,6 +636,9 @@ static void test_parallel_shape()
 int main()
 {
     test_round_trip();
+    test_exact_capacity();
+    test_storage_invariants();
+    test_bounded_elements();
     test_all_default();
     test_guard();
     test_evolution_old_reader_new_data();


### PR DESCRIPTION
## The model

Tables are for data that outlives builds — tools-to-game pipelines, editors that walk properties by name, save/load to memory or disk — declared with `table`, carried on an evolution-tolerant TLV wire where field identity is a name hash, so any reader takes any data in both directions (unknown fields skip, absent fields default, changed kinds skip rather than misdecode, out-of-range values clamp, and every event is counted in a report). Packets stay exactly what they are: exact-match, bit-packed, protocol-id-gated — tables never enter the projection, never move the protocol id, and never change a generated packet byte.

Flatbuffers/protobuf ideas apply to tables, not to types: tables must go wide in generation (the encode surface is a measure/save split, so subtables can be measured in parallel, prefix-summed, and scatter-written from N workers) and must be relocatable (trivially copyable, standard-layout, pointer-free, arrays inline — enforced by generated `static_assert`s). **The exact-capacity guarantee**: for any value that saves at all, `TableSave(value, buf, TableMeasure(value))` succeeds and writes exactly that many bytes — elision (including all-default nested tables) is decided before any byte is emitted, so a scatter-writing worker can be handed exactly `sizes[i]` and nothing more. Tested corpus-wide, including the one-byte-short refusal. Contract ported from prior internal work; the `was` rename attribute and the measure/save split are new here.

## What is generated

For `--lang cpp`, a unit that declares tables gains one `<Base>Table.h` per schema file, holding for the whole table closure (every `table` plus everything one references, transitively):

- storage structs for the `table` declarations (closure `type`s reuse the structs from `<Base>.h`), with declared defaults as member initializers
- `TableMeasureX( const X & )` — exact encoded size, writes nothing
- `TableWriteX( TableWriter &, const X & )` / `TableSaveX( const X &, uint8_t * buffer, int64_t capacity )` — returns bytes written (== measure) or -1
- `TableReadX( const uint8_t *, int64_t, X &, TableReport & )` — prefill defaults in place, overlay, count events
- `TableTypeX()` reflection descriptors: name, wire id/kind, storage offset, array bounds and `_count`/`_length` companions, declared ranges, enum name functions, branch guards — enough to walk/print/diff/edit any table value with no RTTI and no schema files
- relocatability `static_assert`s per closure member
- zero allocation (tested), **no serialize dependency** — the test leg compiles without the serialize include path to prove it

Every other target refuses a unit that declares tables, by name ("tables are C++-only today; the <lang> table backend is a named follow-on").

## The wire, on one page

Neutral by ruling: plain little-endian scalars and length-prefixed regions — implementable by a third party from this description alone. None of the packet wire's density machinery (no bitpacking, no range compression) rides here; schema's opinionated declarations (ranged ints, compressed floats, bits(N), enums, flags) are declaration-side conveniences that validate/clamp on load and map to neutral kinds.

- A table body is a sequence of fields, terminated by `u16 0`.
- Field: `u16 id` (fold16(fnv1a32(name)), 0 rebounds to 1; the `was` alias's hash after a rename), `u8 kind`, payload.
- Kinds: 1 bool(u8) · 2–5 i8/i16/i32/i64 · 6–9 u8/u16/u32/u64 · 10/11 f32/f64 (bit pattern) · 12 string (`u16 len` + bytes) · 13 table (`u32 len` + nested body) · 14 array (`u32 body_len` + `u8 elem_kind` + `u16 count` + elements; table elements are each `u32`-length-prefixed; bytes(N) is an array of u8) · 15 union (`u8 tag`; tag 0 = None is the whole payload; else `u32 len` + selected arm as a nested body).
- Mapping: enums ride at their storage width (out-of-set → None, counted); flags ride u64; bits(N) rides the smallest u-kind with a width clamp; ranged ints ride at full storage width and clamp on load; compressed-float triples ride as plain f32 and clamp to [min, max]. No packing opinion leaks onto the wire (audited; none found in the ported contract either).
- Elision: a field at its declared default stays off the wire; an all-default table is 2 bytes; None unions, empty strings/arrays and all-default nested tables elide; guarded fields stay off the wire when the guard says so, and the reader's prefilled defaults stand in.

## Deviations from the ported contract

1. **`was = "old_name"`** (new): rename aliasing — the field's wire id stays the old name's hash. Refused: `was` naming the field's own current name, empty/non-string values, `was` outside table bodies (by name), and any two fields of one closure member whose effective ids collide (the prior collision refusal, extended over was-ids).
2. **Measure/save split** (owner-ruled): the prior encode surface was write-with-capacity only; `TableMeasureX` + `TableSaveX` are added so generation can go wide. Measure mirrors write's elision decisions exactly; the test asserts measure == save everywhere.
3. **Tables are invisible to the packet wire** (forced by this repo's structure): here a `type` cannot reference a `table`, a table is not a union payload, and tables live beside the decl stream (`Unit.Tables`/`File.Tables`), not in it — the packet backends, the projection and the protocol id never see them. The prior implementation let tables double as packet types; schema's packet emitters are byte-frozen, so tables stay a separate world.
4. **`const`/`reserved`/`align` refused in table bodies** (by name): they describe bit positions, and the table wire has no bit positions.
5. **string/bytes/array extents past 65535 refused in closures**: table-wire lengths and counts ride in u16 (schema's packet wire permits larger; the table wire does not).
6. **Table declarations take no qualification** (day one): no tags, no cpp_native mapping on tables themselves (closure `type`s keep theirs).
7. **Table.h renders folded literals** (no symbolic constant rendering): `string(MaxName)` declares fine; the header prints the folded bound. The packet headers keep their symbolic rendering.
8. **Codec prototypes precede definitions** (layout, not contract): declaration order in the schema is free.
9. **Cross-file include cycles among Table headers are refused by name** (the prior code would emit mutual includes).
10. Same-as-prior refusals, kept: `fixed(I,F)` and `int128`/`uint128` have no table-wire kind; arrays of unions are a named follow-on; self/cyclic table nesting is refused under the existing composition-cycle rule (tables join the cycle graph).
11. **Array elements are bounded by the field's body length** (deliberate deviation from the prior GENERATED reader, ruled by the tolerance model): the prior implementation's generated reader let a lying element count read past the field body into the following fields' bytes — fabricated values accepted silently, then the same bytes decoded again as fields. Its own hand-written generic decoder bounds elements to the body slice, and the ruled model ("changed kinds skip, NEVER misdecoded; malformed = stop + partial + flag") arbitrates the disagreement that way: elements decode through a sub-reader over the field body, a truncated element keeps the decoded prefix and flags `malformed`, and the parent continues at the next field. Probed by test with crafted body_len/count lies.
12. **Write and measure validate storage invariants** (restores prior-encoder behavior the first cut of this port dropped): a `_count`/`_length` outside its bound — negative included — fails the save (`TableMeasure` returns -1, `TableSave` returns -1) instead of reading out of the array onto the wire; an out-of-range union tag fails measure exactly as it fails write.

## Expressiveness gate: "Config.bin / Assets.bin in tables"

Surveyed the production config/asset declarations and loaders (read-only). Each structural need, verified in the compiled test leg:

| Structural need | How tables express it | Verified |
|---|---|---|
| Per-field defaults + ranges (`max_players int32 = MaxPlayers \| min = 1, max = MaxPlayers`) | Same spelling in table bodies; absent-field decode materializes the default, out-of-range clamps and counts | round-trip + evolution + clamp tests |
| Nested tables and bounded collections (`armor_config [..NumArmorLevels]ArmorConfig`, `colliders [..Max]Collider`) | Table-typed fields and `[..N]Table` arrays, const-named bounds; `string(MaxLevelNameLength)` const capacities | corpus `RootConfig`/`LoadoutConfig`, `TestTableRefusals` bounds cases |
| Enum/flags/float/bool/int fields (`ship_type ShipType`) | All native in table bodies; enums clamp out-of-set to None and surface name functions in descriptors | round-trip + reflection tests |
| Guarded optional groups (`has_gunner_settings bool` + `if … { gunner_settings GunnerSettings }`) | `if` guards in table bodies; untaken side stays off the wire, defaults stand in | guard test |
| The container: root envelope (magic + hash) holding per-collection table instances | **The worked answer:** declare a root table with bounded arrays of config tables — the DATA is schema's; the few-line magic/hash envelope stays user code by design (opinion-free, no document concept, no prescribed roots) | corpus `RootConfig` + USAGE's nesting section |
| The evolution doctrine (unknown skip, absent default, kind-change skip, clamp, warn loudly, only structural damage rejects) | This is the wire contract verbatim; the report carries the warn-loudly counts | both-directions evolution tests with exact counter asserts |

Named gap (follow-on, not implemented): the production declarations carry a `json = "name"` field attribute — a tool-side JSON authoring surface, not wire. It joins the follow-ons list.

## Test inventory

- `test/tables/main.cpp` (compiled + run in `make test`, **without** the serialize include path): corpus round trip over ALL 15 wire kinds — every scalar kind now rides and is pinned by descriptor (i8/i16/i32/i64, u8/u16/u32/u64, f32/f64, bool, string, table, array, union) — plus bits, enum, flags, fixed/counted arrays, nested/cross-file tables, guards; all-default = 2 bytes; measure == save everywhere; **exact-capacity suite** (save into a buffer of exactly measure's size succeeds and byte-matches, one-byte-short refuses — across all-default nested elision, guarded elision, deep nesting, fixed table arrays, both evolution shapes); **storage-invariant suite** (count above bound, negative count/length, deep nested violation, invalid union tag — measure and save both refuse); **bounded-element probes** (body_len/count lies yield empty or prefix-only arrays, malformed flagged, following fields decode intact — never fabricated elements); both-directions evolution (old reader × new data, new reader × old data) with exact unknown/kind_mismatch asserts; `was` rename identity in both directions; clamp (ranged int, bits width, over-long string) with counts; malformed framing (truncation) with partial-result keep; reflection walk (ids pinned against an independent C++ implementation of the hash, ranges, enum names, guards, nested descriptors, offset-based generic access); relocation by memcpy; the parallel measure/prefix-sum/scatter-write shape; too-small buffer refusal.
- `internal/check/tables_test.go`: 19 named refusals (see deviations above), table-runtime name claims, id function pins (frozen values), `was` id override, tables-invisible-to-packet-IR, and **adding/editing a table moves neither the projection nor the protocol id**.
- `compiler/tables_test.go`: all eight non-C++ targets (plus aliases) refuse by name; cpp emits Table headers only for table units; **non-table generated files are byte-identical with and without tables**; generated table code contains no allocation, no standard containers, no serialize include/symbols, and carries the codecs and relocatability asserts.
- `internal/check/diagnostics_test.go`: bare `was` (valued-attribute guard), table qualification refusal.

## Locked paths and protocol id, untouched

- No file under `internal/codegen/c/`, `internal/codegen/cpp/`, `generated/c/`, `generated/cpp/`, `generated/c-ludicrous/` is modified (`git diff --stat` on this branch shows none). The Table emitter is a new sibling package, `internal/codegen/cpptable/`, wired in `compiler/builtin.go`.
- `make test` regenerates every committed `generated/` tree; the tree is clean afterwards (the examples corpora declare no tables, and a table-free unit's output is byte-identical by test).
- Protocol-id independence is tested twice: projection/id equality in `internal/check/tables_test.go`, and non-table byte equality in `compiler/tables_test.go`.

## Follow-ons (named, not now)

- Per-language table backends (go, rust, c, cs, js, dart, java, elixir) — each currently a by-name refusal.
- `json = "name"` tool-side authoring attribute.
- Arrays of unions on table-closure paths.
- Symbolic constant rendering in Table headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
