### PR TITLE
dart: the laggard round — chunked lanes, windowed reads, the #165 bulk-bytes path; 363% -> 221% of generated C++

### DIFF
--- a/bench/results/2026-09-01-dartcodec-after-quick-arm64-macbook.csv
+++ b/bench/results/2026-09-01-dartcodec-after-quick-arm64-macbook.csv
@@ -1,0 +1,28 @@
+# schema bench results
+# date: 2026-09-01T03:57:54Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I/Users/glenn/rowan-working/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I/Users/glenn/rowan-working/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: cb858e9 (dart-round)
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: 287e2fe (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 1439c6f (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,3,2851845,2851245,2857586,1191.24,0.22,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,3,1591140,1590230,1591336,664.63,0.07,6b213fbfa1a03a99,gen,aot,contract,default,unknown

--- a/bench/results/2026-09-01-dartcodec-before-quick-arm64-macbook.csv
+++ b/bench/results/2026-09-01-dartcodec-before-quick-arm64-macbook.csv
@@ -1,0 +1,28 @@
+# schema bench results
+# date: 2026-09-01T03:57:20Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I/Users/glenn/rowan-working/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I/Users/glenn/rowan-working/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: e291d86 (HEAD)
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: 287e2fe (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 1439c6f (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,3,1896690,1892583,1900191,792.27,0.40,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,3,972023,950633,972818,406.02,2.28,6b213fbfa1a03a99,gen,aot,contract,default,unknown

--- a/generated/bench/dart/Bench.dart
+++ b/generated/bench/dart/Bench.dart
@@ -275,136 +275,86 @@ bool readBenchPacket(BenchPacket value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 249 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // a smuggled offset is refused
   }
   value.a = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 8) & 0xffff;
   bitsRead += 16;
   value.b = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fffff;
+  v = (window >>> 24) & 0x1fffff;
   bitsRead += 21;
   if (v > 2000000) {
     return false; // a smuggled offset is refused
   }
   value.c = -1000000 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7f;
+  v = (window >>> 45) & 0x7f;
   bitsRead += 7;
   value.bits7 = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1fff;
+  v = window & 0x1fff;
   bitsRead += 13;
   value.bits13 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 13) & 0x7fffff;
   bitsRead += 23;
   value.bits23 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 36) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.x = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.y = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.z = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.big = lo;
@@ -425,13 +375,11 @@ bool readBenchPacket(BenchPacket value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 17; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xff;
+    v = window & 0xff;
     bitsRead += 8;
     value.blob[i0] = v;
   }
@@ -577,124 +525,68 @@ bool readBenchInts(BenchInts value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 110 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // a smuggled offset is refused
   }
   value.f0 = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 8) & 0xffff;
   bitsRead += 16;
   value.f1 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fffff;
+  v = (window >>> 24) & 0x1fffff;
   bitsRead += 21;
   if (v > 2000000) {
     return false; // a smuggled offset is refused
   }
   value.f2 = -1000000 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 45) & 0x3;
   bitsRead += 2;
   value.f3 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 47) & 0x1f;
   bitsRead += 5;
   if (v > 30) {
     return false; // a smuggled offset is refused
   }
   value.f4 = -15 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3ff;
+  v = window & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.f5 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 10) & 0xfff;
   bitsRead += 12;
   value.f6 = -2048 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 22) & 0xff;
   bitsRead += 8;
   value.f7 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fffff;
+  v = (window >>> 30) & 0x1fffff;
   bitsRead += 21;
   if (v > 1200000) {
     return false; // a smuggled offset is refused
   }
   value.f8 = -600000 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   if (v > 100) {
     return false; // a smuggled offset is refused
@@ -808,102 +700,54 @@ bool readBenchBits(BenchBits value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 156 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.b7 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fff;
+  v = (window >>> 7) & 0x1fff;
   bitsRead += 13;
   value.b13 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 20) & 0x7fffff;
   bitsRead += 23;
   value.b23 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 43) & 0x7;
   bitsRead += 3;
   value.b3 = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.b32 = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 32) & 0x7ff;
   bitsRead += 11;
   value.b11 = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7ffff;
+  v = window & 0x7ffff;
   bitsRead += 19;
   value.b19 = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
-  bitsRead += 16;
-  lo |= v << 32;
+  lo = window & 0xffffffffffff;
+  bitsRead += 48;
   value.b48 = lo;
   return true;
 }
@@ -1195,161 +1039,77 @@ bool readMixedEntity(MixedEntity value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 135 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfff;
+  v = window & 0xfff;
   bitsRead += 12;
   value.entityId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fff;
+  v = (window >>> 12) & 0x7fff;
   bitsRead += 15;
   if (v > 32766) {
     return false; // a smuggled offset is refused
   }
   value.posX = -16383 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fff;
+  v = (window >>> 27) & 0x7fff;
   bitsRead += 15;
   if (v > 32766) {
     return false; // a smuggled offset is refused
   }
   value.posY = -16383 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fff;
+  v = (window >>> 42) & 0x7fff;
   bitsRead += 15;
   if (v > 32766) {
     return false; // a smuggled offset is refused
   }
   value.posZ = -16383 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ff;
+  v = window & 0x1ff;
   bitsRead += 9;
   value.yaw = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
+  v = (window >>> 9) & 0x1ff;
   bitsRead += 9;
   value.pitch = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 18) & 0xfff;
   bitsRead += 12;
   value.velX = -2048 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 30) & 0xfff;
   bitsRead += 12;
   value.velY = -2048 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 42) & 0xfff;
   bitsRead += 12;
   value.velZ = -2048 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3ff;
+  v = window & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.health = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 10) & 0xf;
   bitsRead += 4;
   value.weapon = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 14) & 0xff;
   bitsRead += 8;
   value.damage = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 22) & 0x1;
   bitsRead += 1;
   value.moving = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 23) & 0x1;
   bitsRead += 1;
   value.firing = v != 0;
   return true;
@@ -1426,29 +1186,19 @@ bool readMixedStat(MixedStat value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 18 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.statId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 8) & 0x3ff;
   bitsRead += 10;
   value.delta = -512 + v;
   return true;
@@ -1536,49 +1286,25 @@ bool readMixedHitEvent(MixedHitEvent value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 28 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfff;
+  v = window & 0xfff;
   bitsRead += 12;
   value.targetId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 12) & 0xfff;
   bitsRead += 12;
   value.damage = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 24) & 0x7;
   bitsRead += 3;
   value.hitKind = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 27) & 0x1;
   bitsRead += 1;
   value.crit = v != 0;
   return true;
@@ -1655,29 +1381,19 @@ bool readMixedChatEvent(MixedChatEvent value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 14 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.channel = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 2) & 0xfff;
   bitsRead += 12;
   value.speaker = v;
   return true;
@@ -1754,29 +1470,19 @@ bool readMixedPickupEvent(MixedPickupEvent value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 18 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3ff;
+  v = window & 0x3ff;
   bitsRead += 10;
   value.itemId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 10) & 0xff;
   bitsRead += 8;
   value.amount = v;
   return true;
@@ -1912,19 +1618,16 @@ bool readMixedEvent(MixedEvent value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.type = v;
   switch (value.type) {
@@ -1937,43 +1640,21 @@ bool readMixedEvent(MixedEvent value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xfff;
+      v = window & 0xfff;
       bitsRead += 12;
       value.hit.targetId = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xfff;
+      v = (window >>> 12) & 0xfff;
       bitsRead += 12;
       value.hit.damage = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x7;
+      v = (window >>> 24) & 0x7;
       bitsRead += 3;
       value.hit.hitKind = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1;
+      v = (window >>> 27) & 0x1;
       bitsRead += 1;
       value.hit.crit = v != 0;
     case 2:
@@ -1983,23 +1664,15 @@ bool readMixedEvent(MixedEvent value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x3;
+      v = window & 0x3;
       bitsRead += 2;
       value.chat.channel = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xfff;
+      v = (window >>> 2) & 0xfff;
       bitsRead += 12;
       value.chat.speaker = v;
     case 3:
@@ -2009,23 +1682,15 @@ bool readMixedEvent(MixedEvent value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x3ff;
+      v = window & 0x3ff;
       bitsRead += 10;
       value.pickup.itemId = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 10) & 0xff;
       bitsRead += 8;
       value.pickup.amount = v;
   }
@@ -2699,7 +2364,6 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   var hi = 0;
@@ -2707,152 +2371,96 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   if (v != 49374) {
     return false; // a read rejects any other value (SPEC §4.3)
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 16) & 0xffff;
   bitsRead += 16;
   value.sequence = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 32) & 0xffff;
   bitsRead += 16;
   value.ackSequence = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.ackBits = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.sessionId = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.clientId = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.nonce = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
-  bitsRead += 9;
-  lo |= v << 32;
+  lo = window & 0x1ffffffffff;
+  bitsRead += 41;
   if (lo > 2000000000000) {
     return false; // a smuggled offset is refused
   }
   value.worldTime = -1000000000000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
-  bitsRead += 16;
-  lo |= v << 32;
+  lo = window & 0xffffffffffff;
+  bitsRead += 48;
   value.frameTick = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   if (v > 16776960) {
     return false; // a smuggled offset is refused
@@ -2861,14 +2469,7 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   if (bitsRead + 3 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 24) & 0x7;
   bitsRead += 3;
   value.entitiesCount = v + 1;
   if (bitsRead + value.entitiesCount * 135 > numBits) {
@@ -2877,155 +2478,72 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.entitiesCount; i0++) {
     final e0 = value.entities[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xfff;
+    v = window & 0xfff;
     bitsRead += 12;
     e0.entityId = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x7fff;
+    v = (window >>> 12) & 0x7fff;
     bitsRead += 15;
     if (v > 32766) {
       return false; // a smuggled offset is refused
     }
     e0.posX = -16383 + v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x7fff;
+    v = (window >>> 27) & 0x7fff;
     bitsRead += 15;
     if (v > 32766) {
       return false; // a smuggled offset is refused
     }
     e0.posY = -16383 + v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x7fff;
+    v = (window >>> 42) & 0x7fff;
     bitsRead += 15;
     if (v > 32766) {
       return false; // a smuggled offset is refused
     }
     e0.posZ = -16383 + v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1ff;
+    v = window & 0x1ff;
     bitsRead += 9;
     e0.yaw = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1ff;
+    v = (window >>> 9) & 0x1ff;
     bitsRead += 9;
     e0.pitch = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xfff;
+    v = (window >>> 18) & 0xfff;
     bitsRead += 12;
     e0.velX = -2048 + v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xfff;
+    v = (window >>> 30) & 0xfff;
     bitsRead += 12;
     e0.velY = -2048 + v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xfff;
+    v = (window >>> 42) & 0xfff;
     bitsRead += 12;
     e0.velZ = -2048 + v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3ff;
+    v = window & 0x3ff;
     bitsRead += 10;
     if (v > 1000) {
       return false; // a smuggled offset is refused
     }
     e0.health = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xf;
+    v = (window >>> 10) & 0xf;
     bitsRead += 4;
     e0.weapon = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xff;
+    v = (window >>> 14) & 0xff;
     bitsRead += 8;
     e0.damage = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 22) & 0x1;
     bitsRead += 1;
     e0.moving = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 23) & 0x1;
     bitsRead += 1;
     e0.firing = v != 0;
   }
@@ -3033,13 +2551,11 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   if (v > 80) {
     return false; // the count guards the loop — reject, never clamp
@@ -3051,23 +2567,14 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.statsCount; i0++) {
     final e0 = value.stats[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xff;
+    v = window & 0xff;
     bitsRead += 8;
     e0.statId = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3ff;
+    v = (window >>> 8) & 0x3ff;
     bitsRead += 10;
     e0.delta = -512 + v;
   }
@@ -3075,13 +2582,11 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.gameEvent.type = v;
   switch (value.gameEvent.type) {
@@ -3094,43 +2599,21 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xfff;
+      v = window & 0xfff;
       bitsRead += 12;
       value.gameEvent.hit.targetId = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xfff;
+      v = (window >>> 12) & 0xfff;
       bitsRead += 12;
       value.gameEvent.hit.damage = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x7;
+      v = (window >>> 24) & 0x7;
       bitsRead += 3;
       value.gameEvent.hit.hitKind = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1;
+      v = (window >>> 27) & 0x1;
       bitsRead += 1;
       value.gameEvent.hit.crit = v != 0;
     case 2:
@@ -3140,23 +2623,15 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x3;
+      v = window & 0x3;
       bitsRead += 2;
       value.gameEvent.chat.channel = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xfff;
+      v = (window >>> 2) & 0xfff;
       bitsRead += 12;
       value.gameEvent.chat.speaker = v;
     case 3:
@@ -3166,52 +2641,42 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x3ff;
+      v = window & 0x3ff;
       bitsRead += 10;
       value.gameEvent.pickup.itemId = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 10) & 0xff;
       bitsRead += 8;
       value.gameEvent.pickup.amount = v;
   }
   if (bitsRead + 32 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < 4; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xff;
-    bitsRead += 8;
-    value.loadout[i0] = v;
+  if (bitsRead >>> 3 < tailBase) {
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+  } else {
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
+  v = window & 0xff;
+  bitsRead += 8;
+  value.loadout[0] = v;
+  v = (window >>> 8) & 0xff;
+  bitsRead += 8;
+  value.loadout[1] = v;
+  v = (window >>> 16) & 0xff;
+  bitsRead += 8;
+  value.loadout[2] = v;
+  v = (window >>> 24) & 0xff;
+  bitsRead += 8;
+  value.loadout[3] = v;
   if (bitsRead + 4 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 32) & 0xf;
   bitsRead += 4;
   value.playerNameLength = v;
   {
@@ -3245,13 +2710,11 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   if (v > 16) {
     return false; // the length guards the slice — reject, never clamp
@@ -3283,13 +2746,11 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // headroom above the quantum count is refused
@@ -3297,14 +2758,7 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   value.aimX = _fround(
     _fround(_fround(_fround(v.toDouble()) / 200.0) * 2.0) + -1.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 8) & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // headroom above the quantum count is refused
@@ -3312,14 +2766,7 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   value.aimY = _fround(
     _fround(_fround(_fround(v.toDouble()) / 200.0) * 2.0) + -1.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 16) & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // headroom above the quantum count is refused
@@ -3327,116 +2774,84 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   value.aimZ = _fround(
     _fround(_fround(_fround(v.toDouble()) / 200.0) * 2.0) + -1.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 24) & 0xffffffff;
   bitsRead += 32;
   value.recoil = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.drift = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.wideKey = UInt128(hi, lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3f;
+  v = (window >>> 32) & 0x3f;
   bitsRead += 6;
   hi |= v << 32;
   {
@@ -3449,27 +2864,18 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
     const min = UInt128(0xfffffff000000000, 0);
     value.flux = (min + UInt128(hi, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 38) & 0xffff;
   bitsRead += 16;
   if (v > 64000) {
     return false; // a smuggled offset is refused
   }
   value.ping = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v != 0) {
     return false; // reserved bits must read zero (SPEC §4.3)
@@ -3490,23 +2896,14 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.crcHint = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 24) & 0x1;
   bitsRead += 1;
   value.hasExtra = v != 0;
   if (value.hasExtra) {
@@ -3514,13 +2911,11 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xff;
+    v = window & 0xff;
     bitsRead += 8;
     value.extra = v;
     value.idleTicks = 0;
@@ -3529,13 +2924,11 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xf;
+    v = window & 0xf;
     bitsRead += 4;
     value.idleTicks = v;
     value.extra = 0;

--- a/generated/bench/dart/Bench.dart
+++ b/generated/bench/dart/Bench.dart
@@ -1980,18 +1980,47 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (7 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.statsCount; i0++) {
-    final e0 = value.stats[i0];
-    assert(e0.delta >= -512);
-    assert(e0.delta <= 511);
-    v = ((e0.statId) & 0xff) | (((e0.delta + 512) & 0x3ff) << 8);
-    scratch |= v << scratchBits;
-    scratchBits += 18;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (18 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.statsCount; i0 += 3) {
+      final e0 = value.stats[i0];
+      assert(e0.delta >= -512);
+      assert(e0.delta <= 511);
+      final e0g1 = value.stats[i0 + 1];
+      assert(e0g1.delta >= -512);
+      assert(e0g1.delta <= 511);
+      final e0g2 = value.stats[i0 + 2];
+      assert(e0g2.delta >= -512);
+      assert(e0g2.delta <= 511);
+      v =
+          ((e0.statId) & 0xff) |
+          (((e0.delta + 512) & 0x3ff) << 8) |
+          (((e0g1.statId) & 0xff) << 18) |
+          (((e0g1.delta + 512) & 0x3ff) << 26) |
+          (((e0g2.statId) & 0xff) << 36) |
+          (((e0g2.delta + 512) & 0x3ff) << 44);
+      scratch |= v << scratchBits;
+      scratchBits += 54;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (54 - scratchBits);
+      }
+    }
+    for (; i0 < value.statsCount; i0++) {
+      final e0 = value.stats[i0];
+      assert(e0.delta >= -512);
+      assert(e0.delta <= 511);
+      v = ((e0.statId) & 0xff) | (((e0.delta + 512) & 0x3ff) << 8);
+      scratch |= v << scratchBits;
+      scratchBits += 18;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (18 - scratchBits);
+      }
     }
   }
   assert(value.gameEvent.type >= 0);
@@ -2564,19 +2593,52 @@ bool readBenchMixed(BenchMixed value, ByteData view, int numBits) {
   if (bitsRead + value.statsCount * 18 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.statsCount; i0++) {
-    final e0 = value.stats[i0];
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.statsCount; i0 += 3) {
+      final e0 = value.stats[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xff;
+      bitsRead += 8;
+      e0.statId = v;
+      v = (window >>> 8) & 0x3ff;
+      bitsRead += 10;
+      e0.delta = -512 + v;
+      final e0g1 = value.stats[i0 + 1];
+      v = (window >>> 18) & 0xff;
+      bitsRead += 8;
+      e0g1.statId = v;
+      v = (window >>> 26) & 0x3ff;
+      bitsRead += 10;
+      e0g1.delta = -512 + v;
+      final e0g2 = value.stats[i0 + 2];
+      v = (window >>> 36) & 0xff;
+      bitsRead += 8;
+      e0g2.statId = v;
+      v = (window >>> 44) & 0x3ff;
+      bitsRead += 10;
+      e0g2.delta = -512 + v;
     }
-    v = window & 0xff;
-    bitsRead += 8;
-    e0.statId = v;
-    v = (window >>> 8) & 0x3ff;
-    bitsRead += 10;
-    e0.delta = -512 + v;
+    for (; i0 < value.statsCount; i0++) {
+      final e0 = value.stats[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xff;
+      bitsRead += 8;
+      e0.statId = v;
+      v = (window >>> 8) & 0x3ff;
+      bitsRead += 10;
+      e0.delta = -512 + v;
+    }
   }
   if (bitsRead + 2 > numBits) {
     return false;

--- a/generated/bench/dart/Bench.dart
+++ b/generated/bench/dart/Bench.dart
@@ -221,16 +221,32 @@ int writeBenchPacket(BenchPacket value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < 17; i0++) {
-    v = ((value.blob[i0]) & 0xff);
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= 17; i0 += 4) {
+      v =
+          value.blob[i0] |
+          (value.blob[i0 + 1] << 8) |
+          (value.blob[i0 + 2] << 16) |
+          (value.blob[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
     }
+  }
+  v = value.blob[16];
+  scratch |= v << scratchBits;
+  scratchBits += 8;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (8 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2372,27 +2388,21 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
         scratch = v >>> (18 - scratchBits);
       }
   }
-  for (var i0 = 0; i0 < 4; i0++) {
-    v = ((value.loadout[i0]) & 0xff);
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
-    }
-  }
   assert(value.playerNameLength >= 0);
   assert(value.playerNameLength <= 15);
-  v = ((value.playerNameLength) & 0xf);
+  v =
+      value.loadout[0] |
+      (value.loadout[1] << 8) |
+      (value.loadout[2] << 16) |
+      (value.loadout[3] << 24) |
+      (((value.playerNameLength) & 0xf) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 36;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (36 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -2406,15 +2416,33 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.playerNameLength; i0++) {
-    v = value.playerName[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.playerNameLength; i0 += 4) {
+      v =
+          value.playerName[i0] |
+          (value.playerName[i0 + 1] << 8) |
+          (value.playerName[i0 + 2] << 16) |
+          (value.playerName[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.playerNameLength; i0++) {
+      v = value.playerName[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   assert(value.payloadLength >= 0);
@@ -2440,15 +2468,33 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.payloadLength; i0++) {
-    v = value.payload[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.payloadLength; i0 += 4) {
+      v =
+          value.payload[i0] |
+          (value.payload[i0 + 1] << 8) |
+          (value.payload[i0 + 2] << 16) |
+          (value.payload[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.payloadLength; i0++) {
+      v = value.payload[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   {

--- a/generated/bench/dart/Bench.dart
+++ b/generated/bench/dart/Bench.dart
@@ -153,90 +153,43 @@ int writeBenchPacket(BenchPacket value, ByteData view) {
   var v = 0;
   assert(value.a >= -100);
   assert(value.a <= 100);
-  v = (value.a + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.b >= 0);
   assert(value.b <= 65535);
-  v = (value.b) & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
   assert(value.c >= -1000000);
   assert(value.c <= 1000000);
-  v = (value.c + 1000000) & 0x1fffff;
+  v =
+      ((value.a + 100) & 0xff) |
+      (((value.b) & 0xffff) << 8) |
+      (((value.c + 1000000) & 0x1fffff) << 24) |
+      (((value.bits7) & 0x7f) << 45);
   scratch |= v << scratchBits;
-  scratchBits += 21;
+  scratchBits += 52;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (21 - scratchBits);
+    scratch = v >>> (52 - scratchBits);
   }
-  v = value.bits7 & 0x7f;
+  v =
+      ((value.bits13) & 0x1fff) |
+      (((value.bits23) & 0x7fffff) << 13) |
+      ((value.flag ? 1 : 0) << 36);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 37;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
+    scratch = v >>> (37 - scratchBits);
   }
-  v = value.bits13 & 0x1fff;
+  v = _float32BitsFromDouble(value.x) | (_float32BitsFromDouble(value.y) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 13;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (13 - scratchBits);
-  }
-  v = value.bits23 & 0x7fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 23;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.x);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.y);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   v = _float32BitsFromDouble(value.z);
   scratch |= v << scratchBits;
@@ -247,23 +200,14 @@ int writeBenchPacket(BenchPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = value.big & 0xffffffff;
+  v = (value.big);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.big >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -278,7 +222,7 @@ int writeBenchPacket(BenchPacket value, ByteData view) {
     }
   }
   for (var i0 = 0; i0 < 17; i0++) {
-    v = value.blob[i0] & 0xff;
+    v = ((value.blob[i0]) & 0xff);
     scratch |= v << scratchBits;
     scratchBits += 8;
     if (scratchBits >= 64) {
@@ -544,113 +488,51 @@ int writeBenchInts(BenchInts value, ByteData view) {
   var v = 0;
   assert(value.f0 >= -100);
   assert(value.f0 <= 100);
-  v = (value.f0 + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.f1 >= 0);
   assert(value.f1 <= 65535);
-  v = (value.f1) & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
   assert(value.f2 >= -1000000);
   assert(value.f2 <= 1000000);
-  v = (value.f2 + 1000000) & 0x1fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 21;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (21 - scratchBits);
-  }
   assert(value.f3 >= 0);
   assert(value.f3 <= 3);
-  v = (value.f3) & 0x3;
-  scratch |= v << scratchBits;
-  scratchBits += 2;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
-  }
   assert(value.f4 >= -15);
   assert(value.f4 <= 15);
-  v = (value.f4 + 15) & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.f5 >= 0);
   assert(value.f5 <= 1000);
-  v = (value.f5) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.f6 >= -2048);
   assert(value.f6 <= 2047);
-  v = (value.f6 + 2048) & 0xfff;
+  v =
+      ((value.f0 + 100) & 0xff) |
+      (((value.f1) & 0xffff) << 8) |
+      (((value.f2 + 1000000) & 0x1fffff) << 24) |
+      (((value.f3) & 0x3) << 45) |
+      (((value.f4 + 15) & 0x1f) << 47) |
+      (((value.f5) & 0x3ff) << 52);
   scratch |= v << scratchBits;
-  scratchBits += 12;
+  scratchBits += 62;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
+    scratch = v >>> (62 - scratchBits);
   }
   assert(value.f7 >= 0);
   assert(value.f7 <= 255);
-  v = (value.f7) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.f8 >= -600000);
   assert(value.f8 <= 600000);
-  v = (value.f8 + 600000) & 0x1fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 21;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (21 - scratchBits);
-  }
   assert(value.f9 >= 0);
   assert(value.f9 <= 100);
-  v = (value.f9) & 0x7f;
+  v =
+      ((value.f6 + 2048) & 0xfff) |
+      (((value.f7) & 0xff) << 12) |
+      (((value.f8 + 600000) & 0x1fffff) << 20) |
+      (((value.f9) & 0x7f) << 41);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -849,86 +731,39 @@ int writeBenchBits(BenchBits value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.b7 & 0x7f;
+  v =
+      ((value.b7) & 0x7f) |
+      (((value.b13) & 0x1fff) << 7) |
+      (((value.b23) & 0x7fffff) << 20) |
+      (((value.b3) & 0x7) << 43);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 46;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
+    scratch = v >>> (46 - scratchBits);
   }
-  v = value.b13 & 0x1fff;
+  v =
+      ((value.b32) & 0xffffffff) |
+      (((value.b11) & 0x7ff) << 32) |
+      (((value.b19) & 0x7ffff) << 43);
   scratch |= v << scratchBits;
-  scratchBits += 13;
+  scratchBits += 62;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (13 - scratchBits);
+    scratch = v >>> (62 - scratchBits);
   }
-  v = value.b23 & 0x7fffff;
+  v = ((value.b48) & 0xffffffffffff);
   scratch |= v << scratchBits;
-  scratchBits += 23;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
-  v = value.b3 & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = value.b32 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.b11 & 0x7ff;
-  scratch |= v << scratchBits;
-  scratchBits += 11;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (11 - scratchBits);
-  }
-  v = value.b19 & 0x7ffff;
-  scratch |= v << scratchBits;
-  scratchBits += 19;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (19 - scratchBits);
-  }
-  v = value.b48 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.b48 >>> 32) & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1259,148 +1094,63 @@ int writeMixedEntity(MixedEntity value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.entityId & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.posX >= -16383);
   assert(value.posX <= 16383);
-  v = (value.posX + 16383) & 0x7fff;
-  scratch |= v << scratchBits;
-  scratchBits += 15;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (15 - scratchBits);
-  }
   assert(value.posY >= -16383);
   assert(value.posY <= 16383);
-  v = (value.posY + 16383) & 0x7fff;
-  scratch |= v << scratchBits;
-  scratchBits += 15;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (15 - scratchBits);
-  }
   assert(value.posZ >= -16383);
   assert(value.posZ <= 16383);
-  v = (value.posZ + 16383) & 0x7fff;
+  v =
+      ((value.entityId) & 0xfff) |
+      (((value.posX + 16383) & 0x7fff) << 12) |
+      (((value.posY + 16383) & 0x7fff) << 27) |
+      (((value.posZ + 16383) & 0x7fff) << 42);
   scratch |= v << scratchBits;
-  scratchBits += 15;
+  scratchBits += 57;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (15 - scratchBits);
-  }
-  v = value.yaw & 0x1ff;
-  scratch |= v << scratchBits;
-  scratchBits += 9;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (9 - scratchBits);
-  }
-  v = value.pitch & 0x1ff;
-  scratch |= v << scratchBits;
-  scratchBits += 9;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (9 - scratchBits);
+    scratch = v >>> (57 - scratchBits);
   }
   assert(value.velX >= -2048);
   assert(value.velX <= 2047);
-  v = (value.velX + 2048) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.velY >= -2048);
   assert(value.velY <= 2047);
-  v = (value.velY + 2048) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.velZ >= -2048);
   assert(value.velZ <= 2047);
-  v = (value.velZ + 2048) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.health >= 0);
   assert(value.health <= 1000);
-  v = (value.health) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.weapon >= 0);
   assert(value.weapon <= 15);
-  v = value.weapon & 0xf;
+  v =
+      ((value.yaw) & 0x1ff) |
+      (((value.pitch) & 0x1ff) << 9) |
+      (((value.velX + 2048) & 0xfff) << 18) |
+      (((value.velY + 2048) & 0xfff) << 30) |
+      (((value.velZ + 2048) & 0xfff) << 42) |
+      (((value.health) & 0x3ff) << 54);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.damage >>> 8 == 0);
-  v = value.damage & 0xff;
+  v =
+      ((value.weapon) & 0xf) |
+      (((value.damage) & 0xff) << 4) |
+      ((value.moving ? 1 : 0) << 12) |
+      ((value.firing ? 1 : 0) << 13);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 14;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.moving ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.firing ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (14 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1622,25 +1372,16 @@ int writeMixedStat(MixedStat value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.statId & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.delta >= -512);
   assert(value.delta <= 511);
-  v = (value.delta + 512) & 0x3ff;
+  v = ((value.statId) & 0xff) | (((value.delta + 512) & 0x3ff) << 8);
   scratch |= v << scratchBits;
-  scratchBits += 10;
+  scratchBits += 18;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
+    scratch = v >>> (18 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1735,45 +1476,22 @@ int writeMixedHitEvent(MixedHitEvent value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.targetId & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.damage >= 0);
   assert(value.damage <= 4095);
-  v = (value.damage) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.hitKind >= 0);
   assert(value.hitKind <= 7);
-  v = (value.hitKind) & 0x7;
+  v =
+      ((value.targetId) & 0xfff) |
+      (((value.damage) & 0xfff) << 12) |
+      (((value.hitKind) & 0x7) << 24) |
+      ((value.crit ? 1 : 0) << 27);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 28;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = value.crit ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (28 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1885,23 +1603,14 @@ int writeMixedChatEvent(MixedChatEvent value, ByteData view) {
   var v = 0;
   assert(value.channel >= 0);
   assert(value.channel <= 3);
-  v = (value.channel) & 0x3;
+  v = ((value.channel) & 0x3) | (((value.speaker) & 0xfff) << 2);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 14;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
-  }
-  v = value.speaker & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
+    scratch = v >>> (14 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1991,25 +1700,16 @@ int writeMixedPickupEvent(MixedPickupEvent value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.itemId & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.amount >= 0);
   assert(value.amount <= 255);
-  v = (value.amount) & 0xff;
+  v = ((value.itemId) & 0x3ff) | (((value.amount) & 0xff) << 10);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 18;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (18 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2114,7 +1814,7 @@ int writeMixedEvent(MixedEvent value, ByteData view) {
   var v = 0;
   assert(value.type >= 0);
   assert(value.type <= 3);
-  v = value.type & 0x3;
+  v = ((value.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -2125,87 +1825,48 @@ int writeMixedEvent(MixedEvent value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      v = value.hit.targetId & 0xfff;
-      scratch |= v << scratchBits;
-      scratchBits += 12;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (12 - scratchBits);
-      }
       assert(value.hit.damage >= 0);
       assert(value.hit.damage <= 4095);
-      v = (value.hit.damage) & 0xfff;
-      scratch |= v << scratchBits;
-      scratchBits += 12;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (12 - scratchBits);
-      }
       assert(value.hit.hitKind >= 0);
       assert(value.hit.hitKind <= 7);
-      v = (value.hit.hitKind) & 0x7;
+      v =
+          ((value.hit.targetId) & 0xfff) |
+          (((value.hit.damage) & 0xfff) << 12) |
+          (((value.hit.hitKind) & 0x7) << 24) |
+          ((value.hit.crit ? 1 : 0) << 27);
       scratch |= v << scratchBits;
-      scratchBits += 3;
+      scratchBits += 28;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (3 - scratchBits);
-      }
-      v = value.hit.crit ? 1 : 0;
-      scratch |= v << scratchBits;
-      scratchBits += 1;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (1 - scratchBits);
+        scratch = v >>> (28 - scratchBits);
       }
     case 2:
       assert(value.chat.channel >= 0);
       assert(value.chat.channel <= 3);
-      v = (value.chat.channel) & 0x3;
+      v = ((value.chat.channel) & 0x3) | (((value.chat.speaker) & 0xfff) << 2);
       scratch |= v << scratchBits;
-      scratchBits += 2;
+      scratchBits += 14;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (2 - scratchBits);
-      }
-      v = value.chat.speaker & 0xfff;
-      scratch |= v << scratchBits;
-      scratchBits += 12;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (12 - scratchBits);
+        scratch = v >>> (14 - scratchBits);
       }
     case 3:
-      v = value.pickup.itemId & 0x3ff;
-      scratch |= v << scratchBits;
-      scratchBits += 10;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (10 - scratchBits);
-      }
       assert(value.pickup.amount >= 0);
       assert(value.pickup.amount <= 255);
-      v = (value.pickup.amount) & 0xff;
+      v =
+          ((value.pickup.itemId) & 0x3ff) |
+          (((value.pickup.amount) & 0xff) << 10);
       scratch |= v << scratchBits;
-      scratchBits += 8;
+      scratchBits += 18;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (18 - scratchBits);
       }
   }
   if (scratchBits != 0) {
@@ -2481,45 +2142,21 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = 49374;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
-  v = value.sequence & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
   assert(value.ackSequence >= 0);
   assert(value.ackSequence <= 65535);
-  v = (value.ackSequence) & 0xffff;
+  v =
+      49374 |
+      (((value.sequence) & 0xffff) << 16) |
+      (((value.ackSequence) & 0xffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 16;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
-  v = value.ackBits & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.sessionId & 0xffffffff;
+  v = ((value.ackBits) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -2528,34 +2165,16 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = (value.sessionId >>> 32) & 0xffffffff;
+  v = (value.sessionId);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.clientId & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.nonce & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.nonce >>> 32) & 0xffffffff;
+  v = ((value.clientId) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -2566,216 +2185,112 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
   }
   assert(value.worldTime >= -1000000000000);
   assert(value.worldTime <= 1000000000000);
-  {
-    final off = value.worldTime + 1000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x1ff;
-    scratch |= v << scratchBits;
-    scratchBits += 9;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (9 - scratchBits);
-    }
-  }
-  v = value.frameTick & 0xffffffff;
+  v = (value.nonce);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.frameTick >>> 32) & 0xffff;
+  v = ((value.worldTime + 1000000000000) & 0x1ffffffffff);
   scratch |= v << scratchBits;
-  scratchBits += 16;
+  scratchBits += 41;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (41 - scratchBits);
   }
   assert(value.serverTime >= 0);
   assert(value.serverTime <= 16776960);
-  v = (value.serverTime) & 0xffffff;
+  v = ((value.frameTick) & 0xffffffffffff);
   scratch |= v << scratchBits;
-  scratchBits += 24;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
   assert(value.entitiesCount >= 1);
   assert(value.entitiesCount <= 8);
-  v = (value.entitiesCount - 1) & 0x7;
+  v =
+      ((value.serverTime) & 0xffffff) |
+      (((value.entitiesCount - 1) & 0x7) << 24);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 27;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
+    scratch = v >>> (27 - scratchBits);
   }
   for (var i0 = 0; i0 < value.entitiesCount; i0++) {
     final e0 = value.entities[i0];
-    v = e0.entityId & 0xfff;
-    scratch |= v << scratchBits;
-    scratchBits += 12;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (12 - scratchBits);
-    }
     assert(e0.posX >= -16383);
     assert(e0.posX <= 16383);
-    v = (e0.posX + 16383) & 0x7fff;
-    scratch |= v << scratchBits;
-    scratchBits += 15;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (15 - scratchBits);
-    }
     assert(e0.posY >= -16383);
     assert(e0.posY <= 16383);
-    v = (e0.posY + 16383) & 0x7fff;
-    scratch |= v << scratchBits;
-    scratchBits += 15;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (15 - scratchBits);
-    }
     assert(e0.posZ >= -16383);
     assert(e0.posZ <= 16383);
-    v = (e0.posZ + 16383) & 0x7fff;
+    v =
+        ((e0.entityId) & 0xfff) |
+        (((e0.posX + 16383) & 0x7fff) << 12) |
+        (((e0.posY + 16383) & 0x7fff) << 27) |
+        (((e0.posZ + 16383) & 0x7fff) << 42);
     scratch |= v << scratchBits;
-    scratchBits += 15;
+    scratchBits += 57;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (15 - scratchBits);
-    }
-    v = e0.yaw & 0x1ff;
-    scratch |= v << scratchBits;
-    scratchBits += 9;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (9 - scratchBits);
-    }
-    v = e0.pitch & 0x1ff;
-    scratch |= v << scratchBits;
-    scratchBits += 9;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (9 - scratchBits);
+      scratch = v >>> (57 - scratchBits);
     }
     assert(e0.velX >= -2048);
     assert(e0.velX <= 2047);
-    v = (e0.velX + 2048) & 0xfff;
-    scratch |= v << scratchBits;
-    scratchBits += 12;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (12 - scratchBits);
-    }
     assert(e0.velY >= -2048);
     assert(e0.velY <= 2047);
-    v = (e0.velY + 2048) & 0xfff;
-    scratch |= v << scratchBits;
-    scratchBits += 12;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (12 - scratchBits);
-    }
     assert(e0.velZ >= -2048);
     assert(e0.velZ <= 2047);
-    v = (e0.velZ + 2048) & 0xfff;
-    scratch |= v << scratchBits;
-    scratchBits += 12;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (12 - scratchBits);
-    }
     assert(e0.health >= 0);
     assert(e0.health <= 1000);
-    v = (e0.health) & 0x3ff;
-    scratch |= v << scratchBits;
-    scratchBits += 10;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (10 - scratchBits);
-    }
     assert(e0.weapon >= 0);
     assert(e0.weapon <= 15);
-    v = e0.weapon & 0xf;
+    v =
+        ((e0.yaw) & 0x1ff) |
+        (((e0.pitch) & 0x1ff) << 9) |
+        (((e0.velX + 2048) & 0xfff) << 18) |
+        (((e0.velY + 2048) & 0xfff) << 30) |
+        (((e0.velZ + 2048) & 0xfff) << 42) |
+        (((e0.health) & 0x3ff) << 54);
     scratch |= v << scratchBits;
-    scratchBits += 4;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (4 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
     assert(e0.damage >>> 8 == 0);
-    v = e0.damage & 0xff;
+    v =
+        ((e0.weapon) & 0xf) |
+        (((e0.damage) & 0xff) << 4) |
+        ((e0.moving ? 1 : 0) << 12) |
+        ((e0.firing ? 1 : 0) << 13);
     scratch |= v << scratchBits;
-    scratchBits += 8;
+    scratchBits += 14;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
-    }
-    v = e0.moving ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.firing ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+      scratch = v >>> (14 - scratchBits);
     }
   }
   assert(value.statsCount >= 0);
   assert(value.statsCount <= 80);
-  v = (value.statsCount) & 0x7f;
+  v = ((value.statsCount) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -2786,30 +2301,21 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
   }
   for (var i0 = 0; i0 < value.statsCount; i0++) {
     final e0 = value.stats[i0];
-    v = e0.statId & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
-    }
     assert(e0.delta >= -512);
     assert(e0.delta <= 511);
-    v = (e0.delta + 512) & 0x3ff;
+    v = ((e0.statId) & 0xff) | (((e0.delta + 512) & 0x3ff) << 8);
     scratch |= v << scratchBits;
-    scratchBits += 10;
+    scratchBits += 18;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (10 - scratchBits);
+      scratch = v >>> (18 - scratchBits);
     }
   }
   assert(value.gameEvent.type >= 0);
   assert(value.gameEvent.type <= 3);
-  v = value.gameEvent.type & 0x3;
+  v = ((value.gameEvent.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -2820,91 +2326,54 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
   }
   switch (value.gameEvent.type) {
     case 1:
-      v = value.gameEvent.hit.targetId & 0xfff;
-      scratch |= v << scratchBits;
-      scratchBits += 12;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (12 - scratchBits);
-      }
       assert(value.gameEvent.hit.damage >= 0);
       assert(value.gameEvent.hit.damage <= 4095);
-      v = (value.gameEvent.hit.damage) & 0xfff;
-      scratch |= v << scratchBits;
-      scratchBits += 12;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (12 - scratchBits);
-      }
       assert(value.gameEvent.hit.hitKind >= 0);
       assert(value.gameEvent.hit.hitKind <= 7);
-      v = (value.gameEvent.hit.hitKind) & 0x7;
+      v =
+          ((value.gameEvent.hit.targetId) & 0xfff) |
+          (((value.gameEvent.hit.damage) & 0xfff) << 12) |
+          (((value.gameEvent.hit.hitKind) & 0x7) << 24) |
+          ((value.gameEvent.hit.crit ? 1 : 0) << 27);
       scratch |= v << scratchBits;
-      scratchBits += 3;
+      scratchBits += 28;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (3 - scratchBits);
-      }
-      v = value.gameEvent.hit.crit ? 1 : 0;
-      scratch |= v << scratchBits;
-      scratchBits += 1;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (1 - scratchBits);
+        scratch = v >>> (28 - scratchBits);
       }
     case 2:
       assert(value.gameEvent.chat.channel >= 0);
       assert(value.gameEvent.chat.channel <= 3);
-      v = (value.gameEvent.chat.channel) & 0x3;
+      v =
+          ((value.gameEvent.chat.channel) & 0x3) |
+          (((value.gameEvent.chat.speaker) & 0xfff) << 2);
       scratch |= v << scratchBits;
-      scratchBits += 2;
+      scratchBits += 14;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (2 - scratchBits);
-      }
-      v = value.gameEvent.chat.speaker & 0xfff;
-      scratch |= v << scratchBits;
-      scratchBits += 12;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (12 - scratchBits);
+        scratch = v >>> (14 - scratchBits);
       }
     case 3:
-      v = value.gameEvent.pickup.itemId & 0x3ff;
-      scratch |= v << scratchBits;
-      scratchBits += 10;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (10 - scratchBits);
-      }
       assert(value.gameEvent.pickup.amount >= 0);
       assert(value.gameEvent.pickup.amount <= 255);
-      v = (value.gameEvent.pickup.amount) & 0xff;
+      v =
+          ((value.gameEvent.pickup.itemId) & 0x3ff) |
+          (((value.gameEvent.pickup.amount) & 0xff) << 10);
       scratch |= v << scratchBits;
-      scratchBits += 8;
+      scratchBits += 18;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (18 - scratchBits);
       }
   }
   for (var i0 = 0; i0 < 4; i0++) {
-    v = value.loadout[i0] & 0xff;
+    v = ((value.loadout[i0]) & 0xff);
     scratch |= v << scratchBits;
     scratchBits += 8;
     if (scratchBits >= 64) {
@@ -2916,7 +2385,7 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
   }
   assert(value.playerNameLength >= 0);
   assert(value.playerNameLength <= 15);
-  v = (value.playerNameLength) & 0xf;
+  v = ((value.playerNameLength) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -2950,7 +2419,7 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
   }
   assert(value.payloadLength >= 0);
   assert(value.payloadLength <= 16);
-  v = (value.payloadLength) & 0x1f;
+  v = ((value.payloadLength) & 0x1f);
   scratch |= v << scratchBits;
   scratchBits += 5;
   if (scratchBits >= 64) {
@@ -3048,62 +2517,32 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.drift);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.wideKey.lo & 0xffffffff;
+  v = _float64BitsFromDouble(value.drift);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.wideKey.lo >>> 32) & 0xffffffff;
+  v = (value.wideKey.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.wideKey.hi & 0xffffffff;
+  v = (value.wideKey.hi);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wideKey.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     const min = Int128(0xfffffff000000000, 0);
@@ -3111,62 +2550,35 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
     assert(value.flux >= min);
     assert(value.flux <= max);
     final off = (value.flux - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = (off.lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (off.lo >>> 32) & 0xffffffff;
+    v = ((off.hi) & 0x3fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 38;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = off.hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.hi >>> 32) & 0x3f;
-    scratch |= v << scratchBits;
-    scratchBits += 6;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (6 - scratchBits);
+      scratch = v >>> (38 - scratchBits);
     }
   }
   assert(value.ping >= 0);
   assert(value.ping <= 64000);
-  v = (value.ping) & 0xffff;
+  v = ((value.ping) & 0xffff) | (0 << 16);
   scratch |= v << scratchBits;
-  scratchBits += 16;
+  scratchBits += 20;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
-  v = 0;
-  scratch |= v << scratchBits;
-  scratchBits += 4;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (20 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -3180,28 +2592,19 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
       }
     }
   }
-  v = value.crcHint & 0xffffff;
+  v = ((value.crcHint) & 0xffffff) | ((value.hasExtra ? 1 : 0) << 24);
   scratch |= v << scratchBits;
-  scratchBits += 24;
+  scratchBits += 25;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
-  }
-  v = value.hasExtra ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (25 - scratchBits);
   }
   if (value.hasExtra) {
     assert(value.extra >= 0);
     assert(value.extra <= 255);
-    v = (value.extra) & 0xff;
+    v = ((value.extra) & 0xff);
     scratch |= v << scratchBits;
     scratchBits += 8;
     if (scratchBits >= 64) {
@@ -3213,7 +2616,7 @@ int writeBenchMixed(BenchMixed value, ByteData view) {
   } else {
     assert(value.idleTicks >= 0);
     assert(value.idleTicks <= 15);
-    v = (value.idleTicks) & 0xf;
+    v = ((value.idleTicks) & 0xf);
     scratch |= v << scratchBits;
     scratchBits += 4;
     if (scratchBits >= 64) {

--- a/generated/bench/dart/realworld/RealWorld.dart
+++ b/generated/bench/dart/realworld/RealWorld.dart
@@ -1171,67 +1171,46 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 291 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1fffff;
+  v = window & 0x1fffff;
   bitsRead += 21;
   if (v > 1610990) {
     return false; // a smuggled offset is refused
   }
   value.f001Int = -805495 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 21) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f002F64 = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fffff;
+  v = (window >>> 32) & 0x1fffff;
   bitsRead += 21;
   if (v > 1671794) {
     return false; // a smuggled offset is refused
   }
   value.f003Int = -835897 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7fff;
+  v = window & 0x7fff;
   bitsRead += 15;
   if (v > 20000) {
     return false; // headroom above the quantum count is refused
@@ -1239,104 +1218,61 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
   value.f004Cf32 = _fround(
     _fround(_fround(_fround(v.toDouble()) / 20000.0) * 2000.0) + 0.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fff;
+  v = (window >>> 15) & 0x1fff;
   bitsRead += 13;
   if (v > 7316) {
     return false; // a smuggled offset is refused
   }
   value.f005Uint = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 28) & 0xfff;
   bitsRead += 12;
   if (v > 3026) {
     return false; // a smuggled offset is refused
   }
   value.f006Int = -1513 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.f007F32 = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f008U64 = lo;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3f;
+  v = (window >>> 32) & 0x3f;
   bitsRead += 6;
   if (v > 44) {
     return false; // a smuggled offset is refused
   }
   value.f009Int = -22 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.f010F32 = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 32) & 0x3ff;
   bitsRead += 10;
   value.f011Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 42) & 0x1;
   bitsRead += 1;
   value.f012Bool = v != 0;
   if (value.f012Bool) {
@@ -1344,62 +1280,37 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     value.f013F32 = _doubleFromFloat32Bits(v);
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3ff;
+    v = (window >>> 32) & 0x3ff;
     bitsRead += 10;
     if (v > 775) {
       return false; // a smuggled offset is refused
     }
     value.f014Uint = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3f;
+    v = (window >>> 42) & 0x3f;
     bitsRead += 6;
     if (v > 42) {
       return false; // a smuggled offset is refused
     }
     value.f015Int = -21 + v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ffffff;
+    v = window & 0x7ffffff;
     bitsRead += 27;
     if (v > 75497472) {
       return false; // a smuggled offset is refused
     }
     value.f016Fixed = -37748736 + v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1fff;
+    v = (window >>> 27) & 0x1fff;
     bitsRead += 13;
     if (v > 4606) {
       return false; // a smuggled offset is refused
@@ -1416,123 +1327,81 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7ff;
+  v = window & 0x7ff;
   bitsRead += 11;
   if (v > 1668) {
     return false; // a smuggled offset is refused
   }
   value.f018Int = -834 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 11) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f019F64 = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.f020F32 = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7ffffff;
+  v = window & 0x7ffffff;
   bitsRead += 27;
   if (v > 102977536) {
     return false; // a smuggled offset is refused
   }
   value.f021Ufixed = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.f022F32 = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 32) & 0x1ffffff;
   bitsRead += 25;
   value.f023Bits = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.f024F32 = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 32) & 0xffff;
   bitsRead += 16;
   if (v > 60928) {
     return false; // a smuggled offset is refused
   }
   value.f025Fixed = -30464 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
+  v = (window >>> 48) & 0x1ff;
   bitsRead += 9;
   value.f026Bits = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   if (v > 16) {
     return false; // headroom above the quantum count is refused
@@ -1540,193 +1409,94 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
   value.f027Cf32 = _fround(
     _fround(_fround(_fround(v.toDouble()) / 16.0) * 4.0) + -2.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 5) & 0xf;
   bitsRead += 4;
   value.f028Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 9) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f029I64 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.f030F32 = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 32) & 0x1;
   bitsRead += 1;
   value.f031Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 33) & 0x7;
   bitsRead += 3;
   if (v > 6) {
     return false; // a smuggled offset is refused
   }
   value.f032Int = -3 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ffff;
+  v = (window >>> 36) & 0x3ffff;
   bitsRead += 18;
   if (v > 142780) {
     return false; // a smuggled offset is refused
   }
   value.f033Uint = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3fff;
+  v = window & 0x3fff;
   bitsRead += 14;
   if (v > 14149) {
     return false; // a smuggled offset is refused
   }
   value.f034Uint = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
+  v = (window >>> 14) & 0x1ff;
   bitsRead += 9;
   value.f035Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 23) & 0x7;
   bitsRead += 3;
   if (v > 5) {
     return false; // headroom above the wire range is refused
   }
   value.f036Enum = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 26) & 0x1;
   bitsRead += 1;
   value.f037Bool = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 27) & 0x1;
   bitsRead += 1;
   value.f038Bool = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ffff;
+  v = (window >>> 28) & 0x7ffff;
   bitsRead += 19;
   value.f039Bits = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   if (v > 40960) {
     return false; // a smuggled offset is refused
   }
   value.f040Fixed = -20480 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7f;
+  v = (window >>> 16) & 0x7f;
   bitsRead += 7;
   if (v > 110) {
     return false; // a smuggled offset is refused
   }
   value.f041Int = -55 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3fffffff;
+  v = (window >>> 23) & 0x3fffffff;
   bitsRead += 30;
   value.f042Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 53) & 0x1;
   bitsRead += 1;
   value.f043Bool = v != 0;
   if (value.f043Bool) {
@@ -1734,46 +1504,28 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     value.f044F32 = _doubleFromFloat32Bits(v);
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xfff;
+    v = (window >>> 32) & 0xfff;
     bitsRead += 12;
     value.f045Bits = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1ffff;
+    v = window & 0x1ffff;
     bitsRead += 17;
     if (v > 76063) {
       return false; // a smuggled offset is refused
     }
     value.f046Uint = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xfffff;
+    v = (window >>> 17) & 0xfffff;
     bitsRead += 20;
     if (v > 861952) {
       return false; // a smuggled offset is refused
@@ -1789,47 +1541,29 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f048F64 = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 32) & 0xffff;
   bitsRead += 16;
   if (v > 49152) {
     return false; // a smuggled offset is refused
   }
   value.f049Ufixed = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 48) & 0x1;
   bitsRead += 1;
   value.f050Bool = v != 0;
   if (value.f050Bool) {
@@ -1837,46 +1571,23 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1;
+    v = window & 0x1;
     bitsRead += 1;
     value.f051Bool = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x7f;
+    v = (window >>> 1) & 0x7f;
     bitsRead += 7;
     if (v > 114) {
       return false; // a smuggled offset is refused
     }
     value.f052Int = -57 + v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xffffffff;
+    v = (window >>> 8) & 0xffffffff;
     bitsRead += 32;
     value.f053F32 = _doubleFromFloat32Bits(v);
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x7f;
+    v = (window >>> 40) & 0x7f;
     bitsRead += 7;
     if (v > 70) {
       return false; // a smuggled offset is refused
@@ -1892,90 +1603,49 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.f055Bool = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 1) & 0x1f;
   bitsRead += 5;
   if (v > 26) {
     return false; // a smuggled offset is refused
   }
   value.f056Int = -13 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 6) & 0x1f;
   bitsRead += 5;
   if (v > 30) {
     return false; // a smuggled offset is refused
   }
   value.f057Int = -15 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 11) & 0xffffffff;
   bitsRead += 32;
   value.f058F32 = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f059F64 = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.f060Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
+  v = (window >>> 40) & 0x1ff;
   bitsRead += 9;
   if (v > 360) {
     return false; // headroom above the quantum count is refused
@@ -1984,60 +1654,35 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
     _fround(_fround(_fround(v.toDouble()) / 360.0) * 180.0) + -90.0,
   );
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ff;
+  v = window & 0x1ff;
   bitsRead += 9;
   if (v > 503) {
     return false; // a smuggled offset is refused
   }
   value.f062Uint = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 9) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f063I64 = lo;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
+  v = (window >>> 32) & 0x1ff;
   bitsRead += 9;
   if (v > 299) {
     return false; // a smuggled offset is refused
   }
   value.f064Uint = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3f;
+  v = (window >>> 41) & 0x3f;
   bitsRead += 6;
   if (v > 60) {
     return false; // headroom above the quantum count is refused
@@ -2046,26 +1691,17 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
     _fround(_fround(_fround(v.toDouble()) / 60.0) * 30.0) + 0.0,
   );
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   if (v > 32768) {
     return false; // a smuggled offset is refused
   }
   value.f066Ufixed = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 16) & 0x3ff;
   bitsRead += 10;
   if (v > 800) {
     return false; // headroom above the quantum count is refused
@@ -2073,14 +1709,7 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
   value.f067Cf32 = _fround(
     _fround(_fround(_fround(v.toDouble()) / 800.0) * 200.0) + -100.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 26) & 0x7ff;
   bitsRead += 11;
   if (v > 2000) {
     return false; // headroom above the quantum count is refused
@@ -2088,37 +1717,21 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
   value.f068Cf32 = _fround(
     _fround(_fround(_fround(v.toDouble()) / 2000.0) * 2000.0) + 0.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 37) & 0x7ff;
   bitsRead += 11;
   value.f069Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 48) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // a smuggled offset is refused
   }
   value.f070Uint = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ff;
+  v = window & 0x1ff;
   bitsRead += 9;
   if (v > 500) {
     return false; // headroom above the quantum count is refused
@@ -2126,14 +1739,7 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
   value.f071Cf32 = _fround(
     _fround(_fround(_fround(v.toDouble()) / 500.0) * 10.0) + 0.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3fff;
+  v = (window >>> 9) & 0x3fff;
   bitsRead += 14;
   if (v > 10000) {
     return false; // headroom above the quantum count is refused
@@ -2141,27 +1747,13 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
   value.f072Cf32 = _fround(
     _fround(_fround(_fround(v.toDouble()) / 10000.0) * 100.0) + 0.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 23) & 0xf;
   bitsRead += 4;
   if (v > 8) {
     return false; // a smuggled offset is refused
   }
   value.f073Int = -4 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 27) & 0x1;
   bitsRead += 1;
   value.f074Bool = v != 0;
   if (value.f074Bool) {
@@ -2169,70 +1761,43 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.f075U64 = lo;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xffff;
+    v = (window >>> 32) & 0xffff;
     bitsRead += 16;
     if (v > 52436) {
       return false; // a smuggled offset is refused
     }
     value.f076Int = -26218 + v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3f;
+    v = (window >>> 48) & 0x3f;
     bitsRead += 6;
     if (v > 34) {
       return false; // a smuggled offset is refused
     }
     value.f077Int = -17 + v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1ff;
+    v = window & 0x1ff;
     bitsRead += 9;
     value.f078Bits = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1f;
+    v = (window >>> 9) & 0x1f;
     bitsRead += 5;
     if (v > 17) {
       return false; // a smuggled offset is refused
@@ -2249,234 +1814,128 @@ bool readRealPacket(RealPacket value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.f080Bool = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fffffff;
+  v = (window >>> 1) & 0x1fffffff;
   bitsRead += 29;
   value.f081Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 30) & 0x1ffffff;
   bitsRead += 25;
   value.f082Bits = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   if (v > 5) {
     return false; // headroom above the wire range is refused
   }
   value.f083Enum = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 3) & 0xff;
   bitsRead += 8;
   if (v > 128) {
     return false; // a smuggled offset is refused
   }
   value.f084Ufixed = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1fffff;
+  v = (window >>> 11) & 0x1fffff;
   bitsRead += 21;
   value.f085Bits = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
+  v = (window >>> 32) & 0x1ff;
   bitsRead += 9;
   if (v > 399) {
     return false; // a smuggled offset is refused
   }
   value.f086Uint = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f087F64 = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 32) & 0x7ff;
   bitsRead += 11;
   if (v > 1388) {
     return false; // a smuggled offset is refused
   }
   value.f088Int = -694 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
-  bitsRead += 16;
-  lo |= v << 32;
+  lo = window & 0xffffffffffff;
+  bitsRead += 48;
   value.f089Bits = lo;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 48) & 0xff;
   bitsRead += 8;
   if (v > 214) {
     return false; // a smuggled offset is refused
   }
   value.f090Uint = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.f091Flags = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.f092Bool = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 6) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.f093Bits = lo;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 32) & 0x1;
   bitsRead += 1;
   value.f094Bool = v != 0;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffffff;
+  v = window & 0xfffffff;
   bitsRead += 28;
   if (v > 206700544) {
     return false; // a smuggled offset is refused
   }
   value.f095Fixed = -103350272 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ffff;
+  v = (window >>> 28) & 0x3ffff;
   bitsRead += 18;
   value.f096Bits = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfff;
+  v = window & 0xfff;
   bitsRead += 12;
   value.f097Bits = v;
   return true;

--- a/generated/bench/dart/realworld/RealWorld.dart
+++ b/generated/bench/dart/realworld/RealWorld.dart
@@ -474,7 +474,7 @@ int writeRealPacket(RealPacket value, ByteData view) {
   var v = 0;
   assert(value.f001Int >= -805495);
   assert(value.f001Int <= 805495);
-  v = (value.f001Int + 805495) & 0x1fffff;
+  v = ((value.f001Int + 805495) & 0x1fffff);
   scratch |= v << scratchBits;
   scratchBits += 21;
   if (scratchBits >= 64) {
@@ -483,30 +483,18 @@ int writeRealPacket(RealPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (21 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.f002F64);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
   assert(value.f003Int >= -835897);
   assert(value.f003Int <= 835897);
-  v = (value.f003Int + 835897) & 0x1fffff;
+  v = _float64BitsFromDouble(value.f002F64);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.f003Int + 835897) & 0x1fffff);
   scratch |= v << scratchBits;
   scratchBits += 21;
   if (scratchBits >= 64) {
@@ -536,149 +524,80 @@ int writeRealPacket(RealPacket value, ByteData view) {
   }
   assert(value.f005Uint >= 0);
   assert(value.f005Uint <= 7316);
-  v = (value.f005Uint) & 0x1fff;
-  scratch |= v << scratchBits;
-  scratchBits += 13;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (13 - scratchBits);
-  }
   assert(value.f006Int >= -1513);
   assert(value.f006Int <= 1513);
-  v = (value.f006Int + 1513) & 0xfff;
+  v =
+      ((value.f005Uint) & 0x1fff) |
+      (((value.f006Int + 1513) & 0xfff) << 13) |
+      (_float32BitsFromDouble(value.f007F32) << 25);
   scratch |= v << scratchBits;
-  scratchBits += 12;
+  scratchBits += 57;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.f007F32);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.f008U64 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.f008U64 >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (57 - scratchBits);
   }
   assert(value.f009Int >= -22);
   assert(value.f009Int <= 22);
-  v = (value.f009Int + 22) & 0x3f;
+  v = (value.f008U64);
   scratch |= v << scratchBits;
-  scratchBits += 6;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (6 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = _float32BitsFromDouble(value.f010F32);
+  v =
+      ((value.f009Int + 22) & 0x3f) |
+      (_float32BitsFromDouble(value.f010F32) << 6) |
+      (((value.f011Bits) & 0x3ff) << 38) |
+      ((value.f012Bool ? 1 : 0) << 48);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 49;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.f011Bits & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
-  v = value.f012Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (49 - scratchBits);
   }
   if (value.f012Bool) {
-    v = _float32BitsFromDouble(value.f013F32);
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
     assert(value.f014Uint >= 0);
     assert(value.f014Uint <= 775);
-    v = (value.f014Uint) & 0x3ff;
-    scratch |= v << scratchBits;
-    scratchBits += 10;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (10 - scratchBits);
-    }
     assert(value.f015Int >= -21);
     assert(value.f015Int <= 21);
-    v = (value.f015Int + 21) & 0x3f;
-    scratch |= v << scratchBits;
-    scratchBits += 6;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (6 - scratchBits);
-    }
     assert(value.f016Fixed >= -37748736);
     assert(value.f016Fixed <= 37748736);
-    v = (value.f016Fixed + 37748736) & 0x7ffffff;
+    v =
+        _float32BitsFromDouble(value.f013F32) |
+        (((value.f014Uint) & 0x3ff) << 32) |
+        (((value.f015Int + 21) & 0x3f) << 42);
     scratch |= v << scratchBits;
-    scratchBits += 27;
+    scratchBits += 48;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (27 - scratchBits);
+      scratch = v >>> (48 - scratchBits);
     }
     assert(value.f017Uint >= 0);
     assert(value.f017Uint <= 4606);
-    v = (value.f017Uint) & 0x1fff;
+    v =
+        ((value.f016Fixed + 37748736) & 0x7ffffff) |
+        (((value.f017Uint) & 0x1fff) << 27);
     scratch |= v << scratchBits;
-    scratchBits += 13;
+    scratchBits += 40;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (13 - scratchBits);
+      scratch = v >>> (40 - scratchBits);
     }
   }
   assert(value.f018Int >= -834);
   assert(value.f018Int <= 834);
-  v = (value.f018Int + 834) & 0x7ff;
+  v = ((value.f018Int + 834) & 0x7ff);
   scratch |= v << scratchBits;
   scratchBits += 11;
   if (scratchBits >= 64) {
@@ -687,93 +606,52 @@ int writeRealPacket(RealPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (11 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.f019F64);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = _float32BitsFromDouble(value.f020F32);
+  v = _float64BitsFromDouble(value.f019F64);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.f021Ufixed >= 0);
   assert(value.f021Ufixed <= 102977536);
-  v = (value.f021Ufixed) & 0x7ffffff;
+  v =
+      _float32BitsFromDouble(value.f020F32) |
+      (((value.f021Ufixed) & 0x7ffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 27;
+  scratchBits += 59;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (27 - scratchBits);
+    scratch = v >>> (59 - scratchBits);
   }
-  v = _float32BitsFromDouble(value.f022F32);
+  v =
+      _float32BitsFromDouble(value.f022F32) |
+      (((value.f023Bits) & 0x1ffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 57;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.f023Bits & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.f024F32);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (57 - scratchBits);
   }
   assert(value.f025Fixed >= -30464);
   assert(value.f025Fixed <= 30464);
-  v = (value.f025Fixed + 30464) & 0xffff;
+  v =
+      _float32BitsFromDouble(value.f024F32) |
+      (((value.f025Fixed + 30464) & 0xffff) << 32) |
+      (((value.f026Bits) & 0x1ff) << 48);
   scratch |= v << scratchBits;
-  scratchBits += 16;
+  scratchBits += 57;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
-  v = value.f026Bits & 0x1ff;
-  scratch |= v << scratchBits;
-  scratchBits += 9;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (9 - scratchBits);
+    scratch = v >>> (57 - scratchBits);
   }
   {
     final x = _fround(value.f027Cf32);
@@ -794,7 +672,7 @@ int writeRealPacket(RealPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (5 - scratchBits);
   }
-  v = value.f028Bits & 0xf;
+  v = ((value.f028Bits) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -803,195 +681,86 @@ int writeRealPacket(RealPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (4 - scratchBits);
   }
-  v = value.f029I64 & 0xffffffff;
+  v = (value.f029I64);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.f029I64 >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.f030F32);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.f031Bits & 0x1;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.f032Int >= -3);
   assert(value.f032Int <= 3);
-  v = (value.f032Int + 3) & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
   assert(value.f033Uint >= 0);
   assert(value.f033Uint <= 142780);
-  v = (value.f033Uint) & 0x3ffff;
-  scratch |= v << scratchBits;
-  scratchBits += 18;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (18 - scratchBits);
-  }
   assert(value.f034Uint >= 0);
   assert(value.f034Uint <= 14149);
-  v = (value.f034Uint) & 0x3fff;
+  v =
+      _float32BitsFromDouble(value.f030F32) |
+      (((value.f031Bits) & 0x1) << 32) |
+      (((value.f032Int + 3) & 0x7) << 33) |
+      (((value.f033Uint) & 0x3ffff) << 36);
   scratch |= v << scratchBits;
-  scratchBits += 14;
+  scratchBits += 54;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (14 - scratchBits);
-  }
-  v = value.f035Bits & 0x1ff;
-  scratch |= v << scratchBits;
-  scratchBits += 9;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (9 - scratchBits);
+    scratch = v >>> (54 - scratchBits);
   }
   assert(value.f036Enum >= 0);
   assert(value.f036Enum <= 5);
-  v = value.f036Enum & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = value.f037Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.f038Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.f039Bits & 0x7ffff;
-  scratch |= v << scratchBits;
-  scratchBits += 19;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (19 - scratchBits);
-  }
   assert(value.f040Fixed >= -20480);
   assert(value.f040Fixed <= 20480);
-  v = (value.f040Fixed + 20480) & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
   assert(value.f041Int >= -55);
   assert(value.f041Int <= 55);
-  v = (value.f041Int + 55) & 0x7f;
+  v =
+      ((value.f034Uint) & 0x3fff) |
+      (((value.f035Bits) & 0x1ff) << 14) |
+      (((value.f036Enum) & 0x7) << 23) |
+      ((value.f037Bool ? 1 : 0) << 26) |
+      ((value.f038Bool ? 1 : 0) << 27) |
+      (((value.f039Bits) & 0x7ffff) << 28) |
+      (((value.f040Fixed + 20480) & 0xffff) << 47);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 63;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
+    scratch = v >>> (63 - scratchBits);
   }
-  v = value.f042Bits & 0x3fffffff;
+  v =
+      ((value.f041Int + 55) & 0x7f) |
+      (((value.f042Bits) & 0x3fffffff) << 7) |
+      ((value.f043Bool ? 1 : 0) << 37);
   scratch |= v << scratchBits;
-  scratchBits += 30;
+  scratchBits += 38;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (30 - scratchBits);
-  }
-  v = value.f043Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (38 - scratchBits);
   }
   if (value.f043Bool) {
-    v = _float32BitsFromDouble(value.f044F32);
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = value.f045Bits & 0xfff;
-    scratch |= v << scratchBits;
-    scratchBits += 12;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (12 - scratchBits);
-    }
     assert(value.f046Uint >= 0);
     assert(value.f046Uint <= 76063);
-    v = (value.f046Uint) & 0x1ffff;
+    assert(value.f047Int >= -430976);
+    assert(value.f047Int <= 430976);
+    v =
+        _float32BitsFromDouble(value.f044F32) |
+        (((value.f045Bits) & 0xfff) << 32) |
+        (((value.f046Uint) & 0x1ffff) << 44);
     scratch |= v << scratchBits;
-    scratchBits += 17;
+    scratchBits += 61;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (17 - scratchBits);
+      scratch = v >>> (61 - scratchBits);
     }
-    assert(value.f047Int >= -430976);
-    assert(value.f047Int <= 430976);
-    v = (value.f047Int + 430976) & 0xfffff;
+    v = ((value.f047Int + 430976) & 0xfffff);
     scratch |= v << scratchBits;
     scratchBits += 20;
     if (scratchBits >= 64) {
@@ -1001,151 +770,72 @@ int writeRealPacket(RealPacket value, ByteData view) {
       scratch = v >>> (20 - scratchBits);
     }
   }
-  {
-    final b = _float64BitsFromDouble(value.f048F64);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
   assert(value.f049Ufixed >= 0);
   assert(value.f049Ufixed <= 49152);
-  v = (value.f049Ufixed) & 0xffff;
+  v = _float64BitsFromDouble(value.f048F64);
   scratch |= v << scratchBits;
-  scratchBits += 16;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.f050Bool ? 1 : 0;
+  v = ((value.f049Ufixed) & 0xffff) | ((value.f050Bool ? 1 : 0) << 16);
   scratch |= v << scratchBits;
-  scratchBits += 1;
+  scratchBits += 17;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (17 - scratchBits);
   }
   if (value.f050Bool) {
-    v = value.f051Bool ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
     assert(value.f052Int >= -57);
     assert(value.f052Int <= 57);
-    v = (value.f052Int + 57) & 0x7f;
-    scratch |= v << scratchBits;
-    scratchBits += 7;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (7 - scratchBits);
-    }
-    v = _float32BitsFromDouble(value.f053F32);
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
     assert(value.f054Int >= -35);
     assert(value.f054Int <= 35);
-    v = (value.f054Int + 35) & 0x7f;
+    v =
+        (value.f051Bool ? 1 : 0) |
+        (((value.f052Int + 57) & 0x7f) << 1) |
+        (_float32BitsFromDouble(value.f053F32) << 8) |
+        (((value.f054Int + 35) & 0x7f) << 40);
     scratch |= v << scratchBits;
-    scratchBits += 7;
+    scratchBits += 47;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (7 - scratchBits);
+      scratch = v >>> (47 - scratchBits);
     }
-  }
-  v = value.f055Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
   }
   assert(value.f056Int >= -13);
   assert(value.f056Int <= 13);
-  v = (value.f056Int + 13) & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.f057Int >= -15);
   assert(value.f057Int <= 15);
-  v = (value.f057Int + 15) & 0x1f;
+  v =
+      (value.f055Bool ? 1 : 0) |
+      (((value.f056Int + 13) & 0x1f) << 1) |
+      (((value.f057Int + 15) & 0x1f) << 6) |
+      (_float32BitsFromDouble(value.f058F32) << 11);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 43;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (43 - scratchBits);
   }
-  v = _float32BitsFromDouble(value.f058F32);
+  v = _float64BitsFromDouble(value.f059F64);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.f059F64);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.f060Bits & 0xff;
+  v = ((value.f060Bits) & 0xff);
   scratch |= v << scratchBits;
   scratchBits += 8;
   if (scratchBits >= 64) {
@@ -1175,7 +865,7 @@ int writeRealPacket(RealPacket value, ByteData view) {
   }
   assert(value.f062Uint >= 0);
   assert(value.f062Uint <= 503);
-  v = (value.f062Uint) & 0x1ff;
+  v = ((value.f062Uint) & 0x1ff);
   scratch |= v << scratchBits;
   scratchBits += 9;
   if (scratchBits >= 64) {
@@ -1184,27 +874,18 @@ int writeRealPacket(RealPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (9 - scratchBits);
   }
-  v = value.f063I64 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.f063I64 >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.f064Uint >= 0);
   assert(value.f064Uint <= 299);
-  v = (value.f064Uint) & 0x1ff;
+  v = (value.f063I64);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.f064Uint) & 0x1ff);
   scratch |= v << scratchBits;
   scratchBits += 9;
   if (scratchBits >= 64) {
@@ -1234,7 +915,7 @@ int writeRealPacket(RealPacket value, ByteData view) {
   }
   assert(value.f066Ufixed >= 0);
   assert(value.f066Ufixed <= 32768);
-  v = (value.f066Ufixed) & 0xffff;
+  v = ((value.f066Ufixed) & 0xffff);
   scratch |= v << scratchBits;
   scratchBits += 16;
   if (scratchBits >= 64) {
@@ -1281,25 +962,16 @@ int writeRealPacket(RealPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (11 - scratchBits);
   }
-  v = value.f069Bits & 0x7ff;
-  scratch |= v << scratchBits;
-  scratchBits += 11;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (11 - scratchBits);
-  }
   assert(value.f070Uint >= 0);
   assert(value.f070Uint <= 2);
-  v = (value.f070Uint) & 0x3;
+  v = ((value.f069Bits) & 0x7ff) | (((value.f070Uint) & 0x3) << 11);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 13;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (13 - scratchBits);
   }
   {
     final x = _fround(value.f071Cf32);
@@ -1341,218 +1013,7 @@ int writeRealPacket(RealPacket value, ByteData view) {
   }
   assert(value.f073Int >= -4);
   assert(value.f073Int <= 4);
-  v = (value.f073Int + 4) & 0xf;
-  scratch |= v << scratchBits;
-  scratchBits += 4;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
-  }
-  v = value.f074Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  if (value.f074Bool) {
-    v = value.f075U64 & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.f075U64 >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    assert(value.f076Int >= -26218);
-    assert(value.f076Int <= 26218);
-    v = (value.f076Int + 26218) & 0xffff;
-    scratch |= v << scratchBits;
-    scratchBits += 16;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (16 - scratchBits);
-    }
-    assert(value.f077Int >= -17);
-    assert(value.f077Int <= 17);
-    v = (value.f077Int + 17) & 0x3f;
-    scratch |= v << scratchBits;
-    scratchBits += 6;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (6 - scratchBits);
-    }
-    v = value.f078Bits & 0x1ff;
-    scratch |= v << scratchBits;
-    scratchBits += 9;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (9 - scratchBits);
-    }
-    assert(value.f079Uint >= 0);
-    assert(value.f079Uint <= 17);
-    v = (value.f079Uint) & 0x1f;
-    scratch |= v << scratchBits;
-    scratchBits += 5;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (5 - scratchBits);
-    }
-  }
-  v = value.f080Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.f081Bits & 0x1fffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 29;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (29 - scratchBits);
-  }
-  v = value.f082Bits & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
-  assert(value.f083Enum >= 0);
-  assert(value.f083Enum <= 5);
-  v = value.f083Enum & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  assert(value.f084Ufixed >= 0);
-  assert(value.f084Ufixed <= 128);
-  v = (value.f084Ufixed) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.f085Bits & 0x1fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 21;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (21 - scratchBits);
-  }
-  assert(value.f086Uint >= 0);
-  assert(value.f086Uint <= 399);
-  v = (value.f086Uint) & 0x1ff;
-  scratch |= v << scratchBits;
-  scratchBits += 9;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (9 - scratchBits);
-  }
-  {
-    final b = _float64BitsFromDouble(value.f087F64);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  assert(value.f088Int >= -694);
-  assert(value.f088Int <= 694);
-  v = (value.f088Int + 694) & 0x7ff;
-  scratch |= v << scratchBits;
-  scratchBits += 11;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (11 - scratchBits);
-  }
-  v = value.f089Bits & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.f089Bits >>> 32) & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
-  assert(value.f090Uint >= 0);
-  assert(value.f090Uint <= 214);
-  v = (value.f090Uint) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  assert(value.f091Flags >>> 5 == 0);
-  v = value.f091Flags & 0x1f;
+  v = ((value.f073Int + 4) & 0xf) | ((value.f074Bool ? 1 : 0) << 4);
   scratch |= v << scratchBits;
   scratchBits += 5;
   if (scratchBits >= 64) {
@@ -1561,70 +1022,127 @@ int writeRealPacket(RealPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (5 - scratchBits);
   }
-  v = value.f092Bool ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+  if (value.f074Bool) {
+    assert(value.f076Int >= -26218);
+    assert(value.f076Int <= 26218);
+    v = (value.f075U64);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
+    }
+    assert(value.f077Int >= -17);
+    assert(value.f077Int <= 17);
+    assert(value.f079Uint >= 0);
+    assert(value.f079Uint <= 17);
+    v =
+        ((value.f076Int + 26218) & 0xffff) |
+        (((value.f077Int + 17) & 0x3f) << 16) |
+        (((value.f078Bits) & 0x1ff) << 22) |
+        (((value.f079Uint) & 0x1f) << 31);
+    scratch |= v << scratchBits;
+    scratchBits += 36;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (36 - scratchBits);
+    }
   }
-  v = value.f093Bits & 0xffffffff;
+  assert(value.f083Enum >= 0);
+  assert(value.f083Enum <= 5);
+  assert(value.f084Ufixed >= 0);
+  assert(value.f084Ufixed <= 128);
+  v =
+      (value.f080Bool ? 1 : 0) |
+      (((value.f081Bits) & 0x1fffffff) << 1) |
+      (((value.f082Bits) & 0x1ffffff) << 30) |
+      (((value.f083Enum) & 0x7) << 55);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 58;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (58 - scratchBits);
   }
-  v = (value.f093Bits >>> 32) & 0xffffffff;
+  assert(value.f086Uint >= 0);
+  assert(value.f086Uint <= 399);
+  v =
+      ((value.f084Ufixed) & 0xff) |
+      (((value.f085Bits) & 0x1fffff) << 8) |
+      (((value.f086Uint) & 0x1ff) << 29);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 38;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (38 - scratchBits);
   }
-  v = value.f094Bool ? 1 : 0;
+  assert(value.f088Int >= -694);
+  assert(value.f088Int <= 694);
+  v = _float64BitsFromDouble(value.f087F64);
   scratch |= v << scratchBits;
-  scratchBits += 1;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
+  }
+  assert(value.f090Uint >= 0);
+  assert(value.f090Uint <= 214);
+  v =
+      ((value.f088Int + 694) & 0x7ff) |
+      (((value.f089Bits) & 0xffffffffffff) << 11);
+  scratch |= v << scratchBits;
+  scratchBits += 59;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (59 - scratchBits);
+  }
+  assert(value.f091Flags >>> 5 == 0);
+  v =
+      ((value.f090Uint) & 0xff) |
+      (((value.f091Flags) & 0x1f) << 8) |
+      ((value.f092Bool ? 1 : 0) << 13);
+  scratch |= v << scratchBits;
+  scratchBits += 14;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (14 - scratchBits);
+  }
+  v = (value.f093Bits);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.f095Fixed >= -103350272);
   assert(value.f095Fixed <= 103350272);
-  v = (value.f095Fixed + 103350272) & 0xfffffff;
+  v =
+      (value.f094Bool ? 1 : 0) |
+      (((value.f095Fixed + 103350272) & 0xfffffff) << 1) |
+      (((value.f096Bits) & 0x3ffff) << 29) |
+      (((value.f097Bits) & 0xfff) << 47);
   scratch |= v << scratchBits;
-  scratchBits += 28;
+  scratchBits += 59;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (28 - scratchBits);
-  }
-  v = value.f096Bits & 0x3ffff;
-  scratch |= v << scratchBits;
-  scratchBits += 18;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (18 - scratchBits);
-  }
-  v = value.f097Bits & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
+    scratch = v >>> (59 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);

--- a/generated/dart-ludicrous/Ludicrous.dart
+++ b/generated/dart-ludicrous/Ludicrous.dart
@@ -108,25 +108,18 @@ int writeFixedProbe(FixedProbe value, ByteData view) {
   var v = 0;
   assert(value.angle >= -11796480);
   assert(value.angle <= 11796480);
-  v = (value.angle + 11796480) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.position >= -1966080000);
   assert(value.position <= 1966080000);
-  v = (value.position + 1966080000) & 0xffffffff;
+  v =
+      ((value.angle + 11796480) & 0x1ffffff) |
+      (((value.position + 1966080000) & 0xffffffff) << 25);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 57;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (57 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffff0bdc00000);
@@ -134,28 +127,19 @@ int writeFixedProbe(FixedProbe value, ByteData view) {
     assert(value.reach >= min);
     assert(value.reach <= max);
     final off = (value.reach - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x1fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 37;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x1f;
-    scratch |= v << scratchBits;
-    scratchBits += 5;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (5 - scratchBits);
+      scratch = v >>> (37 - scratchBits);
     }
   }
   assert(value.ticks >= 0);
   assert(value.ticks <= 1000000);
-  v = (value.ticks) & 0xfffff;
+  v = ((value.ticks) & 0xfffff);
   scratch |= v << scratchBits;
   scratchBits += 20;
   if (scratchBits >= 64) {
@@ -167,7 +151,7 @@ int writeFixedProbe(FixedProbe value, ByteData view) {
   for (var i0 = 0; i0 < 2; i0++) {
     assert(value.samples[i0] >= -524288);
     assert(value.samples[i0] <= 524288);
-    v = (value.samples[i0] + 524288) & 0x1fffff;
+    v = ((value.samples[i0] + 524288) & 0x1fffff);
     scratch |= v << scratchBits;
     scratchBits += 21;
     if (scratchBits >= 64) {
@@ -344,7 +328,8 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
   var v = 0;
   assert(value.angle >= 0);
   assert(value.angle <= 23592960);
-  v = (value.angle) & 0x1ffffff;
+  assert(!_unsignedLessThan(0xffffffffffff0000, value.span));
+  v = ((value.angle) & 0x1ffffff);
   scratch |= v << scratchBits;
   scratchBits += 25;
   if (scratchBits >= 64) {
@@ -353,50 +338,31 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (25 - scratchBits);
   }
-  assert(!_unsignedLessThan(0xffffffffffff0000, value.span));
-  v = value.span & 0xffffffff;
+  v = (value.span);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.span >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     const max = UInt128(0, 131072000000);
     assert(value.reach <= max);
-    v = value.reach.lo & 0xffffffff;
+    v = ((value.reach.lo) & 0x1fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 37;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.reach.lo >>> 32) & 0x1f;
-    scratch |= v << scratchBits;
-    scratchBits += 5;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (5 - scratchBits);
+      scratch = v >>> (37 - scratchBits);
     }
   }
   assert(value.ticks >= 0);
   assert(value.ticks <= 1000000);
-  v = (value.ticks) & 0xfffff;
+  v = ((value.ticks) & 0xfffff);
   scratch |= v << scratchBits;
   scratchBits += 20;
   if (scratchBits >= 64) {
@@ -408,7 +374,7 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
   for (var i0 = 0; i0 < 2; i0++) {
     assert(value.samples[i0] >= 0);
     assert(value.samples[i0] <= 1048576);
-    v = (value.samples[i0]) & 0x1fffff;
+    v = ((value.samples[i0]) & 0x1fffff);
     scratch |= v << scratchBits;
     scratchBits += 21;
     if (scratchBits >= 64) {
@@ -419,7 +385,7 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
     }
   }
   assert(value.locked == 196608);
-  v = value.tail & 0xff;
+  v = ((value.tail) & 0xff);
   scratch |= v << scratchBits;
   scratchBits += 8;
   if (scratchBits >= 64) {
@@ -606,41 +572,23 @@ int writeWideProbe(WideProbe value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.entityId.lo & 0xffffffff;
+  v = (value.entityId.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.entityId.lo >>> 32) & 0xffffffff;
+  v = (value.entityId.hi);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.entityId.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.entityId.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffffed5fa0e00);
@@ -648,23 +596,14 @@ int writeWideProbe(WideProbe value, ByteData view) {
     assert(value.energy >= min);
     assert(value.energy <= max);
     final off = (value.energy - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x3ffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 34;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+      scratch = v >>> (34 - scratchBits);
     }
   }
   {
@@ -673,41 +612,23 @@ int writeWideProbe(WideProbe value, ByteData view) {
     assert(value.flux >= min);
     assert(value.flux <= max);
     final off = (value.flux - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = (off.lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (off.lo >>> 32) & 0xffffffff;
+    v = ((off.hi) & 0x3fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 38;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = off.hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.hi >>> 32) & 0x3f;
-    scratch |= v << scratchBits;
-    scratchBits += 6;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (6 - scratchBits);
+      scratch = v >>> (38 - scratchBits);
     }
   }
   {
@@ -716,7 +637,7 @@ int writeWideProbe(WideProbe value, ByteData view) {
     assert(value.bias >= min);
     assert(value.bias <= max);
     final off = (value.bias - min).toUnsigned();
-    v = off.lo & 0x7ff;
+    v = ((off.lo) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -726,41 +647,23 @@ int writeWideProbe(WideProbe value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   }
-  v = value.seed.lo & 0xffffffff;
+  v = (value.seed.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.seed.lo >>> 32) & 0xffffffff;
+  v = (value.seed.hi);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.seed.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.seed.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1021,36 +924,21 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
   var v = 0;
   assert(value.mode >= 0);
   assert(value.mode <= 3);
-  v = value.mode & 0x3;
-  scratch |= v << scratchBits;
-  scratchBits += 2;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
-  }
   assert(value.probe.angle >= -11796480);
   assert(value.probe.angle <= 11796480);
-  v = (value.probe.angle + 11796480) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.probe.position >= -1966080000);
   assert(value.probe.position <= 1966080000);
-  v = (value.probe.position + 1966080000) & 0xffffffff;
+  v =
+      ((value.mode) & 0x3) |
+      (((value.probe.angle + 11796480) & 0x1ffffff) << 2) |
+      (((value.probe.position + 1966080000) & 0xffffffff) << 27);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 59;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (59 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffff0bdc00000);
@@ -1058,28 +946,19 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.probe.reach >= min);
     assert(value.probe.reach <= max);
     final off = (value.probe.reach - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x1fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 37;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x1f;
-    scratch |= v << scratchBits;
-    scratchBits += 5;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (5 - scratchBits);
+      scratch = v >>> (37 - scratchBits);
     }
   }
   assert(value.probe.ticks >= 0);
   assert(value.probe.ticks <= 1000000);
-  v = (value.probe.ticks) & 0xfffff;
+  v = ((value.probe.ticks) & 0xfffff);
   scratch |= v << scratchBits;
   scratchBits += 20;
   if (scratchBits >= 64) {
@@ -1091,7 +970,7 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
   for (var i0 = 0; i0 < 2; i0++) {
     assert(value.probe.samples[i0] >= -524288);
     assert(value.probe.samples[i0] <= 524288);
-    v = (value.probe.samples[i0] + 524288) & 0x1fffff;
+    v = ((value.probe.samples[i0] + 524288) & 0x1fffff);
     scratch |= v << scratchBits;
     scratchBits += 21;
     if (scratchBits >= 64) {
@@ -1101,41 +980,23 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
       scratch = v >>> (21 - scratchBits);
     }
   }
-  v = value.wide.entityId.lo & 0xffffffff;
+  v = (value.wide.entityId.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.wide.entityId.lo >>> 32) & 0xffffffff;
+  v = (value.wide.entityId.hi);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.wide.entityId.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide.entityId.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffffed5fa0e00);
@@ -1143,23 +1004,14 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.wide.energy >= min);
     assert(value.wide.energy <= max);
     final off = (value.wide.energy - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x3ffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 34;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+      scratch = v >>> (34 - scratchBits);
     }
   }
   {
@@ -1168,41 +1020,23 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.wide.flux >= min);
     assert(value.wide.flux <= max);
     final off = (value.wide.flux - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = (off.lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (off.lo >>> 32) & 0xffffffff;
+    v = ((off.hi) & 0x3fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 38;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = off.hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.hi >>> 32) & 0x3f;
-    scratch |= v << scratchBits;
-    scratchBits += 6;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (6 - scratchBits);
+      scratch = v >>> (38 - scratchBits);
     }
   }
   {
@@ -1211,7 +1045,7 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.wide.bias >= min);
     assert(value.wide.bias <= max);
     final off = (value.wide.bias - min).toUnsigned();
-    v = off.lo & 0x7ff;
+    v = ((off.lo) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -1221,45 +1055,27 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   }
-  v = value.wide.seed.lo & 0xffffffff;
+  v = (value.wide.seed.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide.seed.lo >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.wide.seed.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide.seed.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.keysCount >= 0);
   assert(value.keysCount <= 4);
-  v = (value.keysCount) & 0x7;
+  v = (value.wide.seed.hi);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.keysCount) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -1269,44 +1085,26 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     scratch = v >>> (3 - scratchBits);
   }
   for (var i0 = 0; i0 < value.keysCount; i0++) {
-    v = value.keys[i0].lo & 0xffffffff;
+    v = (value.keys[i0].lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (value.keys[i0].lo >>> 32) & 0xffffffff;
+    v = (value.keys[i0].hi);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = value.keys[i0].hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.keys[i0].hi >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
-  v = value.hasTarget ? 1 : 0;
+  v = (value.hasTarget ? 1 : 0);
   scratch |= v << scratchBits;
   scratchBits += 1;
   if (scratchBits >= 64) {
@@ -1316,41 +1114,23 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     scratch = v >>> (1 - scratchBits);
   }
   if (value.hasTarget) {
-    v = value.targetId.lo & 0xffffffff;
+    v = (value.targetId.lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (value.targetId.lo >>> 32) & 0xffffffff;
+    v = (value.targetId.hi);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = value.targetId.hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.targetId.hi >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1833,7 +1613,7 @@ int writeDegenerateProbe(DegenerateProbe value, ByteData view) {
     const locked = Int128(0xffffffffffffffff, 0xfffff4c58c31d00e);
     assert(value.lockedWide == locked);
   }
-  v = value.tail & 0xff;
+  v = ((value.tail) & 0xff);
   scratch |= v << scratchBits;
   scratchBits += 8;
   if (scratchBits >= 64) {
@@ -1932,72 +1712,36 @@ int writeFixedVec(FixedVec value, ByteData view) {
   var v = 0;
   assert(value.x >= -6553600000);
   assert(value.x <= 6553600000);
-  {
-    final off = value.x + 6553600000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
-    }
-  }
   assert(value.y >= -6553600000);
   assert(value.y <= 6553600000);
-  {
-    final off = value.y + 6553600000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
-    }
+  v = ((value.x + 6553600000) & 0x3ffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 34;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (34 - scratchBits);
   }
   assert(value.z >= -6553600000);
   assert(value.z <= 6553600000);
-  {
-    final off = value.z + 6553600000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
-    }
+  v = ((value.y + 6553600000) & 0x3ffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 34;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (34 - scratchBits);
+  }
+  v = ((value.z + 6553600000) & 0x3ffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 34;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (34 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2149,47 +1893,33 @@ int writeFixedQuat(FixedQuat value, ByteData view) {
   var v = 0;
   assert(value.x >= -1073741824);
   assert(value.x <= 1073741824);
-  v = (value.x + 1073741824) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.y >= -1073741824);
   assert(value.y <= 1073741824);
-  v = (value.y + 1073741824) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.z >= -1073741824);
   assert(value.z <= 1073741824);
-  v = (value.z + 1073741824) & 0xffffffff;
+  v =
+      ((value.x + 1073741824) & 0xffffffff) |
+      (((value.y + 1073741824) & 0xffffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.w >= -1073741824);
   assert(value.w <= 1073741824);
-  v = (value.w + 1073741824) & 0xffffffff;
+  v =
+      ((value.z + 1073741824) & 0xffffffff) |
+      (((value.w + 1073741824) & 0xffffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);

--- a/generated/dart-ludicrous/Ludicrous.dart
+++ b/generated/dart-ludicrous/Ludicrous.dart
@@ -188,58 +188,35 @@ bool readFixedProbe(FixedProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 156 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 23592960) {
     return false; // a smuggled offset is refused
   }
   value.angle = -11796480 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 25) & 0xffffffff;
   bitsRead += 32;
   if (v > 3932160000) {
     return false; // a smuggled offset is refused
   }
   value.position = -1966080000 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   if (lo > 131072000000) {
     return false; // a smuggled offset is refused
   }
@@ -247,14 +224,7 @@ bool readFixedProbe(FixedProbe value, ByteData view, int numBits) {
     const min = UInt128(0xffffffffffffffff, 0xfffffff0bdc00000);
     value.reach = (min + UInt128(0, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 37) & 0xfffff;
   bitsRead += 20;
   if (v > 1000000) {
     return false; // a smuggled offset is refused
@@ -262,13 +232,11 @@ bool readFixedProbe(FixedProbe value, ByteData view, int numBits) {
   value.ticks = v;
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fffff;
+    v = window & 0x1fffff;
     bitsRead += 21;
     if (v > 1048576) {
       return false; // a smuggled offset is refused
@@ -421,43 +389,31 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 196 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 23592960) {
     return false; // a smuggled offset is refused
   }
   value.angle = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 25) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0xffffffffffff0000, lo)) {
@@ -465,37 +421,17 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   }
   value.span = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   if (lo > 131072000000) {
     return false; // a smuggled offset is refused
   }
   value.reach = UInt128(0, lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 37) & 0xfffff;
   bitsRead += 20;
   if (v > 1000000) {
     return false; // a smuggled offset is refused
@@ -503,13 +439,11 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   value.ticks = v;
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fffff;
+    v = window & 0x1fffff;
     bitsRead += 21;
     if (v > 1048576) {
       return false; // a smuggled offset is refused
@@ -518,13 +452,11 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   }
   value.locked = 196608;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.tail = v;
   return true;
@@ -692,7 +624,6 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   var hi = 0;
@@ -700,66 +631,45 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.entityId = UInt128(hi, lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 10000000000) {
     return false; // a smuggled offset is refused
   }
@@ -768,43 +678,30 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     value.energy = (min + UInt128(0, lo)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3f;
+  v = (window >>> 32) & 0x3f;
   bitsRead += 6;
   hi |= v << 32;
   {
@@ -817,14 +714,7 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     const min = UInt128(0xfffffff000000000, 0);
     value.flux = (min + UInt128(hi, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 38) & 0x7ff;
   bitsRead += 11;
   if (v > 2000) {
     return false; // a smuggled offset is refused
@@ -834,43 +724,35 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     value.bias = (min + UInt128(0, v)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.seed = UInt128(hi, lo);
@@ -1160,7 +1042,6 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   var hi = 0;
@@ -1168,61 +1049,37 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.mode = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 2) & 0x1ffffff;
   bitsRead += 25;
   if (v > 23592960) {
     return false; // a smuggled offset is refused
   }
   value.probe.angle = -11796480 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 3932160000) {
     return false; // a smuggled offset is refused
   }
   value.probe.position = -1966080000 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   if (lo > 131072000000) {
     return false; // a smuggled offset is refused
   }
@@ -1230,14 +1087,7 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     const min = UInt128(0xffffffffffffffff, 0xfffffff0bdc00000);
     value.probe.reach = (min + UInt128(0, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 37) & 0xfffff;
   bitsRead += 20;
   if (v > 1000000) {
     return false; // a smuggled offset is refused
@@ -1245,13 +1095,11 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
   value.probe.ticks = v;
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fffff;
+    v = window & 0x1fffff;
     bitsRead += 21;
     if (v > 1048576) {
       return false; // a smuggled offset is refused
@@ -1259,66 +1107,45 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     value.probe.samples[i0] = -524288 + v;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.wide.entityId = UInt128(hi, lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 10000000000) {
     return false; // a smuggled offset is refused
   }
@@ -1327,43 +1154,30 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     value.wide.energy = (min + UInt128(0, lo)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3f;
+  v = (window >>> 32) & 0x3f;
   bitsRead += 6;
   hi |= v << 32;
   {
@@ -1376,14 +1190,7 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     const min = UInt128(0xfffffff000000000, 0);
     value.wide.flux = (min + UInt128(hi, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 38) & 0x7ff;
   bitsRead += 11;
   if (v > 2000) {
     return false; // a smuggled offset is refused
@@ -1393,57 +1200,42 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     value.wide.bias = (min + UInt128(0, v)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.wide.seed = UInt128(hi, lo);
   if (bitsRead + 3 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 32) & 0x7;
   bitsRead += 3;
   if (v > 4) {
     return false; // the count guards the loop — reject, never clamp
@@ -1454,43 +1246,35 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.keysCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi |= v << 32;
     value.keys[i0] = UInt128(hi, lo);
@@ -1499,13 +1283,11 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.hasTarget = v != 0;
   if (value.hasTarget) {
@@ -1513,43 +1295,35 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi |= v << 32;
     value.targetId = UInt128(hi, lo);
@@ -1649,7 +1423,6 @@ bool readDegenerateProbe(DegenerateProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 8 > numBits) {
     return false;
@@ -1661,13 +1434,11 @@ bool readDegenerateProbe(DegenerateProbe value, ByteData view, int numBits) {
     value.lockedWide = locked;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.tail = v;
   return true;
@@ -1770,80 +1541,39 @@ bool readFixedVec(FixedVec value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
-  var v = 0;
   var lo = 0;
   if (bitsRead + 102 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 13107200000) {
     return false; // a smuggled offset is refused
   }
   value.x = -6553600000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 13107200000) {
     return false; // a smuggled offset is refused
   }
   value.y = -6553600000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 13107200000) {
     return false; // a smuggled offset is refused
   }
@@ -1948,58 +1678,49 @@ bool readFixedQuat(FixedQuat value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 128 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused
   }
   value.x = -1073741824 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused
   }
   value.y = -1073741824 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused
   }
   value.z = -1073741824 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused

--- a/generated/dart/Clauses.dart
+++ b/generated/dart/Clauses.dart
@@ -46,17 +46,43 @@ int writeW13(W13 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (4 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 8191);
-    v = ((value.items[i0]) & 0x1fff);
-    scratch |= v << scratchBits;
-    scratchBits += 13;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (13 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 8191);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 8191);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 8191);
+      v =
+          ((value.items[i0]) & 0x1fff) |
+          (((value.items[i0 + 1]) & 0x1fff) << 13) |
+          (((value.items[i0 + 2]) & 0x1fff) << 26) |
+          (((value.items[i0 + 3]) & 0x1fff) << 39);
+      scratch |= v << scratchBits;
+      scratchBits += 52;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (52 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      v = ((value.items[i0]) & 0x1fff);
+      scratch |= v << scratchBits;
+      scratchBits += 13;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (13 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -104,15 +130,39 @@ bool readW13(W13 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 13 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+      v = (window >>> 13) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 1] = v;
+      v = (window >>> 26) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 2] = v;
+      v = (window >>> 39) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 3] = v;
     }
-    v = window & 0x1fff;
-    bitsRead += 13;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -166,17 +216,40 @@ int writeW17(W17 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (4 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 131071);
-    v = ((value.items[i0]) & 0x1ffff);
-    scratch |= v << scratchBits;
-    scratchBits += 17;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (17 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.itemsCount; i0 += 3) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 131071);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 131071);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 131071);
+      v =
+          ((value.items[i0]) & 0x1ffff) |
+          (((value.items[i0 + 1]) & 0x1ffff) << 17) |
+          (((value.items[i0 + 2]) & 0x1ffff) << 34);
+      scratch |= v << scratchBits;
+      scratchBits += 51;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (51 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 131071);
+      v = ((value.items[i0]) & 0x1ffff);
+      scratch |= v << scratchBits;
+      scratchBits += 17;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (17 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -224,15 +297,36 @@ bool readW17(W17 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 17 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.itemsCount; i0 += 3) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0] = v;
+      v = (window >>> 17) & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0 + 1] = v;
+      v = (window >>> 34) & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0 + 2] = v;
     }
-    v = window & 0x1ffff;
-    bitsRead += 17;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -286,17 +380,37 @@ int writeW26(W26 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (3 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 67108863);
-    v = ((value.items[i0]) & 0x3ffffff);
-    scratch |= v << scratchBits;
-    scratchBits += 26;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (26 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 2 <= value.itemsCount; i0 += 2) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 67108863);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 67108863);
+      v =
+          ((value.items[i0]) & 0x3ffffff) |
+          (((value.items[i0 + 1]) & 0x3ffffff) << 26);
+      scratch |= v << scratchBits;
+      scratchBits += 52;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (52 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 67108863);
+      v = ((value.items[i0]) & 0x3ffffff);
+      scratch |= v << scratchBits;
+      scratchBits += 26;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (26 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -344,15 +458,33 @@ bool readW26(W26 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 26 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 2 <= value.itemsCount; i0 += 2) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x3ffffff;
+      bitsRead += 26;
+      value.items[i0] = v;
+      v = (window >>> 26) & 0x3ffffff;
+      bitsRead += 26;
+      value.items[i0 + 1] = v;
     }
-    v = window & 0x3ffffff;
-    bitsRead += 26;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x3ffffff;
+      bitsRead += 26;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -406,17 +538,223 @@ int writeW1(W1 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (5 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 1);
-    v = ((value.items[i0]) & 0x1);
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 64 <= value.itemsCount; i0 += 64) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 1);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 1);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 1);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 1);
+      assert(value.items[i0 + 4] >= 0);
+      assert(value.items[i0 + 4] <= 1);
+      assert(value.items[i0 + 5] >= 0);
+      assert(value.items[i0 + 5] <= 1);
+      assert(value.items[i0 + 6] >= 0);
+      assert(value.items[i0 + 6] <= 1);
+      assert(value.items[i0 + 7] >= 0);
+      assert(value.items[i0 + 7] <= 1);
+      assert(value.items[i0 + 8] >= 0);
+      assert(value.items[i0 + 8] <= 1);
+      assert(value.items[i0 + 9] >= 0);
+      assert(value.items[i0 + 9] <= 1);
+      assert(value.items[i0 + 10] >= 0);
+      assert(value.items[i0 + 10] <= 1);
+      assert(value.items[i0 + 11] >= 0);
+      assert(value.items[i0 + 11] <= 1);
+      assert(value.items[i0 + 12] >= 0);
+      assert(value.items[i0 + 12] <= 1);
+      assert(value.items[i0 + 13] >= 0);
+      assert(value.items[i0 + 13] <= 1);
+      assert(value.items[i0 + 14] >= 0);
+      assert(value.items[i0 + 14] <= 1);
+      assert(value.items[i0 + 15] >= 0);
+      assert(value.items[i0 + 15] <= 1);
+      assert(value.items[i0 + 16] >= 0);
+      assert(value.items[i0 + 16] <= 1);
+      assert(value.items[i0 + 17] >= 0);
+      assert(value.items[i0 + 17] <= 1);
+      assert(value.items[i0 + 18] >= 0);
+      assert(value.items[i0 + 18] <= 1);
+      assert(value.items[i0 + 19] >= 0);
+      assert(value.items[i0 + 19] <= 1);
+      assert(value.items[i0 + 20] >= 0);
+      assert(value.items[i0 + 20] <= 1);
+      assert(value.items[i0 + 21] >= 0);
+      assert(value.items[i0 + 21] <= 1);
+      assert(value.items[i0 + 22] >= 0);
+      assert(value.items[i0 + 22] <= 1);
+      assert(value.items[i0 + 23] >= 0);
+      assert(value.items[i0 + 23] <= 1);
+      assert(value.items[i0 + 24] >= 0);
+      assert(value.items[i0 + 24] <= 1);
+      assert(value.items[i0 + 25] >= 0);
+      assert(value.items[i0 + 25] <= 1);
+      assert(value.items[i0 + 26] >= 0);
+      assert(value.items[i0 + 26] <= 1);
+      assert(value.items[i0 + 27] >= 0);
+      assert(value.items[i0 + 27] <= 1);
+      assert(value.items[i0 + 28] >= 0);
+      assert(value.items[i0 + 28] <= 1);
+      assert(value.items[i0 + 29] >= 0);
+      assert(value.items[i0 + 29] <= 1);
+      assert(value.items[i0 + 30] >= 0);
+      assert(value.items[i0 + 30] <= 1);
+      assert(value.items[i0 + 31] >= 0);
+      assert(value.items[i0 + 31] <= 1);
+      assert(value.items[i0 + 32] >= 0);
+      assert(value.items[i0 + 32] <= 1);
+      assert(value.items[i0 + 33] >= 0);
+      assert(value.items[i0 + 33] <= 1);
+      assert(value.items[i0 + 34] >= 0);
+      assert(value.items[i0 + 34] <= 1);
+      assert(value.items[i0 + 35] >= 0);
+      assert(value.items[i0 + 35] <= 1);
+      assert(value.items[i0 + 36] >= 0);
+      assert(value.items[i0 + 36] <= 1);
+      assert(value.items[i0 + 37] >= 0);
+      assert(value.items[i0 + 37] <= 1);
+      assert(value.items[i0 + 38] >= 0);
+      assert(value.items[i0 + 38] <= 1);
+      assert(value.items[i0 + 39] >= 0);
+      assert(value.items[i0 + 39] <= 1);
+      assert(value.items[i0 + 40] >= 0);
+      assert(value.items[i0 + 40] <= 1);
+      assert(value.items[i0 + 41] >= 0);
+      assert(value.items[i0 + 41] <= 1);
+      assert(value.items[i0 + 42] >= 0);
+      assert(value.items[i0 + 42] <= 1);
+      assert(value.items[i0 + 43] >= 0);
+      assert(value.items[i0 + 43] <= 1);
+      assert(value.items[i0 + 44] >= 0);
+      assert(value.items[i0 + 44] <= 1);
+      assert(value.items[i0 + 45] >= 0);
+      assert(value.items[i0 + 45] <= 1);
+      assert(value.items[i0 + 46] >= 0);
+      assert(value.items[i0 + 46] <= 1);
+      assert(value.items[i0 + 47] >= 0);
+      assert(value.items[i0 + 47] <= 1);
+      assert(value.items[i0 + 48] >= 0);
+      assert(value.items[i0 + 48] <= 1);
+      assert(value.items[i0 + 49] >= 0);
+      assert(value.items[i0 + 49] <= 1);
+      assert(value.items[i0 + 50] >= 0);
+      assert(value.items[i0 + 50] <= 1);
+      assert(value.items[i0 + 51] >= 0);
+      assert(value.items[i0 + 51] <= 1);
+      assert(value.items[i0 + 52] >= 0);
+      assert(value.items[i0 + 52] <= 1);
+      assert(value.items[i0 + 53] >= 0);
+      assert(value.items[i0 + 53] <= 1);
+      assert(value.items[i0 + 54] >= 0);
+      assert(value.items[i0 + 54] <= 1);
+      assert(value.items[i0 + 55] >= 0);
+      assert(value.items[i0 + 55] <= 1);
+      assert(value.items[i0 + 56] >= 0);
+      assert(value.items[i0 + 56] <= 1);
+      assert(value.items[i0 + 57] >= 0);
+      assert(value.items[i0 + 57] <= 1);
+      assert(value.items[i0 + 58] >= 0);
+      assert(value.items[i0 + 58] <= 1);
+      assert(value.items[i0 + 59] >= 0);
+      assert(value.items[i0 + 59] <= 1);
+      assert(value.items[i0 + 60] >= 0);
+      assert(value.items[i0 + 60] <= 1);
+      assert(value.items[i0 + 61] >= 0);
+      assert(value.items[i0 + 61] <= 1);
+      assert(value.items[i0 + 62] >= 0);
+      assert(value.items[i0 + 62] <= 1);
+      assert(value.items[i0 + 63] >= 0);
+      assert(value.items[i0 + 63] <= 1);
+      v =
+          ((value.items[i0]) & 0x1) |
+          (((value.items[i0 + 1]) & 0x1) << 1) |
+          (((value.items[i0 + 2]) & 0x1) << 2) |
+          (((value.items[i0 + 3]) & 0x1) << 3) |
+          (((value.items[i0 + 4]) & 0x1) << 4) |
+          (((value.items[i0 + 5]) & 0x1) << 5) |
+          (((value.items[i0 + 6]) & 0x1) << 6) |
+          (((value.items[i0 + 7]) & 0x1) << 7) |
+          (((value.items[i0 + 8]) & 0x1) << 8) |
+          (((value.items[i0 + 9]) & 0x1) << 9) |
+          (((value.items[i0 + 10]) & 0x1) << 10) |
+          (((value.items[i0 + 11]) & 0x1) << 11) |
+          (((value.items[i0 + 12]) & 0x1) << 12) |
+          (((value.items[i0 + 13]) & 0x1) << 13) |
+          (((value.items[i0 + 14]) & 0x1) << 14) |
+          (((value.items[i0 + 15]) & 0x1) << 15) |
+          (((value.items[i0 + 16]) & 0x1) << 16) |
+          (((value.items[i0 + 17]) & 0x1) << 17) |
+          (((value.items[i0 + 18]) & 0x1) << 18) |
+          (((value.items[i0 + 19]) & 0x1) << 19) |
+          (((value.items[i0 + 20]) & 0x1) << 20) |
+          (((value.items[i0 + 21]) & 0x1) << 21) |
+          (((value.items[i0 + 22]) & 0x1) << 22) |
+          (((value.items[i0 + 23]) & 0x1) << 23) |
+          (((value.items[i0 + 24]) & 0x1) << 24) |
+          (((value.items[i0 + 25]) & 0x1) << 25) |
+          (((value.items[i0 + 26]) & 0x1) << 26) |
+          (((value.items[i0 + 27]) & 0x1) << 27) |
+          (((value.items[i0 + 28]) & 0x1) << 28) |
+          (((value.items[i0 + 29]) & 0x1) << 29) |
+          (((value.items[i0 + 30]) & 0x1) << 30) |
+          (((value.items[i0 + 31]) & 0x1) << 31) |
+          (((value.items[i0 + 32]) & 0x1) << 32) |
+          (((value.items[i0 + 33]) & 0x1) << 33) |
+          (((value.items[i0 + 34]) & 0x1) << 34) |
+          (((value.items[i0 + 35]) & 0x1) << 35) |
+          (((value.items[i0 + 36]) & 0x1) << 36) |
+          (((value.items[i0 + 37]) & 0x1) << 37) |
+          (((value.items[i0 + 38]) & 0x1) << 38) |
+          (((value.items[i0 + 39]) & 0x1) << 39) |
+          (((value.items[i0 + 40]) & 0x1) << 40) |
+          (((value.items[i0 + 41]) & 0x1) << 41) |
+          (((value.items[i0 + 42]) & 0x1) << 42) |
+          (((value.items[i0 + 43]) & 0x1) << 43) |
+          (((value.items[i0 + 44]) & 0x1) << 44) |
+          (((value.items[i0 + 45]) & 0x1) << 45) |
+          (((value.items[i0 + 46]) & 0x1) << 46) |
+          (((value.items[i0 + 47]) & 0x1) << 47) |
+          (((value.items[i0 + 48]) & 0x1) << 48) |
+          (((value.items[i0 + 49]) & 0x1) << 49) |
+          (((value.items[i0 + 50]) & 0x1) << 50) |
+          (((value.items[i0 + 51]) & 0x1) << 51) |
+          (((value.items[i0 + 52]) & 0x1) << 52) |
+          (((value.items[i0 + 53]) & 0x1) << 53) |
+          (((value.items[i0 + 54]) & 0x1) << 54) |
+          (((value.items[i0 + 55]) & 0x1) << 55) |
+          (((value.items[i0 + 56]) & 0x1) << 56) |
+          (((value.items[i0 + 57]) & 0x1) << 57) |
+          (((value.items[i0 + 58]) & 0x1) << 58) |
+          (((value.items[i0 + 59]) & 0x1) << 59) |
+          (((value.items[i0 + 60]) & 0x1) << 60) |
+          (((value.items[i0 + 61]) & 0x1) << 61) |
+          (((value.items[i0 + 62]) & 0x1) << 62) |
+          (((value.items[i0 + 63]) & 0x1) << 63);
+      scratch |= v << scratchBits;
+      scratchBits += 64;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (64 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 1);
+      v = ((value.items[i0]) & 0x1);
+      scratch |= v << scratchBits;
+      scratchBits += 1;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (1 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -464,15 +802,198 @@ bool readW1(W1 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 1 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 57 <= value.itemsCount; i0 += 57) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      value.items[i0] = v;
+      v = (window >>> 1) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 1] = v;
+      v = (window >>> 2) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 2] = v;
+      v = (window >>> 3) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 3] = v;
+      v = (window >>> 4) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 4] = v;
+      v = (window >>> 5) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 5] = v;
+      v = (window >>> 6) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 6] = v;
+      v = (window >>> 7) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 7] = v;
+      v = (window >>> 8) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 8] = v;
+      v = (window >>> 9) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 9] = v;
+      v = (window >>> 10) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 10] = v;
+      v = (window >>> 11) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 11] = v;
+      v = (window >>> 12) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 12] = v;
+      v = (window >>> 13) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 13] = v;
+      v = (window >>> 14) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 14] = v;
+      v = (window >>> 15) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 15] = v;
+      v = (window >>> 16) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 16] = v;
+      v = (window >>> 17) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 17] = v;
+      v = (window >>> 18) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 18] = v;
+      v = (window >>> 19) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 19] = v;
+      v = (window >>> 20) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 20] = v;
+      v = (window >>> 21) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 21] = v;
+      v = (window >>> 22) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 22] = v;
+      v = (window >>> 23) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 23] = v;
+      v = (window >>> 24) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 24] = v;
+      v = (window >>> 25) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 25] = v;
+      v = (window >>> 26) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 26] = v;
+      v = (window >>> 27) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 27] = v;
+      v = (window >>> 28) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 28] = v;
+      v = (window >>> 29) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 29] = v;
+      v = (window >>> 30) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 30] = v;
+      v = (window >>> 31) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 31] = v;
+      v = (window >>> 32) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 32] = v;
+      v = (window >>> 33) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 33] = v;
+      v = (window >>> 34) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 34] = v;
+      v = (window >>> 35) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 35] = v;
+      v = (window >>> 36) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 36] = v;
+      v = (window >>> 37) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 37] = v;
+      v = (window >>> 38) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 38] = v;
+      v = (window >>> 39) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 39] = v;
+      v = (window >>> 40) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 40] = v;
+      v = (window >>> 41) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 41] = v;
+      v = (window >>> 42) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 42] = v;
+      v = (window >>> 43) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 43] = v;
+      v = (window >>> 44) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 44] = v;
+      v = (window >>> 45) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 45] = v;
+      v = (window >>> 46) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 46] = v;
+      v = (window >>> 47) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 47] = v;
+      v = (window >>> 48) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 48] = v;
+      v = (window >>> 49) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 49] = v;
+      v = (window >>> 50) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 50] = v;
+      v = (window >>> 51) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 51] = v;
+      v = (window >>> 52) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 52] = v;
+      v = (window >>> 53) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 53] = v;
+      v = (window >>> 54) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 54] = v;
+      v = (window >>> 55) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 55] = v;
+      v = (window >>> 56) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 56] = v;
     }
-    v = window & 0x1;
-    bitsRead += 1;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -937,16 +1458,93 @@ int writeArrTri3(ArrTri3 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (4 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    v = ((e0.a) & 0x1) | (((e0.b) & 0x3) << 1);
-    scratch |= v << scratchBits;
-    scratchBits += 3;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (3 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 21 <= value.itemsCount; i0 += 21) {
+      final e0 = value.items[i0];
+      final e0g1 = value.items[i0 + 1];
+      final e0g2 = value.items[i0 + 2];
+      final e0g3 = value.items[i0 + 3];
+      final e0g4 = value.items[i0 + 4];
+      final e0g5 = value.items[i0 + 5];
+      final e0g6 = value.items[i0 + 6];
+      final e0g7 = value.items[i0 + 7];
+      final e0g8 = value.items[i0 + 8];
+      final e0g9 = value.items[i0 + 9];
+      final e0g10 = value.items[i0 + 10];
+      final e0g11 = value.items[i0 + 11];
+      final e0g12 = value.items[i0 + 12];
+      final e0g13 = value.items[i0 + 13];
+      final e0g14 = value.items[i0 + 14];
+      final e0g15 = value.items[i0 + 15];
+      final e0g16 = value.items[i0 + 16];
+      final e0g17 = value.items[i0 + 17];
+      final e0g18 = value.items[i0 + 18];
+      final e0g19 = value.items[i0 + 19];
+      final e0g20 = value.items[i0 + 20];
+      v =
+          ((e0.a) & 0x1) |
+          (((e0.b) & 0x3) << 1) |
+          (((e0g1.a) & 0x1) << 3) |
+          (((e0g1.b) & 0x3) << 4) |
+          (((e0g2.a) & 0x1) << 6) |
+          (((e0g2.b) & 0x3) << 7) |
+          (((e0g3.a) & 0x1) << 9) |
+          (((e0g3.b) & 0x3) << 10) |
+          (((e0g4.a) & 0x1) << 12) |
+          (((e0g4.b) & 0x3) << 13) |
+          (((e0g5.a) & 0x1) << 15) |
+          (((e0g5.b) & 0x3) << 16) |
+          (((e0g6.a) & 0x1) << 18) |
+          (((e0g6.b) & 0x3) << 19) |
+          (((e0g7.a) & 0x1) << 21) |
+          (((e0g7.b) & 0x3) << 22) |
+          (((e0g8.a) & 0x1) << 24) |
+          (((e0g8.b) & 0x3) << 25) |
+          (((e0g9.a) & 0x1) << 27) |
+          (((e0g9.b) & 0x3) << 28) |
+          (((e0g10.a) & 0x1) << 30) |
+          (((e0g10.b) & 0x3) << 31) |
+          (((e0g11.a) & 0x1) << 33) |
+          (((e0g11.b) & 0x3) << 34) |
+          (((e0g12.a) & 0x1) << 36) |
+          (((e0g12.b) & 0x3) << 37) |
+          (((e0g13.a) & 0x1) << 39) |
+          (((e0g13.b) & 0x3) << 40) |
+          (((e0g14.a) & 0x1) << 42) |
+          (((e0g14.b) & 0x3) << 43) |
+          (((e0g15.a) & 0x1) << 45) |
+          (((e0g15.b) & 0x3) << 46) |
+          (((e0g16.a) & 0x1) << 48) |
+          (((e0g16.b) & 0x3) << 49) |
+          (((e0g17.a) & 0x1) << 51) |
+          (((e0g17.b) & 0x3) << 52) |
+          (((e0g18.a) & 0x1) << 54) |
+          (((e0g18.b) & 0x3) << 55) |
+          (((e0g19.a) & 0x1) << 57) |
+          (((e0g19.b) & 0x3) << 58) |
+          (((e0g20.a) & 0x1) << 60) |
+          (((e0g20.b) & 0x3) << 61);
+      scratch |= v << scratchBits;
+      scratchBits += 63;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (63 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      v = ((e0.a) & 0x1) | (((e0.b) & 0x3) << 1);
+      scratch |= v << scratchBits;
+      scratchBits += 3;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (3 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -994,19 +1592,164 @@ bool readArrTri3(ArrTri3 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 3 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 19 <= value.itemsCount; i0 += 19) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      e0.a = v;
+      v = (window >>> 1) & 0x3;
+      bitsRead += 2;
+      e0.b = v;
+      final e0g1 = value.items[i0 + 1];
+      v = (window >>> 3) & 0x1;
+      bitsRead += 1;
+      e0g1.a = v;
+      v = (window >>> 4) & 0x3;
+      bitsRead += 2;
+      e0g1.b = v;
+      final e0g2 = value.items[i0 + 2];
+      v = (window >>> 6) & 0x1;
+      bitsRead += 1;
+      e0g2.a = v;
+      v = (window >>> 7) & 0x3;
+      bitsRead += 2;
+      e0g2.b = v;
+      final e0g3 = value.items[i0 + 3];
+      v = (window >>> 9) & 0x1;
+      bitsRead += 1;
+      e0g3.a = v;
+      v = (window >>> 10) & 0x3;
+      bitsRead += 2;
+      e0g3.b = v;
+      final e0g4 = value.items[i0 + 4];
+      v = (window >>> 12) & 0x1;
+      bitsRead += 1;
+      e0g4.a = v;
+      v = (window >>> 13) & 0x3;
+      bitsRead += 2;
+      e0g4.b = v;
+      final e0g5 = value.items[i0 + 5];
+      v = (window >>> 15) & 0x1;
+      bitsRead += 1;
+      e0g5.a = v;
+      v = (window >>> 16) & 0x3;
+      bitsRead += 2;
+      e0g5.b = v;
+      final e0g6 = value.items[i0 + 6];
+      v = (window >>> 18) & 0x1;
+      bitsRead += 1;
+      e0g6.a = v;
+      v = (window >>> 19) & 0x3;
+      bitsRead += 2;
+      e0g6.b = v;
+      final e0g7 = value.items[i0 + 7];
+      v = (window >>> 21) & 0x1;
+      bitsRead += 1;
+      e0g7.a = v;
+      v = (window >>> 22) & 0x3;
+      bitsRead += 2;
+      e0g7.b = v;
+      final e0g8 = value.items[i0 + 8];
+      v = (window >>> 24) & 0x1;
+      bitsRead += 1;
+      e0g8.a = v;
+      v = (window >>> 25) & 0x3;
+      bitsRead += 2;
+      e0g8.b = v;
+      final e0g9 = value.items[i0 + 9];
+      v = (window >>> 27) & 0x1;
+      bitsRead += 1;
+      e0g9.a = v;
+      v = (window >>> 28) & 0x3;
+      bitsRead += 2;
+      e0g9.b = v;
+      final e0g10 = value.items[i0 + 10];
+      v = (window >>> 30) & 0x1;
+      bitsRead += 1;
+      e0g10.a = v;
+      v = (window >>> 31) & 0x3;
+      bitsRead += 2;
+      e0g10.b = v;
+      final e0g11 = value.items[i0 + 11];
+      v = (window >>> 33) & 0x1;
+      bitsRead += 1;
+      e0g11.a = v;
+      v = (window >>> 34) & 0x3;
+      bitsRead += 2;
+      e0g11.b = v;
+      final e0g12 = value.items[i0 + 12];
+      v = (window >>> 36) & 0x1;
+      bitsRead += 1;
+      e0g12.a = v;
+      v = (window >>> 37) & 0x3;
+      bitsRead += 2;
+      e0g12.b = v;
+      final e0g13 = value.items[i0 + 13];
+      v = (window >>> 39) & 0x1;
+      bitsRead += 1;
+      e0g13.a = v;
+      v = (window >>> 40) & 0x3;
+      bitsRead += 2;
+      e0g13.b = v;
+      final e0g14 = value.items[i0 + 14];
+      v = (window >>> 42) & 0x1;
+      bitsRead += 1;
+      e0g14.a = v;
+      v = (window >>> 43) & 0x3;
+      bitsRead += 2;
+      e0g14.b = v;
+      final e0g15 = value.items[i0 + 15];
+      v = (window >>> 45) & 0x1;
+      bitsRead += 1;
+      e0g15.a = v;
+      v = (window >>> 46) & 0x3;
+      bitsRead += 2;
+      e0g15.b = v;
+      final e0g16 = value.items[i0 + 16];
+      v = (window >>> 48) & 0x1;
+      bitsRead += 1;
+      e0g16.a = v;
+      v = (window >>> 49) & 0x3;
+      bitsRead += 2;
+      e0g16.b = v;
+      final e0g17 = value.items[i0 + 17];
+      v = (window >>> 51) & 0x1;
+      bitsRead += 1;
+      e0g17.a = v;
+      v = (window >>> 52) & 0x3;
+      bitsRead += 2;
+      e0g17.b = v;
+      final e0g18 = value.items[i0 + 18];
+      v = (window >>> 54) & 0x1;
+      bitsRead += 1;
+      e0g18.a = v;
+      v = (window >>> 55) & 0x3;
+      bitsRead += 2;
+      e0g18.b = v;
     }
-    v = window & 0x1;
-    bitsRead += 1;
-    e0.a = v;
-    v = (window >>> 1) & 0x3;
-    bitsRead += 2;
-    e0.b = v;
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      e0.a = v;
+      v = (window >>> 1) & 0x3;
+      bitsRead += 2;
+      e0.b = v;
+    }
   }
   return true;
 }
@@ -1881,16 +2624,45 @@ int writeArrNested(ArrNested value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (8 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    v = ((e0.a) & 0x7) | (((e0.b) & 0xff) << 3);
-    scratch |= v << scratchBits;
-    scratchBits += 11;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (11 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 5 <= value.itemsCount; i0 += 5) {
+      final e0 = value.items[i0];
+      final e0g1 = value.items[i0 + 1];
+      final e0g2 = value.items[i0 + 2];
+      final e0g3 = value.items[i0 + 3];
+      final e0g4 = value.items[i0 + 4];
+      v =
+          ((e0.a) & 0x7) |
+          (((e0.b) & 0xff) << 3) |
+          (((e0g1.a) & 0x7) << 11) |
+          (((e0g1.b) & 0xff) << 14) |
+          (((e0g2.a) & 0x7) << 22) |
+          (((e0g2.b) & 0xff) << 25) |
+          (((e0g3.a) & 0x7) << 33) |
+          (((e0g3.b) & 0xff) << 36) |
+          (((e0g4.a) & 0x7) << 44) |
+          (((e0g4.b) & 0xff) << 47);
+      scratch |= v << scratchBits;
+      scratchBits += 55;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (55 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      v = ((e0.a) & 0x7) | (((e0.b) & 0xff) << 3);
+      scratch |= v << scratchBits;
+      scratchBits += 11;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (11 - scratchBits);
+      }
     }
   }
   v = ((value.tail) & 0x7);
@@ -1953,19 +2725,66 @@ bool readArrNested(ArrNested value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 11 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 5 <= value.itemsCount; i0 += 5) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x7;
+      bitsRead += 3;
+      e0.a = v;
+      v = (window >>> 3) & 0xff;
+      bitsRead += 8;
+      e0.b = v;
+      final e0g1 = value.items[i0 + 1];
+      v = (window >>> 11) & 0x7;
+      bitsRead += 3;
+      e0g1.a = v;
+      v = (window >>> 14) & 0xff;
+      bitsRead += 8;
+      e0g1.b = v;
+      final e0g2 = value.items[i0 + 2];
+      v = (window >>> 22) & 0x7;
+      bitsRead += 3;
+      e0g2.a = v;
+      v = (window >>> 25) & 0xff;
+      bitsRead += 8;
+      e0g2.b = v;
+      final e0g3 = value.items[i0 + 3];
+      v = (window >>> 33) & 0x7;
+      bitsRead += 3;
+      e0g3.a = v;
+      v = (window >>> 36) & 0xff;
+      bitsRead += 8;
+      e0g3.b = v;
+      final e0g4 = value.items[i0 + 4];
+      v = (window >>> 44) & 0x7;
+      bitsRead += 3;
+      e0g4.a = v;
+      v = (window >>> 47) & 0xff;
+      bitsRead += 8;
+      e0g4.b = v;
     }
-    v = window & 0x7;
-    bitsRead += 3;
-    e0.a = v;
-    v = (window >>> 3) & 0xff;
-    bitsRead += 8;
-    e0.b = v;
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x7;
+      bitsRead += 3;
+      e0.a = v;
+      v = (window >>> 3) & 0xff;
+      bitsRead += 8;
+      e0.b = v;
+    }
   }
   if (bitsRead + 3 > numBits) {
     return false;

--- a/generated/dart/Clauses.dart
+++ b/generated/dart/Clauses.dart
@@ -1719,15 +1719,33 @@ int writeStrs(Strs value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.sLength; i0++) {
-    v = value.s[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.sLength; i0 += 4) {
+      v =
+          value.s[i0] |
+          (value.s[i0 + 1] << 8) |
+          (value.s[i0 + 2] << 16) |
+          (value.s[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.sLength; i0++) {
+      v = value.s[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   assert(value.bLength >= 0);
@@ -1753,15 +1771,33 @@ int writeStrs(Strs value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.bLength; i0++) {
-    v = value.b[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.bLength; i0 += 4) {
+      v =
+          value.b[i0] |
+          (value.b[i0 + 1] << 8) |
+          (value.b[i0 + 2] << 16) |
+          (value.b[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.bLength; i0++) {
+      v = value.b[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   v = ((value.tail) & 0x7);

--- a/generated/dart/Clauses.dart
+++ b/generated/dart/Clauses.dart
@@ -86,19 +86,16 @@ bool readW13(W13 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 12) {
     return false; // the count guards the loop — reject, never clamp
@@ -109,13 +106,11 @@ bool readW13(W13 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fff;
+    v = window & 0x1fff;
     bitsRead += 13;
     value.items[i0] = v;
   }
@@ -211,19 +206,16 @@ bool readW17(W17 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 9) {
     return false; // the count guards the loop — reject, never clamp
@@ -234,13 +226,11 @@ bool readW17(W17 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1ffff;
+    v = window & 0x1ffff;
     bitsRead += 17;
     value.items[i0] = v;
   }
@@ -336,19 +326,16 @@ bool readW26(W26 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   if (v > 6) {
     return false; // the count guards the loop — reject, never clamp
@@ -359,13 +346,11 @@ bool readW26(W26 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3ffffff;
+    v = window & 0x3ffffff;
     bitsRead += 26;
     value.items[i0] = v;
   }
@@ -461,19 +446,16 @@ bool readW1(W1 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   if (v > 20) {
     return false; // the count guards the loop — reject, never clamp
@@ -484,13 +466,11 @@ bool readW1(W1 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1;
+    v = window & 0x1;
     bitsRead += 1;
     value.items[i0] = v;
   }
@@ -586,20 +566,17 @@ bool readW52(W52 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   if (bitsRead + value.itemsCount * 52 > numBits) {
@@ -607,25 +584,12 @@ bool readW52(W52 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
-    bitsRead += 32;
-    lo = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xfffff;
-    bitsRead += 20;
-    lo |= v << 32;
+    lo = window & 0xfffffffffffff;
+    bitsRead += 52;
     value.items[i0] = lo;
   }
   return true;
@@ -720,20 +684,17 @@ bool readW50(W50 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   if (bitsRead + value.itemsCount * 50 > numBits) {
@@ -741,25 +702,12 @@ bool readW50(W50 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
-    bitsRead += 32;
-    lo = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3ffff;
-    bitsRead += 18;
-    lo |= v << 32;
+    lo = window & 0x3ffffffffffff;
+    bitsRead += 50;
     value.items[i0] = lo;
   }
   return true;
@@ -841,20 +789,17 @@ bool readF13(F13 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 91 > numBits) {
     return false;
   }
   for (var i0 = 0; i0 < 7; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fff;
+    v = window & 0x1fff;
     bitsRead += 13;
     value.items[i0] = v;
   }
@@ -929,29 +874,19 @@ bool readTri3(Tri3 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 1) & 0x3;
   bitsRead += 2;
   value.b = v;
   return true;
@@ -1041,19 +976,16 @@ bool readArrTri3(ArrTri3 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 10) {
     return false; // the count guards the loop — reject, never clamp
@@ -1065,23 +997,14 @@ bool readArrTri3(ArrTri3 value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     final e0 = value.items[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1;
+    v = window & 0x1;
     bitsRead += 1;
     e0.a = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3;
+    v = (window >>> 1) & 0x3;
     bitsRead += 2;
     e0.b = v;
   }
@@ -1161,29 +1084,19 @@ bool readEleven(Eleven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 11 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 3) & 0xff;
   bitsRead += 8;
   value.b = v;
   return true;
@@ -1260,7 +1173,6 @@ bool readArrEleven(ArrEleven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 99 > numBits) {
     return false;
@@ -1268,23 +1180,14 @@ bool readArrEleven(ArrEleven value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < 9; i0++) {
     final e0 = value.items[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     e0.a = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xff;
+    v = (window >>> 3) & 0xff;
     bitsRead += 8;
     e0.b = v;
   }
@@ -1465,19 +1368,16 @@ bool readEmptyUnion(EmptyUnion value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1589,32 +1489,22 @@ bool readHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1630,13 +1520,11 @@ bool readHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -1836,32 +1724,22 @@ bool readStrs(Strs value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 4 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 5) & 0xf;
   bitsRead += 4;
   if (v > 8) {
     return false; // the length guards the slice — reject, never clamp
@@ -1898,13 +1776,11 @@ bool readStrs(Strs value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 8) {
     return false; // the length guards the slice — reject, never clamp
@@ -1936,13 +1812,11 @@ bool readStrs(Strs value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.tail = v;
   return true;
@@ -2055,32 +1929,22 @@ bool readArrNested(ArrNested value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 3 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 5) & 0x7;
   bitsRead += 3;
   if (v > 4) {
     return false; // the count guards the loop — reject, never clamp
@@ -2092,23 +1956,14 @@ bool readArrNested(ArrNested value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     final e0 = value.items[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     e0.a = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xff;
+    v = (window >>> 3) & 0xff;
     bitsRead += 8;
     e0.b = v;
   }
@@ -2116,13 +1971,11 @@ bool readArrNested(ArrNested value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.tail = v;
   return true;
@@ -2200,19 +2053,16 @@ bool readSole(Sole value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 13 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1fff;
+  v = window & 0x1fff;
   bitsRead += 13;
   value.only = v;
   return true;

--- a/generated/dart/Clauses.dart
+++ b/generated/dart/Clauses.dart
@@ -37,7 +37,7 @@ int writeW13(W13 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 12);
-  v = (value.itemsCount) & 0xf;
+  v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -49,7 +49,7 @@ int writeW13(W13 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 8191);
-    v = (value.items[i0]) & 0x1fff;
+    v = ((value.items[i0]) & 0x1fff);
     scratch |= v << scratchBits;
     scratchBits += 13;
     if (scratchBits >= 64) {
@@ -162,7 +162,7 @@ int writeW17(W17 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 9);
-  v = (value.itemsCount) & 0xf;
+  v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -174,7 +174,7 @@ int writeW17(W17 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 131071);
-    v = (value.items[i0]) & 0x1ffff;
+    v = ((value.items[i0]) & 0x1ffff);
     scratch |= v << scratchBits;
     scratchBits += 17;
     if (scratchBits >= 64) {
@@ -287,7 +287,7 @@ int writeW26(W26 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 6);
-  v = (value.itemsCount) & 0x7;
+  v = ((value.itemsCount) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -299,7 +299,7 @@ int writeW26(W26 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 67108863);
-    v = (value.items[i0]) & 0x3ffffff;
+    v = ((value.items[i0]) & 0x3ffffff);
     scratch |= v << scratchBits;
     scratchBits += 26;
     if (scratchBits >= 64) {
@@ -412,7 +412,7 @@ int writeW1(W1 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 20);
-  v = (value.itemsCount) & 0x1f;
+  v = ((value.itemsCount) & 0x1f);
   scratch |= v << scratchBits;
   scratchBits += 5;
   if (scratchBits >= 64) {
@@ -424,7 +424,7 @@ int writeW1(W1 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 1);
-    v = (value.items[i0]) & 0x1;
+    v = ((value.items[i0]) & 0x1);
     scratch |= v << scratchBits;
     scratchBits += 1;
     if (scratchBits >= 64) {
@@ -537,7 +537,7 @@ int writeW52(W52 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -549,23 +549,14 @@ int writeW52(W52 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 4503599627370495);
-    v = value.items[i0] & 0xffffffff;
+    v = ((value.items[i0]) & 0xfffffffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 52;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.items[i0] >>> 32) & 0xfffff;
-    scratch |= v << scratchBits;
-    scratchBits += 20;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (20 - scratchBits);
+      scratch = v >>> (52 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -680,7 +671,7 @@ int writeW50(W50 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -692,23 +683,14 @@ int writeW50(W50 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 1125899906842623);
-    v = value.items[i0] & 0xffffffff;
+    v = ((value.items[i0]) & 0x3ffffffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 50;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.items[i0] >>> 32) & 0x3ffff;
-    scratch |= v << scratchBits;
-    scratchBits += 18;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (18 - scratchBits);
+      scratch = v >>> (50 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -822,7 +804,7 @@ int writeF13(F13 value, ByteData view) {
   for (var i0 = 0; i0 < 7; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 8191);
-    v = (value.items[i0]) & 0x1fff;
+    v = ((value.items[i0]) & 0x1fff);
     scratch |= v << scratchBits;
     scratchBits += 13;
     if (scratchBits >= 64) {
@@ -911,23 +893,14 @@ int writeTri3(Tri3 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.a & 0x1;
+  v = ((value.a) & 0x1) | (((value.b) & 0x3) << 1);
   scratch |= v << scratchBits;
-  scratchBits += 1;
+  scratchBits += 3;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.b & 0x3;
-  scratch |= v << scratchBits;
-  scratchBits += 2;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (3 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1020,7 +993,7 @@ int writeArrTri3(ArrTri3 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 10);
-  v = (value.itemsCount) & 0xf;
+  v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -1031,23 +1004,14 @@ int writeArrTri3(ArrTri3 value, ByteData view) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     final e0 = value.items[i0];
-    v = e0.a & 0x1;
+    v = ((e0.a) & 0x1) | (((e0.b) & 0x3) << 1);
     scratch |= v << scratchBits;
-    scratchBits += 1;
+    scratchBits += 3;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.b & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+      scratch = v >>> (3 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1161,23 +1125,14 @@ int writeEleven(Eleven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.a & 0x7;
+  v = ((value.a) & 0x7) | (((value.b) & 0xff) << 3);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 11;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = value.b & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (11 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1268,23 +1223,14 @@ int writeArrEleven(ArrEleven value, ByteData view) {
   var v = 0;
   for (var i0 = 0; i0 < 9; i0++) {
     final e0 = value.items[i0];
-    v = e0.a & 0x7;
+    v = ((e0.a) & 0x7) | (((e0.b) & 0xff) << 3);
     scratch |= v << scratchBits;
-    scratchBits += 3;
+    scratchBits += 11;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (3 - scratchBits);
-    }
-    v = e0.b & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+      scratch = v >>> (11 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1477,7 +1423,7 @@ int writeEmptyUnion(EmptyUnion value, ByteData view) {
   var v = 0;
   assert(value.type >= 0);
   assert(value.type <= 2);
-  v = value.type & 0x3;
+  v = ((value.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1590,25 +1536,16 @@ int writeHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.u.type >= 0);
   assert(value.u.type <= 2);
-  v = value.u.type & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.u.type) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
   switch (value.u.type) {
     case 1:
@@ -1616,7 +1553,7 @@ int writeHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view) {
     case 2:
       break; // empty arm — presence is the payload (SPEC §4.6)
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -1759,25 +1696,16 @@ int writeStrs(Strs value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.sLength >= 0);
   assert(value.sLength <= 8);
-  v = (value.sLength) & 0xf;
+  v = ((value.lead) & 0x1f) | (((value.sLength) & 0xf) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 9;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (9 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -1804,7 +1732,7 @@ int writeStrs(Strs value, ByteData view) {
   }
   assert(value.bLength >= 0);
   assert(value.bLength <= 8);
-  v = (value.bLength) & 0xf;
+  v = ((value.bLength) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -1836,7 +1764,7 @@ int writeStrs(Strs value, ByteData view) {
       scratch = v >>> (8 - scratchBits);
     }
   }
-  v = value.tail & 0x7;
+  v = ((value.tail) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -2032,48 +1960,30 @@ int writeArrNested(ArrNested value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 4);
-  v = (value.itemsCount) & 0x7;
+  v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x7) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 8;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
+    scratch = v >>> (8 - scratchBits);
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     final e0 = value.items[i0];
-    v = e0.a & 0x7;
+    v = ((e0.a) & 0x7) | (((e0.b) & 0xff) << 3);
     scratch |= v << scratchBits;
-    scratchBits += 3;
+    scratchBits += 11;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (3 - scratchBits);
-    }
-    v = e0.b & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+      scratch = v >>> (11 - scratchBits);
     }
   }
-  v = value.tail & 0x7;
+  v = ((value.tail) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -2218,7 +2128,7 @@ int writeSole(Sole value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.only & 0x1fff;
+  v = ((value.only) & 0x1fff);
   scratch |= v << scratchBits;
   scratchBits += 13;
   if (scratchBits >= 64) {

--- a/generated/dart/Degenerate.dart
+++ b/generated/dart/Degenerate.dart
@@ -99,51 +99,42 @@ bool readVec2(Vec2 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.y = _doubleFromFloat64Bits(lo);
@@ -218,7 +209,6 @@ bool readSpanF64(SpanF64 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
@@ -226,23 +216,19 @@ bool readSpanF64(SpanF64 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = _doubleFromFloat64Bits(lo);
@@ -318,7 +304,6 @@ bool readSpanU64(SpanU64 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
@@ -326,23 +311,19 @@ bool readSpanU64(SpanU64 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = lo;
@@ -418,7 +399,6 @@ bool readSpanI64(SpanI64 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
@@ -426,23 +406,19 @@ bool readSpanI64(SpanI64 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = lo;
@@ -518,7 +494,6 @@ bool readSpanOne(SpanOne value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 64 > numBits) {
@@ -526,23 +501,19 @@ bool readSpanOne(SpanOne value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 1; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = lo;
@@ -618,20 +589,17 @@ bool readSpanChunk(SpanChunk value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   for (var i0 = 0; i0 < 4; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffff;
+    v = window & 0xffff;
     bitsRead += 16;
     value.values[i0] = v;
   }
@@ -717,7 +685,6 @@ bool readSpanTail(SpanTail value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 160 > numBits) {
@@ -725,35 +692,29 @@ bool readSpanTail(SpanTail value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = _doubleFromFloat64Bits(lo);
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.tail = v;
   return true;
@@ -840,7 +801,6 @@ bool readSpanTwice(SpanTwice value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 256 > numBits) {
@@ -848,46 +808,38 @@ bool readSpanTwice(SpanTwice value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.a[i0] = _doubleFromFloat64Bits(lo);
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.b[i0] = _doubleFromFloat64Bits(lo);
@@ -968,39 +920,27 @@ bool readTrio(Trio value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.c = v;
   return true;
@@ -1075,39 +1015,27 @@ bool readTrioSole(TrioSole value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.inner.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.inner.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.inner.c = v;
   return true;
@@ -1193,49 +1121,30 @@ bool readTrioFirst(TrioFirst value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 80 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.inner.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.inner.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.inner.c = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 24) & 0xffff;
   bitsRead += 16;
   value.trailer = v;
   return true;
@@ -1376,155 +1285,116 @@ bool readTrioStraddle(TrioStraddle value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 408 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad0 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad1 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad2 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad3 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad4 = lo;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffff;
+  v = (window >>> 32) & 0xffffff;
   bitsRead += 24;
   value.pad5 = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.inner.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.inner.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.inner.c = v;
   return true;

--- a/generated/dart/Degenerate.dart
+++ b/generated/dart/Degenerate.dart
@@ -54,47 +54,23 @@ int writeVec2(Vec2 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -205,26 +181,14 @@ int writeSpanF64(SpanF64 value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.values[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.values[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -317,23 +281,14 @@ int writeSpanU64(SpanU64 value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    v = value.values[i0] & 0xffffffff;
+    v = (value.values[i0]);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.values[i0] >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -426,23 +381,14 @@ int writeSpanI64(SpanI64 value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    v = value.values[i0] & 0xffffffff;
+    v = (value.values[i0]);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.values[i0] >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -535,23 +481,14 @@ int writeSpanOne(SpanOne value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 1; i0++) {
-    v = value.values[i0] & 0xffffffff;
+    v = (value.values[i0]);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.values[i0] >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -644,7 +581,7 @@ int writeSpanChunk(SpanChunk value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 4; i0++) {
-    v = value.values[i0] & 0xffff;
+    v = ((value.values[i0]) & 0xffff);
     scratch |= v << scratchBits;
     scratchBits += 16;
     if (scratchBits >= 64) {
@@ -734,29 +671,17 @@ int writeSpanTail(SpanTail value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.values[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.values[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
-  v = value.tail & 0xffffffff;
+  v = ((value.tail) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -867,49 +792,25 @@ int writeSpanTwice(SpanTwice value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.a[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.a[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.b[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.b[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1028,32 +929,17 @@ int writeTrio(Trio value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.a & 0xfffff;
+  v =
+      ((value.a) & 0xfffff) |
+      (((value.b) & 0xfffff) << 20) |
+      (((value.c) & 0xffffff) << 40);
   scratch |= v << scratchBits;
-  scratchBits += 20;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.c & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1150,32 +1036,17 @@ int writeTrioSole(TrioSole value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.inner.a & 0xfffff;
+  v =
+      ((value.inner.a) & 0xfffff) |
+      (((value.inner.b) & 0xfffff) << 20) |
+      (((value.inner.c) & 0xffffff) << 40);
   scratch |= v << scratchBits;
-  scratchBits += 20;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.c & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1274,34 +1145,19 @@ int writeTrioFirst(TrioFirst value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.inner.a & 0xfffff;
+  v =
+      ((value.inner.a) & 0xfffff) |
+      (((value.inner.b) & 0xfffff) << 20) |
+      (((value.inner.c) & 0xffffff) << 40);
   scratch |= v << scratchBits;
-  scratchBits += 20;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.inner.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.c & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
-  }
-  v = value.trailer & 0xffff;
+  v = ((value.trailer) & 0xffff);
   scratch |= v << scratchBits;
   scratchBits += 16;
   if (scratchBits >= 64) {
@@ -1427,124 +1283,64 @@ int writeTrioStraddle(TrioStraddle value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.pad0 & 0xffffffff;
+  v = (value.pad0);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.pad0 >>> 32) & 0xffffffff;
+  v = (value.pad1);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.pad1 & 0xffffffff;
+  v = (value.pad2);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.pad1 >>> 32) & 0xffffffff;
+  v = (value.pad3);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.pad2 & 0xffffffff;
+  v = (value.pad4);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.pad2 >>> 32) & 0xffffffff;
+  v =
+      ((value.pad5) & 0xffffff) |
+      (((value.inner.a) & 0xfffff) << 24) |
+      (((value.inner.b) & 0xfffff) << 44);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.pad3 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.pad3 >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.pad4 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.pad4 >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.pad5 & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
-  }
-  v = value.inner.a & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.c & 0xffffff;
+  v = ((value.inner.c) & 0xffffff);
   scratch |= v << scratchBits;
   scratchBits += 24;
   if (scratchBits >= 64) {

--- a/generated/dart/Joins.dart
+++ b/generated/dart/Joins.dart
@@ -47,26 +47,17 @@ int writeArmsAgree(ArmsAgree value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    v = value.a & 0x7ff;
+    v = ((value.a) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -76,7 +67,7 @@ int writeArmsAgree(ArmsAgree value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   } else {
-    v = value.b & 0x7ff;
+    v = ((value.b) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -86,7 +77,7 @@ int writeArmsAgree(ArmsAgree value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -230,26 +221,17 @@ int writeArmsDisagree(ArmsDisagree value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    v = value.a & 0x7ff;
+    v = ((value.a) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -259,7 +241,7 @@ int writeArmsDisagree(ArmsDisagree value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   } else {
-    v = value.b & 0x7;
+    v = ((value.b) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
     if (scratchBits >= 64) {
@@ -269,7 +251,7 @@ int writeArmsDisagree(ArmsDisagree value, ByteData view) {
       scratch = v >>> (3 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -427,26 +409,17 @@ int writeArmEmpty(ArmEmpty value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    v = value.a & 0x7ffff;
+    v = ((value.a) & 0x7ffff);
     scratch |= v << scratchBits;
     scratchBits += 19;
     if (scratchBits >= 64) {
@@ -456,7 +429,7 @@ int writeArmEmpty(ArmEmpty value, ByteData view) {
       scratch = v >>> (19 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -613,26 +586,17 @@ int writeArmsNested(ArmsNested value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x7;
+  v = ((value.lead) & 0x7) | ((value.outer ? 1 : 0) << 3);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 4;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = value.outer ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (4 - scratchBits);
   }
   if (value.outer) {
-    v = value.inner ? 1 : 0;
+    v = (value.inner ? 1 : 0);
     scratch |= v << scratchBits;
     scratchBits += 1;
     if (scratchBits >= 64) {
@@ -642,7 +606,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
       scratch = v >>> (1 - scratchBits);
     }
     if (value.inner) {
-      v = value.x & 0x1fffffff;
+      v = ((value.x) & 0x1fffffff);
       scratch |= v << scratchBits;
       scratchBits += 29;
       if (scratchBits >= 64) {
@@ -652,7 +616,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
         scratch = v >>> (29 - scratchBits);
       }
     } else {
-      v = value.y & 0x1f;
+      v = ((value.y) & 0x1f);
       scratch |= v << scratchBits;
       scratchBits += 5;
       if (scratchBits >= 64) {
@@ -663,7 +627,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
       }
     }
   } else {
-    v = value.z & 0x1fff;
+    v = ((value.z) & 0x1fff);
     scratch |= v << scratchBits;
     scratchBits += 13;
     if (scratchBits >= 64) {
@@ -673,7 +637,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
       scratch = v >>> (13 - scratchBits);
     }
   }
-  v = value.tail & 0x3f;
+  v = ((value.tail) & 0x3f);
   scratch |= v << scratchBits;
   scratchBits += 6;
   if (scratchBits >= 64) {
@@ -877,28 +841,19 @@ int writeArmAlign(ArmAlign value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
     assert(value.sLength >= 0);
     assert(value.sLength <= 4);
-    v = (value.sLength) & 0x7;
+    v = ((value.sLength) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
     if (scratchBits >= 64) {
@@ -931,7 +886,7 @@ int writeArmAlign(ArmAlign value, ByteData view) {
       }
     }
   } else {
-    v = value.b & 0x3ff;
+    v = ((value.b) & 0x3ff);
     scratch |= v << scratchBits;
     scratchBits += 10;
     if (scratchBits >= 64) {
@@ -941,7 +896,7 @@ int writeArmAlign(ArmAlign value, ByteData view) {
       scratch = v >>> (10 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -1140,28 +1095,19 @@ int writeArmArray(ArmArray value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
     assert(value.itemsCount >= 0);
     assert(value.itemsCount <= 3);
-    v = (value.itemsCount) & 0x3;
+    v = ((value.itemsCount) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
     if (scratchBits >= 64) {
@@ -1173,7 +1119,7 @@ int writeArmArray(ArmArray value, ByteData view) {
     for (var i0 = 0; i0 < value.itemsCount; i0++) {
       assert(value.items[i0] >= 0);
       assert(value.items[i0] <= 8191);
-      v = (value.items[i0]) & 0x1fff;
+      v = ((value.items[i0]) & 0x1fff);
       scratch |= v << scratchBits;
       scratchBits += 13;
       if (scratchBits >= 64) {
@@ -1184,7 +1130,7 @@ int writeArmArray(ArmArray value, ByteData view) {
       }
     }
   } else {
-    v = value.b & 0x1ff;
+    v = ((value.b) & 0x1ff);
     scratch |= v << scratchBits;
     scratchBits += 9;
     if (scratchBits >= 64) {
@@ -1194,7 +1140,7 @@ int writeArmArray(ArmArray value, ByteData view) {
       scratch = v >>> (9 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -1359,7 +1305,7 @@ int writeNarrow(Narrow value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.n & 0x7;
+  v = ((value.n) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -1443,23 +1389,14 @@ int writeWide(Wide value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.w & 0xffffffff;
+  v = ((value.w) & 0x1fffffffff);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 37;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.w >>> 32) & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (37 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1564,7 +1501,7 @@ int writeUneven(Uneven value, ByteData view) {
   var v = 0;
   assert(value.type >= 0);
   assert(value.type <= 2);
-  v = value.type & 0x3;
+  v = ((value.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1575,7 +1512,7 @@ int writeUneven(Uneven value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      v = value.narrow.n & 0x7;
+      v = ((value.narrow.n) & 0x7);
       scratch |= v << scratchBits;
       scratchBits += 3;
       if (scratchBits >= 64) {
@@ -1585,23 +1522,14 @@ int writeUneven(Uneven value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      v = value.wide.w & 0xffffffff;
+      v = ((value.wide.w) & 0x1fffffffff);
       scratch |= v << scratchBits;
-      scratchBits += 32;
+      scratchBits += 37;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (value.wide.w >>> 32) & 0x1f;
-      scratch |= v << scratchBits;
-      scratchBits += 5;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (5 - scratchBits);
+        scratch = v >>> (37 - scratchBits);
       }
   }
   if (scratchBits != 0) {
@@ -1740,29 +1668,20 @@ int writeHoldsUneven(HoldsUneven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.u.type >= 0);
   assert(value.u.type <= 2);
-  v = value.u.type & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.u.type) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
   switch (value.u.type) {
     case 1:
-      v = value.u.narrow.n & 0x7;
+      v = ((value.u.narrow.n) & 0x7);
       scratch |= v << scratchBits;
       scratchBits += 3;
       if (scratchBits >= 64) {
@@ -1772,26 +1691,17 @@ int writeHoldsUneven(HoldsUneven value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      v = value.u.wide.w & 0xffffffff;
+      v = ((value.u.wide.w) & 0x1fffffffff);
       scratch |= v << scratchBits;
-      scratchBits += 32;
+      scratchBits += 37;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (value.u.wide.w >>> 32) & 0x1f;
-      scratch |= v << scratchBits;
-      scratchBits += 5;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (5 - scratchBits);
+        scratch = v >>> (37 - scratchBits);
       }
   }
-  v = value.tail & 0x7ff;
+  v = ((value.tail) & 0x7ff);
   scratch |= v << scratchBits;
   scratchBits += 11;
   if (scratchBits >= 64) {
@@ -1968,31 +1878,22 @@ int writeArrUneven(ArrUneven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     final e0 = value.items[i0];
     assert(e0.type >= 0);
     assert(e0.type <= 2);
-    v = e0.type & 0x3;
+    v = ((e0.type) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
     if (scratchBits >= 64) {
@@ -2003,7 +1904,7 @@ int writeArrUneven(ArrUneven value, ByteData view) {
     }
     switch (e0.type) {
       case 1:
-        v = e0.narrow.n & 0x7;
+        v = ((e0.narrow.n) & 0x7);
         scratch |= v << scratchBits;
         scratchBits += 3;
         if (scratchBits >= 64) {
@@ -2013,27 +1914,18 @@ int writeArrUneven(ArrUneven value, ByteData view) {
           scratch = v >>> (3 - scratchBits);
         }
       case 2:
-        v = e0.wide.w & 0xffffffff;
+        v = ((e0.wide.w) & 0x1fffffffff);
         scratch |= v << scratchBits;
-        scratchBits += 32;
+        scratchBits += 37;
         if (scratchBits >= 64) {
           view.setUint64(wordIndex * 8, scratch, Endian.little);
           wordIndex++;
           scratchBits -= 64;
-          scratch = v >>> (32 - scratchBits);
-        }
-        v = (e0.wide.w >>> 32) & 0x1f;
-        scratch |= v << scratchBits;
-        scratchBits += 5;
-        if (scratchBits >= 64) {
-          view.setUint64(wordIndex * 8, scratch, Endian.little);
-          wordIndex++;
-          scratchBits -= 64;
-          scratch = v >>> (5 - scratchBits);
+          scratch = v >>> (37 - scratchBits);
         }
     }
   }
-  v = value.tail & 0x7;
+  v = ((value.tail) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -2239,30 +2131,21 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 8191);
-    v = (value.items[i0]) & 0x1fff;
+    v = ((value.items[i0]) & 0x1fff);
     scratch |= v << scratchBits;
     scratchBits += 13;
     if (scratchBits >= 64) {
@@ -2274,7 +2157,7 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
   }
   assert(value.sLength >= 0);
   assert(value.sLength <= 4);
-  v = (value.sLength) & 0x7;
+  v = ((value.sLength) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -2306,41 +2189,23 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
       scratch = v >>> (8 - scratchBits);
     }
   }
-  v = value.p & 0xffffffff;
+  v = ((value.p) & 0xffffffff) | (((value.q) & 0x1fffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 61;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (61 - scratchBits);
   }
-  v = value.q & 0x1fffffff;
+  v = ((value.r) & 0x7ffff) | (((value.tail) & 0xf) << 19);
   scratch |= v << scratchBits;
-  scratchBits += 29;
+  scratchBits += 23;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (29 - scratchBits);
-  }
-  v = value.r & 0x7ffff;
-  scratch |= v << scratchBits;
-  scratchBits += 19;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (19 - scratchBits);
-  }
-  v = value.tail & 0xf;
-  scratch |= v << scratchBits;
-  scratchBits += 4;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (23 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);

--- a/generated/dart/Joins.dart
+++ b/generated/dart/Joins.dart
@@ -1054,17 +1054,43 @@ int writeArmArray(ArmArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (2 - scratchBits);
     }
-    for (var i0 = 0; i0 < value.itemsCount; i0++) {
-      assert(value.items[i0] >= 0);
-      assert(value.items[i0] <= 8191);
-      v = ((value.items[i0]) & 0x1fff);
-      scratch |= v << scratchBits;
-      scratchBits += 13;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (13 - scratchBits);
+    {
+      var i0 = 0;
+      for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+        assert(value.items[i0] >= 0);
+        assert(value.items[i0] <= 8191);
+        assert(value.items[i0 + 1] >= 0);
+        assert(value.items[i0 + 1] <= 8191);
+        assert(value.items[i0 + 2] >= 0);
+        assert(value.items[i0 + 2] <= 8191);
+        assert(value.items[i0 + 3] >= 0);
+        assert(value.items[i0 + 3] <= 8191);
+        v =
+            ((value.items[i0]) & 0x1fff) |
+            (((value.items[i0 + 1]) & 0x1fff) << 13) |
+            (((value.items[i0 + 2]) & 0x1fff) << 26) |
+            (((value.items[i0 + 3]) & 0x1fff) << 39);
+        scratch |= v << scratchBits;
+        scratchBits += 52;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (52 - scratchBits);
+        }
+      }
+      for (; i0 < value.itemsCount; i0++) {
+        assert(value.items[i0] >= 0);
+        assert(value.items[i0] <= 8191);
+        v = ((value.items[i0]) & 0x1fff);
+        scratch |= v << scratchBits;
+        scratchBits += 13;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (13 - scratchBits);
+        }
       }
     }
   } else {
@@ -1144,16 +1170,39 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
     if (bitsRead + value.itemsCount * 13 > numBits) {
       return false;
     }
-    for (var i0 = 0; i0 < value.itemsCount; i0++) {
-      if (bitsRead >>> 3 < tailBase) {
-        window =
-            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-      } else {
-        window = tailWord >>> (bitsRead - tailBase * 8);
+    {
+      var i0 = 0;
+      for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0x1fff;
+        bitsRead += 13;
+        value.items[i0] = v;
+        v = (window >>> 13) & 0x1fff;
+        bitsRead += 13;
+        value.items[i0 + 1] = v;
+        v = (window >>> 26) & 0x1fff;
+        bitsRead += 13;
+        value.items[i0 + 2] = v;
+        v = (window >>> 39) & 0x1fff;
+        bitsRead += 13;
+        value.items[i0 + 3] = v;
       }
-      v = window & 0x1fff;
-      bitsRead += 13;
-      value.items[i0] = v;
+      for (; i0 < value.itemsCount; i0++) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0x1fff;
+        bitsRead += 13;
+        value.items[i0] = v;
+      }
     }
     value.b = 0;
   } else {
@@ -1977,17 +2026,43 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (7 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 8191);
-    v = ((value.items[i0]) & 0x1fff);
-    scratch |= v << scratchBits;
-    scratchBits += 13;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (13 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 8191);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 8191);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 8191);
+      v =
+          ((value.items[i0]) & 0x1fff) |
+          (((value.items[i0 + 1]) & 0x1fff) << 13) |
+          (((value.items[i0 + 2]) & 0x1fff) << 26) |
+          (((value.items[i0 + 3]) & 0x1fff) << 39);
+      scratch |= v << scratchBits;
+      scratchBits += 52;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (52 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      v = ((value.items[i0]) & 0x1fff);
+      scratch |= v << scratchBits;
+      scratchBits += 13;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (13 - scratchBits);
+      }
     }
   }
   assert(value.sLength >= 0);
@@ -2108,15 +2183,39 @@ bool readRegainAfterAlign(RegainAfterAlign value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 13 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+      v = (window >>> 13) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 1] = v;
+      v = (window >>> 26) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 2] = v;
+      v = (window >>> 39) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 3] = v;
     }
-    v = window & 0x1fff;
-    bitsRead += 13;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+    }
   }
   if (bitsRead + 3 > numBits) {
     return false;

--- a/generated/dart/Joins.dart
+++ b/generated/dart/Joins.dart
@@ -113,64 +113,48 @@ bool readArmsAgree(ArmsAgree value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 24 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ff;
+    v = window & 0x7ff;
     bitsRead += 11;
     value.a = v;
     value.b = 0;
   } else {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ff;
+    v = window & 0x7ff;
     bitsRead += 11;
     value.b = v;
     value.a = 0;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -287,29 +271,19 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -317,13 +291,11 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ff;
+    v = window & 0x7ff;
     bitsRead += 11;
     value.a = v;
     value.b = 0;
@@ -332,13 +304,11 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     value.b = v;
     value.a = 0;
@@ -347,13 +317,11 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -465,29 +433,19 @@ bool readArmEmpty(ArmEmpty value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -495,13 +453,11 @@ bool readArmEmpty(ArmEmpty value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ffff;
+    v = window & 0x7ffff;
     bitsRead += 19;
     value.a = v;
   } else {
@@ -511,13 +467,11 @@ bool readArmEmpty(ArmEmpty value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -673,29 +627,19 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 3) & 0x1;
   bitsRead += 1;
   value.outer = v != 0;
   if (value.outer) {
@@ -703,13 +647,11 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1;
+    v = window & 0x1;
     bitsRead += 1;
     value.inner = v != 0;
     if (value.inner) {
@@ -717,13 +659,12 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x1fffffff;
+      v = window & 0x1fffffff;
       bitsRead += 29;
       value.x = v;
       value.y = 0;
@@ -732,13 +673,12 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x1f;
+      v = window & 0x1f;
       bitsRead += 5;
       value.y = v;
       value.x = 0;
@@ -749,13 +689,11 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fff;
+    v = window & 0x1fff;
     bitsRead += 13;
     value.z = v;
     value.inner = false;
@@ -766,13 +704,11 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3f;
+  v = window & 0x3f;
   bitsRead += 6;
   value.tail = v;
   return true;
@@ -950,29 +886,19 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -980,13 +906,11 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     if (v > 4) {
       return false; // the length guards the slice — reject, never clamp
@@ -1025,13 +949,11 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3ff;
+    v = window & 0x3ff;
     bitsRead += 10;
     value.b = v;
     value.s.fillRange(0, value.s.length, 0);
@@ -1041,13 +963,11 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -1194,29 +1114,19 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -1224,13 +1134,11 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3;
+    v = window & 0x3;
     bitsRead += 2;
     value.itemsCount = v;
     if (bitsRead + value.itemsCount * 13 > numBits) {
@@ -1238,13 +1146,12 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
     }
     for (var i0 = 0; i0 < value.itemsCount; i0++) {
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x1fff;
+      v = window & 0x1fff;
       bitsRead += 13;
       value.items[i0] = v;
     }
@@ -1254,13 +1161,11 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1ff;
+    v = window & 0x1ff;
     bitsRead += 9;
     value.b = v;
     value.items.fillRange(0, value.items.length, 0);
@@ -1270,13 +1175,11 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -1359,19 +1262,16 @@ bool readNarrow(Narrow value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.n = v;
   return true;
@@ -1443,32 +1343,17 @@ bool readWide(Wide value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
-  var v = 0;
   var lo = 0;
   if (bitsRead + 37 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   value.w = lo;
   return true;
 }
@@ -1577,20 +1462,17 @@ bool readUneven(Uneven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1603,13 +1485,12 @@ bool readUneven(Uneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7;
+      v = window & 0x7;
       bitsRead += 3;
       value.narrow.n = v;
     case 2:
@@ -1618,25 +1499,13 @@ bool readUneven(Uneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffffffff;
-      bitsRead += 32;
-      lo = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1f;
-      bitsRead += 5;
-      lo |= v << 32;
+      lo = window & 0x1fffffffff;
+      bitsRead += 37;
       value.wide.w = lo;
   }
   return true;
@@ -1755,33 +1624,23 @@ bool readHoldsUneven(HoldsUneven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1794,13 +1653,12 @@ bool readHoldsUneven(HoldsUneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7;
+      v = window & 0x7;
       bitsRead += 3;
       value.u.narrow.n = v;
     case 2:
@@ -1809,38 +1667,24 @@ bool readHoldsUneven(HoldsUneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffffffff;
-      bitsRead += 32;
-      lo = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1f;
-      bitsRead += 5;
-      lo |= v << 32;
+      lo = window & 0x1fffffffff;
+      bitsRead += 37;
       value.u.wide.w = lo;
   }
   if (bitsRead + 11 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7ff;
+  v = window & 0x7ff;
   bitsRead += 11;
   value.tail = v;
   return true;
@@ -1979,33 +1823,23 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
@@ -2014,13 +1848,11 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3;
+    v = window & 0x3;
     bitsRead += 2;
     if (v > 2) {
       return false; // not a wire-legal tag (SPEC §4.8)
@@ -2033,13 +1865,12 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0x7;
+        v = window & 0x7;
         bitsRead += 3;
         e0.narrow.n = v;
       case 2:
@@ -2048,25 +1879,13 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0xffffffff;
-        bitsRead += 32;
-        lo = v;
-        if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
-        } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
-        }
-        v = (window >>> shift) & 0x1f;
-        bitsRead += 5;
-        lo |= v << 32;
+        lo = window & 0x1fffffffff;
+        bitsRead += 37;
         e0.wide.w = lo;
     }
   }
@@ -2074,13 +1893,11 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.tail = v;
   return true;
@@ -2270,32 +2087,22 @@ bool readRegainAfterAlign(RegainAfterAlign value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   if (bitsRead + value.itemsCount * 13 > numBits) {
@@ -2303,13 +2110,11 @@ bool readRegainAfterAlign(RegainAfterAlign value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fff;
+    v = window & 0x1fff;
     bitsRead += 13;
     value.items[i0] = v;
   }
@@ -2317,13 +2122,11 @@ bool readRegainAfterAlign(RegainAfterAlign value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   if (v > 4) {
     return false; // the length guards the slice — reject, never clamp
@@ -2360,43 +2163,25 @@ bool readRegainAfterAlign(RegainAfterAlign value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.p = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1fffffff;
+  v = window & 0x1fffffff;
   bitsRead += 29;
   value.q = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ffff;
+  v = (window >>> 29) & 0x7ffff;
   bitsRead += 19;
   value.r = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 48) & 0xf;
   bitsRead += 4;
   value.tail = v;
   return true;

--- a/generated/dart/Joins.dart
+++ b/generated/dart/Joins.dart
@@ -874,15 +874,33 @@ int writeArmAlign(ArmAlign value, ByteData view) {
         }
       }
     }
-    for (var i0 = 0; i0 < value.sLength; i0++) {
-      v = value.s[i0];
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+    {
+      var i0 = 0;
+      for (; i0 + 4 <= value.sLength; i0 += 4) {
+        v =
+            value.s[i0] |
+            (value.s[i0 + 1] << 8) |
+            (value.s[i0 + 2] << 16) |
+            (value.s[i0 + 3] << 24);
+        scratch |= v << scratchBits;
+        scratchBits += 32;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (32 - scratchBits);
+        }
+      }
+      for (; i0 < value.sLength; i0++) {
+        v = value.s[i0];
+        scratch |= v << scratchBits;
+        scratchBits += 8;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (8 - scratchBits);
+        }
       }
     }
   } else {
@@ -2178,15 +2196,33 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.sLength; i0++) {
-    v = value.s[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.sLength; i0 += 4) {
+      v =
+          value.s[i0] |
+          (value.s[i0 + 1] << 8) |
+          (value.s[i0 + 2] << 16) |
+          (value.s[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.sLength; i0++) {
+      v = value.s[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   v = ((value.p) & 0xffffffff) | (((value.q) & 0x1fffffff) << 32);

--- a/generated/dart/Render.dart
+++ b/generated/dart/Render.dart
@@ -100,71 +100,48 @@ bool readRenderSprite(RenderSprite value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 138 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.sortKey = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.meshId = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.materialId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.layer = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 40) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // headroom above the wire range is refused
@@ -295,43 +272,31 @@ bool readRenderBlock(RenderBlock value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.workerIndex = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.spriteCountHint = v;
   if (bitsRead + 7 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7f;
+  v = (window >>> 32) & 0x7f;
   bitsRead += 7;
   if (v > 64) {
     return false; // the count guards the loop — reject, never clamp
@@ -343,64 +308,42 @@ bool readRenderBlock(RenderBlock value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.spritesCount; i0++) {
     final e0 = value.sprites[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     e0.sortKey = lo;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.meshId = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.materialId = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xff;
+    v = (window >>> 32) & 0xff;
     bitsRead += 8;
     e0.layer = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3;
+    v = (window >>> 40) & 0x3;
     bitsRead += 2;
     if (v > 2) {
       return false; // headroom above the wire range is refused

--- a/generated/dart/Render.dart
+++ b/generated/dart/Render.dart
@@ -44,61 +44,34 @@ int writeRenderSprite(RenderSprite value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.sortKey & 0xffffffff;
+  v = (value.sortKey);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.sortKey >>> 32) & 0xffffffff;
+  v = ((value.meshId) & 0xffffffff) | (((value.materialId) & 0xffffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.meshId & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.materialId & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.layer & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.team >= 0);
   assert(value.team <= 2);
-  v = value.team & 0x3;
+  v = ((value.layer) & 0xff) | (((value.team) & 0x3) << 8);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 10;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (10 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -241,27 +214,20 @@ int writeRenderBlock(RenderBlock value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.workerIndex & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.spriteCountHint & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.spritesCount >= 0);
   assert(value.spritesCount <= 64);
-  v = (value.spritesCount) & 0x7f;
+  v =
+      ((value.workerIndex) & 0xffffffff) |
+      (((value.spriteCountHint) & 0xffffffff) << 32);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.spritesCount) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -272,61 +238,34 @@ int writeRenderBlock(RenderBlock value, ByteData view) {
   }
   for (var i0 = 0; i0 < value.spritesCount; i0++) {
     final e0 = value.sprites[i0];
-    v = e0.sortKey & 0xffffffff;
+    v = (e0.sortKey);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (e0.sortKey >>> 32) & 0xffffffff;
+    v = ((e0.meshId) & 0xffffffff) | (((e0.materialId) & 0xffffffff) << 32);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.meshId & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.materialId & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.layer & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
     assert(e0.team >= 0);
     assert(e0.team <= 2);
-    v = e0.team & 0x3;
+    v = ((e0.layer) & 0xff) | (((e0.team) & 0x3) << 8);
     scratch |= v << scratchBits;
-    scratchBits += 2;
+    scratchBits += 10;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+      scratch = v >>> (10 - scratchBits);
     }
   }
   if (scratchBits != 0) {

--- a/generated/dart/Types.dart
+++ b/generated/dart/Types.dart
@@ -100,68 +100,32 @@ int writeVec3(Vec3 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -298,89 +262,41 @@ int writeQuat(Quat value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.w);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.w);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -537,23 +453,14 @@ int writeHandle(Handle value, ByteData view) {
   var v = 0;
   assert(value.objectId >= 0);
   assert(value.objectId <= 9999);
-  v = (value.objectId) & 0x3fff;
+  v = ((value.objectId) & 0x3fff) | (((value.objectSequence) & 0xff) << 14);
   scratch |= v << scratchBits;
-  scratchBits += 14;
+  scratchBits += 22;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (14 - scratchBits);
-  }
-  v = value.objectSequence & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (22 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -652,29 +559,22 @@ int writeQuantizedPosition(QuantizedPosition value, ByteData view) {
   var v = 0;
   assert(value.x >= -8388608);
   assert(value.x <= 8388608);
-  v = (value.x + 8388608) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.y >= -8388608);
   assert(value.y <= 8388608);
-  v = (value.y + 8388608) & 0x1ffffff;
+  assert(value.z >= -8388608);
+  assert(value.z <= 8388608);
+  v =
+      ((value.x + 8388608) & 0x1ffffff) |
+      (((value.y + 8388608) & 0x1ffffff) << 25);
   scratch |= v << scratchBits;
-  scratchBits += 25;
+  scratchBits += 50;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
+    scratch = v >>> (50 - scratchBits);
   }
-  assert(value.z >= -8388608);
-  assert(value.z <= 8388608);
-  v = (value.z + 8388608) & 0x1ffffff;
+  v = ((value.z + 8388608) & 0x1ffffff);
   scratch |= v << scratchBits;
   scratchBits += 25;
   if (scratchBits >= 64) {
@@ -800,29 +700,22 @@ int writeQuantizedVelocity(QuantizedVelocity value, ByteData view) {
   var v = 0;
   assert(value.x >= -2097152);
   assert(value.x <= 2097152);
-  v = (value.x + 2097152) & 0x7fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 23;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
   assert(value.y >= -2097152);
   assert(value.y <= 2097152);
-  v = (value.y + 2097152) & 0x7fffff;
+  assert(value.z >= -2097152);
+  assert(value.z <= 2097152);
+  v =
+      ((value.x + 2097152) & 0x7fffff) |
+      (((value.y + 2097152) & 0x7fffff) << 23);
   scratch |= v << scratchBits;
-  scratchBits += 23;
+  scratchBits += 46;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
+    scratch = v >>> (46 - scratchBits);
   }
-  assert(value.z >= -2097152);
-  assert(value.z <= 2097152);
-  v = (value.z + 2097152) & 0x7fffff;
+  v = ((value.z + 2097152) & 0x7fffff);
   scratch |= v << scratchBits;
   scratchBits += 23;
   if (scratchBits >= 64) {
@@ -951,47 +844,24 @@ int writeQuantizedRotation(QuantizedRotation value, ByteData view) {
   var v = 0;
   assert(value.x >= -1024);
   assert(value.x <= 1024);
-  v = (value.x + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.y >= -1024);
   assert(value.y <= 1024);
-  v = (value.y + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.z >= -1024);
   assert(value.z <= 1024);
-  v = (value.z + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.w >= -1024);
   assert(value.w <= 1024);
-  v = (value.w + 1024) & 0xfff;
+  v =
+      ((value.x + 1024) & 0xfff) |
+      (((value.y + 1024) & 0xfff) << 12) |
+      (((value.z + 1024) & 0xfff) << 24) |
+      (((value.w + 1024) & 0xfff) << 36);
   scratch |= v << scratchBits;
-  scratchBits += 12;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1125,154 +995,70 @@ int writeRigidBody(RigidBody value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.position.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.position.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.position.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.position.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.position.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.position.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.w);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.w);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.atRest ? 1 : 0;
+  v = (value.atRest ? 1 : 0);
   scratch |= v << scratchBits;
   scratchBits += 1;
   if (scratchBits >= 64) {
@@ -1282,131 +1068,59 @@ int writeRigidBody(RigidBody value, ByteData view) {
     scratch = v >>> (1 - scratchBits);
   }
   if (!value.atRest) {
-    {
-      final b = _float64BitsFromDouble(value.linearVelocity.x);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.linearVelocity.x);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.linearVelocity.y);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.linearVelocity.y);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.linearVelocity.z);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.linearVelocity.z);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.angularVelocity.x);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.angularVelocity.x);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.angularVelocity.y);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.angularVelocity.y);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.angularVelocity.z);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.angularVelocity.z);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1801,122 +1515,45 @@ int writeInput(Input value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = _float32BitsFromDouble(value.stickX);
+  v =
+      _float32BitsFromDouble(value.stickX) |
+      (_float32BitsFromDouble(value.stickY) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = _float32BitsFromDouble(value.stickY);
+  v =
+      _float32BitsFromDouble(value.throttle) |
+      (_float32BitsFromDouble(value.yaw) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = _float32BitsFromDouble(value.throttle);
+  v =
+      _float32BitsFromDouble(value.pitch) |
+      ((value.fire ? 1 : 0) << 32) |
+      ((value.altFire ? 1 : 0) << 33) |
+      ((value.boost ? 1 : 0) << 34) |
+      ((value.brake ? 1 : 0) << 35) |
+      ((value.aim ? 1 : 0) << 36) |
+      ((value.lockOn ? 1 : 0) << 37) |
+      ((value.zoom ? 1 : 0) << 38) |
+      ((value.ping ? 1 : 0) << 39);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 40;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.yaw);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.pitch);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.fire ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.altFire ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.boost ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.brake ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.aim ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.lockOn ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.zoom ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.ping ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (40 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2123,7 +1760,7 @@ int writeInputPacket(InputPacket value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.synchronizeSequence & 0xffff;
+  v = ((value.synchronizeSequence) & 0xffff);
   scratch |= v << scratchBits;
   scratchBits += 16;
   if (scratchBits >= 64) {
@@ -2132,45 +1769,27 @@ int writeInputPacket(InputPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (16 - scratchBits);
   }
-  v = value.currentFrame & 0xffffffff;
+  v = (value.currentFrame);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.currentFrame >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.startFrame & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.startFrame >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.inputsCount >= 0);
   assert(value.inputsCount <= 16);
-  v = (value.inputsCount) & 0x1f;
+  v = (value.startFrame);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.inputsCount) & 0x1f);
   scratch |= v << scratchBits;
   scratchBits += 5;
   if (scratchBits >= 64) {
@@ -2181,122 +1800,45 @@ int writeInputPacket(InputPacket value, ByteData view) {
   }
   for (var i0 = 0; i0 < value.inputsCount; i0++) {
     final e0 = value.inputs[i0];
-    v = _float32BitsFromDouble(e0.stickX);
+    v =
+        _float32BitsFromDouble(e0.stickX) |
+        (_float32BitsFromDouble(e0.stickY) << 32);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = _float32BitsFromDouble(e0.stickY);
+    v =
+        _float32BitsFromDouble(e0.throttle) |
+        (_float32BitsFromDouble(e0.yaw) << 32);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = _float32BitsFromDouble(e0.throttle);
+    v =
+        _float32BitsFromDouble(e0.pitch) |
+        ((e0.fire ? 1 : 0) << 32) |
+        ((e0.altFire ? 1 : 0) << 33) |
+        ((e0.boost ? 1 : 0) << 34) |
+        ((e0.brake ? 1 : 0) << 35) |
+        ((e0.aim ? 1 : 0) << 36) |
+        ((e0.lockOn ? 1 : 0) << 37) |
+        ((e0.zoom ? 1 : 0) << 38) |
+        ((e0.ping ? 1 : 0) << 39);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 40;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = _float32BitsFromDouble(e0.yaw);
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = _float32BitsFromDouble(e0.pitch);
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.fire ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.altFire ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.boost ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.brake ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.aim ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.lockOn ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.zoom ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.ping ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+      scratch = v >>> (40 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -2601,137 +2143,77 @@ int writeShipCreate(ShipCreate value, ByteData view) {
   var v = 0;
   assert(value.shipType >= 0);
   assert(value.shipType <= 5);
-  v = value.shipType & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
   assert(value.position.x >= -8388608);
   assert(value.position.x <= 8388608);
-  v = (value.position.x + 8388608) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.position.y >= -8388608);
   assert(value.position.y <= 8388608);
-  v = (value.position.y + 8388608) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.position.z >= -8388608);
   assert(value.position.z <= 8388608);
-  v = (value.position.z + 8388608) & 0x1ffffff;
+  v =
+      ((value.shipType) & 0x7) |
+      (((value.position.x + 8388608) & 0x1ffffff) << 3) |
+      (((value.position.y + 8388608) & 0x1ffffff) << 28);
   scratch |= v << scratchBits;
-  scratchBits += 25;
+  scratchBits += 53;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
+    scratch = v >>> (53 - scratchBits);
   }
   assert(value.rotation.x >= -1024);
   assert(value.rotation.x <= 1024);
-  v = (value.rotation.x + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.rotation.y >= -1024);
   assert(value.rotation.y <= 1024);
-  v = (value.rotation.y + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.rotation.z >= -1024);
   assert(value.rotation.z <= 1024);
-  v = (value.rotation.z + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.rotation.w >= -1024);
   assert(value.rotation.w <= 1024);
-  v = (value.rotation.w + 1024) & 0xfff;
+  v =
+      ((value.position.z + 8388608) & 0x1ffffff) |
+      (((value.rotation.x + 1024) & 0xfff) << 25) |
+      (((value.rotation.y + 1024) & 0xfff) << 37) |
+      (((value.rotation.z + 1024) & 0xfff) << 49);
   scratch |= v << scratchBits;
-  scratchBits += 12;
+  scratchBits += 61;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
+    scratch = v >>> (61 - scratchBits);
   }
   assert(value.linearVelocity.x >= -2097152);
   assert(value.linearVelocity.x <= 2097152);
-  v = (value.linearVelocity.x + 2097152) & 0x7fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 23;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
   assert(value.linearVelocity.y >= -2097152);
   assert(value.linearVelocity.y <= 2097152);
-  v = (value.linearVelocity.y + 2097152) & 0x7fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 23;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
   assert(value.linearVelocity.z >= -2097152);
   assert(value.linearVelocity.z <= 2097152);
-  v = (value.linearVelocity.z + 2097152) & 0x7fffff;
+  v =
+      ((value.rotation.w + 1024) & 0xfff) |
+      (((value.linearVelocity.x + 2097152) & 0x7fffff) << 12) |
+      (((value.linearVelocity.y + 2097152) & 0x7fffff) << 35);
   scratch |= v << scratchBits;
-  scratchBits += 23;
+  scratchBits += 58;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
+    scratch = v >>> (58 - scratchBits);
   }
-  v = value.hasFlags ? 1 : 0;
+  v =
+      ((value.linearVelocity.z + 2097152) & 0x7fffff) |
+      ((value.hasFlags ? 1 : 0) << 23);
   scratch |= v << scratchBits;
-  scratchBits += 1;
+  scratchBits += 24;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (24 - scratchBits);
   }
   if (value.hasFlags) {
     assert(value.flags >>> 4 == 0);
-    v = value.flags & 0xf;
+    v = ((value.flags) & 0xf);
     scratch |= v << scratchBits;
     scratchBits += 4;
     if (scratchBits >= 64) {
@@ -2743,39 +2225,24 @@ int writeShipCreate(ShipCreate value, ByteData view) {
   }
   assert(value.team >= 0);
   assert(value.team <= 2);
-  v = value.team & 0x3;
-  scratch |= v << scratchBits;
-  scratchBits += 2;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
-  }
   assert(value.health >= 0);
   assert(value.health <= 1000);
-  v = (value.health) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.thrust >= 0);
   assert(value.thrust <= 100);
-  v = (value.thrust) & 0x7f;
+  assert(value.pending >= 0);
+  assert(value.pending <= 0);
+  v =
+      ((value.team) & 0x3) |
+      (((value.health) & 0x3ff) << 2) |
+      (((value.thrust) & 0x7f) << 12);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 19;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
+    scratch = v >>> (19 - scratchBits);
   }
-  assert(value.pending >= 0);
-  assert(value.pending <= 0);
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
   }
@@ -3068,25 +2535,18 @@ int writeExpressionProbe(ExpressionProbe value, ByteData view) {
   var v = 0;
   assert(value.hardpointIndex >= 0);
   assert(value.hardpointIndex <= 31);
-  v = (value.hardpointIndex) & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.spinRate >= 1024);
   assert(value.spinRate <= 2048);
-  v = (value.spinRate - 1024) & 0x7ff;
+  v =
+      ((value.hardpointIndex) & 0x1f) |
+      (((value.spinRate - 1024) & 0x7ff) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 11;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (11 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -3194,106 +2654,52 @@ int writeExtremeProbe(ExtremeProbe value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   assert(value.floorBound <= 100);
-  {
-    final off = value.floorBound - 0x8000000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
   assert(value.doubledFloor <= 100);
-  {
-    final off = value.doubledFloor - 0x8000000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = (value.floorBound - 0x8000000000000000);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   assert(!_unsignedLessThan(value.ceilingRange, 1));
-  {
-    final off = value.ceilingRange - 1;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.floorDefault & 0xffffffff;
+  v = (value.doubledFloor - 0x8000000000000000);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.floorDefault >>> 32) & 0xffffffff;
+  v = (value.ceilingRange - 1);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.ceilingDefault & 0xffffffff;
+  v = (value.floorDefault);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.ceilingDefault >>> 32) & 0xffffffff;
+  v = (value.ceilingDefault);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -3486,85 +2892,43 @@ int writeExtremeRow(ExtremeRow value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   assert(value.clampedFloor <= 100);
-  {
-    final off = value.clampedFloor - 0x8000000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
   assert(!_unsignedLessThan(value.clampedCeiling, 1));
   assert(!_unsignedLessThan(0xfffffffffffffffe, value.clampedCeiling));
-  {
-    final off = value.clampedCeiling - 1;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.floorDef & 0xffffffff;
+  v = (value.clampedFloor - 0x8000000000000000);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.floorDef >>> 32) & 0xffffffff;
+  v = (value.clampedCeiling - 1);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.ceilingDef & 0xffffffff;
+  v = (value.floorDef);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.ceilingDef >>> 32) & 0xffffffff;
+  v = (value.ceilingDef);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);

--- a/generated/dart/Types.dart
+++ b/generated/dart/Types.dart
@@ -154,72 +154,59 @@ bool readVec3(Vec3 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 192 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.z = _doubleFromFloat64Bits(lo);
@@ -325,93 +312,76 @@ bool readQuat(Quat value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 256 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.z = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.w = _doubleFromFloat64Bits(lo);
@@ -489,32 +459,22 @@ bool readHandle(Handle value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 22 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3fff;
+  v = window & 0x3fff;
   bitsRead += 14;
   if (v > 9999) {
     return false; // a smuggled offset is refused
   }
   value.objectId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 14) & 0xff;
   bitsRead += 8;
   value.objectSequence = v;
   return true;
@@ -614,45 +574,33 @@ bool readQuantizedPosition(
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 75 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.x = -8388608 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 25) & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.y = -8388608 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
@@ -755,45 +703,33 @@ bool readQuantizedVelocity(
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 69 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7fffff;
+  v = window & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.x = -2097152 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 23) & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.y = -2097152 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7fffff;
+  v = window & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
@@ -894,58 +830,34 @@ bool readQuantizedRotation(
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 48 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfff;
+  v = window & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.x = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 12) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.y = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 24) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.z = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 36) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
@@ -1150,167 +1062,131 @@ bool readRigidBody(RigidBody value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 449 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.position.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.position.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.position.z = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.z = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.w = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 32) & 0x1;
   bitsRead += 1;
   value.atRest = v != 0;
   if (!value.atRest) {
@@ -1318,128 +1194,104 @@ bool readRigidBody(RigidBody value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.linearVelocity.x = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.linearVelocity.y = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.linearVelocity.z = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.angularVelocity.x = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.angularVelocity.y = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.angularVelocity.z = _doubleFromFloat64Bits(lo);
@@ -1582,139 +1434,72 @@ bool readInput(Input value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 168 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.stickX = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.stickY = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.throttle = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.yaw = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.pitch = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 32) & 0x1;
   bitsRead += 1;
   value.fire = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 33) & 0x1;
   bitsRead += 1;
   value.altFire = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 34) & 0x1;
   bitsRead += 1;
   value.boost = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 35) & 0x1;
   bitsRead += 1;
   value.brake = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 36) & 0x1;
   bitsRead += 1;
   value.aim = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 37) & 0x1;
   bitsRead += 1;
   value.lockOn = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 38) & 0x1;
   bitsRead += 1;
   value.zoom = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 39) & 0x1;
   bitsRead += 1;
   value.ping = v != 0;
   return true;
@@ -1868,75 +1653,52 @@ bool readInputPacket(InputPacket value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 144 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   value.synchronizeSequence = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 16) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.currentFrame = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.startFrame = lo;
   if (bitsRead + 5 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 32) & 0x1f;
   bitsRead += 5;
   if (v > 16) {
     return false; // the count guards the loop — reject, never clamp
@@ -1948,133 +1710,67 @@ bool readInputPacket(InputPacket value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.inputsCount; i0++) {
     final e0 = value.inputs[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.stickX = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.stickY = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.throttle = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.yaw = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.pitch = _doubleFromFloat32Bits(v);
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 32) & 0x1;
     bitsRead += 1;
     e0.fire = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 33) & 0x1;
     bitsRead += 1;
     e0.altFire = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 34) & 0x1;
     bitsRead += 1;
     e0.boost = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 35) & 0x1;
     bitsRead += 1;
     e0.brake = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 36) & 0x1;
     bitsRead += 1;
     e0.aim = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 37) & 0x1;
     bitsRead += 1;
     e0.lockOn = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 38) & 0x1;
     bitsRead += 1;
     e0.zoom = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 39) & 0x1;
     bitsRead += 1;
     e0.ping = v != 0;
   }
@@ -2270,162 +1966,97 @@ bool readShipCreate(ShipCreate value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 196 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   if (v > 5) {
     return false; // headroom above the wire range is refused
   }
   value.shipType = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 3) & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.position.x = -8388608 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 28) & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.position.y = -8388608 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.position.z = -8388608 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 25) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.x = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 37) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.y = -1024 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfff;
+  v = window & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.z = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 12) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.w = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 24) & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.linearVelocity.x = -2097152 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7fffff;
+  v = window & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.linearVelocity.y = -2097152 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 23) & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.linearVelocity.z = -2097152 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 46) & 0x1;
   bitsRead += 1;
   value.hasFlags = v != 0;
   if (value.hasFlags) {
@@ -2433,13 +2064,11 @@ bool readShipCreate(ShipCreate value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xf;
+    v = window & 0xf;
     bitsRead += 4;
     value.flags = v;
   } else {
@@ -2449,39 +2078,23 @@ bool readShipCreate(ShipCreate value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // headroom above the wire range is refused
   }
   value.team = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 2) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.health = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7f;
+  v = (window >>> 12) & 0x7f;
   bitsRead += 7;
   if (v > 100) {
     return false; // a smuggled offset is refused
@@ -2575,29 +2188,19 @@ bool readExpressionProbe(ExpressionProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.hardpointIndex = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 5) & 0x7ff;
   bitsRead += 11;
   if (v > 1024) {
     return false; // a smuggled offset is refused
@@ -2728,30 +2331,25 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 320 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0x8000000000000064, lo)) {
@@ -2759,23 +2357,19 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   value.floorBound = 0x8000000000000000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0x8000000000000064, lo)) {
@@ -2783,23 +2377,19 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   value.doubledFloor = 0x8000000000000000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0xfffffffffffffffe, lo)) {
@@ -2807,44 +2397,36 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   value.ceilingRange = 1 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.floorDefault = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.ceilingDefault = lo;
@@ -2957,30 +2539,25 @@ bool readExtremeRow(ExtremeRow value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 256 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0x8000000000000064, lo)) {
@@ -2988,23 +2565,19 @@ bool readExtremeRow(ExtremeRow value, ByteData view, int numBits) {
   }
   value.clampedFloor = 0x8000000000000000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0xfffffffffffffffd, lo)) {
@@ -3012,44 +2585,36 @@ bool readExtremeRow(ExtremeRow value, ByteData view, int numBits) {
   }
   value.clampedCeiling = 1 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.floorDef = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.ceilingDef = lo;

--- a/generated/dart/Wire.dart
+++ b/generated/dart/Wire.dart
@@ -2409,15 +2409,33 @@ int writeBlock(Block value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.dataLength; i0++) {
-    v = value.data[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.dataLength; i0 += 4) {
+      v =
+          value.data[i0] |
+          (value.data[i0 + 1] << 8) |
+          (value.data[i0 + 2] << 16) |
+          (value.data[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.dataLength; i0++) {
+      v = value.data[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -2552,15 +2570,33 @@ int writeChat(Chat value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.textLength; i0++) {
-    v = value.text[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.textLength; i0 += 4) {
+      v =
+          value.text[i0] |
+          (value.text[i0 + 1] << 8) |
+          (value.text[i0 + 2] << 16) |
+          (value.text[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.textLength; i0++) {
+      v = value.text[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -3123,27 +3159,34 @@ int writeTestData(TestData value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < 17; i0++) {
-    v = ((value.fixedBytes[i0]) & 0xff);
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= 17; i0 += 4) {
+      v =
+          value.fixedBytes[i0] |
+          (value.fixedBytes[i0 + 1] << 8) |
+          (value.fixedBytes[i0 + 2] << 16) |
+          (value.fixedBytes[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
     }
   }
   assert(value.textLength >= 0);
   assert(value.textLength <= 255);
-  v = ((value.textLength) & 0xff);
+  v = value.fixedBytes[16] | (((value.textLength) & 0xff) << 8);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -3157,15 +3200,33 @@ int writeTestData(TestData value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.textLength; i0++) {
-    v = value.text[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.textLength; i0 += 4) {
+      v =
+          value.text[i0] |
+          (value.text[i0 + 1] << 8) |
+          (value.text[i0 + 2] << 16) |
+          (value.text[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.textLength; i0++) {
+      v = value.text[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {

--- a/generated/dart/Wire.dart
+++ b/generated/dart/Wire.dart
@@ -243,42 +243,25 @@ bool readProbeHeader(ProbeHeader value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v != 171) {
     return false; // a read rejects any other value (SPEC §4.3)
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 8) & 0x7;
   bitsRead += 3;
   value.version = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 11) & 0x1f;
   bitsRead += 5;
   if (v != 0) {
     return false; // reserved bits must read zero (SPEC §4.3)
@@ -299,23 +282,19 @@ bool readProbeHeader(ProbeHeader value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.probeId = lo;
@@ -433,92 +412,61 @@ bool readProbeBits(ProbeBits value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 202 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ff;
+  v = window & 0x1ff;
   bitsRead += 9;
   value.small = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
-  bitsRead += 1;
-  lo |= v << 32;
+  lo = (window >>> 9) & 0x1ffffffff;
+  bitsRead += 33;
   value.boundary = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.wide = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.sensor = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.nonce = lo;
@@ -714,30 +662,20 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 113 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.active = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 1) & 0xffff;
   bitsRead += 16;
   if (v > 36000) {
     return false; // headroom above the quantum count is refused
@@ -745,34 +683,23 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
   value.orientation = _fround(
     _fround(_fround(_fround(v.toDouble()) / 36000.0) * 360.0) + -180.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 17) & 0xffffffff;
   bitsRead += 32;
   value.rawDelta = (v << 32) >> 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.bigDelta = lo;
@@ -781,23 +708,14 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xf;
+    v = window & 0xf;
     bitsRead += 4;
     value.weapon = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 4) & 0x1;
     bitsRead += 1;
     value.hasTarget = v != 0;
     if (value.hasTarget) {
@@ -805,13 +723,12 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.targetId = v;
     } else {
@@ -823,13 +740,11 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     value.idleTicks = v;
     value.weapon = 0;
@@ -840,13 +755,11 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.samplesCount = v + 1;
   if (bitsRead + value.samplesCount * 16 > numBits) {
@@ -854,13 +767,11 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.samplesCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffff;
+    v = window & 0xffff;
     bitsRead += 16;
     value.samples[i0] = v;
   }
@@ -947,19 +858,16 @@ bool readProbeRing(ProbeRing value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   value.radius = v;
   return true;
@@ -1036,32 +944,22 @@ bool readProbeSlab(ProbeSlab value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 15 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   if (v > 100) {
     return false; // a smuggled offset is refused
   }
   value.width = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 7) & 0xff;
   bitsRead += 8;
   value.height = v;
   return true;
@@ -1173,19 +1071,16 @@ bool readProbeShape(ProbeShape value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1198,13 +1093,12 @@ bool readProbeShape(ProbeShape value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.ring.radius = v;
     case 2:
@@ -1214,26 +1108,18 @@ bool readProbeShape(ProbeShape value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7f;
+      v = window & 0x7f;
       bitsRead += 7;
       if (v > 100) {
         return false; // a smuggled offset is refused
       }
       value.slab.width = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 7) & 0xff;
       bitsRead += 8;
       value.slab.height = v;
   }
@@ -1440,32 +1326,22 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 8 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.armor = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 8) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1478,13 +1354,12 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.shape.ring.radius = v;
     case 2:
@@ -1494,26 +1369,18 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7f;
+      v = window & 0x7f;
       bitsRead += 7;
       if (v > 100) {
         return false; // a smuggled offset is refused
       }
       value.shape.slab.width = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 7) & 0xff;
       bitsRead += 8;
       value.shape.slab.height = v;
   }
@@ -1521,13 +1388,11 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1540,13 +1405,12 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.backup.ring.radius = v;
     case 2:
@@ -1556,26 +1420,18 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7f;
+      v = window & 0x7f;
       bitsRead += 7;
       if (v > 100) {
         return false; // a smuggled offset is refused
       }
       value.backup.slab.width = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 7) & 0xff;
       bitsRead += 8;
       value.backup.slab.height = v;
   }
@@ -1583,13 +1439,11 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // the count guards the loop — reject, never clamp
@@ -1601,13 +1455,11 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3;
+    v = window & 0x3;
     bitsRead += 2;
     if (v > 2) {
       return false; // not a wire-legal tag (SPEC §4.8)
@@ -1620,13 +1472,12 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0xffff;
+        v = window & 0xffff;
         bitsRead += 16;
         e0.ring.radius = v;
       case 2:
@@ -1636,26 +1487,18 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0x7f;
+        v = window & 0x7f;
         bitsRead += 7;
         if (v > 100) {
           return false; // a smuggled offset is refused
         }
         e0.slab.width = v;
-        if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
-        } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
-        }
-        v = (window >>> shift) & 0xff;
+        v = (window >>> 7) & 0xff;
         bitsRead += 8;
         e0.slab.height = v;
     }
@@ -1764,29 +1607,19 @@ bool readProbeConfig(ProbeConfig value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 36 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.retries = (v << 32) >> 32;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 32) & 0xf;
   bitsRead += 4;
   value.preferred = v;
   return true;
@@ -1971,7 +1804,6 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   for (var i0 = 0; i0 < 2; i0++) {
@@ -1980,23 +1812,14 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1;
+    v = window & 0x1;
     bitsRead += 1;
     e0.active = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xffff;
+    v = (window >>> 1) & 0xffff;
     bitsRead += 16;
     if (v > 36000) {
       return false; // headroom above the quantum count is refused
@@ -2004,34 +1827,23 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
     e0.orientation = _fround(
       _fround(_fround(_fround(v.toDouble()) / 36000.0) * 360.0) + -180.0,
     );
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xffffffff;
+    v = (window >>> 17) & 0xffffffff;
     bitsRead += 32;
     e0.rawDelta = (v << 32) >> 32;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     e0.bigDelta = lo;
@@ -2040,23 +1852,15 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xf;
+      v = window & 0xf;
       bitsRead += 4;
       e0.weapon = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1;
+      v = (window >>> 4) & 0x1;
       bitsRead += 1;
       e0.hasTarget = v != 0;
       if (e0.hasTarget) {
@@ -2064,13 +1868,12 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0xffff;
+        v = window & 0xffff;
         bitsRead += 16;
         e0.targetId = v;
       } else {
@@ -2082,13 +1885,12 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffffffff;
+      v = window & 0xffffffff;
       bitsRead += 32;
       e0.idleTicks = v;
       e0.weapon = 0;
@@ -2099,13 +1901,11 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     e0.samplesCount = v + 1;
     if (bitsRead + e0.samplesCount * 16 > numBits) {
@@ -2113,13 +1913,12 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
     }
     for (var i1 = 0; i1 < e0.samplesCount; i1++) {
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       e0.samples[i1] = v;
     }
@@ -2128,23 +1927,14 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.config.retries = (v << 32) >> 32;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 32) & 0xf;
   bitsRead += 4;
   value.config.preferred = v;
   return true;
@@ -2296,55 +2086,31 @@ bool readTest(Test value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 46 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   value.testA = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 16) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.testB = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 26) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.testC = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 36) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
@@ -2465,19 +2231,16 @@ bool readBlock(Block value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 11 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7ff;
+  v = window & 0x7ff;
   bitsRead += 11;
   if (v > 2000) {
     return false; // the length guards the slice — reject, never clamp
@@ -2626,19 +2389,16 @@ bool readChat(Chat value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 9 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ff;
+  v = window & 0x1ff;
   bitsRead += 9;
   if (v > 256) {
     return false; // the length guards the slice — reject, never clamp
@@ -2793,42 +2553,25 @@ bool readProbeReport(ProbeReport value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v != 171) {
     return false; // a read rejects any other value (SPEC §4.3)
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 8) & 0x7;
   bitsRead += 3;
   value.header.version = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 11) & 0x1f;
   bitsRead += 5;
   if (v != 0) {
     return false; // reserved bits must read zero (SPEC §4.3)
@@ -2849,83 +2592,49 @@ bool readProbeReport(ProbeReport value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.header.probeId = lo;
   if (bitsRead + 54 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.flags = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 40) & 0xffff;
   bitsRead += 16;
   value.echo.testA = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3ff;
+  v = window & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.echo.testB = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 10) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.echo.testC = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 20) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
@@ -3256,102 +2965,50 @@ bool readTestData(TestData value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 49 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // a smuggled offset is refused
   }
   value.a = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 8) & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // a smuggled offset is refused
   }
   value.b = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 16) & 0xff;
   bitsRead += 8;
   if (v > 250) {
     return false; // a smuggled offset is refused
   }
   value.c = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 24) & 0xff;
   bitsRead += 8;
   value.d = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.e = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 40) & 0xff;
   bitsRead += 8;
   value.f = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 48) & 0x1;
   bitsRead += 1;
   value.g = v != 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 49) & 0x1f;
   bitsRead += 5;
   if (v > 16) {
     return false; // the count guards the loop — reject, never clamp
@@ -3362,13 +3019,11 @@ bool readTestData(TestData value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xff;
+    v = window & 0xff;
     bitsRead += 8;
     value.items[i0] = v;
   }
@@ -3376,23 +3031,14 @@ bool readTestData(TestData value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.floatValue = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 32) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // headroom above the quantum count is refused
@@ -3401,138 +3047,83 @@ bool readTestData(TestData value, ByteData view, int numBits) {
     _fround(_fround(_fround(v.toDouble()) / 1000.0) * 10.0) + 0.0,
   );
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.doubleValue = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.int8Value = (v << 56) >> 56;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 40) & 0xffff;
   bitsRead += 16;
   value.int16Value = (v << 48) >> 48;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.uint8Value = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 8) & 0xffff;
   bitsRead += 16;
   value.uint16Value = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 24) & 0xffffffff;
   bitsRead += 32;
   value.uint32Value = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.uint64Value = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.int64Full = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
-  bitsRead += 9;
-  lo |= v << 32;
+  lo = window & 0x1ffffffffff;
+  bitsRead += 41;
   if (lo > 2000000000000) {
     return false; // a smuggled offset is refused
   }
@@ -3554,13 +3145,11 @@ bool readTestData(TestData value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 17; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xff;
+    v = window & 0xff;
     bitsRead += 8;
     value.fixedBytes[i0] = v;
   }
@@ -3568,13 +3157,11 @@ bool readTestData(TestData value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.textLength = v;
   {
@@ -3716,19 +3303,16 @@ bool readCompressedProbe(CompressedProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 24 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3ff;
+  v = window & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // headroom above the quantum count is refused
@@ -3736,14 +3320,7 @@ bool readCompressedProbe(CompressedProbe value, ByteData view, int numBits) {
   value.boundary = _fround(
     _fround(_fround(_fround(v.toDouble()) / 1000.0) * 10.0) + 0.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3fff;
+  v = (window >>> 10) & 0x3fff;
   bitsRead += 14;
   if (v > 10000) {
     return false; // headroom above the quantum count is refused

--- a/generated/dart/Wire.dart
+++ b/generated/dart/Wire.dart
@@ -186,32 +186,14 @@ int writeProbeHeader(ProbeHeader value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = 171;
+  v = 171 | (((value.version) & 0x7) << 8) | (0 << 11);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.version & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = 0;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -225,23 +207,14 @@ int writeProbeHeader(ProbeHeader value, ByteData view) {
       }
     }
   }
-  v = value.probeId & 0xffffffff;
+  v = (value.probeId);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.probeId >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -395,54 +368,27 @@ int writeProbeBits(ProbeBits value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.small & 0x1ff;
+  v = ((value.small) & 0x1ff) | (((value.boundary) & 0x1ffffffff) << 9);
   scratch |= v << scratchBits;
-  scratchBits += 9;
+  scratchBits += 42;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (9 - scratchBits);
-  }
-  v = value.boundary & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.boundary >>> 32) & 0x1;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.wide & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (42 - scratchBits);
   }
   assert(value.sensor >= 0);
   assert(value.sensor <= 4294967295);
-  v = (value.sensor) & 0xffffffff;
+  v = (value.wide);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.sensor) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -451,23 +397,14 @@ int writeProbeBits(ProbeBits value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = value.nonce & 0xffffffff;
+  v = (value.nonce);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.nonce >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -648,7 +585,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.active ? 1 : 0;
+  v = (value.active ? 1 : 0);
   scratch |= v << scratchBits;
   scratchBits += 1;
   if (scratchBits >= 64) {
@@ -676,7 +613,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (16 - scratchBits);
   }
-  v = value.rawDelta & 0xffffffff;
+  v = ((value.rawDelta) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -685,47 +622,29 @@ int writeProbeSample(ProbeSample value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = value.bigDelta & 0xffffffff;
+  v = (value.bigDelta);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.bigDelta >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (value.active) {
     assert(value.weapon >= 0);
     assert(value.weapon <= 15);
-    v = value.weapon & 0xf;
+    v = ((value.weapon) & 0xf) | ((value.hasTarget ? 1 : 0) << 4);
     scratch |= v << scratchBits;
-    scratchBits += 4;
+    scratchBits += 5;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (4 - scratchBits);
-    }
-    v = value.hasTarget ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+      scratch = v >>> (5 - scratchBits);
     }
     if (value.hasTarget) {
-      v = value.targetId & 0xffff;
+      v = ((value.targetId) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -736,7 +655,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
       }
     }
   } else {
-    v = value.idleTicks & 0xffffffff;
+    v = ((value.idleTicks) & 0xffffffff);
     scratch |= v << scratchBits;
     scratchBits += 32;
     if (scratchBits >= 64) {
@@ -748,7 +667,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
   }
   assert(value.samplesCount >= 1);
   assert(value.samplesCount <= 8);
-  v = (value.samplesCount - 1) & 0x7;
+  v = ((value.samplesCount - 1) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -758,7 +677,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
     scratch = v >>> (3 - scratchBits);
   }
   for (var i0 = 0; i0 < value.samplesCount; i0++) {
-    v = value.samples[i0] & 0xffff;
+    v = ((value.samples[i0]) & 0xffff);
     scratch |= v << scratchBits;
     scratchBits += 16;
     if (scratchBits >= 64) {
@@ -992,7 +911,7 @@ int writeProbeRing(ProbeRing value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.radius & 0xffff;
+  v = ((value.radius) & 0xffff);
   scratch |= v << scratchBits;
   scratchBits += 16;
   if (scratchBits >= 64) {
@@ -1081,23 +1000,14 @@ int writeProbeSlab(ProbeSlab value, ByteData view) {
   var v = 0;
   assert(value.width >= 0);
   assert(value.width <= 100);
-  v = (value.width) & 0x7f;
+  v = ((value.width) & 0x7f) | (((value.height) & 0xff) << 7);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 15;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
-  }
-  v = value.height & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (15 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1203,7 +1113,7 @@ int writeProbeShape(ProbeShape value, ByteData view) {
   var v = 0;
   assert(value.type >= 0);
   assert(value.type <= 2);
-  v = value.type & 0x3;
+  v = ((value.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1214,7 +1124,7 @@ int writeProbeShape(ProbeShape value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      v = value.ring.radius & 0xffff;
+      v = ((value.ring.radius) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -1226,23 +1136,14 @@ int writeProbeShape(ProbeShape value, ByteData view) {
     case 2:
       assert(value.slab.width >= 0);
       assert(value.slab.width <= 100);
-      v = (value.slab.width) & 0x7f;
+      v = ((value.slab.width) & 0x7f) | (((value.slab.height) & 0xff) << 7);
       scratch |= v << scratchBits;
-      scratchBits += 7;
+      scratchBits += 15;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (7 - scratchBits);
-      }
-      v = value.slab.height & 0xff;
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (15 - scratchBits);
       }
   }
   if (scratchBits != 0) {
@@ -1389,29 +1290,20 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.armor & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.shape.type >= 0);
   assert(value.shape.type <= 2);
-  v = value.shape.type & 0x3;
+  v = ((value.armor) & 0xff) | (((value.shape.type) & 0x3) << 8);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 10;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (10 - scratchBits);
   }
   switch (value.shape.type) {
     case 1:
-      v = value.shape.ring.radius & 0xffff;
+      v = ((value.shape.ring.radius) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -1423,28 +1315,21 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     case 2:
       assert(value.shape.slab.width >= 0);
       assert(value.shape.slab.width <= 100);
-      v = (value.shape.slab.width) & 0x7f;
+      v =
+          ((value.shape.slab.width) & 0x7f) |
+          (((value.shape.slab.height) & 0xff) << 7);
       scratch |= v << scratchBits;
-      scratchBits += 7;
+      scratchBits += 15;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (7 - scratchBits);
-      }
-      v = value.shape.slab.height & 0xff;
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (15 - scratchBits);
       }
   }
   assert(value.backup.type >= 0);
   assert(value.backup.type <= 2);
-  v = value.backup.type & 0x3;
+  v = ((value.backup.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1455,7 +1340,7 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
   }
   switch (value.backup.type) {
     case 1:
-      v = value.backup.ring.radius & 0xffff;
+      v = ((value.backup.ring.radius) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -1467,28 +1352,21 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     case 2:
       assert(value.backup.slab.width >= 0);
       assert(value.backup.slab.width <= 100);
-      v = (value.backup.slab.width) & 0x7f;
+      v =
+          ((value.backup.slab.width) & 0x7f) |
+          (((value.backup.slab.height) & 0xff) << 7);
       scratch |= v << scratchBits;
-      scratchBits += 7;
+      scratchBits += 15;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (7 - scratchBits);
-      }
-      v = value.backup.slab.height & 0xff;
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (15 - scratchBits);
       }
   }
   assert(value.extrasCount >= 0);
   assert(value.extrasCount <= 2);
-  v = (value.extrasCount) & 0x3;
+  v = ((value.extrasCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1501,7 +1379,7 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     final e0 = value.extras[i0];
     assert(e0.type >= 0);
     assert(e0.type <= 2);
-    v = e0.type & 0x3;
+    v = ((e0.type) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
     if (scratchBits >= 64) {
@@ -1512,7 +1390,7 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     }
     switch (e0.type) {
       case 1:
-        v = e0.ring.radius & 0xffff;
+        v = ((e0.ring.radius) & 0xffff);
         scratch |= v << scratchBits;
         scratchBits += 16;
         if (scratchBits >= 64) {
@@ -1524,23 +1402,14 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
       case 2:
         assert(e0.slab.width >= 0);
         assert(e0.slab.width <= 100);
-        v = (e0.slab.width) & 0x7f;
+        v = ((e0.slab.width) & 0x7f) | (((e0.slab.height) & 0xff) << 7);
         scratch |= v << scratchBits;
-        scratchBits += 7;
+        scratchBits += 15;
         if (scratchBits >= 64) {
           view.setUint64(wordIndex * 8, scratch, Endian.little);
           wordIndex++;
           scratchBits -= 64;
-          scratch = v >>> (7 - scratchBits);
-        }
-        v = e0.slab.height & 0xff;
-        scratch |= v << scratchBits;
-        scratchBits += 8;
-        if (scratchBits >= 64) {
-          view.setUint64(wordIndex * 8, scratch, Endian.little);
-          wordIndex++;
-          scratchBits -= 64;
-          scratch = v >>> (8 - scratchBits);
+          scratch = v >>> (15 - scratchBits);
         }
     }
   }
@@ -1857,25 +1726,16 @@ int writeProbeConfig(ProbeConfig value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.retries & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.preferred >= 0);
   assert(value.preferred <= 15);
-  v = value.preferred & 0xf;
+  v = ((value.retries) & 0xffffffff) | (((value.preferred) & 0xf) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 36;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (36 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1968,7 +1828,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
     final e0 = value.samples[i0];
-    v = e0.active ? 1 : 0;
+    v = (e0.active ? 1 : 0);
     scratch |= v << scratchBits;
     scratchBits += 1;
     if (scratchBits >= 64) {
@@ -1996,7 +1856,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (16 - scratchBits);
     }
-    v = e0.rawDelta & 0xffffffff;
+    v = ((e0.rawDelta) & 0xffffffff);
     scratch |= v << scratchBits;
     scratchBits += 32;
     if (scratchBits >= 64) {
@@ -2005,47 +1865,29 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (32 - scratchBits);
     }
-    v = e0.bigDelta & 0xffffffff;
+    v = (e0.bigDelta);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (e0.bigDelta >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
     if (e0.active) {
       assert(e0.weapon >= 0);
       assert(e0.weapon <= 15);
-      v = e0.weapon & 0xf;
+      v = ((e0.weapon) & 0xf) | ((e0.hasTarget ? 1 : 0) << 4);
       scratch |= v << scratchBits;
-      scratchBits += 4;
+      scratchBits += 5;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (4 - scratchBits);
-      }
-      v = e0.hasTarget ? 1 : 0;
-      scratch |= v << scratchBits;
-      scratchBits += 1;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (1 - scratchBits);
+        scratch = v >>> (5 - scratchBits);
       }
       if (e0.hasTarget) {
-        v = e0.targetId & 0xffff;
+        v = ((e0.targetId) & 0xffff);
         scratch |= v << scratchBits;
         scratchBits += 16;
         if (scratchBits >= 64) {
@@ -2056,7 +1898,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
         }
       }
     } else {
-      v = e0.idleTicks & 0xffffffff;
+      v = ((e0.idleTicks) & 0xffffffff);
       scratch |= v << scratchBits;
       scratchBits += 32;
       if (scratchBits >= 64) {
@@ -2068,7 +1910,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
     }
     assert(e0.samplesCount >= 1);
     assert(e0.samplesCount <= 8);
-    v = (e0.samplesCount - 1) & 0x7;
+    v = ((e0.samplesCount - 1) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
     if (scratchBits >= 64) {
@@ -2078,7 +1920,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       scratch = v >>> (3 - scratchBits);
     }
     for (var i1 = 0; i1 < e0.samplesCount; i1++) {
-      v = e0.samples[i1] & 0xffff;
+      v = ((e0.samples[i1]) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -2089,25 +1931,18 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       }
     }
   }
-  v = value.config.retries & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.config.preferred >= 0);
   assert(value.config.preferred <= 15);
-  v = value.config.preferred & 0xf;
+  v =
+      ((value.config.retries) & 0xffffffff) |
+      (((value.config.preferred) & 0xf) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 36;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (36 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2415,47 +2250,24 @@ int writeTest(Test value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.testA & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
   assert(value.testB >= 0);
   assert(value.testB <= 1000);
-  v = (value.testB) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.testC >= 0);
   assert(value.testC <= 1000);
-  v = (value.testC) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.testD >= 0);
   assert(value.testD <= 1000);
-  v = (value.testD) & 0x3ff;
+  v =
+      ((value.testA) & 0xffff) |
+      (((value.testB) & 0x3ff) << 16) |
+      (((value.testC) & 0x3ff) << 26) |
+      (((value.testD) & 0x3ff) << 36);
   scratch |= v << scratchBits;
-  scratchBits += 10;
+  scratchBits += 46;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
+    scratch = v >>> (46 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2576,7 +2388,7 @@ int writeBlock(Block value, ByteData view) {
   var v = 0;
   assert(value.dataLength >= 0);
   assert(value.dataLength <= 2000);
-  v = (value.dataLength) & 0x7ff;
+  v = ((value.dataLength) & 0x7ff);
   scratch |= v << scratchBits;
   scratchBits += 11;
   if (scratchBits >= 64) {
@@ -2719,7 +2531,7 @@ int writeChat(Chat value, ByteData view) {
   var v = 0;
   assert(value.textLength >= 0);
   assert(value.textLength <= 256);
-  v = (value.textLength) & 0x1ff;
+  v = ((value.textLength) & 0x1ff);
   scratch |= v << scratchBits;
   scratchBits += 9;
   if (scratchBits >= 64) {
@@ -2867,32 +2679,14 @@ int writeProbeReport(ProbeReport value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = 171;
+  v = 171 | (((value.header.version) & 0x7) << 8) | (0 << 11);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.header.version & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = 0;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -2906,75 +2700,35 @@ int writeProbeReport(ProbeReport value, ByteData view) {
       }
     }
   }
-  v = value.header.probeId & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.header.probeId >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.flags >>> 8 == 0);
-  v = value.flags & 0xff;
+  v = (value.header.probeId);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.echo.testA & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.echo.testB >= 0);
   assert(value.echo.testB <= 1000);
-  v = (value.echo.testB) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.echo.testC >= 0);
   assert(value.echo.testC <= 1000);
-  v = (value.echo.testC) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.echo.testD >= 0);
   assert(value.echo.testD <= 1000);
-  v = (value.echo.testD) & 0x3ff;
+  v =
+      ((value.flags) & 0xff) |
+      (((value.echo.testA) & 0xffff) << 8) |
+      (((value.echo.testB) & 0x3ff) << 24) |
+      (((value.echo.testC) & 0x3ff) << 34) |
+      (((value.echo.testD) & 0x3ff) << 44);
   scratch |= v << scratchBits;
-  scratchBits += 10;
+  scratchBits += 54;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
+    scratch = v >>> (54 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -3233,88 +2987,33 @@ int writeTestData(TestData value, ByteData view) {
   var v = 0;
   assert(value.a >= -100);
   assert(value.a <= 100);
-  v = (value.a + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.b >= -100);
   assert(value.b <= 100);
-  v = (value.b + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.c >= -100);
   assert(value.c <= 150);
-  v = (value.c + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.d & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.e & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.f & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.g ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 16);
-  v = (value.itemsCount) & 0x1f;
+  v =
+      ((value.a + 100) & 0xff) |
+      (((value.b + 100) & 0xff) << 8) |
+      (((value.c + 100) & 0xff) << 16) |
+      (((value.d) & 0xff) << 24) |
+      (((value.e) & 0xff) << 32) |
+      (((value.f) & 0xff) << 40) |
+      ((value.g ? 1 : 0) << 48) |
+      (((value.itemsCount) & 0x1f) << 49);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 54;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (54 - scratchBits);
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 255);
-    v = (value.items[i0]) & 0xff;
+    v = ((value.items[i0]) & 0xff);
     scratch |= v << scratchBits;
     scratchBits += 8;
     if (scratchBits >= 64) {
@@ -3352,64 +3051,29 @@ int writeTestData(TestData value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (10 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.doubleValue);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.int8Value & 0xff;
+  v = _float64BitsFromDouble(value.doubleValue);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.int16Value & 0xffff;
+  v =
+      ((value.int8Value) & 0xff) |
+      (((value.int16Value) & 0xffff) << 8) |
+      (((value.uint8Value) & 0xff) << 24) |
+      (((value.uint16Value) & 0xffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 16;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
-  v = value.uint8Value & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.uint16Value & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
-  v = value.uint32Value & 0xffffffff;
+  v = ((value.uint32Value) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -3418,64 +3082,34 @@ int writeTestData(TestData value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = value.uint64Value & 0xffffffff;
+  v = (value.uint64Value);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.uint64Value >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.int64Full & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.int64Full >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.int64Range >= -1000000000000);
   assert(value.int64Range <= 1000000000000);
-  {
-    final off = value.int64Range + 1000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x1ff;
-    scratch |= v << scratchBits;
-    scratchBits += 9;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (9 - scratchBits);
-    }
+  v = (value.int64Full);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.int64Range + 1000000000000) & 0x1ffffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 41;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (41 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -3490,7 +3124,7 @@ int writeTestData(TestData value, ByteData view) {
     }
   }
   for (var i0 = 0; i0 < 17; i0++) {
-    v = value.fixedBytes[i0] & 0xff;
+    v = ((value.fixedBytes[i0]) & 0xff);
     scratch |= v << scratchBits;
     scratchBits += 8;
     if (scratchBits >= 64) {
@@ -3502,7 +3136,7 @@ int writeTestData(TestData value, ByteData view) {
   }
   assert(value.textLength >= 0);
   assert(value.textLength <= 255);
-  v = (value.textLength) & 0xff;
+  v = ((value.textLength) & 0xff);
   scratch |= v << scratchBits;
   scratchBits += 8;
   if (scratchBits >= 64) {

--- a/generated/dart/Wire.dart
+++ b/generated/dart/Wire.dart
@@ -624,15 +624,33 @@ int writeProbeSample(ProbeSample value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (3 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.samplesCount; i0++) {
-    v = ((value.samples[i0]) & 0xffff);
-    scratch |= v << scratchBits;
-    scratchBits += 16;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (16 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.samplesCount; i0 += 4) {
+      v =
+          ((value.samples[i0]) & 0xffff) |
+          (((value.samples[i0 + 1]) & 0xffff) << 16) |
+          (((value.samples[i0 + 2]) & 0xffff) << 32) |
+          (((value.samples[i0 + 3]) & 0xffff) << 48);
+      scratch |= v << scratchBits;
+      scratchBits += 64;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (64 - scratchBits);
+      }
+    }
+    for (; i0 < value.samplesCount; i0++) {
+      v = ((value.samples[i0]) & 0xffff);
+      scratch |= v << scratchBits;
+      scratchBits += 16;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (16 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -765,15 +783,36 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
   if (bitsRead + value.samplesCount * 16 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.samplesCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.samplesCount; i0 += 3) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xffff;
+      bitsRead += 16;
+      value.samples[i0] = v;
+      v = (window >>> 16) & 0xffff;
+      bitsRead += 16;
+      value.samples[i0 + 1] = v;
+      v = (window >>> 32) & 0xffff;
+      bitsRead += 16;
+      value.samples[i0 + 2] = v;
     }
-    v = window & 0xffff;
-    bitsRead += 16;
-    value.samples[i0] = v;
+    for (; i0 < value.samplesCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xffff;
+      bitsRead += 16;
+      value.samples[i0] = v;
+    }
   }
   return true;
 }
@@ -1752,15 +1791,33 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (3 - scratchBits);
     }
-    for (var i1 = 0; i1 < e0.samplesCount; i1++) {
-      v = ((e0.samples[i1]) & 0xffff);
-      scratch |= v << scratchBits;
-      scratchBits += 16;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (16 - scratchBits);
+    {
+      var i1 = 0;
+      for (; i1 + 4 <= e0.samplesCount; i1 += 4) {
+        v =
+            ((e0.samples[i1]) & 0xffff) |
+            (((e0.samples[i1 + 1]) & 0xffff) << 16) |
+            (((e0.samples[i1 + 2]) & 0xffff) << 32) |
+            (((e0.samples[i1 + 3]) & 0xffff) << 48);
+        scratch |= v << scratchBits;
+        scratchBits += 64;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (64 - scratchBits);
+        }
+      }
+      for (; i1 < e0.samplesCount; i1++) {
+        v = ((e0.samples[i1]) & 0xffff);
+        scratch |= v << scratchBits;
+        scratchBits += 16;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (16 - scratchBits);
+        }
       }
     }
   }
@@ -1911,16 +1968,36 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
     if (bitsRead + e0.samplesCount * 16 > numBits) {
       return false;
     }
-    for (var i1 = 0; i1 < e0.samplesCount; i1++) {
-      if (bitsRead >>> 3 < tailBase) {
-        window =
-            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-      } else {
-        window = tailWord >>> (bitsRead - tailBase * 8);
+    {
+      var i1 = 0;
+      for (; i1 + 3 <= e0.samplesCount; i1 += 3) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1] = v;
+        v = (window >>> 16) & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1 + 1] = v;
+        v = (window >>> 32) & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1 + 2] = v;
       }
-      v = window & 0xffff;
-      bitsRead += 16;
-      e0.samples[i1] = v;
+      for (; i1 < e0.samplesCount; i1++) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1] = v;
+      }
     }
   }
   if (bitsRead + 36 > numBits) {
@@ -2755,17 +2832,55 @@ int writeTestData(TestData value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (54 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 255);
-    v = ((value.items[i0]) & 0xff);
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 8 <= value.itemsCount; i0 += 8) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 255);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 255);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 255);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 255);
+      assert(value.items[i0 + 4] >= 0);
+      assert(value.items[i0 + 4] <= 255);
+      assert(value.items[i0 + 5] >= 0);
+      assert(value.items[i0 + 5] <= 255);
+      assert(value.items[i0 + 6] >= 0);
+      assert(value.items[i0 + 6] <= 255);
+      assert(value.items[i0 + 7] >= 0);
+      assert(value.items[i0 + 7] <= 255);
+      v =
+          ((value.items[i0]) & 0xff) |
+          (((value.items[i0 + 1]) & 0xff) << 8) |
+          (((value.items[i0 + 2]) & 0xff) << 16) |
+          (((value.items[i0 + 3]) & 0xff) << 24) |
+          (((value.items[i0 + 4]) & 0xff) << 32) |
+          (((value.items[i0 + 5]) & 0xff) << 40) |
+          (((value.items[i0 + 6]) & 0xff) << 48) |
+          (((value.items[i0 + 7]) & 0xff) << 56);
+      scratch |= v << scratchBits;
+      scratchBits += 64;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (64 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 255);
+      v = ((value.items[i0]) & 0xff);
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   v = _float32BitsFromDouble(value.floatValue);
@@ -3017,15 +3132,48 @@ bool readTestData(TestData value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 8 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
-    } else {
-      window = tailWord >>> (bitsRead - tailBase * 8);
+  {
+    var i0 = 0;
+    for (; i0 + 7 <= value.itemsCount; i0 += 7) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xff;
+      bitsRead += 8;
+      value.items[i0] = v;
+      v = (window >>> 8) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 1] = v;
+      v = (window >>> 16) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 2] = v;
+      v = (window >>> 24) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 3] = v;
+      v = (window >>> 32) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 4] = v;
+      v = (window >>> 40) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 5] = v;
+      v = (window >>> 48) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 6] = v;
     }
-    v = window & 0xff;
-    bitsRead += 8;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xff;
+      bitsRead += 8;
+      value.items[i0] = v;
+    }
   }
   if (bitsRead + 355 > numBits) {
     return false;

--- a/internal/codegen/dart/dart.go
+++ b/internal/codegen/dart/dart.go
@@ -225,9 +225,28 @@ type gen struct {
 	fn        strings.Builder
 	loopDepth int
 	needV     bool // the group value temp
-	needLo    bool // the wide-lane accumulator (33..64-bit reads, 128 lanes)
+	needLo    bool // the wide-lane accumulator (58..64-bit reads, 128 lanes)
 	needHi    bool // the high 64-bit lane (129-bit-storage reads)
 	usesRead  bool // read side: the window machinery is used
+
+	// the write-side chunk accumulator: adjacent constant-width fields whose
+	// value expressions are pure (field loads, literals — never a mutable
+	// temp) pack into ONE staged word with literal relative shifts, so a
+	// chunk costs one merge where its fields used to cost one each. Dart's
+	// native 64-bit int carries the whole lane, so the cap is 64 where the
+	// js flat tier's number domain held it to 32. Relative offsets inside a
+	// chunk are static even where the absolute cursor is dynamic (loop
+	// bodies), which is what makes this reach the hot arrays.
+	chunk     []chunkPiece
+	chunkBits int64
+
+	// the read-side window ledger: bits still extractable from the loaded
+	// 64-bit window (windowAvail) and the literal shift of the next field
+	// inside it (windowRel). A load guarantees 57 valid bits (64 minus the
+	// worst-case byte-interior shift), so consecutive constant-width reads
+	// share one load instead of paying a load and a tail branch each.
+	windowAvail int64
+	windowRel   int64
 
 	// per-file helper needs
 	needFround   bool // _fround

--- a/internal/codegen/dart/functions.go
+++ b/internal/codegen/dart/functions.go
@@ -50,7 +50,9 @@ func maskHex(bits int64) string {
 }
 
 // mergeW merges v (already masked to bits) into the write scratch —
-// serialize.dart BitWriter.writeBits inlined, constant width. bits in [1,32].
+// serialize.dart BitWriter.writeBits inlined, constant width. bits in
+// [1,64]: the restore shift `bits - scratchBits` stays in [1,64], and a
+// Dart `>>>` by 64 is a defined zero, which is exactly the full-word case.
 func (g *gen) mergeW(bits int64, ind string) {
 	g.needV = true
 	g.pf("%sscratch |= v << scratchBits;\n", ind)
@@ -61,6 +63,75 @@ func (g *gen) mergeW(bits int64, ind string) {
 	g.pf("%s  scratchBits -= 64;\n", ind)
 	g.pf("%s  scratch = v >>> (%d - scratchBits);\n", ind, bits)
 	g.pf("%s}\n", ind)
+}
+
+// chunkPiece is one field's contribution to a pending write chunk: a pure,
+// parenthesized Dart int expression already masked to bits (a 64-bit piece
+// may ride unmasked — it stands alone in its chunk with a zero shift).
+type chunkPiece struct {
+	expr string
+	bits int64
+}
+
+// chunkAdd registers a pure value expression of the given width, flushing
+// first when it cannot join the pending chunk. Every caller's expression
+// must stay valid until the flush point: field paths, hoisted element refs
+// and literals qualify; v-style temps and block-scoped consts never do (a
+// temp-based merge flushes around itself instead).
+func (g *gen) chunkAdd(expr string, bits int64, ind string) {
+	if bits == 0 {
+		return
+	}
+	if g.chunkBits+bits > 64 {
+		g.chunkFlush(ind)
+	}
+	g.chunk = append(g.chunk, chunkPiece{expr: expr, bits: bits})
+	g.chunkBits += bits
+}
+
+// chunkFlush merges the pending chunk as one staged word. A scope boundary
+// (loop, branch, switch, function end) and every statement-form merge MUST
+// flush first — wire order is emission order.
+func (g *gen) chunkFlush(ind string) {
+	if len(g.chunk) == 0 {
+		return
+	}
+	parts := make([]string, len(g.chunk))
+	shift := int64(0)
+	for i, p := range g.chunk {
+		if shift == 0 {
+			parts[i] = p.expr
+		} else {
+			parts[i] = fmt.Sprintf("(%s << %d)", p.expr, shift)
+		}
+		shift += p.bits
+	}
+	one := fmt.Sprintf("%sv = %s;", ind, strings.Join(parts, " | "))
+	if len(one) <= 80 {
+		g.pf("%s\n", one)
+	} else {
+		// the formatter's tall assignment: `v =`, one operand per line
+		g.pf("%sv =\n", ind)
+		for i, p := range parts {
+			if i < len(parts)-1 {
+				g.pf("%s    %s |\n", ind, p)
+			} else {
+				g.pf("%s    %s;\n", ind, p)
+			}
+		}
+	}
+	g.mergeW(g.chunkBits, ind)
+	g.chunk = g.chunk[:0]
+	g.chunkBits = 0
+}
+
+// maskedPiece renders a chunk piece masked to bits; a full 64-bit piece
+// needs no mask (it stands alone at shift zero and the merge keeps 64 bits).
+func maskedPiece(expr string, bits int64) string {
+	if bits == 64 {
+		return fmt.Sprintf("(%s)", expr)
+	}
+	return fmt.Sprintf("((%s) & %s)", expr, maskHex(bits))
 }
 
 // readR reads bits (in [1,32]) from the 64-bit window at bitsRead into v,
@@ -223,12 +294,16 @@ func (g *gen) resetFn() {
 	g.fn.Reset()
 	g.loopDepth = 0
 	g.needV, g.needLo, g.needHi, g.usesRead = false, false, false, false
+	g.chunk = g.chunk[:0]
+	g.chunkBits = 0
+	g.windowAvail, g.windowRel = 0, 0
 }
 
 func (g *gen) emitWriteFunction(name, low string, items []ir.Item) {
 	g.usesTypeData = true
 	g.resetFn()
 	g.emitWriteItems(items, "value", "  ")
+	g.chunkFlush("  ")
 	body := g.fn.String()
 
 	g.bpf("// write%s packs value into view — the trusted writer (contracts asserted,\n", name)
@@ -334,38 +409,34 @@ func (g *gen) emitWriteItems(items []ir.Item, path, ind string) {
 			if item.Neg {
 				neg = "!"
 			}
+			g.chunkFlush(ind)
 			g.pf("%sif (%s%s.%s) {\n", ind, neg, path, dartName(item.Cond))
 			g.emitWriteItems(item.Then, path, ind+"  ")
+			g.chunkFlush(ind + "  ")
 			if item.Else != nil {
 				g.pf("%s} else {\n", ind)
 				g.emitWriteItems(item.Else, path, ind+"  ")
+				g.chunkFlush(ind + "  ")
 			}
 			g.pf("%s}\n", ind)
 		}
 	}
 }
 
-// emitWriteRaw merges a compile-time constant (const/reserved items) of up
-// to 64 bits, split low dword first past 32 (the serialize group rule).
+// emitWriteRaw queues a compile-time constant (const/reserved items) of up
+// to 64 bits as one chunk piece — the wire is the same 32-bit groups low
+// dword first, because LSB-first merging of a concatenation equals merging
+// the groups in sequence.
 func (g *gen) emitWriteRaw(value *big.Int, bits int64, ind string) {
 	masked := new(big.Int).And(value, new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(bits)), big.NewInt(1)))
-	if bits <= 32 {
-		g.pf("%sv = %s;\n", ind, dartIntLit(masked))
-		g.mergeW(bits, ind)
-		return
-	}
-	lo := new(big.Int).And(masked, new(big.Int).SetUint64(0xffffffff))
-	hi := new(big.Int).Rsh(masked, 32)
-	g.pf("%sv = %s;\n", ind, dartIntLit(lo))
-	g.mergeW(32, ind)
-	g.pf("%sv = %s;\n", ind, dartIntLit(hi))
-	g.mergeW(bits-32, ind)
+	g.chunkAdd(dartIntLit(masked), bits, ind)
 }
 
 // emitWriteAlign pads the write position to the next byte boundary with
 // zeros (nothing merges, so only the counter moves — with the flush kept,
 // exactly as the merge would keep it).
 func (g *gen) emitWriteAlign(ind string) {
+	g.chunkFlush(ind)
 	g.pf("%s{\n", ind)
 	g.pf("%s  final pad = scratchBits & 7;\n", ind)
 	g.pf("%s  if (pad != 0) {\n", ind)
@@ -389,8 +460,10 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 	case ir.ArrayFixed:
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++
+		g.chunkFlush(ind)
 		g.pf("%sfor (var %s = 0; %s < %d; %s++) {\n", ind, iv, iv, f.ArrayBound, iv)
 		g.emitWriteElem(f, name, iv, ind+"  ")
+		g.chunkFlush(ind + "  ")
 		g.pf("%s}\n", ind)
 		g.loopDepth--
 	case ir.ArrayCounted:
@@ -399,8 +472,10 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 		g.emitWriteOffset(count, big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), ind)
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++
+		g.chunkFlush(ind)
 		g.pf("%sfor (var %s = 0; %s < %s; %s++) {\n", ind, iv, iv, count, iv)
 		g.emitWriteElem(f, name, iv, ind+"  ")
+		g.chunkFlush(ind + "  ")
 		g.pf("%s}\n", ind)
 		g.loopDepth--
 	default:
@@ -451,11 +526,11 @@ func (g *gen) assertRange(expr string, min, max *big.Int, signedDomain bool, ind
 	}
 }
 
-// emitWriteOffset merges (expr - min) in the folded bit count for a range
-// inside the 64-bit domain: single group through 32 bits, two groups (low
-// dword first) past it — the serialize group structure exactly. Offsets wrap
-// two's complement, which is the unsigned-domain subtraction every family
-// port performs.
+// emitWriteOffset queues (expr - min) in the folded bit count for a range
+// inside the 64-bit domain as ONE chunk piece — a 33..64-bit field's bits
+// are contiguous on the wire, so the single merge emits the identical bytes
+// the old two-group form did. Offsets wrap two's complement, which is the
+// unsigned-domain subtraction every family port performs.
 func (g *gen) emitWriteOffset(expr string, min, max *big.Int, ind string) {
 	bits := ir.BitsRequired(min, max)
 	if bits == 0 {
@@ -473,46 +548,26 @@ func (g *gen) emitWriteOffset(expr string, min, max *big.Int, ind string) {
 			off = fmt.Sprintf("%s - %s", expr, dartIntLit(min)) // int64 min, a hex literal
 		}
 	}
-	if bits <= 32 {
-		g.pf("%sv = (%s) & %s;\n", ind, off, maskHex(bits))
-		g.mergeW(bits, ind)
-		return
-	}
-	if min.Sign() != 0 {
-		g.pf("%s{\n", ind)
-		g.pf("%s  final off = %s;\n", ind, off)
-		g.emitWriteWide64("off", bits, ind+"  ")
-		g.pf("%s}\n", ind)
-		return
-	}
-	g.emitWriteWide64(expr, bits, ind)
+	g.chunkAdd(maskedPiece(off, bits), bits, ind)
 }
 
-// emitWriteWide64 merges the low `bits` bits (33..64) of an int expression
-// as two groups, low dword first.
+// emitWriteWide64 queues the low `bits` bits (33..64) of an int expression
+// as one chunk piece — one merge where the two-group form paid two.
 func (g *gen) emitWriteWide64(expr string, bits int64, ind string) {
-	g.pf("%sv = %s & 0xffffffff;\n", ind, expr)
-	g.mergeW(32, ind)
-	g.pf("%sv = (%s >>> 32) & %s;\n", ind, expr, maskHex(bits-32))
-	g.mergeW(bits-32, ind)
+	g.chunkAdd(maskedPiece(expr, bits), bits, ind)
 }
 
-// emitWriteWide128 merges the low `bits` bits (1..128) of a (hi, lo) pair
-// expression, 32-bit groups least significant first.
+// emitWriteWide128 queues the low `bits` bits (1..128) of a (hi, lo) pair
+// expression: the lo lane, then the hi remainder — 32-bit groups least
+// significant first on the wire, exactly as before, because each lane's
+// bits are contiguous.
 func (g *gen) emitWriteWide128(loExpr, hiExpr string, bits int64, ind string) {
 	switch {
-	case bits <= 32:
-		g.pf("%sv = %s & %s;\n", ind, loExpr, maskHex(bits))
-		g.mergeW(bits, ind)
 	case bits <= 64:
-		g.emitWriteWide64(loExpr, bits, ind)
-	case bits <= 96:
-		g.emitWriteWide64(loExpr, 64, ind)
-		g.pf("%sv = %s & %s;\n", ind, hiExpr, maskHex(bits-64))
-		g.mergeW(bits-64, ind)
+		g.chunkAdd(maskedPiece(loExpr, bits), bits, ind)
 	default:
-		g.emitWriteWide64(loExpr, 64, ind)
-		g.emitWriteWide64(hiExpr, bits-64, ind)
+		g.chunkAdd(maskedPiece(loExpr, 64), 64, ind)
+		g.chunkAdd(maskedPiece(hiExpr, bits-64), bits-64, ind)
 	}
 }
 
@@ -523,30 +578,19 @@ func (g *gen) emitWriteScalar(f *ir.Field, name, ind string) {
 	case ir.TInt:
 		g.emitWriteInt(f, name, ind)
 	case ir.TBits:
-		w := int64(f.Type.Width)
-		if w <= 32 {
-			g.pf("%sv = %s & %s;\n", ind, name, maskHex(w))
-			g.mergeW(w, ind)
-			return
-		}
-		g.emitWriteWide64(name, w, ind)
+		g.emitWriteWide64(name, int64(f.Type.Width), ind)
 	case ir.TBool:
-		g.pf("%sv = %s ? 1 : 0;\n", ind, name)
-		g.mergeW(1, ind)
+		g.chunkAdd(fmt.Sprintf("(%s ? 1 : 0)", name), 1, ind)
 	case ir.TFloat32:
 		if f.HasFloatRange {
 			g.emitWriteCompressedFloat(f, name, ind)
 			return
 		}
 		g.needScratch, g.needF32Conv = true, true
-		g.pf("%sv = _float32BitsFromDouble(%s);\n", ind, name)
-		g.mergeW(32, ind)
+		g.chunkAdd(fmt.Sprintf("_float32BitsFromDouble(%s)", name), 32, ind)
 	case ir.TFloat64:
 		g.needScratch, g.needF64Conv = true, true
-		g.pf("%s{\n", ind)
-		g.pf("%s  final b = _float64BitsFromDouble(%s);\n", ind, name)
-		g.emitWriteWide64("b", 64, ind+"  ")
-		g.pf("%s}\n", ind)
+		g.chunkAdd(fmt.Sprintf("_float64BitsFromDouble(%s)", name), 64, ind)
 	case ir.TString, ir.TBytes:
 		g.emitWriteBytesField(f, name, ind)
 	case ir.TNamed:
@@ -573,6 +617,7 @@ func f32lit(v float64) string {
 // with the declaration folded: round to float32, normalize, clamp (which
 // also grounds NaN), quantize — every step through _fround (SPEC §4.3).
 func (g *gen) emitWriteCompressedFloat(f *ir.Field, name, ind string) {
+	g.chunkFlush(ind) // statement-form merge: v is computed in a block
 	g.needScratch, g.needFround = true, true
 	maxInt, bits := ir.CompressedFloatParams(f.FMin, f.FMax, f.Resolution)
 	minF := float32(f.FMin)
@@ -642,12 +687,7 @@ func (g *gen) emitWriteInt(f *ir.Field, name, ind string) {
 	// bare integer at storage width; signed values mask to the same-width
 	// unsigned pattern (the sign smear a wider merge would spread corrupts
 	// neighboring wire data, exactly as in C++)
-	if w == 64 {
-		g.emitWriteWide64(name, 64, ind)
-		return
-	}
-	g.pf("%sv = %s & %s;\n", ind, name, maskHex(w))
-	g.mergeW(w, ind)
+	g.emitWriteWide64(name, w, ind)
 }
 
 // emitWrite128Ranged writes a ranged 128-bit-storage value (int128/uint128,
@@ -673,6 +713,7 @@ func (g *gen) emitWrite128Ranged(signed bool, name string, min, max *big.Int, bi
 	guardLo := min.Cmp(loDomain) > 0
 	guardHi := max.Cmp(hiDomain) < 0
 	needMin := guardLo || min.Sign() != 0
+	g.chunkFlush(ind) // the pieces below may reference block-scoped consts
 	g.pf("%s{\n", ind)
 	if needMin {
 		g.pf("%s  const min = %s;\n", ind, g.pairCtor(signed, min))
@@ -696,6 +737,7 @@ func (g *gen) emitWrite128Ranged(signed bool, name string, min, max *big.Int, bi
 		g.pf("%s  final off = (%s - min)%s;\n", ind, name, u)
 		g.emitWriteWide128("off.lo", "off.hi", bits, ind+"  ")
 	}
+	g.chunkFlush(ind + "  ") // off/min are block-scoped: no piece may outlive them
 	g.pf("%s}\n", ind)
 }
 
@@ -706,8 +748,7 @@ func (g *gen) emitWriteEnum(ref *ir.Enum, name, ind string) {
 	if bits == 0 {
 		return // degenerate [0, 0]: zero bits; the assert still rides
 	}
-	g.pf("%sv = %s & %s;\n", ind, name, maskHex(bits))
-	g.mergeW(bits, ind)
+	g.chunkAdd(maskedPiece(name, bits), bits, ind)
 }
 
 func (g *gen) emitWriteFlags(ref *ir.Flags, name, ind string) {
@@ -715,11 +756,6 @@ func (g *gen) emitWriteFlags(ref *ir.Flags, name, ind string) {
 	if wb < 64 {
 		// a mask bit above the wire width cannot ride
 		g.pf("%sassert(%s >>> %d == 0);\n", ind, name, wb)
-	}
-	if wb <= 32 {
-		g.pf("%sv = %s & %s;\n", ind, name, maskHex(wb))
-		g.mergeW(wb, ind)
-		return
 	}
 	g.emitWriteWide64(name, wb, ind)
 }
@@ -752,13 +788,15 @@ func (g *gen) emitWriteUnion(u *ir.Union, expr, ind string) {
 		return // an empty union's degenerate tag range [0, 0] costs zero bits
 	}
 	bits := ir.BitsRequired(big.NewInt(0), big.NewInt(u.Max))
-	g.pf("%sv = %s.type & %s;\n", ind, expr, maskHex(bits))
-	g.mergeW(bits, ind)
+	g.chunkAdd(maskedPiece(expr+".type", bits), bits, ind)
+	g.chunkFlush(ind) // the arms diverge: the tag merges before the switch
 	g.pf("%sswitch (%s.type) {\n", ind, expr)
 	for i, vr := range u.Variants {
 		g.pf("%s  case %d:\n", ind, i+1)
+		before := g.fn.Len()
 		g.emitWriteItems(vr.Ref.Items, expr+"."+dartName(vr.Name), ind+"    ")
-		if len(vr.Ref.Items) == 0 {
+		g.chunkFlush(ind + "    ")
+		if g.fn.Len() == before {
 			g.pf("%s    break; // empty arm — presence is the payload (SPEC §4.6)\n", ind)
 		}
 	}

--- a/internal/codegen/dart/functions.go
+++ b/internal/codegen/dart/functions.go
@@ -516,7 +516,7 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 			g.pf("%s{\n", ind)
 			g.pf("%s  var %s = 0;\n", ind, iv)
 			g.pf("%s  for (; %s + %d <= %s; %s += %d) {\n", ind, iv, k, count, iv, k)
-			for j := int64(0); j < k; j++ {
+			for j := range k {
 				g.emitWriteElemNamed(f, name, groupIdx(iv, j), groupEv(g.loopDepth-1, j), ind+"    ")
 			}
 			g.chunkFlush(ind + "    ")
@@ -897,7 +897,7 @@ func (g *gen) byteAt(f *ir.Field, name, idx string) string {
 // keeps its byte-tail loop.
 func (g *gen) emitWriteByteRun(f *ir.Field, name, count string, staticCount int64, isStatic bool, ind string) {
 	if isStatic && staticCount <= 8 {
-		for k := int64(0); k < staticCount; k++ {
+		for k := range staticCount {
 			g.chunkAdd(g.byteAt(f, name, fmt.Sprintf("%d", k)), 8, ind)
 		}
 		return
@@ -1168,7 +1168,7 @@ func (g *gen) emitReadDynamicField(f *ir.Field, path, ind string) {
 				g.pf("%s{\n", ind)
 				g.pf("%s  var %s = 0;\n", ind, iv)
 				g.pf("%s  for (; %s + %d <= %s; %s += %d) {\n", ind, iv, k, count, iv, k)
-				for j := int64(0); j < k; j++ {
+				for j := range k {
 					g.emitReadElemNamed(f, name, groupIdx(iv, j), groupEv(g.loopDepth-1, j), ind+"    ", true)
 				}
 				g.invalidateWindow()

--- a/internal/codegen/dart/functions.go
+++ b/internal/codegen/dart/functions.go
@@ -509,6 +509,26 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 		g.emitWriteOffset(count, big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound), ind)
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++
+		if k := groupK(g.staticBitsScalarOK(f), 64); k >= 2 {
+			// grouped: k elements per iteration share the chunk lanes, so
+			// short elements merge together instead of one merge each
+			g.chunkFlush(ind)
+			g.pf("%s{\n", ind)
+			g.pf("%s  var %s = 0;\n", ind, iv)
+			g.pf("%s  for (; %s + %d <= %s; %s += %d) {\n", ind, iv, k, count, iv, k)
+			for j := int64(0); j < k; j++ {
+				g.emitWriteElemNamed(f, name, groupIdx(iv, j), groupEv(g.loopDepth-1, j), ind+"    ")
+			}
+			g.chunkFlush(ind + "    ")
+			g.pf("%s  }\n", ind)
+			g.pf("%s  for (; %s < %s; %s++) {\n", ind, iv, count, iv)
+			g.emitWriteElem(f, name, iv, ind+"    ")
+			g.chunkFlush(ind + "    ")
+			g.pf("%s  }\n", ind)
+			g.pf("%s}\n", ind)
+			g.loopDepth--
+			return
+		}
 		g.chunkFlush(ind)
 		g.pf("%sfor (var %s = 0; %s < %s; %s++) {\n", ind, iv, iv, count, iv)
 		g.emitWriteElem(f, name, iv, ind+"  ")
@@ -520,23 +540,64 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 	}
 }
 
+// staticBitsScalarOK is staticBitsScalar with the miss folded to zero bits.
+func (g *gen) staticBitsScalarOK(f *ir.Field) int64 {
+	if bits, ok := g.staticBitsScalar(f); ok {
+		return bits
+	}
+	return 0
+}
+
+// groupK is the element count per grouped loop iteration: how many
+// elemBits-sized elements share one staged lane of laneBits (64 on the
+// write side, 57 on the read side). Zero-bit and lane-filling elements
+// group as 1 — the plain loop.
+func groupK(elemBits, laneBits int64) int64 {
+	if elemBits <= 0 {
+		return 1
+	}
+	return laneBits / elemBits
+}
+
+// groupIdx renders the j-th element index of a grouped loop iteration.
+func groupIdx(iv string, j int64) string {
+	if j == 0 {
+		return iv
+	}
+	return fmt.Sprintf("%s + %d", iv, j)
+}
+
+// groupEv names the j-th hoisted element ref of a grouped loop iteration —
+// e0 keeps its plain-loop name, later elements suffix it (e0g1, e0g2) so
+// the unrolled hoists coexist in one scope.
+func groupEv(depth int, j int64) string {
+	if j == 0 {
+		return fmt.Sprintf("e%d", depth)
+	}
+	return fmt.Sprintf("e%dg%d", depth, j)
+}
+
 // emitWriteElem writes one array element; class elements hoist a final ref.
 func (g *gen) emitWriteElem(f *ir.Field, name, iv, ind string) {
+	g.emitWriteElemNamed(f, name, iv, fmt.Sprintf("e%d", g.loopDepth-1), ind)
+}
+
+// emitWriteElemNamed is emitWriteElem with the hoisted ref name chosen by
+// the caller — the grouped loops unroll several elements into one scope.
+func (g *gen) emitWriteElemNamed(f *ir.Field, name, idx, ev, ind string) {
 	if f.Type.Kind == ir.TNamed {
 		switch ref := f.Type.Ref.(type) {
 		case *ir.Struct:
-			ev := fmt.Sprintf("e%d", g.loopDepth-1)
-			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, iv)
+			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, idx)
 			g.emitWriteItems(ref.Items, ev, ind)
 			return
 		case *ir.Union:
-			ev := fmt.Sprintf("e%d", g.loopDepth-1)
-			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, iv)
+			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, idx)
 			g.emitWriteUnion(ref, ev, ind)
 			return
 		}
 	}
-	g.emitWriteScalar(f, fmt.Sprintf("%s[%s]", name, iv), ind)
+	g.emitWriteScalar(f, fmt.Sprintf("%s[%s]", name, idx), ind)
 }
 
 // assertRange emits the write-contract asserts for an integer path in
@@ -1044,25 +1105,29 @@ func (g *gen) emitReadStaticField(f *ir.Field, path, ind string) {
 }
 
 func (g *gen) emitReadElem(f *ir.Field, name, iv, ind string, bounded bool) {
+	g.emitReadElemNamed(f, name, iv, fmt.Sprintf("e%d", g.loopDepth-1), ind, bounded)
+}
+
+// emitReadElemNamed is emitReadElem with the hoisted ref name chosen by
+// the caller — the grouped loops unroll several elements into one scope.
+func (g *gen) emitReadElemNamed(f *ir.Field, name, idx, ev, ind string, bounded bool) {
 	if f.Type.Kind == ir.TNamed {
 		switch ref := f.Type.Ref.(type) {
 		case *ir.Struct:
-			ev := fmt.Sprintf("e%d", g.loopDepth-1)
-			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, iv)
+			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, idx)
 			g.emitReadItems(ref.Items, ev, ind, bounded)
 			return
 		case *ir.Union:
-			ev := fmt.Sprintf("e%d", g.loopDepth-1)
-			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, iv)
+			g.pf("%sfinal %s = %s[%s];\n", ind, ev, name, idx)
 			g.emitReadUnion(ref, ev, ind, bounded)
 			return
 		}
 	}
 	if is128(f.Type) {
-		g.emitRead128Scalar(f, fmt.Sprintf("%s[%s] = ", name, iv), ind)
+		g.emitRead128Scalar(f, fmt.Sprintf("%s[%s] = ", name, idx), ind)
 		return
 	}
-	g.emitReadScalar(f, fmt.Sprintf("%s[%s]", name, iv), ind, bounded)
+	g.emitReadScalar(f, fmt.Sprintf("%s[%s]", name, idx), ind, bounded)
 }
 
 func (g *gen) emitReadDynamicField(f *ir.Field, path, ind string) {
@@ -1097,6 +1162,24 @@ func (g *gen) emitReadDynamicField(f *ir.Field, path, ind string) {
 		if elemBits, ok := g.staticBitsScalar(f); ok {
 			if elemBits > 0 {
 				g.pf("%sif (bitsRead + %s * %d > numBits) {\n%s  return false;\n%s}\n", ind, count, elemBits, ind, ind)
+			}
+			if k := groupK(elemBits, 57); k >= 2 {
+				// grouped: k elements per iteration share one window load
+				g.pf("%s{\n", ind)
+				g.pf("%s  var %s = 0;\n", ind, iv)
+				g.pf("%s  for (; %s + %d <= %s; %s += %d) {\n", ind, iv, k, count, iv, k)
+				for j := int64(0); j < k; j++ {
+					g.emitReadElemNamed(f, name, groupIdx(iv, j), groupEv(g.loopDepth-1, j), ind+"    ", true)
+				}
+				g.invalidateWindow()
+				g.pf("%s  }\n", ind)
+				g.pf("%s  for (; %s < %s; %s++) {\n", ind, iv, count, iv)
+				g.emitReadElem(f, name, iv, ind+"    ", true)
+				g.invalidateWindow()
+				g.pf("%s  }\n", ind)
+				g.pf("%s}\n", ind)
+				g.loopDepth--
+				return
 			}
 			g.pf("%sfor (var %s = 0; %s < %s; %s++) {\n", ind, iv, iv, count, iv)
 			g.emitReadElem(f, name, iv, ind+"  ", true)

--- a/internal/codegen/dart/functions.go
+++ b/internal/codegen/dart/functions.go
@@ -134,21 +134,55 @@ func maskedPiece(expr string, bits int64) string {
 	return fmt.Sprintf("((%s) & %s)", expr, maskHex(bits))
 }
 
-// readR reads bits (in [1,32]) from the 64-bit window at bitsRead into v,
-// masked — serialize.dart BitReader.readBits inlined, with the tail window
-// pricing the loads inside the buffer (no slack contract).
+// emitWindowLoad pulls a fresh 64-bit extraction window at bitsRead, with
+// the byte-interior shift folded into the load — serialize.dart
+// BitReader.readBits' load half, with the tail window pricing the loads
+// inside the buffer (no slack contract). After the worst-case 7-bit shift
+// the window holds at least 57 valid payload bits (in the tail arm, every
+// bounds-proven remaining bit — numBits cannot exceed the buffer), so
+// consecutive constant-width reads share one load and one branch through
+// the compile-time (windowRel, windowAvail) ledger.
+func (g *gen) emitWindowLoad(ind string) {
+	g.usesRead = true
+	g.pf("%sif (bitsRead >>> 3 < tailBase) {\n", ind)
+	load := fmt.Sprintf("%s  window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);", ind)
+	if len(load) <= 80 {
+		g.pf("%s\n", load)
+	} else {
+		g.pf("%s  window =\n", ind)
+		g.pf("%s      view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);\n", ind)
+	}
+	g.pf("%s} else {\n", ind)
+	g.pf("%s  window = tailWord >>> (bitsRead - tailBase * 8);\n", ind)
+	g.pf("%s}\n", ind)
+	g.windowRel = 0
+	g.windowAvail = 57
+}
+
+// invalidateWindow forgets the extraction window ledger. Every point where
+// bitsRead moves by a dynamic amount, and every scope boundary (loop body,
+// branch arm, switch arm), must invalidate: the ledger is compile-time
+// state and the runtime paths diverge there.
+func (g *gen) invalidateWindow() {
+	g.windowRel, g.windowAvail = 0, 0
+}
+
+// readR reads bits (in [1,32]) at bitsRead into v, masked — an extraction
+// from the shared window, loading a fresh one only when the ledger runs dry.
 func (g *gen) readR(bits int64, ind string) {
 	g.needV = true
 	g.usesRead = true
-	g.pf("%sif (bitsRead >>> 3 < tailBase) {\n", ind)
-	g.pf("%s  window = view.getUint64(bitsRead >>> 3, Endian.little);\n", ind)
-	g.pf("%s  shift = bitsRead & 7;\n", ind)
-	g.pf("%s} else {\n", ind)
-	g.pf("%s  window = tailWord;\n", ind)
-	g.pf("%s  shift = bitsRead - tailBase * 8;\n", ind)
-	g.pf("%s}\n", ind)
-	g.pf("%sv = (window >>> shift) & %s;\n", ind, maskHex(bits))
+	if g.windowAvail < bits {
+		g.emitWindowLoad(ind)
+	}
+	if g.windowRel == 0 {
+		g.pf("%sv = window & %s;\n", ind, maskHex(bits))
+	} else {
+		g.pf("%sv = (window >>> %d) & %s;\n", ind, g.windowRel, maskHex(bits))
+	}
 	g.pf("%sbitsRead += %d;\n", ind, bits)
+	g.windowRel += bits
+	g.windowAvail -= bits
 }
 
 // ---- static wire-width analysis for run fusing ----
@@ -357,7 +391,6 @@ func (g *gen) emitReadFunction(name, low string, items []ir.Item) {
 		g.bpf("  }\n")
 		g.bpf("  var bitsRead = 0;\n")
 		g.bpf("  var window = 0;\n")
-		g.bpf("  var shift = 0;\n")
 	}
 	if g.needV {
 		g.bpf("  var v = 0;\n")
@@ -908,14 +941,17 @@ func (g *gen) emitReadStaticItem(item ir.Item, path, ind string) {
 		if item.Neg {
 			neg = "!"
 		}
+		g.invalidateWindow()
 		g.pf("%sif (%s%s.%s) {\n", ind, neg, path, dartName(item.Cond))
 		g.emitReadItems(item.Then, path, ind+"  ", true)
 		g.emitZeroItems(item.Else, path, ind+"  ")
+		g.invalidateWindow()
 		g.pf("%s} else {\n", ind)
 		if item.Else != nil {
 			g.emitReadItems(item.Else, path, ind+"  ", true)
 		}
 		g.emitZeroItems(item.Then, path, ind+"  ")
+		g.invalidateWindow()
 		g.pf("%s}\n", ind)
 	}
 }
@@ -931,14 +967,17 @@ func (g *gen) emitReadDynamicItem(item ir.Item, path, ind string) {
 		if item.Neg {
 			neg = "!"
 		}
+		g.invalidateWindow()
 		g.pf("%sif (%s%s.%s) {\n", ind, neg, path, dartName(item.Cond))
 		g.emitReadItems(item.Then, path, ind+"  ", false)
 		g.emitZeroItems(item.Else, path, ind+"  ")
+		g.invalidateWindow()
 		g.pf("%s} else {\n", ind)
 		if item.Else != nil {
 			g.emitReadItems(item.Else, path, ind+"  ", false)
 		}
 		g.emitZeroItems(item.Then, path, ind+"  ")
+		g.invalidateWindow()
 		g.pf("%s}\n", ind)
 	}
 }
@@ -946,6 +985,7 @@ func (g *gen) emitReadDynamicItem(item ir.Item, path, ind string) {
 // emitReadAlign verifies zero padding to the byte boundary and advances.
 func (g *gen) emitReadAlign(ind string) {
 	g.usesRead = true
+	g.invalidateWindow() // bitsRead moves by a dynamic amount
 	g.pf("%s{\n", ind)
 	g.pf("%s  final pad = bitsRead & 7;\n", ind)
 	g.pf("%s  if (pad != 0) {\n", ind)
@@ -982,10 +1022,20 @@ func (g *gen) emitReadStaticField(f *ir.Field, path, ind string) {
 		name = path
 	}
 	if f.Array == ir.ArrayFixed {
+		if isBareByte(f) && f.ArrayBound <= 8 {
+			// the bulk-bytes read twin (#165): a short byte array unrolls to
+			// window extractions instead of paying a loop of window loads
+			for k := int64(0); k < f.ArrayBound; k++ {
+				g.emitReadScalar(f, fmt.Sprintf("%s[%d]", name, k), ind, true)
+			}
+			return
+		}
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++
+		g.invalidateWindow()
 		g.pf("%sfor (var %s = 0; %s < %d; %s++) {\n", ind, iv, iv, f.ArrayBound, iv)
 		g.emitReadElem(f, name, iv, ind+"  ", true)
+		g.invalidateWindow()
 		g.pf("%s}\n", ind)
 		g.loopDepth--
 		return
@@ -1043,16 +1093,19 @@ func (g *gen) emitReadDynamicField(f *ir.Field, path, ind string) {
 		}
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++
+		g.invalidateWindow()
 		if elemBits, ok := g.staticBitsScalar(f); ok {
 			if elemBits > 0 {
 				g.pf("%sif (bitsRead + %s * %d > numBits) {\n%s  return false;\n%s}\n", ind, count, elemBits, ind, ind)
 			}
 			g.pf("%sfor (var %s = 0; %s < %s; %s++) {\n", ind, iv, iv, count, iv)
 			g.emitReadElem(f, name, iv, ind+"  ", true)
+			g.invalidateWindow()
 			g.pf("%s}\n", ind)
 		} else {
 			g.pf("%sfor (var %s = 0; %s < %s; %s++) {\n", ind, iv, iv, count, iv)
 			g.emitReadElem(f, name, iv, ind+"  ", false)
+			g.invalidateWindow()
 			g.pf("%s}\n", ind)
 		}
 		g.loopDepth--
@@ -1061,8 +1114,10 @@ func (g *gen) emitReadDynamicField(f *ir.Field, path, ind string) {
 		// strings)
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++
+		g.invalidateWindow()
 		g.pf("%sfor (var %s = 0; %s < %d; %s++) {\n", ind, iv, iv, f.ArrayBound, iv)
 		g.emitReadElem(f, name, iv, ind+"  ", false)
+		g.invalidateWindow()
 		g.pf("%s}\n", ind)
 		g.loopDepth--
 	default:
@@ -1100,6 +1155,7 @@ func (g *gen) emitReadBytesField(f *ir.Field, name, ind string) {
 	g.pf("%s  }\n", ind)
 	g.pf("%s}\n", ind)
 	g.pf("%sbitsRead += %s * 8;\n", ind, length)
+	g.invalidateWindow() // bitsRead moved by a dynamic amount
 	if f.Type.Kind == ir.TString {
 		g.pf("%sfor (var %s = 0; %s < %s; %s++) {\n", ind, iv, iv, length, iv)
 		g.pf("%s  if (%s[%s] == 0) {\n", ind, name, iv)
@@ -1110,10 +1166,26 @@ func (g *gen) emitReadBytesField(f *ir.Field, name, ind string) {
 	g.loopDepth--
 }
 
-// emitReadWide64 assembles a 33..64-bit group pair into lo (low dword
-// first — the serialize group order).
+// emitReadWide64 assembles a 33..64-bit value into lo. Through 57 bits the
+// field is one window extraction — its 32-bit groups are contiguous on the
+// wire, so the single masked read IS the low-dword-first pair. Past 57 the
+// two-group form stands (a window cannot guarantee more than 57 bits).
 func (g *gen) emitReadWide64(bits int64, ind string) {
 	g.needLo = true
+	if bits <= 57 {
+		if g.windowAvail < bits {
+			g.emitWindowLoad(ind)
+		}
+		if g.windowRel == 0 {
+			g.pf("%slo = window & %s;\n", ind, maskHex(bits))
+		} else {
+			g.pf("%slo = (window >>> %d) & %s;\n", ind, g.windowRel, maskHex(bits))
+		}
+		g.pf("%sbitsRead += %d;\n", ind, bits)
+		g.windowRel += bits
+		g.windowAvail -= bits
+		return
+	}
 	g.readR(32, ind)
 	g.pf("%slo = v;\n", ind)
 	g.readR(bits-32, ind)
@@ -1416,6 +1488,7 @@ func (g *gen) emitReadUnion(u *ir.Union, expr, ind string, bounded bool) {
 			g.emitZeroField(nf, arm, ind+"    ", false)
 			empty = false
 		}
+		g.invalidateWindow() // the arms' read positions diverge
 		before := g.fn.Len()
 		g.emitReadItems(vr.Ref.Items, arm, ind+"    ", false)
 		if g.fn.Len() > before {
@@ -1426,6 +1499,7 @@ func (g *gen) emitReadUnion(u *ir.Union, expr, ind string, bounded bool) {
 		}
 	}
 	g.pf("%s}\n", ind)
+	g.invalidateWindow()
 }
 
 // ---- zeroing (SPEC §5: untaken branch sides read as ZERO) ----

--- a/internal/codegen/dart/functions.go
+++ b/internal/codegen/dart/functions.go
@@ -458,6 +458,10 @@ func (g *gen) emitWriteField(f *ir.Field, path, ind string) {
 	}
 	switch f.Array {
 	case ir.ArrayFixed:
+		if isBareByte(f) {
+			g.emitWriteByteRun(f, name, fmt.Sprintf("%d", f.ArrayBound), f.ArrayBound, true, ind)
+			return
+		}
 		iv := fmt.Sprintf("i%d", g.loopDepth)
 		g.loopDepth++
 		g.chunkFlush(ind)
@@ -763,18 +767,72 @@ func (g *gen) emitWriteFlags(ref *ir.Flags, name, ind string) {
 // emitWriteBytesField writes string(N)/bytes(N): folded ranged length,
 // align (zero pad), then the used bytes through the packer — the classic
 // serialize_string framing composed from primitives, byte-identical to
-// every other target's.
+// every other target's. The body rides the bulk-bytes path (#165).
 func (g *gen) emitWriteBytesField(f *ir.Field, name, ind string) {
 	length := name + "Length"
 	g.assertRange(length, big.NewInt(0), big.NewInt(f.Type.Size), true, ind)
 	g.emitWriteOffset(length, big.NewInt(0), big.NewInt(f.Type.Size), ind)
 	g.emitWriteAlign(ind)
+	g.emitWriteByteRun(f, name, length, f.Type.Size, false, ind)
+}
+
+// isBareByte reports a field whose elements are raw uint8/int8 wire bytes —
+// the bulk-bytes shape (#165): each element is exactly one wire byte, so
+// runs group into 32-bit merges instead of paying the merge per byte. The
+// grouping needs no alignment: LSB-first merging of the 4-byte concatenation
+// equals merging the bytes in sequence at ANY bit position.
+func isBareByte(f *ir.Field) bool {
+	return f.Type.Kind == ir.TInt && f.Type.Width == 8 && !f.HasIntRange
+}
+
+// byteAt renders one source byte as a chunk piece expression; int8 storage
+// masks to the wire byte, uint8 storage loads pre-masked.
+func (g *gen) byteAt(f *ir.Field, name, idx string) string {
+	if f.Type.Signed {
+		return fmt.Sprintf("(%s[%s] & 0xff)", name, idx)
+	}
+	return fmt.Sprintf("%s[%s]", name, idx)
+}
+
+// emitWriteByteRun writes `count` raw bytes of a byte-element list (a
+// string/bytes body or a bare [N]uint8 array) through the bulk path:
+// a static run of 8 or fewer bytes queues as chunk pieces (it can join
+// neighboring fields in one merge); longer or dynamic runs take 4 bytes per
+// merge with a byte tail. isStatic says count renders the literal
+// staticCount (a fixed array); a dynamic count (a string/bytes length)
+// keeps its byte-tail loop.
+func (g *gen) emitWriteByteRun(f *ir.Field, name, count string, staticCount int64, isStatic bool, ind string) {
+	if isStatic && staticCount <= 8 {
+		for k := int64(0); k < staticCount; k++ {
+			g.chunkAdd(g.byteAt(f, name, fmt.Sprintf("%d", k)), 8, ind)
+		}
+		return
+	}
 	iv := fmt.Sprintf("i%d", g.loopDepth)
 	g.loopDepth++
-	g.pf("%sfor (var %s = 0; %s < %s; %s++) {\n", ind, iv, iv, length, iv)
-	g.pf("%s  v = %s[%s];\n", ind, name, iv)
-	g.mergeW(8, ind+"  ")
+	g.chunkFlush(ind)
+	g.pf("%s{\n", ind)
+	g.pf("%s  var %s = 0;\n", ind, iv)
+	g.pf("%s  for (; %s + 4 <= %s; %s += 4) {\n", ind, iv, count, iv)
+	g.chunkAdd(g.byteAt(f, name, iv), 8, ind+"    ")
+	g.chunkAdd(g.byteAt(f, name, iv+" + 1"), 8, ind+"    ")
+	g.chunkAdd(g.byteAt(f, name, iv+" + 2"), 8, ind+"    ")
+	g.chunkAdd(g.byteAt(f, name, iv+" + 3"), 8, ind+"    ")
+	g.chunkFlush(ind + "    ")
+	g.pf("%s  }\n", ind)
+	if !isStatic {
+		g.pf("%s  for (; %s < %s; %s++) {\n", ind, iv, count, iv)
+		g.chunkAdd(g.byteAt(f, name, iv), 8, ind+"    ")
+		g.chunkFlush(ind + "    ")
+		g.pf("%s  }\n", ind)
+	}
 	g.pf("%s}\n", ind)
+	if isStatic {
+		// the tail indices are literals: it queues into the neighbor chunks
+		for k := staticCount - staticCount%4; k < staticCount; k++ {
+			g.chunkAdd(g.byteAt(f, name, fmt.Sprintf("%d", k)), 8, ind)
+		}
+	}
 	g.loopDepth--
 }
 

--- a/testdata/golden/dart/Clauses.dart
+++ b/testdata/golden/dart/Clauses.dart
@@ -37,7 +37,7 @@ int writeW13(W13 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 12);
-  v = (value.itemsCount) & 0xf;
+  v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -46,17 +46,43 @@ int writeW13(W13 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (4 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 8191);
-    v = (value.items[i0]) & 0x1fff;
-    scratch |= v << scratchBits;
-    scratchBits += 13;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (13 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 8191);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 8191);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 8191);
+      v =
+          ((value.items[i0]) & 0x1fff) |
+          (((value.items[i0 + 1]) & 0x1fff) << 13) |
+          (((value.items[i0 + 2]) & 0x1fff) << 26) |
+          (((value.items[i0 + 3]) & 0x1fff) << 39);
+      scratch |= v << scratchBits;
+      scratchBits += 52;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (52 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      v = ((value.items[i0]) & 0x1fff);
+      scratch |= v << scratchBits;
+      scratchBits += 13;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (13 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -86,19 +112,16 @@ bool readW13(W13 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 12) {
     return false; // the count guards the loop — reject, never clamp
@@ -107,17 +130,39 @@ bool readW13(W13 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 13 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+      v = (window >>> 13) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 1] = v;
+      v = (window >>> 26) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 2] = v;
+      v = (window >>> 39) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 3] = v;
     }
-    v = (window >>> shift) & 0x1fff;
-    bitsRead += 13;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -162,7 +207,7 @@ int writeW17(W17 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 9);
-  v = (value.itemsCount) & 0xf;
+  v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -171,17 +216,40 @@ int writeW17(W17 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (4 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 131071);
-    v = (value.items[i0]) & 0x1ffff;
-    scratch |= v << scratchBits;
-    scratchBits += 17;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (17 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.itemsCount; i0 += 3) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 131071);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 131071);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 131071);
+      v =
+          ((value.items[i0]) & 0x1ffff) |
+          (((value.items[i0 + 1]) & 0x1ffff) << 17) |
+          (((value.items[i0 + 2]) & 0x1ffff) << 34);
+      scratch |= v << scratchBits;
+      scratchBits += 51;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (51 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 131071);
+      v = ((value.items[i0]) & 0x1ffff);
+      scratch |= v << scratchBits;
+      scratchBits += 17;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (17 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -211,19 +279,16 @@ bool readW17(W17 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 9) {
     return false; // the count guards the loop — reject, never clamp
@@ -232,17 +297,36 @@ bool readW17(W17 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 17 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.itemsCount; i0 += 3) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0] = v;
+      v = (window >>> 17) & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0 + 1] = v;
+      v = (window >>> 34) & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0 + 2] = v;
     }
-    v = (window >>> shift) & 0x1ffff;
-    bitsRead += 17;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1ffff;
+      bitsRead += 17;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -287,7 +371,7 @@ int writeW26(W26 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 6);
-  v = (value.itemsCount) & 0x7;
+  v = ((value.itemsCount) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -296,17 +380,37 @@ int writeW26(W26 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (3 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 67108863);
-    v = (value.items[i0]) & 0x3ffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 26;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (26 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 2 <= value.itemsCount; i0 += 2) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 67108863);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 67108863);
+      v =
+          ((value.items[i0]) & 0x3ffffff) |
+          (((value.items[i0 + 1]) & 0x3ffffff) << 26);
+      scratch |= v << scratchBits;
+      scratchBits += 52;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (52 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 67108863);
+      v = ((value.items[i0]) & 0x3ffffff);
+      scratch |= v << scratchBits;
+      scratchBits += 26;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (26 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -336,19 +440,16 @@ bool readW26(W26 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   if (v > 6) {
     return false; // the count guards the loop — reject, never clamp
@@ -357,17 +458,33 @@ bool readW26(W26 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 26 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 2 <= value.itemsCount; i0 += 2) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x3ffffff;
+      bitsRead += 26;
+      value.items[i0] = v;
+      v = (window >>> 26) & 0x3ffffff;
+      bitsRead += 26;
+      value.items[i0 + 1] = v;
     }
-    v = (window >>> shift) & 0x3ffffff;
-    bitsRead += 26;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x3ffffff;
+      bitsRead += 26;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -412,7 +529,7 @@ int writeW1(W1 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 20);
-  v = (value.itemsCount) & 0x1f;
+  v = ((value.itemsCount) & 0x1f);
   scratch |= v << scratchBits;
   scratchBits += 5;
   if (scratchBits >= 64) {
@@ -421,17 +538,223 @@ int writeW1(W1 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (5 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 1);
-    v = (value.items[i0]) & 0x1;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 64 <= value.itemsCount; i0 += 64) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 1);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 1);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 1);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 1);
+      assert(value.items[i0 + 4] >= 0);
+      assert(value.items[i0 + 4] <= 1);
+      assert(value.items[i0 + 5] >= 0);
+      assert(value.items[i0 + 5] <= 1);
+      assert(value.items[i0 + 6] >= 0);
+      assert(value.items[i0 + 6] <= 1);
+      assert(value.items[i0 + 7] >= 0);
+      assert(value.items[i0 + 7] <= 1);
+      assert(value.items[i0 + 8] >= 0);
+      assert(value.items[i0 + 8] <= 1);
+      assert(value.items[i0 + 9] >= 0);
+      assert(value.items[i0 + 9] <= 1);
+      assert(value.items[i0 + 10] >= 0);
+      assert(value.items[i0 + 10] <= 1);
+      assert(value.items[i0 + 11] >= 0);
+      assert(value.items[i0 + 11] <= 1);
+      assert(value.items[i0 + 12] >= 0);
+      assert(value.items[i0 + 12] <= 1);
+      assert(value.items[i0 + 13] >= 0);
+      assert(value.items[i0 + 13] <= 1);
+      assert(value.items[i0 + 14] >= 0);
+      assert(value.items[i0 + 14] <= 1);
+      assert(value.items[i0 + 15] >= 0);
+      assert(value.items[i0 + 15] <= 1);
+      assert(value.items[i0 + 16] >= 0);
+      assert(value.items[i0 + 16] <= 1);
+      assert(value.items[i0 + 17] >= 0);
+      assert(value.items[i0 + 17] <= 1);
+      assert(value.items[i0 + 18] >= 0);
+      assert(value.items[i0 + 18] <= 1);
+      assert(value.items[i0 + 19] >= 0);
+      assert(value.items[i0 + 19] <= 1);
+      assert(value.items[i0 + 20] >= 0);
+      assert(value.items[i0 + 20] <= 1);
+      assert(value.items[i0 + 21] >= 0);
+      assert(value.items[i0 + 21] <= 1);
+      assert(value.items[i0 + 22] >= 0);
+      assert(value.items[i0 + 22] <= 1);
+      assert(value.items[i0 + 23] >= 0);
+      assert(value.items[i0 + 23] <= 1);
+      assert(value.items[i0 + 24] >= 0);
+      assert(value.items[i0 + 24] <= 1);
+      assert(value.items[i0 + 25] >= 0);
+      assert(value.items[i0 + 25] <= 1);
+      assert(value.items[i0 + 26] >= 0);
+      assert(value.items[i0 + 26] <= 1);
+      assert(value.items[i0 + 27] >= 0);
+      assert(value.items[i0 + 27] <= 1);
+      assert(value.items[i0 + 28] >= 0);
+      assert(value.items[i0 + 28] <= 1);
+      assert(value.items[i0 + 29] >= 0);
+      assert(value.items[i0 + 29] <= 1);
+      assert(value.items[i0 + 30] >= 0);
+      assert(value.items[i0 + 30] <= 1);
+      assert(value.items[i0 + 31] >= 0);
+      assert(value.items[i0 + 31] <= 1);
+      assert(value.items[i0 + 32] >= 0);
+      assert(value.items[i0 + 32] <= 1);
+      assert(value.items[i0 + 33] >= 0);
+      assert(value.items[i0 + 33] <= 1);
+      assert(value.items[i0 + 34] >= 0);
+      assert(value.items[i0 + 34] <= 1);
+      assert(value.items[i0 + 35] >= 0);
+      assert(value.items[i0 + 35] <= 1);
+      assert(value.items[i0 + 36] >= 0);
+      assert(value.items[i0 + 36] <= 1);
+      assert(value.items[i0 + 37] >= 0);
+      assert(value.items[i0 + 37] <= 1);
+      assert(value.items[i0 + 38] >= 0);
+      assert(value.items[i0 + 38] <= 1);
+      assert(value.items[i0 + 39] >= 0);
+      assert(value.items[i0 + 39] <= 1);
+      assert(value.items[i0 + 40] >= 0);
+      assert(value.items[i0 + 40] <= 1);
+      assert(value.items[i0 + 41] >= 0);
+      assert(value.items[i0 + 41] <= 1);
+      assert(value.items[i0 + 42] >= 0);
+      assert(value.items[i0 + 42] <= 1);
+      assert(value.items[i0 + 43] >= 0);
+      assert(value.items[i0 + 43] <= 1);
+      assert(value.items[i0 + 44] >= 0);
+      assert(value.items[i0 + 44] <= 1);
+      assert(value.items[i0 + 45] >= 0);
+      assert(value.items[i0 + 45] <= 1);
+      assert(value.items[i0 + 46] >= 0);
+      assert(value.items[i0 + 46] <= 1);
+      assert(value.items[i0 + 47] >= 0);
+      assert(value.items[i0 + 47] <= 1);
+      assert(value.items[i0 + 48] >= 0);
+      assert(value.items[i0 + 48] <= 1);
+      assert(value.items[i0 + 49] >= 0);
+      assert(value.items[i0 + 49] <= 1);
+      assert(value.items[i0 + 50] >= 0);
+      assert(value.items[i0 + 50] <= 1);
+      assert(value.items[i0 + 51] >= 0);
+      assert(value.items[i0 + 51] <= 1);
+      assert(value.items[i0 + 52] >= 0);
+      assert(value.items[i0 + 52] <= 1);
+      assert(value.items[i0 + 53] >= 0);
+      assert(value.items[i0 + 53] <= 1);
+      assert(value.items[i0 + 54] >= 0);
+      assert(value.items[i0 + 54] <= 1);
+      assert(value.items[i0 + 55] >= 0);
+      assert(value.items[i0 + 55] <= 1);
+      assert(value.items[i0 + 56] >= 0);
+      assert(value.items[i0 + 56] <= 1);
+      assert(value.items[i0 + 57] >= 0);
+      assert(value.items[i0 + 57] <= 1);
+      assert(value.items[i0 + 58] >= 0);
+      assert(value.items[i0 + 58] <= 1);
+      assert(value.items[i0 + 59] >= 0);
+      assert(value.items[i0 + 59] <= 1);
+      assert(value.items[i0 + 60] >= 0);
+      assert(value.items[i0 + 60] <= 1);
+      assert(value.items[i0 + 61] >= 0);
+      assert(value.items[i0 + 61] <= 1);
+      assert(value.items[i0 + 62] >= 0);
+      assert(value.items[i0 + 62] <= 1);
+      assert(value.items[i0 + 63] >= 0);
+      assert(value.items[i0 + 63] <= 1);
+      v =
+          ((value.items[i0]) & 0x1) |
+          (((value.items[i0 + 1]) & 0x1) << 1) |
+          (((value.items[i0 + 2]) & 0x1) << 2) |
+          (((value.items[i0 + 3]) & 0x1) << 3) |
+          (((value.items[i0 + 4]) & 0x1) << 4) |
+          (((value.items[i0 + 5]) & 0x1) << 5) |
+          (((value.items[i0 + 6]) & 0x1) << 6) |
+          (((value.items[i0 + 7]) & 0x1) << 7) |
+          (((value.items[i0 + 8]) & 0x1) << 8) |
+          (((value.items[i0 + 9]) & 0x1) << 9) |
+          (((value.items[i0 + 10]) & 0x1) << 10) |
+          (((value.items[i0 + 11]) & 0x1) << 11) |
+          (((value.items[i0 + 12]) & 0x1) << 12) |
+          (((value.items[i0 + 13]) & 0x1) << 13) |
+          (((value.items[i0 + 14]) & 0x1) << 14) |
+          (((value.items[i0 + 15]) & 0x1) << 15) |
+          (((value.items[i0 + 16]) & 0x1) << 16) |
+          (((value.items[i0 + 17]) & 0x1) << 17) |
+          (((value.items[i0 + 18]) & 0x1) << 18) |
+          (((value.items[i0 + 19]) & 0x1) << 19) |
+          (((value.items[i0 + 20]) & 0x1) << 20) |
+          (((value.items[i0 + 21]) & 0x1) << 21) |
+          (((value.items[i0 + 22]) & 0x1) << 22) |
+          (((value.items[i0 + 23]) & 0x1) << 23) |
+          (((value.items[i0 + 24]) & 0x1) << 24) |
+          (((value.items[i0 + 25]) & 0x1) << 25) |
+          (((value.items[i0 + 26]) & 0x1) << 26) |
+          (((value.items[i0 + 27]) & 0x1) << 27) |
+          (((value.items[i0 + 28]) & 0x1) << 28) |
+          (((value.items[i0 + 29]) & 0x1) << 29) |
+          (((value.items[i0 + 30]) & 0x1) << 30) |
+          (((value.items[i0 + 31]) & 0x1) << 31) |
+          (((value.items[i0 + 32]) & 0x1) << 32) |
+          (((value.items[i0 + 33]) & 0x1) << 33) |
+          (((value.items[i0 + 34]) & 0x1) << 34) |
+          (((value.items[i0 + 35]) & 0x1) << 35) |
+          (((value.items[i0 + 36]) & 0x1) << 36) |
+          (((value.items[i0 + 37]) & 0x1) << 37) |
+          (((value.items[i0 + 38]) & 0x1) << 38) |
+          (((value.items[i0 + 39]) & 0x1) << 39) |
+          (((value.items[i0 + 40]) & 0x1) << 40) |
+          (((value.items[i0 + 41]) & 0x1) << 41) |
+          (((value.items[i0 + 42]) & 0x1) << 42) |
+          (((value.items[i0 + 43]) & 0x1) << 43) |
+          (((value.items[i0 + 44]) & 0x1) << 44) |
+          (((value.items[i0 + 45]) & 0x1) << 45) |
+          (((value.items[i0 + 46]) & 0x1) << 46) |
+          (((value.items[i0 + 47]) & 0x1) << 47) |
+          (((value.items[i0 + 48]) & 0x1) << 48) |
+          (((value.items[i0 + 49]) & 0x1) << 49) |
+          (((value.items[i0 + 50]) & 0x1) << 50) |
+          (((value.items[i0 + 51]) & 0x1) << 51) |
+          (((value.items[i0 + 52]) & 0x1) << 52) |
+          (((value.items[i0 + 53]) & 0x1) << 53) |
+          (((value.items[i0 + 54]) & 0x1) << 54) |
+          (((value.items[i0 + 55]) & 0x1) << 55) |
+          (((value.items[i0 + 56]) & 0x1) << 56) |
+          (((value.items[i0 + 57]) & 0x1) << 57) |
+          (((value.items[i0 + 58]) & 0x1) << 58) |
+          (((value.items[i0 + 59]) & 0x1) << 59) |
+          (((value.items[i0 + 60]) & 0x1) << 60) |
+          (((value.items[i0 + 61]) & 0x1) << 61) |
+          (((value.items[i0 + 62]) & 0x1) << 62) |
+          (((value.items[i0 + 63]) & 0x1) << 63);
+      scratch |= v << scratchBits;
+      scratchBits += 64;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (64 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 1);
+      v = ((value.items[i0]) & 0x1);
+      scratch |= v << scratchBits;
+      scratchBits += 1;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (1 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -461,19 +784,16 @@ bool readW1(W1 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   if (v > 20) {
     return false; // the count guards the loop — reject, never clamp
@@ -482,17 +802,198 @@ bool readW1(W1 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 1 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 57 <= value.itemsCount; i0 += 57) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      value.items[i0] = v;
+      v = (window >>> 1) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 1] = v;
+      v = (window >>> 2) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 2] = v;
+      v = (window >>> 3) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 3] = v;
+      v = (window >>> 4) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 4] = v;
+      v = (window >>> 5) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 5] = v;
+      v = (window >>> 6) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 6] = v;
+      v = (window >>> 7) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 7] = v;
+      v = (window >>> 8) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 8] = v;
+      v = (window >>> 9) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 9] = v;
+      v = (window >>> 10) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 10] = v;
+      v = (window >>> 11) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 11] = v;
+      v = (window >>> 12) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 12] = v;
+      v = (window >>> 13) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 13] = v;
+      v = (window >>> 14) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 14] = v;
+      v = (window >>> 15) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 15] = v;
+      v = (window >>> 16) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 16] = v;
+      v = (window >>> 17) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 17] = v;
+      v = (window >>> 18) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 18] = v;
+      v = (window >>> 19) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 19] = v;
+      v = (window >>> 20) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 20] = v;
+      v = (window >>> 21) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 21] = v;
+      v = (window >>> 22) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 22] = v;
+      v = (window >>> 23) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 23] = v;
+      v = (window >>> 24) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 24] = v;
+      v = (window >>> 25) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 25] = v;
+      v = (window >>> 26) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 26] = v;
+      v = (window >>> 27) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 27] = v;
+      v = (window >>> 28) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 28] = v;
+      v = (window >>> 29) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 29] = v;
+      v = (window >>> 30) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 30] = v;
+      v = (window >>> 31) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 31] = v;
+      v = (window >>> 32) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 32] = v;
+      v = (window >>> 33) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 33] = v;
+      v = (window >>> 34) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 34] = v;
+      v = (window >>> 35) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 35] = v;
+      v = (window >>> 36) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 36] = v;
+      v = (window >>> 37) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 37] = v;
+      v = (window >>> 38) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 38] = v;
+      v = (window >>> 39) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 39] = v;
+      v = (window >>> 40) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 40] = v;
+      v = (window >>> 41) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 41] = v;
+      v = (window >>> 42) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 42] = v;
+      v = (window >>> 43) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 43] = v;
+      v = (window >>> 44) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 44] = v;
+      v = (window >>> 45) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 45] = v;
+      v = (window >>> 46) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 46] = v;
+      v = (window >>> 47) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 47] = v;
+      v = (window >>> 48) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 48] = v;
+      v = (window >>> 49) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 49] = v;
+      v = (window >>> 50) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 50] = v;
+      v = (window >>> 51) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 51] = v;
+      v = (window >>> 52) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 52] = v;
+      v = (window >>> 53) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 53] = v;
+      v = (window >>> 54) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 54] = v;
+      v = (window >>> 55) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 55] = v;
+      v = (window >>> 56) & 0x1;
+      bitsRead += 1;
+      value.items[i0 + 56] = v;
     }
-    v = (window >>> shift) & 0x1;
-    bitsRead += 1;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      value.items[i0] = v;
+    }
   }
   return true;
 }
@@ -537,7 +1038,7 @@ int writeW52(W52 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -549,23 +1050,14 @@ int writeW52(W52 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 4503599627370495);
-    v = value.items[i0] & 0xffffffff;
+    v = ((value.items[i0]) & 0xfffffffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 52;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.items[i0] >>> 32) & 0xfffff;
-    scratch |= v << scratchBits;
-    scratchBits += 20;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (20 - scratchBits);
+      scratch = v >>> (52 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -595,20 +1087,17 @@ bool readW52(W52 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   if (bitsRead + value.itemsCount * 52 > numBits) {
@@ -616,25 +1105,12 @@ bool readW52(W52 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
-    bitsRead += 32;
-    lo = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xfffff;
-    bitsRead += 20;
-    lo |= v << 32;
+    lo = window & 0xfffffffffffff;
+    bitsRead += 52;
     value.items[i0] = lo;
   }
   return true;
@@ -680,7 +1156,7 @@ int writeW50(W50 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.itemsCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -692,23 +1168,14 @@ int writeW50(W50 value, ByteData view) {
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 1125899906842623);
-    v = value.items[i0] & 0xffffffff;
+    v = ((value.items[i0]) & 0x3ffffffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 50;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.items[i0] >>> 32) & 0x3ffff;
-    scratch |= v << scratchBits;
-    scratchBits += 18;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (18 - scratchBits);
+      scratch = v >>> (50 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -738,20 +1205,17 @@ bool readW50(W50 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   if (bitsRead + value.itemsCount * 50 > numBits) {
@@ -759,25 +1223,12 @@ bool readW50(W50 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
-    bitsRead += 32;
-    lo = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3ffff;
-    bitsRead += 18;
-    lo |= v << 32;
+    lo = window & 0x3ffffffffffff;
+    bitsRead += 50;
     value.items[i0] = lo;
   }
   return true;
@@ -822,7 +1273,7 @@ int writeF13(F13 value, ByteData view) {
   for (var i0 = 0; i0 < 7; i0++) {
     assert(value.items[i0] >= 0);
     assert(value.items[i0] <= 8191);
-    v = (value.items[i0]) & 0x1fff;
+    v = ((value.items[i0]) & 0x1fff);
     scratch |= v << scratchBits;
     scratchBits += 13;
     if (scratchBits >= 64) {
@@ -859,20 +1310,17 @@ bool readF13(F13 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 91 > numBits) {
     return false;
   }
   for (var i0 = 0; i0 < 7; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fff;
+    v = window & 0x1fff;
     bitsRead += 13;
     value.items[i0] = v;
   }
@@ -911,23 +1359,14 @@ int writeTri3(Tri3 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.a & 0x1;
+  v = ((value.a) & 0x1) | (((value.b) & 0x3) << 1);
   scratch |= v << scratchBits;
-  scratchBits += 1;
+  scratchBits += 3;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.b & 0x3;
-  scratch |= v << scratchBits;
-  scratchBits += 2;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (3 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -956,29 +1395,19 @@ bool readTri3(Tri3 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 1) & 0x3;
   bitsRead += 2;
   value.b = v;
   return true;
@@ -1020,7 +1449,7 @@ int writeArrTri3(ArrTri3 value, ByteData view) {
   var v = 0;
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 10);
-  v = (value.itemsCount) & 0xf;
+  v = ((value.itemsCount) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -1029,25 +1458,93 @@ int writeArrTri3(ArrTri3 value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (4 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    v = e0.a & 0x1;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 21 <= value.itemsCount; i0 += 21) {
+      final e0 = value.items[i0];
+      final e0g1 = value.items[i0 + 1];
+      final e0g2 = value.items[i0 + 2];
+      final e0g3 = value.items[i0 + 3];
+      final e0g4 = value.items[i0 + 4];
+      final e0g5 = value.items[i0 + 5];
+      final e0g6 = value.items[i0 + 6];
+      final e0g7 = value.items[i0 + 7];
+      final e0g8 = value.items[i0 + 8];
+      final e0g9 = value.items[i0 + 9];
+      final e0g10 = value.items[i0 + 10];
+      final e0g11 = value.items[i0 + 11];
+      final e0g12 = value.items[i0 + 12];
+      final e0g13 = value.items[i0 + 13];
+      final e0g14 = value.items[i0 + 14];
+      final e0g15 = value.items[i0 + 15];
+      final e0g16 = value.items[i0 + 16];
+      final e0g17 = value.items[i0 + 17];
+      final e0g18 = value.items[i0 + 18];
+      final e0g19 = value.items[i0 + 19];
+      final e0g20 = value.items[i0 + 20];
+      v =
+          ((e0.a) & 0x1) |
+          (((e0.b) & 0x3) << 1) |
+          (((e0g1.a) & 0x1) << 3) |
+          (((e0g1.b) & 0x3) << 4) |
+          (((e0g2.a) & 0x1) << 6) |
+          (((e0g2.b) & 0x3) << 7) |
+          (((e0g3.a) & 0x1) << 9) |
+          (((e0g3.b) & 0x3) << 10) |
+          (((e0g4.a) & 0x1) << 12) |
+          (((e0g4.b) & 0x3) << 13) |
+          (((e0g5.a) & 0x1) << 15) |
+          (((e0g5.b) & 0x3) << 16) |
+          (((e0g6.a) & 0x1) << 18) |
+          (((e0g6.b) & 0x3) << 19) |
+          (((e0g7.a) & 0x1) << 21) |
+          (((e0g7.b) & 0x3) << 22) |
+          (((e0g8.a) & 0x1) << 24) |
+          (((e0g8.b) & 0x3) << 25) |
+          (((e0g9.a) & 0x1) << 27) |
+          (((e0g9.b) & 0x3) << 28) |
+          (((e0g10.a) & 0x1) << 30) |
+          (((e0g10.b) & 0x3) << 31) |
+          (((e0g11.a) & 0x1) << 33) |
+          (((e0g11.b) & 0x3) << 34) |
+          (((e0g12.a) & 0x1) << 36) |
+          (((e0g12.b) & 0x3) << 37) |
+          (((e0g13.a) & 0x1) << 39) |
+          (((e0g13.b) & 0x3) << 40) |
+          (((e0g14.a) & 0x1) << 42) |
+          (((e0g14.b) & 0x3) << 43) |
+          (((e0g15.a) & 0x1) << 45) |
+          (((e0g15.b) & 0x3) << 46) |
+          (((e0g16.a) & 0x1) << 48) |
+          (((e0g16.b) & 0x3) << 49) |
+          (((e0g17.a) & 0x1) << 51) |
+          (((e0g17.b) & 0x3) << 52) |
+          (((e0g18.a) & 0x1) << 54) |
+          (((e0g18.b) & 0x3) << 55) |
+          (((e0g19.a) & 0x1) << 57) |
+          (((e0g19.b) & 0x3) << 58) |
+          (((e0g20.a) & 0x1) << 60) |
+          (((e0g20.b) & 0x3) << 61);
+      scratch |= v << scratchBits;
+      scratchBits += 63;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (63 - scratchBits);
+      }
     }
-    v = e0.b & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      v = ((e0.a) & 0x1) | (((e0.b) & 0x3) << 1);
+      scratch |= v << scratchBits;
+      scratchBits += 3;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (3 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -1077,19 +1574,16 @@ bool readArrTri3(ArrTri3 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 10) {
     return false; // the count guards the loop — reject, never clamp
@@ -1098,28 +1592,164 @@ bool readArrTri3(ArrTri3 value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 3 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 19 <= value.itemsCount; i0 += 19) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      e0.a = v;
+      v = (window >>> 1) & 0x3;
+      bitsRead += 2;
+      e0.b = v;
+      final e0g1 = value.items[i0 + 1];
+      v = (window >>> 3) & 0x1;
+      bitsRead += 1;
+      e0g1.a = v;
+      v = (window >>> 4) & 0x3;
+      bitsRead += 2;
+      e0g1.b = v;
+      final e0g2 = value.items[i0 + 2];
+      v = (window >>> 6) & 0x1;
+      bitsRead += 1;
+      e0g2.a = v;
+      v = (window >>> 7) & 0x3;
+      bitsRead += 2;
+      e0g2.b = v;
+      final e0g3 = value.items[i0 + 3];
+      v = (window >>> 9) & 0x1;
+      bitsRead += 1;
+      e0g3.a = v;
+      v = (window >>> 10) & 0x3;
+      bitsRead += 2;
+      e0g3.b = v;
+      final e0g4 = value.items[i0 + 4];
+      v = (window >>> 12) & 0x1;
+      bitsRead += 1;
+      e0g4.a = v;
+      v = (window >>> 13) & 0x3;
+      bitsRead += 2;
+      e0g4.b = v;
+      final e0g5 = value.items[i0 + 5];
+      v = (window >>> 15) & 0x1;
+      bitsRead += 1;
+      e0g5.a = v;
+      v = (window >>> 16) & 0x3;
+      bitsRead += 2;
+      e0g5.b = v;
+      final e0g6 = value.items[i0 + 6];
+      v = (window >>> 18) & 0x1;
+      bitsRead += 1;
+      e0g6.a = v;
+      v = (window >>> 19) & 0x3;
+      bitsRead += 2;
+      e0g6.b = v;
+      final e0g7 = value.items[i0 + 7];
+      v = (window >>> 21) & 0x1;
+      bitsRead += 1;
+      e0g7.a = v;
+      v = (window >>> 22) & 0x3;
+      bitsRead += 2;
+      e0g7.b = v;
+      final e0g8 = value.items[i0 + 8];
+      v = (window >>> 24) & 0x1;
+      bitsRead += 1;
+      e0g8.a = v;
+      v = (window >>> 25) & 0x3;
+      bitsRead += 2;
+      e0g8.b = v;
+      final e0g9 = value.items[i0 + 9];
+      v = (window >>> 27) & 0x1;
+      bitsRead += 1;
+      e0g9.a = v;
+      v = (window >>> 28) & 0x3;
+      bitsRead += 2;
+      e0g9.b = v;
+      final e0g10 = value.items[i0 + 10];
+      v = (window >>> 30) & 0x1;
+      bitsRead += 1;
+      e0g10.a = v;
+      v = (window >>> 31) & 0x3;
+      bitsRead += 2;
+      e0g10.b = v;
+      final e0g11 = value.items[i0 + 11];
+      v = (window >>> 33) & 0x1;
+      bitsRead += 1;
+      e0g11.a = v;
+      v = (window >>> 34) & 0x3;
+      bitsRead += 2;
+      e0g11.b = v;
+      final e0g12 = value.items[i0 + 12];
+      v = (window >>> 36) & 0x1;
+      bitsRead += 1;
+      e0g12.a = v;
+      v = (window >>> 37) & 0x3;
+      bitsRead += 2;
+      e0g12.b = v;
+      final e0g13 = value.items[i0 + 13];
+      v = (window >>> 39) & 0x1;
+      bitsRead += 1;
+      e0g13.a = v;
+      v = (window >>> 40) & 0x3;
+      bitsRead += 2;
+      e0g13.b = v;
+      final e0g14 = value.items[i0 + 14];
+      v = (window >>> 42) & 0x1;
+      bitsRead += 1;
+      e0g14.a = v;
+      v = (window >>> 43) & 0x3;
+      bitsRead += 2;
+      e0g14.b = v;
+      final e0g15 = value.items[i0 + 15];
+      v = (window >>> 45) & 0x1;
+      bitsRead += 1;
+      e0g15.a = v;
+      v = (window >>> 46) & 0x3;
+      bitsRead += 2;
+      e0g15.b = v;
+      final e0g16 = value.items[i0 + 16];
+      v = (window >>> 48) & 0x1;
+      bitsRead += 1;
+      e0g16.a = v;
+      v = (window >>> 49) & 0x3;
+      bitsRead += 2;
+      e0g16.b = v;
+      final e0g17 = value.items[i0 + 17];
+      v = (window >>> 51) & 0x1;
+      bitsRead += 1;
+      e0g17.a = v;
+      v = (window >>> 52) & 0x3;
+      bitsRead += 2;
+      e0g17.b = v;
+      final e0g18 = value.items[i0 + 18];
+      v = (window >>> 54) & 0x1;
+      bitsRead += 1;
+      e0g18.a = v;
+      v = (window >>> 55) & 0x3;
+      bitsRead += 2;
+      e0g18.b = v;
     }
-    v = (window >>> shift) & 0x1;
-    bitsRead += 1;
-    e0.a = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1;
+      bitsRead += 1;
+      e0.a = v;
+      v = (window >>> 1) & 0x3;
+      bitsRead += 2;
+      e0.b = v;
     }
-    v = (window >>> shift) & 0x3;
-    bitsRead += 2;
-    e0.b = v;
   }
   return true;
 }
@@ -1161,23 +1791,14 @@ int writeEleven(Eleven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.a & 0x7;
+  v = ((value.a) & 0x7) | (((value.b) & 0xff) << 3);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 11;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = value.b & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (11 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1206,29 +1827,19 @@ bool readEleven(Eleven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 11 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 3) & 0xff;
   bitsRead += 8;
   value.b = v;
   return true;
@@ -1268,23 +1879,14 @@ int writeArrEleven(ArrEleven value, ByteData view) {
   var v = 0;
   for (var i0 = 0; i0 < 9; i0++) {
     final e0 = value.items[i0];
-    v = e0.a & 0x7;
+    v = ((e0.a) & 0x7) | (((e0.b) & 0xff) << 3);
     scratch |= v << scratchBits;
-    scratchBits += 3;
+    scratchBits += 11;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (3 - scratchBits);
-    }
-    v = e0.b & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+      scratch = v >>> (11 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1314,7 +1916,6 @@ bool readArrEleven(ArrEleven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 99 > numBits) {
     return false;
@@ -1322,23 +1923,14 @@ bool readArrEleven(ArrEleven value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < 9; i0++) {
     final e0 = value.items[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     e0.a = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xff;
+    v = (window >>> 3) & 0xff;
     bitsRead += 8;
     e0.b = v;
   }
@@ -1477,7 +2069,7 @@ int writeEmptyUnion(EmptyUnion value, ByteData view) {
   var v = 0;
   assert(value.type >= 0);
   assert(value.type <= 2);
-  v = value.type & 0x3;
+  v = ((value.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1519,19 +2111,16 @@ bool readEmptyUnion(EmptyUnion value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1590,25 +2179,16 @@ int writeHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.u.type >= 0);
   assert(value.u.type <= 2);
-  v = value.u.type & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.u.type) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
   switch (value.u.type) {
     case 1:
@@ -1616,7 +2196,7 @@ int writeHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view) {
     case 2:
       break; // empty arm — presence is the payload (SPEC §4.6)
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -1652,32 +2232,22 @@ bool readHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1693,13 +2263,11 @@ bool readHoldsEmptyUnion(HoldsEmptyUnion value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -1759,25 +2327,16 @@ int writeStrs(Strs value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.sLength >= 0);
   assert(value.sLength <= 8);
-  v = (value.sLength) & 0xf;
+  v = ((value.lead) & 0x1f) | (((value.sLength) & 0xf) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 9;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (9 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -1791,20 +2350,38 @@ int writeStrs(Strs value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.sLength; i0++) {
-    v = value.s[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.sLength; i0 += 4) {
+      v =
+          value.s[i0] |
+          (value.s[i0 + 1] << 8) |
+          (value.s[i0 + 2] << 16) |
+          (value.s[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.sLength; i0++) {
+      v = value.s[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   assert(value.bLength >= 0);
   assert(value.bLength <= 8);
-  v = (value.bLength) & 0xf;
+  v = ((value.bLength) & 0xf);
   scratch |= v << scratchBits;
   scratchBits += 4;
   if (scratchBits >= 64) {
@@ -1825,18 +2402,36 @@ int writeStrs(Strs value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.bLength; i0++) {
-    v = value.b[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.bLength; i0 += 4) {
+      v =
+          value.b[i0] |
+          (value.b[i0 + 1] << 8) |
+          (value.b[i0 + 2] << 16) |
+          (value.b[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.bLength; i0++) {
+      v = value.b[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
-  v = value.tail & 0x7;
+  v = ((value.tail) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -1872,32 +2467,22 @@ bool readStrs(Strs value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 4 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 5) & 0xf;
   bitsRead += 4;
   if (v > 8) {
     return false; // the length guards the slice — reject, never clamp
@@ -1934,13 +2519,11 @@ bool readStrs(Strs value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xf;
+  v = window & 0xf;
   bitsRead += 4;
   if (v > 8) {
     return false; // the length guards the slice — reject, never clamp
@@ -1972,13 +2555,11 @@ bool readStrs(Strs value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.tail = v;
   return true;
@@ -2032,48 +2613,59 @@ int writeArrNested(ArrNested value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 4);
-  v = (value.itemsCount) & 0x7;
+  v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x7) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 8;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
+    scratch = v >>> (8 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    v = e0.a & 0x7;
-    scratch |= v << scratchBits;
-    scratchBits += 3;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (3 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 5 <= value.itemsCount; i0 += 5) {
+      final e0 = value.items[i0];
+      final e0g1 = value.items[i0 + 1];
+      final e0g2 = value.items[i0 + 2];
+      final e0g3 = value.items[i0 + 3];
+      final e0g4 = value.items[i0 + 4];
+      v =
+          ((e0.a) & 0x7) |
+          (((e0.b) & 0xff) << 3) |
+          (((e0g1.a) & 0x7) << 11) |
+          (((e0g1.b) & 0xff) << 14) |
+          (((e0g2.a) & 0x7) << 22) |
+          (((e0g2.b) & 0xff) << 25) |
+          (((e0g3.a) & 0x7) << 33) |
+          (((e0g3.b) & 0xff) << 36) |
+          (((e0g4.a) & 0x7) << 44) |
+          (((e0g4.b) & 0xff) << 47);
+      scratch |= v << scratchBits;
+      scratchBits += 55;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (55 - scratchBits);
+      }
     }
-    v = e0.b & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      v = ((e0.a) & 0x7) | (((e0.b) & 0xff) << 3);
+      scratch |= v << scratchBits;
+      scratchBits += 11;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (11 - scratchBits);
+      }
     }
   }
-  v = value.tail & 0x7;
+  v = ((value.tail) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -2109,32 +2701,22 @@ bool readArrNested(ArrNested value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 3 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 5) & 0x7;
   bitsRead += 3;
   if (v > 4) {
     return false; // the count guards the loop — reject, never clamp
@@ -2143,40 +2725,76 @@ bool readArrNested(ArrNested value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 11 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    final e0 = value.items[i0];
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 5 <= value.itemsCount; i0 += 5) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x7;
+      bitsRead += 3;
+      e0.a = v;
+      v = (window >>> 3) & 0xff;
+      bitsRead += 8;
+      e0.b = v;
+      final e0g1 = value.items[i0 + 1];
+      v = (window >>> 11) & 0x7;
+      bitsRead += 3;
+      e0g1.a = v;
+      v = (window >>> 14) & 0xff;
+      bitsRead += 8;
+      e0g1.b = v;
+      final e0g2 = value.items[i0 + 2];
+      v = (window >>> 22) & 0x7;
+      bitsRead += 3;
+      e0g2.a = v;
+      v = (window >>> 25) & 0xff;
+      bitsRead += 8;
+      e0g2.b = v;
+      final e0g3 = value.items[i0 + 3];
+      v = (window >>> 33) & 0x7;
+      bitsRead += 3;
+      e0g3.a = v;
+      v = (window >>> 36) & 0xff;
+      bitsRead += 8;
+      e0g3.b = v;
+      final e0g4 = value.items[i0 + 4];
+      v = (window >>> 44) & 0x7;
+      bitsRead += 3;
+      e0g4.a = v;
+      v = (window >>> 47) & 0xff;
+      bitsRead += 8;
+      e0g4.b = v;
     }
-    v = (window >>> shift) & 0x7;
-    bitsRead += 3;
-    e0.a = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+    for (; i0 < value.itemsCount; i0++) {
+      final e0 = value.items[i0];
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x7;
+      bitsRead += 3;
+      e0.a = v;
+      v = (window >>> 3) & 0xff;
+      bitsRead += 8;
+      e0.b = v;
     }
-    v = (window >>> shift) & 0xff;
-    bitsRead += 8;
-    e0.b = v;
   }
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.tail = v;
   return true;
@@ -2218,7 +2836,7 @@ int writeSole(Sole value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.only & 0x1fff;
+  v = ((value.only) & 0x1fff);
   scratch |= v << scratchBits;
   scratchBits += 13;
   if (scratchBits >= 64) {
@@ -2254,19 +2872,16 @@ bool readSole(Sole value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 13 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1fff;
+  v = window & 0x1fff;
   bitsRead += 13;
   value.only = v;
   return true;

--- a/testdata/golden/dart/Degenerate.dart
+++ b/testdata/golden/dart/Degenerate.dart
@@ -54,47 +54,23 @@ int writeVec2(Vec2 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -123,51 +99,42 @@ bool readVec2(Vec2 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.y = _doubleFromFloat64Bits(lo);
@@ -205,26 +172,14 @@ int writeSpanF64(SpanF64 value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.values[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.values[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -254,7 +209,6 @@ bool readSpanF64(SpanF64 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
@@ -262,23 +216,19 @@ bool readSpanF64(SpanF64 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = _doubleFromFloat64Bits(lo);
@@ -317,23 +267,14 @@ int writeSpanU64(SpanU64 value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    v = value.values[i0] & 0xffffffff;
+    v = (value.values[i0]);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.values[i0] >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -363,7 +304,6 @@ bool readSpanU64(SpanU64 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
@@ -371,23 +311,19 @@ bool readSpanU64(SpanU64 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = lo;
@@ -426,23 +362,14 @@ int writeSpanI64(SpanI64 value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    v = value.values[i0] & 0xffffffff;
+    v = (value.values[i0]);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.values[i0] >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -472,7 +399,6 @@ bool readSpanI64(SpanI64 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 128 > numBits) {
@@ -480,23 +406,19 @@ bool readSpanI64(SpanI64 value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = lo;
@@ -535,23 +457,14 @@ int writeSpanOne(SpanOne value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 1; i0++) {
-    v = value.values[i0] & 0xffffffff;
+    v = (value.values[i0]);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.values[i0] >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -581,7 +494,6 @@ bool readSpanOne(SpanOne value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 64 > numBits) {
@@ -589,23 +501,19 @@ bool readSpanOne(SpanOne value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 1; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = lo;
@@ -644,7 +552,7 @@ int writeSpanChunk(SpanChunk value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 4; i0++) {
-    v = value.values[i0] & 0xffff;
+    v = ((value.values[i0]) & 0xffff);
     scratch |= v << scratchBits;
     scratchBits += 16;
     if (scratchBits >= 64) {
@@ -681,20 +589,17 @@ bool readSpanChunk(SpanChunk value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   for (var i0 = 0; i0 < 4; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffff;
+    v = window & 0xffff;
     bitsRead += 16;
     value.values[i0] = v;
   }
@@ -734,29 +639,17 @@ int writeSpanTail(SpanTail value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.values[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.values[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
-  v = value.tail & 0xffffffff;
+  v = ((value.tail) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -792,7 +685,6 @@ bool readSpanTail(SpanTail value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 160 > numBits) {
@@ -800,35 +692,29 @@ bool readSpanTail(SpanTail value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.values[i0] = _doubleFromFloat64Bits(lo);
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.tail = v;
   return true;
@@ -867,49 +753,25 @@ int writeSpanTwice(SpanTwice value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.a[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.a[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   for (var i0 = 0; i0 < 2; i0++) {
-    {
-      final b = _float64BitsFromDouble(value.b[i0]);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.b[i0]);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -939,7 +801,6 @@ bool readSpanTwice(SpanTwice value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 256 > numBits) {
@@ -947,46 +808,38 @@ bool readSpanTwice(SpanTwice value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.a[i0] = _doubleFromFloat64Bits(lo);
   }
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.b[i0] = _doubleFromFloat64Bits(lo);
@@ -1028,32 +881,17 @@ int writeTrio(Trio value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.a & 0xfffff;
+  v =
+      ((value.a) & 0xfffff) |
+      (((value.b) & 0xfffff) << 20) |
+      (((value.c) & 0xffffff) << 40);
   scratch |= v << scratchBits;
-  scratchBits += 20;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.c & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1082,39 +920,27 @@ bool readTrio(Trio value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.c = v;
   return true;
@@ -1150,32 +976,17 @@ int writeTrioSole(TrioSole value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.inner.a & 0xfffff;
+  v =
+      ((value.inner.a) & 0xfffff) |
+      (((value.inner.b) & 0xfffff) << 20) |
+      (((value.inner.c) & 0xffffff) << 40);
   scratch |= v << scratchBits;
-  scratchBits += 20;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.c & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1204,39 +1015,27 @@ bool readTrioSole(TrioSole value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.inner.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.inner.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.inner.c = v;
   return true;
@@ -1274,34 +1073,19 @@ int writeTrioFirst(TrioFirst value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.inner.a & 0xfffff;
+  v =
+      ((value.inner.a) & 0xfffff) |
+      (((value.inner.b) & 0xfffff) << 20) |
+      (((value.inner.c) & 0xffffff) << 40);
   scratch |= v << scratchBits;
-  scratchBits += 20;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.inner.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.c & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
-  }
-  v = value.trailer & 0xffff;
+  v = ((value.trailer) & 0xffff);
   scratch |= v << scratchBits;
   scratchBits += 16;
   if (scratchBits >= 64) {
@@ -1337,49 +1121,30 @@ bool readTrioFirst(TrioFirst value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 80 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.inner.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.inner.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.inner.c = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 24) & 0xffff;
   bitsRead += 16;
   value.trailer = v;
   return true;
@@ -1427,124 +1192,64 @@ int writeTrioStraddle(TrioStraddle value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.pad0 & 0xffffffff;
+  v = (value.pad0);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.pad0 >>> 32) & 0xffffffff;
+  v = (value.pad1);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.pad1 & 0xffffffff;
+  v = (value.pad2);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.pad1 >>> 32) & 0xffffffff;
+  v = (value.pad3);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.pad2 & 0xffffffff;
+  v = (value.pad4);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.pad2 >>> 32) & 0xffffffff;
+  v =
+      ((value.pad5) & 0xffffff) |
+      (((value.inner.a) & 0xfffff) << 24) |
+      (((value.inner.b) & 0xfffff) << 44);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.pad3 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.pad3 >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.pad4 & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.pad4 >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.pad5 & 0xffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 24;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (24 - scratchBits);
-  }
-  v = value.inner.a & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.b & 0xfffff;
-  scratch |= v << scratchBits;
-  scratchBits += 20;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (20 - scratchBits);
-  }
-  v = value.inner.c & 0xffffff;
+  v = ((value.inner.c) & 0xffffff);
   scratch |= v << scratchBits;
   scratchBits += 24;
   if (scratchBits >= 64) {
@@ -1580,155 +1285,116 @@ bool readTrioStraddle(TrioStraddle value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 408 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad0 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad1 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad2 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad3 = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.pad4 = lo;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffff;
+  v = (window >>> 32) & 0xffffff;
   bitsRead += 24;
   value.pad5 = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfffff;
+  v = window & 0xfffff;
   bitsRead += 20;
   value.inner.a = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 20) & 0xfffff;
   bitsRead += 20;
   value.inner.b = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffff;
+  v = window & 0xffffff;
   bitsRead += 24;
   value.inner.c = v;
   return true;

--- a/testdata/golden/dart/Joins.dart
+++ b/testdata/golden/dart/Joins.dart
@@ -47,26 +47,17 @@ int writeArmsAgree(ArmsAgree value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    v = value.a & 0x7ff;
+    v = ((value.a) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -76,7 +67,7 @@ int writeArmsAgree(ArmsAgree value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   } else {
-    v = value.b & 0x7ff;
+    v = ((value.b) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -86,7 +77,7 @@ int writeArmsAgree(ArmsAgree value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -122,64 +113,48 @@ bool readArmsAgree(ArmsAgree value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 24 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ff;
+    v = window & 0x7ff;
     bitsRead += 11;
     value.a = v;
     value.b = 0;
   } else {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ff;
+    v = window & 0x7ff;
     bitsRead += 11;
     value.b = v;
     value.a = 0;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -230,26 +205,17 @@ int writeArmsDisagree(ArmsDisagree value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    v = value.a & 0x7ff;
+    v = ((value.a) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -259,7 +225,7 @@ int writeArmsDisagree(ArmsDisagree value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   } else {
-    v = value.b & 0x7;
+    v = ((value.b) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
     if (scratchBits >= 64) {
@@ -269,7 +235,7 @@ int writeArmsDisagree(ArmsDisagree value, ByteData view) {
       scratch = v >>> (3 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -305,29 +271,19 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -335,13 +291,11 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ff;
+    v = window & 0x7ff;
     bitsRead += 11;
     value.a = v;
     value.b = 0;
@@ -350,13 +304,11 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     value.b = v;
     value.a = 0;
@@ -365,13 +317,11 @@ bool readArmsDisagree(ArmsDisagree value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -427,26 +377,17 @@ int writeArmEmpty(ArmEmpty value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
-    v = value.a & 0x7ffff;
+    v = ((value.a) & 0x7ffff);
     scratch |= v << scratchBits;
     scratchBits += 19;
     if (scratchBits >= 64) {
@@ -456,7 +397,7 @@ int writeArmEmpty(ArmEmpty value, ByteData view) {
       scratch = v >>> (19 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -492,29 +433,19 @@ bool readArmEmpty(ArmEmpty value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -522,13 +453,11 @@ bool readArmEmpty(ArmEmpty value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7ffff;
+    v = window & 0x7ffff;
     bitsRead += 19;
     value.a = v;
   } else {
@@ -538,13 +467,11 @@ bool readArmEmpty(ArmEmpty value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -613,26 +540,17 @@ int writeArmsNested(ArmsNested value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x7;
+  v = ((value.lead) & 0x7) | ((value.outer ? 1 : 0) << 3);
   scratch |= v << scratchBits;
-  scratchBits += 3;
+  scratchBits += 4;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = value.outer ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (4 - scratchBits);
   }
   if (value.outer) {
-    v = value.inner ? 1 : 0;
+    v = (value.inner ? 1 : 0);
     scratch |= v << scratchBits;
     scratchBits += 1;
     if (scratchBits >= 64) {
@@ -642,7 +560,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
       scratch = v >>> (1 - scratchBits);
     }
     if (value.inner) {
-      v = value.x & 0x1fffffff;
+      v = ((value.x) & 0x1fffffff);
       scratch |= v << scratchBits;
       scratchBits += 29;
       if (scratchBits >= 64) {
@@ -652,7 +570,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
         scratch = v >>> (29 - scratchBits);
       }
     } else {
-      v = value.y & 0x1f;
+      v = ((value.y) & 0x1f);
       scratch |= v << scratchBits;
       scratchBits += 5;
       if (scratchBits >= 64) {
@@ -663,7 +581,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
       }
     }
   } else {
-    v = value.z & 0x1fff;
+    v = ((value.z) & 0x1fff);
     scratch |= v << scratchBits;
     scratchBits += 13;
     if (scratchBits >= 64) {
@@ -673,7 +591,7 @@ int writeArmsNested(ArmsNested value, ByteData view) {
       scratch = v >>> (13 - scratchBits);
     }
   }
-  v = value.tail & 0x3f;
+  v = ((value.tail) & 0x3f);
   scratch |= v << scratchBits;
   scratchBits += 6;
   if (scratchBits >= 64) {
@@ -709,29 +627,19 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 4 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 3) & 0x1;
   bitsRead += 1;
   value.outer = v != 0;
   if (value.outer) {
@@ -739,13 +647,11 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1;
+    v = window & 0x1;
     bitsRead += 1;
     value.inner = v != 0;
     if (value.inner) {
@@ -753,13 +659,12 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x1fffffff;
+      v = window & 0x1fffffff;
       bitsRead += 29;
       value.x = v;
       value.y = 0;
@@ -768,13 +673,12 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x1f;
+      v = window & 0x1f;
       bitsRead += 5;
       value.y = v;
       value.x = 0;
@@ -785,13 +689,11 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fff;
+    v = window & 0x1fff;
     bitsRead += 13;
     value.z = v;
     value.inner = false;
@@ -802,13 +704,11 @@ bool readArmsNested(ArmsNested value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3f;
+  v = window & 0x3f;
   bitsRead += 6;
   value.tail = v;
   return true;
@@ -877,28 +777,19 @@ int writeArmAlign(ArmAlign value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
     assert(value.sLength >= 0);
     assert(value.sLength <= 4);
-    v = (value.sLength) & 0x7;
+    v = ((value.sLength) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
     if (scratchBits >= 64) {
@@ -919,19 +810,37 @@ int writeArmAlign(ArmAlign value, ByteData view) {
         }
       }
     }
-    for (var i0 = 0; i0 < value.sLength; i0++) {
-      v = value.s[i0];
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+    {
+      var i0 = 0;
+      for (; i0 + 4 <= value.sLength; i0 += 4) {
+        v =
+            value.s[i0] |
+            (value.s[i0 + 1] << 8) |
+            (value.s[i0 + 2] << 16) |
+            (value.s[i0 + 3] << 24);
+        scratch |= v << scratchBits;
+        scratchBits += 32;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (32 - scratchBits);
+        }
+      }
+      for (; i0 < value.sLength; i0++) {
+        v = value.s[i0];
+        scratch |= v << scratchBits;
+        scratchBits += 8;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (8 - scratchBits);
+        }
       }
     }
   } else {
-    v = value.b & 0x3ff;
+    v = ((value.b) & 0x3ff);
     scratch |= v << scratchBits;
     scratchBits += 10;
     if (scratchBits >= 64) {
@@ -941,7 +850,7 @@ int writeArmAlign(ArmAlign value, ByteData view) {
       scratch = v >>> (10 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -977,29 +886,19 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -1007,13 +906,11 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     if (v > 4) {
       return false; // the length guards the slice — reject, never clamp
@@ -1052,13 +949,11 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3ff;
+    v = window & 0x3ff;
     bitsRead += 10;
     value.b = v;
     value.s.fillRange(0, value.s.length, 0);
@@ -1068,13 +963,11 @@ bool readArmAlign(ArmAlign value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -1140,28 +1033,19 @@ int writeArmArray(ArmArray value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
+  v = ((value.lead) & 0x1f) | ((value.flag ? 1 : 0) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 6;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
-  v = value.flag ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (6 - scratchBits);
   }
   if (value.flag) {
     assert(value.itemsCount >= 0);
     assert(value.itemsCount <= 3);
-    v = (value.itemsCount) & 0x3;
+    v = ((value.itemsCount) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
     if (scratchBits >= 64) {
@@ -1170,21 +1054,47 @@ int writeArmArray(ArmArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (2 - scratchBits);
     }
-    for (var i0 = 0; i0 < value.itemsCount; i0++) {
-      assert(value.items[i0] >= 0);
-      assert(value.items[i0] <= 8191);
-      v = (value.items[i0]) & 0x1fff;
-      scratch |= v << scratchBits;
-      scratchBits += 13;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (13 - scratchBits);
+    {
+      var i0 = 0;
+      for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+        assert(value.items[i0] >= 0);
+        assert(value.items[i0] <= 8191);
+        assert(value.items[i0 + 1] >= 0);
+        assert(value.items[i0 + 1] <= 8191);
+        assert(value.items[i0 + 2] >= 0);
+        assert(value.items[i0 + 2] <= 8191);
+        assert(value.items[i0 + 3] >= 0);
+        assert(value.items[i0 + 3] <= 8191);
+        v =
+            ((value.items[i0]) & 0x1fff) |
+            (((value.items[i0 + 1]) & 0x1fff) << 13) |
+            (((value.items[i0 + 2]) & 0x1fff) << 26) |
+            (((value.items[i0 + 3]) & 0x1fff) << 39);
+        scratch |= v << scratchBits;
+        scratchBits += 52;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (52 - scratchBits);
+        }
+      }
+      for (; i0 < value.itemsCount; i0++) {
+        assert(value.items[i0] >= 0);
+        assert(value.items[i0] <= 8191);
+        v = ((value.items[i0]) & 0x1fff);
+        scratch |= v << scratchBits;
+        scratchBits += 13;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (13 - scratchBits);
+        }
       }
     }
   } else {
-    v = value.b & 0x1ff;
+    v = ((value.b) & 0x1ff);
     scratch |= v << scratchBits;
     scratchBits += 9;
     if (scratchBits >= 64) {
@@ -1194,7 +1104,7 @@ int writeArmArray(ArmArray value, ByteData view) {
       scratch = v >>> (9 - scratchBits);
     }
   }
-  v = value.tail & 0x7f;
+  v = ((value.tail) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -1230,29 +1140,19 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 6 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 5) & 0x1;
   bitsRead += 1;
   value.flag = v != 0;
   if (value.flag) {
@@ -1260,29 +1160,49 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3;
+    v = window & 0x3;
     bitsRead += 2;
     value.itemsCount = v;
     if (bitsRead + value.itemsCount * 13 > numBits) {
       return false;
     }
-    for (var i0 = 0; i0 < value.itemsCount; i0++) {
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+    {
+      var i0 = 0;
+      for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0x1fff;
+        bitsRead += 13;
+        value.items[i0] = v;
+        v = (window >>> 13) & 0x1fff;
+        bitsRead += 13;
+        value.items[i0 + 1] = v;
+        v = (window >>> 26) & 0x1fff;
+        bitsRead += 13;
+        value.items[i0 + 2] = v;
+        v = (window >>> 39) & 0x1fff;
+        bitsRead += 13;
+        value.items[i0 + 3] = v;
       }
-      v = (window >>> shift) & 0x1fff;
-      bitsRead += 13;
-      value.items[i0] = v;
+      for (; i0 < value.itemsCount; i0++) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0x1fff;
+        bitsRead += 13;
+        value.items[i0] = v;
+      }
     }
     value.b = 0;
   } else {
@@ -1290,13 +1210,11 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1ff;
+    v = window & 0x1ff;
     bitsRead += 9;
     value.b = v;
     value.items.fillRange(0, value.items.length, 0);
@@ -1306,13 +1224,11 @@ bool readArmArray(ArmArray value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   value.tail = v;
   return true;
@@ -1359,7 +1275,7 @@ int writeNarrow(Narrow value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.n & 0x7;
+  v = ((value.n) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -1395,19 +1311,16 @@ bool readNarrow(Narrow value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.n = v;
   return true;
@@ -1443,23 +1356,14 @@ int writeWide(Wide value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.w & 0xffffffff;
+  v = ((value.w) & 0x1fffffffff);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 37;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.w >>> 32) & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (37 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1488,32 +1392,17 @@ bool readWide(Wide value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
-  var v = 0;
   var lo = 0;
   if (bitsRead + 37 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   value.w = lo;
   return true;
 }
@@ -1564,7 +1453,7 @@ int writeUneven(Uneven value, ByteData view) {
   var v = 0;
   assert(value.type >= 0);
   assert(value.type <= 2);
-  v = value.type & 0x3;
+  v = ((value.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1575,7 +1464,7 @@ int writeUneven(Uneven value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      v = value.narrow.n & 0x7;
+      v = ((value.narrow.n) & 0x7);
       scratch |= v << scratchBits;
       scratchBits += 3;
       if (scratchBits >= 64) {
@@ -1585,23 +1474,14 @@ int writeUneven(Uneven value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      v = value.wide.w & 0xffffffff;
+      v = ((value.wide.w) & 0x1fffffffff);
       scratch |= v << scratchBits;
-      scratchBits += 32;
+      scratchBits += 37;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (value.wide.w >>> 32) & 0x1f;
-      scratch |= v << scratchBits;
-      scratchBits += 5;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (5 - scratchBits);
+        scratch = v >>> (37 - scratchBits);
       }
   }
   if (scratchBits != 0) {
@@ -1631,20 +1511,17 @@ bool readUneven(Uneven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1657,13 +1534,12 @@ bool readUneven(Uneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7;
+      v = window & 0x7;
       bitsRead += 3;
       value.narrow.n = v;
     case 2:
@@ -1672,25 +1548,13 @@ bool readUneven(Uneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffffffff;
-      bitsRead += 32;
-      lo = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1f;
-      bitsRead += 5;
-      lo |= v << 32;
+      lo = window & 0x1fffffffff;
+      bitsRead += 37;
       value.wide.w = lo;
   }
   return true;
@@ -1740,29 +1604,20 @@ int writeHoldsUneven(HoldsUneven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.u.type >= 0);
   assert(value.u.type <= 2);
-  v = value.u.type & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.u.type) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
   switch (value.u.type) {
     case 1:
-      v = value.u.narrow.n & 0x7;
+      v = ((value.u.narrow.n) & 0x7);
       scratch |= v << scratchBits;
       scratchBits += 3;
       if (scratchBits >= 64) {
@@ -1772,26 +1627,17 @@ int writeHoldsUneven(HoldsUneven value, ByteData view) {
         scratch = v >>> (3 - scratchBits);
       }
     case 2:
-      v = value.u.wide.w & 0xffffffff;
+      v = ((value.u.wide.w) & 0x1fffffffff);
       scratch |= v << scratchBits;
-      scratchBits += 32;
+      scratchBits += 37;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (value.u.wide.w >>> 32) & 0x1f;
-      scratch |= v << scratchBits;
-      scratchBits += 5;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (5 - scratchBits);
+        scratch = v >>> (37 - scratchBits);
       }
   }
-  v = value.tail & 0x7ff;
+  v = ((value.tail) & 0x7ff);
   scratch |= v << scratchBits;
   scratchBits += 11;
   if (scratchBits >= 64) {
@@ -1827,33 +1673,23 @@ bool readHoldsUneven(HoldsUneven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1866,13 +1702,12 @@ bool readHoldsUneven(HoldsUneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7;
+      v = window & 0x7;
       bitsRead += 3;
       value.u.narrow.n = v;
     case 2:
@@ -1881,38 +1716,24 @@ bool readHoldsUneven(HoldsUneven value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffffffff;
-      bitsRead += 32;
-      lo = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1f;
-      bitsRead += 5;
-      lo |= v << 32;
+      lo = window & 0x1fffffffff;
+      bitsRead += 37;
       value.u.wide.w = lo;
   }
   if (bitsRead + 11 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7ff;
+  v = window & 0x7ff;
   bitsRead += 11;
   value.tail = v;
   return true;
@@ -1968,31 +1789,22 @@ int writeArrUneven(ArrUneven value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
     final e0 = value.items[i0];
     assert(e0.type >= 0);
     assert(e0.type <= 2);
-    v = e0.type & 0x3;
+    v = ((e0.type) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
     if (scratchBits >= 64) {
@@ -2003,7 +1815,7 @@ int writeArrUneven(ArrUneven value, ByteData view) {
     }
     switch (e0.type) {
       case 1:
-        v = e0.narrow.n & 0x7;
+        v = ((e0.narrow.n) & 0x7);
         scratch |= v << scratchBits;
         scratchBits += 3;
         if (scratchBits >= 64) {
@@ -2013,27 +1825,18 @@ int writeArrUneven(ArrUneven value, ByteData view) {
           scratch = v >>> (3 - scratchBits);
         }
       case 2:
-        v = e0.wide.w & 0xffffffff;
+        v = ((e0.wide.w) & 0x1fffffffff);
         scratch |= v << scratchBits;
-        scratchBits += 32;
+        scratchBits += 37;
         if (scratchBits >= 64) {
           view.setUint64(wordIndex * 8, scratch, Endian.little);
           wordIndex++;
           scratchBits -= 64;
-          scratch = v >>> (32 - scratchBits);
-        }
-        v = (e0.wide.w >>> 32) & 0x1f;
-        scratch |= v << scratchBits;
-        scratchBits += 5;
-        if (scratchBits >= 64) {
-          view.setUint64(wordIndex * 8, scratch, Endian.little);
-          wordIndex++;
-          scratchBits -= 64;
-          scratch = v >>> (5 - scratchBits);
+          scratch = v >>> (37 - scratchBits);
         }
     }
   }
-  v = value.tail & 0x7;
+  v = ((value.tail) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -2069,33 +1872,23 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   for (var i0 = 0; i0 < value.itemsCount; i0++) {
@@ -2104,13 +1897,11 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3;
+    v = window & 0x3;
     bitsRead += 2;
     if (v > 2) {
       return false; // not a wire-legal tag (SPEC §4.8)
@@ -2123,13 +1914,12 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0x7;
+        v = window & 0x7;
         bitsRead += 3;
         e0.narrow.n = v;
       case 2:
@@ -2138,25 +1928,13 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0xffffffff;
-        bitsRead += 32;
-        lo = v;
-        if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
-        } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
-        }
-        v = (window >>> shift) & 0x1f;
-        bitsRead += 5;
-        lo |= v << 32;
+        lo = window & 0x1fffffffff;
+        bitsRead += 37;
         e0.wide.w = lo;
     }
   }
@@ -2164,13 +1942,11 @@ bool readArrUneven(ArrUneven value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.tail = v;
   return true;
@@ -2239,42 +2015,59 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.lead & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 3);
-  v = (value.itemsCount) & 0x3;
+  v = ((value.lead) & 0x1f) | (((value.itemsCount) & 0x3) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 7;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (7 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 8191);
-    v = (value.items[i0]) & 0x1fff;
-    scratch |= v << scratchBits;
-    scratchBits += 13;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (13 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 8191);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 8191);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 8191);
+      v =
+          ((value.items[i0]) & 0x1fff) |
+          (((value.items[i0 + 1]) & 0x1fff) << 13) |
+          (((value.items[i0 + 2]) & 0x1fff) << 26) |
+          (((value.items[i0 + 3]) & 0x1fff) << 39);
+      scratch |= v << scratchBits;
+      scratchBits += 52;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (52 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 8191);
+      v = ((value.items[i0]) & 0x1fff);
+      scratch |= v << scratchBits;
+      scratchBits += 13;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (13 - scratchBits);
+      }
     }
   }
   assert(value.sLength >= 0);
   assert(value.sLength <= 4);
-  v = (value.sLength) & 0x7;
+  v = ((value.sLength) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -2295,52 +2088,52 @@ int writeRegainAfterAlign(RegainAfterAlign value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.sLength; i0++) {
-    v = value.s[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.sLength; i0 += 4) {
+      v =
+          value.s[i0] |
+          (value.s[i0 + 1] << 8) |
+          (value.s[i0 + 2] << 16) |
+          (value.s[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.sLength; i0++) {
+      v = value.s[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
-  v = value.p & 0xffffffff;
+  v = ((value.p) & 0xffffffff) | (((value.q) & 0x1fffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 61;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (61 - scratchBits);
   }
-  v = value.q & 0x1fffffff;
+  v = ((value.r) & 0x7ffff) | (((value.tail) & 0xf) << 19);
   scratch |= v << scratchBits;
-  scratchBits += 29;
+  scratchBits += 23;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (29 - scratchBits);
-  }
-  v = value.r & 0x7ffff;
-  scratch |= v << scratchBits;
-  scratchBits += 19;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (19 - scratchBits);
-  }
-  v = value.tail & 0xf;
-  scratch |= v << scratchBits;
-  scratchBits += 4;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (23 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2369,60 +2162,70 @@ bool readRegainAfterAlign(RegainAfterAlign value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.lead = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 5) & 0x3;
   bitsRead += 2;
   value.itemsCount = v;
   if (bitsRead + value.itemsCount * 13 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.itemsCount; i0 += 4) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+      v = (window >>> 13) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 1] = v;
+      v = (window >>> 26) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 2] = v;
+      v = (window >>> 39) & 0x1fff;
+      bitsRead += 13;
+      value.items[i0 + 3] = v;
     }
-    v = (window >>> shift) & 0x1fff;
-    bitsRead += 13;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0x1fff;
+      bitsRead += 13;
+      value.items[i0] = v;
+    }
   }
   if (bitsRead + 3 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   if (v > 4) {
     return false; // the length guards the slice — reject, never clamp
@@ -2459,43 +2262,25 @@ bool readRegainAfterAlign(RegainAfterAlign value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.p = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1fffffff;
+  v = window & 0x1fffffff;
   bitsRead += 29;
   value.q = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ffff;
+  v = (window >>> 29) & 0x7ffff;
   bitsRead += 19;
   value.r = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 48) & 0xf;
   bitsRead += 4;
   value.tail = v;
   return true;

--- a/testdata/golden/dart/Render.dart
+++ b/testdata/golden/dart/Render.dart
@@ -44,61 +44,34 @@ int writeRenderSprite(RenderSprite value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.sortKey & 0xffffffff;
+  v = (value.sortKey);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.sortKey >>> 32) & 0xffffffff;
+  v = ((value.meshId) & 0xffffffff) | (((value.materialId) & 0xffffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.meshId & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.materialId & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.layer & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.team >= 0);
   assert(value.team <= 2);
-  v = value.team & 0x3;
+  v = ((value.layer) & 0xff) | (((value.team) & 0x3) << 8);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 10;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (10 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -127,71 +100,48 @@ bool readRenderSprite(RenderSprite value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 138 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.sortKey = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.meshId = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.materialId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.layer = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 40) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // headroom above the wire range is refused
@@ -241,27 +191,20 @@ int writeRenderBlock(RenderBlock value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.workerIndex & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.spriteCountHint & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.spritesCount >= 0);
   assert(value.spritesCount <= 64);
-  v = (value.spritesCount) & 0x7f;
+  v =
+      ((value.workerIndex) & 0xffffffff) |
+      (((value.spriteCountHint) & 0xffffffff) << 32);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.spritesCount) & 0x7f);
   scratch |= v << scratchBits;
   scratchBits += 7;
   if (scratchBits >= 64) {
@@ -272,61 +215,34 @@ int writeRenderBlock(RenderBlock value, ByteData view) {
   }
   for (var i0 = 0; i0 < value.spritesCount; i0++) {
     final e0 = value.sprites[i0];
-    v = e0.sortKey & 0xffffffff;
+    v = (e0.sortKey);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (e0.sortKey >>> 32) & 0xffffffff;
+    v = ((e0.meshId) & 0xffffffff) | (((e0.materialId) & 0xffffffff) << 32);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.meshId & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.materialId & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.layer & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
     assert(e0.team >= 0);
     assert(e0.team <= 2);
-    v = e0.team & 0x3;
+    v = ((e0.layer) & 0xff) | (((e0.team) & 0x3) << 8);
     scratch |= v << scratchBits;
-    scratchBits += 2;
+    scratchBits += 10;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+      scratch = v >>> (10 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -356,43 +272,31 @@ bool readRenderBlock(RenderBlock value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 64 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.workerIndex = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.spriteCountHint = v;
   if (bitsRead + 7 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7f;
+  v = (window >>> 32) & 0x7f;
   bitsRead += 7;
   if (v > 64) {
     return false; // the count guards the loop — reject, never clamp
@@ -404,64 +308,42 @@ bool readRenderBlock(RenderBlock value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.spritesCount; i0++) {
     final e0 = value.sprites[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     e0.sortKey = lo;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.meshId = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.materialId = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xff;
+    v = (window >>> 32) & 0xff;
     bitsRead += 8;
     e0.layer = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x3;
+    v = (window >>> 40) & 0x3;
     bitsRead += 2;
     if (v > 2) {
       return false; // headroom above the wire range is refused

--- a/testdata/golden/dart/Types.dart
+++ b/testdata/golden/dart/Types.dart
@@ -100,68 +100,32 @@ int writeVec3(Vec3 value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -190,72 +154,59 @@ bool readVec3(Vec3 value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 192 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.z = _doubleFromFloat64Bits(lo);
@@ -298,89 +249,41 @@ int writeQuat(Quat value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.w);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.w);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -409,93 +312,76 @@ bool readQuat(Quat value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 256 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.z = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.w = _doubleFromFloat64Bits(lo);
@@ -537,23 +423,14 @@ int writeHandle(Handle value, ByteData view) {
   var v = 0;
   assert(value.objectId >= 0);
   assert(value.objectId <= 9999);
-  v = (value.objectId) & 0x3fff;
+  v = ((value.objectId) & 0x3fff) | (((value.objectSequence) & 0xff) << 14);
   scratch |= v << scratchBits;
-  scratchBits += 14;
+  scratchBits += 22;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (14 - scratchBits);
-  }
-  v = value.objectSequence & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (22 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -582,32 +459,22 @@ bool readHandle(Handle value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 22 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3fff;
+  v = window & 0x3fff;
   bitsRead += 14;
   if (v > 9999) {
     return false; // a smuggled offset is refused
   }
   value.objectId = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 14) & 0xff;
   bitsRead += 8;
   value.objectSequence = v;
   return true;
@@ -652,29 +519,22 @@ int writeQuantizedPosition(QuantizedPosition value, ByteData view) {
   var v = 0;
   assert(value.x >= -8388608);
   assert(value.x <= 8388608);
-  v = (value.x + 8388608) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.y >= -8388608);
   assert(value.y <= 8388608);
-  v = (value.y + 8388608) & 0x1ffffff;
+  assert(value.z >= -8388608);
+  assert(value.z <= 8388608);
+  v =
+      ((value.x + 8388608) & 0x1ffffff) |
+      (((value.y + 8388608) & 0x1ffffff) << 25);
   scratch |= v << scratchBits;
-  scratchBits += 25;
+  scratchBits += 50;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
+    scratch = v >>> (50 - scratchBits);
   }
-  assert(value.z >= -8388608);
-  assert(value.z <= 8388608);
-  v = (value.z + 8388608) & 0x1ffffff;
+  v = ((value.z + 8388608) & 0x1ffffff);
   scratch |= v << scratchBits;
   scratchBits += 25;
   if (scratchBits >= 64) {
@@ -714,45 +574,33 @@ bool readQuantizedPosition(
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 75 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.x = -8388608 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 25) & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.y = -8388608 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
@@ -800,29 +648,22 @@ int writeQuantizedVelocity(QuantizedVelocity value, ByteData view) {
   var v = 0;
   assert(value.x >= -2097152);
   assert(value.x <= 2097152);
-  v = (value.x + 2097152) & 0x7fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 23;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
   assert(value.y >= -2097152);
   assert(value.y <= 2097152);
-  v = (value.y + 2097152) & 0x7fffff;
+  assert(value.z >= -2097152);
+  assert(value.z <= 2097152);
+  v =
+      ((value.x + 2097152) & 0x7fffff) |
+      (((value.y + 2097152) & 0x7fffff) << 23);
   scratch |= v << scratchBits;
-  scratchBits += 23;
+  scratchBits += 46;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
+    scratch = v >>> (46 - scratchBits);
   }
-  assert(value.z >= -2097152);
-  assert(value.z <= 2097152);
-  v = (value.z + 2097152) & 0x7fffff;
+  v = ((value.z + 2097152) & 0x7fffff);
   scratch |= v << scratchBits;
   scratchBits += 23;
   if (scratchBits >= 64) {
@@ -862,45 +703,33 @@ bool readQuantizedVelocity(
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 69 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7fffff;
+  v = window & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.x = -2097152 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 23) & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.y = -2097152 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7fffff;
+  v = window & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
@@ -951,47 +780,24 @@ int writeQuantizedRotation(QuantizedRotation value, ByteData view) {
   var v = 0;
   assert(value.x >= -1024);
   assert(value.x <= 1024);
-  v = (value.x + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.y >= -1024);
   assert(value.y <= 1024);
-  v = (value.y + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.z >= -1024);
   assert(value.z <= 1024);
-  v = (value.z + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.w >= -1024);
   assert(value.w <= 1024);
-  v = (value.w + 1024) & 0xfff;
+  v =
+      ((value.x + 1024) & 0xfff) |
+      (((value.y + 1024) & 0xfff) << 12) |
+      (((value.z + 1024) & 0xfff) << 24) |
+      (((value.w + 1024) & 0xfff) << 36);
   scratch |= v << scratchBits;
-  scratchBits += 12;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1024,58 +830,34 @@ bool readQuantizedRotation(
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 48 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfff;
+  v = window & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.x = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 12) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.y = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 24) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.z = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 36) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
@@ -1125,154 +907,70 @@ int writeRigidBody(RigidBody value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  {
-    final b = _float64BitsFromDouble(value.position.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.position.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.position.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.position.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.position.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.position.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.x);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.x);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.y);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.y);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.z);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.z);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.orientation.w);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = _float64BitsFromDouble(value.orientation.w);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.atRest ? 1 : 0;
+  v = (value.atRest ? 1 : 0);
   scratch |= v << scratchBits;
   scratchBits += 1;
   if (scratchBits >= 64) {
@@ -1282,131 +980,59 @@ int writeRigidBody(RigidBody value, ByteData view) {
     scratch = v >>> (1 - scratchBits);
   }
   if (!value.atRest) {
-    {
-      final b = _float64BitsFromDouble(value.linearVelocity.x);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.linearVelocity.x);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.linearVelocity.y);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.linearVelocity.y);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.linearVelocity.z);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.linearVelocity.z);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.angularVelocity.x);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.angularVelocity.x);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.angularVelocity.y);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.angularVelocity.y);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
-    {
-      final b = _float64BitsFromDouble(value.angularVelocity.z);
-      v = b & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
-      v = (b >>> 32) & 0xffffffff;
-      scratch |= v << scratchBits;
-      scratchBits += 32;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (32 - scratchBits);
-      }
+    v = _float64BitsFromDouble(value.angularVelocity.z);
+    scratch |= v << scratchBits;
+    scratchBits += 64;
+    if (scratchBits >= 64) {
+      view.setUint64(wordIndex * 8, scratch, Endian.little);
+      wordIndex++;
+      scratchBits -= 64;
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1436,167 +1062,131 @@ bool readRigidBody(RigidBody value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 449 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.position.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.position.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.position.z = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.x = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.y = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.z = _doubleFromFloat64Bits(lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.orientation.w = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 32) & 0x1;
   bitsRead += 1;
   value.atRest = v != 0;
   if (!value.atRest) {
@@ -1604,128 +1194,104 @@ bool readRigidBody(RigidBody value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.linearVelocity.x = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.linearVelocity.y = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.linearVelocity.z = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.angularVelocity.x = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.angularVelocity.y = _doubleFromFloat64Bits(lo);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     value.angularVelocity.z = _doubleFromFloat64Bits(lo);
@@ -1801,122 +1367,45 @@ int writeInput(Input value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = _float32BitsFromDouble(value.stickX);
+  v =
+      _float32BitsFromDouble(value.stickX) |
+      (_float32BitsFromDouble(value.stickY) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = _float32BitsFromDouble(value.stickY);
+  v =
+      _float32BitsFromDouble(value.throttle) |
+      (_float32BitsFromDouble(value.yaw) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = _float32BitsFromDouble(value.throttle);
+  v =
+      _float32BitsFromDouble(value.pitch) |
+      ((value.fire ? 1 : 0) << 32) |
+      ((value.altFire ? 1 : 0) << 33) |
+      ((value.boost ? 1 : 0) << 34) |
+      ((value.brake ? 1 : 0) << 35) |
+      ((value.aim ? 1 : 0) << 36) |
+      ((value.lockOn ? 1 : 0) << 37) |
+      ((value.zoom ? 1 : 0) << 38) |
+      ((value.ping ? 1 : 0) << 39);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 40;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.yaw);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = _float32BitsFromDouble(value.pitch);
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.fire ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.altFire ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.boost ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.brake ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.aim ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.lockOn ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.zoom ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.ping ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (40 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1945,139 +1434,72 @@ bool readInput(Input value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 168 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.stickX = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.stickY = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.throttle = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.yaw = _doubleFromFloat32Bits(v);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.pitch = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 32) & 0x1;
   bitsRead += 1;
   value.fire = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 33) & 0x1;
   bitsRead += 1;
   value.altFire = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 34) & 0x1;
   bitsRead += 1;
   value.boost = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 35) & 0x1;
   bitsRead += 1;
   value.brake = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 36) & 0x1;
   bitsRead += 1;
   value.aim = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 37) & 0x1;
   bitsRead += 1;
   value.lockOn = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 38) & 0x1;
   bitsRead += 1;
   value.zoom = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 39) & 0x1;
   bitsRead += 1;
   value.ping = v != 0;
   return true;
@@ -2123,7 +1545,7 @@ int writeInputPacket(InputPacket value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.synchronizeSequence & 0xffff;
+  v = ((value.synchronizeSequence) & 0xffff);
   scratch |= v << scratchBits;
   scratchBits += 16;
   if (scratchBits >= 64) {
@@ -2132,45 +1554,27 @@ int writeInputPacket(InputPacket value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (16 - scratchBits);
   }
-  v = value.currentFrame & 0xffffffff;
+  v = (value.currentFrame);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.currentFrame >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.startFrame & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.startFrame >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.inputsCount >= 0);
   assert(value.inputsCount <= 16);
-  v = (value.inputsCount) & 0x1f;
+  v = (value.startFrame);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.inputsCount) & 0x1f);
   scratch |= v << scratchBits;
   scratchBits += 5;
   if (scratchBits >= 64) {
@@ -2181,122 +1585,45 @@ int writeInputPacket(InputPacket value, ByteData view) {
   }
   for (var i0 = 0; i0 < value.inputsCount; i0++) {
     final e0 = value.inputs[i0];
-    v = _float32BitsFromDouble(e0.stickX);
+    v =
+        _float32BitsFromDouble(e0.stickX) |
+        (_float32BitsFromDouble(e0.stickY) << 32);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = _float32BitsFromDouble(e0.stickY);
+    v =
+        _float32BitsFromDouble(e0.throttle) |
+        (_float32BitsFromDouble(e0.yaw) << 32);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = _float32BitsFromDouble(e0.throttle);
+    v =
+        _float32BitsFromDouble(e0.pitch) |
+        ((e0.fire ? 1 : 0) << 32) |
+        ((e0.altFire ? 1 : 0) << 33) |
+        ((e0.boost ? 1 : 0) << 34) |
+        ((e0.brake ? 1 : 0) << 35) |
+        ((e0.aim ? 1 : 0) << 36) |
+        ((e0.lockOn ? 1 : 0) << 37) |
+        ((e0.zoom ? 1 : 0) << 38) |
+        ((e0.ping ? 1 : 0) << 39);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 40;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = _float32BitsFromDouble(e0.yaw);
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = _float32BitsFromDouble(e0.pitch);
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = e0.fire ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.altFire ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.boost ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.brake ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.aim ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.lockOn ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.zoom ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
-    }
-    v = e0.ping ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+      scratch = v >>> (40 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -2326,75 +1653,52 @@ bool readInputPacket(InputPacket value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 144 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   value.synchronizeSequence = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 16) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.currentFrame = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.startFrame = lo;
   if (bitsRead + 5 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 32) & 0x1f;
   bitsRead += 5;
   if (v > 16) {
     return false; // the count guards the loop — reject, never clamp
@@ -2406,133 +1710,67 @@ bool readInputPacket(InputPacket value, ByteData view, int numBits) {
   for (var i0 = 0; i0 < value.inputsCount; i0++) {
     final e0 = value.inputs[i0];
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.stickX = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.stickY = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.throttle = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.yaw = _doubleFromFloat32Bits(v);
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     e0.pitch = _doubleFromFloat32Bits(v);
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 32) & 0x1;
     bitsRead += 1;
     e0.fire = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 33) & 0x1;
     bitsRead += 1;
     e0.altFire = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 34) & 0x1;
     bitsRead += 1;
     e0.boost = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 35) & 0x1;
     bitsRead += 1;
     e0.brake = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 36) & 0x1;
     bitsRead += 1;
     e0.aim = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 37) & 0x1;
     bitsRead += 1;
     e0.lockOn = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 38) & 0x1;
     bitsRead += 1;
     e0.zoom = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 39) & 0x1;
     bitsRead += 1;
     e0.ping = v != 0;
   }
@@ -2601,137 +1839,77 @@ int writeShipCreate(ShipCreate value, ByteData view) {
   var v = 0;
   assert(value.shipType >= 0);
   assert(value.shipType <= 5);
-  v = value.shipType & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
   assert(value.position.x >= -8388608);
   assert(value.position.x <= 8388608);
-  v = (value.position.x + 8388608) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.position.y >= -8388608);
   assert(value.position.y <= 8388608);
-  v = (value.position.y + 8388608) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.position.z >= -8388608);
   assert(value.position.z <= 8388608);
-  v = (value.position.z + 8388608) & 0x1ffffff;
+  v =
+      ((value.shipType) & 0x7) |
+      (((value.position.x + 8388608) & 0x1ffffff) << 3) |
+      (((value.position.y + 8388608) & 0x1ffffff) << 28);
   scratch |= v << scratchBits;
-  scratchBits += 25;
+  scratchBits += 53;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
+    scratch = v >>> (53 - scratchBits);
   }
   assert(value.rotation.x >= -1024);
   assert(value.rotation.x <= 1024);
-  v = (value.rotation.x + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.rotation.y >= -1024);
   assert(value.rotation.y <= 1024);
-  v = (value.rotation.y + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.rotation.z >= -1024);
   assert(value.rotation.z <= 1024);
-  v = (value.rotation.z + 1024) & 0xfff;
-  scratch |= v << scratchBits;
-  scratchBits += 12;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
-  }
   assert(value.rotation.w >= -1024);
   assert(value.rotation.w <= 1024);
-  v = (value.rotation.w + 1024) & 0xfff;
+  v =
+      ((value.position.z + 8388608) & 0x1ffffff) |
+      (((value.rotation.x + 1024) & 0xfff) << 25) |
+      (((value.rotation.y + 1024) & 0xfff) << 37) |
+      (((value.rotation.z + 1024) & 0xfff) << 49);
   scratch |= v << scratchBits;
-  scratchBits += 12;
+  scratchBits += 61;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (12 - scratchBits);
+    scratch = v >>> (61 - scratchBits);
   }
   assert(value.linearVelocity.x >= -2097152);
   assert(value.linearVelocity.x <= 2097152);
-  v = (value.linearVelocity.x + 2097152) & 0x7fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 23;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
   assert(value.linearVelocity.y >= -2097152);
   assert(value.linearVelocity.y <= 2097152);
-  v = (value.linearVelocity.y + 2097152) & 0x7fffff;
-  scratch |= v << scratchBits;
-  scratchBits += 23;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
-  }
   assert(value.linearVelocity.z >= -2097152);
   assert(value.linearVelocity.z <= 2097152);
-  v = (value.linearVelocity.z + 2097152) & 0x7fffff;
+  v =
+      ((value.rotation.w + 1024) & 0xfff) |
+      (((value.linearVelocity.x + 2097152) & 0x7fffff) << 12) |
+      (((value.linearVelocity.y + 2097152) & 0x7fffff) << 35);
   scratch |= v << scratchBits;
-  scratchBits += 23;
+  scratchBits += 58;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (23 - scratchBits);
+    scratch = v >>> (58 - scratchBits);
   }
-  v = value.hasFlags ? 1 : 0;
+  v =
+      ((value.linearVelocity.z + 2097152) & 0x7fffff) |
+      ((value.hasFlags ? 1 : 0) << 23);
   scratch |= v << scratchBits;
-  scratchBits += 1;
+  scratchBits += 24;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
+    scratch = v >>> (24 - scratchBits);
   }
   if (value.hasFlags) {
     assert(value.flags >>> 4 == 0);
-    v = value.flags & 0xf;
+    v = ((value.flags) & 0xf);
     scratch |= v << scratchBits;
     scratchBits += 4;
     if (scratchBits >= 64) {
@@ -2743,39 +1921,24 @@ int writeShipCreate(ShipCreate value, ByteData view) {
   }
   assert(value.team >= 0);
   assert(value.team <= 2);
-  v = value.team & 0x3;
-  scratch |= v << scratchBits;
-  scratchBits += 2;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
-  }
   assert(value.health >= 0);
   assert(value.health <= 1000);
-  v = (value.health) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.thrust >= 0);
   assert(value.thrust <= 100);
-  v = (value.thrust) & 0x7f;
+  assert(value.pending >= 0);
+  assert(value.pending <= 0);
+  v =
+      ((value.team) & 0x3) |
+      (((value.health) & 0x3ff) << 2) |
+      (((value.thrust) & 0x7f) << 12);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 19;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
+    scratch = v >>> (19 - scratchBits);
   }
-  assert(value.pending >= 0);
-  assert(value.pending <= 0);
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
   }
@@ -2803,162 +1966,97 @@ bool readShipCreate(ShipCreate value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 196 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   if (v > 5) {
     return false; // headroom above the wire range is refused
   }
   value.shipType = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 3) & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.position.x = -8388608 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 28) & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.position.y = -8388608 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 16777216) {
     return false; // a smuggled offset is refused
   }
   value.position.z = -8388608 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 25) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.x = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 37) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.y = -1024 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xfff;
+  v = window & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.z = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfff;
+  v = (window >>> 12) & 0xfff;
   bitsRead += 12;
   if (v > 2048) {
     return false; // a smuggled offset is refused
   }
   value.rotation.w = -1024 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 24) & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.linearVelocity.x = -2097152 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7fffff;
+  v = window & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.linearVelocity.y = -2097152 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7fffff;
+  v = (window >>> 23) & 0x7fffff;
   bitsRead += 23;
   if (v > 4194304) {
     return false; // a smuggled offset is refused
   }
   value.linearVelocity.z = -2097152 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 46) & 0x1;
   bitsRead += 1;
   value.hasFlags = v != 0;
   if (value.hasFlags) {
@@ -2966,13 +2064,11 @@ bool readShipCreate(ShipCreate value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xf;
+    v = window & 0xf;
     bitsRead += 4;
     value.flags = v;
   } else {
@@ -2982,39 +2078,23 @@ bool readShipCreate(ShipCreate value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // headroom above the wire range is refused
   }
   value.team = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 2) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.health = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7f;
+  v = (window >>> 12) & 0x7f;
   bitsRead += 7;
   if (v > 100) {
     return false; // a smuggled offset is refused
@@ -3068,25 +2148,18 @@ int writeExpressionProbe(ExpressionProbe value, ByteData view) {
   var v = 0;
   assert(value.hardpointIndex >= 0);
   assert(value.hardpointIndex <= 31);
-  v = (value.hardpointIndex) & 0x1f;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
-  }
   assert(value.spinRate >= 1024);
   assert(value.spinRate <= 2048);
-  v = (value.spinRate - 1024) & 0x7ff;
+  v =
+      ((value.hardpointIndex) & 0x1f) |
+      (((value.spinRate - 1024) & 0x7ff) << 5);
   scratch |= v << scratchBits;
-  scratchBits += 11;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (11 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -3115,29 +2188,19 @@ bool readExpressionProbe(ExpressionProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1f;
+  v = window & 0x1f;
   bitsRead += 5;
   value.hardpointIndex = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 5) & 0x7ff;
   bitsRead += 11;
   if (v > 1024) {
     return false; // a smuggled offset is refused
@@ -3194,106 +2257,52 @@ int writeExtremeProbe(ExtremeProbe value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   assert(value.floorBound <= 100);
-  {
-    final off = value.floorBound - 0x8000000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
   assert(value.doubledFloor <= 100);
-  {
-    final off = value.doubledFloor - 0x8000000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
+  v = (value.floorBound - 0x8000000000000000);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
   }
   assert(!_unsignedLessThan(value.ceilingRange, 1));
-  {
-    final off = value.ceilingRange - 1;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.floorDefault & 0xffffffff;
+  v = (value.doubledFloor - 0x8000000000000000);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.floorDefault >>> 32) & 0xffffffff;
+  v = (value.ceilingRange - 1);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.ceilingDefault & 0xffffffff;
+  v = (value.floorDefault);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.ceilingDefault >>> 32) & 0xffffffff;
+  v = (value.ceilingDefault);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -3322,30 +2331,25 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 320 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0x8000000000000064, lo)) {
@@ -3353,23 +2357,19 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   value.floorBound = 0x8000000000000000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0x8000000000000064, lo)) {
@@ -3377,23 +2377,19 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   value.doubledFloor = 0x8000000000000000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0xfffffffffffffffe, lo)) {
@@ -3401,44 +2397,36 @@ bool readExtremeProbe(ExtremeProbe value, ByteData view, int numBits) {
   }
   value.ceilingRange = 1 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.floorDefault = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.ceilingDefault = lo;
@@ -3486,85 +2474,43 @@ int writeExtremeRow(ExtremeRow value, ByteData view) {
   var wordIndex = 0;
   var v = 0;
   assert(value.clampedFloor <= 100);
-  {
-    final off = value.clampedFloor - 0x8000000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
   assert(!_unsignedLessThan(value.clampedCeiling, 1));
   assert(!_unsignedLessThan(0xfffffffffffffffe, value.clampedCeiling));
-  {
-    final off = value.clampedCeiling - 1;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.floorDef & 0xffffffff;
+  v = (value.clampedFloor - 0x8000000000000000);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.floorDef >>> 32) & 0xffffffff;
+  v = (value.clampedCeiling - 1);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.ceilingDef & 0xffffffff;
+  v = (value.floorDef);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.ceilingDef >>> 32) & 0xffffffff;
+  v = (value.ceilingDef);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -3593,30 +2539,25 @@ bool readExtremeRow(ExtremeRow value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 256 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0x8000000000000064, lo)) {
@@ -3624,23 +2565,19 @@ bool readExtremeRow(ExtremeRow value, ByteData view, int numBits) {
   }
   value.clampedFloor = 0x8000000000000000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0xfffffffffffffffd, lo)) {
@@ -3648,44 +2585,36 @@ bool readExtremeRow(ExtremeRow value, ByteData view, int numBits) {
   }
   value.clampedCeiling = 1 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.floorDef = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.ceilingDef = lo;

--- a/testdata/golden/dart/Wire.dart
+++ b/testdata/golden/dart/Wire.dart
@@ -186,32 +186,14 @@ int writeProbeHeader(ProbeHeader value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = 171;
+  v = 171 | (((value.version) & 0x7) << 8) | (0 << 11);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.version & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = 0;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -225,23 +207,14 @@ int writeProbeHeader(ProbeHeader value, ByteData view) {
       }
     }
   }
-  v = value.probeId & 0xffffffff;
+  v = (value.probeId);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.probeId >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -270,42 +243,25 @@ bool readProbeHeader(ProbeHeader value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v != 171) {
     return false; // a read rejects any other value (SPEC §4.3)
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 8) & 0x7;
   bitsRead += 3;
   value.version = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 11) & 0x1f;
   bitsRead += 5;
   if (v != 0) {
     return false; // reserved bits must read zero (SPEC §4.3)
@@ -326,23 +282,19 @@ bool readProbeHeader(ProbeHeader value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.probeId = lo;
@@ -395,54 +347,27 @@ int writeProbeBits(ProbeBits value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.small & 0x1ff;
+  v = ((value.small) & 0x1ff) | (((value.boundary) & 0x1ffffffff) << 9);
   scratch |= v << scratchBits;
-  scratchBits += 9;
+  scratchBits += 42;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (9 - scratchBits);
-  }
-  v = value.boundary & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.boundary >>> 32) & 0x1;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
-  v = value.wide & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (42 - scratchBits);
   }
   assert(value.sensor >= 0);
   assert(value.sensor <= 4294967295);
-  v = (value.sensor) & 0xffffffff;
+  v = (value.wide);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.sensor) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -451,23 +376,14 @@ int writeProbeBits(ProbeBits value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = value.nonce & 0xffffffff;
+  v = (value.nonce);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.nonce >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -496,92 +412,61 @@ bool readProbeBits(ProbeBits value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 202 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ff;
+  v = window & 0x1ff;
   bitsRead += 9;
   value.small = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
-  bitsRead += 1;
-  lo |= v << 32;
+  lo = (window >>> 9) & 0x1ffffffff;
+  bitsRead += 33;
   value.boundary = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.wide = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.sensor = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.nonce = lo;
@@ -648,7 +533,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.active ? 1 : 0;
+  v = (value.active ? 1 : 0);
   scratch |= v << scratchBits;
   scratchBits += 1;
   if (scratchBits >= 64) {
@@ -676,7 +561,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (16 - scratchBits);
   }
-  v = value.rawDelta & 0xffffffff;
+  v = ((value.rawDelta) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -685,47 +570,29 @@ int writeProbeSample(ProbeSample value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = value.bigDelta & 0xffffffff;
+  v = (value.bigDelta);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.bigDelta >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (value.active) {
     assert(value.weapon >= 0);
     assert(value.weapon <= 15);
-    v = value.weapon & 0xf;
+    v = ((value.weapon) & 0xf) | ((value.hasTarget ? 1 : 0) << 4);
     scratch |= v << scratchBits;
-    scratchBits += 4;
+    scratchBits += 5;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (4 - scratchBits);
-    }
-    v = value.hasTarget ? 1 : 0;
-    scratch |= v << scratchBits;
-    scratchBits += 1;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (1 - scratchBits);
+      scratch = v >>> (5 - scratchBits);
     }
     if (value.hasTarget) {
-      v = value.targetId & 0xffff;
+      v = ((value.targetId) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -736,7 +603,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
       }
     }
   } else {
-    v = value.idleTicks & 0xffffffff;
+    v = ((value.idleTicks) & 0xffffffff);
     scratch |= v << scratchBits;
     scratchBits += 32;
     if (scratchBits >= 64) {
@@ -748,7 +615,7 @@ int writeProbeSample(ProbeSample value, ByteData view) {
   }
   assert(value.samplesCount >= 1);
   assert(value.samplesCount <= 8);
-  v = (value.samplesCount - 1) & 0x7;
+  v = ((value.samplesCount - 1) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -757,15 +624,33 @@ int writeProbeSample(ProbeSample value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (3 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.samplesCount; i0++) {
-    v = value.samples[i0] & 0xffff;
-    scratch |= v << scratchBits;
-    scratchBits += 16;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (16 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.samplesCount; i0 += 4) {
+      v =
+          ((value.samples[i0]) & 0xffff) |
+          (((value.samples[i0 + 1]) & 0xffff) << 16) |
+          (((value.samples[i0 + 2]) & 0xffff) << 32) |
+          (((value.samples[i0 + 3]) & 0xffff) << 48);
+      scratch |= v << scratchBits;
+      scratchBits += 64;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (64 - scratchBits);
+      }
+    }
+    for (; i0 < value.samplesCount; i0++) {
+      v = ((value.samples[i0]) & 0xffff);
+      scratch |= v << scratchBits;
+      scratchBits += 16;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (16 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -795,30 +680,20 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 113 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.active = v != 0;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 1) & 0xffff;
   bitsRead += 16;
   if (v > 36000) {
     return false; // headroom above the quantum count is refused
@@ -826,34 +701,23 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
   value.orientation = _fround(
     _fround(_fround(_fround(v.toDouble()) / 36000.0) * 360.0) + -180.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 17) & 0xffffffff;
   bitsRead += 32;
   value.rawDelta = (v << 32) >> 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.bigDelta = lo;
@@ -862,23 +726,14 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xf;
+    v = window & 0xf;
     bitsRead += 4;
     value.weapon = v;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0x1;
+    v = (window >>> 4) & 0x1;
     bitsRead += 1;
     value.hasTarget = v != 0;
     if (value.hasTarget) {
@@ -886,13 +741,12 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.targetId = v;
     } else {
@@ -904,13 +758,11 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     value.idleTicks = v;
     value.weapon = 0;
@@ -921,29 +773,46 @@ bool readProbeSample(ProbeSample value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7;
+  v = window & 0x7;
   bitsRead += 3;
   value.samplesCount = v + 1;
   if (bitsRead + value.samplesCount * 16 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.samplesCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 3 <= value.samplesCount; i0 += 3) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xffff;
+      bitsRead += 16;
+      value.samples[i0] = v;
+      v = (window >>> 16) & 0xffff;
+      bitsRead += 16;
+      value.samples[i0 + 1] = v;
+      v = (window >>> 32) & 0xffff;
+      bitsRead += 16;
+      value.samples[i0 + 2] = v;
     }
-    v = (window >>> shift) & 0xffff;
-    bitsRead += 16;
-    value.samples[i0] = v;
+    for (; i0 < value.samplesCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xffff;
+      bitsRead += 16;
+      value.samples[i0] = v;
+    }
   }
   return true;
 }
@@ -992,7 +861,7 @@ int writeProbeRing(ProbeRing value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.radius & 0xffff;
+  v = ((value.radius) & 0xffff);
   scratch |= v << scratchBits;
   scratchBits += 16;
   if (scratchBits >= 64) {
@@ -1028,19 +897,16 @@ bool readProbeRing(ProbeRing value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   value.radius = v;
   return true;
@@ -1081,23 +947,14 @@ int writeProbeSlab(ProbeSlab value, ByteData view) {
   var v = 0;
   assert(value.width >= 0);
   assert(value.width <= 100);
-  v = (value.width) & 0x7f;
+  v = ((value.width) & 0x7f) | (((value.height) & 0xff) << 7);
   scratch |= v << scratchBits;
-  scratchBits += 7;
+  scratchBits += 15;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (7 - scratchBits);
-  }
-  v = value.height & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (15 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1126,32 +983,22 @@ bool readProbeSlab(ProbeSlab value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 15 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7f;
+  v = window & 0x7f;
   bitsRead += 7;
   if (v > 100) {
     return false; // a smuggled offset is refused
   }
   value.width = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 7) & 0xff;
   bitsRead += 8;
   value.height = v;
   return true;
@@ -1203,7 +1050,7 @@ int writeProbeShape(ProbeShape value, ByteData view) {
   var v = 0;
   assert(value.type >= 0);
   assert(value.type <= 2);
-  v = value.type & 0x3;
+  v = ((value.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1214,7 +1061,7 @@ int writeProbeShape(ProbeShape value, ByteData view) {
   }
   switch (value.type) {
     case 1:
-      v = value.ring.radius & 0xffff;
+      v = ((value.ring.radius) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -1226,23 +1073,14 @@ int writeProbeShape(ProbeShape value, ByteData view) {
     case 2:
       assert(value.slab.width >= 0);
       assert(value.slab.width <= 100);
-      v = (value.slab.width) & 0x7f;
+      v = ((value.slab.width) & 0x7f) | (((value.slab.height) & 0xff) << 7);
       scratch |= v << scratchBits;
-      scratchBits += 7;
+      scratchBits += 15;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (7 - scratchBits);
-      }
-      v = value.slab.height & 0xff;
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (15 - scratchBits);
       }
   }
   if (scratchBits != 0) {
@@ -1272,19 +1110,16 @@ bool readProbeShape(ProbeShape value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 2 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1297,13 +1132,12 @@ bool readProbeShape(ProbeShape value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.ring.radius = v;
     case 2:
@@ -1313,26 +1147,18 @@ bool readProbeShape(ProbeShape value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7f;
+      v = window & 0x7f;
       bitsRead += 7;
       if (v > 100) {
         return false; // a smuggled offset is refused
       }
       value.slab.width = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 7) & 0xff;
       bitsRead += 8;
       value.slab.height = v;
   }
@@ -1389,29 +1215,20 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.armor & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.shape.type >= 0);
   assert(value.shape.type <= 2);
-  v = value.shape.type & 0x3;
+  v = ((value.armor) & 0xff) | (((value.shape.type) & 0x3) << 8);
   scratch |= v << scratchBits;
-  scratchBits += 2;
+  scratchBits += 10;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
+    scratch = v >>> (10 - scratchBits);
   }
   switch (value.shape.type) {
     case 1:
-      v = value.shape.ring.radius & 0xffff;
+      v = ((value.shape.ring.radius) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -1423,28 +1240,21 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     case 2:
       assert(value.shape.slab.width >= 0);
       assert(value.shape.slab.width <= 100);
-      v = (value.shape.slab.width) & 0x7f;
+      v =
+          ((value.shape.slab.width) & 0x7f) |
+          (((value.shape.slab.height) & 0xff) << 7);
       scratch |= v << scratchBits;
-      scratchBits += 7;
+      scratchBits += 15;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (7 - scratchBits);
-      }
-      v = value.shape.slab.height & 0xff;
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (15 - scratchBits);
       }
   }
   assert(value.backup.type >= 0);
   assert(value.backup.type <= 2);
-  v = value.backup.type & 0x3;
+  v = ((value.backup.type) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1455,7 +1265,7 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
   }
   switch (value.backup.type) {
     case 1:
-      v = value.backup.ring.radius & 0xffff;
+      v = ((value.backup.ring.radius) & 0xffff);
       scratch |= v << scratchBits;
       scratchBits += 16;
       if (scratchBits >= 64) {
@@ -1467,28 +1277,21 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     case 2:
       assert(value.backup.slab.width >= 0);
       assert(value.backup.slab.width <= 100);
-      v = (value.backup.slab.width) & 0x7f;
+      v =
+          ((value.backup.slab.width) & 0x7f) |
+          (((value.backup.slab.height) & 0xff) << 7);
       scratch |= v << scratchBits;
-      scratchBits += 7;
+      scratchBits += 15;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (7 - scratchBits);
-      }
-      v = value.backup.slab.height & 0xff;
-      scratch |= v << scratchBits;
-      scratchBits += 8;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (8 - scratchBits);
+        scratch = v >>> (15 - scratchBits);
       }
   }
   assert(value.extrasCount >= 0);
   assert(value.extrasCount <= 2);
-  v = (value.extrasCount) & 0x3;
+  v = ((value.extrasCount) & 0x3);
   scratch |= v << scratchBits;
   scratchBits += 2;
   if (scratchBits >= 64) {
@@ -1501,7 +1304,7 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     final e0 = value.extras[i0];
     assert(e0.type >= 0);
     assert(e0.type <= 2);
-    v = e0.type & 0x3;
+    v = ((e0.type) & 0x3);
     scratch |= v << scratchBits;
     scratchBits += 2;
     if (scratchBits >= 64) {
@@ -1512,7 +1315,7 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
     }
     switch (e0.type) {
       case 1:
-        v = e0.ring.radius & 0xffff;
+        v = ((e0.ring.radius) & 0xffff);
         scratch |= v << scratchBits;
         scratchBits += 16;
         if (scratchBits >= 64) {
@@ -1524,23 +1327,14 @@ int writeProbeCollider(ProbeCollider value, ByteData view) {
       case 2:
         assert(e0.slab.width >= 0);
         assert(e0.slab.width <= 100);
-        v = (e0.slab.width) & 0x7f;
+        v = ((e0.slab.width) & 0x7f) | (((e0.slab.height) & 0xff) << 7);
         scratch |= v << scratchBits;
-        scratchBits += 7;
+        scratchBits += 15;
         if (scratchBits >= 64) {
           view.setUint64(wordIndex * 8, scratch, Endian.little);
           wordIndex++;
           scratchBits -= 64;
-          scratch = v >>> (7 - scratchBits);
-        }
-        v = e0.slab.height & 0xff;
-        scratch |= v << scratchBits;
-        scratchBits += 8;
-        if (scratchBits >= 64) {
-          view.setUint64(wordIndex * 8, scratch, Endian.little);
-          wordIndex++;
-          scratchBits -= 64;
-          scratch = v >>> (8 - scratchBits);
+          scratch = v >>> (15 - scratchBits);
         }
     }
   }
@@ -1571,32 +1365,22 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 8 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.armor = v;
   if (bitsRead + 2 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
+  v = (window >>> 8) & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1609,13 +1393,12 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.shape.ring.radius = v;
     case 2:
@@ -1625,26 +1408,18 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7f;
+      v = window & 0x7f;
       bitsRead += 7;
       if (v > 100) {
         return false; // a smuggled offset is refused
       }
       value.shape.slab.width = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 7) & 0xff;
       bitsRead += 8;
       value.shape.slab.height = v;
   }
@@ -1652,13 +1427,11 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // not a wire-legal tag (SPEC §4.8)
@@ -1671,13 +1444,12 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffff;
+      v = window & 0xffff;
       bitsRead += 16;
       value.backup.ring.radius = v;
     case 2:
@@ -1687,26 +1459,18 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0x7f;
+      v = window & 0x7f;
       bitsRead += 7;
       if (v > 100) {
         return false; // a smuggled offset is refused
       }
       value.backup.slab.width = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0xff;
+      v = (window >>> 7) & 0xff;
       bitsRead += 8;
       value.backup.slab.height = v;
   }
@@ -1714,13 +1478,11 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   if (v > 2) {
     return false; // the count guards the loop — reject, never clamp
@@ -1732,13 +1494,11 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x3;
+    v = window & 0x3;
     bitsRead += 2;
     if (v > 2) {
       return false; // not a wire-legal tag (SPEC §4.8)
@@ -1751,13 +1511,12 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0xffff;
+        v = window & 0xffff;
         bitsRead += 16;
         e0.ring.radius = v;
       case 2:
@@ -1767,26 +1526,18 @@ bool readProbeCollider(ProbeCollider value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0x7f;
+        v = window & 0x7f;
         bitsRead += 7;
         if (v > 100) {
           return false; // a smuggled offset is refused
         }
         e0.slab.width = v;
-        if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
-        } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
-        }
-        v = (window >>> shift) & 0xff;
+        v = (window >>> 7) & 0xff;
         bitsRead += 8;
         e0.slab.height = v;
     }
@@ -1857,25 +1608,16 @@ int writeProbeConfig(ProbeConfig value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.retries & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.preferred >= 0);
   assert(value.preferred <= 15);
-  v = value.preferred & 0xf;
+  v = ((value.retries) & 0xffffffff) | (((value.preferred) & 0xf) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 36;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (36 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -1904,29 +1646,19 @@ bool readProbeConfig(ProbeConfig value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 36 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.retries = (v << 32) >> 32;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 32) & 0xf;
   bitsRead += 4;
   value.preferred = v;
   return true;
@@ -1968,7 +1700,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
   var v = 0;
   for (var i0 = 0; i0 < 2; i0++) {
     final e0 = value.samples[i0];
-    v = e0.active ? 1 : 0;
+    v = (e0.active ? 1 : 0);
     scratch |= v << scratchBits;
     scratchBits += 1;
     if (scratchBits >= 64) {
@@ -1996,7 +1728,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (16 - scratchBits);
     }
-    v = e0.rawDelta & 0xffffffff;
+    v = ((e0.rawDelta) & 0xffffffff);
     scratch |= v << scratchBits;
     scratchBits += 32;
     if (scratchBits >= 64) {
@@ -2005,47 +1737,29 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (32 - scratchBits);
     }
-    v = e0.bigDelta & 0xffffffff;
+    v = (e0.bigDelta);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (e0.bigDelta >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
     if (e0.active) {
       assert(e0.weapon >= 0);
       assert(e0.weapon <= 15);
-      v = e0.weapon & 0xf;
+      v = ((e0.weapon) & 0xf) | ((e0.hasTarget ? 1 : 0) << 4);
       scratch |= v << scratchBits;
-      scratchBits += 4;
+      scratchBits += 5;
       if (scratchBits >= 64) {
         view.setUint64(wordIndex * 8, scratch, Endian.little);
         wordIndex++;
         scratchBits -= 64;
-        scratch = v >>> (4 - scratchBits);
-      }
-      v = e0.hasTarget ? 1 : 0;
-      scratch |= v << scratchBits;
-      scratchBits += 1;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (1 - scratchBits);
+        scratch = v >>> (5 - scratchBits);
       }
       if (e0.hasTarget) {
-        v = e0.targetId & 0xffff;
+        v = ((e0.targetId) & 0xffff);
         scratch |= v << scratchBits;
         scratchBits += 16;
         if (scratchBits >= 64) {
@@ -2056,7 +1770,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
         }
       }
     } else {
-      v = e0.idleTicks & 0xffffffff;
+      v = ((e0.idleTicks) & 0xffffffff);
       scratch |= v << scratchBits;
       scratchBits += 32;
       if (scratchBits >= 64) {
@@ -2068,7 +1782,7 @@ int writeProbeArray(ProbeArray value, ByteData view) {
     }
     assert(e0.samplesCount >= 1);
     assert(e0.samplesCount <= 8);
-    v = (e0.samplesCount - 1) & 0x7;
+    v = ((e0.samplesCount - 1) & 0x7);
     scratch |= v << scratchBits;
     scratchBits += 3;
     if (scratchBits >= 64) {
@@ -2077,37 +1791,48 @@ int writeProbeArray(ProbeArray value, ByteData view) {
       scratchBits -= 64;
       scratch = v >>> (3 - scratchBits);
     }
-    for (var i1 = 0; i1 < e0.samplesCount; i1++) {
-      v = e0.samples[i1] & 0xffff;
-      scratch |= v << scratchBits;
-      scratchBits += 16;
-      if (scratchBits >= 64) {
-        view.setUint64(wordIndex * 8, scratch, Endian.little);
-        wordIndex++;
-        scratchBits -= 64;
-        scratch = v >>> (16 - scratchBits);
+    {
+      var i1 = 0;
+      for (; i1 + 4 <= e0.samplesCount; i1 += 4) {
+        v =
+            ((e0.samples[i1]) & 0xffff) |
+            (((e0.samples[i1 + 1]) & 0xffff) << 16) |
+            (((e0.samples[i1 + 2]) & 0xffff) << 32) |
+            (((e0.samples[i1 + 3]) & 0xffff) << 48);
+        scratch |= v << scratchBits;
+        scratchBits += 64;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (64 - scratchBits);
+        }
+      }
+      for (; i1 < e0.samplesCount; i1++) {
+        v = ((e0.samples[i1]) & 0xffff);
+        scratch |= v << scratchBits;
+        scratchBits += 16;
+        if (scratchBits >= 64) {
+          view.setUint64(wordIndex * 8, scratch, Endian.little);
+          wordIndex++;
+          scratchBits -= 64;
+          scratch = v >>> (16 - scratchBits);
+        }
       }
     }
   }
-  v = value.config.retries & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.config.preferred >= 0);
   assert(value.config.preferred <= 15);
-  v = value.config.preferred & 0xf;
+  v =
+      ((value.config.retries) & 0xffffffff) |
+      (((value.config.preferred) & 0xf) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 4;
+  scratchBits += 36;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (4 - scratchBits);
+    scratch = v >>> (36 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2136,7 +1861,6 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   for (var i0 = 0; i0 < 2; i0++) {
@@ -2145,23 +1869,14 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1;
+    v = window & 0x1;
     bitsRead += 1;
     e0.active = v != 0;
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xffff;
+    v = (window >>> 1) & 0xffff;
     bitsRead += 16;
     if (v > 36000) {
       return false; // headroom above the quantum count is refused
@@ -2169,34 +1884,23 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
     e0.orientation = _fround(
       _fround(_fround(_fround(v.toDouble()) / 36000.0) * 360.0) + -180.0,
     );
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
-    }
-    v = (window >>> shift) & 0xffffffff;
+    v = (window >>> 17) & 0xffffffff;
     bitsRead += 32;
     e0.rawDelta = (v << 32) >> 32;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     e0.bigDelta = lo;
@@ -2205,23 +1909,15 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xf;
+      v = window & 0xf;
       bitsRead += 4;
       e0.weapon = v;
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
-      }
-      v = (window >>> shift) & 0x1;
+      v = (window >>> 4) & 0x1;
       bitsRead += 1;
       e0.hasTarget = v != 0;
       if (e0.hasTarget) {
@@ -2229,13 +1925,12 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
           return false;
         }
         if (bitsRead >>> 3 < tailBase) {
-          window = view.getUint64(bitsRead >>> 3, Endian.little);
-          shift = bitsRead & 7;
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
         } else {
-          window = tailWord;
-          shift = bitsRead - tailBase * 8;
+          window = tailWord >>> (bitsRead - tailBase * 8);
         }
-        v = (window >>> shift) & 0xffff;
+        v = window & 0xffff;
         bitsRead += 16;
         e0.targetId = v;
       } else {
@@ -2247,13 +1942,12 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
         return false;
       }
       if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
       } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+        window = tailWord >>> (bitsRead - tailBase * 8);
       }
-      v = (window >>> shift) & 0xffffffff;
+      v = window & 0xffffffff;
       bitsRead += 32;
       e0.idleTicks = v;
       e0.weapon = 0;
@@ -2264,52 +1958,60 @@ bool readProbeArray(ProbeArray value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x7;
+    v = window & 0x7;
     bitsRead += 3;
     e0.samplesCount = v + 1;
     if (bitsRead + e0.samplesCount * 16 > numBits) {
       return false;
     }
-    for (var i1 = 0; i1 < e0.samplesCount; i1++) {
-      if (bitsRead >>> 3 < tailBase) {
-        window = view.getUint64(bitsRead >>> 3, Endian.little);
-        shift = bitsRead & 7;
-      } else {
-        window = tailWord;
-        shift = bitsRead - tailBase * 8;
+    {
+      var i1 = 0;
+      for (; i1 + 3 <= e0.samplesCount; i1 += 3) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1] = v;
+        v = (window >>> 16) & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1 + 1] = v;
+        v = (window >>> 32) & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1 + 2] = v;
       }
-      v = (window >>> shift) & 0xffff;
-      bitsRead += 16;
-      e0.samples[i1] = v;
+      for (; i1 < e0.samplesCount; i1++) {
+        if (bitsRead >>> 3 < tailBase) {
+          window =
+              view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+        } else {
+          window = tailWord >>> (bitsRead - tailBase * 8);
+        }
+        v = window & 0xffff;
+        bitsRead += 16;
+        e0.samples[i1] = v;
+      }
     }
   }
   if (bitsRead + 36 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.config.retries = (v << 32) >> 32;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xf;
+  v = (window >>> 32) & 0xf;
   bitsRead += 4;
   value.config.preferred = v;
   return true;
@@ -2415,47 +2117,24 @@ int writeTest(Test value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.testA & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
   assert(value.testB >= 0);
   assert(value.testB <= 1000);
-  v = (value.testB) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.testC >= 0);
   assert(value.testC <= 1000);
-  v = (value.testC) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.testD >= 0);
   assert(value.testD <= 1000);
-  v = (value.testD) & 0x3ff;
+  v =
+      ((value.testA) & 0xffff) |
+      (((value.testB) & 0x3ff) << 16) |
+      (((value.testC) & 0x3ff) << 26) |
+      (((value.testD) & 0x3ff) << 36);
   scratch |= v << scratchBits;
-  scratchBits += 10;
+  scratchBits += 46;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
+    scratch = v >>> (46 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2484,55 +2163,31 @@ bool readTest(Test value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 46 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffff;
+  v = window & 0xffff;
   bitsRead += 16;
   value.testA = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 16) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.testB = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 26) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.testC = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 36) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
@@ -2576,7 +2231,7 @@ int writeBlock(Block value, ByteData view) {
   var v = 0;
   assert(value.dataLength >= 0);
   assert(value.dataLength <= 2000);
-  v = (value.dataLength) & 0x7ff;
+  v = ((value.dataLength) & 0x7ff);
   scratch |= v << scratchBits;
   scratchBits += 11;
   if (scratchBits >= 64) {
@@ -2597,15 +2252,33 @@ int writeBlock(Block value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.dataLength; i0++) {
-    v = value.data[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.dataLength; i0 += 4) {
+      v =
+          value.data[i0] |
+          (value.data[i0 + 1] << 8) |
+          (value.data[i0 + 2] << 16) |
+          (value.data[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.dataLength; i0++) {
+      v = value.data[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -2635,19 +2308,16 @@ bool readBlock(Block value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 11 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x7ff;
+  v = window & 0x7ff;
   bitsRead += 11;
   if (v > 2000) {
     return false; // the length guards the slice — reject, never clamp
@@ -2719,7 +2389,7 @@ int writeChat(Chat value, ByteData view) {
   var v = 0;
   assert(value.textLength >= 0);
   assert(value.textLength <= 256);
-  v = (value.textLength) & 0x1ff;
+  v = ((value.textLength) & 0x1ff);
   scratch |= v << scratchBits;
   scratchBits += 9;
   if (scratchBits >= 64) {
@@ -2740,15 +2410,33 @@ int writeChat(Chat value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.textLength; i0++) {
-    v = value.text[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.textLength; i0 += 4) {
+      v =
+          value.text[i0] |
+          (value.text[i0 + 1] << 8) |
+          (value.text[i0 + 2] << 16) |
+          (value.text[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.textLength; i0++) {
+      v = value.text[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -2778,19 +2466,16 @@ bool readChat(Chat value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 9 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ff;
+  v = window & 0x1ff;
   bitsRead += 9;
   if (v > 256) {
     return false; // the length guards the slice — reject, never clamp
@@ -2867,32 +2552,14 @@ int writeProbeReport(ProbeReport value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = 171;
+  v = 171 | (((value.header.version) & 0x7) << 8) | (0 << 11);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.header.version & 0x7;
-  scratch |= v << scratchBits;
-  scratchBits += 3;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (3 - scratchBits);
-  }
-  v = 0;
-  scratch |= v << scratchBits;
-  scratchBits += 5;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -2906,75 +2573,35 @@ int writeProbeReport(ProbeReport value, ByteData view) {
       }
     }
   }
-  v = value.header.probeId & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.header.probeId >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.flags >>> 8 == 0);
-  v = value.flags & 0xff;
+  v = (value.header.probeId);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.echo.testA & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.echo.testB >= 0);
   assert(value.echo.testB <= 1000);
-  v = (value.echo.testB) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.echo.testC >= 0);
   assert(value.echo.testC <= 1000);
-  v = (value.echo.testC) & 0x3ff;
-  scratch |= v << scratchBits;
-  scratchBits += 10;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
-  }
   assert(value.echo.testD >= 0);
   assert(value.echo.testD <= 1000);
-  v = (value.echo.testD) & 0x3ff;
+  v =
+      ((value.flags) & 0xff) |
+      (((value.echo.testA) & 0xffff) << 8) |
+      (((value.echo.testB) & 0x3ff) << 24) |
+      (((value.echo.testC) & 0x3ff) << 34) |
+      (((value.echo.testD) & 0x3ff) << 44);
   scratch |= v << scratchBits;
-  scratchBits += 10;
+  scratchBits += 54;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (10 - scratchBits);
+    scratch = v >>> (54 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -3003,42 +2630,25 @@ bool readProbeReport(ProbeReport value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 16 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v != 171) {
     return false; // a read rejects any other value (SPEC §4.3)
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 8) & 0x7;
   bitsRead += 3;
   value.header.version = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 11) & 0x1f;
   bitsRead += 5;
   if (v != 0) {
     return false; // reserved bits must read zero (SPEC §4.3)
@@ -3059,83 +2669,49 @@ bool readProbeReport(ProbeReport value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.header.probeId = lo;
   if (bitsRead + 54 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.flags = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 40) & 0xffff;
   bitsRead += 16;
   value.echo.testA = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3ff;
+  v = window & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.echo.testB = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 10) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
   }
   value.echo.testC = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 20) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // a smuggled offset is refused
@@ -3233,95 +2809,78 @@ int writeTestData(TestData value, ByteData view) {
   var v = 0;
   assert(value.a >= -100);
   assert(value.a <= 100);
-  v = (value.a + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.b >= -100);
   assert(value.b <= 100);
-  v = (value.b + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
   assert(value.c >= -100);
   assert(value.c <= 150);
-  v = (value.c + 100) & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.d & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.e & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.f & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.g ? 1 : 0;
-  scratch |= v << scratchBits;
-  scratchBits += 1;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (1 - scratchBits);
-  }
   assert(value.itemsCount >= 0);
   assert(value.itemsCount <= 16);
-  v = (value.itemsCount) & 0x1f;
+  v =
+      ((value.a + 100) & 0xff) |
+      (((value.b + 100) & 0xff) << 8) |
+      (((value.c + 100) & 0xff) << 16) |
+      (((value.d) & 0xff) << 24) |
+      (((value.e) & 0xff) << 32) |
+      (((value.f) & 0xff) << 40) |
+      ((value.g ? 1 : 0) << 48) |
+      (((value.itemsCount) & 0x1f) << 49);
   scratch |= v << scratchBits;
-  scratchBits += 5;
+  scratchBits += 54;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (5 - scratchBits);
+    scratch = v >>> (54 - scratchBits);
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    assert(value.items[i0] >= 0);
-    assert(value.items[i0] <= 255);
-    v = (value.items[i0]) & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 8 <= value.itemsCount; i0 += 8) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 255);
+      assert(value.items[i0 + 1] >= 0);
+      assert(value.items[i0 + 1] <= 255);
+      assert(value.items[i0 + 2] >= 0);
+      assert(value.items[i0 + 2] <= 255);
+      assert(value.items[i0 + 3] >= 0);
+      assert(value.items[i0 + 3] <= 255);
+      assert(value.items[i0 + 4] >= 0);
+      assert(value.items[i0 + 4] <= 255);
+      assert(value.items[i0 + 5] >= 0);
+      assert(value.items[i0 + 5] <= 255);
+      assert(value.items[i0 + 6] >= 0);
+      assert(value.items[i0 + 6] <= 255);
+      assert(value.items[i0 + 7] >= 0);
+      assert(value.items[i0 + 7] <= 255);
+      v =
+          ((value.items[i0]) & 0xff) |
+          (((value.items[i0 + 1]) & 0xff) << 8) |
+          (((value.items[i0 + 2]) & 0xff) << 16) |
+          (((value.items[i0 + 3]) & 0xff) << 24) |
+          (((value.items[i0 + 4]) & 0xff) << 32) |
+          (((value.items[i0 + 5]) & 0xff) << 40) |
+          (((value.items[i0 + 6]) & 0xff) << 48) |
+          (((value.items[i0 + 7]) & 0xff) << 56);
+      scratch |= v << scratchBits;
+      scratchBits += 64;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (64 - scratchBits);
+      }
+    }
+    for (; i0 < value.itemsCount; i0++) {
+      assert(value.items[i0] >= 0);
+      assert(value.items[i0] <= 255);
+      v = ((value.items[i0]) & 0xff);
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   v = _float32BitsFromDouble(value.floatValue);
@@ -3352,64 +2911,29 @@ int writeTestData(TestData value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (10 - scratchBits);
   }
-  {
-    final b = _float64BitsFromDouble(value.doubleValue);
-    v = b & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (b >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-  }
-  v = value.int8Value & 0xff;
+  v = _float64BitsFromDouble(value.doubleValue);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = value.int16Value & 0xffff;
+  v =
+      ((value.int8Value) & 0xff) |
+      (((value.int16Value) & 0xffff) << 8) |
+      (((value.uint8Value) & 0xff) << 24) |
+      (((value.uint16Value) & 0xffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 16;
+  scratchBits += 48;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
+    scratch = v >>> (48 - scratchBits);
   }
-  v = value.uint8Value & 0xff;
-  scratch |= v << scratchBits;
-  scratchBits += 8;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
-  }
-  v = value.uint16Value & 0xffff;
-  scratch |= v << scratchBits;
-  scratchBits += 16;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (16 - scratchBits);
-  }
-  v = value.uint32Value & 0xffffffff;
+  v = ((value.uint32Value) & 0xffffffff);
   scratch |= v << scratchBits;
   scratchBits += 32;
   if (scratchBits >= 64) {
@@ -3418,64 +2942,34 @@ int writeTestData(TestData value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (32 - scratchBits);
   }
-  v = value.uint64Value & 0xffffffff;
+  v = (value.uint64Value);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.uint64Value >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.int64Full & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.int64Full >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.int64Range >= -1000000000000);
   assert(value.int64Range <= 1000000000000);
-  {
-    final off = value.int64Range + 1000000000000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x1ff;
-    scratch |= v << scratchBits;
-    scratchBits += 9;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (9 - scratchBits);
-    }
+  v = (value.int64Full);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.int64Range + 1000000000000) & 0x1ffffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 41;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (41 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -3489,27 +2983,34 @@ int writeTestData(TestData value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < 17; i0++) {
-    v = value.fixedBytes[i0] & 0xff;
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= 17; i0 += 4) {
+      v =
+          value.fixedBytes[i0] |
+          (value.fixedBytes[i0 + 1] << 8) |
+          (value.fixedBytes[i0 + 2] << 16) |
+          (value.fixedBytes[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
     }
   }
   assert(value.textLength >= 0);
   assert(value.textLength <= 255);
-  v = (value.textLength) & 0xff;
+  v = value.fixedBytes[16] | (((value.textLength) & 0xff) << 8);
   scratch |= v << scratchBits;
-  scratchBits += 8;
+  scratchBits += 16;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (8 - scratchBits);
+    scratch = v >>> (16 - scratchBits);
   }
   {
     final pad = scratchBits & 7;
@@ -3523,15 +3024,33 @@ int writeTestData(TestData value, ByteData view) {
       }
     }
   }
-  for (var i0 = 0; i0 < value.textLength; i0++) {
-    v = value.text[i0];
-    scratch |= v << scratchBits;
-    scratchBits += 8;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (8 - scratchBits);
+  {
+    var i0 = 0;
+    for (; i0 + 4 <= value.textLength; i0 += 4) {
+      v =
+          value.text[i0] |
+          (value.text[i0 + 1] << 8) |
+          (value.text[i0 + 2] << 16) |
+          (value.text[i0 + 3] << 24);
+      scratch |= v << scratchBits;
+      scratchBits += 32;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (32 - scratchBits);
+      }
+    }
+    for (; i0 < value.textLength; i0++) {
+      v = value.text[i0];
+      scratch |= v << scratchBits;
+      scratchBits += 8;
+      if (scratchBits >= 64) {
+        view.setUint64(wordIndex * 8, scratch, Endian.little);
+        wordIndex++;
+        scratchBits -= 64;
+        scratch = v >>> (8 - scratchBits);
+      }
     }
   }
   if (scratchBits != 0) {
@@ -3561,102 +3080,50 @@ bool readTestData(TestData value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 49 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // a smuggled offset is refused
   }
   value.a = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 8) & 0xff;
   bitsRead += 8;
   if (v > 200) {
     return false; // a smuggled offset is refused
   }
   value.b = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 16) & 0xff;
   bitsRead += 8;
   if (v > 250) {
     return false; // a smuggled offset is refused
   }
   value.c = -100 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 24) & 0xff;
   bitsRead += 8;
   value.d = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.e = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 40) & 0xff;
   bitsRead += 8;
   value.f = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1;
+  v = (window >>> 48) & 0x1;
   bitsRead += 1;
   value.g = v != 0;
   if (bitsRead + 5 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
+  v = (window >>> 49) & 0x1f;
   bitsRead += 5;
   if (v > 16) {
     return false; // the count guards the loop — reject, never clamp
@@ -3665,39 +3132,61 @@ bool readTestData(TestData value, ByteData view, int numBits) {
   if (bitsRead + value.itemsCount * 8 > numBits) {
     return false;
   }
-  for (var i0 = 0; i0 < value.itemsCount; i0++) {
-    if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
-    } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+  {
+    var i0 = 0;
+    for (; i0 + 7 <= value.itemsCount; i0 += 7) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xff;
+      bitsRead += 8;
+      value.items[i0] = v;
+      v = (window >>> 8) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 1] = v;
+      v = (window >>> 16) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 2] = v;
+      v = (window >>> 24) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 3] = v;
+      v = (window >>> 32) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 4] = v;
+      v = (window >>> 40) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 5] = v;
+      v = (window >>> 48) & 0xff;
+      bitsRead += 8;
+      value.items[i0 + 6] = v;
     }
-    v = (window >>> shift) & 0xff;
-    bitsRead += 8;
-    value.items[i0] = v;
+    for (; i0 < value.itemsCount; i0++) {
+      if (bitsRead >>> 3 < tailBase) {
+        window =
+            view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
+      } else {
+        window = tailWord >>> (bitsRead - tailBase * 8);
+      }
+      v = window & 0xff;
+      bitsRead += 8;
+      value.items[i0] = v;
+    }
   }
   if (bitsRead + 355 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   value.floatValue = _doubleFromFloat32Bits(v);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3ff;
+  v = (window >>> 32) & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // headroom above the quantum count is refused
@@ -3706,138 +3195,83 @@ bool readTestData(TestData value, ByteData view, int numBits) {
     _fround(_fround(_fround(v.toDouble()) / 1000.0) * 10.0) + 0.0,
   );
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.doubleValue = _doubleFromFloat64Bits(lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xff;
+  v = (window >>> 32) & 0xff;
   bitsRead += 8;
   value.int8Value = (v << 56) >> 56;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 40) & 0xffff;
   bitsRead += 16;
   value.int16Value = (v << 48) >> 48;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.uint8Value = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffff;
+  v = (window >>> 8) & 0xffff;
   bitsRead += 16;
   value.uint16Value = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 24) & 0xffffffff;
   bitsRead += 32;
   value.uint32Value = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.uint64Value = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   value.int64Full = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ff;
-  bitsRead += 9;
-  lo |= v << 32;
+  lo = window & 0x1ffffffffff;
+  bitsRead += 41;
   if (lo > 2000000000000) {
     return false; // a smuggled offset is refused
   }
@@ -3859,13 +3293,11 @@ bool readTestData(TestData value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < 17; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xff;
+    v = window & 0xff;
     bitsRead += 8;
     value.fixedBytes[i0] = v;
   }
@@ -3873,13 +3305,11 @@ bool readTestData(TestData value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.textLength = v;
   {
@@ -4021,19 +3451,16 @@ bool readCompressedProbe(CompressedProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 24 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3ff;
+  v = window & 0x3ff;
   bitsRead += 10;
   if (v > 1000) {
     return false; // headroom above the quantum count is refused
@@ -4041,14 +3468,7 @@ bool readCompressedProbe(CompressedProbe value, ByteData view, int numBits) {
   value.boundary = _fround(
     _fround(_fround(_fround(v.toDouble()) / 1000.0) * 10.0) + 0.0,
   );
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3fff;
+  v = (window >>> 10) & 0x3fff;
   bitsRead += 14;
   if (v > 10000) {
     return false; // headroom above the quantum count is refused

--- a/testdata/golden/ludicrous/dart/Ludicrous.dart
+++ b/testdata/golden/ludicrous/dart/Ludicrous.dart
@@ -108,25 +108,18 @@ int writeFixedProbe(FixedProbe value, ByteData view) {
   var v = 0;
   assert(value.angle >= -11796480);
   assert(value.angle <= 11796480);
-  v = (value.angle + 11796480) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.position >= -1966080000);
   assert(value.position <= 1966080000);
-  v = (value.position + 1966080000) & 0xffffffff;
+  v =
+      ((value.angle + 11796480) & 0x1ffffff) |
+      (((value.position + 1966080000) & 0xffffffff) << 25);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 57;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (57 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffff0bdc00000);
@@ -134,28 +127,19 @@ int writeFixedProbe(FixedProbe value, ByteData view) {
     assert(value.reach >= min);
     assert(value.reach <= max);
     final off = (value.reach - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x1fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 37;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x1f;
-    scratch |= v << scratchBits;
-    scratchBits += 5;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (5 - scratchBits);
+      scratch = v >>> (37 - scratchBits);
     }
   }
   assert(value.ticks >= 0);
   assert(value.ticks <= 1000000);
-  v = (value.ticks) & 0xfffff;
+  v = ((value.ticks) & 0xfffff);
   scratch |= v << scratchBits;
   scratchBits += 20;
   if (scratchBits >= 64) {
@@ -167,7 +151,7 @@ int writeFixedProbe(FixedProbe value, ByteData view) {
   for (var i0 = 0; i0 < 2; i0++) {
     assert(value.samples[i0] >= -524288);
     assert(value.samples[i0] <= 524288);
-    v = (value.samples[i0] + 524288) & 0x1fffff;
+    v = ((value.samples[i0] + 524288) & 0x1fffff);
     scratch |= v << scratchBits;
     scratchBits += 21;
     if (scratchBits >= 64) {
@@ -204,58 +188,35 @@ bool readFixedProbe(FixedProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 156 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 23592960) {
     return false; // a smuggled offset is refused
   }
   value.angle = -11796480 + v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 25) & 0xffffffff;
   bitsRead += 32;
   if (v > 3932160000) {
     return false; // a smuggled offset is refused
   }
   value.position = -1966080000 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   if (lo > 131072000000) {
     return false; // a smuggled offset is refused
   }
@@ -263,14 +224,7 @@ bool readFixedProbe(FixedProbe value, ByteData view, int numBits) {
     const min = UInt128(0xffffffffffffffff, 0xfffffff0bdc00000);
     value.reach = (min + UInt128(0, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 37) & 0xfffff;
   bitsRead += 20;
   if (v > 1000000) {
     return false; // a smuggled offset is refused
@@ -278,13 +232,11 @@ bool readFixedProbe(FixedProbe value, ByteData view, int numBits) {
   value.ticks = v;
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fffff;
+    v = window & 0x1fffff;
     bitsRead += 21;
     if (v > 1048576) {
       return false; // a smuggled offset is refused
@@ -344,7 +296,8 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
   var v = 0;
   assert(value.angle >= 0);
   assert(value.angle <= 23592960);
-  v = (value.angle) & 0x1ffffff;
+  assert(!_unsignedLessThan(0xffffffffffff0000, value.span));
+  v = ((value.angle) & 0x1ffffff);
   scratch |= v << scratchBits;
   scratchBits += 25;
   if (scratchBits >= 64) {
@@ -353,50 +306,31 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
     scratchBits -= 64;
     scratch = v >>> (25 - scratchBits);
   }
-  assert(!_unsignedLessThan(0xffffffffffff0000, value.span));
-  v = value.span & 0xffffffff;
+  v = (value.span);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.span >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     const max = UInt128(0, 131072000000);
     assert(value.reach <= max);
-    v = value.reach.lo & 0xffffffff;
+    v = ((value.reach.lo) & 0x1fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 37;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.reach.lo >>> 32) & 0x1f;
-    scratch |= v << scratchBits;
-    scratchBits += 5;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (5 - scratchBits);
+      scratch = v >>> (37 - scratchBits);
     }
   }
   assert(value.ticks >= 0);
   assert(value.ticks <= 1000000);
-  v = (value.ticks) & 0xfffff;
+  v = ((value.ticks) & 0xfffff);
   scratch |= v << scratchBits;
   scratchBits += 20;
   if (scratchBits >= 64) {
@@ -408,7 +342,7 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
   for (var i0 = 0; i0 < 2; i0++) {
     assert(value.samples[i0] >= 0);
     assert(value.samples[i0] <= 1048576);
-    v = (value.samples[i0]) & 0x1fffff;
+    v = ((value.samples[i0]) & 0x1fffff);
     scratch |= v << scratchBits;
     scratchBits += 21;
     if (scratchBits >= 64) {
@@ -419,7 +353,7 @@ int writeUnsignedProbe(UnsignedProbe value, ByteData view) {
     }
   }
   assert(value.locked == 196608);
-  v = value.tail & 0xff;
+  v = ((value.tail) & 0xff);
   scratch |= v << scratchBits;
   scratchBits += 8;
   if (scratchBits >= 64) {
@@ -455,43 +389,31 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   if (bitsRead + 196 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1ffffff;
+  v = window & 0x1ffffff;
   bitsRead += 25;
   if (v > 23592960) {
     return false; // a smuggled offset is refused
   }
   value.angle = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xffffffff;
+  v = (window >>> 25) & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (_unsignedLessThan(0xffffffffffff0000, lo)) {
@@ -499,37 +421,17 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   }
   value.span = lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   if (lo > 131072000000) {
     return false; // a smuggled offset is refused
   }
   value.reach = UInt128(0, lo);
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 37) & 0xfffff;
   bitsRead += 20;
   if (v > 1000000) {
     return false; // a smuggled offset is refused
@@ -537,13 +439,11 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   value.ticks = v;
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fffff;
+    v = window & 0x1fffff;
     bitsRead += 21;
     if (v > 1048576) {
       return false; // a smuggled offset is refused
@@ -552,13 +452,11 @@ bool readUnsignedProbe(UnsignedProbe value, ByteData view, int numBits) {
   }
   value.locked = 196608;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.tail = v;
   return true;
@@ -606,41 +504,23 @@ int writeWideProbe(WideProbe value, ByteData view) {
   var scratchBits = 0;
   var wordIndex = 0;
   var v = 0;
-  v = value.entityId.lo & 0xffffffff;
+  v = (value.entityId.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.entityId.lo >>> 32) & 0xffffffff;
+  v = (value.entityId.hi);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.entityId.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.entityId.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffffed5fa0e00);
@@ -648,23 +528,14 @@ int writeWideProbe(WideProbe value, ByteData view) {
     assert(value.energy >= min);
     assert(value.energy <= max);
     final off = (value.energy - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x3ffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 34;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+      scratch = v >>> (34 - scratchBits);
     }
   }
   {
@@ -673,41 +544,23 @@ int writeWideProbe(WideProbe value, ByteData view) {
     assert(value.flux >= min);
     assert(value.flux <= max);
     final off = (value.flux - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = (off.lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (off.lo >>> 32) & 0xffffffff;
+    v = ((off.hi) & 0x3fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 38;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = off.hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.hi >>> 32) & 0x3f;
-    scratch |= v << scratchBits;
-    scratchBits += 6;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (6 - scratchBits);
+      scratch = v >>> (38 - scratchBits);
     }
   }
   {
@@ -716,7 +569,7 @@ int writeWideProbe(WideProbe value, ByteData view) {
     assert(value.bias >= min);
     assert(value.bias <= max);
     final off = (value.bias - min).toUnsigned();
-    v = off.lo & 0x7ff;
+    v = ((off.lo) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -726,41 +579,23 @@ int writeWideProbe(WideProbe value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   }
-  v = value.seed.lo & 0xffffffff;
+  v = (value.seed.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.seed.lo >>> 32) & 0xffffffff;
+  v = (value.seed.hi);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.seed.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.seed.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -789,7 +624,6 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   var hi = 0;
@@ -797,66 +631,45 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.entityId = UInt128(hi, lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 10000000000) {
     return false; // a smuggled offset is refused
   }
@@ -865,43 +678,30 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     value.energy = (min + UInt128(0, lo)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3f;
+  v = (window >>> 32) & 0x3f;
   bitsRead += 6;
   hi |= v << 32;
   {
@@ -914,14 +714,7 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     const min = UInt128(0xfffffff000000000, 0);
     value.flux = (min + UInt128(hi, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 38) & 0x7ff;
   bitsRead += 11;
   if (v > 2000) {
     return false; // a smuggled offset is refused
@@ -931,43 +724,35 @@ bool readWideProbe(WideProbe value, ByteData view, int numBits) {
     value.bias = (min + UInt128(0, v)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.seed = UInt128(hi, lo);
@@ -1021,36 +806,21 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
   var v = 0;
   assert(value.mode >= 0);
   assert(value.mode <= 3);
-  v = value.mode & 0x3;
-  scratch |= v << scratchBits;
-  scratchBits += 2;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (2 - scratchBits);
-  }
   assert(value.probe.angle >= -11796480);
   assert(value.probe.angle <= 11796480);
-  v = (value.probe.angle + 11796480) & 0x1ffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 25;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (25 - scratchBits);
-  }
   assert(value.probe.position >= -1966080000);
   assert(value.probe.position <= 1966080000);
-  v = (value.probe.position + 1966080000) & 0xffffffff;
+  v =
+      ((value.mode) & 0x3) |
+      (((value.probe.angle + 11796480) & 0x1ffffff) << 2) |
+      (((value.probe.position + 1966080000) & 0xffffffff) << 27);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 59;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (59 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffff0bdc00000);
@@ -1058,28 +828,19 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.probe.reach >= min);
     assert(value.probe.reach <= max);
     final off = (value.probe.reach - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x1fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 37;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x1f;
-    scratch |= v << scratchBits;
-    scratchBits += 5;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (5 - scratchBits);
+      scratch = v >>> (37 - scratchBits);
     }
   }
   assert(value.probe.ticks >= 0);
   assert(value.probe.ticks <= 1000000);
-  v = (value.probe.ticks) & 0xfffff;
+  v = ((value.probe.ticks) & 0xfffff);
   scratch |= v << scratchBits;
   scratchBits += 20;
   if (scratchBits >= 64) {
@@ -1091,7 +852,7 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
   for (var i0 = 0; i0 < 2; i0++) {
     assert(value.probe.samples[i0] >= -524288);
     assert(value.probe.samples[i0] <= 524288);
-    v = (value.probe.samples[i0] + 524288) & 0x1fffff;
+    v = ((value.probe.samples[i0] + 524288) & 0x1fffff);
     scratch |= v << scratchBits;
     scratchBits += 21;
     if (scratchBits >= 64) {
@@ -1101,41 +862,23 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
       scratch = v >>> (21 - scratchBits);
     }
   }
-  v = value.wide.entityId.lo & 0xffffffff;
+  v = (value.wide.entityId.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
-  v = (value.wide.entityId.lo >>> 32) & 0xffffffff;
+  v = (value.wide.entityId.hi);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.wide.entityId.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide.entityId.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   {
     const min = Int128(0xffffffffffffffff, 0xfffffffed5fa0e00);
@@ -1143,23 +886,14 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.wide.energy >= min);
     assert(value.wide.energy <= max);
     final off = (value.wide.energy - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = ((off.lo) & 0x3ffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 34;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.lo >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
+      scratch = v >>> (34 - scratchBits);
     }
   }
   {
@@ -1168,41 +902,23 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.wide.flux >= min);
     assert(value.wide.flux <= max);
     final off = (value.wide.flux - min).toUnsigned();
-    v = off.lo & 0xffffffff;
+    v = (off.lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (off.lo >>> 32) & 0xffffffff;
+    v = ((off.hi) & 0x3fffffffff);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 38;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = off.hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off.hi >>> 32) & 0x3f;
-    scratch |= v << scratchBits;
-    scratchBits += 6;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (6 - scratchBits);
+      scratch = v >>> (38 - scratchBits);
     }
   }
   {
@@ -1211,7 +927,7 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     assert(value.wide.bias >= min);
     assert(value.wide.bias <= max);
     final off = (value.wide.bias - min).toUnsigned();
-    v = off.lo & 0x7ff;
+    v = ((off.lo) & 0x7ff);
     scratch |= v << scratchBits;
     scratchBits += 11;
     if (scratchBits >= 64) {
@@ -1221,45 +937,27 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
       scratch = v >>> (11 - scratchBits);
     }
   }
-  v = value.wide.seed.lo & 0xffffffff;
+  v = (value.wide.seed.lo);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide.seed.lo >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = value.wide.seed.hi & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
-  v = (value.wide.seed.hi >>> 32) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.keysCount >= 0);
   assert(value.keysCount <= 4);
-  v = (value.keysCount) & 0x7;
+  v = (value.wide.seed.hi);
+  scratch |= v << scratchBits;
+  scratchBits += 64;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (64 - scratchBits);
+  }
+  v = ((value.keysCount) & 0x7);
   scratch |= v << scratchBits;
   scratchBits += 3;
   if (scratchBits >= 64) {
@@ -1269,44 +967,26 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     scratch = v >>> (3 - scratchBits);
   }
   for (var i0 = 0; i0 < value.keysCount; i0++) {
-    v = value.keys[i0].lo & 0xffffffff;
+    v = (value.keys[i0].lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (value.keys[i0].lo >>> 32) & 0xffffffff;
+    v = (value.keys[i0].hi);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = value.keys[i0].hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.keys[i0].hi >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
-  v = value.hasTarget ? 1 : 0;
+  v = (value.hasTarget ? 1 : 0);
   scratch |= v << scratchBits;
   scratchBits += 1;
   if (scratchBits >= 64) {
@@ -1316,41 +996,23 @@ int writeLudicrousState(LudicrousState value, ByteData view) {
     scratch = v >>> (1 - scratchBits);
   }
   if (value.hasTarget) {
-    v = value.targetId.lo & 0xffffffff;
+    v = (value.targetId.lo);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
-    v = (value.targetId.lo >>> 32) & 0xffffffff;
+    v = (value.targetId.hi);
     scratch |= v << scratchBits;
-    scratchBits += 32;
+    scratchBits += 64;
     if (scratchBits >= 64) {
       view.setUint64(wordIndex * 8, scratch, Endian.little);
       wordIndex++;
       scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = value.targetId.hi & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (value.targetId.hi >>> 32) & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
+      scratch = v >>> (64 - scratchBits);
     }
   }
   if (scratchBits != 0) {
@@ -1380,7 +1042,6 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   var lo = 0;
   var hi = 0;
@@ -1388,61 +1049,37 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x3;
+  v = window & 0x3;
   bitsRead += 2;
   value.mode = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1ffffff;
+  v = (window >>> 2) & 0x1ffffff;
   bitsRead += 25;
   if (v > 23592960) {
     return false; // a smuggled offset is refused
   }
   value.probe.angle = -11796480 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 3932160000) {
     return false; // a smuggled offset is refused
   }
   value.probe.position = -1966080000 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x1f;
-  bitsRead += 5;
-  lo |= v << 32;
+  lo = window & 0x1fffffffff;
+  bitsRead += 37;
   if (lo > 131072000000) {
     return false; // a smuggled offset is refused
   }
@@ -1450,14 +1087,7 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     const min = UInt128(0xffffffffffffffff, 0xfffffff0bdc00000);
     value.probe.reach = (min + UInt128(0, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0xfffff;
+  v = (window >>> 37) & 0xfffff;
   bitsRead += 20;
   if (v > 1000000) {
     return false; // a smuggled offset is refused
@@ -1465,13 +1095,11 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
   value.probe.ticks = v;
   for (var i0 = 0; i0 < 2; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0x1fffff;
+    v = window & 0x1fffff;
     bitsRead += 21;
     if (v > 1048576) {
       return false; // a smuggled offset is refused
@@ -1479,66 +1107,45 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     value.probe.samples[i0] = -524288 + v;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.wide.entityId = UInt128(hi, lo);
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 10000000000) {
     return false; // a smuggled offset is refused
   }
@@ -1547,43 +1154,30 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     value.wide.energy = (min + UInt128(0, lo)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3f;
+  v = (window >>> 32) & 0x3f;
   bitsRead += 6;
   hi |= v << 32;
   {
@@ -1596,14 +1190,7 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     const min = UInt128(0xfffffff000000000, 0);
     value.wide.flux = (min + UInt128(hi, lo)).toSigned();
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7ff;
+  v = (window >>> 38) & 0x7ff;
   bitsRead += 11;
   if (v > 2000) {
     return false; // a smuggled offset is refused
@@ -1613,57 +1200,42 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     value.wide.bias = (min + UInt128(0, v)).toSigned();
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   lo |= v << 32;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi = v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   hi |= v << 32;
   value.wide.seed = UInt128(hi, lo);
   if (bitsRead + 3 > numBits) {
     return false;
   }
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x7;
+  v = (window >>> 32) & 0x7;
   bitsRead += 3;
   if (v > 4) {
     return false; // the count guards the loop — reject, never clamp
@@ -1674,43 +1246,35 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
   }
   for (var i0 = 0; i0 < value.keysCount; i0++) {
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi |= v << 32;
     value.keys[i0] = UInt128(hi, lo);
@@ -1719,13 +1283,11 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0x1;
+  v = window & 0x1;
   bitsRead += 1;
   value.hasTarget = v != 0;
   if (value.hasTarget) {
@@ -1733,43 +1295,35 @@ bool readLudicrousState(LudicrousState value, ByteData view, int numBits) {
       return false;
     }
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     lo |= v << 32;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi = v;
     if (bitsRead >>> 3 < tailBase) {
-      window = view.getUint64(bitsRead >>> 3, Endian.little);
-      shift = bitsRead & 7;
+      window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
     } else {
-      window = tailWord;
-      shift = bitsRead - tailBase * 8;
+      window = tailWord >>> (bitsRead - tailBase * 8);
     }
-    v = (window >>> shift) & 0xffffffff;
+    v = window & 0xffffffff;
     bitsRead += 32;
     hi |= v << 32;
     value.targetId = UInt128(hi, lo);
@@ -1833,7 +1387,7 @@ int writeDegenerateProbe(DegenerateProbe value, ByteData view) {
     const locked = Int128(0xffffffffffffffff, 0xfffff4c58c31d00e);
     assert(value.lockedWide == locked);
   }
-  v = value.tail & 0xff;
+  v = ((value.tail) & 0xff);
   scratch |= v << scratchBits;
   scratchBits += 8;
   if (scratchBits >= 64) {
@@ -1869,7 +1423,6 @@ bool readDegenerateProbe(DegenerateProbe value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 8 > numBits) {
     return false;
@@ -1881,13 +1434,11 @@ bool readDegenerateProbe(DegenerateProbe value, ByteData view, int numBits) {
     value.lockedWide = locked;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xff;
+  v = window & 0xff;
   bitsRead += 8;
   value.tail = v;
   return true;
@@ -1932,72 +1483,36 @@ int writeFixedVec(FixedVec value, ByteData view) {
   var v = 0;
   assert(value.x >= -6553600000);
   assert(value.x <= 6553600000);
-  {
-    final off = value.x + 6553600000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
-    }
-  }
   assert(value.y >= -6553600000);
   assert(value.y <= 6553600000);
-  {
-    final off = value.y + 6553600000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
-    }
+  v = ((value.x + 6553600000) & 0x3ffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 34;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (34 - scratchBits);
   }
   assert(value.z >= -6553600000);
   assert(value.z <= 6553600000);
-  {
-    final off = value.z + 6553600000;
-    v = off & 0xffffffff;
-    scratch |= v << scratchBits;
-    scratchBits += 32;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (32 - scratchBits);
-    }
-    v = (off >>> 32) & 0x3;
-    scratch |= v << scratchBits;
-    scratchBits += 2;
-    if (scratchBits >= 64) {
-      view.setUint64(wordIndex * 8, scratch, Endian.little);
-      wordIndex++;
-      scratchBits -= 64;
-      scratch = v >>> (2 - scratchBits);
-    }
+  v = ((value.y + 6553600000) & 0x3ffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 34;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (34 - scratchBits);
+  }
+  v = ((value.z + 6553600000) & 0x3ffffffff);
+  scratch |= v << scratchBits;
+  scratchBits += 34;
+  if (scratchBits >= 64) {
+    view.setUint64(wordIndex * 8, scratch, Endian.little);
+    wordIndex++;
+    scratchBits -= 64;
+    scratch = v >>> (34 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2026,80 +1541,39 @@ bool readFixedVec(FixedVec value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
-  var v = 0;
   var lo = 0;
   if (bitsRead + 102 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 13107200000) {
     return false; // a smuggled offset is refused
   }
   value.x = -6553600000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 13107200000) {
     return false; // a smuggled offset is refused
   }
   value.y = -6553600000 + lo;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
-  bitsRead += 32;
-  lo = v;
-  if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
-  } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
-  }
-  v = (window >>> shift) & 0x3;
-  bitsRead += 2;
-  lo |= v << 32;
+  lo = window & 0x3ffffffff;
+  bitsRead += 34;
   if (lo > 13107200000) {
     return false; // a smuggled offset is refused
   }
@@ -2149,47 +1623,33 @@ int writeFixedQuat(FixedQuat value, ByteData view) {
   var v = 0;
   assert(value.x >= -1073741824);
   assert(value.x <= 1073741824);
-  v = (value.x + 1073741824) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.y >= -1073741824);
   assert(value.y <= 1073741824);
-  v = (value.y + 1073741824) & 0xffffffff;
-  scratch |= v << scratchBits;
-  scratchBits += 32;
-  if (scratchBits >= 64) {
-    view.setUint64(wordIndex * 8, scratch, Endian.little);
-    wordIndex++;
-    scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
-  }
   assert(value.z >= -1073741824);
   assert(value.z <= 1073741824);
-  v = (value.z + 1073741824) & 0xffffffff;
+  v =
+      ((value.x + 1073741824) & 0xffffffff) |
+      (((value.y + 1073741824) & 0xffffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   assert(value.w >= -1073741824);
   assert(value.w <= 1073741824);
-  v = (value.w + 1073741824) & 0xffffffff;
+  v =
+      ((value.z + 1073741824) & 0xffffffff) |
+      (((value.w + 1073741824) & 0xffffffff) << 32);
   scratch |= v << scratchBits;
-  scratchBits += 32;
+  scratchBits += 64;
   if (scratchBits >= 64) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
     wordIndex++;
     scratchBits -= 64;
-    scratch = v >>> (32 - scratchBits);
+    scratch = v >>> (64 - scratchBits);
   }
   if (scratchBits != 0) {
     view.setUint64(wordIndex * 8, scratch, Endian.little);
@@ -2218,58 +1678,49 @@ bool readFixedQuat(FixedQuat value, ByteData view, int numBits) {
   }
   var bitsRead = 0;
   var window = 0;
-  var shift = 0;
   var v = 0;
   if (bitsRead + 128 > numBits) {
     return false;
   }
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused
   }
   value.x = -1073741824 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused
   }
   value.y = -1073741824 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused
   }
   value.z = -1073741824 + v;
   if (bitsRead >>> 3 < tailBase) {
-    window = view.getUint64(bitsRead >>> 3, Endian.little);
-    shift = bitsRead & 7;
+    window = view.getUint64(bitsRead >>> 3, Endian.little) >>> (bitsRead & 7);
   } else {
-    window = tailWord;
-    shift = bitsRead - tailBase * 8;
+    window = tailWord >>> (bitsRead - tailBase * 8);
   }
-  v = (window >>> shift) & 0xffffffff;
+  v = window & 0xffffffff;
   bitsRead += 32;
   if (v > 2147483648) {
     return false; // a smuggled offset is refused


### PR DESCRIPTION
Laggard round for generated **Dart** (#165, the last open laggard round). The issue's named lead — the bulk-bytes path — lands, and the profile named three larger levers beside it.

**Headline** (`--only dart --quick`, both halves in one sitting minutes apart, `bench_mixed`, family `gen`, AOT, `checks=contract`, corpus `6b213fbfa1a03a99`, max rates per §2.2, spreads 0.07–2.28%):

| path | before max | after max | |
|---|---|---|---|
| write | 1,900,191 | **2,857,586** | **1.50x** |
| round_trip | 972,818 | **1,591,336** | **1.64x** |

Against the arm64 sitting-2 certification reference at the same `corpus_id` (cpp round_trip max 3,512,100 — the LOCKed reference, untouched by this round): **361% → 220.7% of generated C++** on the canonical round_trip blend — the ledger's standing 363% reproduced within 0.6% by this pair's own before leg. Derived read moved 1.99 → 3.60 M msg/s. The measurement CSVs live outside `bench/results/` (scratch, per the round's rules); the numbers above are their rows verbatim.

## 1. MEASURE FIRST — where the time actually was

Dart's `--observe` profiler is interactive, so the round profiled the AOT executable with macOS `sample` (file output, no UI) plus AOT micro-harnesses per the family method:

- **write phase**: ~80% of user-code samples inside `writeBenchMixed` itself — the per-field merge with its data-dependent flush branch; ~13% in one ~72-byte out-of-line stub reached from the driver loop (the generic tear-off dispatch of the data-driven contract — **harness parity**, every leg's driver calls through a function value; named, not touched).
- **round_trip phase**: reader region 47%, re-encode writer 40%, same stub 6%.
- The reader reloaded its 64-bit window — one `getUint64` plus a tail branch — at EVERY field.

**The micro that ranked the forms** (interleaved arms, AOT, M2, stats-loop shape): chunked write merge 1.21x over per-field; chunked window read 1.35x over per-field reload; bulk 4-byte grouping 2.33x over per-byte; `Uint64List` store vs `ByteData.setUint64` +0.8% (see refusals).

## 2. THE LEVERS, each landed as one commit with its paired numbers

| # | lever | leg (write / round_trip, M msg/s) |
|---|---|---|
| L1 | **Chunked write merges, 64-bit lanes** — the family lever (#198/#208/#237), capped at Dart's native 64-bit int where the js number domain held it to 32; wide 33..64-bit fields merge ONCE (their wire bits are contiguous, so the single merge emits the identical bytes the two-group form did) | 1.894→2.380 (+26%) / 0.974→1.088 (+12%) |
| L2 | **Bulk-bytes write path — the #165 lead**: string/bytes bodies and bare `[N]uint8` arrays stop paying a merge per byte; ≤8-byte static runs queue as chunk pieces (joining neighbor fields in one merge), longer/dynamic runs take 4 bytes per merge with a byte tail. No alignment requirement — LSB-first merging of the concatenation equals merging the bytes in sequence at any bit position, so it reaches the unaligned `loadout` too | 2.380→2.499 (+5.0%) / 1.088→1.104 (+1.4%) — bulk is only 3.65% of bench_mixed's wire by construction; the lever is for the real packets the issue names |
| L3 | **Chunked read windows**: one load + one tail branch per run, not per field — the load folds the byte-interior shift in and guarantees 57 valid bits (in the tail arm, every bounds-proven remaining bit), consecutive fields extract at literal relative shifts through a compile-time ledger; wide 33..57-bit fields extract in one masked read; short bare byte arrays unroll into the same windows (#165's read twin) | 2.499→2.493 (flat) / 1.104→1.367 (+23.8%) |
| L4 | **Grouped counted loops**: k = lane/elemBits elements per iteration (64-bit chunk lane on write, 57-bit window on read) with a remainder loop — the chunk accumulator and window ledger span the unrolled elements, so bench_mixed's 80-element stat array drops from one merge and one window load per element to one per three. Bounded FIRST by a hand-patched generated leg (+10% round_trip read-side alone), then landed | 2.493→2.856 (+14.6%) / 1.367→1.592 (+16.5%) |

### Refused by measurement (results, per the method)

- **`Uint64List` word stores instead of `ByteData.setUint64`**: micro 3,888 → 3,918 K ops/s (+0.8%) — noise-level; the generated API keeps its `ByteData` surface. Refused.
- **Temp-based chunking of statement-form merges** (compressed floats): the shape carries 3 such fields against ~120 remaining merges; #237 bounded the identical lever at 1–2% and refused — same here, bounded under 1% by shape arithmetic. Not taken.
- **Slack-window reads** (drop the tail branch by requiring 8 spare buffer bytes): refused on contract, not measurement — the Dart reader's no-slack stance is the family read contract.
- **The remaining 13–15% driver-dispatch cost**: the data-driven contract's generic function-value call, present in every leg's driver — harness parity, named and left alone.

## 3. Discipline

- **Wire held**: full nine-language `make test` green; `testdata/wire` untouched (the one re-pin commit touches SOURCE goldens only — SPEC §3.1's deliberate-change path); the bench leg's §1.5 golden + 64-variant decode→re-encode gates pass at `corpus_id 6b213fbfa1a03a99`.
- **Byte-equivalence argument, stated**: an LSB-first packer merging a concatenation of masked pieces emits the identical byte stream to merging the pieces in sequence, and a contiguous 33..64-bit field's single merge equals its two 32-bit groups low-dword-first; the gates then prove it on every pinned instance and variant.
- **Differential oracle, run rather than assumed** (the significant-restructure rule, as in #237's review): one harness compiled against the origin/main tree and the branch tree, 5 seeds × 2,000 rounds × 3 corpora (bench_mixed's 64 variants, real_packet, ludicrous_state ×2 goldens) of bit-flipped, numBits-jittered, view-length-varied hostile buffers — accept/reject verdicts and every accepted re-encoding folded and **byte-identical** (~14k accepts across 30k rounds, both paths exercised).
- **Negative control**: one relative shift in a generated chunk broken by one bit → the oracle's fold diverges; restored → identical again.
- **Ledger correctness designed out, not tested away**: the window ledger and chunk accumulator invalidate/flush at every scope boundary and every dynamic `bitsRead`/cursor move; a piece referencing a block-scoped temp flushes inside its scope; grouped-loop bodies begin with an invalidated ledger so every iteration executes the same straight-line code.
- Quality gates: gofmt clean, `go vet` clean, modernize clean, `dart analyze` + `dart format --set-exit-if-changed` clean on all generated dart trees, shape-gate clean (19 exemptions, all on ledger), generated tree current.
- `bench/LOCK` untouched: nothing under `internal/codegen/{c,cpp}` or `generated/{c,cpp,c-ludicrous}` moved. The dart emitter's tests (fixed-default, reserved-name pins) stay green.
- One commit per lever, paired numbers per commit; refusals measured on the same instrument.

### Named follow-on (land-and-expand, not this round)

- **Grouped FIXED arrays of static-width elements** — the L4 unroll currently reaches counted arrays only; the fixed-array twin is mechanical when a shape warrants it.
- **Bulk read for long byte bodies** (4-byte `getUint32` loads feeding the byte stores) — bounded small on this corpus; priced when a bulk-heavy real schema needs it.

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
