### PR TITLE
bench provenance: -dirty on every commit line when the tree differs from HEAD (#186)

### DIFF
--- a/bench/BENCH-STANDARD.md
+++ b/bench/BENCH-STANDARD.md
@@ -998,6 +998,13 @@ benchmarks two different versions of the same C++ library and publishes both.
 > `msbuild -getItem:Compile`) before it is printed — **and a leg that cannot
 > prove its runtime path REFUSES (no rows) rather than reporting.**
 
+**Every commit line records a `-dirty` suffix when the tree differs from
+HEAD** (added 2026-09-01, closing #186): a sweep of uncommitted work must say
+so in its own preamble, or the archaeology of an experiment run reconstructs
+the wrong configuration from a clean-looking sha — which is exactly what the
+2026-08-15 rust-read CSVs did, recording a commit while measuring work that
+never shipped as that commit.
+
 **The schema commit records its BRANCH too** (added 2026-09-01, alongside the
 runtime lines that already did). The failure it closes is the twin of the one
 below: a sweep that silently measured the wrong tree, and a CSV that could not

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -306,10 +306,17 @@ emit_preamble() {
 }
 
 commit_of() {
-    local sha branch
+    local sha branch dirty
     sha="$(git -C "$1" rev-parse --short HEAD 2>/dev/null || echo unknown)"
     branch="$(git -C "$1" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
-    echo "$sha ($branch)"
+    # -dirty when the tree differs from HEAD (tracked changes only): a sweep
+    # of uncommitted work must SAY so, or the archaeology of an experiment
+    # run reconstructs the wrong configuration from a clean-looking sha
+    dirty=""
+    if [ "$sha" != "unknown" ] && ! git -C "$1" diff-index --quiet HEAD -- 2>/dev/null; then
+        dirty="-dirty"
+    fi
+    echo "$sha$dirty ($branch)"
 }
 
 # ---- §3.5 provenance guard: verify BEFORE any row or preamble exists ----


### PR DESCRIPTION
Closes #186. `commit_of` appends `-dirty` (`git diff-index --quiet HEAD`, tracked changes only) to the schema line and every sibling runtime line, and BENCH-STANDARD §3.5 now requires it — a sweep of uncommitted work says so in its own preamble instead of leaving a clean-looking sha for a later archaeology to trust. The §3.5 path verifier is untouched (it proves paths, not sha strings — checked). Controls: clean sibling → bare sha; the clone carrying this edit → `-dirty`. `bash -n` clean; the x86 sweep (#218) flagged the same hole independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)