### PR TITLE
Two wires: types and tables — the framing corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ would have hand-written, not an interpreter walking a schema at runtime.
   sibling `ufixed(48, 16)` are declared like any other field, and the compiler
   owns both the storage and the wire for them.
 - **128-bit integers**, ranged like any other, in every target language.
-- **Two wires: types and tables.** Types are bitpacked with protocol-id
-  versioning; tables are flexible data structures with in-wire versioning
-  (C++ today): unknown fields skip, absent fields default, renames survive
+- **A second wire for things that version: tables.** The bitpacked
+  `type` wire above is the key feature of the library; `table` is its
+  companion for data that must cross builds — flexible data structures
+  with in-wire versioning (C++ today): unknown fields skip, absent fields default, renames survive
   via `was = "old_name"`, and every table ships with reflection
   descriptors for tools that walk fields by name. Use tables as files,
   blobs, or messages — a config a tool saves, an archive a build bakes, or

--- a/README.md
+++ b/README.md
@@ -106,12 +106,15 @@ would have hand-written, not an interpreter walking a schema at runtime.
   sibling `ufixed(48, 16)` are declared like any other field, and the compiler
   owns both the storage and the wire for them.
 - **128-bit integers**, ranged like any other, in every target language.
-- **Tables for data that outlives builds** — `table` declares save/load
-  structures on an evolution-tolerant wire (C++ today): unknown fields skip,
-  absent fields default, renames survive via `was = "old_name"`, and every
-  table ships with reflection descriptors for tools that walk fields by name.
-  Packets and tables version independently — a table never moves the
-  protocol id.
+- **Two wires: types and tables.** `table` declares records on an
+  evolution-tolerant wire (C++ today): unknown fields skip, absent fields
+  default, renames survive via `was = "old_name"`, and every table ships
+  with reflection descriptors for tools that walk fields by name. Use them
+  as files, blobs, or messages — a config a tool saves, an archive a build
+  bakes, or a versioned message between peers that don't deploy in
+  lockstep: schema's take on the protobufs/flatbuffers class, beside the
+  hardcoded `type` wire rather than replacing it. The two version
+  independently — a table never moves the protocol id.
 - **Zero allocation, no runtime reflection** — straight-line code reading and
   writing your own buffers.
 - **Reads validate, always — in every language.** Out-of-range values are

--- a/README.md
+++ b/README.md
@@ -106,15 +106,16 @@ would have hand-written, not an interpreter walking a schema at runtime.
   sibling `ufixed(48, 16)` are declared like any other field, and the compiler
   owns both the storage and the wire for them.
 - **128-bit integers**, ranged like any other, in every target language.
-- **Two wires: types and tables.** `table` declares records on an
-  evolution-tolerant wire (C++ today): unknown fields skip, absent fields
-  default, renames survive via `was = "old_name"`, and every table ships
-  with reflection descriptors for tools that walk fields by name. Use them
-  as files, blobs, or messages — a config a tool saves, an archive a build
-  bakes, or a versioned message between peers that don't deploy in
-  lockstep: schema's take on the protobufs/flatbuffers class, beside the
-  hardcoded `type` wire rather than replacing it. The two version
-  independently — a table never moves the protocol id.
+- **Two wires: types and tables.** Types are bitpacked with protocol-id
+  versioning; tables are flexible data structures with in-wire versioning
+  (C++ today): unknown fields skip, absent fields default, renames survive
+  via `was = "old_name"`, and every table ships with reflection
+  descriptors for tools that walk fields by name. Use tables as files,
+  blobs, or messages — a config a tool saves, an archive a build bakes, or
+  a versioned message between peers that don't deploy in lockstep:
+  schema's take on the protobufs/flatbuffers class, beside the bitpacked
+  wire rather than replacing it. The two version independently — a table
+  never moves the protocol id.
 - **Zero allocation, no runtime reflection** — straight-line code reading and
   writing your own buffers.
 - **Reads validate, always — in every language.** Out-of-range values are

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1,8 +1,9 @@
 # schema — tables
 
-**Schema has two wires: types and tables.** Types are the hardcoded,
-same-build wire; tables are the evolution-tolerant one. This document
-specifies the second.
+**Schema has two wires: types and tables.** Types are serialized
+bitpacked, versioned by the protocol id — the hardcoded, same-build wire.
+Tables are more flexible structures with in-wire versioning — data
+structures, if you will. This document specifies the second.
 
 Tables are schema's declarations for **data that crosses builds**: config
 files, asset archives, tool output, editor state — and just as much,

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1,12 +1,19 @@
 # schema — tables
 
