### PR TITLE
cs: the fusion-consequence comment names its whole class; reserved cites SPEC §4.3 (#213)

### DIFF
--- a/generated/cs/Wire.cs
+++ b/generated/cs/Wire.cs
@@ -363,7 +363,7 @@ namespace Example
                 ulong v1 = (c0 >> 8) & 0x7UL;
                 value.Version = (uint)v1;
                 ulong v2 = (c0 >> 11) & 0x1fUL;
-                if (v2 != 0UL) // reserved(5): a read rejects nonzero
+                if (v2 != 0UL) // reserved(5): a read rejects nonzero (SPEC §4.3)
                 {
                     return false;
                 }

--- a/internal/codegen/csharp/flat.go
+++ b/internal/codegen/csharp/flat.go
@@ -406,9 +406,10 @@ func (g *gen) flatWriteEnumPiece(item *ir.FieldItem, ref *ir.Enum, name string) 
 //
 // TWO CONSEQUENCES, both named rather than discovered later:
 //
-//   - A stream that is BOTH truncated inside a run AND carries an
-//     out-of-range value before the truncation now surfaces the stream's
-//     overflow error where the per-field form surfaced the range refusal.
+//   - A stream that is BOTH truncated inside a run AND carries, before the
+//     truncation, a value the run's own validation refuses — a wrong const,
+//     a nonzero reserved, an out-of-range value — now surfaces the stream's
+//     overflow error where the per-field form surfaced that refusal.
 //     Both refuse the packet; the set of ACCEPTED streams is unchanged, which
 //     is the property that matters at the trust boundary. Java, Dart, JS-flat,
 //     Rust and Go already carry this consequence.
@@ -507,7 +508,7 @@ func (g *gen) flatReadPieceOf(item ir.Item) (flatPiece, bool) {
 			return flatPiece{}, false
 		}
 		return flatPiece{item: item, bits: item.Bits, read: func(ind, src string) {
-			g.sf("%sif (%s != 0UL) // reserved(%d): a read rejects nonzero\n", ind, src, item.Bits)
+			g.sf("%sif (%s != 0UL) // reserved(%d): a read rejects nonzero (SPEC §4.3)\n", ind, src, item.Bits)
 			g.sf("%s{\n%s    return false;\n%s}\n", ind, ind, ind)
 		}}, true
 	case *ir.FieldItem:

--- a/testdata/golden/cs/Wire.cs
+++ b/testdata/golden/cs/Wire.cs
@@ -363,7 +363,7 @@ namespace Example
                 ulong v1 = (c0 >> 8) & 0x7UL;
                 value.Version = (uint)v1;
                 ulong v2 = (c0 >> 11) & 0x1fUL;
-                if (v2 != 0UL) // reserved(5): a read rejects nonzero
+                if (v2 != 0UL) // reserved(5): a read rejects nonzero (SPEC §4.3)
                 {
                     return false;
                 }


### PR DESCRIPTION
Closes #213 (the #208 review's finding §4 and the §10 citation nit). The consequence bullet now names the full refusal class (wrong `const`, nonzero `reserved`, out-of-range) — the review reproduced the const case 35x on the shipped corpus with identical verdicts, so the accepted set is unchanged and the comment now says exactly that. The flat read path's reserved refusal gains its `(SPEC §4.3)` citation. Exactly one emitted line changes; `generated/cs/Wire.cs` and its golden move together; no wire bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)