### PR TITLE
fuzz: js and dart join the backend table — seven fuzzed emitters (#164)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,11 +75,11 @@ what the language specifies, in a way that weakens a check.
 
 ## What we do to find these ourselves
 
-- A native Go fuzz harness drives parse → check → generate across the C, C++, C#, Go and Rust
+- A native Go fuzz harness drives parse → check → generate across the C, C++, C#, Dart, Go, JavaScript and Rust
   backends. Every crasher ever found is committed as a permanent regression
   input and re-run on every push.
-- The cross-language corpus generates the same schemas in C, C++, C#, Dart, Go,
-  Java, JavaScript and Rust
+- The cross-language corpus generates the same schemas in C, C++, C#, Dart,
+  Elixir, Go, Java, JavaScript and Rust
   and compares emitted wire bit for bit against pinned goldens, on Linux and
   macOS, on every push. Divergence between languages fails CI.
 - Generated readers are exercised against hand-crafted hostile bytes.

--- a/internal/fuzz/fuzz_test.go
+++ b/internal/fuzz/fuzz_test.go
@@ -29,7 +29,9 @@ import (
 	cgen "github.com/mas-bandwidth/schema/v2/internal/codegen/c"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/cpp"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/csharp"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/dart"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/golang"
+	"github.com/mas-bandwidth/schema/v2/internal/codegen/js"
 	"github.com/mas-bandwidth/schema/v2/internal/codegen/rust"
 	"github.com/mas-bandwidth/schema/v2/internal/parser"
 	"github.com/mas-bandwidth/schema/v2/ir"
@@ -46,6 +48,12 @@ var backends = []struct {
 	{"golang", golang.Generate},
 	{"rust", rust.Generate},
 	{"c", cgen.Generate},
+	// the refusal-capable emitters (#164): js and dart may return
+	// generate-time refusals on checked units (reserved-word collisions and
+	// similar) — drive already tolerates a reported error; the panic and the
+	// malformed-output cases below are the bugs.
+	{"js", js.Generate},
+	{"dart", dart.Generate},
 }
 
 // unitOf runs parse+check over the named sources. A parse or check failure is

--- a/internal/fuzz/oracle_test.go
+++ b/internal/fuzz/oracle_test.go
@@ -44,6 +44,10 @@ func checkGenerated(t *testing.T, backend string, out map[string][]byte) {
 			checkDupDefLines(t, backend, name, data, cFamilyDefLine)
 		case strings.HasSuffix(name, ".cs"):
 			checkDupDefLines(t, backend, name, data, csTypeDefLine)
+		case strings.HasSuffix(name, ".dart"):
+			checkDupDefLines(t, backend, name, data, dartTypeDefLine)
+		case strings.HasSuffix(name, ".js"):
+			checkDupDefLines(t, backend, name, data, jsDefLine)
 		}
 	}
 }
@@ -152,6 +156,18 @@ var cFamilyDefLine = regexp.MustCompile(`^(static |inline |constexpr |struct |cl
 // legal C# an emitter may legitimately produce, so `partial` is excluded too.
 var csTypeDefLine = regexp.MustCompile(`^(public |internal |static )*(sealed |static )*(class|struct|enum|interface) `)
 
+// dartTypeDefLine matches Dart top-level type declarations (column 0).
+// Members and methods are excluded for the same reason as C#'s.
+var dartTypeDefLine = regexp.MustCompile(`^(abstract )?(final |base |sealed )?(class|enum|extension|mixin) `)
+
+// jsDefLine matches the js emitters' EXPORTED surface only: checkDupDefLines
+// trims lines before matching, so a bare `const ` would also match the
+// function-local consts the codecs emit legitimately (e0 aliases in element
+// loops). `export` cannot appear in function scope, so it is top-level by
+// construction — the miss on unexported module-scope consts is the cheap
+// side of the harness's own trade (a false match costs a bogus report).
+var jsDefLine = regexp.MustCompile(`^export (const |class |function |function\* )`)
+
 // pure forward declarations may legally repeat.
 var forwardDecl = regexp.MustCompile(`^(struct|class|enum|union)\s+[A-Za-z_][A-Za-z0-9_]*\s*;$`)
 
@@ -168,5 +184,33 @@ func checkDupDefLines(t *testing.T, backend, name string, data []byte, def *rege
 				backend, name, prev, i+1, line, name, data)
 		}
 		seen[line] = i + 1
+	}
+}
+
+// The matchers' own discrimination, pinned: what each must catch and what it
+// must NOT (checkDupDefLines trims before matching, so a matcher that hits
+// function-local lines files bogus crash reports).
+func TestDefLineMatchers(t *testing.T) {
+	match := []struct {
+		re   *regexp.Regexp
+		line string
+		want bool
+	}{
+		{jsDefLine, "export const ProbeId = 244837814094590n;", true},
+		{jsDefLine, "export class ProbeHeader {", true},
+		{jsDefLine, "export function writeProbeHeader(value, stream) {", true},
+		{jsDefLine, "const e0 = value.Items[i0];", false}, // function-local alias, trimmed
+		{jsDefLine, "const NUMBER_SCRATCH = { value: 0 };", false},
+		{dartTypeDefLine, "final class ProbeHeader {", true},
+		{dartTypeDefLine, "abstract final class Weapon {", true},
+		{dartTypeDefLine, "enum Team {", true},
+		{dartTypeDefLine, "extension ProbeWire on ProbeHeader {", true},
+		{dartTypeDefLine, "int w = 1073741824;", false},
+		{dartTypeDefLine, "final int hi;", false},
+	}
+	for _, c := range match {
+		if got := c.re.MatchString(c.line); got != c.want {
+			t.Errorf("%v on %q: got %v, want %v", c.re, c.line, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
Closes #164. The harness's shared driver already tolerates generate-time refusals on checked units (the blocker the issue recorded), so js and dart slot into the backends table directly — every seed and every committed crasher now drives seven emitters, and the compile fuzz picks them up automatically. The output oracle gains `.dart` and `.js` duplicate-definition checks; the js matcher covers the EXPORTED surface only, because `checkDupDefLines` trims lines and the first run proved a bare-const matcher reports legitimate function-local aliases. `TestDefLineMatchers` pins both matchers' positive and negative cases. SECURITY.md updated to seven fuzzed backends (and the corpus list regains Elixir — nine legs run, the list said eight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)