### PR TITLE
ci: certify against serialize.js v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ env:
   SERIALIZE_GO_TAG: v1.14.0
   SERIALIZE_RS_TAG: v2.2.2
   SERIALIZE_CS_TAG: v1.5.0
-  SERIALIZE_JS_TAG: v1.1.0
+  SERIALIZE_JS_TAG: v1.3.0
 
 jobs:
   # The fast gate, and the conformance half of certification. `make test`


### PR DESCRIPTION
The pin bump both #244 and serialize.js#11 named as their landing follow-on: CI now proves the emitter + runtime pair users install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)