### PR TITLE
Sitting 4: the overnight board — js 264, elixir 1283

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Cost to serialize a representative game packet, relative to generated C++ at 100
 |---|---:|
 | C | 100% |
 | C++ | 100% |
-| Rust | 153% |
-| Java | 156% |
-| Go | 209% |
-| C# | 224% |
-| Dart | 225% |
-| JavaScript | 318% |
-| Elixir | 1364% |
+| Rust | 154% |
+| Java | 162% |
+| Go | 210% |
+| C# | 225% |
+| Dart | 227% |
+| JavaScript | 264% |
+| Elixir | 1283% |
 
 Measured by [the benchmark](bench/): the real generated code in every language, over the same
 wire corpus — a 438-byte packet exercising every construct, with integers carrying 92% of the

--- a/bench/results/2026-09-02-sitting4-arm64-macbook.csv
+++ b/bench/results/2026-09-02-sitting4-arm64-macbook.csv
@@ -1,0 +1,61 @@
+# schema bench results
+# date: 2026-09-01T16:13:35Z
+# host: macbook  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M2
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.0 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 7eba63f (main)
+# serialize commit: cebaed2 (main) [build-verified: /Users/glenn/rowan-working/serialize]
+# serialize.c commit: 37db942 (main) [build-verified: /Users/glenn/rowan-working/serialize.c]
+# serialize.go commit: 287e2fe (main) [build-verified: /Users/glenn/rowan-working/serialize.go]
+# serialize.rs commit: 6b52aa6 (main) [build-verified: /Users/glenn/rowan-working/serialize.rs]
+# serialize.cs commit: 1439c6f (main) [build-verified: /Users/glenn/rowan-working/serialize.cs]
+# serialize.js commit: e391f1e (main) [build-verified: /Users/glenn/rowan-working/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,7,7645271,7620707,7720871,3193.50,1.31,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,7,3579821,3550240,3594435,1495.32,1.23,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,7,62198,60773,62294,3886.28,2.45,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,7,95892,91931,96069,5991.63,4.32,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,7,7538664,7405158,7545106,3148.97,1.86,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,7,3656514,3613719,3662957,1527.36,1.35,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,7,61301,59335,62298,3830.23,4.83,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,7,57611,57360,58959,3599.70,2.78,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,7,3451303,3449026,3453956,1441.64,0.14,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,7,1714768,1712669,1715160,716.27,0.15,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,7,9921,9867,9936,619.92,0.69,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,7,11527,11495,11533,720.27,0.33,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,7,6097174,6094572,6100504,2546.85,0.10,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,7,2336072,2334903,2336475,975.80,0.07,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,7,33637,33526,34025,2101.73,1.48,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,7,36538,36445,36615,2283.00,0.47,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+cs,bench_mixed,write,4000000,438,7,3351295,3346191,3352466,1399.87,0.19,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,1599017,1594178,1599897,667.92,0.36,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,17464,17450,17467,1091.21,0.10,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,18629,18513,18636,1163.99,0.66,6b213fbfa1a03a99,bits,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,7,2567646,2552459,2591069,1072.53,1.50,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,7,1357487,1354202,1361635,567.04,0.55,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bitpacker,write,24576,65518,7,6144,6142,6151,383.92,0.14,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,5720,5715,5724,357.38,0.16,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,7,5804199,5782630,5805094,2424.47,0.39,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,7,2186359,2148023,2216563,913.26,3.13,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,7,2818680,2813248,2822817,1177.39,0.34,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,7,1585548,1582026,1586561,662.30,0.29,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,4000000,438,7,449798,448801,450535,187.88,0.39,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,4000000,438,7,279313,278665,280148,116.67,0.53,6b213fbfa1a03a99,gen,beam,contract,default,unknown


### PR DESCRIPTION
The full sweep on post-#240/#244 main joins the ledger and the README table updates to its column: js 318→264 (the reads round + serialize.js v1.3.0), elixir 1364→1283 (round two's levers, measured in a full sitting — better than the 1301 cross-sitting projection, as the projection's own honesty note anticipated). The cpp red-line is green through both rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)