-Tables are schema's declarations for **data that outlives builds**: config
-files, asset archives, tool output, editor state — bytes written by one
-build of one tool and read by another build of another program, possibly
-years apart. The packet wire (`type`, SPEC.md) is hardcoded and guarded by
-the protocol id: same-or-refuse. The table wire is the opposite contract:
-**any reader reads any data**, and the differences are reported, never
-fatal.
+**Schema has two wires: types and tables.** Types are the hardcoded,
+same-build wire; tables are the evolution-tolerant one. This document
+specifies the second.
+
+Tables are schema's declarations for **data that crosses builds**: config
+files, asset archives, tool output, editor state — and just as much,
+**messages**: bytes produced by one build of one program and consumed by
+another build of another, whether the trip is a disk file read years later
+or a datagram read milliseconds later by a peer that deployed last week.
+The hardcoded wire (`type`, SPEC.md) is the same-build contract, guarded by
+the protocol id: same-or-refuse. Packets are its loudest user, not its
+definition — any data whose writer and reader share a schema build belongs
+there. The table wire is the opposite contract: **any reader reads any
+data**, and the differences are reported, never fatal.
 
 The two contracts never mix. Flatbuffers- and protobuf-class evolution
 ideas apply here, to tables — they do not apply to `type`, whose wire is
@@ -105,8 +112,10 @@ schema's codebase:
   clamp on load (§4) — they never change what the bytes look like.
 
 The same bytes serve every use: a file on disk, a blob in memory, a
-payload handed from a tool to a game. Save and load are symmetric over
-caller-provided buffers; generated code allocates nothing.
+payload handed from a tool to a game, a message between services whose
+deploys never align. Save and load are symmetric over caller-provided
+buffers — message-ready by construction; generated code allocates
+nothing.
 
 ## 4. Versioning is wire tolerance
 
@@ -193,12 +202,12 @@ held by construction:
   and a reader can fan nested-table decodes out the same way. The framing
   guarantees the option; callers choose whether to take it.
 
-## 8. Independence from the packet wire
+## 8. Independence from the hardcoded wire
 
 Table declarations do not enter the unit's wire-shape projection. Adding,
-editing or deleting a table moves no `ProtocolId` and no generated packet
-byte: peers whose packets did not change are never forced into a lockstep
-redeploy by a content edit. This independence is held by test.
+editing or deleting a table moves no `ProtocolId` and no generated `type`
+byte: peers whose hardcoded wire did not change are never forced into a
+lockstep redeploy by a table edit. This independence is held by test.
 
 ## 9. Refused by name
 

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1,9 +1,11 @@
 # schema — tables
 
-**Schema has two wires: types and tables.** Types are serialized
-bitpacked, versioned by the protocol id — the hardcoded, same-build wire.
-Tables are more flexible structures with in-wire versioning — data
-structures, if you will. This document specifies the second.
+**Schema has two wires: types and tables — and the types wire leads.**
+Types are serialized bitpacked, versioned by the protocol id: the
+hardcoded, same-build wire that is the key feature of the library. Tables
+are for when you need things that version — more flexible structures with
+in-wire versioning; data structures, if you will. This document specifies
+the second.
 
 Tables are schema's declarations for **data that crosses builds**: config
 files, asset archives, tool output, editor state — and just as much,

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -4,8 +4,14 @@
 Types are serialized bitpacked, versioned by the protocol id: the
 hardcoded, same-build wire that is the key feature of the library. Tables
 are for when you need things that version — more flexible structures with
-in-wire versioning; data structures, if you will. This document specifies
-the second.
+in-wire versioning; data structures, if you will. The founding line for
+the split: types remain VALUE semantics; tables ALLOW POINTER semantics —
+"we can't be a generic system if we don't have pointers to tables." The
+compiler derives two classes of table from that freedom: FIXED-SIZE
+(a by-value closure, storage a plain struct of known sizeof — every table
+today) and VARIABLE-LENGTH (a pointer anywhere in the closure — root plus
+arena). This document specifies the tables wire; the pointer/arena design
+is the named next round.
 
 Tables are schema's declarations for **data that crosses builds**: config
 files, asset archives, tool output, editor state — and just as much,

--- a/USAGE.md
+++ b/USAGE.md
@@ -616,7 +616,8 @@ saves as 2 bytes and loads back complete.
 
 A field whose type is another table nests it by value; bounded arrays of
 tables give you collections. That is the whole recipe for a config or asset
-bin — declare the root, and the file format falls out:
+bin — declare the root, and the format falls out (the same bytes work as a
+file on disk or a message on a socket):
 
 ```
 table WeaponConfig


### PR DESCRIPTION
Owner correction: the docs wrote tables as a file format and `type` as "the packet wire". Reframed across README, SPEC-TABLES and USAGE: **schema has two wires — types (hardcoded, same-build, protocol-id-guarded) and tables (evolution-tolerant)** — and tables serve equally as files, blobs, or versioned messages between peers that don't deploy in lockstep. `packet wire` no longer appears as the name of the type wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)