### PR TITLE
Tables: pointer semantics — derived modes, the arena lifecycle, and the cooked form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,8 @@ build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POI
 # is recorded in the round log; this is the standing gate.)
 .PHONY: tables-zero-cost
 tables-zero-cost: build/tables-generated/.stamp
-	@for f in build/tables-generated/examples/*Table.h build/tables-generated/v1/*Table.h build/tables-generated/v2/*Table.h; do \
+	@for f in build/tables-generated/examples/*Table.h build/tables-generated/v1/*Table.h \
+	          build/tables-generated/v2/*Table.h build/tables-generated/p1/*Table.h; do \
 		if grep -nE "TableArena|TableSlot|TableWorker|TableRef|TableRegion|kTableSegment|kTableSlab|kTableMaxDepth|is_pointer|Builder|LayoutId|OpenWalk|PackMeasure|LoadMeasure|Cook|Open\\(" $$f; then \
 			echo "ZERO-COST GATE FAILED: pointer machinery leaked into $$f"; exit 1; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ tables-zero-cost: build/tables-generated/.stamp
 build/schema_test_tables: build/tables-generated/.stamp test/tables/main.cpp
 	@mkdir -p build
 	$(CXX) -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -pthread \
-		-Ibuild/tables-generated/examples -Ibuild/tables-generated/pointers \
+		-Ibuild/tables-generated/examples -Ibuild/tables-generated/pointers -Itest/tables \
 		-Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
 		-Ibuild/tables-generated/p1 -Ibuild/tables-generated/p2 \
 		test/tables/main.cpp -o $@

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ SCHEMAS      := $(wildcard examples/*.schema)
 SCHEMAS128   := $(wildcard examples128/*.schema)
 SCHEMAS_BENCH := $(wildcard bench/corpus/*.schema)
 SCHEMAS_TABLES := $(wildcard tables/examples/*.schema)
+SCHEMAS_TABLES_POINTERS := $(wildcard tables/pointers/*.schema)
 
 all: bin/schema
 
@@ -198,19 +199,39 @@ build/schema_test_guard: build/guard-generated/.stamp test/guard/main.cpp
 # The tables corpus (SPEC-TABLES.md): the tabledemo unit plus the
 # two-generation evolution pair (tblv1/tblv2), generated at build time into
 # build/ — test-only, never part of the committed generated/ tree.
-build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) test/tables/V1.schema test/tables/V2.schema
+build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P2.schema
 	@mkdir -p build/tables-generated
 	./bin/schema generate --lang cpp --out build/tables-generated/examples tables/examples
+	./bin/schema generate --lang cpp --out build/tables-generated/pointers tables/pointers
 	./bin/schema generate --lang cpp --out build/tables-generated/v1 test/tables/V1.schema
 	./bin/schema generate --lang cpp --out build/tables-generated/v2 test/tables/V2.schema
+	./bin/schema generate --lang cpp --out build/tables-generated/p1 test/tables/P1.schema
+	./bin/schema generate --lang cpp --out build/tables-generated/p2 test/tables/P2.schema
 	@touch $@
+
+# The ZERO-COST GATE (SPEC-TABLES.md): a table with no pointer in its by-value
+# closure must pay NOTHING for the pointer machinery — no builder, no arena, no
+# handles, no lifecycle surface, no extra descriptor columns. The pointer-free
+# corpus's generated headers must not contain one symbol of it. (The stronger
+# one-time proof — byte-identical emission against the pre-pointer baseline —
+# is recorded in the round log; this is the standing gate.)
+.PHONY: tables-zero-cost
+tables-zero-cost: build/tables-generated/.stamp
+	@for f in build/tables-generated/examples/*Table.h build/tables-generated/v1/*Table.h build/tables-generated/v2/*Table.h; do \
+		if grep -nE "TableArena|TableSlot|TableWorker|TableRef|TableRegion|kTableSegment|kTableSlab|kTableMaxDepth|is_pointer|Builder|LayoutId|OpenWalk|PackMeasure|LoadMeasure|Cook|Open\\(" $$f; then \
+			echo "ZERO-COST GATE FAILED: pointer machinery leaked into $$f"; exit 1; \
+		fi; \
+	done
+	@echo "tables zero-cost gate: value-only tables carry no pointer machinery"
 
 # Deliberately compiled WITHOUT -I$(SERIALIZE): the generated Table headers
 # carry no serialize dependency, and this build proves it stays that way.
 build/schema_test_tables: build/tables-generated/.stamp test/tables/main.cpp
 	@mkdir -p build
-	$(CXX) -std=c++17 -Wall -Wextra -Werror -ffp-contract=off \
-		-Ibuild/tables-generated/examples -Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
+	$(CXX) -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -pthread \
+		-Ibuild/tables-generated/examples -Ibuild/tables-generated/pointers \
+		-Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
+		-Ibuild/tables-generated/p1 -Ibuild/tables-generated/p2 \
 		test/tables/main.cpp -o $@
 
 build/schema_test_random: generated/cpp/.stamp test/random_main.cpp
@@ -365,6 +386,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	./build/schema_test
 	./build/schema_test_guard
 	./build/schema_test_tables
+	$(MAKE) tables-zero-cost
 	./build/schema_test_random
 	./build/schema_test_ludicrous
 	cd test/c && ../../build/schema_test_c
@@ -451,8 +473,11 @@ check: bin/schema
 	./bin/schema check examples
 	./bin/schema check examples128
 	./bin/schema check tables/examples
+	./bin/schema check tables/pointers
 	./bin/schema check test/tables/V1.schema
 	./bin/schema check test/tables/V2.schema
+	./bin/schema check test/tables/P1.schema
+	./bin/schema check test/tables/P2.schema
 	./bin/schema check bench/corpus/Bench.schema
 	./bin/schema check bench/corpus/RealWorld.schema
 
@@ -466,8 +491,11 @@ fmt: bin/schema
 	./bin/schema fmt examples
 	./bin/schema fmt examples128
 	./bin/schema fmt tables/examples
+	./bin/schema fmt tables/pointers
 	./bin/schema fmt test/tables/V1.schema
 	./bin/schema fmt test/tables/V2.schema
+	./bin/schema fmt test/tables/P1.schema
+	./bin/schema fmt test/tables/P2.schema
 	./bin/schema fmt bench/corpus/Bench.schema
 	./bin/schema fmt bench/corpus/RealWorld.schema
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ would have hand-written, not an interpreter walking a schema at runtime.
   schema's take on the protobufs/flatbuffers class, beside the bitpacked
   wire rather than replacing it. The two version independently — a table
   never moves the protocol id.
+- **Pointers, where they belong.** Types stay value semantics; TABLES may
+  point at tables (`next *Node`), so linked lists, trees and optional
+  subtables are expressible. The compiler DERIVES the consequence and you
+  never declare it: a table with no pointer in its by-value closure is a
+  plain struct that pays nothing for any of this, and a table with one is
+  built through a lock-free arena, locked once into a single packed region,
+  and read through a root pointer. That region also cooks: write it verbatim
+  behind a build-locked header and a later run points at its root — no copy,
+  no parse — while the tolerant wire stays the format of record.
 - **Zero allocation, no runtime reflection** — straight-line code reading and
   writing your own buffers.
 - **Reads validate, always — in every language.** Out-of-range values are

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -1,188 +1,48 @@
-# elixir round two — ROUND-LOG
+# tables POINTER SEMANTICS — ROUND-LOG
 
-One line per milestone: lever name, paired numbers, decision. A future resume
-reads the round's state from this file plus the branch commits alone.
+One line per unit: what landed, the ruling it serves, the decision taken. A
+future resume reads the round's state from this file plus the branch commits.
 
-- RESUME 2026-09-01: process death mid-round; branch had 2e71846 (fr fast path,
-  Veltkamp/Dekker) only. Its profile findings died with the worker — re-profiling.
-  Standing: elixir 1364% (bench/results/2026-09-01-sitting3-arm64-macbook.csv:
-  write 449772 msg/s MEDIAN, round_trip 262329 msg/s MEDIAN — the same row's
-  round_trip MAX is 262385, which is the number the §2.9 statistic and the
-  certification bullet below both quote; the two figures are the same sitting
-  read off different columns, not a disagreement). Board home: issue #174.
-- PROFILE (fresh, branch head, eprof 30k + tprof 200k iters, write and rt
-  separately, outputs in session scratch): WRITE — w_bench_mixed_stats 26.7%,
-  write_bench_mixed own 21.8%, w_bench_mixed_entities 16.0%, cf_quantize 14.8%
-  (0.27us own/call), fr 13.0% (15 calls/msg), cf_clamp01 2.4%, f32/f64_bits 1.8%.
-  RT — r_bench_mixed_stats 29.6% (0.09us/call, 41 calls/msg), w_stats 11.6%,
-  fr 10.1% (27/msg), write_bm 7.7%, read_bm own 7.5%, w_entities 6.9%,
-  cf_quantize 6.2%, r_entities 5.0%, cf_decode 4.5%, Enum.reverse+lists:reverse
-  3.7%, binary:match 1.2%. The profile names: (1) stats read clause, (2) float
-  pipeline (fr/cf_quantize), (3) reverse elimination, (4) write barrier appends.
-  rd/rdw are compiler-inlined (absent from traces) — their cost rides the callers.
-- HARNESS-VS-CODEC SPLIT (owner question, eprof by module): nothing was
-  filtered from the profile summaries — the only non-codec entries eprof
-  recorded inside the timed region are the driver loop frames themselves:
-  write 1.58% (Prof.write_loop, the elem/&&&/byte_size/acc frame mirroring
-  the runner's dd_write_loop), rt 1.03% (Prof.rt_loop); erlang:apply +
-  compiler shims 0.00%. Everything else, including binary:decode_unsigned
-  (rd/rdw tail fallback), binary:match (the reader's player_name NUL check,
-  Bench.ex:2339), and lists:reverse/Enum.reverse (element-loop terminals), is
-  the generated codec + emitted helpers: codec share 98.4% of write, 99.0% of
-  rt. The certification runner's golden gates run OUTSIDE its timed region and
-  its per-run sink is one Process.put per run, not per iteration. Harness is
-  immaterial (<2% both paths, well under the 5% bar) — no harness-parity
-  exclusion applies; lever math stands on codec time alone.
-- INSTRUMENT FINDING: a paired run that measures write then rt in ONE VM
-  poisons the rt comparison (heap state from the write loop; rt read 4500-4800
-  ns/msg vs 3826 clean, matching certification's 262k msg/s). Lever decisions
-  now use single-path pair runs. Between-invocation write deltas can flip sign
-  (+4.8/-3.4%) — decisions use repeated invocations + max statistic.
-- INSTRUMENT CALIBRATION (A/A null, and the correction it forces): the pair
-  instrument timed arm A then arm B every round, with no rotation. It now
-  ALTERNATES arm order by round parity. The A/A null — both arms the same
-  module, a pure rename, wire gate 64/64 — is what says whether a ratio
-  means anything, and it was run on all three paths at 400k iters x 7 rounds:
-    read  B/A 0.998, 1.003        -> +/-0.3%, trustworthy
-    rt    B/A 1.012, 0.995        -> +/-1.2%, trustworthy well above that
-    write B/A 1.045, 0.959, 1.057 -> +/-5%,   NOT trustworthy at lever scale
-  Rotation did not rescue the write path. The bias there is not a slot effect:
-  within one invocation every round of one arm is faster than every round of
-  the other, and which arm that is flips between invocations — a whole-VM
-  layout/GC-regime effect the max statistic cannot average out. So the write
-  path's null band is the size of every write lever this round decided, and
-  the honest statement is that this instrument DOES NOT RESOLVE write-time
-  differences of a few percent, in either direction.
-  Allocation is the axis that survives: across every null run the two arms'
-  words reclaimed agree to under 0.001% on write (794760324 vs 794763984) and
-  under 0.02% on read and rt. Word counts are what the write-path decisions
-  below now rest on. The read and rt TIMES stand on their own: read gains of
-  11-14% sit ~40x above a 0.3% null, and rt gains of 7-8% sit ~6x above a
-  1.2% null.
-- LEVER fr (2e71846, inherited from dead worker): KEEP, ON ALLOCATION.
-  Decisive metric — GC words reclaimed on the write loop 1021.8M -> 601.3M,
-  -41% (the same -41% the round first measured at its own smaller scale,
-  167M vs 284M): the JIT keeps the Veltkamp/Dekker temporaries unboxed, so
-  the arithmetic path allocates one float where construct/match allocated a
-  binary plus a float. That axis is deterministic and the A/A null puts the
-  two arms within 0.001% of each other, so a 41% gap is real.
-  Supporting: micros cf_decode 89.2->62.3 ns (1.43x), cf_quantize 108.9->83.4
-  (1.31x).
-  WITHDRAWN: the full-bench write timing (best-vs-best 2222 vs 2329 ns,
-  1.048x, faster in 6/7 invocations) is INSIDE the write null's +/-5% band and
-  is UNRESOLVED BY THE INSTRUMENT — it is not evidence for or against the
-  lever. rt 1.0002x and read 1.003x were reported as neutral and remain so;
-  both sit inside their own (much tighter) nulls, which is what "neutral"
-  should mean.
-- LEVER B (single-match-context stats read), PROTOTYPE VERDICT: build. Design:
-  4 stats per 9-byte head-match (<<w1::little-40, w2::little-32, rest::binary>>,
-  constant carry c = (8 - start_phase) mod 8; lo = carry ||| w1 <<< c up to 47
-  bits, hi = lo >>> 36 ||| w2 <<< (c+4) up to 43 bits — fixnum envelope holds),
-  body-recursive so the list builds IN ORDER on unwind (no Enum.reverse for the
-  fast portion); scalar rd() path kept as entry fallback, tail (<4), and
-  truncated-buffer fallback. +bin_opt_info: "OPTIMIZED: match context reused"
-  at all three fast-loop sites. Paired vs head: read 1833.8 -> 1647.7 ns
-  (1.113x), rt 3916.1 -> 3743.9 ns (1.046x); GC words down ~7%. Tail-call acc
-  variant alone was read 1.071x/rt 1.03x; body-recursion added 1.036x/1.011x.
-- LEVER B LANDED (emitter form): fastReadClauses in internal/codegen/elixir/
-  functions.go — aligning entry + body-recursive single-match-context clause
-  behind every qualifying array read loop (static element width <= 20 bits,
-  plain fields only — no branches/unions/strings/arrays; m elements per
-  iteration with m*eb = 0 mod 8, capped 72 bits/16 elems/ArrayBound). Feeds
-  the existing element emission through readFeed (chained fixnum registers,
-  runtime carry only ever `c + literal`). Emitter-form paired vs pre-lever
-  head: read 1746.8 -> 1571.7 ns (1.111x, matching the 1.113x prototype), rt
-  4173.0 -> 3867.8 best (1.079x best-vs-best on a thermally noisy sitting;
-  prototype said 1.046x), write neutral (1.016x, noise). Wire gate 64/64
-  byte-identical; test/elixir + test/elixir-ludicrous OK; mix format clean;
-  goldens re-pinned (text only — wire bytes untouched). Also fires for
-  bench_packet blob (9x8-bit) and examples arrays (Wire/Clauses/Degenerate).
-- HYPOTHESIS A (iolist emission) REFUTED. Writers building [data | <<segs>>]
-  trees with one :erlang.iolist_to_binary at return, wire gate 64/64 green.
-  RE-MEASURED with the rotating instrument at 400k iters x 7 rounds:
-  write 2596.3 -> 2943.7 ns/msg (1.134x SLOWER), rt 4051.2 -> 4359.5 (1.076x
-  SLOWER), words reclaimed on the write loop 794.6M -> 1019.4M (1.283x MORE).
-  The refusal stands on the timing, which is the one place a write-time claim
-  survives the null: 13.4% is well outside the +/-5% band, and the direction
-  reproduced in every arm order tried.
-  CORRECTED: the first write-up said words 267M -> 582M (2.2x). That figure
-  does not reproduce; the allocation penalty is 1.28x, not 2.2x. Direction
-  unchanged, magnitude overstated.
-  Mechanism: bs_append grows a writable binary in place (the segment copy is
-  paid either way), while the iolist pays a fresh heap binary + cons per
-  barrier AND the final flatten traversal+copy. Zero-intermediate-append
-  emission is a loss on the BEAM; the lever-M multi-segment barrier append
-  stands as the floor's write shape.
-- LEVER u8 (write unroll 4->8) REFUSED: write 2462.4 vs 2496.8 ns (1.4%
-  AGAINST), rt 0.99x noise — the append count per stat was already amortized
-  at 4-wide; the fixnum cap bounds what wider grouping can remove (#202's law
-  reconfirmed at the next scale).
-- LEVER rc (combined range check, masked one-branch form) REFUSED: write
-  2349.0 vs 2363.4 ns (0.6% against, noise) — predicted branches were free.
-- LEVER C (cf decode tables) LANDED: a compressed-float read whose quantum
-  count is <= 1024 decodes through a module-attribute tuple (elem/2) computed
-  at GENERATED-module compile time by literally the cf_decode chain (full fr
-  with guard + fr_slow + nonfinite mapping) — equality by construction, and
-  verified: 201-entry domain === cf_decode on all values, wire gate 64/64.
-  Prototype: read 1638.3 -> 1431.9 ns (1.144x), rt 1.069x. Emitter form:
-  read 1652.6 -> 1446.6 (1.142x), rt 1.070x. Tables: Bench 1 (aim, 201
-  entries), RealWorld 5, Wire 1. cf_decode stays the shipped path past 1024.
-- LEVER cfq (per-declaration cf_quantize specialization, constants folded)
-  REFUSED: write 2449.1 vs 2453.2 ns (0.2%, noise) — BEAM argument passing
-  and literal loading are already free; the quantize cost is the float chain
-  itself, which the wire contract pins step-for-step.
-- REFUSALS UNDER THE NULL (u8, rc, cfq): all three are write-path deltas of
-  0.2-1.4%, so all three sit deep inside the +/-5% write null and none of them
-  was ever resolved by the instrument either. They STAND, unchanged, and the
-  null makes them MORE secure rather than less: each was refused on a number
-  pointing slightly AGAINST the candidate, and a bias that can manufacture a
-  few percent in either direction cannot manufacture evidence for refusing —
-  the worst it can do is hide a small win, and a win this instrument cannot
-  see is not one worth carrying the complexity for. Each refusal also has a
-  mechanism behind it (fixnum cap, free predicted branches, free literal
-  loading), which is what the decision actually rests on.
-- CONSIDERED, NOT BUILT: direct float segments in barrier appends (skip
-  f32/f64_bits construct/match, ~1.8% of write) — refused by reasoning: the
-  {:nonfinite, bits} write form makes every float segment conditional, which
-  breaks the one-construction-per-barrier shape lever M bought; revisit only
-  if a nonfinite-free declaration class ever exists.
-- CERTIFICATION PAIR (quick legs, one sitting, --out scratch; §2.9 statistic
-  is round_trip over MAX rates): before (clean worktree at origin/main
-  b63c22e): write 427700 max / 426651 median, rt 253090 max / 242109 median
-  (warm sitting — spreads 2.3/4.7%). after (branch head): write 449568 max /
-  449244 median, rt 275088 max / 274908 median (spreads 0.1%). In-sitting rt:
-  1.087x on max (medians 1.135x — the before rt max is a single cool-run
-  outlier). The rt gain is the one that stands: it is corroborated by the
-  paired instrument, whose rt null is +/-1.2%, and by the adversarial
-  reviewer's independent re-run.
-  WITHDRAWN: the in-sitting WRITE figure (1.051x on max, 1.053x on median) is
-  the size of this round's demonstrated write-path measurement uncertainty and
-  is UNRESOLVED. The certification runner is not the pair instrument, but the
-  before leg's own write spread was 2.3% and the A/A null puts the pair
-  instrument's write band at +/-5%; nothing this round measured can separate a
-  5% write move from the noise. No write-time improvement is claimed. What the
-  branch does claim on the write path is allocation: -41% words on the fr
-  lever (above), an axis that reproduces to 0.001%.
-  Against the standing sitting3 ledger point (rt max 262385, cpp rt max
-  3579797, = 1364%): after rt max 275088
-  puts elixir at ~1301% of generated C++ — cross-sitting projection, a full
-  sitting re-certifies. CSVs: scratchpad/prof/cert-before-quick.csv,
-  cert-after-quick.csv (session scratch, never bench/results/).
-- GATES: make test green (nine legs), shape-gate clean (19 exemptions, all
-  on ledger), generated-current green (tree clean post-test), mix format
-  clean, gofmt/vet/modernize clean, ZERO warnings from every generated Elixir
-  module (each required standalone; the whole generated tree, not just the
-  legs make test compiles).
-- DRAFT PR: https://github.com/mas-bandwidth/schema/pull/240 — round closed;
-  left in draft per the round brief (never marked ready, never merged).
-- ADVERSARIAL REVIEW, repaired: (1) cf_decode/4 was emitted dead in Bench.ex —
-  needCf gated quantize and decode together and the write path set it, so a
-  module whose every compressed-float read went through a table still carried
-  the function, and the compiler said so. Split into needCfQ/needCfD; fr/1 and
-  fr_slow/1 back both halves. Bench.ex is the only module affected, 16 lines
-  removed, wire bytes untouched. (2) the pair instrument's missing rotation and
-  the A/A null it hid — instrument fixed, null published above, every write-time
-  claim in this log restated as unresolved. (3) the iolist allocation figure
-  re-measured and corrected, 2.2x -> 1.28x. (4) the feed exclusion invariant
-  and the fast clause's ceil(n/m) frame depth written into the emitter.
-  (5) the sitting-3 median/max pair annotated at the RESUME line.
+Base: origin/main @ 5e11117 (the tables-framing PR #241 had already merged, so
+no rebase debt).
+
+## Owner rulings this round (the design's authority)
+
+1. "types can remain value semantics. tables should ALLOW pointer semantics" —
+   "we can't be a generic system if we don't have pointers to tables."
+2. Spelling: "literally same C++-like syntax for pointers is fine" → `next *Node`.
+   Table-to-table only; pointer-to-`type` refused by name.
+3. Modes are COMPILER-DERIVED, never declared: "i wouldn't want to manually have
+   to specify this… the compiler can work it out and go, oh it's the variable
+   table mode."
+4. "i think variable tables need to live in a growable array."
+5. Const vs mutable is a LIFECYCLE: "maybe you 'lock' a table and it is constant
+   from that point forward… since how else will you construct Assets.bin."
+6. "mutable vs. non-mutable tables may be different at runtime."
+7. "the builder needs to be able to be multithreaded" ("That's very flatbuffers");
+   then "I prefer lockless if possible."
+8. Naming: `<Name><Verb>` — `ChatMessageSave`, `ChatMessageLoad`,
+   `ChatMessageMeasure`, `ChatMessageBuilder` with `Alloc<T>()`/`Lock()` methods.
+   Shared symbol table ratified: "do tables and types share the same symbol
+   table then, I vote yes."
+9. Zero-cost gate: "Make sure we don't pay this cost when we have nice, small
+   messages… when the table is inferred to be value types only."
+10. "Let's assume larger types will probably have pointers to things."
+11. File-format-scale tables "can't be a struct" — pointer-bearing tables are
+    never held by value; their const surface is region + root view.
+12. "you don't need to recreate sizeof" — no generated size constants of any
+    kind. `sizeof(X)` is the memory answer, `XMeasure(value)` the wire answer.
+
+## Units
+
+- UNIT 1 — the name-first rename (ruling 8). `TableMeasureX` → `XMeasure`,
+  `TableSaveX` → `XSave`, `TableWriteX` → `XSaveBody`, `TableReadX(reader)` →
+  `XLoadBody`, `TableReadX(buffer)` → `XLoad( value, buffer, bytes, &report )`
+  (value first, report by pointer, per the owner's approved snippet),
+  `TableTypeX` → `XTableType`. The claimed-name registry grew the full
+  name-first suffix set for EVERY closure member — including the mutable-life
+  suffixes a value-only table does not emit — so a table gaining pointers later
+  never turns a legal declaration into a collision. Deliberate asymmetry
+  recorded: the TYPE wire stays verb-first (`WriteX`/`ReadX`), tables are
+  name-first; the verb position tells a reader which wire the call site is on.
+  Nine legs + tables green after the rename.

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -64,3 +64,37 @@ no rebase debt).
   multiplication keeps its spaces (`max = K * 2`) — type position at index 1
   is what tells them apart. The C++ emitter REFUSES a pointer-bearing unit for
   now, loudly, so the tree stays green until unit 3 emits the backend.
+
+- UNIT 3 — the C++ variable-length backend (rulings 4, 5, 6, 7, 9, 11). The
+  MUTABLE form is a segmented slab arena: equal-size 4 MiB segments whose count
+  saturates the u32 reference space exactly (1024 -> 4 GiB), handed to workers
+  in 64 KiB slabs with ONE compare-exchange per slab and zero atomics per node.
+  Nodes are born at final offsets and segments never move, so a `T*` from Alloc
+  stays valid while other workers allocate and while the arena grows. The
+  REJECTED model is named in the emitted comment: one buffer under a lock grown
+  by realloc, whose realloc moves memory under a mid-write worker. Slack: one
+  slab tail per worker plus one per segment (<2% + threads x 64 KiB).
+  `Lock()` is one-way and IS the compaction: the arena packs into one exact
+  region, root at base, references rewritten SELF-RELATIVE — so a deref is one
+  add with no base pointer and a region relocates by pure memcpy with zero
+  fix-up. Lock's output and Load's output are the SAME representation, one view
+  API. Aliasing is not preserved anywhere (two pointers to one node pack and
+  ride as two), stated in the emitted comments and the spec.
+  Wire: a pointer rides as a nested table body — framing IDENTICAL to a
+  by-value nesting, so a field can change between the two without moving a
+  byte. Null elides; a non-null pointer rides even when the pointee is
+  all-default, or null and empty would be one value. Depth cap kTableMaxDepth
+  = 128 on every walk (save, load, cook, open): a data cycle is an ERROR, never
+  a hang. Cooked form: 32-byte header carrying magic (which is also the
+  byte-order check), a layout id digesting the schema's packed-layout facts
+  mixed with this build's own sizeof for every closure type, and the region
+  length; `<Name>Open` runs a bounds walk over the REFERENCE GRAPH only —
+  pointer slots and the count companions that bound a traversal — before
+  handing out the root. Packed references are strictly forward, so that walk is
+  cycle-free with no visited set.
+  ZERO-COST GATE, PROVEN: the whole pointer-free corpus (tables/examples,
+  test/tables/V1, test/tables/V2) regenerates BYTE-IDENTICAL to the
+  rename-applied baseline at 974ff0f — `diff -r` clean. Three leaks were found
+  and closed to get there: the descriptor's `is_pointer` column, TableTypeInfo's
+  `variable` column, and a reworded relocatability comment are now emitted only
+  in a unit that actually has pointers.

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -241,3 +241,44 @@ RE-RUN MATRIX: make test exit 0 (nine legs + tables, 0 warnings); tables leg
 shape-gate clean; reviewer adv battery 240126 checks, the single remaining
 "failure" being their own CHECK that garbage in the header's reserved words
 still opens — now refused, which was minor 3.
+
+## Delta round (one new blocker, introduced by the C2 repair)
+
+- R1 FIXED — C2 widened Open's descend-set to ALL by-value structs, but the
+  walks were emitted per FILE and `emitVariableSurface` early-returned when a
+  file had no varMembers. A multi-file pointered unit whose second file
+  declares neither a variable table NOR a pointer target then referenced walks
+  that existed nowhere: the header did not compile. Fix taken is the second of
+  the two sketched — the OpenWalk half is keyed on the UNIT being pointered,
+  never on the file, so each walk is emitted exactly once by its DECLARING
+  file and the referencing file picks it up through the include it already
+  has. Emitting per referencing file instead would have defined each twice.
+  Value-only UNITS stay at zero cost because the key is `anyVariable`; the
+  byte-identity proof against 974ff0f was re-run post-fix and is clean.
+- MANDATORY CORPUS added: `tables/pointers` is now a genuinely multi-file
+  pointered unit. `Parts.schema` declares a native-mapped TYPE (Colour) and a
+  FIXED table (Stamp) and is deliberately BOTH pointer-free AND pointer-target
+  free — the first corpus attempt missed the bug because Stamp was a pointer
+  target, which put it in varMembers and papered over the gap. `Marks.schema`
+  declares the cross-file VARIABLE member (Marker, pointing at Tally).
+  `Graph.schema`'s new `Album` nests all three across file boundaries and
+  points at Marker. `test/tables/graph_colour.h` supplies the native type, so
+  the cross-file cpp_native case is covered too: the Open walk reaches
+  ::ColourMath through a derived-to-base conversion.
+  `test_cross_file_pointer_unit` round-trips Album through measure/save/exact
+  capacity/Lock/cook/open/load and forges three cross-file corruptions — the
+  fixed table's count, the variable member's count, and its pointer.
+  NEGATIVE CONTROLS: restoring the file-scoped emission makes GraphTable.h fail
+  to compile with ColourOpenWalk/StampOpenWalk undefined; narrowing the
+  descend-set back to variable members turns three assertions red, one of them
+  the cross-file one.
+- COSMETICS: the generated OpenWalk comment no longer cites `<X>Pack` for a
+  member that has none — a reference-free member gets a comment saying its
+  placement is decided by whatever variable table nests it, that the watermark
+  passes through untouched, and that its count companions are what the walk
+  owes. The PR body's layout-id bullet now says per-field offsetof, matching
+  C4 and the spec.
+
+RE-RUN MATRIX (post-fix): make test exit 0 (nine legs + tables, 0 warnings);
+tables leg 20 cases; zero-cost byte-identity against 974ff0f clean; grep gate
+clean; gofmt/vet/golangci-lint(0)/modernize/shape-gate clean.

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -46,3 +46,21 @@ no rebase debt).
   recorded: the TYPE wire stays verb-first (`WriteX`/`ReadX`), tables are
   name-first; the verb position tells a reader which wire the call site is on.
   Nine legs + tables green after the rename.
+
+- UNIT 2 — the language: `next *Node` (rulings 1, 2, 3). Scanner already had
+  `Star`; the parser accepts it in type position and the CHECKER owns every
+  rule, so a bad pointer names the real problem instead of "expected a field
+  type". Refused by name: pointer to a `type`/enum/flags/union (the founding
+  line — types remain value semantics), a pointer outside a table body, an
+  array of pointers (§12 follow-on), a specified default on a pointer (null is
+  the only value one could name). The by-value composition-cycle refusal now
+  EXEMPTS pointer edges — `table Node { next *Node }` is legal and finite,
+  while `table Node { self Node }` still refuses. Mode derivation lives in
+  `ir.VariableTables` as a least-fixed-point over BY-VALUE edges only:
+  FIXED-SIZE = no pointer in the by-value closure; VARIABLE-LENGTH = a pointer
+  anywhere in it, propagating up through by-value nesting and bounded arrays.
+  `ir.PointerTargets` names the tables that need an allocation surface.
+  Formatter: the pointer star binds tight to its target (`next *Node`) while
+  multiplication keeps its spaces (`max = K * 2`) — type position at index 1
+  is what tells them apart. The C++ emitter REFUSES a pointer-bearing unit for
+  now, loudly, so the tree stays green until unit 3 emits the backend.

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -98,3 +98,37 @@ no rebase debt).
   and closed to get there: the descriptor's `is_pointer` column, TableTypeInfo's
   `variable` column, and a reworded relocatability comment are now emitted only
   in a unit that actually has pointers.
+
+- UNIT 4 — corpus, tests, gates. The pointer corpus lives in its OWN unit
+  (`tables/pointers/Graph.schema`, package graphdemo) so `tables/examples`
+  stays pointer-free and keeps proving the zero-cost gate. Graph carries a
+  value-only table (Meta), a value-only POINTER TARGET (Settings), a
+  self-recursive list (ListNode), a tree (TreeNode), a variable table nested by
+  value (Layer) and a bounded array of them — the derived mode has to get all
+  six right in one file. The evolution pair `test/tables/P1|P2.schema` turns one
+  field from a by-value nesting into a pointer and gives its target a pointer of
+  its own: both directions read, because a pointer's framing IS a by-value
+  nesting's.
+  Battery (12 new cases, all in test/tables/main.cpp): lifecycle
+  (build/measure/save/lock/relocate-by-memcpy/load/re-save byte-identical),
+  exact-capacity across a pointer graph, Lock layout determinism (two builds
+  memcmp equal; two cooks byte-identical), aliasing (two references, two nodes,
+  in the packed form AND across the wire), the data-cycle refusal (measure,
+  save, cook and Lock all refuse; nothing recurses away), the depth cap at and
+  past kTableMaxDepth, arena growth across 200k allocations with a pointer held
+  the whole time, four workers single-threaded plus a real four-thread
+  concurrent build joined before Lock, the cooked form (cook/open/point,
+  cook-open-cook stable) with a nine-case refusal battery (magic, layout id,
+  truncation, sub-header size, unaligned base, out-of-region reference, BACKWARD
+  reference, misaligned reference, out-of-bound count companion), evolution both
+  directions including load-into-builder, the null-vs-empty-pointee distinction,
+  and reflection (derived mode surfaced, is_pointer, the target descriptor,
+  a self-referential pointer resolving to its own type).
+  NEGATIVE CONTROL run: inverting the aliasing assertion turns the leg red at
+  the expected line and exit 1 — the battery is wired in, not decorative.
+  Standing gates: `make tables-zero-cost` greps the pointer-free corpus's
+  generated headers for every pointer-machinery symbol and fails the build on a
+  hit; it runs inside `make test`. Go-side: TestZeroCostForValueOnlyTables,
+  TestPointerSurfaceEmitted (per-TABLE, not per-file: a value-only table sharing
+  a pointered unit still gets no builder), TestPointerGenerationDeterministic,
+  TestLayoutIdMovesWithTheSchema.

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -153,3 +153,13 @@ no rebase debt).
   JSON walk over the descriptors. Sections 6..15 renumbered; every code citation
   updated to match. USAGE gained the pointer, builder/threading and cooked-form
   sections; README gained the pointers bullet.
+
+- UNIT 6 — gates, all local, all green. `gofmt -l` clean; `go vet ./...` clean;
+  `golangci-lint run` clean (one real finding fixed: a helper left unused after
+  the language unit's temporary refusal came out); `modernize` clean (one
+  finding fixed: range-over-int); `make shape-gate` clean (19 ledgered files,
+  no new shape knowledge); `make test` EXIT 0 across all nine backend legs plus
+  the tables leg, with the zero-cost gate running inside it, and ZERO warnings
+  from the generated modules. The clone needed the read-only serialize siblings
+  and the pinned dist toolchains symlinked in to run the full matrix; nothing in
+  ~/rowan-working was written.

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -132,3 +132,24 @@ no rebase debt).
   TestPointerSurfaceEmitted (per-TABLE, not per-file: a value-only table sharing
   a pointered unit still gets no builder), TestPointerGenerationDeterministic,
   TestLayoutIdMovesWithTheSchema.
+
+- UNIT 5 — SPEC-TABLES.md, USAGE.md, README. Spec gained §2.1 (pointers, with
+  every refusal named), §2.2 (the mode derived as a least-fixed-point over
+  by-value edges, the zero-cost gate stated as a gate, and the stated
+  assumption that size and mode correlate), §3.1 (the pointer wire: tree
+  semantics loud, null elides, a non-null pointer always rides, pointer and
+  by-value nesting wire-identical, the depth cap and what it costs), a NEW §6
+  (the two lives: value surface vs Builder→Lock→region, the two reference
+  encodings, the threading contract, both load paths, the authoring-vs-reading
+  allocation split), a NEW §7 (the cooked form — accelerator not archive,
+  layout id, the bounds walk as reads-validate-always, every refusal, alignment,
+  endianness refusing in v1). §8 reflection gained the pointer kind and the
+  derived mode; §9 relocatability now covers both forms and states measure==save
+  at exact capacity as a hard invariant; §11 grew the pointer, cycle, depth-cap
+  and cooked-file refusals; §13.1 records the rulings verbatim; a NEW §14
+  weighs all four builder-storage models with lock+realloc REJECTED and the
+  moved-node hazard named; §15 grew graph/DAG identity, arrays of pointers,
+  lifting the depth cap, cross-endian Open, the fallback loader, and the generic
+  JSON walk over the descriptors. Sections 6..15 renumbered; every code citation
+  updated to match. USAGE gained the pointer, builder/threading and cooked-form
+  sections; README gained the pointers bullet.

--- a/ROUND-LOG.md
+++ b/ROUND-LOG.md
@@ -163,3 +163,81 @@ no rebase debt).
   from the generated modules. The clone needed the read-only serialize siblings
   and the pinned dist toolchains symlinked in to run the full matrix; nothing in
   ~/rowan-working was written.
+
+## Adversarial review round (verdict: MERGE-WITH-CONDITIONS)
+
+Reviewer batteries at scratchpad/adv/ (adv/det/evo/tsan). Disposition per
+finding, and the re-run matrix, below.
+
+- B1 FIXED — Open's bounds walk was exponential on a forged aliased-forward
+  DAG (reviewer measured 26 nodes = 312 ms, ~60 = never). Fix is the ruled
+  high-water mark: `at >= watermark`, then `watermark = at + aligned sizeof`.
+  The invariant it rests on — Pack is pre-order bump allocation, OpenWalk
+  visits in the SAME order — is now stated at BOTH sites with "neither may
+  change alone". It also closes mid-node overlaps the alignment check caught
+  only by luck. Regression `test_open_walk_is_linear` ports the repro at
+  n = 16/26/40/64 (n = 64 would not return unbounded) plus
+  `test_open_refuses_overlap`. NEGATIVE CONTROL: with the mark disabled the
+  forged file is ACCEPTED again at n = 16 and 24.
+- B2 FIXED — Lock/Cook memcpy'd uninitialised arena padding into regions and
+  cooked FILES; the old determinism test passed on fresh-mmap luck. Segments
+  are calloc'd now. `test_lock_deterministic_on_dirty_heap` dirties the heap
+  with 0xA5 then 0x5C between builds and asserts identical regions AND
+  identical cooked files, plus zero padding bytes. NEGATIVE CONTROL: restoring
+  malloc turns it red on both assertions. The reviewer's own det.cpp now
+  reports IDENTICAL on a dirtied heap and zero padding on disk.
+- B3 FIXED — (a) `table Root`/`table Const` emitted non-compiling headers
+  because a member function hides the type name it shares. The METHODS moved
+  (Root -> GetRoot, Const -> AsConst) since Root is the spec's own canonical
+  root-table name; every remaining builder member name is now REFUSED as a
+  table name, so the door is shut rather than narrowed. `table Root` and
+  `table Const` verified compiling and running end to end. (b) Emplace, Pack,
+  PackMeasure, LoadMeasureBody, LoadBuilder, OpenWalk — plus TableInfo and
+  TableFields from the C3 fix — added to the claimed-name registry, with a
+  refusal test each.
+- C1 FIXED — by-value nesting charged depth on measure/save/load but not on
+  pack/cook/open, so a structure could Lock and Cook but not Save. Ruled fix
+  taken: ONLY POINTER EDGES CHARGE DEPTH, one rule expressed once
+  (depthSame/depthDown) and applied in all four walks.
+  `test_depth_agrees_through_by_value_nesting` builds the 127-chain through
+  Scene::ground and round-trips it through measure, save, Lock, Cook, Open and
+  Load.
+- C2 FIXED — Open never bounded count companions of by-value nested FIXED
+  tables (meta.tag_length = 30000 survived). Every closure member now gets an
+  Open walk, unions bound their tag before the arm is walked, and
+  `test_open_bounds_nested_fixed_companions` covers both a by-value nested
+  fixed table and one reached through a pointer. The reviewer's D4.2 note
+  flipped to "ok".
+- C3 FIXED — TSAN race on the descriptors' lazy link (a plain bool RMW). A
+  magic static could not have fixed it either: a self-reference re-enters its
+  own initialisation. Descriptors in a pointered unit are now
+  CONSTANT-INITIALISED namespace data with addresses for targets — verified
+  landing in __DATA,__const with no __cxx_global_var_init, and verified
+  linking across two TUs. tsan.cpp is clean; the alloc path was already clean
+  and stays so. `test_descriptors_are_constant` reads the surface from four
+  threads.
+- C4 FIXED — the layout id digested field NAMES (a `was` rename invalidated
+  every cooked file) and carried only sizeof (blind to a member that moved
+  inside an unchanged total). It now keys fields by WIRE ID — the identity
+  `was` preserves — and mixes per-field offsetof. Matrix re-run:
+  MOVES on widen / bare rename / reorder / add / by-value-to-pointer; HOLDS on
+  a `was` rename (asserted at value level: identical digest, and terms
+  identical once the renamed field's spelling inside offsetof is normalised,
+  which is value identity because a rename moves no member).
+- MINORS all done: zero-cost gate covers P1; stale TableMeasure/TableSave
+  names in comments; the cooked header's reserved words must be zero (with a
+  regression sweeping all 20 bytes); null-root guards on Measure/Save/Cook
+  from a builder; dead walker-less arms deleted; USAGE states
+  sizeof(<Name>Builder) is ~8 KB (measured 8240, arena 8200).
+- CLAIMS corrected: the PR body's zero-cost section now states the per-TABLE
+  property exactly (no Builder, no walkers, unchanged codecs) and the
+  per-UNIT one separately; TestPointerSurfaceEmitted asserts exactly that,
+  including that a value-only table DOES get an Open walk. "O(references)"
+  replaced with the linearity argument. The pointer-to-type refusal relabelled
+  COORDINATOR-DESIGNED. The Scene.base "forced rename" note dropped.
+
+RE-RUN MATRIX: make test exit 0 (nine legs + tables, 0 warnings); tables leg
+19 cases; tables-zero-cost clean; gofmt/vet/golangci-lint(0)/modernize/
+shape-gate clean; reviewer adv battery 240126 checks, the single remaining
+"failure" being their own CHECK that garbage in the header's reserved words
+still opens — now refused, which was minor 3.

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -7,11 +7,13 @@ are for when you need things that version — more flexible structures with
 in-wire versioning; data structures, if you will. The founding line for
 the split: types remain VALUE semantics; tables ALLOW POINTER semantics —
 "we can't be a generic system if we don't have pointers to tables." The
-compiler derives two classes of table from that freedom: FIXED-SIZE
-(a by-value closure, storage a plain struct of known sizeof — every table
-today) and VARIABLE-LENGTH (a pointer anywhere in the closure — root plus
-arena). This document specifies the tables wire; the pointer/arena design
-is the named next round.
+compiler DERIVES two classes of table from that freedom, and nobody
+declares which: FIXED-SIZE (no pointer anywhere in the by-value closure —
+a plain struct of known `sizeof`, saved and loaded by value) and
+VARIABLE-LENGTH (a pointer anywhere in that closure — built through an
+arena, read through a region and a root pointer, never held by value).
+A fixed-size table pays for none of the variable-length machinery: that
+property is a gate, held by test, not an intention (§2.2).
 
 Tables are schema's declarations for **data that crosses builds**: config
 files, asset archives, tool output, editor state — and just as much,
@@ -74,10 +76,78 @@ compressed floats, enums, flags, strings, bytes, bounded arrays, unions,
 
 - **Tables nest.** A named table is a field type (above); nesting is by
   value, and a bounded array of tables is a collection. A table may not
-  contain itself, directly or through any chain — recursion is refused
-  with the cycle named. (Inline anonymous subtables are a spelling
-  follow-on; the named form is the feature.)
+  contain itself BY VALUE, directly or through any chain — that recursion
+  is refused with the cycle named, because a by-value cycle has infinite
+  size. (Inline anonymous subtables are a spelling follow-on; the named
+  form is the feature.)
+- **Tables point** (§2.1). `next *Node` declares a POINTER to a table.
+  Recursion THROUGH a pointer edge is legal and expected — the by-value
+  cycle rule exempts pointer edges, because a pointer carries no size.
 - **`was` — the rename attribute** (§5).
+
+### 2.1 Pointers
+
+```
+table Node
+{
+    value int32
+    next  *Node          // a pointer: legal recursion, finite size
+}
+
+table Scene
+{
+    head     *Node
+    settings *Settings   // an optional subtable: null when absent
+}
+```
+
+The spelling is C's, deliberately: it reads as what it is. The rules,
+each refused by name (§11):
+
+- **A pointer targets a `table`, and only a `table`.** `*SomeType`,
+  `*SomeEnum`, `*SomeUnion` are refused: value-semantics data has no
+  independent identity to point at. Nest it by value instead.
+- **A pointer is declared inside a table body, and nowhere else.** A
+  `type` body refuses one: types remain value semantics, and that is the
+  founding line of the split.
+- **An array of pointers is a named follow-on** (§15). Declare a bounded
+  array of tables by value, or a pointer to a table that holds the array.
+- **A pointer field takes no specified default.** A fresh pointer is
+  null, and null is the only value a default could name.
+
+A pointer's STORAGE is a four-byte relocatable reference — never a
+machine address — which is what keeps §9's relocatability true with
+pointers in the struct. Its meaning depends on the form it sits in
+(§6.3).
+
+### 2.2 The mode is derived, never declared
+
+The compiler works out which class a table belongs to; the schema never
+says. The rule is a least-fixed-point over BY-VALUE edges:
+
+- A table is **VARIABLE-LENGTH** if it declares a pointer, or if anything
+  it nests by value — directly, or as a bounded array — is
+  variable-length.
+- Every other table is **FIXED-SIZE**.
+
+Pointer edges do not propagate the mode: a table that is merely POINTED
+AT stays fixed-size if it holds no pointer of its own. It gains an
+allocation and a resolution entry, and nothing else.
+
+**A fixed-size table pays nothing for any of this**, and that is a gate,
+not a hope: for a unit whose tables are all fixed-size, the generated
+output is byte-for-byte what it was before pointers existed — no
+builder, no arena, no reference type, no lifecycle surface, not one extra
+descriptor column, not one extra branch in a codec, not one extra
+`#include`. The build fails if a single symbol of the pointer machinery
+appears in a pointer-free unit's generated header.
+
+The assumption behind the split, stated so nobody quietly designs against
+it: size and mode correlate in practice. Value-only tables are assumed
+SMALL — messages, records, config fragments — so they are passed by
+struct and loaded directly, and no large-flat-struct machinery is
+warranted for them without a real case forcing it. Pointer-bearing tables
+are where size lives, and the arena and the region are the size answer.
 
 The exclusions, each refused by name: `fixed`/`ufixed` and the 128-bit
 family have no table-wire kind; `const`/`reserved`/`align` describe bit
@@ -120,11 +190,48 @@ schema's codebase:
   vocabularies stay on the DECLARATION side, where they validate and
   clamp on load (§4) — they never change what the bytes look like.
 
+### 3.1 Pointers on the wire: a tree
+
+A pointer rides as its pointee's table body, framed exactly as a
+by-value nesting is: `id (u16), kind = table, u32 byte length, body`.
+Three consequences, all deliberate:
+
+- **A null pointer is not written at all.** Absence decodes as null, so
+  an old reader that never knew the field is already correct, and a
+  reader whose writer had nothing to point at is correct too.
+- **A non-null pointer ALWAYS rides**, even when its pointee is entirely
+  default. Elision is decided by presence, not by content — otherwise
+  null and "points at an empty node" would be one value on the wire.
+- **A pointer field and a by-value nesting are wire-identical.** A schema
+  may change one into the other and no byte moves: old readers take the
+  first body by value; new readers allocate one node from it. The corpus
+  holds that as a both-directions evolution test.
+
+**Wire v1 is a TREE, and identity is not preserved.** Two pointers to one
+node write two bodies and load as two nodes. Aliasing, sharing and DAG
+identity are a named follow-on (§15); nothing in v1 pretends otherwise,
+and the corpus asserts the tree semantics rather than hiding them.
+
+A pointer chain's nesting depth on the wire EQUALS its length: a chain of
+N nodes is N levels deep. Both sides therefore cap nesting at a declared
+depth (128 in the C++ backend):
+
+- **Writing**, a graph deeper than the cap — including any data cycle —
+  is a save ERROR. Measure and save return failure; nothing recurses
+  away, and no cycle detection state is needed to guarantee it.
+- **Reading**, a body nested past the cap is refused: the subtree is
+  skipped, the pointer stays null, the read is flagged malformed, and the
+  parent reads on. This is the framing-damage rule of §4 applied to
+  depth.
+
+Wide structures are unbounded; deep ones are capped. Lifting the cap
+wants a flat, indexed node encoding — a named follow-on (§15).
+
 The same bytes serve every use: a file on disk, a blob in memory, a
 payload handed from a tool to a game, a message between services whose
 deploys never align. Save and load are symmetric over caller-provided
 buffers — message-ready by construction; generated code allocates
-nothing.
+nothing on the reading path.
 
 ## 4. Versioning is wire tolerance
 
@@ -181,28 +288,199 @@ at compile time:
   tag systems cannot see; the compiler sees every id in the closure and
   refuses once, forever.
 
-## 6. Reflection
+## 6. The two lives of a table
+
+The mode (§2.2) decides the shape of the API, because the two classes are
+genuinely different things at runtime and neither should be contorted to
+look like the other.
+
+### 6.1 Fixed-size: a value
+
+A fixed-size table is a struct. Its whole surface is three free
+functions, name first:
+
+```cpp
+ChatMessage msg;
+int64_t size = ChatMessageMeasure( msg );          // exact wire bytes
+ChatMessageSave( msg, buffer, size );
+ChatMessageLoad( msg, buffer, size, &report );     // destination first
+```
+
+`sizeof( ChatMessage )` is the memory answer and `ChatMessageMeasure` is
+the wire answer; schema generates no size constants of any kind, because
+those two already exist.
+
+### 6.2 Variable-length: a lifecycle
+
+A file-format-scale structure is not a struct you copy. It is built
+mutable, then locked const, and read through a region and a root pointer.
+The state machine is MONOTONIC — there is no unlock:
+
+```cpp
+SceneBuilder builder;                        // MUTABLE: an arena
+Scene * root = builder.Root();
+Node * n = builder.Alloc<Node>();            // usable as node AND as reference
+root->head = builder.Alloc<Node>();
+builder.Lock();                              // ONE WAY, and it is the compaction
+const Scene * scene = builder.Const();       // CONST: one packed region
+```
+
+- **Builder** — a growable arena. `Alloc<T>()` hands back a node that is
+  usable both as the pointer to write fields through and as the reference
+  to store in a pointer field. Growth never invalidates anything already
+  allocated (§6.4).
+- **`Lock()`** — one way, and it IS the compaction: the arena is walked,
+  measured exactly, and laid back to back into ONE region with zero
+  slack, the root at its base. The mutable life is released. Locking
+  twice is a no-op, and there is no unlock: re-editing means loading the
+  const form into a fresh builder, which is a copy and says so.
+- **Const** — one region, one root pointer. `Load` produces the same
+  representation `Lock` does, so a locked structure and a loaded one are
+  read through one view API.
+
+Reading a pointer is `NodeAt( node->next )` — one add (§6.3), NULL when
+the reference is null.
+
+### 6.3 Two reference encodings, one slot
+
+A pointer's four-byte slot means different things in the two forms, and
+the form in hand always says which:
+
+- **In the arena**, it is the node's arena offset.
+- **In a region**, it is the SELF-RELATIVE byte delta from the slot's own
+  address. A deref is therefore one add and needs no base pointer at all,
+  and a whole region relocates by plain `memcpy` with zero fix-up — which
+  is the strongest form §9's relocatability can take.
+
+Lock and Load both produce the region encoding; Lock is already
+rewriting layout, so the conversion is free.
+
+Region references are always POSITIVE: a region is packed depth-first, so
+a child always sits after the slot that names it. A packed region
+therefore cannot contain a cycle, which is what lets §7's validation walk
+be cycle-free with no visited set.
+
+### 6.4 Building on many threads
+
+The builder is designed to go wide, lock-free by ownership:
+
+- Allocation is thread-local. Each worker owns its own front into the
+  arena and allocates privately within it; synchronization happens once
+  per large slab of arena, not once per node.
+- Nothing ever moves. The arena grows by appending storage, never by
+  relocating what exists, so a `T*` taken from `Alloc` stays valid for
+  the arena's whole life while other workers allocate and while the arena
+  grows, and a reference stays correct forever.
+- **The contract, stated plainly.** Allocating on YOUR OWN worker is safe
+  concurrently with any other worker's. Writing fields of a node another
+  worker allocated is your own synchronization problem; this runtime does
+  not arbitrate it. `Lock`, `Save`, `Cook` and `Open` are
+  single-threaded — call them after the workers have joined.
+- Slack is bounded and stated: one partial slab per worker, plus one per
+  arena segment. That is the price of never synchronizing per node, and
+  `Lock` removes all of it.
+
+### 6.5 The two load paths
+
+- **Into a region** — the game's path, for `Config.bin` and
+  `Assets.bin`. `<Name>LoadMeasure( wire, size )` computes the EXACT
+  region bytes from the wire's framing alone, reading no field values, so
+  the caller owns the allocation; `<Name>Load( region, region_size, wire,
+  wire_size, &report )` decodes into it and returns the root. The load
+  path allocates nothing.
+- **Into a builder** — the tool's path. The same tolerant decode into a
+  fresh builder, so loaded data can be edited and locked again.
+
+Contract split, stated once: the AUTHORING path (builder growth, `Lock`)
+may allocate; the reading path never does.
+
+## 7. The cooked form
+
+The wire (§3) is the generic form: it allocates, it walks, it parses, and
+any build reads any data. That generality is the point of it, and it is
+the format of record.
+
+The COOKED form answers a different requirement: load a big file, point
+at its root, without copying it and without parsing it. It is the
+structure laid out exactly as the runtime reads it — `Lock`'s region,
+written verbatim behind a small header.
+
+```cpp
+int64_t size = SceneCookMeasure( builder );
+SceneCook( builder, buffer, size );          // write it
+
+const Scene * scene = SceneOpen( bytes, size ); // point at it, or NULL
+```
+
+- **It is an accelerator, not an archive.** A cooked file is BUILD-LOCKED
+  and regenerated whenever the schema moves. The tolerant wire remains
+  the format of record; a cooked file is a cache beside it. Both
+  sentences are load-bearing.
+- **The header build-locks it**: a magic (which is also the byte-order
+  check), a LAYOUT ID, and the region's length. The layout id is a
+  compile-time digest of the schema's packed-layout facts mixed with this
+  build's own `sizeof` for every type in the closure, so schema drift AND
+  ABI drift both refuse. It is the region form's twin of the protocol id.
+- **Reads validate, always.** Before handing out the root, `Open` walks
+  the REFERENCE GRAPH: every pointer slot, and the count companions that
+  bound a traversal. It reads no field value and decodes no payload —
+  that is the distinction between validating before pointing and parsing
+  the whole thing, and it costs O(references). There is no trust-mode
+  bypass.
+- **Every refusal is loud and the fallback is a real wire load**: wrong
+  magic or byte order, a layout id this build did not produce, a
+  truncated region, an unaligned base, a reference that leaves the
+  region, a backward reference (impossible in a packed region), a
+  misaligned reference, a count companion outside its declared bound.
+- **Alignment.** The header pads the root to the region's alignment, so a
+  base the allocator or `mmap` gave you is already aligned; `mmap` gives
+  page alignment for free.
+- **Endianness** is recorded and a mismatch REFUSES in v1. An in-place,
+  descriptor-driven fix-up pass sharing `Open`'s traversal is a named
+  follow-on (§15).
+
+Prior art gets one sentence, and it is the contrast: systems that made
+pointed-at access their ONLY wire coupled access to evolution and paid
+for it. Here the tolerant wire stays the format of record and the cooked
+form is a build-locked accelerator beside it. The two-form split is the
+design.
+
+## 8. Reflection
 
 For every table in the unit's closure the generated header carries static
 descriptors: field name, type name, wire id and kind, storage offset and
 element size, array bound and count-companion offset, declared bounds,
 enum max and a value→name function, branch guards, and the nested table's
-descriptor. `TableType<X>()` returns X's descriptor. This is the surface
+descriptor. `<Name>TableType()` returns that table's descriptor.
+
+A unit that has pointers carries two more facts, and a unit that has none
+carries neither (§2.2): a field's **`is_pointer`** flag — whose `table`
+member then names the TARGET table's descriptor, and whose `elem_size` is
+the reference slot's width — and a type's derived **`variable`** mode, so
+a tool can tell at runtime which of §6's two lives a table has without
+being told. A self-referential pointer resolves to its own type's
+descriptor; the link is made once, after construction, so a recursive
+graph cannot recurse through the descriptors. This is the surface
 editors and tools build on — walk properties by name, print a value, diff
 two, bind a property grid — with no RTTI and no schema files at runtime.
 
-## 7. Relocatable, and built wide
+## 9. Relocatable, and built wide
 
 Two properties are load-bearing for real content pipelines, and both are
 held by construction:
 
-- **Relocatable, where possible.** Generated table structs are trivially
-  copyable and standard-layout — nesting by value, bounded arrays inline
-  with their count companions, no pointers anywhere. A loaded value is
-  one memcpy-able region, and the generated header enforces it with
-  static asserts. The owner's ruling holds this as a goal, not an
-  absolute: a construct that genuinely cannot be relocatable is flagged
-  and decided, never contorted around.
+- **Relocatable, where possible — and it holds in BOTH forms.** Generated
+  table structs are trivially copyable and standard-layout, and the
+  generated header enforces that with static asserts. A pointer FIELD is
+  a four-byte reference, never a machine address, so the property
+  survives pointers: a fixed-size table is one memcpy-able struct, and a
+  packed region (§6.3) is one memcpy-able BLOCK whose references are
+  self-relative and therefore need no fix-up at a new address. A
+  non-compacted builder is relocatable only per storage segment — which
+  is exactly why `Lock` exists and produces the single contiguous form.
+  The owner's ruling holds relocatability as a goal, not an absolute: a
+  construct that genuinely cannot be relocatable is flagged and decided,
+  never contorted around.
 - **Parallel generation.** Encoding splits into **measure** and **save**:
   measure computes a value's exact encoded size writing nothing; save
   writes into a caller-provided buffer. Because nested tables are
@@ -210,15 +488,22 @@ held by construction:
   prefix-sum the offsets, and scatter-write disjoint ranges in parallel —
   and a reader can fan nested-table decodes out the same way. The framing
   guarantees the option; callers choose whether to take it.
+  **measure == save at exact capacity** is a hard invariant, held by a
+  mandatory battery across the corpus and across pointer graphs: saving
+  into a buffer of exactly measure's answer always succeeds and
+  byte-matches a roomy save, and one byte short always refuses.
+- **Going wide on the BUILDING side** is §6.4: allocation is thread-local
+  and nothing ever moves, so N workers fill one arena with no lock and no
+  per-node atomic.
 
-## 8. Independence from the hardcoded wire
+## 10. Independence from the hardcoded wire
 
 Table declarations do not enter the unit's wire-shape projection. Adding,
 editing or deleting a table moves no `ProtocolId` and no generated `type`
 byte: peers whose hardcoded wire did not change are never forced into a
 lockstep redeploy by a table edit. This independence is held by test.
 
-## 9. Refused by name
+## 11. Refused by name
 
 - `table` bodies containing `fixed`/`ufixed` or the 128-bit family (§2 —
   no wire kind), `const`/`reserved`/`align` (§2 — no bit positions),
@@ -230,8 +515,25 @@ lockstep redeploy by a table edit. This independence is held by test.
 - `was` outside a table body (§5).
 - Tables under any backend but C++ (status, above) — refused with the
   follow-on named, never silently ignored.
+- **Pointers** (§2.1): `*T` where T is a `type`, enum, flags or union —
+  value-semantics data has no identity to point at; a pointer declared
+  outside a table body; an array of pointers (§15); a specified default
+  on a pointer field.
+- **A save-time data cycle or over-deep graph** (§3.1): measure, save,
+  cook and `Lock` all return failure. Nothing recurses away.
+- **A read-time nesting past the depth cap** (§3.1): the subtree is
+  refused, the pointer stays null, and the read is flagged malformed.
+- **A cooked file this build cannot point at** (§7): wrong magic or byte
+  order, a foreign layout id, truncation, an unaligned base, or an offset
+  graph that leaves the region, goes backward, misaligns, or is bounded
+  by an out-of-range count. `Open` returns NULL; the caller falls back to
+  a wire load.
+- A cross-file reference CYCLE among table declarations — the generated
+  headers would have to include each other. Same-file recursion through
+  pointers is fine; move a declaration so the cross-file graph is
+  acyclic.
 
-## 10. The expressiveness gate
+## 12. The expressiveness gate
 
 The feature's acceptance test: a real game's binary config and asset
 archive formats — a root table of nested collections of typed records,
@@ -239,7 +541,7 @@ built by tools, loaded by the game — must be expressible as declared
 tables with nothing left over, without schema prescribing any of their
 structure. The corpus carries a config-format example holding that gate.
 
-## 11. Rulings, recorded
+## 13. Rulings, recorded
 
 Owner rulings, 2026-09-01, in the order given. The fenced/append-only
 draft this document previously carried is dead; these replace it.
@@ -271,9 +573,114 @@ draft this document previously carried is dead; these replace it.
   except what is needed to make versioning safe, multi-threaded generate
   work, and relocatability work (if possible)."
 
-## 12. Named follow-ons
+### 13.1 Pointer semantics, ruled
 
-- Per-language backends beyond C++ (the refusal in §9 names this).
+- **The founding line**: "types can remain value semantics. tables should
+  ALLOW pointer semantics" — "we can't be a generic system if we don't
+  have pointers to tables."
+- **The spelling**: "literally same C++-like syntax for pointers is fine."
+- **The mode is the compiler's job**: "i wouldn't want to manually have
+  to specify this… the compiler can work it out and go, oh it's the
+  variable table mode."
+- **The mutable form**: "i think variable tables need to live in a
+  growable array."
+- **Const is a lifecycle, not a marking**: "maybe you 'lock' a table and
+  it is constant from that point forward… since how else will you
+  construct Assets.bin and Config.bin."
+- **The two forms are genuinely different**: "mutable vs. non-mutable
+  tables may be different at runtime."
+- **Building goes wide, without locks**: "the builder needs to be able to
+  be multithreaded"; then "I prefer lockless if possible."
+- **The generated surface**: name first — `ChatMessageMeasure`,
+  `ChatMessageSave`, `ChatMessageLoad`, `ChatMessageBuilder` with
+  `Alloc<T>()` and `Lock()`. Tables and types share one symbol table:
+  "do tables and types share the same symbol table then, i vote yes" —
+  which is exactly what makes the unprefixed surface collision-free, and
+  the checker refuses a declaration colliding with any generated
+  spelling.
+- **Small messages pay nothing**: "make sure we don't pay this cost when
+  we have nice, small messages… when the table is inferred to be value
+  types only."
+- **Size and mode correlate**: "let's assume larger types will probably
+  have pointers to things."
+- **The big class is not a struct**: file-format-scale tables "can't be a
+  struct" — pointer-bearing tables are never held by value.
+- **No generated size constants**: "you don't need to recreate sizeof."
+- **Point at a file, do not parse it**: the requirement behind §7 — load
+  a big file and point at its root, without copying it and without
+  parsing the whole thing.
+
+## 14. Design notes: the models weighed
+
+Recorded because the rejected options are the useful part.
+
+**The builder's storage.** Four models were weighed against the owner's
+criterion — lockless if possible, and minimize copying:
+
+1. **One buffer under a lock, grown by `realloc` — REJECTED.** The hazard
+   is specific and worth naming: a `realloc` moves the buffer under a
+   worker that is mid-write. Offsets fix identity but they do not fix the
+   raw references already resolved from them, and the resulting
+   corruption is invisible until much later. This design does not admit
+   that bug class.
+2. **Sharded builders merged at Lock — considered.** Each worker owns a
+   private growable array; references are (worker, slot) handles;
+   `Lock` merges the shards and resolves every handle. Contention-free,
+   but it pays a full memcpy of every node at merge and a handle-to-offset
+   resolution pass on top of it.
+3. **Reserve-max with an atomic bump — considered.** One buffer sized to
+   a declared bound; allocation is one atomic add and nothing ever
+   resizes. It is the allocate-max law dissolving the lock, and it is the
+   right answer for a caller who genuinely knows the bound; it is kept as
+   the documented alternative rather than the default, because a general
+   builder cannot require one.
+4. **A segmented slab arena — THE DESIGN OF RECORD.** One logical arena
+   made of equal-size segments; a worker takes a slab with a single
+   atomic and then allocates privately inside it. One synchronization per
+   thousands of nodes, nodes born at final offsets, no handles and no
+   resolution pass, growth by appending a segment, and nothing ever
+   moves.
+
+`Lock` remains a full copy, because it is the compaction: it produces the
+single contiguous exact-packed region that §6.2 and §7 both need, and it
+is the ONLY copy in the lifecycle besides `Save` (which is inherent — it
+writes a wire). A non-compacted arena is relocatable only per segment;
+that is the reason `Lock` compacts rather than merely freezing.
+
+**Reference encoding.** The arena's offset is segment-indexed, so a deref
+there is a small table load plus an add. The region's is self-relative,
+so a deref there is one add with no base pointer — and it makes the
+region relocatable by pure `memcpy`. Two encodings, converted where a
+copy already happens.
+
+**Depth versus a visited set.** A depth cap, not cycle detection: it
+needs no state, it bounds the C stack against hostile data, and a packed
+region cannot contain a cycle at all (§6.3), so the cooked form's
+validation walk needs neither.
+
+## 15. Named follow-ons
+
+- Per-language backends beyond C++ (the refusal in §11 names this).
+- **Graph and DAG identity**: preserving aliasing and sharing across the
+  wire, so two references to one node stay one node. Wire v1 is a tree
+  (§3.1) and says so.
+- **Arrays of pointers** (§2.1).
+- **Lifting the depth cap** with a flat, indexed node encoding, so a
+  pointer chain's length stops being a nesting depth (§3.1).
+- **Cross-endian `Open`**: an in-place, descriptor-driven byte-swap pass
+  sharing `Open`'s existing traversal — the same nodes and fields are
+  already visited, and kinds and offsets are already in the descriptors.
+  v1 refuses a foreign byte order instead (§7).
+- **A hash-guarded fallback loader** — open the cooked form, else load
+  the wire — as a convenience helper.
+- **A generic JSON walk over the reflection descriptors.** A text
+  authoring form is a pattern the owner described from practice: humans
+  and tools edit text, a build cooks it, the runtime points at the
+  result. Because the descriptors carry every field's name, kind and
+  offset, that walk is ONE implementation over the reflection surface —
+  no per-table codecs — which is what makes it worth doing as its own
+  round. It pairs with the field-level name-mapping attribute already
+  filed below.
 - A generic dump/diff tool over the reflection surface.
 - Keyed lookup conveniences over loaded collections (library-side, never
   stored semantics).

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -451,6 +451,14 @@ const Scene * scene = SceneOpen( bytes, size ); // point at it, or NULL
   do. It reads no field value and decodes no payload; that is the
   distinction between validating before pointing and parsing the whole
   thing. There is no trust-mode bypass.
+- **A member's walk lives in the file that DECLARES it.** A variable table
+  may nest a plain type, a fixed table or another variable table declared
+  anywhere in the unit, and the walk for each is emitted once, by its
+  declaring file — including by a file that declares no variable table of
+  its own, and for a member nothing points at. The referencing file picks it
+  up through the header it already includes. Emitting per referencing file
+  would define each walk twice; emitting only where pointers are declared
+  leaves the by-value members of a value-only file undefined.
 - **The walk is LINEAR IN THE REGION, and that takes a proof.** Bounds
   and forwardness alone do not give it: a forged file whose references
   alias forward — every node's second pointer aimed at its first child —

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -214,7 +214,17 @@ and the corpus asserts the tree semantics rather than hiding them.
 
 A pointer chain's nesting depth on the wire EQUALS its length: a chain of
 N nodes is N levels deep. Both sides therefore cap nesting at a declared
-depth (128 in the C++ backend):
+depth (128 in the C++ backend).
+
+**ONLY POINTER EDGES CHARGE DEPTH.** By-value nesting — a table inside a
+table, or a bounded array of them — charges nothing, because by-value
+composition is already finite: §2 refuses by-value cycles, so its nesting
+is bounded by the schema and cannot be driven by data. The rule must hold
+identically in ALL FOUR walks — measure, save, load and pack — or the
+forms disagree about which structures are legal and a structure that
+locks and cooks is refused by the wire. That agreement is held by test.
+
+The cap in force:
 
 - **Writing**, a graph deeper than the cap — including any data cycle —
   is a save ERROR. Measure and save return failure; nothing recurses
@@ -318,11 +328,11 @@ The state machine is MONOTONIC — there is no unlock:
 
 ```cpp
 SceneBuilder builder;                        // MUTABLE: an arena
-Scene * root = builder.Root();
+Scene * root = builder.GetRoot();
 Node * n = builder.Alloc<Node>();            // usable as node AND as reference
 root->head = builder.Alloc<Node>();
 builder.Lock();                              // ONE WAY, and it is the compaction
-const Scene * scene = builder.Const();       // CONST: one packed region
+const Scene * scene = builder.AsConst();       // CONST: one packed region
 ```
 
 - **Builder** — a growable arena. `Alloc<T>()` hands back a node that is
@@ -375,7 +385,9 @@ The builder is designed to go wide, lock-free by ownership:
   concurrently with any other worker's. Writing fields of a node another
   worker allocated is your own synchronization problem; this runtime does
   not arbitrate it. `Lock`, `Save`, `Cook` and `Open` are
-  single-threaded — call them after the workers have joined.
+  single-threaded — call them after the workers have joined. The
+  reflection descriptors (§8) are immutable constant data and carry no
+  first-use state, so reading them needs no synchronization at all.
 - Slack is bounded and stated: one partial slab per worker, plus one per
   arena segment. That is the price of never synchronizing per node, and
   `Lock` removes all of it.
@@ -417,16 +429,42 @@ const Scene * scene = SceneOpen( bytes, size ); // point at it, or NULL
   the format of record; a cooked file is a cache beside it. Both
   sentences are load-bearing.
 - **The header build-locks it**: a magic (which is also the byte-order
-  check), a LAYOUT ID, and the region's length. The layout id is a
-  compile-time digest of the schema's packed-layout facts mixed with this
-  build's own `sizeof` for every type in the closure, so schema drift AND
-  ABI drift both refuse. It is the region form's twin of the protocol id.
+  check), a LAYOUT ID, and the region's length. The reserved words are
+  reserved: a non-zero one means a writer used a form this build does not
+  understand, and Open refuses rather than ignoring it.
+  The layout id is a compile-time digest mixing the schema's
+  packed-layout facts with this build's own `sizeof` AND `offsetof` for
+  every type and field in the closure, so schema drift and ABI drift both
+  refuse — `sizeof` alone cannot see a member that moved inside an
+  unchanged total, and the packed form is read by offset. It is the
+  region form's twin of the protocol id.
+
+  **It keys a field by its WIRE ID, not its source name.** That is the
+  identity `was` preserves (§5), and a `was` rename moves no byte — so it
+  must not invalidate every cooked file in existence. Reordering two
+  same-shaped fields does move bytes, and it moves which id sits at which
+  offset, so it still refuses. Both directions are held by test.
 - **Reads validate, always.** Before handing out the root, `Open` walks
   the REFERENCE GRAPH: every pointer slot, and the count companions that
-  bound a traversal. It reads no field value and decodes no payload —
-  that is the distinction between validating before pointing and parsing
-  the whole thing, and it costs O(references). There is no trust-mode
-  bypass.
+  bound a traversal — including those of fixed-size tables and plain
+  types nested by value, whose counts bound a walker just as a table's
+  do. It reads no field value and decodes no payload; that is the
+  distinction between validating before pointing and parsing the whole
+  thing. There is no trust-mode bypass.
+- **The walk is LINEAR IN THE REGION, and that takes a proof.** Bounds
+  and forwardness alone do not give it: a forged file whose references
+  alias forward — every node's second pointer aimed at its first child —
+  is a legal-looking DAG that a stateless walk explores exponentially
+  (measured on an earlier revision: 26 nodes, 312 ms; ~60 nodes, never).
+  The walk therefore carries a HIGH-WATER MARK. Packing lays nodes out in
+  pre-order by bump allocation and the walk visits them in the same
+  order, so in a genuine region every reference lands at or past the end
+  of everything visited so far; requiring that, and advancing the mark
+  past each node, makes the walk consume region bytes monotonically. It
+  visits each byte at most once, it terminates, and it also rules out the
+  mid-node overlaps a range check alone admits. **The pack order and the
+  walk order are one invariant and neither may change alone** — the
+  generated code says so at both sites.
 - **Every refusal is loud and the fallback is a real wire load**: wrong
   magic or byte order, a layout id this build did not produce, a
   truncated region, an unaligned base, a reference that leaves the
@@ -459,8 +497,11 @@ member then names the TARGET table's descriptor, and whose `elem_size` is
 the reference slot's width — and a type's derived **`variable`** mode, so
 a tool can tell at runtime which of §6's two lives a table has without
 being told. A self-referential pointer resolves to its own type's
-descriptor; the link is made once, after construction, so a recursive
-graph cannot recurse through the descriptors. This is the surface
+descriptor. Where pointers exist the descriptors are CONSTANT-INITIALISED
+data and a target is the ADDRESS of another descriptor, so `Node` naming
+itself through `*Node` is expressible directly: no first-use link, which
+could not have been written both race-free and recursion-safe, and no
+mutable state anywhere on the surface. This is the surface
 editors and tools build on — walk properties by name, print a value, diff
 two, bind a property grid — with no RTTI and no schema files at runtime.
 
@@ -528,6 +569,11 @@ lockstep redeploy by a table edit. This independence is held by test.
   graph that leaves the region, goes backward, misaligns, or is bounded
   by an out-of-range count. `Open` returns NULL; the caller falls back to
   a wire load.
+- **A table named after a member of its generated builder** — a member
+  function hides the type name it shares, so the header would not
+  compile. The two accessors a real schema would plausibly hit were
+  renamed instead (`GetRoot`, `AsConst`), so `table Root`, this
+  document's own canonical example, stays legal.
 - A cross-file reference CYCLE among table declarations — the generated
   headers would have to include each other. Same-file recursion through
   pointers is fine; move a declaration so the cross-file graph is
@@ -655,8 +701,16 @@ copy already happens.
 
 **Depth versus a visited set.** A depth cap, not cycle detection: it
 needs no state, it bounds the C stack against hostile data, and a packed
-region cannot contain a cycle at all (§6.3), so the cooked form's
-validation walk needs neither.
+region cannot contain a cycle at all (§6.3).
+
+**Why the cooked walk still needs order state.** Acyclicity is not
+enough. A forged region can be a legal DAG — forward, in range, aligned —
+and a walk with no memory of where it has been re-visits shared subtrees
+exponentially. The fix is not a visited SET, which would need allocation
+proportional to the graph; it is a single monotonic high-water mark,
+which works precisely because packing is pre-order and the walk follows
+it (§7). One integer buys linearity, termination and overlap rejection
+together.
 
 ## 15. Named follow-ons
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -641,6 +641,115 @@ schema deliberately does not prescribe one. Tables may also reference plain
 A `type` cannot reference a table (packets stay exact-match), and a table
 cannot nest itself.
 
+### Pointers: `next *Node`
+
+Types are value semantics. Tables ALLOW pointer semantics, because a generic
+system needs pointers to tables:
+
+```
+table Node
+{
+    value int32
+    next  *Node          // recursion through a pointer is legal
+}
+
+table Scene
+{
+    head     *Node
+    settings *Settings   // an optional subtable: null when absent
+}
+```
+
+A pointer targets a `table`, never a `type` — and lives in a table body,
+never a type body. Arrays of pointers, and a specified default on a pointer,
+are refused by name.
+
+**The compiler derives the mode; you never declare it.** A table with no
+pointer anywhere in its by-value closure is FIXED-SIZE — a plain struct with
+the three functions above, and it pays nothing at all for what follows. A
+table with a pointer in that closure is VARIABLE-LENGTH, and it is never held
+by value: you build it, lock it, and read it through a root pointer.
+
+```cpp
+SceneBuilder builder;                       // MUTABLE
+Scene * root = builder.Root();
+Node * first = builder.Alloc<Node>();
+first->value = 10;
+root->head = builder.Alloc<Node>();         // the slot is both node and reference
+
+builder.Lock();                             // ONE WAY, and it compacts
+const Scene * scene = builder.Const();      // CONST: one packed region
+const Node * head = NodeAt( scene->head );  // one add; NULL when null
+```
+
+`Lock()` walks the arena, measures it exactly and lays every node back to
+back into one region with the root at its base — zero slack, references
+rewritten self-relative, so the whole region relocates by plain `memcpy`.
+There is no unlock: to edit again, load the const form into a fresh builder.
+
+Building goes wide with no lock and no per-node atomic — one worker per
+thread, each allocating on its own front:
+
+```cpp
+SceneBuilder builder;
+std::thread workers[4];
+for ( int t = 0; t < 4; t++ )
+    workers[t] = std::thread( [&]{
+        TableWorker worker = builder.Worker();     // one per THREAD
+        Node * n = worker.Alloc<Node>();           // no lock, no atomic per node
+        ...
+    } );
+for ( auto & w : workers ) w.join();               // join, THEN lock
+builder.Lock();
+```
+
+Allocating on your own worker is safe concurrently. Writing fields of a node
+another worker allocated is your own synchronization. `Lock`, `Save`, `Cook`
+and `Open` are single-threaded.
+
+Reading from the wire, the caller owns the allocation as always:
+
+```cpp
+int64_t need = SceneLoadMeasure( wire, wire_size ); // exact, reads no values
+uint8_t * region = your_allocator( need );
+TableReport report;
+const Scene * scene = SceneLoad( region, need, wire, wire_size, &report );
+```
+
+On the wire a pointer rides as its pointee's table body — framing identical
+to a by-value nesting, so a field may change between the two and no byte
+moves. Null pointers are simply absent. **Wire v1 is a tree**: two pointers
+to one node write two bodies and load as two nodes.
+
+### The cooked form: point at a file instead of parsing it
+
+The wire is generic — it allocates, walks and parses, and any build reads any
+data. When you want a big file to start instantly, cook it: the locked region
+written verbatim behind a small header, laid out exactly as the runtime reads
+it.
+
+```cpp
+int64_t size = SceneCookMeasure( builder );
+SceneCook( builder, buffer, size );                  // write Scene.bin
+
+// later, in the game — mmap it or read it, then just point:
+const Scene * scene = SceneOpen( bytes, size );
+if ( scene == NULL )
+{
+    // wrong build, corrupt, or foreign byte order: fall back to the wire
+}
+```
+
+A cooked file is an ACCELERATOR, not an archive: it is build-locked by a
+layout id that mixes the schema's packed-layout facts with this build's own
+`sizeof`s, so it refuses the moment either moves, and you regenerate it. The
+tolerant wire stays the format of record.
+
+`Open` validates before it points — a bounds walk over the reference graph
+alone, never a field value: O(references), not a parse. Value-only tables get
+no `Cook`/`Open`: they are structs, and `sizeof` plus `memcpy` already is
+their region form.
+
 ### Renaming a field: `was`
 
 Wire identity is the name hash, so a rename would orphan stored data. `was`

--- a/USAGE.md
+++ b/USAGE.md
@@ -672,13 +672,13 @@ by value: you build it, lock it, and read it through a root pointer.
 
 ```cpp
 SceneBuilder builder;                       // MUTABLE
-Scene * root = builder.Root();
+Scene * root = builder.GetRoot();
 Node * first = builder.Alloc<Node>();
 first->value = 10;
 root->head = builder.Alloc<Node>();         // the slot is both node and reference
 
 builder.Lock();                             // ONE WAY, and it compacts
-const Scene * scene = builder.Const();      // CONST: one packed region
+const Scene * scene = builder.AsConst();      // CONST: one packed region
 const Node * head = NodeAt( scene->head );  // one add; NULL when null
 ```
 
@@ -705,7 +705,12 @@ builder.Lock();
 
 Allocating on your own worker is safe concurrently. Writing fields of a node
 another worker allocated is your own synchronization. `Lock`, `Save`, `Cook`
-and `Open` are single-threaded.
+and `Open` are single-threaded. The reflection descriptors are immutable
+constant data, so reading them needs no synchronization at all.
+
+A `<Name>Builder` is about 8 KB (it carries the arena's segment table inline),
+which is fine on the stack and fine as a member; it is not something to put in
+an array of thousands.
 
 Reading from the wire, the caller owns the allocation as always:
 
@@ -745,10 +750,15 @@ layout id that mixes the schema's packed-layout facts with this build's own
 `sizeof`s, so it refuses the moment either moves, and you regenerate it. The
 tolerant wire stays the format of record.
 
-`Open` validates before it points — a bounds walk over the reference graph
-alone, never a field value: O(references), not a parse. Value-only tables get
-no `Cook`/`Open`: they are structs, and `sizeof` plus `memcpy` already is
-their region form.
+`Open` validates before it points — a bounds walk over the reference graph and
+the counts that bound a traversal of it, never a field value. It is linear in
+the region and cannot be driven exponentially by a forged file: packing lays
+nodes out in pre-order and the walk follows that order behind a high-water
+mark, so it consumes region bytes monotonically and visits each byte at most
+once. A walk, not a parse.
+
+Value-only tables get no `Cook`/`Open` of their own: they are structs, and
+`sizeof` plus `memcpy` already is their region form.
 
 ### Renaming a field: `was`
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -589,16 +589,16 @@ The encode surface is a measure/save split, and the caller owns every buffer
 ShipConfig ship;
 ship.health = 250.0f;
 
-int64_t size = TableMeasureShipConfig( ship );     // exact, writes nothing
+int64_t size = ShipConfigMeasure( ship );     // exact, writes nothing
 std::vector<uint8_t> buffer( size );               // or any storage you own
-TableSaveShipConfig( ship, buffer.data(), size );  // returns size — a buffer
-// of exactly TableMeasure's answer always suffices; -1 means the buffer is
+ShipConfigSave( ship, buffer.data(), size );  // returns size — a buffer
+// of exactly Measure's answer always suffices; -1 means the buffer is
 // too small, or the value violates a storage bound (a _count or _length
 // outside its declared range — measure returns -1 for those too)
 
 TableReport report;
 ShipConfig loaded;
-if ( !TableReadShipConfig( buffer.data(), size, loaded, report ) )
+if ( !ShipConfigLoad( loaded, buffer.data(), size, &report ) )
 {
     // framing damage: report.malformed is set, the good prefix is kept
 }
@@ -635,7 +635,7 @@ table GameConfig
 ```
 
 Whatever envelope you want around it — a magic, a content hash, several roots
-in one file — is a few lines of your code on top of `TableSave`/`TableRead`.
+in one file — is a few lines of your code on top of `<Name>Save`/`<Name>Load`.
 schema deliberately does not prescribe one. Tables may also reference plain
 `type`s, enums and flags; everything a table reaches gets table codecs too.
 A `type` cannot reference a table (packets stay exact-match), and a table
@@ -668,7 +668,7 @@ and scatter-write disjoint ranges — no worker touches another's bytes.
 int64_t sizes[kProfiles], total = 0;
 for ( int i = 0; i < kProfiles; i++ )
 {
-    sizes[i] = TableMeasureProfileConfig( profiles[i] ); // parallel-safe: read-only
+    sizes[i] = ProfileConfigMeasure( profiles[i] ); // parallel-safe: read-only
     total += sizes[i];
 }
 uint8_t * buffer = arena_alloc( total );
@@ -676,7 +676,7 @@ int64_t offsets[kProfiles], at = 0;
 for ( int i = 0; i < kProfiles; i++ ) { offsets[i] = at; at += sizes[i]; }
 for ( int i = 0; i < kProfiles; i++ ) // each iteration is an independent job
 {
-    TableSaveProfileConfig( profiles[i], buffer + offsets[i], sizes[i] );
+    ProfileConfigSave( profiles[i], buffer + offsets[i], sizes[i] );
 }
 ```
 
@@ -691,7 +691,7 @@ name functions, branch guards — enough to write a generic editor, printer or
 differ with no RTTI and no schema files at runtime:
 
 ```cpp
-const TableTypeInfo * type = TableTypeShipConfig();
+const TableTypeInfo * type = ShipConfigTableType();
 for ( int32_t i = 0; i < type->num_fields; i++ )
 {
     const TableFieldInfo & field = type->fields[i];

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -279,7 +279,7 @@ func TestPointerSurfaceEmitted(t *testing.T) {
 // graphs and layout ids included.
 func TestPointerGenerationDeterministic(t *testing.T) {
 	first := tableHeader(t, pointerSrc)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if again := tableHeader(t, pointerSrc); again != first {
 			t.Fatal("regeneration is not byte-stable across runs")
 		}

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -169,3 +169,144 @@ func TestGeneratedTableCodeAllocatesNothing(t *testing.T) {
 		}
 	}
 }
+
+const pointerSrc = packetSrc + `
+table Leaf
+{
+    quality int32 = 2 | min = 0, max = 4
+}
+
+table Node
+{
+    value int32
+    next  *Node
+}
+
+table Plain
+{
+    scale float32 = 1.0
+}
+
+table Root
+{
+    head *Node
+    leaf *Leaf
+    meta Plain
+}
+`
+
+// tableHeader returns the generated Table header's text.
+func tableHeader(t *testing.T, src string) string {
+	t.Helper()
+	files, err := New().Generate(unitFromSource(t, src), "cpp", Options{})
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	for name, body := range files {
+		if strings.HasSuffix(name, "Table.h") {
+			return string(body)
+		}
+	}
+	t.Fatal("no Table header generated")
+	return ""
+}
+
+// TestZeroCostForValueOnlyTables is the mode's whole justification: a table
+// with no pointer in its by-value closure must pay NOTHING for the pointer
+// machinery — no builder, no arena, no handles, no lifecycle surface, no extra
+// descriptor columns (SPEC-TABLES.md §2).
+func TestZeroCostForValueOnlyTables(t *testing.T) {
+	header := tableHeader(t, tableSrc)
+	for _, leak := range []string{
+		"TableArena", "TableSlot", "TableWorker", "TableRef", "TableRegion",
+		"kTableSegment", "kTableSlab", "kTableMaxDepth", "is_pointer", "variable",
+		"Builder", "LayoutId", "OpenWalk", "PackMeasure", "LoadMeasure",
+		"Cook", "Open", "<atomic>", "<cstdlib>", "template",
+	} {
+		if strings.Contains(header, leak) {
+			t.Errorf("pointer machinery leaked into a value-only unit: %q", leak)
+		}
+	}
+	// what a value-only table DOES get: the struct and the three free functions
+	for _, want := range []string{
+		"struct Config", "ConfigMeasure", "ConfigSave", "ConfigLoad",
+	} {
+		if !strings.Contains(header, want) {
+			t.Errorf("value-only table lost its surface: %q missing", want)
+		}
+	}
+}
+
+// TestPointerSurfaceEmitted: the variable-length surface appears exactly where
+// a pointer does, and the value-only table SHARING THE UNIT still gets none of
+// it — the mode is per table, not per file.
+func TestPointerSurfaceEmitted(t *testing.T) {
+	header := tableHeader(t, pointerSrc)
+	for _, want := range []string{
+		"struct TableArena", "struct TableRef", "struct TableSlot",
+		"struct RootBuilder", "struct NodeBuilder",
+		"RootLayoutId", "RootCook", "RootOpen", "RootLoadMeasure", "RootOpenWalk",
+		"NodeAt(", "NodeEmplace(", "TableRef next;", "TableRef head;",
+		"#include <atomic>",
+	} {
+		if !strings.Contains(header, want) {
+			t.Errorf("the pointer surface is missing %q", want)
+		}
+	}
+	// Plain has no pointer in its by-value closure: it stays a plain struct
+	// with the three free functions and gets no builder of its own
+	if strings.Contains(header, "struct PlainBuilder") {
+		t.Error("a value-only table in a pointered unit grew a Builder")
+	}
+	if !strings.Contains(header, "inline int64_t PlainMeasure( const Plain & value )") {
+		t.Error("a value-only table in a pointered unit lost its by-value Measure")
+	}
+	// Leaf is POINTED AT but pointer-free: it needs allocation and resolution,
+	// and still no builder
+	if strings.Contains(header, "struct LeafBuilder") {
+		t.Error("a pointed-at but pointer-free table grew a Builder")
+	}
+	if !strings.Contains(header, "LeafEmplace(") {
+		t.Error("a pointed-at table lost its allocation entry")
+	}
+	// a variable-length table is never held by value: no by-value Load
+	if strings.Contains(header, "inline bool RootLoad( Root & value") {
+		t.Error("a pointer-bearing table emitted a by-value Load")
+	}
+}
+
+// TestPointerGenerationDeterministic: regeneration is byte-stable, pointer
+// graphs and layout ids included.
+func TestPointerGenerationDeterministic(t *testing.T) {
+	first := tableHeader(t, pointerSrc)
+	for i := 0; i < 3; i++ {
+		if again := tableHeader(t, pointerSrc); again != first {
+			t.Fatal("regeneration is not byte-stable across runs")
+		}
+	}
+}
+
+// TestLayoutIdMovesWithTheSchema: the cooked form's build lock. A schema edit
+// that changes the packed layout must change the layout id, or a stale cooked
+// file would be pointed at and misread.
+func TestLayoutIdMovesWithTheSchema(t *testing.T) {
+	base := layoutIdOf(t, tableHeader(t, pointerSrc))
+	widened := layoutIdOf(t, tableHeader(t, strings.Replace(pointerSrc, "value int32", "value int64", 1)))
+	if base == widened {
+		t.Error("widening a field did not move the layout id — a stale cooked file would be pointed at")
+	}
+	renamed := layoutIdOf(t, tableHeader(t, strings.Replace(pointerSrc, "meta Plain", "info Plain", 1)))
+	if base == renamed {
+		t.Error("renaming a field did not move the layout id")
+	}
+}
+
+func layoutIdOf(t *testing.T, header string) string {
+	t.Helper()
+	i := strings.Index(header, "inline constexpr uint32_t RootLayoutId =")
+	if i < 0 {
+		t.Fatal("no RootLayoutId in the generated header")
+	}
+	end := strings.Index(header[i:], ";")
+	return header[i : i+end]
+}

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -152,8 +152,8 @@ func TestGeneratedTableCodeAllocatesNothing(t *testing.T) {
 	}
 	// the load-bearing surfaces are present
 	for _, want := range []string{
-		"TableMeasureConfig", "TableSaveConfig", "TableReadConfig", "TableWriteConfig",
-		"TableTypeConfig", "struct TableReport",
+		"ConfigMeasure", "ConfigSave", "ConfigLoad", "ConfigSaveBody", "ConfigLoadBody",
+		"ConfigTableType", "struct TableReport",
 		"static_assert( std::is_trivially_copyable<Config>::value",
 		"static_assert( std::is_standard_layout<Config>::value",
 	} {

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -211,10 +211,12 @@ func tableHeader(t *testing.T, src string) string {
 	return ""
 }
 
-// TestZeroCostForValueOnlyTables is the mode's whole justification: a table
-// with no pointer in its by-value closure must pay NOTHING for the pointer
-// machinery — no builder, no arena, no handles, no lifecycle surface, no extra
-// descriptor columns (SPEC-TABLES.md §2).
+// TestZeroCostForValueOnlyTables is the mode's whole justification, at the
+// grain the property actually holds: a UNIT whose tables are all fixed-size
+// emits none of the pointer machinery — no builder, no arena, no reference
+// type, no lifecycle surface, not one extra descriptor column, not one extra
+// include (SPEC-TABLES.md §2.2). Per TABLE the guarantee is narrower and
+// TestPointerSurfaceEmitted states it exactly.
 func TestZeroCostForValueOnlyTables(t *testing.T) {
 	header := tableHeader(t, tableSrc)
 	for _, leak := range []string{
@@ -253,13 +255,39 @@ func TestPointerSurfaceEmitted(t *testing.T) {
 			t.Errorf("the pointer surface is missing %q", want)
 		}
 	}
-	// Plain has no pointer in its by-value closure: it stays a plain struct
-	// with the three free functions and gets no builder of its own
-	if strings.Contains(header, "struct PlainBuilder") {
-		t.Error("a value-only table in a pointered unit grew a Builder")
+	// ---- the PER-TABLE property, stated exactly ----
+	//
+	// A value-only table sharing a unit with pointered ones gets: no Builder,
+	// no pointer-graph walkers, and codecs identical to the ones it would have
+	// had in a pointer-free unit — no ctx parameter, no depth parameter, no
+	// template. What it DOES share with the unit are the per-UNIT facts: the
+	// arena runtime and the two extra descriptor columns, which are emitted
+	// once per header and belong to the unit, not to any table in it.
+	for _, absent := range []string{
+		"struct PlainBuilder", "PlainPackMeasure", "PlainPack(",
+		"PlainLoadMeasureBody", "PlainEmplace", "PlainCook", "PlainOpen(",
+		"PlainLayoutId", "PlainLoadBuilder",
+	} {
+		if strings.Contains(header, absent) {
+			t.Errorf("a value-only table in a pointered unit grew %q", absent)
+		}
 	}
-	if !strings.Contains(header, "inline int64_t PlainMeasure( const Plain & value )") {
-		t.Error("a value-only table in a pointered unit lost its by-value Measure")
+	// its codecs are the by-value ones, character for character
+	for _, want := range []string{
+		"inline int64_t PlainMeasure( const Plain & value )",
+		"inline bool PlainSaveBody( TableWriter & w, const Plain & value )",
+		"inline bool PlainLoadBody( TableReader & r, Plain & value )",
+		"inline bool PlainLoad( Plain & value, const uint8_t * buffer, int64_t bytes, TableReport * report )",
+	} {
+		if !strings.Contains(header, want) {
+			t.Errorf("a value-only table in a pointered unit lost its by-value codec: %q", want)
+		}
+	}
+	// it DOES get an Open walk: Open bounds the count companions of every
+	// by-value nested member, and a fixed table nested in a variable root is
+	// exactly such a member
+	if !strings.Contains(header, "PlainOpenWalk") {
+		t.Error("a value-only table lost its Open bounds walk — its companions would go unchecked")
 	}
 	// Leaf is POINTED AT but pointer-free: it needs allocation and resolution,
 	// and still no builder
@@ -286,18 +314,104 @@ func TestPointerGenerationDeterministic(t *testing.T) {
 	}
 }
 
-// TestLayoutIdMovesWithTheSchema: the cooked form's build lock. A schema edit
-// that changes the packed layout must change the layout id, or a stale cooked
-// file would be pointed at and misread.
+// TestLayoutIdMovesWithTheSchema: the cooked form's build lock. The rule is
+// exact — it MOVES when the packed layout moves, and HOLDS when it does not,
+// because a false alarm invalidates every cooked file in existence.
 func TestLayoutIdMovesWithTheSchema(t *testing.T) {
 	base := layoutIdOf(t, tableHeader(t, pointerSrc))
-	widened := layoutIdOf(t, tableHeader(t, strings.Replace(pointerSrc, "value int32", "value int64", 1)))
-	if base == widened {
-		t.Error("widening a field did not move the layout id — a stale cooked file would be pointed at")
+
+	moves := []struct {
+		name string
+		src  string
+	}{
+		{"widening a field", strings.Replace(pointerSrc, "value int32", "value int64", 1)},
+		{"renaming a field without was", strings.Replace(pointerSrc, "meta Plain", "info Plain", 1)},
+		{"reordering two fields", strings.Replace(pointerSrc,
+			"    head *Node\n    leaf *Leaf", "    leaf *Leaf\n    head *Node", 1)},
+		{"adding a field", strings.Replace(pointerSrc, "    meta Plain", "    extra int32\n    meta Plain", 1)},
+		{"turning a by-value nesting into a pointer", strings.Replace(pointerSrc, "meta Plain", "meta *Plain", 1)},
 	}
-	renamed := layoutIdOf(t, tableHeader(t, strings.Replace(pointerSrc, "meta Plain", "info Plain", 1)))
-	if base == renamed {
-		t.Error("renaming a field did not move the layout id")
+	for _, tc := range moves {
+		if layoutIdOf(t, tableHeader(t, tc.src)) == base {
+			t.Errorf("%s did not move the layout id — a stale cooked file would be pointed at", tc.name)
+		}
+	}
+	_ = base
+
+	// HOLDS: a `was` rename moves no byte. The field keeps its wire id, keeps
+	// its offset, and every cooked file in the world stays valid — so the id
+	// must not budge. This is why the digest keys fields by WIRE ID and not by
+	// source name.
+	// The id's VALUE is the schema digest xor'd with this build's sizeof and
+	// offsetof terms. A `was` rename cannot change any of those values — same
+	// type, same field order, same offsets — so identity of the digest plus
+	// identity of the term structure IS identity of the value. The field's
+	// spelling inside offsetof() is the only thing allowed to differ, and
+	// normalising it is what separates "the value held" from "the text held".
+	renamedWithWas := strings.Replace(pointerSrc, "    meta Plain", "    facts Plain | was = \"meta\"", 1)
+	renamedExpr := layoutIdOf(t, tableHeader(t, renamedWithWas))
+	if layoutDigestOf(t, renamedExpr) != layoutDigestOf(t, base) {
+		t.Error("a `was` rename moved the layout id's schema digest — it moves no byte, and invalidating every cooked file for it is a false alarm")
+	}
+	if normalizeOffsets(renamedExpr) != normalizeOffsets(base) {
+		t.Error("a `was` rename changed the layout id's sizeof/offsetof terms — a rename moves no member, so every term must be value-identical")
+	}
+}
+
+// layoutDigestOf returns the schema-side digest constant that opens a layout
+// id expression.
+func layoutDigestOf(t *testing.T, expr string) string {
+	t.Helper()
+	i := strings.Index(expr, "0x")
+	if i < 0 {
+		t.Fatalf("no digest constant in %q", expr)
+	}
+	end := strings.IndexByte(expr[i:], '\n')
+	if end < 0 {
+		t.Fatalf("no digest constant in %q", expr)
+	}
+	return strings.TrimSpace(expr[i : i+end])
+}
+
+// normalizeOffsets rewrites `offsetof( T, field )` to `offsetof( T, ? )`, so
+// two expressions compare on the terms' VALUES rather than on the spelling of
+// a field that was renamed.
+func normalizeOffsets(expr string) string {
+	var b strings.Builder
+	for {
+		i := strings.Index(expr, "offsetof( ")
+		if i < 0 {
+			b.WriteString(expr)
+			return b.String()
+		}
+		comma := strings.Index(expr[i:], ", ")
+		close := strings.Index(expr[i:], " )")
+		if comma < 0 || close < 0 {
+			b.WriteString(expr)
+			return b.String()
+		}
+		b.WriteString(expr[:i+comma])
+		b.WriteString(", ? ")
+		expr = expr[i+close+2:]
+	}
+}
+
+// TestLayoutIdCarriesTheABI: the digest is not schema-only. Field offsets ride
+// in it as compile-time terms, so a padding or ABI difference that shifts a
+// member refuses the cooked file instead of misreading it — a fact no
+// schema-side test can produce, and one the emitted expression must show.
+func TestLayoutIdCarriesTheABI(t *testing.T) {
+	expr := layoutIdOf(t, tableHeader(t, pointerSrc))
+	if !strings.Contains(expr, "sizeof( Root )") {
+		t.Error("the layout id does not mix this build's sizeof")
+	}
+	for _, want := range []string{
+		"offsetof( Root, head )", "offsetof( Root, leaf )", "offsetof( Root, meta )",
+		"offsetof( Node, next )", "offsetof( Leaf, quality )",
+	} {
+		if !strings.Contains(expr, want) {
+			t.Errorf("the layout id does not mix %s — a member that moved would not refuse", want)
+		}
 	}
 }
 

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -141,12 +141,16 @@ const (
 
 type ScalarType struct {
 	Kind   ScalarKind
-	Signed bool   // ScalarInt; ScalarFixed (fixed = true, ufixed = false)
-	Width  int    // ScalarInt: 8/16/32/64/128
-	Arg    Expr   // ScalarBits/ScalarString/ScalarBytes: the (N); ScalarFixed: I
-	Arg2   Expr   // ScalarFixed: F
-	Name   string // ScalarNamed
-	Pos    Pos
+	Signed bool // ScalarInt; ScalarFixed (fixed = true, ufixed = false)
+	Width  int  // ScalarInt: 8/16/32/64/128
+	Arg    Expr // ScalarBits/ScalarString/ScalarBytes: the (N); ScalarFixed: I
+	Arg2   Expr // ScalarFixed: F
+	// Pointer marks the `*T` spelling (ScalarNamed only): a POINTER to a
+	// table rather than a by-value nesting (SPEC-TABLES.md). Types remain
+	// value semantics; tables allow pointer semantics.
+	Pointer bool
+	Name    string // ScalarNamed
+	Pos     Pos
 }
 
 type ConstField struct {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1697,6 +1697,10 @@ func (c *checker) checkTables() {
 		if st.IsTable {
 			what = "table"
 		}
+		if st.IsTable && slices.Contains(tableBuilderMembers, name) {
+			c.errf(pos, "table %s: the name collides with a member of the generated %sBuilder — a member function hides the type name it shares, and the header would not compile; rename the table (SPEC-TABLES.md §6.2)",
+				name, name)
+		}
 		seen := map[uint16]*ir.Field{}
 		for _, f := range st.Fields {
 			if f.Type.Pointer {
@@ -2231,8 +2235,21 @@ func (c *checker) addTableSymbols(add func(name, what string, pos ast.Pos), name
 // not become a collision tomorrow (SPEC-TABLES.md).
 var tableGeneratedVerbs = []string{
 	"Measure", "MeasureBody", "Save", "SaveBody", "Load", "LoadBody",
-	"LoadMeasure", "TableType", "Builder", "At", "Root",
-	"Cook", "CookMeasure", "Open", "LayoutId",
+	"LoadMeasure", "LoadMeasureBody", "LoadBuilder", "TableType", "Builder",
+	"At", "Root", "Emplace", "Pack", "PackMeasure", "OpenWalk",
+	"Cook", "CookMeasure", "Open", "LayoutId", "TableFields", "TableInfo",
+}
+
+// tableBuilderMembers are the member names of a generated <Name>Builder. A
+// member function hides a type name it shares, so a table whose NAME is one of
+// these produces a header that cannot compile — silently, at the user's build
+// rather than ours. The two accessors that a real schema would plausibly hit
+// were renamed instead (Root -> GetRoot, Const -> AsConst, because `table Root`
+// is this spec's own canonical example); the rest are refused here, so no
+// legal schema can reach a non-compiling header through this door.
+var tableBuilderMembers = []string{
+	"Alloc", "AsConst", "GetRoot", "Lock", "Locked", "Region", "RegionBytes",
+	"Worker", "arena", "main", "region", "region_bytes", "root_ref",
 }
 
 // addStructSymbols registers the per-type generated names: the split

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1761,7 +1761,7 @@ func (c *checker) checkTables() {
 }
 
 // checkPointerSpelling enforces the `*T` spelling's rules, each refused by
-// name (SPEC-TABLES.md §9). The founding line: types remain VALUE semantics;
+// name (SPEC-TABLES.md §11). The founding line: types remain VALUE semantics;
 // tables ALLOW POINTER semantics — so a pointer is a table-to-table edge
 // declared inside a table body, and nowhere else.
 func (c *checker) checkPointerSpelling(f *ast.Field, inTable bool, d ast.Decl) bool {
@@ -1776,7 +1776,7 @@ func (c *checker) checkPointerSpelling(f *ast.Field, inTable bool, d ast.Decl) b
 		return false
 	}
 	if f.Array != nil {
-		c.errf(f.Type.Pos, "field %s: an array of pointers is a named follow-on — declare a bounded array of tables by value, or a pointer to a table that holds the array (SPEC-TABLES.md §12)", f.Name)
+		c.errf(f.Type.Pos, "field %s: an array of pointers is a named follow-on — declare a bounded array of tables by value, or a pointer to a table that holds the array (SPEC-TABLES.md §15)", f.Name)
 		return false
 	}
 	if f.Default != nil {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2138,15 +2138,29 @@ func (c *checker) checkClaimedNames() {
 }
 
 // addTableSymbols registers the TABLE-wire generated names of one closure
-// member: the measure/write/save/read codecs and the reflection descriptor
-// (SPEC-TABLES.md). C++-only today, so only the CamelCase spellings claim.
+// member. The table surface is NAME-FIRST — <Name>Measure, <Name>Save,
+// <Name>Load, <Name>Builder — so a table's whole surface autocompletes under
+// its own name, while the TYPE wire stays verb-first (WriteX/ReadX): the verb
+// position tells a reader which wire the call site is on (SPEC-TABLES.md).
+// Tables and types share ONE symbol table, and that is exactly what makes the
+// unprefixed surface collision-free: a declaration colliding with any of
+// these spellings is refused at the source.
+// C++-only today, so only the CamelCase spellings claim.
 func (c *checker) addTableSymbols(add func(name, what string, pos ast.Pos), name string, pos ast.Pos) {
 	why := fmt.Sprintf("%s's generated TABLE-wire functions", name)
-	add("TableMeasure"+name, why, pos)
-	add("TableWrite"+name, why, pos)
-	add("TableSave"+name, why, pos)
-	add("TableRead"+name, why, pos)
-	add("TableType"+name, why, pos)
+	for _, verb := range tableGeneratedVerbs {
+		add(name+verb, why, pos)
+	}
+}
+
+// tableGeneratedVerbs is the full name-first suffix set a closure member
+// claims. The mutable-life suffixes (Builder, LoadMeasure, At, Root) are
+// claimed for EVERY closure member, not only pointer-bearing ones: a table
+// gains or loses pointers as an edit, and a name that was free yesterday must
+// not become a collision tomorrow (SPEC-TABLES.md).
+var tableGeneratedVerbs = []string{
+	"Measure", "MeasureBody", "Save", "SaveBody", "Load", "LoadBody",
+	"LoadMeasure", "TableType", "Builder", "At", "Root",
 }
 
 // addStructSymbols registers the per-type generated names: the split

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1056,6 +1056,9 @@ func (c *checker) resolveField(owner string, f *ast.Field, inTable bool) *ir.Fie
 			c.errf(f.Type.Pos, "undefined type %s", f.Type.Name)
 			return nil
 		}
+		if f.Type.Pointer && !c.checkPointerSpelling(f, inTable, d) {
+			return nil
+		}
 		switch d.(type) {
 		case *ast.TypeDecl:
 			out.Type = ir.FieldType{Kind: ir.TNamed, Name: f.Type.Name, Ref: c.structs[f.Type.Name]}
@@ -1064,7 +1067,7 @@ func (c *checker) resolveField(owner string, f *ast.Field, inTable bool) *ir.Fie
 				c.errf(f.Type.Pos, "%s is a table, not a wire type — tables live on the TABLE wire and cannot ride in a `type`; declare the field's type with `type`, or move the declaring type to a `table` (SPEC-TABLES.md)", f.Type.Name)
 				return nil
 			}
-			out.Type = ir.FieldType{Kind: ir.TNamed, Name: f.Type.Name, Ref: c.tables[f.Type.Name]}
+			out.Type = ir.FieldType{Kind: ir.TNamed, Name: f.Type.Name, Ref: c.tables[f.Type.Name], Pointer: f.Type.Pointer}
 		case *ast.EnumDecl:
 			out.Type = ir.FieldType{Kind: ir.TNamed, Name: f.Type.Name, Ref: c.enums[f.Type.Name]}
 		case *ast.FlagsDecl:
@@ -1554,8 +1557,14 @@ func (c *checker) checkCycles() {
 		if st := c.tables[name]; st != nil {
 			// tables join the composition graph exactly as types do: nesting
 			// is by value, so a table holding itself — directly or through a
-			// chain — has infinite size (SPEC-TABLES.md, the §4.6 rule)
+			// chain — has infinite size (SPEC-TABLES.md, the §4.6 rule).
+			// POINTER edges are exempt and carry no size: `next *Node` inside
+			// Node is finite, and recursion through pointers is the whole
+			// point of the freedom tables were given.
 			for _, f := range st.Fields {
+				if f.Type.Pointer {
+					continue
+				}
 				if f.Type.Kind == ir.TNamed {
 					switch f.Type.Ref.(type) {
 					case *ir.Struct, *ir.Union:
@@ -1690,6 +1699,19 @@ func (c *checker) checkTables() {
 		}
 		seen := map[uint16]*ir.Field{}
 		for _, f := range st.Fields {
+			if f.Type.Pointer {
+				// a pointer carries no extent of its own: the checks below
+				// bound STORAGE, and a pointer's storage is one relocatable
+				// u32 slot. Identity still applies — the id check runs below.
+				id := ir.TableFieldId(f)
+				if prev, dup := seen[id]; dup {
+					c.errf(pos, "%s %s: fields %s and %s collide on table-wire id 0x%04x — rename one (SPEC-TABLES.md)",
+						what, name, describeTableField(prev), describeTableField(f), id)
+					continue
+				}
+				seen[id] = f
+				continue
+			}
 			var bad string
 			switch {
 			case f.Type.Kind == ir.TInt && f.Type.Width == 128:
@@ -1736,6 +1758,49 @@ func (c *checker) checkTables() {
 			seen[id] = f
 		}
 	}
+}
+
+// checkPointerSpelling enforces the `*T` spelling's rules, each refused by
+// name (SPEC-TABLES.md §9). The founding line: types remain VALUE semantics;
+// tables ALLOW POINTER semantics — so a pointer is a table-to-table edge
+// declared inside a table body, and nowhere else.
+func (c *checker) checkPointerSpelling(f *ast.Field, inTable bool, d ast.Decl) bool {
+	if !inTable {
+		c.errf(f.Type.Pos, "field %s: *%s is a pointer, and pointers are a TABLE construct — types remain value semantics, tables allow pointer semantics; nest the field by value, or move the declaring type to a `table` (SPEC-TABLES.md)",
+			f.Name, f.Type.Name)
+		return false
+	}
+	if _, isTable := d.(*ast.TableDecl); !isTable {
+		c.errf(f.Type.Pos, "field %s: *%s points at a %s, and a pointer may only target a `table` — %s is value-semantics data with no independent identity to point at; nest it by value, or declare %s as a table (SPEC-TABLES.md)",
+			f.Name, f.Type.Name, declKindName(d), f.Type.Name, f.Type.Name)
+		return false
+	}
+	if f.Array != nil {
+		c.errf(f.Type.Pos, "field %s: an array of pointers is a named follow-on — declare a bounded array of tables by value, or a pointer to a table that holds the array (SPEC-TABLES.md §12)", f.Name)
+		return false
+	}
+	if f.Default != nil {
+		c.errf(f.Pos, "field %s: a pointer field takes no specified default — a fresh pointer is null, and null is the only value a default could name (SPEC-TABLES.md)", f.Name)
+		return false
+	}
+	return true
+}
+
+// declKindName names a declaration's kind for a diagnostic.
+func declKindName(d ast.Decl) string {
+	switch d.(type) {
+	case *ast.TypeDecl:
+		return "type"
+	case *ast.EnumDecl:
+		return "enum"
+	case *ast.FlagsDecl:
+		return "flags"
+	case *ast.UnionDecl:
+		return "union"
+	case *ast.TableDecl:
+		return "table"
+	}
+	return "declaration"
 }
 
 // describeTableField names a field for the id-collision diagnostic, showing
@@ -2017,7 +2082,13 @@ func (c *checker) checkClaimedNames() {
 		// table, so table-free units keep their whole namespace
 		for _, gen := range []string{"TableReport", "TableWriter", "TableReader",
 			"TableTypeInfo", "TableFieldInfo", "table_bits_to_float",
-			"table_float_to_bits", "table_bits_to_double", "table_double_to_bits"} {
+			"table_float_to_bits", "table_bits_to_double", "table_double_to_bits",
+			// the VARIABLE-LENGTH runtime (SPEC-TABLES.md): claimed whenever a
+			// unit declares a table, not only when one carries pointers, so
+			// adding a pointer to an existing table never turns a legal
+			// declaration into a collision
+			"TableRef", "TableSlot", "TableArena", "TableSlab", "TableWorker",
+			"TableBuilder", "TableRegion", "TableRegionHeader"} {
 			add(gen, "the generated TABLE-wire runtime (SPEC-TABLES.md)", unitPos)
 		}
 	}
@@ -2161,6 +2232,7 @@ func (c *checker) addTableSymbols(add func(name, what string, pos ast.Pos), name
 var tableGeneratedVerbs = []string{
 	"Measure", "MeasureBody", "Save", "SaveBody", "Load", "LoadBody",
 	"LoadMeasure", "TableType", "Builder", "At", "Root",
+	"Cook", "CookMeasure", "Open", "LayoutId",
 }
 
 // addStructSymbols registers the per-type generated names: the split

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -87,6 +87,35 @@ func TestTableRefusals(t *testing.T) {
 			src: "package t\ntable Node { x int32 }\ntable Tab { kids [..4]*Node }\n"},
 		{name: "a pointer field takes no specified default", want: "a pointer field takes no specified default",
 			src: "package t\ntable Node { x int32 }\ntable Tab { head *Node = 0 }\n"},
+		// every generated name-first spelling is claimed, including the ones a
+		// value-only table never emits: adding a pointer to a table must not
+		// turn a legal declaration elsewhere into a collision
+		{name: "a declaration colliding with the pointer allocation entry", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeEmplace { y int32 }\n"},
+		{name: "a declaration colliding with the pack walker", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodePack { y int32 }\n"},
+		{name: "a declaration colliding with the pack sizer", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodePackMeasure { y int32 }\n"},
+		{name: "a declaration colliding with the wire sizing pre-pass", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeLoadMeasureBody { y int32 }\n"},
+		{name: "a declaration colliding with the builder load path", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeLoadBuilder { y int32 }\n"},
+		{name: "a declaration colliding with the Open bounds walk", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeOpenWalk { y int32 }\n"},
+		{name: "a declaration colliding with the descriptor storage", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeTableInfo { y int32 }\n"},
+		{name: "a declaration colliding with the descriptor field storage", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeTableFields { y int32 }\n"},
+
+		// a table named after a Builder member would emit a header that cannot
+		// compile — a member function hides the type name it shares
+		{name: "a table named after a builder member", want: "collides with a member of the generated",
+			src: "package t\ntable Alloc { x int32 }\n"},
+		{name: "a table named after the builder's lock", want: "collides with a member of the generated",
+			src: "package t\ntable Lock { x int32 }\n"},
+		{name: "a table named after the arena member", want: "collides with a member of the generated",
+			src: "package t\ntable arena { x int32 }\n"},
+
 		{name: "a pointer to an undeclared table", want: "undefined type",
 			src: "package t\ntable Tab { head *Ghost }\n"},
 		{name: "by-value recursion stays refused with pointers in the language",
@@ -302,5 +331,20 @@ func TestPointerRecursionIsLegal(t *testing.T) {
 	}
 	if f.Type.Ref == nil || f.Type.Name != "Node" {
 		t.Fatalf("the pointer's target did not resolve: %+v", f.Type)
+	}
+}
+
+// TestCanonicalRootTableNameIsLegal: `table Root` is this spec's own canonical
+// example, and the expressiveness gate (§12) is written around a root table.
+// The generated builder's accessors are GetRoot/AsConst precisely so that the
+// name stays available — a member function would otherwise hide the type name
+// it shares and the header would not compile.
+func TestCanonicalRootTableNameIsLegal(t *testing.T) {
+	u := buildUnit(t, "package t\ntable Node\n{\n    v    int32\n    next *Node\n}\n\ntable Root\n{\n    head *Node\n}\n")
+	if u.Tables["Root"] == nil {
+		t.Fatal("table Root did not survive checking")
+	}
+	if !ir.VariableTables(u)["Root"] {
+		t.Error("table Root did not derive VARIABLE-LENGTH")
 	}
 }

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -73,6 +73,28 @@ func TestTableRefusals(t *testing.T) {
 			src: "package t\ntable Tab { x int32 }\ntype TableReport { y int32 }\n"},
 		{name: "a declaration colliding with generated table codecs", want: "generated TABLE-wire functions",
 			src: "package t\ntable Tab { x int32 }\ntype TabLoad { y int32 }\n"},
+		{name: "a declaration colliding with the mutable-life surface", want: "generated TABLE-wire functions",
+			src: "package t\ntable Tab { x int32 }\ntype TabBuilder { y int32 }\n"},
+
+		// ---- pointers (SPEC-TABLES.md §9) ----
+		{name: "a pointer to a type is refused by name", want: "may only target a `table`",
+			src: "package t\ntype P { x int32 }\ntable Tab { p *P }\n"},
+		{name: "a pointer to an enum is refused by name", want: "may only target a `table`",
+			src: "package t\nenum E { A }\ntable Tab { e *E }\n"},
+		{name: "a pointer inside a type body is refused by name", want: "pointers are a TABLE construct",
+			src: "package t\ntable Tab { x int32 }\ntype P { t *Tab }\n"},
+		{name: "an array of pointers is a named follow-on", want: "an array of pointers is a named follow-on",
+			src: "package t\ntable Node { x int32 }\ntable Tab { kids [..4]*Node }\n"},
+		{name: "a pointer field takes no specified default", want: "a pointer field takes no specified default",
+			src: "package t\ntable Node { x int32 }\ntable Tab { head *Node = 0 }\n"},
+		{name: "a pointer to an undeclared table", want: "undefined type",
+			src: "package t\ntable Tab { head *Ghost }\n"},
+		{name: "by-value recursion stays refused with pointers in the language",
+			want: "type composition cycle",
+			src:  "package t\ntable Node { x int32\n  self Node }\n"},
+		{name: "by-value recursion through a chain stays refused",
+			want: "type composition cycle",
+			src:  "package t\ntable A { b B }\ntable B { a A }\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -197,5 +219,88 @@ func TestTablesInvisibleToPacketIR(t *testing.T) {
 	}
 	if strings.Contains(ir.WireProjection(u), "Config") {
 		t.Fatal("a table leaked into the wire projection — the protocol id depends on it")
+	}
+}
+
+// TestTableModeDerivation: the mode is DERIVED, never declared. Fixed-size is
+// the pointer-free by-value closure — a plain struct, exactly as every table
+// was before pointers existed. Variable-length is a pointer anywhere in that
+// closure, and the mode propagates UP through by-value nesting only
+// (SPEC-TABLES.md §2).
+func TestTableModeDerivation(t *testing.T) {
+	u := buildUnit(t, `package t
+
+type Plain
+{
+    x int32
+}
+
+table Leaf
+{
+    v int32
+}
+
+table Node
+{
+    v    int32
+    next *Node
+}
+
+table HoldsPointer
+{
+    head *Leaf
+}
+
+table NestsVariable
+{
+    inner Node
+}
+
+table ArrayOfVariable
+{
+    kids [..4]Node
+}
+
+table StaysFixed
+{
+    leaf  Leaf
+    p     Plain
+    items [..4]int32
+}
+`)
+	variable := ir.VariableTables(u)
+	for _, name := range []string{"Node", "HoldsPointer", "NestsVariable", "ArrayOfVariable"} {
+		if !variable[name] {
+			t.Errorf("%s should derive VARIABLE-LENGTH (a pointer in its by-value closure)", name)
+		}
+	}
+	for _, name := range []string{"Leaf", "StaysFixed", "Plain"} {
+		if variable[name] {
+			t.Errorf("%s should stay FIXED-SIZE — no pointer in its by-value closure, so it pays for none of the machinery", name)
+		}
+	}
+
+	// pointing AT a variable table does not make the pointer's owner's
+	// NESTER variable through the pointer edge — only the declaring table
+	targets := ir.PointerTargets(u)
+	if !targets["Node"] || !targets["Leaf"] {
+		t.Errorf("pointer targets missing: %v", targets)
+	}
+	if targets["StaysFixed"] {
+		t.Error("StaysFixed is nobody's pointer target")
+	}
+}
+
+// TestPointerRecursionIsLegal: recursion through a POINTER edge is the whole
+// point of the freedom tables were given — the by-value cycle refusal must
+// exempt it (SPEC-TABLES.md §2).
+func TestPointerRecursionIsLegal(t *testing.T) {
+	u := buildUnit(t, "package t\ntable Node\n{\n    v    int32\n    next *Node\n}\n")
+	f := u.Tables["Node"].Fields[1]
+	if !f.Type.Pointer {
+		t.Fatal("the *Node field did not resolve as a pointer")
+	}
+	if f.Type.Ref == nil || f.Type.Name != "Node" {
+		t.Fatalf("the pointer's target did not resolve: %+v", f.Type)
 	}
 }

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -76,7 +76,7 @@ func TestTableRefusals(t *testing.T) {
 		{name: "a declaration colliding with the mutable-life surface", want: "generated TABLE-wire functions",
 			src: "package t\ntable Tab { x int32 }\ntype TabBuilder { y int32 }\n"},
 
-		// ---- pointers (SPEC-TABLES.md §9) ----
+		// ---- pointers (SPEC-TABLES.md §11) ----
 		{name: "a pointer to a type is refused by name", want: "may only target a `table`",
 			src: "package t\ntype P { x int32 }\ntable Tab { p *P }\n"},
 		{name: "a pointer to an enum is refused by name", want: "may only target a `table`",

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -72,7 +72,7 @@ func TestTableRefusals(t *testing.T) {
 		{name: "a declaration colliding with the table runtime", want: "generated TABLE-wire runtime",
 			src: "package t\ntable Tab { x int32 }\ntype TableReport { y int32 }\n"},
 		{name: "a declaration colliding with generated table codecs", want: "generated TABLE-wire functions",
-			src: "package t\ntable Tab { x int32 }\ntype TableReadTab { y int32 }\n"},
+			src: "package t\ntable Tab { x int32 }\ntype TabLoad { y int32 }\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/codegen/cpptable/arena.go
+++ b/internal/codegen/cpptable/arena.go
@@ -1,0 +1,289 @@
+// The VARIABLE-LENGTH table runtime, emitted once per package and only when
+// the unit declares a table with a pointer anywhere in its by-value closure
+// (SPEC-TABLES.md §2). A unit of pointer-free tables emits none of this and
+// its generated output is byte-identical to a build with this file deleted —
+// that zero-cost property is the point of deriving the mode.
+//
+// The three pieces:
+//
+//	TableArena  — the MUTABLE form: one logical arena of equal-size segments,
+//	              handed out to workers in thread-local slabs with a single
+//	              atomic per slab. Nodes are born at their final offsets and
+//	              segments never move, so a T* stays valid for the arena's
+//	              whole life and growth never invalidates anyone.
+//	the region  — the CONST form: one exact-packed block, nodes laid back to
+//	              back, references SELF-RELATIVE so a deref is one add and a
+//	              whole region relocates by pure memcpy with zero fix-up.
+//	the header  — the cooked form's guard: magic, layout id, size. A cooked
+//	              file is an accelerator, build-locked; a mismatch refuses
+//	              loudly and the caller falls back to a wire load.
+package cpptable
+
+import "strings"
+
+// tableArenaRuntime is the variable-length runtime, guarded per package like
+// tablePrimitives so one definition survives any include order.
+func tableArenaRuntime(pkg string) string {
+	guard := strings.ToUpper(pkg) + "_SCHEMA_TABLE_ARENA"
+	return `#ifndef ` + guard + `
+#define ` + guard + `
+
+namespace ` + pkg + ` {
+
+// ---- variable-length tables: tuning constants (SPEC-TABLES.md) ----
+//
+// The segment size and the count multiply to exactly 2^32: the u32 reference
+// is the arena's hard ceiling, and these constants saturate it rather than
+// leaving address space unreachable. Slab handout costs one atomic per slab,
+// so per-node allocation costs no synchronization at all.
+
+static const uint32_t kTableSegmentBits = 22;                          // 4 MiB segments
+static const uint32_t kTableSegmentSize = 1u << kTableSegmentBits;
+static const uint32_t kTableSegmentMask = kTableSegmentSize - 1u;
+static const uint32_t kTableMaxSegments = 1u << ( 32 - kTableSegmentBits ); // 1024 -> 4 GiB
+static const uint32_t kTableSlabBytes   = 64u * 1024u;                 // one atomic per slab
+static const uint32_t kTableAlign       = 8;                           // every node starts 8-aligned
+static const uint32_t kTableAllocFailed = 0xFFFFFFFFu;
+
+// The pointer-chain depth cap. It bounds recursion on every walk — save,
+// load, cook and open — so a data cycle is an ERROR and never a hang, and a
+// hostile wire cannot drive the C stack into the ground. A pointer chain's
+// WIRE nesting equals its length (§3), so this also caps chain length: wide
+// structures are unbounded, deep ones are not. Lifting it wants a flat,
+// indexed node encoding — a named follow-on (§12).
+static const int32_t kTableMaxDepth = 128;
+
+// ---- TableRef: a relocatable reference (never a machine pointer) ----
+//
+// Two encodings, one slot, and the FORM says which is in force:
+//
+//   in the arena  — the node's arena offset (segment index in the high bits)
+//   in a region   — the SELF-RELATIVE byte delta from this slot's own address,
+//                   so a deref is one add, needs no base pointer, and a whole
+//                   region relocates by memcpy with zero fix-up
+//
+// 0 is null in both. Region deltas are always POSITIVE: a region is packed by
+// a depth-first walk, so a child always sits after the slot that names it —
+// which is also what makes the cooked-form bounds walk cycle-free by
+// construction.
+struct TableRef
+{
+    uint32_t value = 0;
+    bool null() const { return value == 0; }
+};
+
+// TableSlot is what Alloc hands back: usable as the node pointer (write
+// fields through it) AND as the reference to store in a pointer field.
+template <typename T> struct TableSlot
+{
+    T * ptr = NULL;
+    TableRef ref;
+    T * operator->() const { return ptr; }
+    T & operator*() const { return *ptr; }
+    operator T *() const { return ptr; }
+    operator TableRef() const { return ref; }
+    bool null() const { return ptr == NULL; }
+};
+
+inline uint32_t TableAlignUp( uint32_t bytes ) { return ( bytes + kTableAlign - 1 ) & ~( kTableAlign - 1 ); }
+inline int64_t TableAlignUp64( int64_t bytes ) { return ( bytes + kTableAlign - 1 ) & ~( int64_t( kTableAlign ) - 1 ); }
+
+// ---- the arena: segmented, slab-handed, lock-free by ownership ----
+//
+// Allocation is thread-local inside a worker's slab — no atomics on the node
+// path. A worker takes its next slab with ONE compare-exchange, and a new
+// segment is published with one more. Nothing ever moves: a segment, once
+// allocated, lives untouched until the arena is torn down, so a T* obtained
+// from Alloc stays valid while other workers allocate, and an offset stays
+// correct while the arena grows.
+//
+// The model this DELIBERATELY refuses: one buffer under a lock, grown by
+// realloc. A realloc moves the buffer under workers mid-write; offsets fix
+// identity but not the raw references already resolved from them, and the
+// resulting corruption is invisible until much later. Segments never move, so
+// that bug class cannot be written here.
+//
+// Slack: at most one slab tail per worker plus one slab per segment (a slab
+// that will not fit is skipped rather than split), i.e. under 2% of a segment
+// plus threads x 64 KiB. That is the price of never synchronizing per node.
+struct TableArena
+{
+    std::atomic<uint8_t *> segments[ kTableMaxSegments ];
+    std::atomic<uint32_t> cursor; // (segment << kTableSegmentBits) | bytes handed out
+    bool locked = false;          // MONOTONIC: Lock() is one-way, there is no unlock
+};
+
+inline void TableArenaInit( TableArena & arena )
+{
+    for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
+    {
+        arena.segments[i].store( NULL, std::memory_order_relaxed );
+    }
+    arena.cursor.store( 0, std::memory_order_relaxed );
+    arena.locked = false;
+}
+
+inline void TableArenaShutdown( TableArena & arena )
+{
+    for ( uint32_t i = 0; i < kTableMaxSegments; i++ )
+    {
+        uint8_t * segment = arena.segments[i].exchange( NULL, std::memory_order_acq_rel );
+        if ( segment != NULL ) { free( segment ); }
+    }
+    arena.cursor.store( 0, std::memory_order_relaxed );
+}
+
+// one L1 load plus an add: the segment table is 8 KiB and stays hot
+inline uint8_t * TableArenaAt( const TableArena & arena, uint32_t offset )
+{
+    return arena.segments[ offset >> kTableSegmentBits ].load( std::memory_order_relaxed ) + ( offset & kTableSegmentMask );
+}
+
+// TableArenaGrabSlab hands one worker its next private slab. Returns
+// kTableAllocFailed when the arena's address space or the allocator is
+// exhausted — a loud refusal, never a silent smaller slab.
+inline uint32_t TableArenaGrabSlab( TableArena & arena )
+{
+    for ( ;; )
+    {
+        uint32_t cursor = arena.cursor.load( std::memory_order_acquire );
+        uint32_t segment = cursor >> kTableSegmentBits;
+        uint32_t used = cursor & kTableSegmentMask;
+        // strictly less: a slab is never split across segments, and the tail
+        // is the documented slack
+        if ( used + kTableSlabBytes < kTableSegmentSize )
+        {
+            if ( arena.segments[segment].load( std::memory_order_acquire ) == NULL )
+            {
+                uint8_t * memory = (uint8_t *) malloc( kTableSegmentSize );
+                if ( memory == NULL ) { return kTableAllocFailed; }
+                uint8_t * expected = NULL;
+                if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
+                {
+                    free( memory ); // another worker published this segment first
+                }
+            }
+            if ( arena.cursor.compare_exchange_weak( cursor, cursor + kTableSlabBytes, std::memory_order_acq_rel ) )
+            {
+                return ( segment << kTableSegmentBits ) | used;
+            }
+            continue;
+        }
+        uint32_t next_segment = segment + 1;
+        if ( next_segment >= kTableMaxSegments ) { return kTableAllocFailed; } // 4 GiB: the u32 reference's ceiling
+        arena.cursor.compare_exchange_weak( cursor, next_segment << kTableSegmentBits, std::memory_order_acq_rel );
+    }
+}
+
+// ---- TableWorker: one thread's allocation front ----
+//
+// The threading contract, stated plainly:
+//   * Alloc on YOUR OWN worker is safe concurrently with any other worker's.
+//     No locks, no atomics per node.
+//   * Writing fields of a node ANOTHER worker allocated is your own
+//     synchronization problem — this runtime does not arbitrate it.
+//   * Lock, Save, Cook and Open are single-threaded: call them after the
+//     workers have joined.
+struct TableWorker
+{
+    TableArena * arena = NULL;
+    uint32_t next = 0;
+    uint32_t end = 0;
+
+    template <typename T> TableSlot<T> Alloc()
+    {
+        static_assert( alignof( T ) <= kTableAlign, "a table node's alignment must fit the arena's" );
+        TableSlot<T> slot;
+        if ( arena == NULL || arena->locked ) { return slot; }
+        uint32_t bytes = TableAlignUp( (uint32_t) sizeof( T ) );
+        if ( bytes > kTableSlabBytes ) { return slot; } // a node larger than a slab: refused, never split
+        if ( end == 0 || next + bytes > end )
+        {
+            uint32_t offset = TableArenaGrabSlab( *arena );
+            if ( offset == kTableAllocFailed ) { return slot; }
+            next = offset;
+            end = offset + kTableSlabBytes;
+            if ( next == 0 ) { next = kTableAlign; } // offset 0 is null: the arena's head stays reserved
+        }
+        uint32_t at = next;
+        next += bytes;
+        slot.ptr = new ( TableArenaAt( *arena, at ) ) T{};
+        slot.ref.value = at;
+        return slot;
+    }
+};
+
+// ---- resolution contexts: which encoding a walk is reading ----
+
+struct TableArenaCtx { const TableArena * arena; };
+struct TableRegionCtx {};
+
+// ---- the region sink: bump-allocating into the caller's exact buffer ----
+//
+// LoadMeasure sized the buffer exactly, so this allocates nothing and nothing
+// moves. References come out SELF-RELATIVE, which is the region encoding.
+struct TableRegionSink
+{
+    uint8_t * base = NULL;
+    int64_t capacity = 0;
+    int64_t used = 0;
+};
+
+// ---- the cooked form's header ----
+//
+// The cooked form answers one requirement: load a big file, point at its
+// root, without copying it and without parsing it. It is an accelerator
+// beside the wire, not an archive — the tolerant wire (§3) stays the format
+// of record, and a cooked file is regenerated whenever the schema moves.
+// The header is what makes the build-locking honest:
+//
+//   magic     — identifies the form AND the byte order (a foreign-endian
+//               writer's magic reads wrong, and Open refuses)
+//   layout_id — a compile-time digest of the packed-layout facts: the field
+//               shape from the schema, mixed with each closure type's sizeof
+//               as this build compiled it, so schema drift AND ABI drift both
+//               refuse
+//   bytes     — the packed region's length
+//
+// 32 bytes, so a root at base + 32 keeps the alignment the allocator gave the
+// base (mmap gives page alignment for free).
+static const uint32_t kTableCookedMagic = 0x314B4353u; // 'S','C','K','1'
+static const int64_t kTableCookedHeaderBytes = 32;
+
+struct TableRegionHeader
+{
+    uint32_t magic;
+    uint32_t layout_id;
+    uint32_t bytes;
+    uint32_t reserved[5];
+};
+
+inline void TableCookedHeaderWrite( uint8_t * at, uint32_t layout_id, uint32_t bytes )
+{
+    TableRegionHeader header = {};
+    header.magic = kTableCookedMagic;
+    header.layout_id = layout_id;
+    header.bytes = bytes;
+    memcpy( at, &header, sizeof( header ) );
+}
+
+// TableCookedHeaderCheck refuses a region this build cannot point at. Every
+// refusal is loud and the caller's fallback is a real wire Load.
+inline bool TableCookedHeaderCheck( const uint8_t * bytes, int64_t size, uint32_t layout_id, int64_t * region_bytes )
+{
+    if ( bytes == NULL || size < kTableCookedHeaderBytes ) { return false; }
+    if ( ( ( (uintptr_t) bytes ) & ( kTableAlign - 1 ) ) != 0 ) { return false; } // an unaligned base cannot be pointed at
+    TableRegionHeader header;
+    memcpy( &header, bytes, sizeof( header ) );
+    if ( header.magic != kTableCookedMagic ) { return false; } // wrong form, or foreign byte order
+    if ( header.layout_id != layout_id ) { return false; }     // schema or ABI drift: regenerate the cooked file
+    if ( (int64_t) header.bytes > size - kTableCookedHeaderBytes ) { return false; }
+    *region_bytes = (int64_t) header.bytes;
+    return true;
+}
+
+} // namespace ` + pkg + `
+
+#endif // ` + guard + `
+`
+}

--- a/internal/codegen/cpptable/arena.go
+++ b/internal/codegen/cpptable/arena.go
@@ -155,7 +155,14 @@ inline uint32_t TableArenaGrabSlab( TableArena & arena )
         {
             if ( arena.segments[segment].load( std::memory_order_acquire ) == NULL )
             {
-                uint8_t * memory = (uint8_t *) malloc( kTableSegmentSize );
+                // calloc, NOT malloc: Lock and Cook copy whole nodes, PADDING
+                // INCLUDED, so anything uninitialised here reaches a packed
+                // region and a cooked file on disk. Value-initialising a node
+                // with placement new zeroes its MEMBERS and not its padding, so
+                // the zeroing has to happen here or not at all. It costs nothing
+                // measurable: a fresh segment is untouched pages either way, and
+                // calloc has the kernel hand them over zeroed.
+                uint8_t * memory = (uint8_t *) calloc( 1, kTableSegmentSize );
                 if ( memory == NULL ) { return kTableAllocFailed; }
                 uint8_t * expected = NULL;
                 if ( !arena.segments[segment].compare_exchange_strong( expected, memory, std::memory_order_acq_rel ) )
@@ -278,6 +285,13 @@ inline bool TableCookedHeaderCheck( const uint8_t * bytes, int64_t size, uint32_
     if ( header.magic != kTableCookedMagic ) { return false; } // wrong form, or foreign byte order
     if ( header.layout_id != layout_id ) { return false; }     // schema or ABI drift: regenerate the cooked file
     if ( (int64_t) header.bytes > size - kTableCookedHeaderBytes ) { return false; }
+    // the reserved words are reserved: a writer that used them wrote a form
+    // this build does not understand, and silently ignoring them would make
+    // them unusable later
+    for ( size_t i = 0; i < sizeof( header.reserved ) / sizeof( header.reserved[0] ); i++ )
+    {
+        if ( header.reserved[i] != 0 ) { return false; }
+    }
     *region_bytes = (int64_t) header.bytes;
     return true;
 }

--- a/internal/codegen/cpptable/arena.go
+++ b/internal/codegen/cpptable/arena.go
@@ -50,7 +50,7 @@ static const uint32_t kTableAllocFailed = 0xFFFFFFFFu;
 // hostile wire cannot drive the C stack into the ground. A pointer chain's
 // WIRE nesting equals its length (§3), so this also caps chain length: wide
 // structures are unbounded, deep ones are not. Lifting it wants a flat,
-// indexed node encoding — a named follow-on (§12).
+// indexed node encoding — a named follow-on (§15).
 static const int32_t kTableMaxDepth = 128;
 
 // ---- TableRef: a relocatable reference (never a machine pointer) ----

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -132,6 +132,14 @@ func (g *tableGen) emitTableStruct(st *ir.Struct) {
 }
 
 func (g *tableGen) emitTableStorageField(f *ir.Field) {
+	if f.Type.Pointer {
+		// a pointer is FOUR BYTES and no address: an arena offset while the
+		// builder is mutable, a self-relative delta once packed. That is what
+		// keeps a pointer-bearing table relocatable in both forms.
+		g.noteRef(f.Type.Name)
+		g.pf("    TableRef %s; // *%s — null until assigned\n", f.Name, f.Type.Name)
+		return
+	}
 	typ, selfInit := g.cppFieldType(f.Type)
 	switch {
 	case f.Type.Kind == ir.TString:
@@ -213,7 +221,15 @@ func guardWalk(st *ir.Struct, prefix string) map[string]string {
 // its bound, an out-of-range union tag) measures as -1, exactly as the
 // write side refuses it.
 func (g *tableGen) emitTableMeasure(st *ir.Struct) {
-	g.pf("inline int64_t %sMeasure( const %s & value )\n{\n", st.Name, st.Name)
+	if g.isVar(st.Name) {
+		g.pf("template <typename Ctx>\ninline int64_t %sMeasureBody( const Ctx & ctx, const %s & value, int32_t depth )\n{\n", st.Name, st.Name)
+		g.pf("    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap\n")
+		if len(pointerFields(st)) == 0 && len(g.byValueVariableFields(st)) == 0 {
+			g.pf("    (void) ctx;\n")
+		}
+	} else {
+		g.pf("inline int64_t %sMeasure( const %s & value )\n{\n", st.Name, st.Name)
+	}
 	if len(st.Fields) == 0 {
 		g.pf("    (void) value; // empty type: presence is the payload\n")
 	}
@@ -237,6 +253,17 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 	kind := tableScalarKind(f)
 	width := tableKindWidth(kind)
 	switch {
+	case f.Type.Pointer:
+		t := f.Type.Name
+		g.pf("    {\n")
+		g.pf("        const %s * pointee_%s = %sAt( ctx, value.%s ); // *%s\n", t, f.Name, t, f.Name, t)
+		g.pf("        if ( pointee_%s != NULL )\n        {\n", f.Name)
+		g.pf("            int64_t body_%s = %s;\n", f.Name, g.measureCall(t, "*pointee_"+f.Name))
+		g.pf("            if ( body_%s < 0 ) { return -1; }\n", f.Name)
+		g.pf("            // a pointer's PRESENCE is the payload: it rides even when the\n")
+		g.pf("            // pointee is all-default, or null and non-null would be one\n")
+		g.pf("            bytes += 3 + 4 + body_%s;\n", f.Name)
+		g.pf("        }\n    }\n")
 	case f.Type.Kind == ir.TString:
 		g.pf("    if ( value.%s_length < 0 || value.%s_length > %d ) { return -1; } // storage invariant\n", f.Name, f.Name, f.Type.Size)
 		g.pf("    if ( value.%s_length > 0 ) { bytes += 3 + 2 + value.%s_length; } // %s\n", f.Name, f.Name, f.Name)
@@ -248,7 +275,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    if ( value.%s_count > 0 )\n    {\n", f.Name)
 		g.pf("        bytes += 3 + 4 + 3; // %s\n", f.Name)
 		g.pf("        for ( int32_t i = 0; i < value.%s_count; i++ )\n        {\n", f.Name)
-		g.pf("            int64_t elem_%s = %sMeasure( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("            int64_t elem_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, fmt.Sprintf("value.%s[i]", f.Name)))
 		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
@@ -259,7 +286,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    {\n")
 		g.pf("        bytes += 3 + 4 + 3; // %s (fixed [%d])\n", f.Name, f.ArrayBound)
 		g.pf("        for ( int32_t i = 0; i < %d; i++ )\n        {\n", f.ArrayBound)
-		g.pf("            int64_t elem_%s = %sMeasure( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("            int64_t elem_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, fmt.Sprintf("value.%s[i]", f.Name)))
 		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
@@ -276,7 +303,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("        case %sType::None: break; // None elides — TLV absence is the None\n", un.Name)
 		for _, v := range un.Variants {
 			g.pf("        case %sType::%s:\n        {\n", un.Name, ir.GoExportName(v.Name))
-			g.pf("            int64_t arm_%s = %sMeasure( value.%s.%s );\n", f.Name, v.Type, f.Name, v.Name)
+			g.pf("            int64_t arm_%s = %s;\n", f.Name, g.measureCall(v.Type, fmt.Sprintf("value.%s.%s", f.Name, v.Name)))
 			g.pf("            if ( arm_%s < 0 ) { return -1; }\n", f.Name)
 			g.pf("            bytes += 3 + 1 + 4 + arm_%s;\n            break;\n        }\n", f.Name)
 		}
@@ -284,7 +311,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    }\n")
 	case kind == tkTable:
 		g.pf("    {\n")
-		g.pf("        int64_t body_%s = %sMeasure( value.%s );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("        int64_t body_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, "value."+f.Name))
 		g.pf("        if ( body_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("        if ( body_%s > 2 ) { bytes += 3 + 4 + body_%s; } // %s: all-default nested elides\n", f.Name, f.Name, f.Name)
 		g.pf("    }\n")
@@ -296,7 +323,15 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 // ---- write / save ----
 
 func (g *tableGen) emitTableWrite(st *ir.Struct) {
-	g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value )\n{\n", st.Name, st.Name)
+	if g.isVar(st.Name) {
+		g.pf("template <typename Ctx>\ninline bool %sSaveBody( const Ctx & ctx, TableWriter & w, const %s & value, int32_t depth )\n{\n", st.Name, st.Name)
+		g.pf("    if ( depth > kTableMaxDepth ) { return false; } // a data cycle, or a chain past the cap\n")
+		if len(pointerFields(st)) == 0 && len(g.byValueVariableFields(st)) == 0 {
+			g.pf("    (void) ctx;\n")
+		}
+	} else {
+		g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value )\n{\n", st.Name, st.Name)
+	}
 	if len(st.Fields) == 0 {
 		g.pf("    (void) value; // empty type: presence is the payload\n")
 	}
@@ -321,6 +356,9 @@ func (g *tableGen) emitTableWrite(st *ir.Struct) {
 // written — exactly TableMeasure's answer — or -1 when the buffer is too
 // small. No allocation anywhere: the caller owns the buffer.
 func (g *tableGen) emitTableSave(st *ir.Struct) {
+	if g.isVar(st.Name) {
+		return // a variable-length table's Save takes a builder or a region root
+	}
 	g.pf("inline int64_t %sSave( const %s & value, uint8_t * buffer, int64_t capacity )\n{\n", st.Name, st.Name)
 	g.pf("    TableWriter w( buffer, capacity );\n")
 	g.pf("    if ( !%sSaveBody( w, value ) ) { return -1; }\n", st.Name)
@@ -334,6 +372,17 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		g.noteRef(f.Type.Name)
 	}
 	switch {
+	case f.Type.Pointer:
+		t := f.Type.Name
+		g.pf("    {\n")
+		g.pf("        const %s * pointee_%s = %sAt( ctx, value.%s ); // *%s\n", t, f.Name, t, f.Name, t)
+		g.pf("        if ( pointee_%s != NULL )\n        {\n", f.Name)
+		g.pf("            int64_t body_%s = %s;\n", f.Name, g.measureCall(t, "*pointee_"+f.Name))
+		g.pf("            if ( body_%s < 0 ) { return false; }\n", f.Name)
+		g.pf("            w.put16( 0x%04x ); w.put8( %d ); // %s — the pointee rides as a nested body\n", id, tkTable, f.Name)
+		g.pf("            w.put32( uint32_t( body_%s ) );\n", f.Name)
+		g.pf("            if ( !%s ) { return false; }\n", g.saveCall(t, "*pointee_"+f.Name))
+		g.pf("        }\n    }\n")
 	case f.Type.Kind == ir.TString:
 		g.pf("    if ( value.%s_length < 0 || value.%s_length > %d ) { return false; } // storage invariant\n", f.Name, f.Name, f.Type.Size)
 		g.pf("    if ( value.%s_length > 0 )\n    {\n", f.Name)
@@ -394,8 +443,8 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
 		g.pf("        switch ( value.%s.type )\n        {\n", f.Name)
 		for _, v := range un.Variants {
-			g.pf("            case %sType::%s: if ( !%sSaveBody( w, value.%s.%s ) ) return false; break;\n",
-				un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
+			g.pf("            case %sType::%s: if ( !%s ) return false; break;\n",
+				un.Name, ir.GoExportName(v.Name), g.saveCall(v.Type, fmt.Sprintf("value.%s.%s", f.Name, v.Name)))
 		}
 		g.pf("            default: return false; // write validates the tag before it rides\n")
 		g.pf("        }\n")
@@ -406,12 +455,12 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		// so saving into a buffer of exactly TableMeasure's size never
 		// trips overflow on transient header bytes
 		g.pf("    {\n")
-		g.pf("        int64_t body_%s = %sMeasure( value.%s );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("        int64_t body_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, "value."+f.Name))
 		g.pf("        if ( body_%s < 0 ) return false; // storage invariant, refused as measure refuses it\n", f.Name)
 		g.pf("        if ( body_%s > 2 ) // all-default nested elides\n        {\n", f.Name)
 		g.pf("            w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkTable, f.Name)
 		g.pf("            w.put32( uint32_t( body_%s ) );\n", f.Name)
-		g.pf("            if ( !%sSaveBody( w, value.%s ) ) return false;\n", f.Type.Name, f.Name)
+		g.pf("            if ( !%s ) return false;\n", g.saveCall(f.Type.Name, "value."+f.Name))
 		g.pf("        }\n    }\n")
 	default:
 		g.pf("    if ( value.%s != %s )\n    {\n", f.Name, g.fieldDefaultExpr(f))
@@ -431,7 +480,7 @@ func (g *tableGen) emitTableWriteElement(f *ir.Field, kind int, expr, ind string
 		g.pf("%sw.put64( table_double_to_bits( %s ) );\n", ind, expr)
 	case tkTable:
 		g.pf("%s{\n%s    int64_t elem_len_at = w.offset; w.put32( 0 );\n", ind, ind)
-		g.pf("%s    if ( !%sSaveBody( w, %s ) ) return false;\n", ind, f.Type.Name, expr)
+		g.pf("%s    if ( !%s ) return false;\n", ind, g.saveCall(f.Type.Name, expr))
 		g.pf("%s    w.patch32( elem_len_at, uint32_t( w.offset - elem_len_at - 4 ) );\n%s}\n", ind, ind)
 	default:
 		width := tableKindWidth(kind)
@@ -443,7 +492,14 @@ func (g *tableGen) emitTableWriteElement(f *ir.Field, kind int, expr, ind string
 // ---- read ----
 
 func (g *tableGen) emitTableRead(st *ir.Struct) {
-	g.pf("inline bool %sLoadBody( TableReader & r, %s & value )\n{\n", st.Name, st.Name)
+	if g.isVar(st.Name) {
+		g.pf("template <typename Sink>\ninline bool %sLoadBody( TableReader & r, Sink & sink, %s & value, int32_t depth )\n{\n", st.Name, st.Name)
+		if len(pointerFields(st)) == 0 && len(g.byValueVariableFields(st)) == 0 {
+			g.pf("    (void) sink; (void) depth;\n")
+		}
+	} else {
+		g.pf("inline bool %sLoadBody( TableReader & r, %s & value )\n{\n", st.Name, st.Name)
+	}
 	// placement new, NOT `value = T{}`: assignment materializes a temporary,
 	// and generated types can be large — a stack bomb on worker threads.
 	// In-place value-init applies the same NSDMI defaults with no temporary.
@@ -460,6 +516,12 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 			id := ir.TableFieldId(f)
 			kind := tableScalarKind(f)
 			wireKind := kind
+			if f.Type.Pointer {
+				// a pointer rides as a nested table body — framing identical to
+				// a by-value nesting, which is why a field can change between
+				// the two without moving a byte (SPEC-TABLES.md §3)
+				kind, wireKind = tkTable, tkTable
+			}
 			if f.Array != ir.ArrayNone || f.Type.Kind == ir.TBytes {
 				wireKind = tkArray
 			}
@@ -485,7 +547,12 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 		g.pf("    }\n}\n\n")
 	}
 
-	// buffer-level convenience entry
+	// buffer-level convenience entry. A VARIABLE-LENGTH table has none: it is
+	// never held by value, so its Load takes the caller's region and hands back
+	// the root instead (SPEC-TABLES.md §2).
+	if g.isVar(st.Name) {
+		return
+	}
 	g.pf("inline bool %sLoad( %s & value, const uint8_t * buffer, int64_t bytes, TableReport * report )\n{\n", st.Name, st.Name)
 	g.pf("    TableReport ignored;\n")
 	g.pf("    TableReader r( buffer, bytes, report != NULL ? report : &ignored );\n")
@@ -495,6 +562,24 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 	ind := "                "
 	switch {
+	case f.Type.Pointer:
+		t := f.Type.Name
+		g.pf("%sif ( !r.has( 4 ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%suint32_t body_len = r.get32();\n", ind)
+		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
+		g.pf("%sif ( depth >= kTableMaxDepth )\n%s{\n", ind, ind)
+		g.pf("%s    // past the nesting cap: the subtree is refused, the pointer stays\n", ind)
+		g.pf("%s    // null, and the parent reads on (SPEC-TABLES.md §4)\n", ind)
+		g.pf("%s    r.report->malformed = true;\n", ind)
+		g.pf("%s    r.offset += body_len;\n%s    break;\n%s}\n", ind, ind, ind)
+		g.pf("%s{\n%s    %s * pointee = %sEmplace( sink, value.%s );\n", ind, ind, t, t, f.Name)
+		g.pf("%s    if ( pointee == NULL )\n%s    {\n", ind, ind)
+		g.pf("%s        r.report->malformed = true; // the caller's region was short\n", ind)
+		g.pf("%s        r.offset += body_len;\n%s        break;\n%s    }\n", ind, ind, ind)
+		g.pf("%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind)
+		g.pf("%s    %s;\n", ind, g.loadCall(t, "sub", "*pointee"))
+		g.pf("%s}\n", ind)
+		g.pf("%sr.offset += body_len;\n", ind)
 	case f.Type.Kind == ir.TString:
 		g.pf("%sif ( !r.has( 2 ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%suint16_t len = r.get16();\n", ind)
@@ -555,8 +640,8 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind, ind)
 		g.pf("%s    switch ( value.%s.type )\n%s    {\n", ind, f.Name, ind)
 		for _, v := range un.Variants {
-			g.pf("%s        case %sType::%s: %sLoadBody( sub, value.%s.%s ); break;\n",
-				ind, un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
+			g.pf("%s        case %sType::%s: %s; break;\n",
+				ind, un.Name, ir.GoExportName(v.Name), g.loadCall(v.Type, "sub", fmt.Sprintf("value.%s.%s", f.Name, v.Name)))
 		}
 		g.pf("%s        default: break; // unreachable: the tag was ranged above\n", ind)
 		g.pf("%s    }\n%s}\n", ind, ind)
@@ -566,7 +651,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%suint32_t body_len = r.get32();\n", ind)
 		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind, ind)
-		g.pf("%s    %sLoadBody( sub, value.%s );\n", ind, f.Type.Name, f.Name)
+		g.pf("%s    %s;\n", ind, g.loadCall(f.Type.Name, "sub", "value."+f.Name))
 		g.pf("%s}\n", ind)
 		g.pf("%sr.offset += body_len;\n", ind)
 	default:
@@ -585,7 +670,7 @@ func (g *tableGen) emitTableReadElement(f *ir.Field, kind int, ind string) {
 		g.pf("%suint32_t elem_len = sub.get32();\n", ind)
 		g.pf("%sif ( !sub.has( elem_len ) ) { r.report->malformed = true; break; }\n", ind)
 		g.pf("%s{\n%s    TableReader elem( sub.buffer + sub.offset, elem_len, r.report );\n", ind, ind)
-		g.pf("%s    %sLoadBody( elem, value.%s[i] );\n", ind, f.Type.Name, f.Name)
+		g.pf("%s    %s;\n", ind, g.loadCall(f.Type.Name, "elem", fmt.Sprintf("value.%s[i]", f.Name)))
 		g.pf("%s}\n", ind)
 		g.pf("%ssub.offset += elem_len;\n", ind)
 	default:
@@ -685,8 +770,15 @@ func bigToDouble(v *big.Int) string {
 func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 	guards := tableGuardStrings(st)
 	g.pf("inline const TableTypeInfo * %sTableType()\n{\n", st.Name)
+	ptrs := pointerFields(st)
+	qualifier := "static const"
+	infoQualifier := "static const"
+	if len(ptrs) > 0 {
+		// mutable: the pointer targets are LINKED after construction (below)
+		qualifier = "static"
+	}
 	if len(st.Fields) > 0 {
-		g.pf("    static const TableFieldInfo fields[] = {\n")
+		g.pf("    %s TableFieldInfo fields[] = {\n", qualifier)
 		for _, f := range st.Fields {
 			id := ir.TableFieldId(f)
 			kind := tableScalarKind(f)
@@ -694,6 +786,9 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 				kind = tkU8
 			}
 			isArray := f.Array != ir.ArrayNone || f.Type.Kind == ir.TBytes
+			if f.Type.Pointer {
+				kind = tkTable
+			}
 			counted := f.Array == ir.ArrayCounted || f.Type.Kind == ir.TBytes || f.Type.Kind == ir.TString
 
 			bound := int64(0)
@@ -718,8 +813,26 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 				countOffset = fmt.Sprintf("(uint32_t) offsetof( %s, %s )", st.Name, companion)
 			}
 
+			elemSizeOverride := ""
+			if f.Type.Pointer {
+				// a pointer's storage IS the reference slot: offset names it,
+				// elem_size is the slot's width, and there is no companion
+				elemSizeOverride = "(uint32_t) sizeof( TableRef )"
+				counted = false
+				bound = 0
+			}
+			if elemSizeOverride != "" {
+				elemSize = elemSizeOverride
+				countOffset = "0xffffffffu"
+			}
 			table := "NULL"
-			if _, isStruct := f.Type.Ref.(*ir.Struct); f.Type.Kind == ir.TNamed && isStruct {
+			if f.Type.Pointer {
+				// linked below, not here: a *T descriptor that named its target
+				// during its own initializer would recurse forever on a
+				// self-referential graph (Node -> *Node)
+				g.noteRef(f.Type.Name)
+			}
+			if _, isStruct := f.Type.Ref.(*ir.Struct); f.Type.Kind == ir.TNamed && isStruct && !f.Type.Pointer {
 				table = fmt.Sprintf("%sTableType()", f.Type.Name)
 				g.noteRef(f.Type.Name)
 			}
@@ -741,17 +854,37 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 				enumName = fmt.Sprintf("+[]( uint64_t v ) { return EnumName( %s( v ) ); }", f.Type.Name)
 			}
 
-			g.pf("        { \"%s\", \"%s\", 0x%04x, %d, %v, %v, %d, (uint32_t) offsetof( %s, %s ), %s, %s, %s, %s, %s, %s, %s, %s, \"%s\" },\n",
-				f.Name, tableFieldTypeName(f), id, kind, isArray, counted, bound,
+			pointerColumn := ""
+			if g.anyVariable {
+				pointerColumn = fmt.Sprintf("%v, ", f.Type.Pointer)
+			}
+			g.pf("        { \"%s\", \"%s\", 0x%04x, %d, %v, %s%v, %d, (uint32_t) offsetof( %s, %s ), %s, %s, %s, %s, %s, %s, %s, %s, \"%s\" },\n",
+				f.Name, tableFieldTypeName(f), id, kind, isArray, pointerColumn, counted, bound,
 				st.Name, f.Name, elemSize, countOffset, table,
 				hasRange, rangeMin, rangeMax, enumMax, enumName, guards[f.Name])
 		}
 		g.pf("    };\n")
-		g.pf("    static const TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), %d, fields };\n",
-			st.Name, st.Name, len(st.Fields))
+		g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), %d, fields%s };\n",
+			infoQualifier, st.Name, st.Name, len(st.Fields), g.modeColumn(st))
 	} else {
-		g.pf("    static const TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL };\n",
-			st.Name, st.Name)
+		g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL%s };\n",
+			infoQualifier, st.Name, st.Name, g.modeColumn(st))
+	}
+	if len(ptrs) > 0 {
+		g.pf("    // link the pointer targets once, AFTER info exists: a *T descriptor\n")
+		g.pf("    // naming its target inside its own initializer would recurse forever\n")
+		g.pf("    // on Node -> *Node. The flag is set BEFORE the calls, so a cycle\n")
+		g.pf("    // through another type's descriptor terminates here too.\n")
+		g.pf("    static bool linked = false;\n")
+		g.pf("    if ( !linked )\n    {\n")
+		g.pf("        linked = true;\n")
+		for i, f := range st.Fields {
+			if !f.Type.Pointer {
+				continue
+			}
+			g.pf("        fields[%d].table = %sTableType(); // %s\n", i, f.Type.Name, f.Name)
+		}
+		g.pf("    }\n")
 	}
 	g.pf("    return &info;\n}\n\n")
 }

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -211,13 +211,13 @@ func guardWalk(st *ir.Struct, prefix string) map[string]string {
 
 // ---- measure ----
 
-// emitTableMeasure emits TableMeasure<X>: the EXACT encoded size of a value,
+// emitTableMeasure emits <X>Measure (<X>MeasureBody where pointers reach): the
+// EXACT encoded size of a value,
 // no writing — the parallel-generation lever. Every nested table on the wire
 // is length-prefixed, so a caller can measure subtables in parallel,
 // prefix-sum offsets, and scatter-write disjoint ranges from N workers.
 // Mirrors TableWrite's elision decisions branch for branch: for any value,
-// TableSave writes exactly this many bytes into a buffer of exactly this
-// size. A value violating its storage invariants (a count or length outside
+// Save writes exactly this many bytes into a buffer of exactly this size. A value violating its storage invariants (a count or length outside
 // its bound, an out-of-range union tag) measures as -1, exactly as the
 // write side refuses it.
 func (g *tableGen) emitTableMeasure(st *ir.Struct) {
@@ -258,7 +258,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    {\n")
 		g.pf("        const %s * pointee_%s = %sAt( ctx, value.%s ); // *%s\n", t, f.Name, t, f.Name, t)
 		g.pf("        if ( pointee_%s != NULL )\n        {\n", f.Name)
-		g.pf("            int64_t body_%s = %s;\n", f.Name, g.measureCall(t, "*pointee_"+f.Name))
+		g.pf("            int64_t body_%s = %s;\n", f.Name, g.measureCall(t, "*pointee_"+f.Name, depthDown))
 		g.pf("            if ( body_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("            // a pointer's PRESENCE is the payload: it rides even when the\n")
 		g.pf("            // pointee is all-default, or null and non-null would be one\n")
@@ -275,7 +275,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    if ( value.%s_count > 0 )\n    {\n", f.Name)
 		g.pf("        bytes += 3 + 4 + 3; // %s\n", f.Name)
 		g.pf("        for ( int32_t i = 0; i < value.%s_count; i++ )\n        {\n", f.Name)
-		g.pf("            int64_t elem_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, fmt.Sprintf("value.%s[i]", f.Name)))
+		g.pf("            int64_t elem_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, fmt.Sprintf("value.%s[i]", f.Name), depthSame))
 		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
@@ -286,7 +286,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    {\n")
 		g.pf("        bytes += 3 + 4 + 3; // %s (fixed [%d])\n", f.Name, f.ArrayBound)
 		g.pf("        for ( int32_t i = 0; i < %d; i++ )\n        {\n", f.ArrayBound)
-		g.pf("            int64_t elem_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, fmt.Sprintf("value.%s[i]", f.Name)))
+		g.pf("            int64_t elem_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, fmt.Sprintf("value.%s[i]", f.Name), depthSame))
 		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
@@ -303,7 +303,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("        case %sType::None: break; // None elides — TLV absence is the None\n", un.Name)
 		for _, v := range un.Variants {
 			g.pf("        case %sType::%s:\n        {\n", un.Name, ir.GoExportName(v.Name))
-			g.pf("            int64_t arm_%s = %s;\n", f.Name, g.measureCall(v.Type, fmt.Sprintf("value.%s.%s", f.Name, v.Name)))
+			g.pf("            int64_t arm_%s = %s;\n", f.Name, g.measureCall(v.Type, fmt.Sprintf("value.%s.%s", f.Name, v.Name), depthSame))
 			g.pf("            if ( arm_%s < 0 ) { return -1; }\n", f.Name)
 			g.pf("            bytes += 3 + 1 + 4 + arm_%s;\n            break;\n        }\n", f.Name)
 		}
@@ -311,7 +311,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    }\n")
 	case kind == tkTable:
 		g.pf("    {\n")
-		g.pf("        int64_t body_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, "value."+f.Name))
+		g.pf("        int64_t body_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, "value."+f.Name, depthSame))
 		g.pf("        if ( body_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("        if ( body_%s > 2 ) { bytes += 3 + 4 + body_%s; } // %s: all-default nested elides\n", f.Name, f.Name, f.Name)
 		g.pf("    }\n")
@@ -352,9 +352,8 @@ func (g *tableGen) emitTableWrite(st *ir.Struct) {
 }
 
 // emitTableSave emits the buffer-level entry of the measure/save pair:
-// TableSave writes into a caller-provided buffer and returns the bytes
-// written — exactly TableMeasure's answer — or -1 when the buffer is too
-// small. No allocation anywhere: the caller owns the buffer.
+// <X>Save writes into a caller-provided buffer and returns the bytes written —
+// exactly <X>Measure's answer — or -1 when the buffer is too small. No allocation anywhere: the caller owns the buffer.
 func (g *tableGen) emitTableSave(st *ir.Struct) {
 	if g.isVar(st.Name) {
 		return // a variable-length table's Save takes a builder or a region root
@@ -377,11 +376,11 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		g.pf("    {\n")
 		g.pf("        const %s * pointee_%s = %sAt( ctx, value.%s ); // *%s\n", t, f.Name, t, f.Name, t)
 		g.pf("        if ( pointee_%s != NULL )\n        {\n", f.Name)
-		g.pf("            int64_t body_%s = %s;\n", f.Name, g.measureCall(t, "*pointee_"+f.Name))
+		g.pf("            int64_t body_%s = %s;\n", f.Name, g.measureCall(t, "*pointee_"+f.Name, depthDown))
 		g.pf("            if ( body_%s < 0 ) { return false; }\n", f.Name)
 		g.pf("            w.put16( 0x%04x ); w.put8( %d ); // %s — the pointee rides as a nested body\n", id, tkTable, f.Name)
 		g.pf("            w.put32( uint32_t( body_%s ) );\n", f.Name)
-		g.pf("            if ( !%s ) { return false; }\n", g.saveCall(t, "*pointee_"+f.Name))
+		g.pf("            if ( !%s ) { return false; }\n", g.saveCall(t, "*pointee_"+f.Name, depthDown))
 		g.pf("        }\n    }\n")
 	case f.Type.Kind == ir.TString:
 		g.pf("    if ( value.%s_length < 0 || value.%s_length > %d ) { return false; } // storage invariant\n", f.Name, f.Name, f.Type.Size)
@@ -444,7 +443,7 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		g.pf("        switch ( value.%s.type )\n        {\n", f.Name)
 		for _, v := range un.Variants {
 			g.pf("            case %sType::%s: if ( !%s ) return false; break;\n",
-				un.Name, ir.GoExportName(v.Name), g.saveCall(v.Type, fmt.Sprintf("value.%s.%s", f.Name, v.Name)))
+				un.Name, ir.GoExportName(v.Name), g.saveCall(v.Type, fmt.Sprintf("value.%s.%s", f.Name, v.Name), depthSame))
 		}
 		g.pf("            default: return false; // write validates the tag before it rides\n")
 		g.pf("        }\n")
@@ -455,12 +454,12 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		// so saving into a buffer of exactly TableMeasure's size never
 		// trips overflow on transient header bytes
 		g.pf("    {\n")
-		g.pf("        int64_t body_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, "value."+f.Name))
+		g.pf("        int64_t body_%s = %s;\n", f.Name, g.measureCall(f.Type.Name, "value."+f.Name, depthSame))
 		g.pf("        if ( body_%s < 0 ) return false; // storage invariant, refused as measure refuses it\n", f.Name)
 		g.pf("        if ( body_%s > 2 ) // all-default nested elides\n        {\n", f.Name)
 		g.pf("            w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkTable, f.Name)
 		g.pf("            w.put32( uint32_t( body_%s ) );\n", f.Name)
-		g.pf("            if ( !%s ) return false;\n", g.saveCall(f.Type.Name, "value."+f.Name))
+		g.pf("            if ( !%s ) return false;\n", g.saveCall(f.Type.Name, "value."+f.Name, depthSame))
 		g.pf("        }\n    }\n")
 	default:
 		g.pf("    if ( value.%s != %s )\n    {\n", f.Name, g.fieldDefaultExpr(f))
@@ -480,7 +479,7 @@ func (g *tableGen) emitTableWriteElement(f *ir.Field, kind int, expr, ind string
 		g.pf("%sw.put64( table_double_to_bits( %s ) );\n", ind, expr)
 	case tkTable:
 		g.pf("%s{\n%s    int64_t elem_len_at = w.offset; w.put32( 0 );\n", ind, ind)
-		g.pf("%s    if ( !%s ) return false;\n", ind, g.saveCall(f.Type.Name, expr))
+		g.pf("%s    if ( !%s ) return false;\n", ind, g.saveCall(f.Type.Name, expr, depthSame))
 		g.pf("%s    w.patch32( elem_len_at, uint32_t( w.offset - elem_len_at - 4 ) );\n%s}\n", ind, ind)
 	default:
 		width := tableKindWidth(kind)
@@ -577,7 +576,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%s        r.report->malformed = true; // the caller's region was short\n", ind)
 		g.pf("%s        r.offset += body_len;\n%s        break;\n%s    }\n", ind, ind, ind)
 		g.pf("%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind)
-		g.pf("%s    %s;\n", ind, g.loadCall(t, "sub", "*pointee"))
+		g.pf("%s    %s;\n", ind, g.loadCall(t, "sub", "*pointee", depthDown))
 		g.pf("%s}\n", ind)
 		g.pf("%sr.offset += body_len;\n", ind)
 	case f.Type.Kind == ir.TString:
@@ -641,7 +640,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%s    switch ( value.%s.type )\n%s    {\n", ind, f.Name, ind)
 		for _, v := range un.Variants {
 			g.pf("%s        case %sType::%s: %s; break;\n",
-				ind, un.Name, ir.GoExportName(v.Name), g.loadCall(v.Type, "sub", fmt.Sprintf("value.%s.%s", f.Name, v.Name)))
+				ind, un.Name, ir.GoExportName(v.Name), g.loadCall(v.Type, "sub", fmt.Sprintf("value.%s.%s", f.Name, v.Name), depthSame))
 		}
 		g.pf("%s        default: break; // unreachable: the tag was ranged above\n", ind)
 		g.pf("%s    }\n%s}\n", ind, ind)
@@ -651,7 +650,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%suint32_t body_len = r.get32();\n", ind)
 		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind, ind)
-		g.pf("%s    %s;\n", ind, g.loadCall(f.Type.Name, "sub", "value."+f.Name))
+		g.pf("%s    %s;\n", ind, g.loadCall(f.Type.Name, "sub", "value."+f.Name, depthSame))
 		g.pf("%s}\n", ind)
 		g.pf("%sr.offset += body_len;\n", ind)
 	default:
@@ -670,7 +669,7 @@ func (g *tableGen) emitTableReadElement(f *ir.Field, kind int, ind string) {
 		g.pf("%suint32_t elem_len = sub.get32();\n", ind)
 		g.pf("%sif ( !sub.has( elem_len ) ) { r.report->malformed = true; break; }\n", ind)
 		g.pf("%s{\n%s    TableReader elem( sub.buffer + sub.offset, elem_len, r.report );\n", ind, ind)
-		g.pf("%s    %s;\n", ind, g.loadCall(f.Type.Name, "elem", fmt.Sprintf("value.%s[i]", f.Name)))
+		g.pf("%s    %s;\n", ind, g.loadCall(f.Type.Name, "elem", fmt.Sprintf("value.%s[i]", f.Name), depthSame))
 		g.pf("%s}\n", ind)
 		g.pf("%ssub.offset += elem_len;\n", ind)
 	default:
@@ -769,16 +768,33 @@ func bigToDouble(v *big.Int) string {
 // functions), built once on first use.
 func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 	guards := tableGuardStrings(st)
-	g.pf("inline const TableTypeInfo * %sTableType()\n{\n", st.Name)
-	ptrs := pointerFields(st)
+	// In a unit with pointers the descriptors are CONSTANT-INITIALISED data at
+	// namespace scope, and a field's target is the ADDRESS of another
+	// descriptor rather than a call. That is what makes a self- or
+	// mutually-referential graph expressible at all: a lazy link cannot
+	// describe Node -> *Node without re-entering its own initialisation, and
+	// the read-modify-write it needed to try was a data race on first use. As
+	// constant data the whole reflection surface is immutable and readable from
+	// any thread at any time with no synchronisation.
+	//
+	// A pointer-free unit keeps the function-local statics it always had, to
+	// the byte (SPEC-TABLES.md §2.2, the zero-cost gate).
+	hoisted := g.anyVariable
+	indent := "    "
+	if hoisted {
+		indent = ""
+	} else {
+		g.pf("inline const TableTypeInfo * %sTableType()\n{\n", st.Name)
+	}
 	qualifier := "static const"
 	infoQualifier := "static const"
-	if len(ptrs) > 0 {
-		// mutable: the pointer targets are LINKED after construction (below)
-		qualifier = "static"
-	}
-	if len(st.Fields) > 0 {
-		g.pf("    %s TableFieldInfo fields[] = {\n", qualifier)
+	switch {
+	case len(st.Fields) > 0:
+		if hoisted {
+			g.pf("inline const TableFieldInfo %sTableFields[] = {\n", st.Name)
+		} else {
+			g.pf("    %s TableFieldInfo fields[] = {\n", qualifier)
+		}
 		for _, f := range st.Fields {
 			id := ir.TableFieldId(f)
 			kind := tableScalarKind(f)
@@ -826,14 +842,14 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 				countOffset = "0xffffffffu"
 			}
 			table := "NULL"
-			if f.Type.Pointer {
-				// linked below, not here: a *T descriptor that named its target
-				// during its own initializer would recurse forever on a
-				// self-referential graph (Node -> *Node)
-				g.noteRef(f.Type.Name)
-			}
-			if _, isStruct := f.Type.Ref.(*ir.Struct); f.Type.Kind == ir.TNamed && isStruct && !f.Type.Pointer {
-				table = fmt.Sprintf("%sTableType()", f.Type.Name)
+			if _, isStruct := f.Type.Ref.(*ir.Struct); f.Type.Kind == ir.TNamed && isStruct {
+				if hoisted {
+					// an ADDRESS, not a call: constant-initialisable, so a
+					// self-reference (Node -> *Node) is simply &NodeTableInfo
+					table = "&" + f.Type.Name + "TableInfo"
+				} else {
+					table = fmt.Sprintf("%sTableType()", f.Type.Name)
+				}
 				g.noteRef(f.Type.Name)
 			}
 
@@ -858,33 +874,30 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 			if g.anyVariable {
 				pointerColumn = fmt.Sprintf("%v, ", f.Type.Pointer)
 			}
-			g.pf("        { \"%s\", \"%s\", 0x%04x, %d, %v, %s%v, %d, (uint32_t) offsetof( %s, %s ), %s, %s, %s, %s, %s, %s, %s, %s, \"%s\" },\n",
-				f.Name, tableFieldTypeName(f), id, kind, isArray, pointerColumn, counted, bound,
+			g.pf("%s    { \"%s\", \"%s\", 0x%04x, %d, %v, %s%v, %d, (uint32_t) offsetof( %s, %s ), %s, %s, %s, %s, %s, %s, %s, %s, \"%s\" },\n",
+				indent, f.Name, tableFieldTypeName(f), id, kind, isArray, pointerColumn, counted, bound,
 				st.Name, f.Name, elemSize, countOffset, table,
 				hasRange, rangeMin, rangeMax, enumMax, enumName, guards[f.Name])
 		}
-		g.pf("    };\n")
-		g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), %d, fields%s };\n",
-			infoQualifier, st.Name, st.Name, len(st.Fields), g.modeColumn(st))
-	} else {
+		if hoisted {
+			g.pf("};\n")
+			g.pf("inline const TableTypeInfo %sTableInfo = { \"%s\", (uint32_t) sizeof( %s ), %d, %sTableFields%s };\n",
+				st.Name, st.Name, st.Name, len(st.Fields), st.Name, g.modeColumn(st))
+		} else {
+			g.pf("    };\n")
+			g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), %d, fields%s };\n",
+				infoQualifier, st.Name, st.Name, len(st.Fields), g.modeColumn(st))
+		}
+	case hoisted:
+		g.pf("inline const TableTypeInfo %sTableInfo = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL%s };\n",
+			st.Name, st.Name, st.Name, g.modeColumn(st))
+	default:
 		g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL%s };\n",
 			infoQualifier, st.Name, st.Name, g.modeColumn(st))
 	}
-	if len(ptrs) > 0 {
-		g.pf("    // link the pointer targets once, AFTER info exists: a *T descriptor\n")
-		g.pf("    // naming its target inside its own initializer would recurse forever\n")
-		g.pf("    // on Node -> *Node. The flag is set BEFORE the calls, so a cycle\n")
-		g.pf("    // through another type's descriptor terminates here too.\n")
-		g.pf("    static bool linked = false;\n")
-		g.pf("    if ( !linked )\n    {\n")
-		g.pf("        linked = true;\n")
-		for i, f := range st.Fields {
-			if !f.Type.Pointer {
-				continue
-			}
-			g.pf("        fields[%d].table = %sTableType(); // %s\n", i, f.Type.Name, f.Name)
-		}
-		g.pf("    }\n")
+	if hoisted {
+		g.pf("inline const TableTypeInfo * %sTableType() { return &%sTableInfo; }\n\n", st.Name, st.Name)
+		return
 	}
 	g.pf("    return &info;\n}\n\n")
 }

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -213,7 +213,7 @@ func guardWalk(st *ir.Struct, prefix string) map[string]string {
 // its bound, an out-of-range union tag) measures as -1, exactly as the
 // write side refuses it.
 func (g *tableGen) emitTableMeasure(st *ir.Struct) {
-	g.pf("inline int64_t TableMeasure%s( const %s & value )\n{\n", st.Name, st.Name)
+	g.pf("inline int64_t %sMeasure( const %s & value )\n{\n", st.Name, st.Name)
 	if len(st.Fields) == 0 {
 		g.pf("    (void) value; // empty type: presence is the payload\n")
 	}
@@ -248,7 +248,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    if ( value.%s_count > 0 )\n    {\n", f.Name)
 		g.pf("        bytes += 3 + 4 + 3; // %s\n", f.Name)
 		g.pf("        for ( int32_t i = 0; i < value.%s_count; i++ )\n        {\n", f.Name)
-		g.pf("            int64_t elem_%s = TableMeasure%s( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("            int64_t elem_%s = %sMeasure( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
 		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
@@ -259,7 +259,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    {\n")
 		g.pf("        bytes += 3 + 4 + 3; // %s (fixed [%d])\n", f.Name, f.ArrayBound)
 		g.pf("        for ( int32_t i = 0; i < %d; i++ )\n        {\n", f.ArrayBound)
-		g.pf("            int64_t elem_%s = TableMeasure%s( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("            int64_t elem_%s = %sMeasure( value.%s[i] );\n", f.Name, f.Type.Name, f.Name)
 		g.pf("            if ( elem_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("            bytes += 4 + elem_%s;\n", f.Name)
 		g.pf("        }\n    }\n")
@@ -276,7 +276,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("        case %sType::None: break; // None elides — TLV absence is the None\n", un.Name)
 		for _, v := range un.Variants {
 			g.pf("        case %sType::%s:\n        {\n", un.Name, ir.GoExportName(v.Name))
-			g.pf("            int64_t arm_%s = TableMeasure%s( value.%s.%s );\n", f.Name, v.Type, f.Name, v.Name)
+			g.pf("            int64_t arm_%s = %sMeasure( value.%s.%s );\n", f.Name, v.Type, f.Name, v.Name)
 			g.pf("            if ( arm_%s < 0 ) { return -1; }\n", f.Name)
 			g.pf("            bytes += 3 + 1 + 4 + arm_%s;\n            break;\n        }\n", f.Name)
 		}
@@ -284,7 +284,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 		g.pf("    }\n")
 	case kind == tkTable:
 		g.pf("    {\n")
-		g.pf("        int64_t body_%s = TableMeasure%s( value.%s );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("        int64_t body_%s = %sMeasure( value.%s );\n", f.Name, f.Type.Name, f.Name)
 		g.pf("        if ( body_%s < 0 ) { return -1; }\n", f.Name)
 		g.pf("        if ( body_%s > 2 ) { bytes += 3 + 4 + body_%s; } // %s: all-default nested elides\n", f.Name, f.Name, f.Name)
 		g.pf("    }\n")
@@ -296,7 +296,7 @@ func (g *tableGen) emitTableMeasureField(f *ir.Field) {
 // ---- write / save ----
 
 func (g *tableGen) emitTableWrite(st *ir.Struct) {
-	g.pf("inline bool TableWrite%s( TableWriter & w, const %s & value )\n{\n", st.Name, st.Name)
+	g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value )\n{\n", st.Name, st.Name)
 	if len(st.Fields) == 0 {
 		g.pf("    (void) value; // empty type: presence is the payload\n")
 	}
@@ -321,10 +321,10 @@ func (g *tableGen) emitTableWrite(st *ir.Struct) {
 // written — exactly TableMeasure's answer — or -1 when the buffer is too
 // small. No allocation anywhere: the caller owns the buffer.
 func (g *tableGen) emitTableSave(st *ir.Struct) {
-	g.pf("inline int64_t TableSave%s( const %s & value, uint8_t * buffer, int64_t capacity )\n{\n", st.Name, st.Name)
+	g.pf("inline int64_t %sSave( const %s & value, uint8_t * buffer, int64_t capacity )\n{\n", st.Name, st.Name)
 	g.pf("    TableWriter w( buffer, capacity );\n")
-	g.pf("    if ( !TableWrite%s( w, value ) ) { return -1; }\n", st.Name)
-	g.pf("    return w.offset; // == TableMeasure%s( value )\n}\n\n", st.Name)
+	g.pf("    if ( !%sSaveBody( w, value ) ) { return -1; }\n", st.Name)
+	g.pf("    return w.offset; // == %sMeasure( value )\n}\n\n", st.Name)
 }
 
 func (g *tableGen) emitTableWriteField(f *ir.Field) {
@@ -394,7 +394,7 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		g.pf("        int64_t len_at_%s = w.offset; w.put32( 0 );\n", f.Name)
 		g.pf("        switch ( value.%s.type )\n        {\n", f.Name)
 		for _, v := range un.Variants {
-			g.pf("            case %sType::%s: if ( !TableWrite%s( w, value.%s.%s ) ) return false; break;\n",
+			g.pf("            case %sType::%s: if ( !%sSaveBody( w, value.%s.%s ) ) return false; break;\n",
 				un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
 		}
 		g.pf("            default: return false; // write validates the tag before it rides\n")
@@ -406,12 +406,12 @@ func (g *tableGen) emitTableWriteField(f *ir.Field) {
 		// so saving into a buffer of exactly TableMeasure's size never
 		// trips overflow on transient header bytes
 		g.pf("    {\n")
-		g.pf("        int64_t body_%s = TableMeasure%s( value.%s );\n", f.Name, f.Type.Name, f.Name)
+		g.pf("        int64_t body_%s = %sMeasure( value.%s );\n", f.Name, f.Type.Name, f.Name)
 		g.pf("        if ( body_%s < 0 ) return false; // storage invariant, refused as measure refuses it\n", f.Name)
 		g.pf("        if ( body_%s > 2 ) // all-default nested elides\n        {\n", f.Name)
 		g.pf("            w.put16( 0x%04x ); w.put8( %d ); // %s\n", id, tkTable, f.Name)
 		g.pf("            w.put32( uint32_t( body_%s ) );\n", f.Name)
-		g.pf("            if ( !TableWrite%s( w, value.%s ) ) return false;\n", f.Type.Name, f.Name)
+		g.pf("            if ( !%sSaveBody( w, value.%s ) ) return false;\n", f.Type.Name, f.Name)
 		g.pf("        }\n    }\n")
 	default:
 		g.pf("    if ( value.%s != %s )\n    {\n", f.Name, g.fieldDefaultExpr(f))
@@ -431,7 +431,7 @@ func (g *tableGen) emitTableWriteElement(f *ir.Field, kind int, expr, ind string
 		g.pf("%sw.put64( table_double_to_bits( %s ) );\n", ind, expr)
 	case tkTable:
 		g.pf("%s{\n%s    int64_t elem_len_at = w.offset; w.put32( 0 );\n", ind, ind)
-		g.pf("%s    if ( !TableWrite%s( w, %s ) ) return false;\n", ind, f.Type.Name, expr)
+		g.pf("%s    if ( !%sSaveBody( w, %s ) ) return false;\n", ind, f.Type.Name, expr)
 		g.pf("%s    w.patch32( elem_len_at, uint32_t( w.offset - elem_len_at - 4 ) );\n%s}\n", ind, ind)
 	default:
 		width := tableKindWidth(kind)
@@ -443,7 +443,7 @@ func (g *tableGen) emitTableWriteElement(f *ir.Field, kind int, expr, ind string
 // ---- read ----
 
 func (g *tableGen) emitTableRead(st *ir.Struct) {
-	g.pf("inline bool TableRead%s( TableReader & r, %s & value )\n{\n", st.Name, st.Name)
+	g.pf("inline bool %sLoadBody( TableReader & r, %s & value )\n{\n", st.Name, st.Name)
 	// placement new, NOT `value = T{}`: assignment materializes a temporary,
 	// and generated types can be large — a stack bomb on worker threads.
 	// In-place value-init applies the same NSDMI defaults with no temporary.
@@ -486,9 +486,10 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 	}
 
 	// buffer-level convenience entry
-	g.pf("inline bool TableRead%s( const uint8_t * buffer, int64_t bytes, %s & value, TableReport & report )\n{\n", st.Name, st.Name)
-	g.pf("    TableReader r( buffer, bytes, &report );\n")
-	g.pf("    return TableRead%s( r, value );\n}\n\n", st.Name)
+	g.pf("inline bool %sLoad( %s & value, const uint8_t * buffer, int64_t bytes, TableReport * report )\n{\n", st.Name, st.Name)
+	g.pf("    TableReport ignored;\n")
+	g.pf("    TableReader r( buffer, bytes, report != NULL ? report : &ignored );\n")
+	g.pf("    return %sLoadBody( r, value );\n}\n\n", st.Name)
 }
 
 func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
@@ -554,7 +555,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind, ind)
 		g.pf("%s    switch ( value.%s.type )\n%s    {\n", ind, f.Name, ind)
 		for _, v := range un.Variants {
-			g.pf("%s        case %sType::%s: TableRead%s( sub, value.%s.%s ); break;\n",
+			g.pf("%s        case %sType::%s: %sLoadBody( sub, value.%s.%s ); break;\n",
 				ind, un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
 		}
 		g.pf("%s        default: break; // unreachable: the tag was ranged above\n", ind)
@@ -565,7 +566,7 @@ func (g *tableGen) emitTableReadField(f *ir.Field, kind int) {
 		g.pf("%suint32_t body_len = r.get32();\n", ind)
 		g.pf("%sif ( !r.has( body_len ) ) { r.report->malformed = true; return false; }\n", ind)
 		g.pf("%s{\n%s    TableReader sub( r.buffer + r.offset, body_len, r.report );\n", ind, ind)
-		g.pf("%s    TableRead%s( sub, value.%s );\n", ind, f.Type.Name, f.Name)
+		g.pf("%s    %sLoadBody( sub, value.%s );\n", ind, f.Type.Name, f.Name)
 		g.pf("%s}\n", ind)
 		g.pf("%sr.offset += body_len;\n", ind)
 	default:
@@ -584,7 +585,7 @@ func (g *tableGen) emitTableReadElement(f *ir.Field, kind int, ind string) {
 		g.pf("%suint32_t elem_len = sub.get32();\n", ind)
 		g.pf("%sif ( !sub.has( elem_len ) ) { r.report->malformed = true; break; }\n", ind)
 		g.pf("%s{\n%s    TableReader elem( sub.buffer + sub.offset, elem_len, r.report );\n", ind, ind)
-		g.pf("%s    TableRead%s( elem, value.%s[i] );\n", ind, f.Type.Name, f.Name)
+		g.pf("%s    %sLoadBody( elem, value.%s[i] );\n", ind, f.Type.Name, f.Name)
 		g.pf("%s}\n", ind)
 		g.pf("%ssub.offset += elem_len;\n", ind)
 	default:
@@ -683,7 +684,7 @@ func bigToDouble(v *big.Int) string {
 // functions), built once on first use.
 func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 	guards := tableGuardStrings(st)
-	g.pf("inline const TableTypeInfo * TableType%s()\n{\n", st.Name)
+	g.pf("inline const TableTypeInfo * %sTableType()\n{\n", st.Name)
 	if len(st.Fields) > 0 {
 		g.pf("    static const TableFieldInfo fields[] = {\n")
 		for _, f := range st.Fields {
@@ -719,7 +720,7 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 
 			table := "NULL"
 			if _, isStruct := f.Type.Ref.(*ir.Struct); f.Type.Kind == ir.TNamed && isStruct {
-				table = fmt.Sprintf("TableType%s()", f.Type.Name)
+				table = fmt.Sprintf("%sTableType()", f.Type.Name)
 				g.noteRef(f.Type.Name)
 			}
 

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -128,17 +128,6 @@ func tableKindWidth(kind int) int {
 	return 0
 }
 
-// sortedKeys returns a set's members in a stable order — generated output and
-// diagnostics must never depend on map iteration.
-func sortedKeys(set map[string]bool) []string {
-	out := make([]string, 0, len(set))
-	for k := range set {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
-
 func tablePut(width int) string { return fmt.Sprintf("put%d", width*8) }
 func tableGet(width int) string { return fmt.Sprintf("get%d", width*8) }
 

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -388,6 +388,17 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 			for _, st := range members {
 				g.pf("inline const TableTypeInfo * %sTableType();\n", st.Name)
 			}
+			if anyVariable {
+				g.pf("// The descriptors are CONSTANT-INITIALISED data, and a field's target is\n")
+				g.pf("// the ADDRESS of another descriptor. These declarations are what let a\n")
+				g.pf("// self- or mutually-referential graph — Node naming itself through *Node —\n")
+				g.pf("// be expressed as constant data instead of a lazy link, which could not\n")
+				g.pf("// have been written race-free OR recursion-safe. The whole reflection\n")
+				g.pf("// surface is therefore immutable: read it from any thread, any time.\n")
+				for _, st := range members {
+					g.pf("extern const TableTypeInfo %sTableInfo;\n", st.Name)
+				}
+			}
 			g.pf("\n")
 			for _, st := range members {
 				g.emitTableDescriptor(st)

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -1,7 +1,7 @@
 // Package cpptable emits <Base>Table.h — the TABLE-wire C++ codecs
 // (SPEC-TABLES.md). One header per unit file, emitted only when the unit
 // declares tables: storage structs for the `table` declarations, then
-// measure/write/save/read codecs and reflection descriptors for the whole
+// measure/save/load codecs and reflection descriptors for the whole
 // TABLE CLOSURE (every table plus everything one references, transitively).
 //
 // The wire is neutral, evolution-tolerant TLV: field identity is the name
@@ -352,11 +352,11 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 					g.emitTableStruct(st)
 				}
 			}
-			g.pf("// ---- codecs: measure/write/save/read per closure member ----\n\n")
+			g.pf("// ---- codecs: measure/save/load per closure member ----\n\n")
 			for _, st := range members {
-				g.pf("inline int64_t TableMeasure%s( const %s & value );\n", st.Name, st.Name)
-				g.pf("inline bool TableWrite%s( TableWriter & w, const %s & value );\n", st.Name, st.Name)
-				g.pf("inline bool TableRead%s( TableReader & r, %s & value );\n", st.Name, st.Name)
+				g.pf("inline int64_t %sMeasure( const %s & value );\n", st.Name, st.Name)
+				g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value );\n", st.Name, st.Name)
+				g.pf("inline bool %sLoadBody( TableReader & r, %s & value );\n", st.Name, st.Name)
 			}
 			g.pf("\n")
 			for _, st := range members {
@@ -378,7 +378,7 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 			g.pf("\n")
 			g.pf("// ---- reflection descriptors (tables only, SPEC-TABLES.md) ----\n\n")
 			for _, st := range members {
-				g.pf("inline const TableTypeInfo * TableType%s();\n", st.Name)
+				g.pf("inline const TableTypeInfo * %sTableType();\n", st.Name)
 			}
 			g.pf("\n")
 			for _, st := range members {

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -145,6 +145,9 @@ func tableGet(width int) string { return fmt.Sprintf("get%d", width*8) }
 type tableGen struct {
 	unit           *ir.Unit
 	file           *ir.File
+	anyVariable    bool            // the unit declares at least one variable-length table
+	variable       map[string]bool // the derived VARIABLE-LENGTH members (ir.VariableTables)
+	targets        map[string]bool // tables some pointer targets (ir.PointerTargets)
 	body           strings.Builder
 	includes       map[string]bool // referenced files -> #include "<base>Table.h"
 	nativeIncludes map[string]bool // cpp_include headers of mapped types
@@ -193,8 +196,19 @@ func formatFloat(v float64, single bool) string {
 // tablePrimitives is the shared runtime, emitted into every Table.h behind a
 // per-package guard — one definition per TU whatever the include order, and a
 // lone Table.h works standalone.
-func tablePrimitives(pkg string) string {
+func tablePrimitives(pkg string, anyVariable bool) string {
 	guard := strings.ToUpper(pkg) + "_SCHEMA_TABLE_PRIMITIVES"
+	// the two pointer-era descriptor members exist only in a unit that HAS
+	// pointers: a unit of value-only tables emits the descriptor surface it
+	// always emitted, to the byte (SPEC-TABLES.md §2, the zero-cost gate)
+	pointerFieldMember, pointerTypeMember := "", ""
+	if anyVariable {
+		pointerFieldMember = "\n    bool is_pointer;        // a *T pointer field: storage is a 4-byte TableRef; the target is a table"
+		pointerTypeMember = "\n    // the DERIVED mode (SPEC-TABLES.md): false = fixed-size, a plain\n" +
+			"    // relocatable struct; true = variable-length, built through a Builder\n" +
+			"    // and read through a region root. Nobody declares it; the compiler\n" +
+			"    // works it out.\n    bool variable;"
+	}
 	return `#ifndef ` + guard + `
 #define ` + guard + `
 
@@ -225,7 +239,7 @@ struct TableFieldInfo
     const char * type_name; // schema type name, e.g. "float32", "Grade"
     uint16_t id;            // table-wire field id (name hash; the was alias's hash after a rename)
     uint8_t kind;           // table-wire kind; for arrays/strings/bytes, the ELEMENT kind
-    bool is_array;          // fixed or counted array (bytes included)
+    bool is_array;          // fixed or counted array (bytes included)` + pointerFieldMember + `
     bool counted;           // a _count/_length int32 companion exists (counted arrays, strings, bytes)
     int32_t array_bound;    // array capacity / string max length; 0 for plain scalars
     uint32_t offset;        // offsetof the storage member
@@ -245,7 +259,7 @@ struct TableTypeInfo
     const char * name;   // schema type name
     uint32_t size;       // sizeof the storage struct
     int32_t num_fields;
-    const TableFieldInfo * fields;
+    const TableFieldInfo * fields;` + pointerTypeMember + `
 };
 
 struct TableWriter
@@ -346,22 +360,14 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	if err := checkIncludeCycle(u); err != nil {
 		return nil, err
 	}
-	// the variable-length emission (arena, builder, cooked form) lands in the
-	// next unit of this round; the LANGUAGE accepts `*T` already, so refuse
-	// generation loudly rather than emitting a struct with a missing member
-	for _, name := range sortedKeys(ir.VariableTables(u)) {
-		if st := u.Tables[name]; st != nil {
-			for _, f := range st.Fields {
-				if f.Type.Pointer {
-					return nil, fmt.Errorf("table %s: pointer field %s *%s — the variable-length table backend is not emitted yet (SPEC-TABLES.md)", name, f.Name, f.Type.Name)
-				}
-			}
-		}
-	}
 	closure := ir.TableClosure(u)
+	variable := ir.VariableTables(u)
+	targets := ir.PointerTargets(u)
+	anyVariable := len(variable) > 0
 	out := map[string][]byte{}
 	for _, f := range u.Files {
-		g := &tableGen{unit: u, file: f, includes: map[string]bool{}, nativeIncludes: map[string]bool{}}
+		g := &tableGen{unit: u, file: f, anyVariable: anyVariable, variable: variable, targets: targets,
+			includes: map[string]bool{}, nativeIncludes: map[string]bool{}}
 		var members []*ir.Struct
 		members = append(members, orderTables(f.Tables)...)
 		for _, d := range f.Decls {
@@ -375,25 +381,15 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 					g.emitTableStruct(st)
 				}
 			}
-			g.pf("// ---- codecs: measure/save/load per closure member ----\n\n")
-			for _, st := range members {
-				g.pf("inline int64_t %sMeasure( const %s & value );\n", st.Name, st.Name)
-				g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value );\n", st.Name, st.Name)
-				g.pf("inline bool %sLoadBody( TableReader & r, %s & value );\n", st.Name, st.Name)
-			}
-			g.pf("\n")
+			g.emitCodecDeclarations(members)
 			for _, st := range members {
 				g.emitTableMeasure(st)
 				g.emitTableWrite(st)
 				g.emitTableSave(st)
 				g.emitTableRead(st)
 			}
-			g.pf("// ---- relocatability, enforced: the wire is a pure length-prefixed\n")
-			g.pf("// stream AND the decoded storage is pointer-free — every closure type\n")
-			g.pf("// must stay trivially copyable and standard-layout, so instances can be\n")
-			g.pf("// memcpy'd, mmap'd, shared across processes, and walked through\n")
-			g.pf("// descriptor offsets. A failure here means a pointer, virtual or\n")
-			g.pf("// non-trivial member crept into generated storage.\n")
+			g.emitVariableSurface(members)
+			g.emitRelocatabilityPreamble()
 			for _, st := range members {
 				g.pf("static_assert( std::is_trivially_copyable<%s>::value, \"%s must stay relocatable\" );\n", st.Name, st.Name)
 				g.pf("static_assert( std::is_standard_layout<%s>::value, \"%s must stay standard-layout for offsetof\" );\n", st.Name, st.Name)
@@ -417,6 +413,12 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		h.WriteString("// The TABLE wire (evolution-tolerant, SPEC-TABLES.md): no serialize\n")
 		h.WriteString("// dependency — includable from any TU.\n\n")
 		h.WriteString("#pragma once\n\n#include <cstdint>\n#include <cstring>\n#include <cstddef> // offsetof, for the reflection descriptors\n#include <new> // in-place prefill (placement new): no giant stack temporaries\n#include <type_traits> // the enforced relocatability asserts\n")
+		if anyVariable {
+			// VARIABLE-LENGTH tables only: a unit of pointer-free tables pays
+			// for neither header (SPEC-TABLES.md §2, the zero-cost gate)
+			h.WriteString("#include <cstdlib> // the arena's segments (the AUTHORING path may allocate)\n")
+			h.WriteString("#include <atomic> // one atomic per slab: the arena is lock-free by ownership\n")
+		}
 		fmt.Fprintf(&h, "\n#include \"%s.h\"\n", f.Base)
 		names := make([]string, 0, len(g.includes))
 		for n := range g.includes {
@@ -435,7 +437,11 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 			fmt.Fprintf(&h, "#include \"%s\"\n", n)
 		}
 		h.WriteString("\n")
-		h.WriteString(tablePrimitives(u.Package))
+		h.WriteString(tablePrimitives(u.Package, anyVariable))
+		if anyVariable {
+			h.WriteString("\n")
+			h.WriteString(tableArenaRuntime(u.Package))
+		}
 		fmt.Fprintf(&h, "\nnamespace %s {\n\n", u.Package)
 		h.WriteString(g.body.String())
 		fmt.Fprintf(&h, "} // namespace %s\n", u.Package)

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -128,6 +128,17 @@ func tableKindWidth(kind int) int {
 	return 0
 }
 
+// sortedKeys returns a set's members in a stable order — generated output and
+// diagnostics must never depend on map iteration.
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func tablePut(width int) string { return fmt.Sprintf("put%d", width*8) }
 func tableGet(width int) string { return fmt.Sprintf("get%d", width*8) }
 
@@ -334,6 +345,18 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 	}
 	if err := checkIncludeCycle(u); err != nil {
 		return nil, err
+	}
+	// the variable-length emission (arena, builder, cooked form) lands in the
+	// next unit of this round; the LANGUAGE accepts `*T` already, so refuse
+	// generation loudly rather than emitting a struct with a missing member
+	for _, name := range sortedKeys(ir.VariableTables(u)) {
+		if st := u.Tables[name]; st != nil {
+			for _, f := range st.Fields {
+				if f.Type.Pointer {
+					return nil, fmt.Errorf("table %s: pointer field %s *%s — the variable-length table backend is not emitted yet (SPEC-TABLES.md)", name, f.Name, f.Type.Name)
+				}
+			}
+		}
 	}
 	closure := ir.TableClosure(u)
 	out := map[string][]byte{}

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -143,6 +143,11 @@ func (g *tableGen) emitPointerTargetSurface(st *ir.Struct) {
 	g.pf("inline const %s * %sAt( const TableRegionCtx &, const TableRef & ref ) { return %sAt( ref ); }\n", n, n, n)
 	g.pf("inline const %s * %sAt( const TableArenaCtx & ctx, const TableRef & ref )\n{\n", n, n)
 	g.pf("    return ref.value != 0 ? (const %s *) TableArenaAt( *ctx.arena, ref.value ) : NULL;\n}\n", n)
+	g.pf("// while the builder is mutable, resolve against the arena itself\n")
+	g.pf("inline %s * %sAt( TableArena & arena, const TableRef & ref )\n{\n", n, n)
+	g.pf("    return ref.value != 0 ? (%s *) TableArenaAt( arena, ref.value ) : NULL;\n}\n", n)
+	g.pf("inline const %s * %sAt( const TableArena & arena, const TableRef & ref )\n{\n", n, n)
+	g.pf("    return ref.value != 0 ? (const %s *) TableArenaAt( arena, ref.value ) : NULL;\n}\n", n)
 	g.pf("// bump one %s into the caller's exact region; the slot comes out self-relative\n", n)
 	g.pf("inline %s * %sEmplace( TableRegionSink & sink, TableRef & slot )\n{\n", n, n)
 	g.pf("    int64_t at = TableAlignUp64( sink.used );\n")
@@ -386,10 +391,10 @@ func (g *tableGen) emitOpenWalk(st *ir.Struct) {
 	ptrs := pointerFields(st)
 	nested := g.byValueVariableFields(st)
 	counted := countedCompanions(st)
-	if len(ptrs) == 0 && len(nested) == 0 && len(counted) == 0 {
-		g.pf("    (void) node; (void) base; (void) bytes; // no references and no counts to bound\n")
-		g.pf("    return true;\n}\n\n")
-		return
+	if len(ptrs) == 0 && len(nested) == 0 {
+		// nothing here addresses the region: only the count companions bound a
+		// traversal, and those are read out of the node itself
+		g.pf("    (void) base; (void) bytes;\n")
 	}
 	for _, c := range counted {
 		g.pf("    if ( node->%s < 0 || node->%s > %d ) { return false; } // %s\n", c.companion, c.companion, c.bound, c.field)

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -141,10 +141,18 @@ func (g *tableGen) emitCodecDeclarations(members []*ir.Struct) {
 			g.pf("template <typename Ctx> inline bool %sPack( const Ctx & ctx, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );\n", st.Name, st.Name, st.Name)
 			g.pf("inline int64_t %sLoadMeasureBody( TableReader & r, int32_t depth );\n", st.Name)
 		}
-		// EVERY closure member gets an Open walk, not only the ones pointers
-		// reach: a fixed table or a plain type nested by value carries count
-		// companions, and an unbounded one is an over-read waiting for the first
-		// reflection walker (SPEC-TABLES.md §7)
+		g.pf("\n")
+	}
+	// EVERY closure member this file DECLARES gets an Open walk — not only the
+	// ones pointers reach, and not only in files that declare a variable table.
+	// A fixed table or a plain type nested by value carries count companions,
+	// and an unbounded one is an over-read waiting for the first reflection
+	// walker (SPEC-TABLES.md §7). The DECLARING file is the single home for
+	// each walk, so a file that references one across the unit picks it up
+	// through the Table header it already includes — which is why this is
+	// keyed on the UNIT having pointers, never on this file having them.
+	if g.anyVariable && len(members) > 0 {
+		g.pf("// ---- the cooked form's bounds walks (SPEC-TABLES.md §7) ----\n\n")
 		for _, st := range members {
 			g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int64_t & watermark, int32_t depth );\n", st.Name, st.Name)
 		}
@@ -187,15 +195,16 @@ func (g *tableGen) emitPointerTargetSurface(st *ir.Struct) {
 // ---- the walkers and the public variable-length surface ----
 
 func (g *tableGen) emitVariableSurface(members []*ir.Struct) {
-	vars := g.varMembers(members)
-	if len(vars) == 0 {
+	if !g.anyVariable {
 		return
 	}
-	for _, st := range vars {
+	for _, st := range g.varMembers(members) {
 		g.emitPackMeasure(st)
 		g.emitPack(st)
 		g.emitLoadMeasureBody(st)
 	}
+	// every member THIS FILE declares, whether or not this file declares a
+	// variable table: a sibling file's table may nest one of these by value
 	for _, st := range members {
 		g.emitOpenWalk(st)
 	}
@@ -448,19 +457,29 @@ func unionFields(st *ir.Struct) []*ir.Field {
 // PACK AND THIS WALK MUST KEEP THE SAME ORDER. Neither may be reordered
 // without the other; the invariant is stated at both sites for that reason.
 func (g *tableGen) emitOpenWalk(st *ir.Struct) {
+	ptrs := pointerFields(st)
 	g.pf("// %sOpenWalk: validate the REFERENCE GRAPH and the counts that bound a\n", st.Name)
 	g.pf("// traversal of it — no field value is read, no payload is decoded.\n")
 	g.pf("//\n")
-	g.pf("// The watermark is the termination proof. %sPack lays nodes out in PRE-ORDER\n", st.Name)
-	g.pf("// by bump allocation and this walk visits them in the SAME ORDER, so a\n")
-	g.pf("// genuine region always satisfies `at >= watermark`. Requiring it makes the\n")
-	g.pf("// walk consume region bytes monotonically: linear in the region, immune to a\n")
-	g.pf("// forged file whose references alias forward (which without it costs 2^n),\n")
-	g.pf("// and closed to mid-node overlaps a range check alone would admit.\n")
-	g.pf("// NEITHER THIS ORDER NOR PACK'S MAY CHANGE ALONE.\n")
+	if len(ptrs) > 0 {
+		g.pf("// The watermark is the termination proof. %sPack lays nodes out in PRE-ORDER\n", st.Name)
+		g.pf("// by bump allocation and this walk visits them in the SAME ORDER, so a\n")
+		g.pf("// genuine region always satisfies `at >= watermark`. Requiring it makes the\n")
+		g.pf("// walk consume region bytes monotonically: linear in the region, immune to a\n")
+		g.pf("// forged file whose references alias forward (which without it costs 2^n),\n")
+		g.pf("// and closed to mid-node overlaps a range check alone would admit.\n")
+		g.pf("// NEITHER THIS ORDER NOR PACK'S MAY CHANGE ALONE.\n")
+	} else {
+		g.pf("// %s holds no reference of its own, so it neither reads the watermark nor\n", st.Name)
+		g.pf("// advances it: its placement in the region is decided entirely by the pack\n")
+		g.pf("// of whatever variable table nests it, and the mark passes through here\n")
+		g.pf("// untouched. What this walk owes is the COUNT COMPANIONS — a member nested\n")
+		g.pf("// by value carries bounds that any traversal trusts, and an unbounded one\n")
+		g.pf("// is the over-read. That is why it is emitted even for a table nothing\n")
+		g.pf("// points at, in a file that declares no variable table at all.\n")
+	}
 	g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int64_t & watermark, int32_t depth )\n{\n", st.Name, st.Name)
 	g.pf("    if ( node == NULL || depth > kTableMaxDepth ) { return false; }\n")
-	ptrs := pointerFields(st)
 	nested := byValueStructFields(st)
 	unions := unionFields(st)
 	counted := countedCompanions(st)

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -1,4 +1,4 @@
-// The per-table VARIABLE-LENGTH surface (SPEC-TABLES.md §2, §7): the
+// The per-table VARIABLE-LENGTH surface (SPEC-TABLES.md §2, §6, §9): the
 // allocation accessors, the pack walkers behind Lock and Cook, the wire
 // sizing pre-pass behind Load, the cooked form's bounds walk behind Open, and
 // the Builder itself.
@@ -454,7 +454,7 @@ func countedCompanions(st *ir.Struct) []companion {
 
 func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	n := st.Name
-	g.pf("// ---- %s: the variable-length life (SPEC-TABLES.md §2, §7) ----\n", n)
+	g.pf("// ---- %s: the variable-length life (SPEC-TABLES.md §2, §6, §9) ----\n", n)
 	g.pf("//\n")
 	g.pf("// MUTABLE: %sBuilder — allocate nodes, wire them together, then Lock.\n", n)
 	g.pf("// CONST:   one packed region, root at its base. Lock produces it and Load\n")
@@ -587,7 +587,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    return %sLoadBody( r, builder.main, *root, 1 );\n}\n\n", n)
 
 	// cooked form
-	g.pf("// ---- %s cooked: the region form (SPEC-TABLES.md §6) ----\n", n)
+	g.pf("// ---- %s cooked: the region form (SPEC-TABLES.md §7) ----\n", n)
 	g.pf("//\n")
 	g.pf("// One requirement: load a big file, point at its root, without copying it\n")
 	g.pf("// and without parsing it. The cooked form is the structure laid out exactly\n")

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -1,0 +1,747 @@
+// The per-table VARIABLE-LENGTH surface (SPEC-TABLES.md §2, §7): the
+// allocation accessors, the pack walkers behind Lock and Cook, the wire
+// sizing pre-pass behind Load, the cooked form's bounds walk behind Open, and
+// the Builder itself.
+//
+// Nothing here is emitted for a FIXED-SIZE table. A table whose by-value
+// closure holds no pointer gets its struct and its three free functions —
+// <Name>Measure, <Name>Save, <Name>Load — and not one byte more, which is the
+// point of deriving the mode instead of declaring it.
+package cpptable
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// ---- mode helpers: what a call site must pass ----
+
+func (g *tableGen) isVar(name string) bool { return g.variable[name] }
+
+// measureCall renders a nested MEASURE call on a closure member: a variable
+// member takes the resolution context and the depth, a fixed one takes
+// neither — so a fixed table's codec is character-for-character what it was
+// before pointers existed.
+func (g *tableGen) measureCall(name, expr string) string {
+	if g.isVar(name) {
+		return fmt.Sprintf("%sMeasureBody( ctx, %s, depth + 1 )", name, expr)
+	}
+	return fmt.Sprintf("%sMeasure( %s )", name, expr)
+}
+
+func (g *tableGen) saveCall(name, expr string) string {
+	if g.isVar(name) {
+		return fmt.Sprintf("%sSaveBody( ctx, w, %s, depth + 1 )", name, expr)
+	}
+	return fmt.Sprintf("%sSaveBody( w, %s )", name, expr)
+}
+
+func (g *tableGen) loadCall(name, reader, expr string) string {
+	if g.isVar(name) {
+		return fmt.Sprintf("%sLoadBody( %s, sink, %s, depth + 1 )", name, reader, expr)
+	}
+	return fmt.Sprintf("%sLoadBody( %s, %s )", name, reader, expr)
+}
+
+// walker returns true when a member needs the pointer-graph walkers: every
+// variable member, plus every table some pointer targets (a pointed-at table
+// may itself be pointer-free, and still needs to be allocated, packed,
+// measured and bounds-walked).
+func (g *tableGen) needsWalkers(name string) bool { return g.variable[name] || g.targets[name] }
+
+// varMembers filters a file's closure members down to those needing the
+// variable-length surface, in emission order.
+func (g *tableGen) varMembers(members []*ir.Struct) []*ir.Struct {
+	var out []*ir.Struct
+	for _, st := range members {
+		if g.needsWalkers(st.Name) {
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
+// pointerFields returns a member's pointer fields, in declaration order.
+func pointerFields(st *ir.Struct) []*ir.Field {
+	var out []*ir.Field
+	for _, f := range st.Fields {
+		if f.Type.Pointer {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// byValueVariableFields returns the fields that nest a VARIABLE table by
+// value — directly or as a bounded array. Their pointer slots live inside the
+// owner's storage, so every walk has to descend into them.
+func (g *tableGen) byValueVariableFields(st *ir.Struct) []*ir.Field {
+	var out []*ir.Field
+	for _, f := range st.Fields {
+		if f.Type.Pointer || f.Type.Kind != ir.TNamed {
+			continue
+		}
+		if ref, ok := f.Type.Ref.(*ir.Struct); ok && g.isVar(ref.Name) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ---- declarations ----
+
+func (g *tableGen) emitCodecDeclarations(members []*ir.Struct) {
+	if vars := g.varMembers(members); len(vars) > 0 {
+		g.pf("// ---- pointer targets: allocation and resolution (SPEC-TABLES.md §2) ----\n")
+		g.pf("//\n")
+		g.pf("// A reference resolves differently in the two forms, and the CONTEXT says\n")
+		g.pf("// which: in the arena it is an offset; in a region it is a self-relative\n")
+		g.pf("// delta, so the const deref below is one add and needs no base pointer.\n\n")
+		for _, st := range members {
+			if !g.targets[st.Name] {
+				continue
+			}
+			g.emitPointerTargetSurface(st)
+		}
+	}
+	g.pf("// ---- codecs: measure/save/load per closure member ----\n\n")
+	for _, st := range members {
+		if g.isVar(st.Name) {
+			g.pf("template <typename Ctx> inline int64_t %sMeasureBody( const Ctx & ctx, const %s & value, int32_t depth );\n", st.Name, st.Name)
+			g.pf("template <typename Ctx> inline bool %sSaveBody( const Ctx & ctx, TableWriter & w, const %s & value, int32_t depth );\n", st.Name, st.Name)
+			g.pf("template <typename Sink> inline bool %sLoadBody( TableReader & r, Sink & sink, %s & value, int32_t depth );\n", st.Name, st.Name)
+			continue
+		}
+		g.pf("inline int64_t %sMeasure( const %s & value );\n", st.Name, st.Name)
+		g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value );\n", st.Name, st.Name)
+		g.pf("inline bool %sLoadBody( TableReader & r, %s & value );\n", st.Name, st.Name)
+	}
+	g.pf("\n")
+	if vars := g.varMembers(members); len(vars) > 0 {
+		g.pf("// ---- pointer-graph walkers: pack (Lock/Cook), size (Load), bound (Open) ----\n\n")
+		for _, st := range vars {
+			g.pf("template <typename Ctx> inline int64_t %sPackMeasure( const Ctx & ctx, const %s & value, int32_t depth );\n", st.Name, st.Name)
+			g.pf("template <typename Ctx> inline bool %sPack( const Ctx & ctx, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );\n", st.Name, st.Name, st.Name)
+			g.pf("inline int64_t %sLoadMeasureBody( TableReader & r, int32_t depth );\n", st.Name)
+			g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int32_t depth );\n", st.Name, st.Name)
+		}
+		g.pf("\n")
+	}
+}
+
+// emitPointerTargetSurface emits one pointed-at table's resolution and
+// allocation entries.
+func (g *tableGen) emitPointerTargetSurface(st *ir.Struct) {
+	n := st.Name
+	g.pf("// %s is a pointer target.\n", n)
+	g.pf("inline const %s * %sAt( const TableRef & ref ) // the const form's hot path: one add, no base\n{\n", n, n)
+	g.pf("    return ref.value != 0 ? (const %s *) ( (const uint8_t *) &ref + (int32_t) ref.value ) : NULL;\n}\n", n)
+	g.pf("inline %s * %sAt( TableRef & ref )\n{\n", n, n)
+	g.pf("    return ref.value != 0 ? (%s *) ( (uint8_t *) &ref + (int32_t) ref.value ) : NULL;\n}\n", n)
+	g.pf("inline const %s * %sAt( const TableRegionCtx &, const TableRef & ref ) { return %sAt( ref ); }\n", n, n, n)
+	g.pf("inline const %s * %sAt( const TableArenaCtx & ctx, const TableRef & ref )\n{\n", n, n)
+	g.pf("    return ref.value != 0 ? (const %s *) TableArenaAt( *ctx.arena, ref.value ) : NULL;\n}\n", n)
+	g.pf("// bump one %s into the caller's exact region; the slot comes out self-relative\n", n)
+	g.pf("inline %s * %sEmplace( TableRegionSink & sink, TableRef & slot )\n{\n", n, n)
+	g.pf("    int64_t at = TableAlignUp64( sink.used );\n")
+	g.pf("    if ( at + (int64_t) sizeof( %s ) > sink.capacity ) { return NULL; }\n", n)
+	g.pf("    sink.used = at + TableAlignUp64( (int64_t) sizeof( %s ) );\n", n)
+	g.pf("    %s * node = new ( sink.base + at ) %s{};\n", n, n)
+	g.pf("    slot.value = (uint32_t) ( ( sink.base + at ) - (uint8_t *) &slot );\n")
+	g.pf("    return node;\n}\n")
+	g.pf("// allocate one %s in the arena; the slot holds the arena offset\n", n)
+	g.pf("inline %s * %sEmplace( TableWorker & worker, TableRef & slot )\n{\n", n, n)
+	g.pf("    TableSlot<%s> allocated = worker.Alloc<%s>();\n", n, n)
+	g.pf("    slot = allocated.ref;\n")
+	g.pf("    return allocated.ptr;\n}\n\n")
+}
+
+// ---- the walkers and the public variable-length surface ----
+
+func (g *tableGen) emitVariableSurface(members []*ir.Struct) {
+	vars := g.varMembers(members)
+	if len(vars) == 0 {
+		return
+	}
+	for _, st := range vars {
+		g.emitPackMeasure(st)
+		g.emitPack(st)
+		g.emitLoadMeasureBody(st)
+		g.emitOpenWalk(st)
+	}
+	for _, st := range members {
+		if g.isVar(st.Name) {
+			g.emitBuilderAndPublicSurface(st)
+		}
+	}
+}
+
+// emitPackMeasure emits the exact byte count of a value's DESCENDANT nodes in
+// the packed form — Lock's and Cook's sizing half.
+func (g *tableGen) emitPackMeasure(st *ir.Struct) {
+	g.pf("// %sPackMeasure: the packed region bytes of everything %s POINTS AT.\n", st.Name, st.Name)
+	g.pf("// Aliasing is not preserved: two pointers to one node pack as two nodes,\n")
+	g.pf("// exactly as they ride the wire as two bodies (SPEC-TABLES.md §3).\n")
+	g.pf("template <typename Ctx>\ninline int64_t %sPackMeasure( const Ctx & ctx, const %s & value, int32_t depth )\n{\n", st.Name, st.Name)
+	g.pf("    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap\n")
+	g.pf("    int64_t bytes = 0;\n")
+	if len(pointerFields(st)) == 0 && len(g.byValueVariableFields(st)) == 0 {
+		g.pf("    (void) ctx; (void) value; // no pointers below this node\n")
+	}
+	for _, f := range pointerFields(st) {
+		t := f.Type.Name
+		g.pf("    {\n")
+		g.pf("        const %s * pointee = %sAt( ctx, value.%s ); // %s\n", t, t, f.Name, f.Name)
+		g.pf("        if ( pointee != NULL )\n        {\n")
+		if g.needsWalkers(t) {
+			g.pf("            int64_t inner = %sPackMeasure( ctx, *pointee, depth + 1 );\n", t)
+			g.pf("            if ( inner < 0 ) { return -1; }\n")
+			g.pf("            bytes += TableAlignUp64( (int64_t) sizeof( %s ) ) + inner;\n", t)
+		} else {
+			g.pf("            bytes += TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
+		}
+		g.pf("        }\n    }\n")
+	}
+	for _, f := range g.byValueVariableFields(st) {
+		g.emitVariableByValueWalk(f, func(expr string) {
+			g.pf("        int64_t inner = %sPackMeasure( ctx, %s, depth );\n", f.Type.Name, expr)
+			g.pf("        if ( inner < 0 ) { return -1; }\n")
+			g.pf("        bytes += inner;\n")
+		})
+	}
+	g.pf("    return bytes;\n}\n\n")
+}
+
+// emitVariableByValueWalk emits the loop shape for descending into a by-value
+// nested variable table, scalar or array, and calls body with the element
+// expression.
+func (g *tableGen) emitVariableByValueWalk(f *ir.Field, body func(expr string)) {
+	switch f.Array {
+	case ir.ArrayNone:
+		g.pf("    { // %s (nested by value)\n", f.Name)
+		body("value." + f.Name)
+		g.pf("    }\n")
+	case ir.ArrayCounted:
+		g.pf("    for ( int32_t i = 0; i < value.%s_count && i < %d; i++ ) // %s\n    {\n", f.Name, f.ArrayBound, f.Name)
+		body(fmt.Sprintf("value.%s[i]", f.Name))
+		g.pf("    }\n")
+	default:
+		g.pf("    for ( int32_t i = 0; i < %d; i++ ) // %s\n    {\n", f.ArrayBound, f.Name)
+		body(fmt.Sprintf("value.%s[i]", f.Name))
+		g.pf("    }\n")
+	}
+}
+
+// emitPack copies one node into the packed region and lays its pointees out
+// depth-first behind it, rewriting every reference into the region's
+// self-relative encoding.
+func (g *tableGen) emitPack(st *ir.Struct) {
+	g.pf("// %sPack: copy src into dst (already placed), then lay every pointee out\n", st.Name)
+	g.pf("// depth-first behind it. A child always lands AFTER the slot naming it, so\n")
+	g.pf("// region deltas are strictly positive and a packed region cannot contain a\n")
+	g.pf("// cycle — which is what makes %sOpenWalk cycle-free without a visited set.\n", st.Name)
+	g.pf("template <typename Ctx>\ninline bool %sPack( const Ctx & ctx, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )\n{\n", st.Name, st.Name, st.Name)
+	g.pf("    if ( depth > kTableMaxDepth ) { return false; }\n")
+	g.pf("    memcpy( (void *) &dst, (const void *) &src, sizeof( %s ) ); // trivially copyable, by construction\n", st.Name)
+	if len(pointerFields(st)) == 0 && len(g.byValueVariableFields(st)) == 0 {
+		g.pf("    (void) ctx; (void) base; (void) capacity; (void) used;\n")
+	}
+	for _, f := range pointerFields(st) {
+		t := f.Type.Name
+		g.pf("    {\n")
+		g.pf("        dst.%s.value = 0; // %s\n", f.Name, f.Name)
+		g.pf("        const %s * pointee = %sAt( ctx, src.%s );\n", t, t, f.Name)
+		g.pf("        if ( pointee != NULL )\n        {\n")
+		g.pf("            int64_t at = TableAlignUp64( used );\n")
+		g.pf("            if ( at + (int64_t) sizeof( %s ) > capacity ) { return false; }\n", t)
+		g.pf("            used = at + TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
+		g.pf("            %s * child = new ( base + at ) %s{};\n", t, t)
+		g.pf("            dst.%s.value = (uint32_t) ( ( base + at ) - (const uint8_t *) &dst.%s );\n", f.Name, f.Name)
+		if g.needsWalkers(t) {
+			g.pf("            if ( !%sPack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }\n", t)
+		} else {
+			g.pf("            memcpy( (void *) child, (const void *) pointee, sizeof( %s ) );\n", t)
+		}
+		g.pf("        }\n    }\n")
+	}
+	for _, f := range g.byValueVariableFields(st) {
+		g.emitVariableByValueWalkPack(f)
+	}
+	g.pf("    return true;\n}\n\n")
+}
+
+func (g *tableGen) emitVariableByValueWalkPack(f *ir.Field) {
+	t := f.Type.Name
+	call := func(srcExpr, dstExpr string) {
+		g.pf("        if ( !%sPack( ctx, %s, %s, base, capacity, used, depth ) ) { return false; }\n", t, srcExpr, dstExpr)
+	}
+	switch f.Array {
+	case ir.ArrayNone:
+		g.pf("    { // %s (nested by value)\n", f.Name)
+		call("src."+f.Name, "dst."+f.Name)
+		g.pf("    }\n")
+	case ir.ArrayCounted:
+		g.pf("    for ( int32_t i = 0; i < src.%s_count && i < %d; i++ ) // %s\n    {\n", f.Name, f.ArrayBound, f.Name)
+		call(fmt.Sprintf("src.%s[i]", f.Name), fmt.Sprintf("dst.%s[i]", f.Name))
+		g.pf("    }\n")
+	default:
+		g.pf("    for ( int32_t i = 0; i < %d; i++ ) // %s\n    {\n", f.ArrayBound, f.Name)
+		call(fmt.Sprintf("src.%s[i]", f.Name), fmt.Sprintf("dst.%s[i]", f.Name))
+		g.pf("    }\n")
+	}
+}
+
+// emitLoadMeasureBody emits the wire sizing pre-pass: how many region bytes
+// the nodes BELOW this body will need. Skip-based — it reads framing and
+// nothing else, which is what lets a caller own the allocation (SPEC §7).
+func (g *tableGen) emitLoadMeasureBody(st *ir.Struct) {
+	ptrs := pointerFields(st)
+	nested := g.byValueVariableFields(st)
+	g.pf("// %sLoadMeasureBody: region bytes for the nodes under this wire body.\n", st.Name)
+	g.pf("// Framing only — no field value is decoded, so a caller can size its\n")
+	g.pf("// buffer before a single byte is placed.\n")
+	g.pf("inline int64_t %sLoadMeasureBody( TableReader & r, int32_t depth )\n{\n", st.Name)
+	g.pf("    int64_t bytes = 0;\n")
+	if len(ptrs) == 0 && len(nested) == 0 {
+		g.pf("    (void) r; (void) depth; // nothing below this body allocates\n")
+		g.pf("    return bytes;\n}\n\n")
+		return
+	}
+	g.pf("    for ( ;; )\n    {\n")
+	g.pf("        if ( !r.has( 2 ) ) { return bytes; }\n")
+	g.pf("        uint16_t field_id = r.get16();\n")
+	g.pf("        if ( field_id == 0 ) { return bytes; }\n")
+	g.pf("        if ( !r.has( 1 ) ) { return bytes; }\n")
+	g.pf("        uint8_t kind = r.get8();\n")
+	g.pf("        switch ( field_id )\n        {\n")
+	for _, f := range ptrs {
+		t := f.Type.Name
+		g.pf("            case 0x%04x: // %s (*%s)\n            {\n", ir.TableFieldId(f), f.Name, t)
+		g.pf("                if ( kind != %d ) { if ( !r.skip( kind ) ) { return bytes; } break; }\n", tkTable)
+		g.pf("                if ( !r.has( 4 ) ) { return bytes; }\n")
+		g.pf("                uint32_t body_len = r.get32();\n")
+		g.pf("                if ( !r.has( body_len ) ) { return bytes; }\n")
+		g.pf("                if ( depth < kTableMaxDepth )\n                {\n")
+		g.pf("                    bytes += TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
+		if g.needsWalkers(t) {
+			g.pf("                    TableReader sub( r.buffer + r.offset, body_len, r.report );\n")
+			g.pf("                    bytes += %sLoadMeasureBody( sub, depth + 1 );\n", t)
+		}
+		g.pf("                }\n")
+		g.pf("                r.offset += body_len;\n")
+		g.pf("                break;\n            }\n")
+	}
+	for _, f := range nested {
+		t := f.Type.Name
+		wireKind := tkTable
+		if f.Array != ir.ArrayNone {
+			wireKind = tkArray
+		}
+		g.pf("            case 0x%04x: // %s (%s nested by value)\n            {\n", ir.TableFieldId(f), f.Name, t)
+		g.pf("                if ( kind != %d ) { if ( !r.skip( kind ) ) { return bytes; } break; }\n", wireKind)
+		g.pf("                if ( !r.has( 4 ) ) { return bytes; }\n")
+		g.pf("                uint32_t body_len = r.get32();\n")
+		g.pf("                if ( !r.has( body_len ) ) { return bytes; }\n")
+		g.pf("                int64_t body_end = r.offset + body_len;\n")
+		if f.Array == ir.ArrayNone {
+			g.pf("                {\n")
+			g.pf("                    TableReader sub( r.buffer + r.offset, body_len, r.report );\n")
+			g.pf("                    bytes += %sLoadMeasureBody( sub, depth );\n", t)
+			g.pf("                }\n")
+		} else {
+			g.pf("                if ( body_len >= 3 )\n                {\n")
+			g.pf("                    r.get8(); // element kind\n")
+			g.pf("                    uint16_t count = r.get16();\n")
+			g.pf("                    TableReader elems( r.buffer + r.offset, body_end - r.offset, r.report );\n")
+			g.pf("                    for ( uint16_t i = 0; i < count && i < %d; i++ )\n                    {\n", f.ArrayBound)
+			g.pf("                        if ( !elems.has( 4 ) ) { break; }\n")
+			g.pf("                        uint32_t elem_len = elems.get32();\n")
+			g.pf("                        if ( !elems.has( elem_len ) ) { break; }\n")
+			g.pf("                        TableReader elem( elems.buffer + elems.offset, elem_len, r.report );\n")
+			g.pf("                        bytes += %sLoadMeasureBody( elem, depth );\n", t)
+			g.pf("                        elems.offset += elem_len;\n")
+			g.pf("                    }\n")
+			g.pf("                }\n")
+		}
+		g.pf("                r.offset = body_end;\n")
+		g.pf("                break;\n            }\n")
+	}
+	g.pf("            default:\n            {\n")
+	g.pf("                if ( !r.skip( kind ) ) { return bytes; }\n")
+	g.pf("                break;\n            }\n")
+	g.pf("        }\n    }\n}\n\n")
+}
+
+// emitOpenWalk emits the cooked form's bounds walk: reads-validate-always,
+// applied to the only thing a cooked region can lie about — its offset graph.
+func (g *tableGen) emitOpenWalk(st *ir.Struct) {
+	g.pf("// %sOpenWalk: the cooked form's validation. It visits the REFERENCE GRAPH —\n", st.Name)
+	g.pf("// every pointer slot and the count companions that bound a traversal — and\n")
+	g.pf("// nothing else: no field value is read, no payload is decoded. That is what\n")
+	g.pf("// separates \"validate before pointing\" from \"parse the whole thing\".\n")
+	g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int32_t depth )\n{\n", st.Name, st.Name)
+	g.pf("    if ( node == NULL || depth > kTableMaxDepth ) { return false; }\n")
+	ptrs := pointerFields(st)
+	nested := g.byValueVariableFields(st)
+	counted := countedCompanions(st)
+	if len(ptrs) == 0 && len(nested) == 0 && len(counted) == 0 {
+		g.pf("    (void) node; (void) base; (void) bytes; // no references and no counts to bound\n")
+		g.pf("    return true;\n}\n\n")
+		return
+	}
+	for _, c := range counted {
+		g.pf("    if ( node->%s < 0 || node->%s > %d ) { return false; } // %s\n", c.companion, c.companion, c.bound, c.field)
+	}
+	for _, f := range ptrs {
+		t := f.Type.Name
+		g.pf("    {\n")
+		g.pf("        uint32_t delta = node->%s.value; // %s\n", f.Name, f.Name)
+		g.pf("        if ( delta != 0 )\n        {\n")
+		g.pf("            if ( (int32_t) delta <= 0 ) { return false; } // a packed reference is strictly forward\n")
+		g.pf("            int64_t at = ( (const uint8_t *) &node->%s - base ) + (int64_t) delta;\n", f.Name)
+		g.pf("            if ( at < 0 || ( at & ( kTableAlign - 1 ) ) != 0 ) { return false; }\n")
+		g.pf("            if ( at + (int64_t) sizeof( %s ) > bytes ) { return false; }\n", t)
+		if g.needsWalkers(t) {
+			g.pf("            if ( !%sOpenWalk( (const %s *) ( base + at ), base, bytes, depth + 1 ) ) { return false; }\n", t, t)
+		}
+		g.pf("        }\n    }\n")
+	}
+	for _, f := range nested {
+		t := f.Type.Name
+		switch f.Array {
+		case ir.ArrayNone:
+			g.pf("    if ( !%sOpenWalk( &node->%s, base, bytes, depth ) ) { return false; }\n", t, f.Name)
+		case ir.ArrayCounted:
+			g.pf("    for ( int32_t i = 0; i < node->%s_count && i < %d; i++ )\n", f.Name, f.ArrayBound)
+			g.pf("    {\n        if ( !%sOpenWalk( &node->%s[i], base, bytes, depth ) ) { return false; }\n    }\n", t, f.Name)
+		default:
+			g.pf("    for ( int32_t i = 0; i < %d; i++ )\n", f.ArrayBound)
+			g.pf("    {\n        if ( !%sOpenWalk( &node->%s[i], base, bytes, depth ) ) { return false; }\n    }\n", t, f.Name)
+		}
+	}
+	g.pf("    return true;\n}\n\n")
+}
+
+type companion struct {
+	field     string
+	companion string
+	bound     int64
+}
+
+// countedCompanions lists a member's _count/_length companions and their
+// declared bounds — the values a traversal trusts, so the values Open checks.
+func countedCompanions(st *ir.Struct) []companion {
+	var out []companion
+	for _, f := range st.Fields {
+		switch {
+		case f.Type.Kind == ir.TString, f.Type.Kind == ir.TBytes:
+			out = append(out, companion{f.Name, f.Name + "_length", f.Type.Size})
+		case f.Array == ir.ArrayCounted:
+			out = append(out, companion{f.Name, f.Name + "_count", f.ArrayBound})
+		}
+	}
+	return out
+}
+
+// ---- the builder and the public surface ----
+
+func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
+	n := st.Name
+	g.pf("// ---- %s: the variable-length life (SPEC-TABLES.md §2, §7) ----\n", n)
+	g.pf("//\n")
+	g.pf("// MUTABLE: %sBuilder — allocate nodes, wire them together, then Lock.\n", n)
+	g.pf("// CONST:   one packed region, root at its base. Lock produces it and Load\n")
+	g.pf("//          produces it, so a locked structure and a loaded one are the\n")
+	g.pf("//          SAME representation with one view API. There is no unlock:\n")
+	g.pf("//          re-editing means loading the const form into a fresh builder.\n")
+	g.pf("// %s is never held by value — a file-format-scale structure is a region\n", n)
+	g.pf("// and a root pointer, not a struct you copy.\n\n")
+
+	g.pf("// The cooked form's build lock: the schema's packed-layout facts mixed with\n")
+	g.pf("// this build's own sizeof for every type in the closure, so schema drift AND\n")
+	g.pf("// ABI drift both refuse at Open.\n")
+	g.pf("inline constexpr uint32_t %sLayoutId =\n    0x%08xu", n, g.layoutSchemaHash(st))
+	for i, dep := range g.layoutClosure(st) {
+		g.pf("\n    ^ ( (uint32_t) sizeof( %s ) * 0x%08xu )", dep, layoutMixer(i))
+	}
+	g.pf(";\n\n")
+
+	g.pf("struct %sBuilder\n{\n", n)
+	g.pf("    TableArena arena;\n")
+	g.pf("    TableWorker main;      // the calling thread's allocation front\n")
+	g.pf("    TableRef root_ref;\n")
+	g.pf("    uint8_t * region = NULL; // the packed const form, produced by Lock()\n")
+	g.pf("    int64_t region_bytes = 0;\n\n")
+	g.pf("    %sBuilder()\n    {\n", n)
+	g.pf("        TableArenaInit( arena );\n")
+	g.pf("        main.arena = &arena;\n")
+	g.pf("        TableSlot<%s> slot = main.Alloc<%s>();\n", n, n)
+	g.pf("        root_ref = slot.ref;\n")
+	g.pf("    }\n")
+	g.pf("    ~%sBuilder() { TableArenaShutdown( arena ); free( region ); }\n", n)
+	g.pf("    %sBuilder( const %sBuilder & ) = delete;\n", n, n)
+	g.pf("    %sBuilder & operator=( const %sBuilder & ) = delete;\n\n", n, n)
+	g.pf("    // Alloc a node in THIS thread's slab: no lock, no atomic per node.\n")
+	g.pf("    // The result is usable both as the node pointer and as the reference\n")
+	g.pf("    // to store in a pointer field.\n")
+	g.pf("    template <typename T> TableSlot<T> Alloc() { return main.Alloc<T>(); }\n")
+	g.pf("    // one worker per thread; allocate on your own, and synchronize your own\n")
+	g.pf("    // writes to nodes another worker allocated\n")
+	g.pf("    TableWorker Worker() { TableWorker worker; worker.arena = &arena; return worker; }\n\n")
+	g.pf("    %s * Root() { return arena.locked ? NULL : (%s *) TableArenaAt( arena, root_ref.value ); }\n", n, n)
+	g.pf("    bool Locked() const { return arena.locked; }\n")
+	g.pf("    const %s * Const() const { return (const %s *) region; }\n", n, n)
+	g.pf("    const uint8_t * Region() const { return region; }\n")
+	g.pf("    int64_t RegionBytes() const { return region_bytes; }\n\n")
+	g.pf("    // Lock is ONE WAY and it is the compaction: the segmented arena becomes\n")
+	g.pf("    // one exact-packed region with zero slack, references rewritten\n")
+	g.pf("    // self-relative, and the mutable life released. Single-threaded: call\n")
+	g.pf("    // it after the workers have joined.\n")
+	g.pf("    bool Lock();\n")
+	g.pf("};\n\n")
+
+	g.pf("inline bool %sBuilder::Lock()\n{\n", n)
+	g.pf("    if ( arena.locked ) { return region != NULL; }\n")
+	g.pf("    if ( root_ref.null() ) { return false; }\n")
+	g.pf("    TableArenaCtx ctx = { &arena };\n")
+	g.pf("    const %s & root = *(const %s *) TableArenaAt( arena, root_ref.value );\n", n, n)
+	g.pf("    int64_t below = %sPackMeasure( ctx, root, 1 );\n", n)
+	g.pf("    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth\n")
+	g.pf("    int64_t total = TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n", n)
+	g.pf("    uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate\n")
+	g.pf("    if ( packed == NULL ) { return false; }\n")
+	g.pf("    memset( packed, 0, (size_t) total );\n")
+	g.pf("    int64_t used = TableAlignUp64( (int64_t) sizeof( %s ) );\n", n)
+	g.pf("    %s * destination = new ( packed ) %s{};\n", n, n)
+	g.pf("    if ( !%sPack( ctx, root, *destination, packed, total, used, 1 ) || used != total )\n    {\n", n)
+	g.pf("        free( packed );\n        return false;\n    }\n")
+	g.pf("    region = packed;\n")
+	g.pf("    region_bytes = total;\n")
+	g.pf("    arena.locked = true; // MONOTONIC: there is no unlock\n")
+	g.pf("    TableArenaShutdown( arena );\n")
+	g.pf("    return true;\n}\n\n")
+
+	// wire out
+	g.pf("// ---- %s on the wire: the generic, tolerant form (SPEC-TABLES.md §3) ----\n\n", n)
+	g.pf("inline int64_t %sMeasure( const %s * root )\n{\n", n, n)
+	g.pf("    TableRegionCtx ctx;\n")
+	g.pf("    return root != NULL ? %sMeasureBody( ctx, *root, 1 ) : -1;\n}\n\n", n)
+	g.pf("inline int64_t %sSave( const %s * root, uint8_t * buffer, int64_t capacity )\n{\n", n, n)
+	g.pf("    if ( root == NULL ) { return -1; }\n")
+	g.pf("    TableRegionCtx ctx;\n")
+	g.pf("    TableWriter w( buffer, capacity );\n")
+	g.pf("    if ( !%sSaveBody( ctx, w, *root, 1 ) ) { return -1; }\n", n)
+	g.pf("    return w.offset; // == %sMeasure( root )\n}\n\n", n)
+	g.pf("inline int64_t %sMeasure( const %sBuilder & builder )\n{\n", n, n)
+	g.pf("    if ( builder.region != NULL ) { return %sMeasure( builder.Const() ); }\n", n)
+	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
+	g.pf("    return %sMeasureBody( ctx, *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value ), 1 );\n}\n\n", n, n)
+	g.pf("inline int64_t %sSave( const %sBuilder & builder, uint8_t * buffer, int64_t capacity )\n{\n", n, n)
+	g.pf("    if ( builder.region != NULL ) { return %sSave( builder.Const(), buffer, capacity ); }\n", n)
+	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
+	g.pf("    TableWriter w( buffer, capacity );\n")
+	g.pf("    if ( !%sSaveBody( ctx, w, *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value ), 1 ) ) { return -1; }\n", n, n)
+	g.pf("    return w.offset;\n}\n\n")
+
+	// load
+	g.pf("// %sLoadMeasure: the exact region bytes a wire buffer will need. The\n", n)
+	g.pf("// caller owns the allocation — generated load code allocates nothing.\n")
+	g.pf("inline int64_t %sLoadMeasure( const uint8_t * wire, int64_t wire_bytes )\n{\n", n)
+	g.pf("    TableReport ignored;\n")
+	g.pf("    TableReader r( wire, wire_bytes, &ignored );\n")
+	g.pf("    int64_t below = %sLoadMeasureBody( r, 1 );\n", n)
+	g.pf("    if ( below < 0 ) { below = 0; }\n")
+	g.pf("    return TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n}\n\n", n)
+	g.pf("// %sLoad: decode the tolerant wire into the caller's exact-sized region and\n", n)
+	g.pf("// return the root. Partial results are kept, as everywhere on this wire —\n")
+	g.pf("// the report says what happened. NULL means the CALLER's buffer was wrong.\n")
+	g.pf("inline const %s * %sLoad( uint8_t * region, int64_t region_bytes, const uint8_t * wire, int64_t wire_bytes, TableReport * report )\n{\n", n, n)
+	g.pf("    TableReport ignored;\n")
+	g.pf("    TableReport * out = report != NULL ? report : &ignored;\n")
+	g.pf("    if ( region == NULL || region_bytes < (int64_t) sizeof( %s ) ) { out->malformed = true; return NULL; }\n", n)
+	g.pf("    if ( ( ( (uintptr_t) region ) & ( kTableAlign - 1 ) ) != 0 ) { out->malformed = true; return NULL; }\n")
+	g.pf("    memset( region, 0, (size_t) region_bytes );\n")
+	g.pf("    TableRegionSink sink;\n")
+	g.pf("    sink.base = region;\n")
+	g.pf("    sink.capacity = region_bytes;\n")
+	g.pf("    sink.used = TableAlignUp64( (int64_t) sizeof( %s ) );\n", n)
+	g.pf("    %s * root = new ( region ) %s{};\n", n, n)
+	g.pf("    TableReader r( wire, wire_bytes, out );\n")
+	g.pf("    %sLoadBody( r, sink, *root, 1 );\n", n)
+	g.pf("    return root;\n}\n\n")
+	g.pf("// %sLoadBuilder: the TOOL's path — the same tolerant decode into a fresh\n", n)
+	g.pf("// builder, so loaded data can be edited and locked again.\n")
+	g.pf("inline bool %sLoadBuilder( %sBuilder & builder, const uint8_t * wire, int64_t wire_bytes, TableReport * report )\n{\n", n, n)
+	g.pf("    TableReport ignored;\n")
+	g.pf("    TableReport * out = report != NULL ? report : &ignored;\n")
+	g.pf("    %s * root = builder.Root();\n", n)
+	g.pf("    if ( root == NULL ) { out->malformed = true; return false; }\n")
+	g.pf("    TableReader r( wire, wire_bytes, out );\n")
+	g.pf("    return %sLoadBody( r, builder.main, *root, 1 );\n}\n\n", n)
+
+	// cooked form
+	g.pf("// ---- %s cooked: the region form (SPEC-TABLES.md §6) ----\n", n)
+	g.pf("//\n")
+	g.pf("// One requirement: load a big file, point at its root, without copying it\n")
+	g.pf("// and without parsing it. The cooked form is the structure laid out exactly\n")
+	g.pf("// as the runtime reads it, behind a header that build-locks it. It is an\n")
+	g.pf("// ACCELERATOR, regenerated whenever the schema moves; the tolerant wire is\n")
+	g.pf("// the format of record, and a cooked file is never an archive.\n\n")
+	g.pf("inline int64_t %sCookMeasure( const %s * root )\n{\n", n, n)
+	g.pf("    if ( root == NULL ) { return -1; }\n")
+	g.pf("    TableRegionCtx ctx;\n")
+	g.pf("    int64_t below = %sPackMeasure( ctx, *root, 1 );\n", n)
+	g.pf("    if ( below < 0 ) { return -1; }\n")
+	g.pf("    return kTableCookedHeaderBytes + TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n}\n\n", n)
+	g.pf("inline int64_t %sCookMeasure( const %sBuilder & builder )\n{\n", n, n)
+	g.pf("    if ( builder.region != NULL ) { return kTableCookedHeaderBytes + builder.region_bytes; }\n")
+	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
+	g.pf("    int64_t below = %sPackMeasure( ctx, *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value ), 1 );\n", n, n)
+	g.pf("    if ( below < 0 ) { return -1; }\n")
+	g.pf("    return kTableCookedHeaderBytes + TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n}\n\n", n)
+	g.pf("inline int64_t %sCook( const %s * root, uint8_t * buffer, int64_t capacity )\n{\n", n, n)
+	g.pf("    if ( root == NULL || buffer == NULL ) { return -1; }\n")
+	g.pf("    if ( ( ( (uintptr_t) buffer ) & ( kTableAlign - 1 ) ) != 0 ) { return -1; }\n")
+	g.pf("    TableRegionCtx ctx;\n")
+	g.pf("    int64_t below = %sPackMeasure( ctx, *root, 1 );\n", n)
+	g.pf("    if ( below < 0 ) { return -1; }\n")
+	g.pf("    int64_t region_bytes = TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n", n)
+	g.pf("    if ( kTableCookedHeaderBytes + region_bytes > capacity ) { return -1; }\n")
+	g.pf("    uint8_t * base = buffer + kTableCookedHeaderBytes;\n")
+	g.pf("    memset( base, 0, (size_t) region_bytes );\n")
+	g.pf("    int64_t used = TableAlignUp64( (int64_t) sizeof( %s ) );\n", n)
+	g.pf("    %s * destination = new ( base ) %s{};\n", n, n)
+	g.pf("    if ( !%sPack( ctx, *root, *destination, base, region_bytes, used, 1 ) || used != region_bytes ) { return -1; }\n", n)
+	g.pf("    TableCookedHeaderWrite( buffer, %sLayoutId, (uint32_t) region_bytes );\n", n)
+	g.pf("    return kTableCookedHeaderBytes + region_bytes;\n}\n\n")
+	g.pf("inline int64_t %sCook( const %sBuilder & builder, uint8_t * buffer, int64_t capacity )\n{\n", n, n)
+	g.pf("    if ( builder.region != NULL )\n    {\n")
+	g.pf("        // already packed by Lock: the cooked file IS those bytes\n")
+	g.pf("        if ( buffer == NULL || kTableCookedHeaderBytes + builder.region_bytes > capacity ) { return -1; }\n")
+	g.pf("        if ( ( ( (uintptr_t) buffer ) & ( kTableAlign - 1 ) ) != 0 ) { return -1; }\n")
+	g.pf("        memcpy( buffer + kTableCookedHeaderBytes, builder.region, (size_t) builder.region_bytes );\n")
+	g.pf("        TableCookedHeaderWrite( buffer, %sLayoutId, (uint32_t) builder.region_bytes );\n", n)
+	g.pf("        return kTableCookedHeaderBytes + builder.region_bytes;\n    }\n")
+	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
+	g.pf("    const %s & root = *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value );\n", n, n)
+	g.pf("    int64_t below = %sPackMeasure( ctx, root, 1 );\n", n)
+	g.pf("    if ( below < 0 || buffer == NULL ) { return -1; }\n")
+	g.pf("    if ( ( ( (uintptr_t) buffer ) & ( kTableAlign - 1 ) ) != 0 ) { return -1; }\n")
+	g.pf("    int64_t region_bytes = TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n", n)
+	g.pf("    if ( kTableCookedHeaderBytes + region_bytes > capacity ) { return -1; }\n")
+	g.pf("    uint8_t * base = buffer + kTableCookedHeaderBytes;\n")
+	g.pf("    memset( base, 0, (size_t) region_bytes );\n")
+	g.pf("    int64_t used = TableAlignUp64( (int64_t) sizeof( %s ) );\n", n)
+	g.pf("    %s * destination = new ( base ) %s{};\n", n, n)
+	g.pf("    if ( !%sPack( ctx, root, *destination, base, region_bytes, used, 1 ) || used != region_bytes ) { return -1; }\n", n)
+	g.pf("    TableCookedHeaderWrite( buffer, %sLayoutId, (uint32_t) region_bytes );\n", n)
+	g.pf("    return kTableCookedHeaderBytes + region_bytes;\n}\n\n")
+	g.pf("// %sOpen: point at a cooked file's root. Every refusal is loud and the\n", n)
+	g.pf("// caller's fallback is a real wire Load: wrong form or byte order, a layout\n")
+	g.pf("// id this build did not produce, a truncated region, an unaligned base, or\n")
+	g.pf("// an offset graph that leaves the region.\n")
+	g.pf("inline const %s * %sOpen( const uint8_t * bytes, int64_t size )\n{\n", n, n)
+	g.pf("    int64_t region_bytes = 0;\n")
+	g.pf("    if ( !TableCookedHeaderCheck( bytes, size, %sLayoutId, &region_bytes ) ) { return NULL; }\n", n)
+	g.pf("    if ( region_bytes < (int64_t) sizeof( %s ) ) { return NULL; }\n", n)
+	g.pf("    const uint8_t * base = bytes + kTableCookedHeaderBytes;\n")
+	g.pf("    const %s * root = (const %s *) base;\n", n, n)
+	g.pf("    if ( !%sOpenWalk( root, base, region_bytes, 1 ) ) { return NULL; }\n", n)
+	g.pf("    return root;\n}\n\n")
+}
+
+// layoutClosure returns, in stable order, every closure type whose sizeof
+// participates in a root's layout id.
+func (g *tableGen) layoutClosure(root *ir.Struct) []string {
+	seen := map[string]bool{}
+	var order []string
+	var walk func(st *ir.Struct)
+	walk = func(st *ir.Struct) {
+		if st == nil || seen[st.Name] {
+			return
+		}
+		seen[st.Name] = true
+		order = append(order, st.Name)
+		for _, f := range st.Fields {
+			if f.Type.Kind != ir.TNamed {
+				continue
+			}
+			switch ref := f.Type.Ref.(type) {
+			case *ir.Struct:
+				walk(ref)
+			case *ir.Union:
+				for _, v := range ref.Variants {
+					if next, ok := g.unit.Structs[v.Type]; ok {
+						walk(next)
+					}
+				}
+			}
+		}
+	}
+	walk(root)
+	return order
+}
+
+// layoutSchemaHash digests the SCHEMA-side facts that decide a packed
+// layout: every closure member's fields in order, with the shape that moves
+// bytes. It is the region form's twin of the protocol id — a cooked file
+// whose schema moved refuses instead of being misread.
+func (g *tableGen) layoutSchemaHash(root *ir.Struct) uint32 {
+	var b strings.Builder
+	b.WriteString("schema-table-cooked-v1\n")
+	for _, name := range g.layoutClosure(root) {
+		st := g.unit.Tables[name]
+		if st == nil {
+			st = g.unit.Structs[name]
+		}
+		if st == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "type %s\n", name)
+		for _, f := range st.Fields {
+			fmt.Fprintf(&b, "  %s kind=%d ptr=%v array=%d bound=%d size=%d width=%d signed=%v guard=%q\n",
+				f.Name, f.Type.Kind, f.Type.Pointer, f.Array, f.ArrayBound,
+				f.Type.Size, f.Type.Width, f.Type.Signed, f.Guard)
+		}
+	}
+	h := uint64(0xCBF29CE484222325)
+	for _, c := range []byte(b.String()) {
+		h ^= uint64(c)
+		h *= 0x100000001B3
+	}
+	return uint32(h) ^ uint32(h>>32)
+}
+
+// layoutMixer gives each closure position its own odd multiplier, so a
+// permutation of the same sizes digests differently.
+func layoutMixer(i int) uint32 {
+	return 0x9E3779B1 + uint32(i)*0x85EBCA6B | 1
+}
+
+// emitRelocatabilityPreamble writes the comment above the static asserts,
+// which now covers both forms.
+func (g *tableGen) emitRelocatabilityPreamble() {
+	g.pf("// ---- relocatability, enforced: the wire is a pure length-prefixed\n")
+	g.pf("// stream AND the decoded storage is pointer-free — every closure type\n")
+	g.pf("// must stay trivially copyable and standard-layout, so instances can be\n")
+	g.pf("// memcpy'd, mmap'd, shared across processes, and walked through\n")
+	g.pf("// descriptor offsets. A failure here means a pointer, virtual or\n")
+	g.pf("// non-trivial member crept into generated storage.\n")
+	if g.anyVariable {
+		g.pf("// A pointer FIELD is a TableRef — four bytes and no address — so the\n")
+		g.pf("// property holds in BOTH forms: a fixed-size table is one relocatable\n")
+		g.pf("// struct, and a packed region is one relocatable block whose references\n")
+		g.pf("// are self-relative and therefore survive a plain memcpy.\n")
+	}
+}
+
+// modeColumn renders the descriptor's derived-mode column, present only in a
+// unit that has pointers (the zero-cost gate).
+func (g *tableGen) modeColumn(st *ir.Struct) string {
+	if !g.anyVariable {
+		return ""
+	}
+	return fmt.Sprintf(", %v", g.isVar(st.Name))
+}

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -20,27 +20,42 @@ import (
 
 func (g *tableGen) isVar(name string) bool { return g.variable[name] }
 
+// ---- what the depth cap counts (SPEC-TABLES.md §3.1) ----
+//
+// ONLY POINTER EDGES CHARGE DEPTH. By-value nesting — a table inside a table,
+// or a bounded array of them — charges nothing, because by-value composition is
+// already finite: the checker refuses by-value cycles, so its nesting is
+// bounded by the schema itself and cannot be driven by data.
+//
+// This has to hold in ALL FOUR walks — measure, save, load and pack — or the
+// forms disagree about which structures are legal, and a structure that Locks
+// and Cooks is refused by the wire. The two constants below are the whole rule.
+const (
+	depthSame = "depth"     // by-value nesting: the schema already bounds it
+	depthDown = "depth + 1" // a pointer edge: only DATA can make this deep
+)
+
 // measureCall renders a nested MEASURE call on a closure member: a variable
 // member takes the resolution context and the depth, a fixed one takes
 // neither — so a fixed table's codec is character-for-character what it was
 // before pointers existed.
-func (g *tableGen) measureCall(name, expr string) string {
+func (g *tableGen) measureCall(name, expr, depth string) string {
 	if g.isVar(name) {
-		return fmt.Sprintf("%sMeasureBody( ctx, %s, depth + 1 )", name, expr)
+		return fmt.Sprintf("%sMeasureBody( ctx, %s, %s )", name, expr, depth)
 	}
 	return fmt.Sprintf("%sMeasure( %s )", name, expr)
 }
 
-func (g *tableGen) saveCall(name, expr string) string {
+func (g *tableGen) saveCall(name, expr, depth string) string {
 	if g.isVar(name) {
-		return fmt.Sprintf("%sSaveBody( ctx, w, %s, depth + 1 )", name, expr)
+		return fmt.Sprintf("%sSaveBody( ctx, w, %s, %s )", name, expr, depth)
 	}
 	return fmt.Sprintf("%sSaveBody( w, %s )", name, expr)
 }
 
-func (g *tableGen) loadCall(name, reader, expr string) string {
+func (g *tableGen) loadCall(name, reader, expr, depth string) string {
 	if g.isVar(name) {
-		return fmt.Sprintf("%sLoadBody( %s, sink, %s, depth + 1 )", name, reader, expr)
+		return fmt.Sprintf("%sLoadBody( %s, sink, %s, %s )", name, reader, expr, depth)
 	}
 	return fmt.Sprintf("%sLoadBody( %s, %s )", name, reader, expr)
 }
@@ -125,7 +140,13 @@ func (g *tableGen) emitCodecDeclarations(members []*ir.Struct) {
 			g.pf("template <typename Ctx> inline int64_t %sPackMeasure( const Ctx & ctx, const %s & value, int32_t depth );\n", st.Name, st.Name)
 			g.pf("template <typename Ctx> inline bool %sPack( const Ctx & ctx, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );\n", st.Name, st.Name, st.Name)
 			g.pf("inline int64_t %sLoadMeasureBody( TableReader & r, int32_t depth );\n", st.Name)
-			g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int32_t depth );\n", st.Name, st.Name)
+		}
+		// EVERY closure member gets an Open walk, not only the ones pointers
+		// reach: a fixed table or a plain type nested by value carries count
+		// companions, and an unbounded one is an over-read waiting for the first
+		// reflection walker (SPEC-TABLES.md §7)
+		for _, st := range members {
+			g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int64_t & watermark, int32_t depth );\n", st.Name, st.Name)
 		}
 		g.pf("\n")
 	}
@@ -174,6 +195,8 @@ func (g *tableGen) emitVariableSurface(members []*ir.Struct) {
 		g.emitPackMeasure(st)
 		g.emitPack(st)
 		g.emitLoadMeasureBody(st)
+	}
+	for _, st := range members {
 		g.emitOpenWalk(st)
 	}
 	for _, st := range members {
@@ -200,13 +223,11 @@ func (g *tableGen) emitPackMeasure(st *ir.Struct) {
 		g.pf("    {\n")
 		g.pf("        const %s * pointee = %sAt( ctx, value.%s ); // %s\n", t, t, f.Name, f.Name)
 		g.pf("        if ( pointee != NULL )\n        {\n")
-		if g.needsWalkers(t) {
-			g.pf("            int64_t inner = %sPackMeasure( ctx, *pointee, depth + 1 );\n", t)
-			g.pf("            if ( inner < 0 ) { return -1; }\n")
-			g.pf("            bytes += TableAlignUp64( (int64_t) sizeof( %s ) ) + inner;\n", t)
-		} else {
-			g.pf("            bytes += TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
-		}
+		// a pointer TARGET always has walkers (ir.PointerTargets feeds them), so
+		// there is no walker-less arm to write here
+		g.pf("            int64_t inner = %sPackMeasure( ctx, *pointee, depth + 1 );\n", t)
+		g.pf("            if ( inner < 0 ) { return -1; }\n")
+		g.pf("            bytes += TableAlignUp64( (int64_t) sizeof( %s ) ) + inner;\n", t)
 		g.pf("        }\n    }\n")
 	}
 	for _, f := range g.byValueVariableFields(st) {
@@ -244,9 +265,14 @@ func (g *tableGen) emitVariableByValueWalk(f *ir.Field, body func(expr string)) 
 // self-relative encoding.
 func (g *tableGen) emitPack(st *ir.Struct) {
 	g.pf("// %sPack: copy src into dst (already placed), then lay every pointee out\n", st.Name)
-	g.pf("// depth-first behind it. A child always lands AFTER the slot naming it, so\n")
-	g.pf("// region deltas are strictly positive and a packed region cannot contain a\n")
-	g.pf("// cycle — which is what makes %sOpenWalk cycle-free without a visited set.\n", st.Name)
+	g.pf("// depth-first behind it, in FIELD ORDER, by bump allocation.\n")
+	g.pf("//\n")
+	g.pf("// THAT PRE-ORDER IS AN INVARIANT %sOpenWalk DEPENDS ON. Because a child\n", st.Name)
+	g.pf("// always lands after the slot naming it, region deltas are strictly\n")
+	g.pf("// positive and a packed region cannot contain a cycle; because siblings\n")
+	g.pf("// land in field order, OpenWalk's high-water mark — which is what keeps\n")
+	g.pf("// validation linear rather than exponential — is satisfied by every\n")
+	g.pf("// genuine region. NEITHER THIS ORDER NOR OPENWALK'S MAY CHANGE ALONE.\n")
 	g.pf("template <typename Ctx>\ninline bool %sPack( const Ctx & ctx, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )\n{\n", st.Name, st.Name, st.Name)
 	g.pf("    if ( depth > kTableMaxDepth ) { return false; }\n")
 	g.pf("    memcpy( (void *) &dst, (const void *) &src, sizeof( %s ) ); // trivially copyable, by construction\n", st.Name)
@@ -264,11 +290,7 @@ func (g *tableGen) emitPack(st *ir.Struct) {
 		g.pf("            used = at + TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
 		g.pf("            %s * child = new ( base + at ) %s{};\n", t, t)
 		g.pf("            dst.%s.value = (uint32_t) ( ( base + at ) - (const uint8_t *) &dst.%s );\n", f.Name, f.Name)
-		if g.needsWalkers(t) {
-			g.pf("            if ( !%sPack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }\n", t)
-		} else {
-			g.pf("            memcpy( (void *) child, (const void *) pointee, sizeof( %s ) );\n", t)
-		}
+		g.pf("            if ( !%sPack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }\n", t)
 		g.pf("        }\n    }\n")
 	}
 	for _, f := range g.byValueVariableFields(st) {
@@ -330,10 +352,8 @@ func (g *tableGen) emitLoadMeasureBody(st *ir.Struct) {
 		g.pf("                if ( !r.has( body_len ) ) { return bytes; }\n")
 		g.pf("                if ( depth < kTableMaxDepth )\n                {\n")
 		g.pf("                    bytes += TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
-		if g.needsWalkers(t) {
-			g.pf("                    TableReader sub( r.buffer + r.offset, body_len, r.report );\n")
-			g.pf("                    bytes += %sLoadMeasureBody( sub, depth + 1 );\n", t)
-		}
+		g.pf("                    TableReader sub( r.buffer + r.offset, body_len, r.report );\n")
+		g.pf("                    bytes += %sLoadMeasureBody( sub, depth + 1 );\n", t)
 		g.pf("                }\n")
 		g.pf("                r.offset += body_len;\n")
 		g.pf("                break;\n            }\n")
@@ -379,22 +399,73 @@ func (g *tableGen) emitLoadMeasureBody(st *ir.Struct) {
 	g.pf("        }\n    }\n}\n\n")
 }
 
-// emitOpenWalk emits the cooked form's bounds walk: reads-validate-always,
-// applied to the only thing a cooked region can lie about — its offset graph.
+// byValueStructFields returns the fields that nest a declared struct BY VALUE
+// — table or plain type, scalar or bounded array. Open descends into all of
+// them: a nested type's own count companions bound a traversal just as a
+// table's do, and an unbounded one is exactly the over-read a reflection
+// walker would take.
+func byValueStructFields(st *ir.Struct) []*ir.Field {
+	var out []*ir.Field
+	for _, f := range st.Fields {
+		if f.Type.Pointer || f.Type.Kind != ir.TNamed {
+			continue
+		}
+		if _, ok := f.Type.Ref.(*ir.Struct); ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// unionFields returns a member's union-typed fields.
+func unionFields(st *ir.Struct) []*ir.Field {
+	var out []*ir.Field
+	for _, f := range st.Fields {
+		if f.Type.Kind != ir.TNamed || f.Array != ir.ArrayNone {
+			continue
+		}
+		if _, ok := f.Type.Ref.(*ir.Union); ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// emitOpenWalk emits the cooked form's validation — reads-validate-always,
+// applied to the only things a cooked file can lie about: its offset graph and
+// the counts that bound a traversal of it.
+//
+// THE HIGH-WATER MARK IS WHAT MAKES THIS LINEAR. Pack lays nodes out in
+// PRE-ORDER by bump allocation (a node, then its pointees in field order,
+// depth first), and this walk visits them in exactly that order — so in a
+// genuine region every reference lands at or past the end of everything
+// visited so far. Requiring that, and advancing the mark past each node,
+// makes the walk visit each byte of the region at most once: it is O(region),
+// it terminates, and it cannot be driven exponentially by a forged file whose
+// references alias forward. It also rules out mid-node overlaps that a bounds
+// check alone lets through.
+//
+// PACK AND THIS WALK MUST KEEP THE SAME ORDER. Neither may be reordered
+// without the other; the invariant is stated at both sites for that reason.
 func (g *tableGen) emitOpenWalk(st *ir.Struct) {
-	g.pf("// %sOpenWalk: the cooked form's validation. It visits the REFERENCE GRAPH —\n", st.Name)
-	g.pf("// every pointer slot and the count companions that bound a traversal — and\n")
-	g.pf("// nothing else: no field value is read, no payload is decoded. That is what\n")
-	g.pf("// separates \"validate before pointing\" from \"parse the whole thing\".\n")
-	g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int32_t depth )\n{\n", st.Name, st.Name)
+	g.pf("// %sOpenWalk: validate the REFERENCE GRAPH and the counts that bound a\n", st.Name)
+	g.pf("// traversal of it — no field value is read, no payload is decoded.\n")
+	g.pf("//\n")
+	g.pf("// The watermark is the termination proof. %sPack lays nodes out in PRE-ORDER\n", st.Name)
+	g.pf("// by bump allocation and this walk visits them in the SAME ORDER, so a\n")
+	g.pf("// genuine region always satisfies `at >= watermark`. Requiring it makes the\n")
+	g.pf("// walk consume region bytes monotonically: linear in the region, immune to a\n")
+	g.pf("// forged file whose references alias forward (which without it costs 2^n),\n")
+	g.pf("// and closed to mid-node overlaps a range check alone would admit.\n")
+	g.pf("// NEITHER THIS ORDER NOR PACK'S MAY CHANGE ALONE.\n")
+	g.pf("inline bool %sOpenWalk( const %s * node, const uint8_t * base, int64_t bytes, int64_t & watermark, int32_t depth )\n{\n", st.Name, st.Name)
 	g.pf("    if ( node == NULL || depth > kTableMaxDepth ) { return false; }\n")
 	ptrs := pointerFields(st)
-	nested := g.byValueVariableFields(st)
+	nested := byValueStructFields(st)
+	unions := unionFields(st)
 	counted := countedCompanions(st)
-	if len(ptrs) == 0 && len(nested) == 0 {
-		// nothing here addresses the region: only the count companions bound a
-		// traversal, and those are read out of the node itself
-		g.pf("    (void) base; (void) bytes;\n")
+	if len(ptrs) == 0 && len(nested) == 0 && len(unions) == 0 {
+		g.pf("    (void) base; (void) bytes; (void) watermark; (void) depth;\n")
 	}
 	for _, c := range counted {
 		g.pf("    if ( node->%s < 0 || node->%s > %d ) { return false; } // %s\n", c.companion, c.companion, c.bound, c.field)
@@ -406,25 +477,39 @@ func (g *tableGen) emitOpenWalk(st *ir.Struct) {
 		g.pf("        if ( delta != 0 )\n        {\n")
 		g.pf("            if ( (int32_t) delta <= 0 ) { return false; } // a packed reference is strictly forward\n")
 		g.pf("            int64_t at = ( (const uint8_t *) &node->%s - base ) + (int64_t) delta;\n", f.Name)
-		g.pf("            if ( at < 0 || ( at & ( kTableAlign - 1 ) ) != 0 ) { return false; }\n")
+		g.pf("            if ( at < watermark ) { return false; } // out of pre-order: an alias, or an overlap\n")
+		g.pf("            if ( ( at & ( kTableAlign - 1 ) ) != 0 ) { return false; }\n")
 		g.pf("            if ( at + (int64_t) sizeof( %s ) > bytes ) { return false; }\n", t)
-		if g.needsWalkers(t) {
-			g.pf("            if ( !%sOpenWalk( (const %s *) ( base + at ), base, bytes, depth + 1 ) ) { return false; }\n", t, t)
-		}
+		g.pf("            watermark = at + TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
+		g.pf("            if ( !%sOpenWalk( (const %s *) ( base + at ), base, bytes, watermark, depth + 1 ) ) { return false; }\n", t, t)
 		g.pf("        }\n    }\n")
 	}
 	for _, f := range nested {
 		t := f.Type.Name
 		switch f.Array {
 		case ir.ArrayNone:
-			g.pf("    if ( !%sOpenWalk( &node->%s, base, bytes, depth ) ) { return false; }\n", t, f.Name)
+			g.pf("    if ( !%sOpenWalk( &node->%s, base, bytes, watermark, depth ) ) { return false; }\n", t, f.Name)
 		case ir.ArrayCounted:
 			g.pf("    for ( int32_t i = 0; i < node->%s_count && i < %d; i++ )\n", f.Name, f.ArrayBound)
-			g.pf("    {\n        if ( !%sOpenWalk( &node->%s[i], base, bytes, depth ) ) { return false; }\n    }\n", t, f.Name)
+			g.pf("    {\n        if ( !%sOpenWalk( &node->%s[i], base, bytes, watermark, depth ) ) { return false; }\n    }\n", t, f.Name)
 		default:
 			g.pf("    for ( int32_t i = 0; i < %d; i++ )\n", f.ArrayBound)
-			g.pf("    {\n        if ( !%sOpenWalk( &node->%s[i], base, bytes, depth ) ) { return false; }\n    }\n", t, f.Name)
+			g.pf("    {\n        if ( !%sOpenWalk( &node->%s[i], base, bytes, watermark, depth ) ) { return false; }\n    }\n", t, f.Name)
 		}
+	}
+	for _, f := range unions {
+		un := f.Type.Ref.(*ir.Union)
+		g.pf("    { // %s: the tag selects the arm, so the tag is bounded before the arm is walked\n", f.Name)
+		g.pf("        uint32_t tag = (uint32_t) node->%s.type;\n", f.Name)
+		g.pf("        if ( tag > %d ) { return false; }\n", len(un.Variants))
+		g.pf("        switch ( node->%s.type )\n        {\n", f.Name)
+		for _, v := range un.Variants {
+			g.pf("            case %sType::%s: if ( !%sOpenWalk( &node->%s.%s, base, bytes, watermark, depth ) ) { return false; } break;\n",
+				un.Name, ir.GoExportName(v.Name), v.Type, f.Name, v.Name)
+			g.noteRef(v.Type)
+		}
+		g.pf("            default: break; // None: no arm to walk\n")
+		g.pf("        }\n    }\n")
 	}
 	g.pf("    return true;\n}\n\n")
 }
@@ -468,8 +553,25 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("// this build's own sizeof for every type in the closure, so schema drift AND\n")
 	g.pf("// ABI drift both refuse at Open.\n")
 	g.pf("inline constexpr uint32_t %sLayoutId =\n    0x%08xu", n, g.layoutSchemaHash(st))
-	for i, dep := range g.layoutClosure(st) {
-		g.pf("\n    ^ ( (uint32_t) sizeof( %s ) * 0x%08xu )", dep, layoutMixer(i))
+	mix := 0
+	for _, dep := range g.layoutClosure(st) {
+		g.pf("\n    ^ ( (uint32_t) sizeof( %s ) * 0x%08xu )", dep, layoutMixer(mix))
+		mix++
+		member := g.unit.Tables[dep]
+		if member == nil {
+			member = g.unit.Structs[dep]
+		}
+		if member == nil {
+			continue
+		}
+		// every field's OFFSET rides too. sizeof alone cannot see a field that
+		// moved within an unchanged total, and the packed form is read by
+		// offset: an ABI or padding difference that shifts one member has to
+		// refuse the cooked file, not misread it.
+		for _, f := range member.Fields {
+			g.pf("\n    ^ ( (uint32_t) offsetof( %s, %s ) * 0x%08xu )", dep, f.Name, layoutMixer(mix))
+			mix++
+		}
 	}
 	g.pf(";\n\n")
 
@@ -495,9 +597,13 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    // one worker per thread; allocate on your own, and synchronize your own\n")
 	g.pf("    // writes to nodes another worker allocated\n")
 	g.pf("    TableWorker Worker() { TableWorker worker; worker.arena = &arena; return worker; }\n\n")
-	g.pf("    %s * Root() { return arena.locked ? NULL : (%s *) TableArenaAt( arena, root_ref.value ); }\n", n, n)
+	g.pf("    // GetRoot/AsConst, not Root/Const: a member function hides the type\n")
+	g.pf("    // name it shares, and `table Root` is this spec's own canonical\n")
+	g.pf("    // example. The checker refuses a table named after any member here,\n")
+	g.pf("    // so the remaining spellings cannot collide either.\n")
+	g.pf("    %s * GetRoot() { return arena.locked ? NULL : (%s *) TableArenaAt( arena, root_ref.value ); }\n", n, n)
 	g.pf("    bool Locked() const { return arena.locked; }\n")
-	g.pf("    const %s * Const() const { return (const %s *) region; }\n", n, n)
+	g.pf("    const %s * AsConst() const { return (const %s *) region; }\n", n, n)
 	g.pf("    const uint8_t * Region() const { return region; }\n")
 	g.pf("    int64_t RegionBytes() const { return region_bytes; }\n\n")
 	g.pf("    // Lock is ONE WAY and it is the compaction: the segmented arena becomes\n")
@@ -540,11 +646,13 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    if ( !%sSaveBody( ctx, w, *root, 1 ) ) { return -1; }\n", n)
 	g.pf("    return w.offset; // == %sMeasure( root )\n}\n\n", n)
 	g.pf("inline int64_t %sMeasure( const %sBuilder & builder )\n{\n", n, n)
-	g.pf("    if ( builder.region != NULL ) { return %sMeasure( builder.Const() ); }\n", n)
+	g.pf("    if ( builder.region != NULL ) { return %sMeasure( builder.AsConst() ); }\n", n)
+	g.pf("    if ( builder.root_ref.null() ) { return -1; } // the root allocation failed\n")
 	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
 	g.pf("    return %sMeasureBody( ctx, *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value ), 1 );\n}\n\n", n, n)
 	g.pf("inline int64_t %sSave( const %sBuilder & builder, uint8_t * buffer, int64_t capacity )\n{\n", n, n)
-	g.pf("    if ( builder.region != NULL ) { return %sSave( builder.Const(), buffer, capacity ); }\n", n)
+	g.pf("    if ( builder.region != NULL ) { return %sSave( builder.AsConst(), buffer, capacity ); }\n", n)
+	g.pf("    if ( builder.root_ref.null() ) { return -1; } // the root allocation failed\n")
 	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
 	g.pf("    TableWriter w( buffer, capacity );\n")
 	g.pf("    if ( !%sSaveBody( ctx, w, *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value ), 1 ) ) { return -1; }\n", n, n)
@@ -581,7 +689,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("inline bool %sLoadBuilder( %sBuilder & builder, const uint8_t * wire, int64_t wire_bytes, TableReport * report )\n{\n", n, n)
 	g.pf("    TableReport ignored;\n")
 	g.pf("    TableReport * out = report != NULL ? report : &ignored;\n")
-	g.pf("    %s * root = builder.Root();\n", n)
+	g.pf("    %s * root = builder.GetRoot();\n", n)
 	g.pf("    if ( root == NULL ) { out->malformed = true; return false; }\n")
 	g.pf("    TableReader r( wire, wire_bytes, out );\n")
 	g.pf("    return %sLoadBody( r, builder.main, *root, 1 );\n}\n\n", n)
@@ -602,6 +710,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    return kTableCookedHeaderBytes + TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n}\n\n", n)
 	g.pf("inline int64_t %sCookMeasure( const %sBuilder & builder )\n{\n", n, n)
 	g.pf("    if ( builder.region != NULL ) { return kTableCookedHeaderBytes + builder.region_bytes; }\n")
+	g.pf("    if ( builder.root_ref.null() ) { return -1; } // the root allocation failed\n")
 	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
 	g.pf("    int64_t below = %sPackMeasure( ctx, *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value ), 1 );\n", n, n)
 	g.pf("    if ( below < 0 ) { return -1; }\n")
@@ -629,6 +738,7 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("        memcpy( buffer + kTableCookedHeaderBytes, builder.region, (size_t) builder.region_bytes );\n")
 	g.pf("        TableCookedHeaderWrite( buffer, %sLayoutId, (uint32_t) builder.region_bytes );\n", n)
 	g.pf("        return kTableCookedHeaderBytes + builder.region_bytes;\n    }\n")
+	g.pf("    if ( builder.root_ref.null() ) { return -1; } // the root allocation failed\n")
 	g.pf("    TableArenaCtx ctx = { &builder.arena };\n")
 	g.pf("    const %s & root = *(const %s *) TableArenaAt( builder.arena, builder.root_ref.value );\n", n, n)
 	g.pf("    int64_t below = %sPackMeasure( ctx, root, 1 );\n", n)
@@ -653,7 +763,11 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    if ( region_bytes < (int64_t) sizeof( %s ) ) { return NULL; }\n", n)
 	g.pf("    const uint8_t * base = bytes + kTableCookedHeaderBytes;\n")
 	g.pf("    const %s * root = (const %s *) base;\n", n, n)
-	g.pf("    if ( !%sOpenWalk( root, base, region_bytes, 1 ) ) { return NULL; }\n", n)
+	g.pf("    // the root occupies the head of the region, so everything it names must\n")
+	g.pf("    // land at or past its end — the walk's high-water mark starts there\n")
+	g.pf("    int64_t watermark = TableAlignUp64( (int64_t) sizeof( %s ) );\n", n)
+	g.pf("    if ( watermark > region_bytes ) { return NULL; }\n")
+	g.pf("    if ( !%sOpenWalk( root, base, region_bytes, watermark, 1 ) ) { return NULL; }\n", n)
 	g.pf("    return root;\n}\n\n")
 }
 
@@ -689,10 +803,16 @@ func (g *tableGen) layoutClosure(root *ir.Struct) []string {
 	return order
 }
 
-// layoutSchemaHash digests the SCHEMA-side facts that decide a packed
-// layout: every closure member's fields in order, with the shape that moves
-// bytes. It is the region form's twin of the protocol id — a cooked file
-// whose schema moved refuses instead of being misread.
+// layoutSchemaHash digests the SCHEMA-side facts that decide a packed layout:
+// every closure member's fields in order, with the shape that moves bytes. It
+// is the region form's twin of the protocol id — a cooked file whose schema
+// moved refuses instead of being misread.
+//
+// A field is keyed by its WIRE ID, not its source name. That is the identity
+// that survives a `was` rename, and a rename moves no byte — so renaming a
+// field must NOT invalidate every cooked file in existence. Reordering two
+// same-shaped fields does move bytes, and it changes which id sits at which
+// offset, so it still refuses.
 func (g *tableGen) layoutSchemaHash(root *ir.Struct) uint32 {
 	var b strings.Builder
 	b.WriteString("schema-table-cooked-v1\n")
@@ -706,8 +826,8 @@ func (g *tableGen) layoutSchemaHash(root *ir.Struct) uint32 {
 		}
 		fmt.Fprintf(&b, "type %s\n", name)
 		for _, f := range st.Fields {
-			fmt.Fprintf(&b, "  %s kind=%d ptr=%v array=%d bound=%d size=%d width=%d signed=%v guard=%q\n",
-				f.Name, f.Type.Kind, f.Type.Pointer, f.Array, f.ArrayBound,
+			fmt.Fprintf(&b, "  id=%04x kind=%d ptr=%v array=%d bound=%d size=%d width=%d signed=%v guard=%q\n",
+				ir.TableFieldId(f), f.Type.Kind, f.Type.Pointer, f.Array, f.ArrayBound,
 				f.Type.Size, f.Type.Width, f.Type.Signed, f.Guard)
 		}
 	}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -315,6 +315,12 @@ func needSpace(prev, cur scanner.Token, tokens []scanner.Token, i int) bool {
 	switch prev.Kind {
 	case scanner.LParen, scanner.Dot, scanner.DotDot, scanner.Not:
 		return false
+	case scanner.Star:
+		// the POINTER star binds to the type it targets — `next *Node`, never
+		// `next * Node` (SPEC-TABLES.md). A star in TYPE POSITION (directly
+		// after the field name that opens the line) is the pointer spelling;
+		// every other star is multiplication and keeps its spaces.
+		return !isPointerStar(tokens, i-1)
 	case scanner.LBrack:
 		return false
 	case scanner.Minus:
@@ -329,6 +335,13 @@ func needSpace(prev, cur scanner.Token, tokens []scanner.Token, i int) bool {
 		return true // one-line lists open with `{ `
 	}
 	return true
+}
+
+// isPointerStar reports whether the star at index i is the POINTER spelling
+// rather than multiplication. A field line opens with its name, so type
+// position is index 1; multiplication never appears there.
+func isPointerStar(tokens []scanner.Token, i int) bool {
+	return i == 1 && tokens[i].Kind == scanner.Star && tokens[0].Kind == scanner.Ident
 }
 
 // isUnary reports whether the minus at index i is unary.
@@ -606,6 +619,11 @@ func fpScalar(t ast.ScalarType) string {
 		}
 		return fmt.Sprintf("ufixed(%s,%s)", fpExpr(t.Arg), fpExpr(t.Arg2))
 	default:
+		if t.Pointer {
+			// `next *Node` — the pointer binds to the type, not the name, so
+			// the star sits against the target (SPEC-TABLES.md)
+			return "*" + t.Name
+		}
 		return t.Name
 	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -569,6 +569,15 @@ func (p *parser) parseScalar() ast.ScalarType {
 	case scanner.Ident:
 		p.advance()
 		return ast.ScalarType{Kind: ast.ScalarNamed, Name: t.Text, Pos: t.Pos}
+	case scanner.Star:
+		// `next *Node` — a POINTER to a table (SPEC-TABLES.md). The C-like
+		// spelling is deliberate: it reads as what it is. What may sit on the
+		// right of the star is the CHECKER's business (a table, inside a table
+		// body); the grammar accepts any name so the diagnostic names the real
+		// problem instead of "expected a field type".
+		p.advance()
+		name := p.expect(scanner.Ident, "the table a pointer targets")
+		return ast.ScalarType{Kind: ast.ScalarNamed, Pointer: true, Name: name.Text, Pos: t.Pos}
 	default:
 		p.errf(t.Pos, "expected a field type, found %q", describe(t))
 		return ast.ScalarType{Kind: ast.ScalarNamed, Name: "<error>", Pos: t.Pos}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -251,6 +251,13 @@ type FieldType struct {
 	SizeExpr Expr   // TString/TBytes: the declared N expression
 	Name     string // TNamed
 	Ref      Decl   // TNamed: *Struct, *Enum, *Flags or *Union
+
+	// Pointer marks a `*T` field: a POINTER to a table, not a by-value
+	// nesting (SPEC-TABLES.md). Only ever set on a TNamed field whose Ref is
+	// a table, declared inside a table body — the checker refuses every other
+	// spelling by name. A pointer's presence is what makes its owner a
+	// VARIABLE-LENGTH table (ir.VariableTables).
+	Pointer bool
 }
 
 // GoExportName is the one true mapping from a schema field name to its

--- a/ir/table.go
+++ b/ir/table.go
@@ -30,6 +30,96 @@ func TableFieldId(f *Field) uint16 {
 	return FieldId(f.Name)
 }
 
+// VariableTables derives the table MODE — the compiler works it out; nobody
+// declares it (the owner's ruling: "i wouldn't want to manually have to
+// specify this… the compiler can work it out"). A closure member is
+// VARIABLE-LENGTH when a pointer appears anywhere in its BY-VALUE closure:
+// its own `*T` fields, or those of anything it nests by value. Everything
+// else is FIXED-SIZE — a plain struct of known sizeof, exactly as every table
+// was before pointers existed, and it gets none of the arena machinery.
+//
+// The derivation is a least-fixed-point over the by-value edges: pointer
+// edges carry no size and never propagate the mode to the POINTING table's
+// nester, they only mark the table that declares them.
+func VariableTables(u *Unit) map[string]bool {
+	closure := TableClosure(u)
+	member := func(name string) *Struct {
+		if st := u.Tables[name]; st != nil {
+			return st
+		}
+		return u.Structs[name]
+	}
+	names := make([]string, 0, len(closure))
+	for name := range closure {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	variable := map[string]bool{}
+	for changed := true; changed; {
+		changed = false
+		for _, name := range names {
+			if variable[name] {
+				continue
+			}
+			st := member(name)
+			if st == nil {
+				continue
+			}
+			for _, f := range st.Fields {
+				if f.Type.Pointer {
+					variable[name] = true
+					break
+				}
+				if f.Type.Kind != TNamed {
+					continue
+				}
+				switch ref := f.Type.Ref.(type) {
+				case *Struct:
+					if variable[ref.Name] {
+						variable[name] = true
+					}
+				case *Union:
+					for _, v := range ref.Variants {
+						if variable[v.Type] {
+							variable[name] = true
+						}
+					}
+				}
+				if variable[name] {
+					break
+				}
+			}
+			if variable[name] {
+				changed = true
+			}
+		}
+	}
+	return variable
+}
+
+// PointerTargets is the set of tables some pointer field targets — the tables
+// that need an arena allocation surface (Builder.Alloc<T>()) and a cooked
+// accessor. A table can be a pointer target and a root at once.
+func PointerTargets(u *Unit) map[string]bool {
+	targets := map[string]bool{}
+	for name := range TableClosure(u) {
+		st := u.Tables[name]
+		if st == nil {
+			st = u.Structs[name]
+		}
+		if st == nil {
+			continue
+		}
+		for _, f := range st.Fields {
+			if f.Type.Pointer {
+				targets[f.Type.Name] = true
+			}
+		}
+	}
+	return targets
+}
+
 // TableClosure is the set of structs that carry table codecs and reflection
 // descriptors: every `table` declaration plus every struct reachable from one
 // through fields (nested tables and types, array elements, union payloads),

--- a/tables/pointers/Graph.schema
+++ b/tables/pointers/Graph.schema
@@ -63,3 +63,20 @@ table Scene
     layers   [..MaxLayers]Layer
     meta     Meta
 }
+
+// CROSS-FILE, and all three kinds at once: a plain type and a FIXED table
+// from Parts.schema — a file that declares NO variable table — plus a VARIABLE
+// table from Marks.schema, nested by value and pointed at from here. The Open
+// walk for each lives in the member's DECLARING file, which this one already
+// includes; emitting them in the referencing file instead would define each
+// twice, and emitting them only in files that declare a variable table leaves
+// Parts's two undefined.
+table Album
+{
+    name   string(16)
+    tint   Colour
+    stamp  Stamp
+    marker Marker
+    pin    *Marker
+    head   *ListNode
+}

--- a/tables/pointers/Graph.schema
+++ b/tables/pointers/Graph.schema
@@ -1,0 +1,65 @@
+// Graph.schema — the POINTER corpus (SPEC-TABLES.md §2). Types remain value
+// semantics; tables allow pointer semantics, and this unit exercises every
+// consequence: recursion through a pointer edge, a tree, an optional
+// subtable, aliasing, a variable table nested by value, a bounded array of
+// variable tables — and, deliberately, a value-only table living beside them
+// all so the derived mode can be seen doing its job.
+//
+// Kept in its OWN unit, apart from tables/examples: the pointer-free corpus
+// must stay able to prove, byte for byte, that it pays nothing for any of this.
+package graphdemo
+
+const MaxLayers = 4
+
+// value-only: no pointer anywhere in its by-value closure, so it derives
+// FIXED-SIZE and gets a plain struct plus Measure/Save/Load — nothing else
+table Meta
+{
+    build int32 = 1 | min = 0, max = 1000
+    tag   string(8)
+}
+
+// value-only too, but POINTED AT: it gains the allocation and resolution
+// entries a pointer target needs, and still no builder of its own
+table Settings
+{
+    quality int32 = 2  | min = 0, max = 4
+    label   string(16)
+}
+
+// recursion through a pointer edge — the freedom the by-value cycle rule
+// could never allow
+table ListNode
+{
+    value int32
+    name  string(12)
+    next  *ListNode
+}
+
+table TreeNode
+{
+    label string(12)
+    left  *TreeNode
+    right *TreeNode
+}
+
+// a VARIABLE table that Scene nests BY VALUE: the mode propagates up through
+// by-value nesting, and every walk descends into it
+table Layer
+{
+    depth int32 = 0 | min = 0, max = 64
+    head  *ListNode
+}
+
+table Scene
+{
+    name     string(24)
+    version  int32 = 1          | min = 0, max = 99
+    head     *ListNode
+    tree     *TreeNode
+    settings *Settings
+    alias    *ListNode
+    ground   Layer
+    layers   [..MaxLayers]Layer
+    meta     Meta
+}

--- a/tables/pointers/Marks.schema
+++ b/tables/pointers/Marks.schema
@@ -1,0 +1,16 @@
+// Marks.schema — a VARIABLE table declared in its own file, nested by value
+// and pointed at from a third (Graph). The cross-file variable member: its
+// pack walkers and its Open walk both live here, and the file that nests it
+// picks them up through the include it already has.
+package graphdemo
+
+table Tally
+{
+    hits int32 = 0 | min = 0, max = 10000
+}
+
+table Marker
+{
+    label string(8)
+    note  *Tally
+}

--- a/tables/pointers/Parts.schema
+++ b/tables/pointers/Parts.schema
@@ -1,0 +1,28 @@
+// Parts.schema — a VALUE-ONLY file inside a POINTERED unit (SPEC-TABLES.md
+// §7). Nothing here declares a pointer, and that is the whole point of the
+// file: the cooked form's bounds walk for a member lives in the member's
+// DECLARING file, so a file with no variable table of its own must still emit
+// walks for what sibling files nest by value. A file-scoped emission rule
+// misses exactly this shape, and the generated header of the file that
+// REFERENCES these members then names walks that exist nowhere.
+package graphdemo
+
+// native-mapped, and referenced from another file: the storage there spells
+// ::ColourMath, so every generated call on it — the codecs and the Open walk
+// alike — goes through a derived-to-base conversion
+type Colour | cpp_native = ColourMath, cpp_include = "graph_colour.h"
+{
+    r uint8
+    g uint8
+    b uint8
+}
+
+// a FIXED table that nothing points at: it is only ever nested BY VALUE, so
+// neither the variable set nor the pointer-target set names it — which is
+// exactly why a file-scoped emission rule forgets it. Its count companion
+// still bounds any traversal of tag, so it still needs an Open walk.
+table Stamp
+{
+    tag string(8)
+    seq int32 = 0 | min = 0, max = 1000
+}

--- a/test/tables/P1.schema
+++ b/test/tables/P1.schema
@@ -1,0 +1,18 @@
+// P1.schema — the PRE-POINTER side of the pointer evolution pair
+// (SPEC-TABLES.md §3): `link` nests Link BY VALUE, and Link has no `next`.
+// P2 turns the same field into a pointer and gives Link a pointer of its own.
+// A pointer rides with exactly a by-value nesting's framing, so both
+// directions must read.
+package tblp1
+
+table Link
+{
+    value int32 = 0 | min = 0, max = 1000
+    tag   string(8)
+}
+
+table Chain
+{
+    name string(16)
+    link Link
+}

--- a/test/tables/P2.schema
+++ b/test/tables/P2.schema
@@ -1,0 +1,18 @@
+// P2.schema — the POINTERED side of the evolution pair: `link` became a
+// pointer and Link gained `next`, so P2 can express a chain P1 cannot.
+// Old reader x new data: P1 decodes the first Link and counts `next` unknown.
+// New reader x old data: P2 allocates one node from the by-value body.
+package tblp2
+
+table Link
+{
+    value int32 = 0 | min = 0, max = 1000
+    tag   string(8)
+    next  *Link
+}
+
+table Chain
+{
+    name string(16)
+    link *Link
+}

--- a/test/tables/graph_colour.h
+++ b/test/tables/graph_colour.h
@@ -1,0 +1,24 @@
+// graph_colour.h — the pointer corpus's native-mapped type (SPEC §4.2, Native
+// type mapping), the cross-file case: Colour is declared in Parts.schema and
+// used from Graph.schema, so the storage there spells ::ColourMath and every
+// generated call on it — the codecs AND the cooked form's Open walk — goes
+// through a derived-to-base conversion. Derivation adds behavior, never
+// layout, which is what keeps the storage relocatable.
+
+#pragma once
+
+#include "Parts.h"
+
+#include <type_traits>
+
+struct ColourMath : public graphdemo::Colour
+{
+    ColourMath() { r = 0; g = 0; b = 0; }
+    ColourMath( uint8_t red, uint8_t green, uint8_t blue ) { r = red; g = green; b = blue; }
+
+    uint32_t packed() const { return uint32_t( r ) << 16 | uint32_t( g ) << 8 | uint32_t( b ); }
+};
+
+static_assert( sizeof( ColourMath ) == sizeof( graphdemo::Colour ), "derivation must not change layout" );
+static_assert( std::is_trivially_copyable<ColourMath>::value, "native storage stays relocatable" );
+static_assert( std::is_standard_layout<ColourMath>::value, "native storage stays standard-layout" );

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -15,6 +15,8 @@
 #include "V1Table.h"
 #include "V2Table.h"
 #include "GraphTable.h"
+#include "PartsTable.h"
+#include "MarksTable.h"
 #include "P1Table.h"
 #include "P2Table.h"
 
@@ -1525,6 +1527,114 @@ static void test_descriptors_are_constant()
     for ( auto & reader : readers ) { reader.join(); }
 }
 
+
+// ---- R1: a multi-file pointered unit, across every kind of member ----
+//
+// The gap that let the defect through: `Album` nests a plain TYPE and a FIXED
+// table declared in Parts.schema — a file that declares no variable table and
+// owns no pointer target — plus a VARIABLE table from Marks.schema. The Open
+// walk for each lives in its DECLARING file's header, so a file-scoped
+// emission rule leaves Parts's two undefined and the referencing header will
+// not compile. Colour is native-mapped as well, so the walk is reached through
+// a derived-to-base conversion.
+
+static void test_cross_file_pointer_unit()
+{
+    graphdemo::AlbumBuilder builder;
+    graphdemo::Album * album = builder.GetRoot();
+    set_string( album->name, album->name_length, "cross" );
+
+    // a native-mapped TYPE from another file: the storage speaks ::ColourMath
+    album->tint = ColourMath( 10, 20, 30 );
+    CHECK( album->tint.packed() == 0x0A141Eu );
+
+    // a FIXED table from a file with no variable table of its own
+    set_string( album->stamp.tag, album->stamp.tag_length, "s1" );
+    album->stamp.seq = 42;
+
+    // a VARIABLE table from a third file, nested by value AND pointed at
+    set_string( album->marker.label, album->marker.label_length, "by-val" );
+    graphdemo::TableSlot<graphdemo::Tally> tally = builder.Alloc<graphdemo::Tally>();
+    tally->hits = 7;
+    album->marker.note = tally;
+
+    graphdemo::TableSlot<graphdemo::Marker> pinned = builder.Alloc<graphdemo::Marker>();
+    set_string( pinned->label, pinned->label_length, "pinned" );
+    graphdemo::TableSlot<graphdemo::Tally> pinned_tally = builder.Alloc<graphdemo::Tally>();
+    pinned_tally->hits = 9;
+    pinned->note = pinned_tally;
+    album->pin = pinned;
+
+    graphdemo::TableSlot<graphdemo::ListNode> head = builder.Alloc<graphdemo::ListNode>();
+    head->value = 5;
+    album->head = head;
+
+    // the wire, exactly measured
+    int64_t need = graphdemo::AlbumMeasure( builder );
+    CHECK( need > 0 );
+    uint8_t wire[2048];
+    CHECK( graphdemo::AlbumSave( builder, wire, sizeof( wire ) ) == need );
+    CHECK( graphdemo::AlbumSave( builder, wire, need ) == need );
+    CHECK( graphdemo::AlbumSave( builder, wire, need - 1 ) == -1 );
+
+    CHECK( builder.Lock() );
+    const graphdemo::Album * locked = builder.AsConst();
+    CHECK( locked != NULL );
+
+    // every cross-file member survives the compaction
+    CHECK( strcmp( locked->name, "cross" ) == 0 );
+    CHECK( locked->tint.r == 10 && locked->tint.g == 20 && locked->tint.b == 30 );
+    CHECK( locked->tint.packed() == 0x0A141Eu ); // the native behaviour still rides
+    CHECK( strcmp( locked->stamp.tag, "s1" ) == 0 && locked->stamp.seq == 42 );
+    CHECK( strcmp( locked->marker.label, "by-val" ) == 0 );
+    CHECK( graphdemo::TallyAt( locked->marker.note )->hits == 7 );
+    CHECK( strcmp( graphdemo::MarkerAt( locked->pin )->label, "pinned" ) == 0 );
+    CHECK( graphdemo::TallyAt( graphdemo::MarkerAt( locked->pin )->note )->hits == 9 );
+    CHECK( graphdemo::ListNodeAt( locked->head )->value == 5 );
+
+    // and the round trip through the wire
+    int64_t region_need = graphdemo::AlbumLoadMeasure( wire, need );
+    CHECK( region_need == builder.RegionBytes() );
+    uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
+    graphdemo::TableReport report;
+    const graphdemo::Album * loaded = graphdemo::AlbumLoad( region, region_need, wire, need, &report );
+    CHECK( loaded != NULL );
+    CHECK( report.unknown == 0 && report.kind_mismatch == 0 && report.clamped == 0 && !report.malformed );
+    CHECK( loaded->tint.b == 30 && loaded->stamp.seq == 42 );
+    CHECK( graphdemo::TallyAt( loaded->marker.note )->hits == 7 );
+    CHECK( graphdemo::TallyAt( graphdemo::MarkerAt( loaded->pin )->note )->hits == 9 );
+    free( region );
+
+    // ---- and Open bounds the CROSS-FILE members' companions ----
+    int64_t cook_need = graphdemo::AlbumCookMeasure( builder );
+    uint8_t * file = (uint8_t *) malloc( (size_t) cook_need );
+    CHECK( graphdemo::AlbumCook( builder, file, cook_need ) == cook_need );
+    CHECK( graphdemo::AlbumOpen( file, cook_need ) != NULL );
+
+    graphdemo::Album * forged = (graphdemo::Album *) ( file + graphdemo::kTableCookedHeaderBytes );
+
+    // a FIXED table declared in a file with no variable table at all
+    int32_t good_tag = forged->stamp.tag_length;
+    forged->stamp.tag_length = 30000;
+    CHECK( graphdemo::AlbumOpen( file, cook_need ) == NULL );
+    forged->stamp.tag_length = good_tag;
+
+    // a VARIABLE table declared in a third file, nested by value
+    int32_t good_label = forged->marker.label_length;
+    forged->marker.label_length = -4;
+    CHECK( graphdemo::AlbumOpen( file, cook_need ) == NULL );
+    forged->marker.label_length = good_label;
+
+    // its pointer, out of the region
+    uint32_t good_note = forged->marker.note.value;
+    forged->marker.note.value = 0x7FFFFFF0u;
+    CHECK( graphdemo::AlbumOpen( file, cook_need ) == NULL );
+    forged->marker.note.value = good_note;
+
+    CHECK( graphdemo::AlbumOpen( file, cook_need ) != NULL ); // nothing else broke
+    free( file );
+}
+
 int main()
 {
     test_round_trip();
@@ -1561,6 +1671,7 @@ int main()
     test_open_bounds_nested_fixed_companions();
     test_open_refuses_dirty_reserved();
     test_descriptors_are_constant();
+    test_cross_file_pointer_unit();
 
     if ( failures > 0 )
     {

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -70,8 +70,8 @@ static void set_string( char * dest, int32_t & length, const char * s )
 static void le16( uint8_t * p, uint16_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); }
 static void le32( uint8_t * p, uint32_t v ) { p[0] = (uint8_t) v; p[1] = (uint8_t) ( v >> 8 ); p[2] = (uint8_t) ( v >> 16 ); p[3] = (uint8_t) ( v >> 24 ); }
 
-// check_exact_capacity is the go-wide guarantee: TableSave into a buffer of
-// EXACTLY TableMeasure's size succeeds and byte-matches a roomy save — a
+// check_exact_capacity is the go-wide guarantee: <X>Save into a buffer of
+// EXACTLY <X>Measure's size succeeds and byte-matches a roomy save — a
 // scatter-writing worker gets exactly sizes[i] and nothing more.
 template <typename T>
 static void check_exact_capacity( const T & value,
@@ -658,7 +658,7 @@ static const graphdemo::TableFieldInfo * graph_field( const graphdemo::TableType
 // list nodes on the chain.
 static int build_scene( graphdemo::SceneBuilder & builder )
 {
-    graphdemo::Scene * root = builder.Root();
+    graphdemo::Scene * root = builder.GetRoot();
     set_string( root->name, root->name_length, "graph" );
     root->version = 7;
     root->meta.build = 42;
@@ -764,11 +764,11 @@ static void test_pointer_lifecycle()
     // Lock: one way, and it IS the compaction
     CHECK( builder.Lock() );
     CHECK( builder.Locked() );
-    CHECK( builder.Root() == NULL );      // the mutable life is over
+    CHECK( builder.GetRoot() == NULL );      // the mutable life is over
     CHECK( builder.Alloc<graphdemo::ListNode>().null() ); // and Alloc refuses
     CHECK( builder.Lock() );              // idempotent, never a second compaction
 
-    const graphdemo::Scene * locked = builder.Const();
+    const graphdemo::Scene * locked = builder.AsConst();
     check_scene( locked );
 
     // the packed region has zero slack and every node is 8-aligned
@@ -845,14 +845,14 @@ static void test_lock_layout_stable()
 static void test_pointer_alias()
 {
     graphdemo::SceneBuilder builder;
-    graphdemo::Scene * root = builder.Root();
+    graphdemo::Scene * root = builder.GetRoot();
     graphdemo::TableSlot<graphdemo::ListNode> shared = builder.Alloc<graphdemo::ListNode>();
     shared->value = 1234;
     root->head = shared;
     root->alias = shared; // the SAME node named twice
 
     CHECK( builder.Lock() );
-    const graphdemo::Scene * locked = builder.Const();
+    const graphdemo::Scene * locked = builder.AsConst();
     const graphdemo::ListNode * viaHead = graphdemo::ListNodeAt( locked->head );
     const graphdemo::ListNode * viaAlias = graphdemo::ListNodeAt( locked->alias );
     CHECK( viaHead != NULL && viaAlias != NULL );
@@ -880,7 +880,7 @@ static void test_pointer_alias()
 static void test_pointer_cycle_refused()
 {
     graphdemo::SceneBuilder builder;
-    graphdemo::Scene * root = builder.Root();
+    graphdemo::Scene * root = builder.GetRoot();
     graphdemo::TableSlot<graphdemo::ListNode> loop = builder.Alloc<graphdemo::ListNode>();
     loop->value = 1;
     loop->next = loop;   // a node pointing at itself
@@ -901,7 +901,7 @@ static void test_pointer_depth_cap()
     // root is level 1
     {
         graphdemo::SceneBuilder builder;
-        graphdemo::Scene * root = builder.Root();
+        graphdemo::Scene * root = builder.GetRoot();
         graphdemo::TableSlot<graphdemo::ListNode> head = builder.Alloc<graphdemo::ListNode>();
         head->value = 0;
         root->head = head;
@@ -918,7 +918,7 @@ static void test_pointer_depth_cap()
     // one link past it refuses instead of recursing away
     {
         graphdemo::SceneBuilder builder;
-        graphdemo::Scene * root = builder.Root();
+        graphdemo::Scene * root = builder.GetRoot();
         graphdemo::TableSlot<graphdemo::ListNode> head = builder.Alloc<graphdemo::ListNode>();
         root->head = head;
         graphdemo::ListNode * tail = head;
@@ -941,7 +941,7 @@ static void test_pointer_depth_cap()
 static void test_builder_grow()
 {
     graphdemo::SceneBuilder builder;
-    graphdemo::Scene * root = builder.Root();
+    graphdemo::Scene * root = builder.GetRoot();
 
     // enough nodes to cross many 64 KiB slabs and more than one 4 MiB segment
     const int count = 200000;
@@ -960,7 +960,7 @@ static void test_builder_grow()
     // the same node, and the root the builder handed out is still valid
     CHECK( held->value == 1 );
     CHECK( middle.ptr != NULL && middle->value == count / 2 + 1 );
-    CHECK( builder.Root() == root );
+    CHECK( builder.GetRoot() == root );
 
     root->head = first;
     CHECK( graphdemo::SceneMeasure( builder ) > 0 );
@@ -972,7 +972,7 @@ static void test_builder_workers()
 {
     // deterministic first: four workers, interleaved, single-threaded
     graphdemo::SceneBuilder builder;
-    graphdemo::Scene * root = builder.Root();
+    graphdemo::Scene * root = builder.GetRoot();
     graphdemo::TableWorker workers[4];
     for ( int i = 0; i < 4; i++ ) { workers[i] = builder.Worker(); }
 
@@ -990,7 +990,7 @@ static void test_builder_workers()
         tail = node;
     }
     CHECK( builder.Lock() );
-    const graphdemo::ListNode * walk = graphdemo::ListNodeAt( builder.Const()->head );
+    const graphdemo::ListNode * walk = graphdemo::ListNodeAt( builder.AsConst()->head );
     for ( int i = 0; i < 64; i++ )
     {
         CHECK( walk != NULL && walk->value == i );
@@ -1024,7 +1024,7 @@ static void test_builder_workers()
     }
     for ( auto & thread : threads ) { thread.join(); }
     // the join is the barrier; everything below is single-threaded
-    graphdemo::Scene * threaded_root = threaded.Root();
+    graphdemo::Scene * threaded_root = threaded.GetRoot();
     threaded_root->layers_count = 4;
     for ( int t = 0; t < 4; t++ )
     {
@@ -1127,7 +1127,7 @@ static void test_pointer_evolution_old_reader_new_data()
 {
     // P2 writes a chain of two Links through a POINTER field
     tblp2::ChainBuilder builder;
-    tblp2::Chain * root = builder.Root();
+    tblp2::Chain * root = builder.GetRoot();
     set_string( root->name, root->name_length, "chain" );
     tblp2::TableSlot<tblp2::Link> first = builder.Alloc<tblp2::Link>();
     tblp2::TableSlot<tblp2::Link> second = builder.Alloc<tblp2::Link>();
@@ -1184,13 +1184,13 @@ static void test_pointer_evolution_new_reader_old_data()
     tblp2::TableReport builder_report;
     CHECK( tblp2::ChainLoadBuilder( builder, wire, wrote, &builder_report ) );
     CHECK( !builder_report.malformed );
-    tblp2::Link * loaded = tblp2::LinkAt( builder.arena, builder.Root()->link );
+    tblp2::Link * loaded = tblp2::LinkAt( builder.arena, builder.GetRoot()->link );
     CHECK( loaded != NULL && loaded->value == 77 );
     tblp2::TableSlot<tblp2::Link> added = builder.Alloc<tblp2::Link>();
     added->value = 88;
     loaded->next = added;
     CHECK( builder.Lock() );
-    CHECK( tblp2::LinkAt( tblp2::LinkAt( builder.Const()->link )->next )->value == 88 );
+    CHECK( tblp2::LinkAt( tblp2::LinkAt( builder.AsConst()->link )->next )->value == 88 );
 }
 
 // ---- a null pointer elides; a non-null one rides even when all-default ----
@@ -1203,7 +1203,7 @@ static void test_pointer_null_and_empty()
 
     graphdemo::SceneBuilder one;
     graphdemo::TableSlot<graphdemo::ListNode> node = one.Alloc<graphdemo::ListNode>();
-    one.Root()->head = node; // an ALL-DEFAULT pointee behind a non-null pointer
+    one.GetRoot()->head = node; // an ALL-DEFAULT pointee behind a non-null pointer
     int64_t with_empty = graphdemo::SceneMeasure( one );
     CHECK( with_empty == 2 + 3 + 4 + 2 ); // id + kind + length + the empty body
 
@@ -1259,6 +1259,272 @@ static void test_pointer_reflection()
     CHECK( sizeof( graphdemo::TableRef ) == 4 );
 }
 
+
+// ============================================================================
+// REGRESSIONS from the adversarial review. Each is the reviewer's own repro,
+// reduced to an assertion that goes red if the defect returns.
+// ============================================================================
+
+// ---- B1: Open's walk is LINEAR, not exponential ----
+//
+// The repro: a legal cooked file whose TreeNode chain runs down `left`, then
+// forged so every node's `right` ALIASES its `left`. Every reference stays
+// forward, in range and aligned, so a walk with no order state explores 2^n
+// paths — 26 nodes took 312 ms and ~60 nodes never returned. The high-water
+// mark refuses the second (aliasing) reference outright, in linear time.
+static void test_open_walk_is_linear()
+{
+    for ( int n : { 16, 26, 40, 64 } )
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::TableRef * slot = &builder.GetRoot()->tree;
+        for ( int i = 0; i < n; i++ )
+        {
+            graphdemo::TableSlot<graphdemo::TreeNode> node = builder.Alloc<graphdemo::TreeNode>();
+            *slot = node.ref;
+            slot = &node.ptr->left;
+        }
+        CHECK( builder.Lock() );
+        int64_t need = graphdemo::SceneCookMeasure( builder );
+        uint8_t * file = (uint8_t *) malloc( (size_t) need );
+        CHECK( graphdemo::SceneCook( builder, file, need ) == need );
+        CHECK( graphdemo::SceneOpen( file, need ) != NULL ); // the genuine file opens
+
+        // forge: every node's right aliases its left — forward, in range, aligned
+        uint8_t * base = file + graphdemo::kTableCookedHeaderBytes;
+        int64_t region = need - graphdemo::kTableCookedHeaderBytes;
+        graphdemo::Scene * root = (graphdemo::Scene *) base;
+        int64_t at = ( (uint8_t *) &root->tree - base ) + (int64_t) root->tree.value;
+        int patched = 0;
+        while ( at + (int64_t) sizeof( graphdemo::TreeNode ) <= region )
+        {
+            graphdemo::TreeNode * node = (graphdemo::TreeNode *) ( base + at );
+            if ( node->left.value == 0 ) { break; }
+            int64_t next_at = ( (uint8_t *) &node->left - base ) + (int64_t) node->left.value;
+            node->right.value = (uint32_t) ( ( base + next_at ) - (uint8_t *) &node->right );
+            patched++;
+            at = next_at;
+        }
+        CHECK( patched == n - 1 );
+        // REFUSED, and refused in linear time: the mark makes each accepted
+        // reference consume region bytes, so the walk cannot revisit a node.
+        // At n = 64 an unbounded walk would not return in the age of the
+        // universe; this returns before the next line runs.
+        CHECK( graphdemo::SceneOpen( file, need ) == NULL );
+        free( file );
+    }
+}
+
+// ---- B1's companion: the mark also closes mid-node overlap ----
+
+static void test_open_refuses_overlap()
+{
+    graphdemo::SceneBuilder builder;
+    graphdemo::TableSlot<graphdemo::ListNode> a = builder.Alloc<graphdemo::ListNode>();
+    graphdemo::TableSlot<graphdemo::ListNode> b = builder.Alloc<graphdemo::ListNode>();
+    a->value = 1;
+    b->value = 2;
+    a->next = b;
+    builder.GetRoot()->head = a;
+    CHECK( builder.Lock() );
+    int64_t need = graphdemo::SceneCookMeasure( builder );
+    uint8_t * file = (uint8_t *) malloc( (size_t) need );
+    CHECK( graphdemo::SceneCook( builder, file, need ) == need );
+    CHECK( graphdemo::SceneOpen( file, need ) != NULL );
+
+    // point head at a node-sized window that STARTS inside the first node:
+    // in range, aligned, forward — and an overlap the mark refuses
+    uint8_t * base = file + graphdemo::kTableCookedHeaderBytes;
+    graphdemo::Scene * root = (graphdemo::Scene *) base;
+    root->head.value += 8;
+    CHECK( graphdemo::SceneOpen( file, need ) == NULL );
+    free( file );
+}
+
+// ---- B2: Lock and Cook are deterministic on a DIRTIED heap ----
+//
+// Lock and Cook memcpy whole nodes, struct PADDING included. Value-initialising
+// a node zeroes its members and not its padding, so before the arena's segments
+// were zeroed this test passed only when the allocator happened to hand back
+// fresh zero pages — and a cooked FILE carried heap bytes to disk.
+
+static void dirty_the_heap( int pattern )
+{
+    void * blocks[6];
+    for ( int i = 0; i < 6; i++ )
+    {
+        blocks[i] = malloc( 4u << 20 );
+        memset( blocks[i], pattern, 4u << 20 );
+    }
+    for ( int i = 0; i < 6; i++ ) { free( blocks[i] ); }
+}
+
+static void test_lock_deterministic_on_dirty_heap()
+{
+    dirty_the_heap( 0xA5 );
+    graphdemo::SceneBuilder first;
+    build_scene( first );
+    CHECK( first.Lock() );
+    int64_t bytes = first.RegionBytes();
+    uint8_t * saved = (uint8_t *) malloc( (size_t) bytes );
+    memcpy( saved, first.Region(), (size_t) bytes );
+    int64_t cook_bytes = graphdemo::SceneCookMeasure( first );
+    uint8_t * cooked_first = (uint8_t *) malloc( (size_t) cook_bytes );
+    CHECK( graphdemo::SceneCook( first, cooked_first, cook_bytes ) == cook_bytes );
+
+    dirty_the_heap( 0x5C ); // a DIFFERENT pattern, so any leak shows as a diff
+    graphdemo::SceneBuilder second;
+    build_scene( second );
+    CHECK( second.Lock() );
+    CHECK( second.RegionBytes() == bytes );
+    CHECK( memcmp( saved, second.Region(), (size_t) bytes ) == 0 );
+
+    uint8_t * cooked_second = (uint8_t *) malloc( (size_t) cook_bytes );
+    CHECK( graphdemo::SceneCook( second, cooked_second, cook_bytes ) == cook_bytes );
+    CHECK( memcmp( cooked_first, cooked_second, (size_t) cook_bytes ) == 0 );
+
+    // and no padding byte carries heap content: the region's tail padding of
+    // the root's string is zero, whatever the allocator handed back
+    const uint8_t * region = second.Region();
+    for ( int64_t i = (int64_t) offsetof( graphdemo::Scene, name ) + 6;
+          i < (int64_t) offsetof( graphdemo::Scene, name ) + 24; i++ )
+    {
+        CHECK( region[i] == 0 );
+    }
+    free( saved );
+    free( cooked_first );
+    free( cooked_second );
+}
+
+// ---- C1: the four walks agree about what depth costs ----
+//
+// By-value nesting charges depth in NEITHER walk, so a chain that Locks and
+// Cooks is a chain the wire accepts. Before the fix, measure/save/load charged
+// a by-value nesting and pack/cook/open did not, and a structure reachable
+// through Scene::ground was lockable and cookable but unsaveable.
+
+static void test_depth_agrees_through_by_value_nesting()
+{
+    graphdemo::SceneBuilder builder;
+    // the chain hangs off `ground`, a VARIABLE table nested BY VALUE
+    graphdemo::TableSlot<graphdemo::ListNode> head = builder.Alloc<graphdemo::ListNode>();
+    head->value = 0;
+    builder.GetRoot()->ground.head = head;
+    graphdemo::ListNode * tail = head;
+    for ( int i = 1; i < graphdemo::kTableMaxDepth - 1; i++ ) // 127 nodes
+    {
+        graphdemo::TableSlot<graphdemo::ListNode> node = builder.Alloc<graphdemo::ListNode>();
+        node->value = i;
+        tail->next = node;
+        tail = node;
+    }
+
+    // every walk accepts it: measure, save, pack (Lock), cook, open, load
+    int64_t need = graphdemo::SceneMeasure( builder );
+    CHECK( need > 0 );
+    uint8_t * wire = (uint8_t *) malloc( (size_t) need );
+    CHECK( graphdemo::SceneSave( builder, wire, need ) == need );
+    CHECK( builder.Lock() );
+    int64_t cook_bytes = graphdemo::SceneCookMeasure( builder );
+    CHECK( cook_bytes > 0 );
+    uint8_t * cooked = (uint8_t *) malloc( (size_t) cook_bytes );
+    CHECK( graphdemo::SceneCook( builder, cooked, cook_bytes ) == cook_bytes );
+    CHECK( graphdemo::SceneOpen( cooked, cook_bytes ) != NULL );
+
+    int64_t region_need = graphdemo::SceneLoadMeasure( wire, need );
+    uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
+    graphdemo::TableReport report;
+    const graphdemo::Scene * loaded = graphdemo::SceneLoad( region, region_need, wire, need, &report );
+    CHECK( loaded != NULL && !report.malformed ); // the wire agrees with Lock
+    int walked = 0;
+    for ( const graphdemo::ListNode * node = graphdemo::ListNodeAt( loaded->ground.head );
+          node != NULL; node = graphdemo::ListNodeAt( node->next ) )
+    {
+        CHECK( node->value == walked );
+        walked++;
+    }
+    CHECK( walked == graphdemo::kTableMaxDepth - 1 );
+    free( wire );
+    free( cooked );
+    free( region );
+}
+
+// ---- C2: Open bounds the companions of by-value nested FIXED tables ----
+
+static void test_open_bounds_nested_fixed_companions()
+{
+    graphdemo::SceneBuilder builder;
+    build_scene( builder );
+    CHECK( builder.Lock() );
+    int64_t need = graphdemo::SceneCookMeasure( builder );
+    uint8_t * file = (uint8_t *) malloc( (size_t) need );
+    CHECK( graphdemo::SceneCook( builder, file, need ) == need );
+    CHECK( graphdemo::SceneOpen( file, need ) != NULL );
+
+    // Meta is FIXED-SIZE and nested BY VALUE in Scene. Its tag_length bounds
+    // any walk of tag[8]; an unbounded one is the over-read.
+    graphdemo::Scene * root = (graphdemo::Scene *) ( file + graphdemo::kTableCookedHeaderBytes );
+    int32_t good = root->meta.tag_length;
+    root->meta.tag_length = 30000;
+    CHECK( graphdemo::SceneOpen( file, need ) == NULL );
+    root->meta.tag_length = -1;
+    CHECK( graphdemo::SceneOpen( file, need ) == NULL );
+    root->meta.tag_length = good;
+    CHECK( graphdemo::SceneOpen( file, need ) != NULL );
+
+    // the same for a fixed table reached through a POINTER
+    graphdemo::Settings * settings = (graphdemo::Settings *) graphdemo::SettingsAt( root->settings );
+    CHECK( settings != NULL );
+    settings->label_length = 9999;
+    CHECK( graphdemo::SceneOpen( file, need ) == NULL );
+    free( file );
+}
+
+// ---- the cooked header's reserved words are reserved ----
+
+static void test_open_refuses_dirty_reserved()
+{
+    graphdemo::SceneBuilder builder;
+    build_scene( builder );
+    CHECK( builder.Lock() );
+    int64_t need = graphdemo::SceneCookMeasure( builder );
+    uint8_t * file = (uint8_t *) malloc( (size_t) need );
+    CHECK( graphdemo::SceneCook( builder, file, need ) == need );
+    CHECK( graphdemo::SceneOpen( file, need ) != NULL );
+    for ( int64_t at = 12; at < graphdemo::kTableCookedHeaderBytes; at++ )
+    {
+        file[at] = 0x7F; // a writer that used a reserved word
+        CHECK( graphdemo::SceneOpen( file, need ) == NULL );
+        file[at] = 0;
+    }
+    CHECK( graphdemo::SceneOpen( file, need ) != NULL );
+    free( file );
+}
+
+// ---- C3: the reflection surface is immutable constant data ----
+
+static void test_descriptors_are_constant()
+{
+    // no lazy link, so a self-referential target is already resolved on the
+    // first read from any thread — the descriptors carry no mutable state
+    const graphdemo::TableTypeInfo * list = graphdemo::ListNodeTableType();
+    CHECK( graph_field( list, "next" )->table == list );
+    CHECK( graphdemo::ListNodeTableType() == list ); // one instance, always
+    // reading from several threads at once is a plain read of constant data
+    std::vector<std::thread> readers;
+    for ( int t = 0; t < 4; t++ )
+    {
+        readers.emplace_back( [list]() {
+            for ( int i = 0; i < 2000; i++ )
+            {
+                CHECK( graphdemo::ListNodeTableType() == list );
+                CHECK( graphdemo::SceneTableType()->variable );
+            }
+        } );
+    }
+    for ( auto & reader : readers ) { reader.join(); }
+}
+
 int main()
 {
     test_round_trip();
@@ -1287,6 +1553,14 @@ int main()
     test_pointer_evolution_new_reader_old_data();
     test_pointer_null_and_empty();
     test_pointer_reflection();
+
+    test_open_walk_is_linear();
+    test_open_refuses_overlap();
+    test_lock_deterministic_on_dirty_heap();
+    test_depth_agrees_through_by_value_nesting();
+    test_open_bounds_nested_fixed_companions();
+    test_open_refuses_dirty_reserved();
+    test_descriptors_are_constant();
 
     if ( failures > 0 )
     {

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -7,10 +7,16 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <thread>
+#include <vector>
+
 #include "TablesTable.h"
 #include "NestedTable.h"
 #include "V1Table.h"
 #include "V2Table.h"
+#include "GraphTable.h"
+#include "P1Table.h"
+#include "P2Table.h"
 
 static int failures = 0;
 
@@ -633,6 +639,626 @@ static void test_parallel_shape()
     }
 }
 
+
+// ============================================================================
+// POINTER SEMANTICS (SPEC-TABLES.md §2, §6). Types remain value semantics;
+// tables allow pointer semantics — and everything below is a consequence.
+// ============================================================================
+
+static const graphdemo::TableFieldInfo * graph_field( const graphdemo::TableTypeInfo * type, const char * name )
+{
+    for ( int32_t i = 0; i < type->num_fields; i++ )
+        if ( strcmp( type->fields[i].name, name ) == 0 )
+            return &type->fields[i];
+    return NULL;
+}
+
+// build_scene populates a builder with a list, a tree, an optional subtable, a
+// by-value nested variable table and an array of them. Returns the number of
+// list nodes on the chain.
+static int build_scene( graphdemo::SceneBuilder & builder )
+{
+    graphdemo::Scene * root = builder.Root();
+    set_string( root->name, root->name_length, "graph" );
+    root->version = 7;
+    root->meta.build = 42;
+    set_string( root->meta.tag, root->meta.tag_length, "m" );
+
+    graphdemo::TableSlot<graphdemo::Settings> settings = builder.Alloc<graphdemo::Settings>();
+    settings->quality = 4;
+    set_string( settings->label, settings->label_length, "high" );
+    root->settings = settings;
+
+    graphdemo::TableSlot<graphdemo::ListNode> n0 = builder.Alloc<graphdemo::ListNode>();
+    graphdemo::TableSlot<graphdemo::ListNode> n1 = builder.Alloc<graphdemo::ListNode>();
+    graphdemo::TableSlot<graphdemo::ListNode> n2 = builder.Alloc<graphdemo::ListNode>();
+    n0->value = 10; set_string( n0->name, n0->name_length, "a" );
+    n1->value = 20; set_string( n1->name, n1->name_length, "b" );
+    n2->value = 30;
+    n0->next = n1;
+    n1->next = n2;
+    root->head = n0;
+
+    graphdemo::TableSlot<graphdemo::TreeNode> t = builder.Alloc<graphdemo::TreeNode>();
+    graphdemo::TableSlot<graphdemo::TreeNode> tl = builder.Alloc<graphdemo::TreeNode>();
+    graphdemo::TableSlot<graphdemo::TreeNode> tr = builder.Alloc<graphdemo::TreeNode>();
+    set_string( t->label, t->label_length, "root" );
+    set_string( tl->label, tl->label_length, "left" );
+    set_string( tr->label, tr->label_length, "right" );
+    t->left = tl;
+    t->right = tr;
+    root->tree = t;
+
+    // a variable table nested BY VALUE, with a pointer of its own
+    root->ground.depth = 3;
+    graphdemo::TableSlot<graphdemo::ListNode> g0 = builder.Alloc<graphdemo::ListNode>();
+    g0->value = 99;
+    root->ground.head = g0;
+
+    // a bounded array of variable tables
+    root->layers_count = 2;
+    root->layers[0].depth = 1;
+    root->layers[1].depth = 2;
+    graphdemo::TableSlot<graphdemo::ListNode> l1 = builder.Alloc<graphdemo::ListNode>();
+    l1->value = 55;
+    root->layers[1].head = l1;
+
+    return 3;
+}
+
+// check_scene reads a scene through a CONST root — the only way a
+// pointer-bearing table is ever read: a region and a root view, never a value.
+static void check_scene( const graphdemo::Scene * scene )
+{
+    CHECK( scene != NULL );
+    if ( scene == NULL ) return;
+    CHECK( strcmp( scene->name, "graph" ) == 0 );
+    CHECK( scene->version == 7 );
+    CHECK( scene->meta.build == 42 );
+
+    const graphdemo::ListNode * a = graphdemo::ListNodeAt( scene->head );
+    CHECK( a != NULL && a->value == 10 && strcmp( a->name, "a" ) == 0 );
+    const graphdemo::ListNode * b = graphdemo::ListNodeAt( a->next );
+    CHECK( b != NULL && b->value == 20 );
+    const graphdemo::ListNode * c = graphdemo::ListNodeAt( b->next );
+    CHECK( c != NULL && c->value == 30 );
+    CHECK( graphdemo::ListNodeAt( c->next ) == NULL ); // the chain ends in null
+
+    const graphdemo::TreeNode * t = graphdemo::TreeNodeAt( scene->tree );
+    CHECK( t != NULL && strcmp( t->label, "root" ) == 0 );
+    CHECK( strcmp( graphdemo::TreeNodeAt( t->left )->label, "left" ) == 0 );
+    CHECK( strcmp( graphdemo::TreeNodeAt( t->right )->label, "right" ) == 0 );
+    CHECK( graphdemo::TreeNodeAt( graphdemo::TreeNodeAt( t->left )->left ) == NULL );
+
+    const graphdemo::Settings * settings = graphdemo::SettingsAt( scene->settings );
+    CHECK( settings != NULL && settings->quality == 4 && strcmp( settings->label, "high" ) == 0 );
+
+    CHECK( scene->ground.depth == 3 );
+    CHECK( graphdemo::ListNodeAt( scene->ground.head )->value == 99 );
+    CHECK( scene->layers_count == 2 );
+    CHECK( scene->layers[0].depth == 1 );
+    CHECK( graphdemo::ListNodeAt( scene->layers[0].head ) == NULL ); // never set: null
+    CHECK( graphdemo::ListNodeAt( scene->layers[1].head )->value == 55 );
+}
+
+// ---- the lifecycle: build -> Lock -> the region; wire out and back ----
+
+static void test_pointer_lifecycle()
+{
+    graphdemo::SceneBuilder builder;
+    build_scene( builder );
+
+    // measure/save straight out of the MUTABLE arena
+    int64_t need = graphdemo::SceneMeasure( builder );
+    CHECK( need > 0 );
+    static uint8_t wire[8192];
+    int64_t wrote = graphdemo::SceneSave( builder, wire, sizeof( wire ) );
+    CHECK( wrote == need );
+
+    // the exact-capacity guarantee, across a pointer graph
+    static uint8_t exact[8192];
+    CHECK( graphdemo::SceneSave( builder, exact, need ) == need );
+    CHECK( memcmp( wire, exact, (size_t) need ) == 0 );
+    CHECK( graphdemo::SceneSave( builder, exact, need - 1 ) == -1 );
+
+    // Lock: one way, and it IS the compaction
+    CHECK( builder.Lock() );
+    CHECK( builder.Locked() );
+    CHECK( builder.Root() == NULL );      // the mutable life is over
+    CHECK( builder.Alloc<graphdemo::ListNode>().null() ); // and Alloc refuses
+    CHECK( builder.Lock() );              // idempotent, never a second compaction
+
+    const graphdemo::Scene * locked = builder.Const();
+    check_scene( locked );
+
+    // the packed region has zero slack and every node is 8-aligned
+    CHECK( builder.RegionBytes() > 0 );
+    CHECK( ( builder.RegionBytes() % 8 ) == 0 );
+
+    // saving from the locked region gives byte-identical wire to saving from
+    // the arena: one structure, two representations, one meaning
+    static uint8_t after_lock[8192];
+    int64_t wrote2 = graphdemo::SceneSave( locked, after_lock, sizeof( after_lock ) );
+    CHECK( wrote2 == wrote );
+    CHECK( memcmp( wire, after_lock, (size_t) wrote ) == 0 );
+
+    // the region relocates by PURE MEMCPY: self-relative references need no
+    // fix-up, so a copy at a different address reads the same
+    uint8_t * moved = (uint8_t *) malloc( (size_t) builder.RegionBytes() );
+    memcpy( moved, builder.Region(), (size_t) builder.RegionBytes() );
+    check_scene( (const graphdemo::Scene *) moved );
+    free( moved );
+
+    // wire -> const region, sized EXACTLY by the pre-pass
+    int64_t region_need = graphdemo::SceneLoadMeasure( wire, wrote );
+    CHECK( region_need == builder.RegionBytes() ); // the two forms agree
+    uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
+    graphdemo::TableReport report;
+    const graphdemo::Scene * loaded = graphdemo::SceneLoad( region, region_need, wire, wrote, &report );
+    CHECK( loaded != NULL );
+    CHECK( report.unknown == 0 && report.kind_mismatch == 0 && report.clamped == 0 && !report.malformed );
+    check_scene( loaded );
+
+    // a loaded region re-saves to the same bytes
+    static uint8_t again[8192];
+    CHECK( graphdemo::SceneSave( loaded, again, sizeof( again ) ) == wrote );
+    CHECK( memcmp( wire, again, (size_t) wrote ) == 0 );
+
+    // a region one byte short refuses rather than overrunning
+    uint8_t * tight = (uint8_t *) malloc( (size_t) region_need );
+    graphdemo::TableReport short_report;
+    const graphdemo::Scene * partial = graphdemo::SceneLoad( tight, region_need - 8, wire, wrote, &short_report );
+    CHECK( partial != NULL && short_report.malformed ); // partial result, flagged
+    free( tight );
+
+    free( region );
+}
+
+// ---- Lock's byte layout is deterministic: same input, same region ----
+
+static void test_lock_layout_stable()
+{
+    graphdemo::SceneBuilder first;
+    build_scene( first );
+    CHECK( first.Lock() );
+
+    graphdemo::SceneBuilder second;
+    build_scene( second );
+    CHECK( second.Lock() );
+
+    CHECK( first.RegionBytes() == second.RegionBytes() );
+    CHECK( memcmp( first.Region(), second.Region(), (size_t) first.RegionBytes() ) == 0 );
+
+    // and cooking twice gives identical files
+    int64_t need = graphdemo::SceneCookMeasure( first );
+    uint8_t * a = (uint8_t *) malloc( (size_t) need );
+    uint8_t * b = (uint8_t *) malloc( (size_t) need );
+    CHECK( graphdemo::SceneCook( first, a, need ) == need );
+    CHECK( graphdemo::SceneCook( second, b, need ) == need );
+    CHECK( memcmp( a, b, (size_t) need ) == 0 );
+    free( a );
+    free( b );
+}
+
+// ---- aliasing: two pointers to one node are TWO nodes, everywhere ----
+
+static void test_pointer_alias()
+{
+    graphdemo::SceneBuilder builder;
+    graphdemo::Scene * root = builder.Root();
+    graphdemo::TableSlot<graphdemo::ListNode> shared = builder.Alloc<graphdemo::ListNode>();
+    shared->value = 1234;
+    root->head = shared;
+    root->alias = shared; // the SAME node named twice
+
+    CHECK( builder.Lock() );
+    const graphdemo::Scene * locked = builder.Const();
+    const graphdemo::ListNode * viaHead = graphdemo::ListNodeAt( locked->head );
+    const graphdemo::ListNode * viaAlias = graphdemo::ListNodeAt( locked->alias );
+    CHECK( viaHead != NULL && viaAlias != NULL );
+    CHECK( viaHead->value == 1234 && viaAlias->value == 1234 );
+    // wire v1 is a TREE: identity is NOT preserved, and the packed form says so
+    // in the same voice — two references, two nodes (SPEC-TABLES.md §3)
+    CHECK( viaHead != viaAlias );
+
+    static uint8_t wire[1024];
+    int64_t wrote = graphdemo::SceneSave( locked, wire, sizeof( wire ) );
+    CHECK( wrote > 0 );
+    int64_t region_need = graphdemo::SceneLoadMeasure( wire, wrote );
+    uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
+    graphdemo::TableReport report;
+    const graphdemo::Scene * loaded = graphdemo::SceneLoad( region, region_need, wire, wrote, &report );
+    CHECK( loaded != NULL && !report.malformed );
+    CHECK( graphdemo::ListNodeAt( loaded->head )->value == 1234 );
+    CHECK( graphdemo::ListNodeAt( loaded->alias )->value == 1234 );
+    CHECK( graphdemo::ListNodeAt( loaded->head ) != graphdemo::ListNodeAt( loaded->alias ) );
+    free( region );
+}
+
+// ---- a data cycle is an ERROR, never a hang ----
+
+static void test_pointer_cycle_refused()
+{
+    graphdemo::SceneBuilder builder;
+    graphdemo::Scene * root = builder.Root();
+    graphdemo::TableSlot<graphdemo::ListNode> loop = builder.Alloc<graphdemo::ListNode>();
+    loop->value = 1;
+    loop->next = loop;   // a node pointing at itself
+    root->head = loop;
+
+    static uint8_t buffer[4096];
+    CHECK( graphdemo::SceneMeasure( builder ) == -1 );
+    CHECK( graphdemo::SceneSave( builder, buffer, sizeof( buffer ) ) == -1 );
+    CHECK( graphdemo::SceneCookMeasure( builder ) == -1 );
+    CHECK( !builder.Lock() ); // the compaction refuses too
+}
+
+// ---- the depth cap: a chain past it refuses, and the wire stops at it ----
+
+static void test_pointer_depth_cap()
+{
+    // a chain exactly AT the cap saves; the cap counts nesting levels, and the
+    // root is level 1
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.Root();
+        graphdemo::TableSlot<graphdemo::ListNode> head = builder.Alloc<graphdemo::ListNode>();
+        head->value = 0;
+        root->head = head;
+        graphdemo::ListNode * tail = head;
+        for ( int i = 1; i < graphdemo::kTableMaxDepth - 1; i++ )
+        {
+            graphdemo::TableSlot<graphdemo::ListNode> node = builder.Alloc<graphdemo::ListNode>();
+            node->value = i;
+            tail->next = node;
+            tail = node;
+        }
+        CHECK( graphdemo::SceneMeasure( builder ) > 0 );
+    }
+    // one link past it refuses instead of recursing away
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.Root();
+        graphdemo::TableSlot<graphdemo::ListNode> head = builder.Alloc<graphdemo::ListNode>();
+        root->head = head;
+        graphdemo::ListNode * tail = head;
+        for ( int i = 1; i < graphdemo::kTableMaxDepth + 8; i++ )
+        {
+            graphdemo::TableSlot<graphdemo::ListNode> node = builder.Alloc<graphdemo::ListNode>();
+            node->value = i;
+            tail->next = node;
+            tail = node;
+        }
+        static uint8_t buffer[65536];
+        CHECK( graphdemo::SceneMeasure( builder ) == -1 );
+        CHECK( graphdemo::SceneSave( builder, buffer, sizeof( buffer ) ) == -1 );
+        CHECK( !builder.Lock() );
+    }
+}
+
+// ---- the arena grows without invalidating anything ----
+
+static void test_builder_grow()
+{
+    graphdemo::SceneBuilder builder;
+    graphdemo::Scene * root = builder.Root();
+
+    // enough nodes to cross many 64 KiB slabs and more than one 4 MiB segment
+    const int count = 200000;
+    graphdemo::TableSlot<graphdemo::ListNode> first = builder.Alloc<graphdemo::ListNode>();
+    first->value = 1;
+    graphdemo::ListNode * held = first;          // a pointer held ACROSS all the growth
+    graphdemo::TableSlot<graphdemo::ListNode> middle;
+    for ( int i = 1; i < count; i++ )
+    {
+        graphdemo::TableSlot<graphdemo::ListNode> node = builder.Alloc<graphdemo::ListNode>();
+        CHECK( !node.null() || i == 0 );
+        node->value = i + 1;
+        if ( i == count / 2 ) { middle = node; }
+    }
+    // segments never move: the pointer taken before 200k allocations is still
+    // the same node, and the root the builder handed out is still valid
+    CHECK( held->value == 1 );
+    CHECK( middle.ptr != NULL && middle->value == count / 2 + 1 );
+    CHECK( builder.Root() == root );
+
+    root->head = first;
+    CHECK( graphdemo::SceneMeasure( builder ) > 0 );
+}
+
+// ---- many workers, one arena: allocation is lock-free by ownership ----
+
+static void test_builder_workers()
+{
+    // deterministic first: four workers, interleaved, single-threaded
+    graphdemo::SceneBuilder builder;
+    graphdemo::Scene * root = builder.Root();
+    graphdemo::TableWorker workers[4];
+    for ( int i = 0; i < 4; i++ ) { workers[i] = builder.Worker(); }
+
+    graphdemo::TableSlot<graphdemo::ListNode> head = workers[0].Alloc<graphdemo::ListNode>();
+    head->value = 0;
+    root->head = head;
+    graphdemo::ListNode * tail = head;
+    for ( int i = 1; i < 64; i++ )
+    {
+        // each link allocated by a DIFFERENT worker: a cross-worker reference
+        // is an ordinary reference, because offsets are arena-global
+        graphdemo::TableSlot<graphdemo::ListNode> node = workers[i % 4].Alloc<graphdemo::ListNode>();
+        node->value = i;
+        tail->next = node;
+        tail = node;
+    }
+    CHECK( builder.Lock() );
+    const graphdemo::ListNode * walk = graphdemo::ListNodeAt( builder.Const()->head );
+    for ( int i = 0; i < 64; i++ )
+    {
+        CHECK( walk != NULL && walk->value == i );
+        if ( walk == NULL ) break;
+        walk = graphdemo::ListNodeAt( walk->next );
+    }
+    CHECK( walk == NULL );
+
+    // then the real thing: four threads allocating concurrently on their own
+    // workers. Each thread owns its nodes; nothing is shared, nothing is locked.
+    graphdemo::SceneBuilder threaded;
+    const int per_thread = 20000;
+    std::vector<graphdemo::TableRef> heads( 4 );
+    std::vector<std::thread> threads;
+    for ( int t = 0; t < 4; t++ )
+    {
+        threads.emplace_back( [&threaded, &heads, t]() {
+            graphdemo::TableWorker worker = threaded.Worker();
+            graphdemo::TableSlot<graphdemo::ListNode> first = worker.Alloc<graphdemo::ListNode>();
+            first->value = t;
+            graphdemo::ListNode * tail = first;
+            for ( int i = 1; i < per_thread; i++ )
+            {
+                graphdemo::TableSlot<graphdemo::ListNode> node = worker.Alloc<graphdemo::ListNode>();
+                node->value = t * 1000000 + i;
+                tail->next = node;
+                tail = node;
+            }
+            heads[t] = first.ref;
+        } );
+    }
+    for ( auto & thread : threads ) { thread.join(); }
+    // the join is the barrier; everything below is single-threaded
+    graphdemo::Scene * threaded_root = threaded.Root();
+    threaded_root->layers_count = 4;
+    for ( int t = 0; t < 4; t++ )
+    {
+        threaded_root->layers[t].depth = t;
+        threaded_root->layers[t].head = heads[t];
+        const graphdemo::ListNode * node = graphdemo::ListNodeAt( threaded.arena, heads[t] );
+        CHECK( node != NULL && node->value == t );
+    }
+}
+
+// ---- the cooked form: point at it, or refuse loudly ----
+
+static void test_cooked_form()
+{
+    graphdemo::SceneBuilder builder;
+    build_scene( builder );
+    CHECK( builder.Lock() );
+
+    int64_t need = graphdemo::SceneCookMeasure( builder );
+    CHECK( need == graphdemo::kTableCookedHeaderBytes + builder.RegionBytes() );
+    uint8_t * cooked = (uint8_t *) malloc( (size_t) need );
+    CHECK( graphdemo::SceneCook( builder, cooked, need ) == need );
+    CHECK( graphdemo::SceneCook( builder, cooked, need - 1 ) == -1 ); // short buffer refuses
+
+    // open by POINTING: no copy, no decode
+    const graphdemo::Scene * opened = graphdemo::SceneOpen( cooked, need );
+    CHECK( opened != NULL );
+    CHECK( (const uint8_t *) opened == cooked + graphdemo::kTableCookedHeaderBytes );
+    check_scene( opened );
+
+    // cook -> open -> cook is stable
+    uint8_t * again = (uint8_t *) malloc( (size_t) need );
+    CHECK( graphdemo::SceneCook( opened, again, need ) == need );
+    CHECK( memcmp( cooked, again, (size_t) need ) == 0 );
+    free( again );
+
+    // the wire still reads out of a cooked root: the two forms agree
+    static uint8_t wire[8192];
+    int64_t wrote = graphdemo::SceneSave( opened, wire, sizeof( wire ) );
+    CHECK( wrote == graphdemo::SceneMeasure( builder ) );
+
+    // ---- the refusal battery ----
+    uint8_t * broken = (uint8_t *) malloc( (size_t) need );
+
+    memcpy( broken, cooked, (size_t) need );
+    broken[0] ^= 0xFF; // magic: wrong form, or a foreign byte order
+    CHECK( graphdemo::SceneOpen( broken, need ) == NULL );
+
+    memcpy( broken, cooked, (size_t) need );
+    broken[4] ^= 0xFF; // layout id: the schema or the ABI moved
+    CHECK( graphdemo::SceneOpen( broken, need ) == NULL );
+
+    memcpy( broken, cooked, (size_t) need );
+    CHECK( graphdemo::SceneOpen( broken, need - 1 ) == NULL ); // truncated region
+
+    memcpy( broken, cooked, (size_t) need );
+    CHECK( graphdemo::SceneOpen( broken, 4 ) == NULL ); // shorter than the header
+
+    memcpy( broken, cooked, (size_t) need );
+    CHECK( graphdemo::SceneOpen( broken + 1, need - 1 ) == NULL ); // unaligned base
+
+    // an offset graph that leaves the region: the bounds walk catches it
+    memcpy( broken, cooked, (size_t) need );
+    {
+        graphdemo::Scene * root = (graphdemo::Scene *) ( broken + graphdemo::kTableCookedHeaderBytes );
+        root->head.value = 0x7FFFFFF0u; // far past the end
+        CHECK( graphdemo::SceneOpen( broken, need ) == NULL );
+    }
+    // a BACKWARD reference: impossible in a packed region, so it is corruption
+    memcpy( broken, cooked, (size_t) need );
+    {
+        graphdemo::Scene * root = (graphdemo::Scene *) ( broken + graphdemo::kTableCookedHeaderBytes );
+        root->head.value = 0xFFFFFFF8u; // -8 as an int32
+        CHECK( graphdemo::SceneOpen( broken, need ) == NULL );
+    }
+    // a misaligned reference
+    memcpy( broken, cooked, (size_t) need );
+    {
+        graphdemo::Scene * root = (graphdemo::Scene *) ( broken + graphdemo::kTableCookedHeaderBytes );
+        root->head.value += 1;
+        CHECK( graphdemo::SceneOpen( broken, need ) == NULL );
+    }
+    // a count companion outside its declared bound
+    memcpy( broken, cooked, (size_t) need );
+    {
+        graphdemo::Scene * root = (graphdemo::Scene *) ( broken + graphdemo::kTableCookedHeaderBytes );
+        root->layers_count = 99;
+        CHECK( graphdemo::SceneOpen( broken, need ) == NULL );
+    }
+    // and the untouched file still opens: the battery broke nothing else
+    CHECK( graphdemo::SceneOpen( cooked, need ) != NULL );
+
+    free( broken );
+    free( cooked );
+}
+
+// ---- evolution across a pointer field, both directions ----
+
+static void test_pointer_evolution_old_reader_new_data()
+{
+    // P2 writes a chain of two Links through a POINTER field
+    tblp2::ChainBuilder builder;
+    tblp2::Chain * root = builder.Root();
+    set_string( root->name, root->name_length, "chain" );
+    tblp2::TableSlot<tblp2::Link> first = builder.Alloc<tblp2::Link>();
+    tblp2::TableSlot<tblp2::Link> second = builder.Alloc<tblp2::Link>();
+    first->value = 11;
+    set_string( first->tag, first->tag_length, "one" );
+    second->value = 22;
+    first->next = second;
+    root->link = first;
+
+    uint8_t wire[512];
+    int64_t wrote = tblp2::ChainSave( builder, wire, sizeof( wire ) );
+    CHECK( wrote > 0 );
+
+    // P1 has `link` as a BY-VALUE nesting and no `next` at all. A pointer rides
+    // with a by-value nesting's framing, so the first Link decodes cleanly and
+    // the chain's tail lands as one unknown field.
+    tblp1::Chain out;
+    tblp1::TableReport report;
+    CHECK( tblp1::ChainLoad( out, wire, wrote, &report ) );
+    CHECK( !report.malformed );
+    CHECK( report.unknown == 1 ); // Link.next, which P1 cannot name
+    CHECK( strcmp( out.name, "chain" ) == 0 );
+    CHECK( out.link.value == 11 );
+    CHECK( strcmp( out.link.tag, "one" ) == 0 );
+}
+
+static void test_pointer_evolution_new_reader_old_data()
+{
+    // P1 writes a by-value nesting
+    tblp1::Chain v1;
+    set_string( v1.name, v1.name_length, "aged" );
+    v1.link.value = 77;
+    set_string( v1.link.tag, v1.link.tag_length, "old" );
+
+    uint8_t wire[512];
+    int64_t wrote = tblp1::ChainSave( v1, wire, sizeof( wire ) );
+    CHECK( wrote > 0 && wrote == tblp1::ChainMeasure( v1 ) );
+
+    // P2 has `link` as a POINTER: the same body allocates one node
+    int64_t region_need = tblp2::ChainLoadMeasure( wire, wrote );
+    uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
+    tblp2::TableReport report;
+    const tblp2::Chain * out = tblp2::ChainLoad( region, region_need, wire, wrote, &report );
+    CHECK( out != NULL );
+    CHECK( !report.malformed && report.unknown == 0 && report.kind_mismatch == 0 );
+    CHECK( strcmp( out->name, "aged" ) == 0 );
+    const tblp2::Link * link = tblp2::LinkAt( out->link );
+    CHECK( link != NULL && link->value == 77 && strcmp( link->tag, "old" ) == 0 );
+    CHECK( tblp2::LinkAt( link->next ) == NULL ); // a field old data never wrote is null
+    free( region );
+
+    // and into a BUILDER — the tool's path: load, edit, lock again
+    tblp2::ChainBuilder builder;
+    tblp2::TableReport builder_report;
+    CHECK( tblp2::ChainLoadBuilder( builder, wire, wrote, &builder_report ) );
+    CHECK( !builder_report.malformed );
+    tblp2::Link * loaded = tblp2::LinkAt( builder.arena, builder.Root()->link );
+    CHECK( loaded != NULL && loaded->value == 77 );
+    tblp2::TableSlot<tblp2::Link> added = builder.Alloc<tblp2::Link>();
+    added->value = 88;
+    loaded->next = added;
+    CHECK( builder.Lock() );
+    CHECK( tblp2::LinkAt( tblp2::LinkAt( builder.Const()->link )->next )->value == 88 );
+}
+
+// ---- a null pointer elides; a non-null one rides even when all-default ----
+
+static void test_pointer_null_and_empty()
+{
+    graphdemo::SceneBuilder empty;
+    int64_t bare = graphdemo::SceneMeasure( empty );
+    CHECK( bare == 2 ); // every pointer null, everything else default: nothing rides
+
+    graphdemo::SceneBuilder one;
+    graphdemo::TableSlot<graphdemo::ListNode> node = one.Alloc<graphdemo::ListNode>();
+    one.Root()->head = node; // an ALL-DEFAULT pointee behind a non-null pointer
+    int64_t with_empty = graphdemo::SceneMeasure( one );
+    CHECK( with_empty == 2 + 3 + 4 + 2 ); // id + kind + length + the empty body
+
+    uint8_t wire[64];
+    int64_t wrote = graphdemo::SceneSave( one, wire, sizeof( wire ) );
+    CHECK( wrote == with_empty );
+    int64_t region_need = graphdemo::SceneLoadMeasure( wire, wrote );
+    uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
+    graphdemo::TableReport report;
+    const graphdemo::Scene * loaded = graphdemo::SceneLoad( region, region_need, wire, wrote, &report );
+    // the distinction survives: an empty pointee is NOT null
+    CHECK( loaded != NULL && graphdemo::ListNodeAt( loaded->head ) != NULL );
+    CHECK( graphdemo::ListNodeAt( loaded->head )->value == 0 );
+    free( region );
+}
+
+// ---- reflection: the derived mode and the pointer kind are visible ----
+
+static void test_pointer_reflection()
+{
+    const graphdemo::TableTypeInfo * scene = graphdemo::SceneTableType();
+    const graphdemo::TableTypeInfo * meta = graphdemo::MetaTableType();
+    const graphdemo::TableTypeInfo * list = graphdemo::ListNodeTableType();
+
+    // the MODE is derived and surfaced: nobody declared either of these
+    CHECK( scene->variable );
+    CHECK( list->variable );
+    CHECK( !meta->variable );
+    CHECK( !graphdemo::SettingsTableType()->variable ); // pointed at, still fixed
+    CHECK( graphdemo::LayerTableType()->variable );     // a pointer of its own
+
+    const graphdemo::TableFieldInfo * head = graph_field( scene, "head" );
+    CHECK( head != NULL && head->is_pointer );
+    CHECK( head->kind == 13 ); // a pointer rides as a nested table body
+    CHECK( head->elem_size == sizeof( graphdemo::TableRef ) );
+    CHECK( head->table == graphdemo::ListNodeTableType() ); // the TARGET's descriptor
+    CHECK( !head->is_array && !head->counted );
+
+    // a self-referential pointer resolves to its own type's descriptor
+    const graphdemo::TableFieldInfo * next = graph_field( list, "next" );
+    CHECK( next != NULL && next->is_pointer && next->table == list );
+
+    // a by-value nesting is not a pointer
+    const graphdemo::TableFieldInfo * ground = graph_field( scene, "ground" );
+    CHECK( ground != NULL && !ground->is_pointer && ground->kind == 13 );
+    const graphdemo::TableFieldInfo * meta_field = graph_field( scene, "meta" );
+    CHECK( meta_field != NULL && !meta_field->is_pointer );
+
+    // a pointer field's id is its name's hash, exactly as any other field's
+    CHECK( head->id == field_id( "head" ) );
+
+    // relocatability holds with pointers in the struct: the slot is four bytes
+    CHECK( sizeof( graphdemo::TableRef ) == 4 );
+}
+
 int main()
 {
     test_round_trip();
@@ -648,6 +1274,19 @@ int main()
     test_reflection();
     test_cross_file();
     test_parallel_shape();
+
+    test_pointer_lifecycle();
+    test_lock_layout_stable();
+    test_pointer_alias();
+    test_pointer_cycle_refused();
+    test_pointer_depth_cap();
+    test_builder_grow();
+    test_builder_workers();
+    test_cooked_form();
+    test_pointer_evolution_old_reader_new_data();
+    test_pointer_evolution_new_reader_old_data();
+    test_pointer_null_and_empty();
+    test_pointer_reflection();
 
     if ( failures > 0 )
     {

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -124,14 +124,14 @@ static void test_round_trip()
     p.loadout.attachments[0].power = 2.0f;
 
     uint8_t buffer[16384];
-    int64_t need = tabledemo::TableMeasureRootConfig( root );
-    int64_t wrote = tabledemo::TableSaveRootConfig( root, buffer, sizeof( buffer ) );
+    int64_t need = tabledemo::RootConfigMeasure( root );
+    int64_t wrote = tabledemo::RootConfigSave( root, buffer, sizeof( buffer ) );
     CHECK( wrote > 0 );
     CHECK( need == wrote ); // measure/save split: measure is EXACT
 
     tabledemo::TableReport report;
     tabledemo::RootConfig out;
-    CHECK( tabledemo::TableReadRootConfig( buffer, wrote, out, report ) );
+    CHECK( tabledemo::RootConfigLoad( out, buffer, wrote, &report ) );
     CHECK( report.unknown == 0 && report.kind_mismatch == 0 && report.clamped == 0 && !report.malformed );
 
     CHECK( strcmp( out.version_note, "v-one" ) == 0 && out.version_note_length == 5 );
@@ -173,10 +173,10 @@ static void test_round_trip()
 
     // a too-small buffer refuses instead of truncating
     uint8_t tiny[8];
-    CHECK( tabledemo::TableSaveRootConfig( root, tiny, sizeof( tiny ) ) == -1 );
+    CHECK( tabledemo::RootConfigSave( root, tiny, sizeof( tiny ) ) == -1 );
 
     // the exact-capacity guarantee holds for the fully-populated root
-    check_exact_capacity( root, tabledemo::TableMeasureRootConfig, tabledemo::TableSaveRootConfig );
+    check_exact_capacity( root, tabledemo::RootConfigMeasure, tabledemo::RootConfigSave );
 }
 
 // ---- exact capacity: measure's answer IS the buffer size, corpus-wide ----
@@ -191,36 +191,36 @@ static void test_exact_capacity()
     cfg.b = 8.5f;
     set_string( cfg.name, cfg.name_length, "exact" );
     // cfg.inner stays all-default: elides
-    check_exact_capacity( cfg, tblv1::TableMeasureCfg, tblv1::TableSaveCfg );
+    check_exact_capacity( cfg, tblv1::CfgMeasure, tblv1::CfgSave );
 
     // all-default everything (2 bytes)
     tblv1::Cfg empty;
-    check_exact_capacity( empty, tblv1::TableMeasureCfg, tblv1::TableSaveCfg );
+    check_exact_capacity( empty, tblv1::CfgMeasure, tblv1::CfgSave );
     tabledemo::WeaponConfig weapon;
-    check_exact_capacity( weapon, tabledemo::TableMeasureWeaponConfig, tabledemo::TableSaveWeaponConfig );
+    check_exact_capacity( weapon, tabledemo::WeaponConfigMeasure, tabledemo::WeaponConfigSave );
 
     // an elided nested table inside a GUARDED group
     tabledemo::ProfileConfig profile;
     profile.experience = 1;
     profile.has_loadout = true; // loadout itself stays all-default: elides
-    check_exact_capacity( profile, tabledemo::TableMeasureProfileConfig, tabledemo::TableSaveProfileConfig );
+    check_exact_capacity( profile, tabledemo::ProfileConfigMeasure, tabledemo::ProfileConfigSave );
 
     // nested tables of nested tables, some elided, some riding
     static tabledemo::ArchiveConfig archive;
     archive.count = 9;
     archive.root.weapons_count = 1; // weapons[0] all-default: rides as an element, its nested union elides
-    check_exact_capacity( archive, tabledemo::TableMeasureArchiveConfig, tabledemo::TableSaveArchiveConfig );
+    check_exact_capacity( archive, tabledemo::ArchiveConfigMeasure, tabledemo::ArchiveConfigSave );
 
     // loadout: fixed array of tables (always rides) around all-default elements
     tabledemo::LoadoutConfig loadout;
     loadout.grade = tabledemo::Grade::Gold;
-    check_exact_capacity( loadout, tabledemo::TableMeasureLoadoutConfig, tabledemo::TableSaveLoadoutConfig );
+    check_exact_capacity( loadout, tabledemo::LoadoutConfigMeasure, tabledemo::LoadoutConfigSave );
 
     // the v2 evolution shape
     tblv2::Cfg v2;
     v2.a = 1.0f;
     v2.inner.gain = 2.0f;
-    check_exact_capacity( v2, tblv2::TableMeasureCfg, tblv2::TableSaveCfg );
+    check_exact_capacity( v2, tblv2::CfgMeasure, tblv2::CfgSave );
 }
 
 // ---- storage invariants: the write side validates what it reads ----
@@ -232,33 +232,33 @@ static void test_storage_invariants()
     // a count above the bound must not read out of the array into the wire
     tabledemo::RootConfig root;
     root.weapons_count = 9; // bound is 8
-    CHECK( tabledemo::TableMeasureRootConfig( root ) == -1 );
-    CHECK( tabledemo::TableSaveRootConfig( root, buffer, sizeof( buffer ) ) == -1 );
+    CHECK( tabledemo::RootConfigMeasure( root ) == -1 );
+    CHECK( tabledemo::RootConfigSave( root, buffer, sizeof( buffer ) ) == -1 );
 
     // a negative length must not memcpy a huge size_t
     tblv1::Cfg cfg;
     cfg.name_length = -1;
-    CHECK( tblv1::TableMeasureCfg( cfg ) == -1 );
-    CHECK( tblv1::TableSaveCfg( cfg, buffer, sizeof( buffer ) ) == -1 );
+    CHECK( tblv1::CfgMeasure( cfg ) == -1 );
+    CHECK( tblv1::CfgSave( cfg, buffer, sizeof( buffer ) ) == -1 );
 
     // a negative count refuses too
     tblv1::Cfg cfg2;
     cfg2.items_count = -3;
-    CHECK( tblv1::TableMeasureCfg( cfg2 ) == -1 );
-    CHECK( tblv1::TableSaveCfg( cfg2, buffer, sizeof( buffer ) ) == -1 );
+    CHECK( tblv1::CfgMeasure( cfg2 ) == -1 );
+    CHECK( tblv1::CfgSave( cfg2, buffer, sizeof( buffer ) ) == -1 );
 
     // a violation deep inside a nested, guarded table propagates up
     tabledemo::ProfileConfig profile;
     profile.has_loadout = true;
     profile.loadout.attachments_count = -5;
-    CHECK( tabledemo::TableMeasureProfileConfig( profile ) == -1 );
-    CHECK( tabledemo::TableSaveProfileConfig( profile, buffer, sizeof( buffer ) ) == -1 );
+    CHECK( tabledemo::ProfileConfigMeasure( profile ) == -1 );
+    CHECK( tabledemo::ProfileConfigSave( profile, buffer, sizeof( buffer ) ) == -1 );
 
     // an out-of-range union tag refuses in measure exactly as in write
     tabledemo::WeaponConfig weapon;
     weapon.effect.type = (tabledemo::EffectType) 9;
-    CHECK( tabledemo::TableMeasureWeaponConfig( weapon ) == -1 );
-    CHECK( tabledemo::TableSaveWeaponConfig( weapon, buffer, sizeof( buffer ) ) == -1 );
+    CHECK( tabledemo::WeaponConfigMeasure( weapon ) == -1 );
+    CHECK( tabledemo::WeaponConfigSave( weapon, buffer, sizeof( buffer ) ) == -1 );
 }
 
 // ---- bounded elements: a count the body length cannot cover never reads
@@ -266,8 +266,8 @@ static void test_storage_invariants()
 
 static void test_bounded_elements()
 {
-    const tblv1::TableFieldInfo * items = v1_field( tblv1::TableTypeCfg(), "items" );
-    const tblv1::TableFieldInfo * a = v1_field( tblv1::TableTypeCfg(), "a" );
+    const tblv1::TableFieldInfo * items = v1_field( tblv1::CfgTableType(), "items" );
+    const tblv1::TableFieldInfo * a = v1_field( tblv1::CfgTableType(), "a" );
     CHECK( items != NULL && a != NULL );
 
     // body_len = 3 covers only elem_kind + count; count claims 2 elements —
@@ -287,7 +287,7 @@ static void test_bounded_elements()
 
     tblv1::TableReport report;
     tblv1::Cfg out;
-    CHECK( tblv1::TableReadCfg( wire, n, out, report ) );
+    CHECK( tblv1::CfgLoad( out, wire, n, &report ) );
     CHECK( report.malformed );        // the lie is framing damage, flagged
     CHECK( out.items_count == 0 );    // no fabricated elements
     CHECK( out.a == 42 );             // the parent continued at the next field
@@ -308,7 +308,7 @@ static void test_bounded_elements()
 
     tblv1::TableReport report2;
     tblv1::Cfg out2;
-    CHECK( tblv1::TableReadCfg( wire, n, out2, report2 ) );
+    CHECK( tblv1::CfgLoad( out2, wire, n, &report2 ) );
     CHECK( report2.malformed );
     CHECK( out2.items_count == 1 && out2.items[0] == 10 ); // bounded prefix
     CHECK( out2.a == 42 );
@@ -320,14 +320,14 @@ static void test_all_default()
 {
     tabledemo::WeaponConfig weapon;
     uint8_t buffer[64];
-    int64_t wrote = tabledemo::TableSaveWeaponConfig( weapon, buffer, sizeof( buffer ) );
+    int64_t wrote = tabledemo::WeaponConfigSave( weapon, buffer, sizeof( buffer ) );
     CHECK( wrote == 2 ); // bare terminator
-    CHECK( tabledemo::TableMeasureWeaponConfig( weapon ) == 2 );
+    CHECK( tabledemo::WeaponConfigMeasure( weapon ) == 2 );
 
     tabledemo::TableReport report;
     tabledemo::WeaponConfig out;
     out.damage = -1.0f; // garbage that the prefill must erase
-    CHECK( tabledemo::TableReadWeaponConfig( buffer, wrote, out, report ) );
+    CHECK( tabledemo::WeaponConfigLoad( out, buffer, wrote, &report ) );
     CHECK( out.damage == 21.0f && out.speed == 500.0f && out.penetration == 1 );
     CHECK( !report.malformed && report.unknown == 0 );
 }
@@ -341,13 +341,13 @@ static void test_guard()
     p.loadout.grade = tabledemo::Grade::Gold; // junk behind an untaken guard
 
     uint8_t buffer[512];
-    int64_t wrote = tabledemo::TableSaveProfileConfig( p, buffer, sizeof( buffer ) );
+    int64_t wrote = tabledemo::ProfileConfigSave( p, buffer, sizeof( buffer ) );
     CHECK( wrote == 2 ); // guard false + everything else default: all elides
-    CHECK( tabledemo::TableMeasureProfileConfig( p ) == wrote );
+    CHECK( tabledemo::ProfileConfigMeasure( p ) == wrote );
 
     tabledemo::TableReport report;
     tabledemo::ProfileConfig out;
-    CHECK( tabledemo::TableReadProfileConfig( buffer, wrote, out, report ) );
+    CHECK( tabledemo::ProfileConfigLoad( out, buffer, wrote, &report ) );
     CHECK( out.loadout.grade == tabledemo::Grade::Silver ); // untaken side decodes to defaults
 }
 
@@ -366,12 +366,12 @@ static void test_evolution_old_reader_new_data()
     v2.items_count = 1;
 
     uint8_t wire[1024];
-    int64_t bytes = tblv2::TableSaveCfg( v2, wire, sizeof( wire ) );
-    CHECK( bytes > 0 && bytes == tblv2::TableMeasureCfg( v2 ) );
+    int64_t bytes = tblv2::CfgSave( v2, wire, sizeof( wire ) );
+    CHECK( bytes > 0 && bytes == tblv2::CfgMeasure( v2 ) );
 
     tblv1::TableReport report;
     tblv1::Cfg out;
-    CHECK( tblv1::TableReadCfg( wire, bytes, out, report ) );
+    CHECK( tblv1::CfgLoad( out, wire, bytes, &report ) );
     CHECK( !report.malformed );
     CHECK( report.unknown == 2 );       // c (top level) + gain (nested)
     CHECK( report.kind_mismatch == 1 ); // a: f32 wire vs v1's i32 expectation
@@ -392,12 +392,12 @@ static void test_evolution_new_reader_old_data()
     v1.inner.factor = 1.25f;
 
     uint8_t wire[1024];
-    int64_t bytes = tblv1::TableSaveCfg( v1, wire, sizeof( wire ) );
-    CHECK( bytes > 0 && bytes == tblv1::TableMeasureCfg( v1 ) );
+    int64_t bytes = tblv1::CfgSave( v1, wire, sizeof( wire ) );
+    CHECK( bytes > 0 && bytes == tblv1::CfgMeasure( v1 ) );
 
     tblv2::TableReport report;
     tblv2::Cfg out;
-    CHECK( tblv2::TableReadCfg( wire, bytes, out, report ) );
+    CHECK( tblv2::CfgLoad( out, wire, bytes, &report ) );
     CHECK( !report.malformed );
     CHECK( report.unknown == 1 );       // b, removed in v2
     CHECK( report.kind_mismatch == 1 ); // a: i32 wire vs v2's f32 expectation
@@ -415,7 +415,7 @@ static void test_clamping()
 {
     // a wider writer sent a = 2000; v1's a is [0, 1000] — crafted from the
     // descriptor's own id so the bytes are exactly what such a writer emits
-    const tblv1::TableFieldInfo * a = v1_field( tblv1::TableTypeCfg(), "a" );
+    const tblv1::TableFieldInfo * a = v1_field( tblv1::CfgTableType(), "a" );
     CHECK( a != NULL && a->kind == 4 && a->has_range && a->range_max == 1000.0 );
 
     uint8_t wire[16];
@@ -427,11 +427,11 @@ static void test_clamping()
 
     tblv1::TableReport report;
     tblv1::Cfg out;
-    CHECK( tblv1::TableReadCfg( wire, n, out, report ) );
+    CHECK( tblv1::CfgLoad( out, wire, n, &report ) );
     CHECK( report.clamped == 1 && out.a == 1000 );
 
     // bits(6) width clamp: a u8 payload of 200 clamps to 63
-    const tabledemo::TableFieldInfo * ch = demo_field( tabledemo::TableTypeWeaponConfig(), "channel" );
+    const tabledemo::TableFieldInfo * ch = demo_field( tabledemo::WeaponConfigTableType(), "channel" );
     CHECK( ch != NULL && ch->kind == 6 );
     uint8_t wire2[8];
     n = 0;
@@ -442,12 +442,12 @@ static void test_clamping()
 
     tabledemo::TableReport report2;
     tabledemo::WeaponConfig weapon;
-    CHECK( tabledemo::TableReadWeaponConfig( wire2, n, weapon, report2 ) );
+    CHECK( tabledemo::WeaponConfigLoad( weapon, wire2, n, &report2 ) );
     CHECK( report2.clamped == 1 && weapon.channel == 63 );
 
     // an over-long string — a future schema widened string(32) — clamps to
     // capacity, stays NUL-terminated, and counts
-    const tblv1::TableFieldInfo * nameInfo = v1_field( tblv1::TableTypeCfg(), "name" );
+    const tblv1::TableFieldInfo * nameInfo = v1_field( tblv1::CfgTableType(), "name" );
     uint8_t wire4[64];
     n = 0;
     le16( wire4 + n, nameInfo->id ); n += 2;
@@ -458,7 +458,7 @@ static void test_clamping()
 
     tblv1::TableReport report4;
     tblv1::Cfg out4;
-    CHECK( tblv1::TableReadCfg( wire4, n, out4, report4 ) );
+    CHECK( tblv1::CfgLoad( out4, wire4, n, &report4 ) );
     CHECK( report4.clamped == 1 && out4.name_length == 32 && out4.name[32] == 0 );
 }
 
@@ -470,29 +470,29 @@ static void test_malformed()
     tblv1::Cfg out;
 
     uint8_t one_byte[1] = { 0x34 };
-    CHECK( !tblv1::TableReadCfg( one_byte, 1, out, report ) );
+    CHECK( !tblv1::CfgLoad( out, one_byte, 1, &report ) );
     CHECK( report.malformed );
 
     // a valid field id whose payload is truncated mid-scalar
-    const tblv1::TableFieldInfo * a = v1_field( tblv1::TableTypeCfg(), "a" );
+    const tblv1::TableFieldInfo * a = v1_field( tblv1::CfgTableType(), "a" );
     uint8_t truncated[5];
     le16( truncated, a->id );
     truncated[2] = 4;  // kI32 wants 4 payload bytes; only 2 follow
     truncated[3] = 0;
     truncated[4] = 0;
     tblv1::TableReport report2;
-    CHECK( !tblv1::TableReadCfg( truncated, 5, out, report2 ) );
+    CHECK( !tblv1::CfgLoad( out, truncated, 5, &report2 ) );
     CHECK( report2.malformed );
 
     // damage after good fields: the good prefix survives (partial result)
     tblv1::Cfg src;
     src.a = 42;
     uint8_t wire[256];
-    int64_t bytes = tblv1::TableSaveCfg( src, wire, sizeof( wire ) );
+    int64_t bytes = tblv1::CfgSave( src, wire, sizeof( wire ) );
     CHECK( bytes > 0 );
     tblv1::TableReport report3;
     tblv1::Cfg out3;
-    CHECK( !tblv1::TableReadCfg( wire, bytes - 2, out3, report3 ) ); // terminator cut off
+    CHECK( !tblv1::CfgLoad( out3, wire, bytes - 2, &report3 ) ); // terminator cut off
     CHECK( report3.malformed && out3.a == 42 );
 }
 
@@ -500,7 +500,7 @@ static void test_malformed()
 
 static void test_reflection()
 {
-    const tabledemo::TableTypeInfo * weapon = tabledemo::TableTypeWeaponConfig();
+    const tabledemo::TableTypeInfo * weapon = tabledemo::WeaponConfigTableType();
     CHECK( strcmp( weapon->name, "WeaponConfig" ) == 0 );
     CHECK( weapon->size == sizeof( tabledemo::WeaponConfig ) );
 
@@ -519,27 +519,27 @@ static void test_reflection()
     CHECK( pen != NULL && pen->has_range && pen->range_min == 0.0 && pen->range_max == 10.0 );
 
     // enum name function: value -> name, out-of-set included
-    const tabledemo::TableFieldInfo * grade = demo_field( tabledemo::TableTypeLoadoutConfig(), "grade" );
+    const tabledemo::TableFieldInfo * grade = demo_field( tabledemo::LoadoutConfigTableType(), "grade" );
     CHECK( grade != NULL && grade->enum_max == 3 && grade->enum_name != NULL );
     CHECK( strcmp( grade->enum_name( 3 ), "Gold" ) == 0 );
     CHECK( strcmp( grade->enum_name( 9 ), "???" ) == 0 );
 
     // nested-table descriptors chain, arrays carry bounds and companions
-    const tabledemo::TableTypeInfo * rootType = tabledemo::TableTypeRootConfig();
+    const tabledemo::TableTypeInfo * rootType = tabledemo::RootConfigTableType();
     const tabledemo::TableFieldInfo * profiles = demo_field( rootType, "profiles" );
     CHECK( profiles != NULL && profiles->kind == 13 && profiles->is_array && profiles->counted );
     CHECK( profiles->array_bound == 4 );
-    CHECK( profiles->table == tabledemo::TableTypeProfileConfig() );
+    CHECK( profiles->table == tabledemo::ProfileConfigTableType() );
 
     // guards surface machine-usable
-    const tabledemo::TableFieldInfo * loadout = demo_field( tabledemo::TableTypeProfileConfig(), "loadout" );
+    const tabledemo::TableFieldInfo * loadout = demo_field( tabledemo::ProfileConfigTableType(), "loadout" );
     CHECK( loadout != NULL && strcmp( loadout->guard, "has_loadout" ) == 0 );
 
     // every one of the 15 wire kinds rides somewhere in the corpus battery;
     // the scalar kinds pin here by descriptor (containers pinned above and
     // in the round trip: 12 string, 13 table, 14 array, 15 union; 1 bool on
     // homing, 10 f32 on damage)
-    const tabledemo::TableTypeInfo * profileType = tabledemo::TableTypeProfileConfig();
+    const tabledemo::TableTypeInfo * profileType = tabledemo::ProfileConfigTableType();
     struct { const char * field; uint8_t kind; } scalar_kinds[] = {
         { "tilt", 2 },       // i8
         { "heading", 3 },    // i16
@@ -565,7 +565,7 @@ static void test_reflection()
     // generic field access through offset — an editor walking properties
     tabledemo::ProfileConfig p;
     p.experience = 777;
-    const tabledemo::TableFieldInfo * exp = demo_field( tabledemo::TableTypeProfileConfig(), "experience" );
+    const tabledemo::TableFieldInfo * exp = demo_field( tabledemo::ProfileConfigTableType(), "experience" );
     CHECK( exp != NULL );
     uint32_t read_back;
     memcpy( &read_back, (const uint8_t *) &p + exp->offset, sizeof( read_back ) );
@@ -583,12 +583,12 @@ static void test_cross_file()
     archive.count = 5;
 
     static uint8_t buffer[16384];
-    int64_t wrote = tabledemo::TableSaveArchiveConfig( archive, buffer, sizeof( buffer ) );
-    CHECK( wrote > 0 && wrote == tabledemo::TableMeasureArchiveConfig( archive ) );
+    int64_t wrote = tabledemo::ArchiveConfigSave( archive, buffer, sizeof( buffer ) );
+    CHECK( wrote > 0 && wrote == tabledemo::ArchiveConfigMeasure( archive ) );
 
     tabledemo::TableReport report;
     static tabledemo::ArchiveConfig out;
-    CHECK( tabledemo::TableReadArchiveConfig( buffer, wrote, out, report ) );
+    CHECK( tabledemo::ArchiveConfigLoad( out, buffer, wrote, &report ) );
     CHECK( strcmp( out.root.version_note, "deep" ) == 0 );
     CHECK( out.root.weapons_count == 1 && out.root.weapons[0].homing );
     CHECK( out.count == 5 );
@@ -610,14 +610,14 @@ static void test_parallel_shape()
     int64_t total = 0;
     for ( int i = 0; i < 3; i++ )
     {
-        sizes[i] = tabledemo::TableMeasureProfileConfig( profiles[i] );
+        sizes[i] = tabledemo::ProfileConfigMeasure( profiles[i] );
         total += sizes[i];
     }
     static uint8_t buffer[4096];
     int64_t offset = 0;
     for ( int i = 0; i < 3; i++ ) // each iteration is independent: a worker
     {
-        int64_t wrote = tabledemo::TableSaveProfileConfig( profiles[i], buffer + offset, sizes[i] );
+        int64_t wrote = tabledemo::ProfileConfigSave( profiles[i], buffer + offset, sizes[i] );
         CHECK( wrote == sizes[i] );
         offset += wrote;
     }
@@ -627,7 +627,7 @@ static void test_parallel_shape()
     {
         tabledemo::TableReport report;
         tabledemo::ProfileConfig out;
-        CHECK( tabledemo::TableReadProfileConfig( buffer + offset, sizes[i], out, report ) );
+        CHECK( tabledemo::ProfileConfigLoad( out, buffer + offset, sizes[i], &report ) );
         CHECK( out.experience == (uint32_t) ( 100 + i ) );
         offset += sizes[i];
     }


### PR DESCRIPTION
Tables gain pointer semantics. The founding line, in the owner's words: *"types
can remain value semantics. tables should ALLOW pointer semantics"* — *"we
can't be a generic system if we don't have pointers to tables."*

`next *Node` declares a pointer to a table. The compiler DERIVES what follows
and nobody declares it: a table with no pointer in its by-value closure stays a
plain struct and pays nothing; a table with one is built through a lock-free
arena, locked once into a single packed region, and read through a root
pointer. That region also cooks — written verbatim behind a build-locked header
so a later run points at its root without copying or parsing it — while the
tolerant wire stays the format of record.

---

## Every element, labelled

**OWNER-RULED**

- Pointer semantics for tables, and the C-like spelling `next *Node`.
- The mode is COMPILER-DERIVED, never declared: *"i wouldn't want to manually
  have to specify this… the compiler can work it out."*
- Const-vs-mutable is a LIFECYCLE, not a schema marking: *"maybe you 'lock' a
  table and it is constant from that point forward."*
- The two forms are genuinely different at runtime; neither is contorted to
  look like the other.
- The builder is multithreaded, and *"I prefer lockless if possible."*
- The generated surface, verbatim from the approved snippet: struct with a
  clean name, `<Name>Measure` / `<Name>Save` / `<Name>Load` free functions,
  `<Name>Builder` with `Alloc<T>()` and `Lock()` as methods.
- Tables and types share one symbol table — *"i vote yes."*
- The zero-cost gate: *"make sure we don't pay this cost when we have nice,
  small messages… when the table is inferred to be value types only."*
- No generated size constants — *"you don't need to recreate sizeof."*
- Pointer-bearing tables are never held by value; file-format-scale tables
  *"can't be a struct."*
- A pointed-at region form exists at all: load a big file, point at the root,
  no copy, no full parse.

**COORDINATOR-DESIGNED** (my calls; veto any of them)

- The **segmented slab arena** as the builder's storage, chosen under the
  lockless preference. SPEC §14 weighs all four models considered.
- **Cook/Open** as the region form's verbs — grounded in the game-industry
  vocabulary the owner used, but the naming choice is mine.
- **Pointer-to-`type` refused by name.** Inferred from "types remain value
  semantics" rather than quoted — the owner never ruled on the spelling
  `*SomeType`, and this is my reading of what the split implies.
- **Self-relative references inside a region**, so a deref is one add with no
  base pointer and a region relocates by pure `memcpy` with zero fix-up.
- **A high-water mark rather than a visited set** in `Open`'s walk.
- **Only pointer edges charge depth**; by-value nesting charges none.
- **Wire v1 is a tree**: aliasing is not preserved. Loud in the spec, in the
  generated comments, and asserted by a test rather than hidden.
- **A depth cap (128) instead of cycle detection**, on every walk.
- The **layout id** construction: a compile-time digest of the schema's
  packed-layout facts — fields keyed by WIRE ID, so a `was` rename holds —
  mixed with this build's own `sizeof` and per-field `offsetof`, so schema
  drift and ABI drift both refuse.
- Argument orders and the exact spellings of `SaveBody` / `LoadBody` /
  `LoadMeasure` / `OpenWalk`.

**FOLLOW-ONS, filed not built** (SPEC §15)

Graph and DAG identity; arrays of pointers; lifting the depth cap with a flat
indexed node encoding; cross-endian `Open` (v1 REFUSES a foreign byte order —
the descriptor-driven fix-up pass is filed with its mechanism sketched); a
hash-guarded fallback loader; and a generic JSON walk over the reflection
descriptors, which is one implementation over the descriptor surface rather
than per-table codecs.

---

## The zero-cost gate — stated at the grain it holds

The owner's criterion: a value-only table gets none of the new machinery. That
is true at two different grains, and the earlier draft of this section blurred
them. Precisely:

**Per UNIT.** A unit whose tables are all fixed-size emits nothing new at all —
no arena runtime, no reference type, no builder, no `<atomic>`, and not one
extra descriptor column. Proof: the entire pointer-free corpus
(`tables/examples`, `test/tables/V1.schema`, `test/tables/V2.schema`)
regenerates **byte-identical** to a rename-applied baseline built at commit
`974ff0f`. `diff -r` over both trees: **clean, zero differences.** Closing that
found three real leaks — the `is_pointer` column, the `variable` column, and a
reworded comment — all now gated on the unit having pointers.

**Per TABLE.** Inside a unit that DOES have pointers, a value-only table gets
**no Builder, no pointer-graph walkers, and codecs character-for-character
identical to the pointer-free ones** — no ctx parameter, no depth parameter, no
template. What it shares with the unit are the per-UNIT facts above: the arena
runtime and the two descriptor columns are emitted once per header and belong
to the unit, not to any table in it. (It does gain one thing: an `Open` bounds
walk, because `Open` must bound its count companions — see C2 below.)

**Standing gates**, so both stay true:

- `make tables-zero-cost` (inside `make test`) greps every pointer-free
  corpus header — now including `P1` — for every pointer-machinery symbol and
  fails the build on a hit.
- `TestZeroCostForValueOnlyTables` pins the per-UNIT property.
- `TestPointerSurfaceEmitted` pins the per-TABLE property, asserting exactly
  the list above rather than more than it can hold.

---

## The design

**Mutable: a segmented slab arena.** Equal-size 4 MiB segments whose count
saturates the u32 reference space exactly (1024 → 4 GiB), handed to workers in
64 KiB slabs with one compare-exchange each. No atomic on the per-node path, no
lock anywhere. Nodes are born at final offsets and a segment never moves, so a
`T*` from `Alloc` stays valid while other workers allocate and while the arena
grows.

The rejected model is named in the generated header and in SPEC §14: one buffer
under a lock, grown by `realloc`. A `realloc` moves the buffer under a worker
mid-write; offsets fix identity but not the references already resolved from
them, and the corruption surfaces much later. Segments never move, so that bug
cannot be written here. Slack is bounded and stated: one slab tail per worker
plus one per segment.

**`Lock()` is one way and it IS the compaction.** The arena packs into a single
exact region, root at base, every reference rewritten self-relative. Lock's
output and Load's output are the same representation, read through one view
API. No unlock: re-editing means loading into a fresh builder, which is a copy
and says so.

**Threading contract, stated in the header:** allocating on your own worker is
safe concurrently; writing fields of a node another worker allocated is your
own synchronization; `Lock`/`Save`/`Cook`/`Open` are single-threaded, after the
join.

**On the wire**, a pointer rides as its pointee's table body — framing
*identical* to a by-value nesting, which is why a field can change between the
two without moving a byte (there is a both-directions evolution test for
exactly that). Null elides. A non-null pointer rides even when its pointee is
all-default, or null and empty would be one value.

**The cooked form** is an accelerator, not an archive. `<Name>Open` validates
before it points: a bounds walk over the reference graph and the counts that
bound a traversal of it, never a field value.

That walk is **linear in the region**, and it takes a proof rather than an
assertion — the first draft said "O(references)" and was wrong. Forward,
in-range and aligned are not enough: a forged file whose references alias
forward is a legal-looking DAG that a stateless walk explores exponentially.
The walk carries a **high-water mark**. Packing lays nodes out in pre-order by
bump allocation and the walk follows that order, so a genuine region always
satisfies `at >= watermark`; requiring it and advancing past each node makes
the walk consume region bytes monotonically — it visits each byte at most once,
it terminates, and it rejects mid-node overlaps too. Not a visited set, which
would allocate in proportion to the graph. One integer buys all three. The pack
order and the walk order are now one invariant, stated at both sites. No
trust-mode bypass.

---

## Test inventory

Twelve new cases in the tables leg (`test/tables/main.cpp`), plus the corpus
and Go-side additions:

| Case | What it holds |
|---|---|
| `test_pointer_lifecycle` | build → measure → save → Lock → relocate by memcpy → LoadMeasure → Load → re-save byte-identical |
| **exact-capacity battery** | save into exactly `Measure`'s answer succeeds and byte-matches a roomy save; one byte short refuses — now across a **pointer graph**, extending the #228-F4 battery |
| `test_lock_layout_stable` | two independent builds `memcmp` equal; two cooks byte-identical |
| `test_pointer_alias` | two references to one node are two nodes — in the packed form AND across the wire |
| `test_pointer_cycle_refused` | a self-pointing node: Measure, Save, CookMeasure and Lock all refuse; nothing recurses |
| `test_pointer_depth_cap` | a chain at the cap saves; one link past it refuses everywhere |
| `test_builder_grow` | 200 000 allocations across many slabs and segments; a `T*` taken first is still valid last |
| `test_builder_workers` | four workers single-threaded (deterministic) **plus a real four-thread concurrent build**, joined before Lock |
| `test_cooked_form` | cook → open → point; cook-open-cook stable; **nine refusals**: magic, layout id, truncation, sub-header size, unaligned base, out-of-region reference, backward reference, misaligned reference, out-of-bound count |
| `test_pointer_evolution_old_reader_new_data` | P1 (by-value) reads P2 (pointered): first node decodes, the chain's tail is one unknown |
| `test_pointer_evolution_new_reader_old_data` | P2 reads P1: one node allocated from the by-value body, `next` null — plus load-into-builder, edit, re-Lock |
| `test_pointer_null_and_empty` | a null pointer elides; a non-null pointer at an all-default node does not — the distinction survives the round trip |
| `test_pointer_reflection` | derived mode surfaced, `is_pointer`, the target descriptor, a self-referential pointer resolving to its own type |

Seven more from the adversarial round, each the reviewer's own repro reduced to
an assertion:

| Regression | Finding it guards |
|---|---|
| `test_open_walk_is_linear` | B1 — a forged aliased-forward DAG at n = 16/26/40/64 is refused; n = 64 would not return unbounded |
| `test_open_refuses_overlap` | B1 — an 8-aligned reference landing mid-node |
| `test_lock_deterministic_on_dirty_heap` | B2 — heap dirtied 0xA5 then 0x5C between builds; identical regions AND cooked files, zero padding |
| `test_depth_agrees_through_by_value_nesting` | C1 — the 127-chain through a by-value nested variable table round-trips all four walks |
| `test_open_bounds_nested_fixed_companions` | C2 — a by-value nested fixed table's count, and one reached through a pointer |
| `test_open_refuses_dirty_reserved` | the header's reserved words, all 20 bytes swept |
| `test_descriptors_are_constant` | C3 — the surface read from four threads, no first-use state |
| `test_cross_file_pointer_unit` | R1 — a multi-file pointered unit: a native-mapped type, a fixed table and a variable table nested across file boundaries, round-tripped and forged |

Go-side: `TestTableModeDerivation` (six shapes, propagation up by-value edges
only), `TestPointerRecursionIsLegal`, eight new refusal cases,
`TestZeroCostForValueOnlyTables`, `TestPointerSurfaceEmitted`,
`TestPointerGenerationDeterministic`, `TestLayoutIdMovesWithTheSchema`.

Corpus: `tables/pointers/Graph.schema` (a value-only table, a value-only
pointer target, a self-recursive list, a tree, a variable table nested by
value, a bounded array of them) in its **own unit**, so `tables/examples` stays
pointer-free and keeps proving the gate; `test/tables/P1|P2.schema` for the
pointer evolution pair.

**Negative control run:** inverting the aliasing assertion turns the tables leg
red at the expected line and exits 1. The battery is wired in, not decorative.

---

## Adversarial round: disposition per finding

All BLOCKING and SHOULD-FIX findings are fixed in this branch; the reviewer's
batteries live at `scratchpad/adv/`.

| # | Finding | Disposition |
|---|---|---|
| B1 | `Open`'s walk exponential on a forged aliased DAG (26 nodes = 312 ms) | FIXED — high-water mark; invariant stated at both Pack and OpenWalk with "neither may change alone" |
| B2 | Lock/Cook copied uninitialised arena padding into regions and cooked files | FIXED — segments `calloc`'d; the determinism test now dirties the heap first |
| B3a | `table Root` / `table Const` emitted non-compiling headers | FIXED — methods moved to `GetRoot`/`AsConst`; every other builder member name refused as a table name |
| B3b | six generated spellings missing from the claimed-name registry | FIXED — plus `TableInfo`/`TableFields` from the C3 fix; a refusal test each |
| C1 | the four walks spent depth differently | FIXED — only pointer edges charge depth, one rule in one place |
| C2 | `Open` never bounded nested fixed tables' companions | FIXED — every closure member gets an Open walk; union tags bounded too |
| C3 | TSAN race in the descriptors' lazy link | FIXED — constant-initialised namespace data, no first-use state; TSAN clean |
| C4 | layout id cried wolf on `was`, missed a moved member | FIXED — keyed by wire id, mixes per-field `offsetof` |
| R1 | *(introduced by C2)* a multi-file pointered unit emitted a non-compiling header | FIXED — a member's Open walk is emitted by the file that DECLARES it, keyed on the UNIT having pointers rather than the file |

**Negative controls run on the two subtle ones.** Restoring `malloc` turns the
determinism regression red on both assertions. Removing the watermark makes the
forged DAG **ACCEPTED** again at n = 16 and 24 — the defect returns exactly
where the test looks for it.

**The alloc path was already TSAN-clean and stays so**: the race was in the
reflection surface, not in allocation.

**R1, and the corpus gap that hid it.** Widening `Open`'s descend-set (C2) was
right; emitting the walks per FILE was not — a pointered unit whose second file
declares neither a variable table nor a pointer target named walks that existed
nowhere. `tables/pointers` is now a genuinely multi-file unit: `Parts.schema`
holds a native-mapped type and a fixed table and is deliberately both
pointer-free AND pointer-target free (the first attempt at this corpus missed
the bug because its fixed table *was* a pointer target, which put it in the
walker set anyway); `Marks.schema` holds the cross-file variable member;
`Album` nests all three across file boundaries. Since Album's `Colour` storage
spells `::ColourMath`, the cross-file native mapping is covered too — the walk
is reached through a derived-to-base conversion.
`test_cross_file_pointer_unit` round-trips it and forges three cross-file
corruptions. The byte-identity proof was **re-run after this fix and is still
clean**.

Re-running the reviewer's own battery: **240 126 checks, one remaining
"failure"** — their `CHECK` that garbage in the header's reserved words still
opens. That was minor 3; it is now refused, so their assertion of the old
behaviour is what fails.

---

## Gates

All run locally, all green:

- `make test` — **exit 0**, all nine backend legs plus the tables leg, **zero
  warnings** from the generated modules. `make tables-zero-cost` runs inside it.
- `gofmt -l` clean · `go vet ./...` clean · `golangci-lint run` **0 issues** ·
  `modernize` clean · `make shape-gate` clean (19 ledgered files, no new shape
  knowledge).
- Locked paths untouched: `internal/codegen/{c,cpp}/`,
  `generated/{c,cpp,c-ludicrous}/`.

`golangci-lint` and `modernize` each found real things across the two rounds (an
unused helper, a range-over-int, an if-else chain, a `slices.Contains` loop);
all fixed.

---

Draft on purpose. `ROUND-LOG.md` on the branch carries the unit-by-unit record.
