### PR TITLE
The tables baseline: an optional committed projection, and the check that refuses silent edits until it moves with a reason (#256)

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -99,6 +99,17 @@ emitters — carries no promise and may change in any
 release. Building on the compiler means `compiler.Generator` and `ir`, which is
 the same door the built-in backends come through.
 
+The tables baseline (SPEC-TABLES.md §16) adds to that covered surface:
+`compiler.TablesBaselineText` and `compiler.UpdateTablesBaseline`, the
+`TablesBaseline` and `OnWarn` policy fields on `compiler.Compiler`, and in `ir`
+the table-wire kind vocabulary — the `TableKind*` constants and
+`TableScalarKind` / `TableFieldKind` / `TableElemKind`, which are wire law and
+therefore frozen (SPEC-TABLES.md §3). The baseline FILE's own rendering carries
+its own version on its first line, independent of these: a bump there makes
+every committed baseline stale at once and is repaired with
+`schema tables-baseline --update --reason "..."`, which preserves each file's
+history section.
+
 **The SPEC is versioned with the compiler.** [SPEC.md](SPEC.md) is normative;
 where the compiler and the SPEC disagree, one of them is a bug.
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -99,7 +99,7 @@ emitters — carries no promise and may change in any
 release. Building on the compiler means `compiler.Generator` and `ir`, which is
 the same door the built-in backends come through.
 
-The tables baseline (SPEC-TABLES.md §16) adds to that covered surface:
+The tables baseline (SPEC-TABLES.md §18) adds to that covered surface:
 `compiler.TablesBaselineText` and `compiler.UpdateTablesBaseline`, the
 `TablesBaseline` and `OnWarn` policy fields on `compiler.Compiler`, and in `ir`
 the table-wire kind vocabulary — the `TableKind*` constants and

--- a/bench/SHAPE-GATE.allow
+++ b/bench/SHAPE-GATE.allow
@@ -99,3 +99,14 @@ consts bench/tools/variantgen/main.go 3 three comments stating the 438-byte gold
 
 paths test/bench/c_main.c 1 the §1.5 golden pinner: correctness code, no timing
 paths test/bench/main.cpp 1 the §1.5 golden pinner: correctness code, no timing
+
+# ---------------------------------------------------------------------------
+# A CALENDAR DATE IS NOT A CLOCK.
+#
+# The tables baseline (SPEC-TABLES.md §16) stamps each history entry with the
+# day it was written, so a person reading the intentional-break log years
+# later knows when the break happened. It measures no interval and times
+# nothing; the timing check is lexical and cannot tell a date from a clock.
+# ---------------------------------------------------------------------------
+
+timing internal/baseline/file.go 1 the history entry's calendar date — a day written into a text log, no interval measured (prose)

--- a/bench/SHAPE-GATE.allow
+++ b/bench/SHAPE-GATE.allow
@@ -103,7 +103,7 @@ paths test/bench/main.cpp 1 the §1.5 golden pinner: correctness code, no timing
 # ---------------------------------------------------------------------------
 # A CALENDAR DATE IS NOT A CLOCK.
 #
-# The tables baseline (SPEC-TABLES.md §16) stamps each history entry with the
+# The tables baseline (SPEC-TABLES.md §18.4) stamps each history entry with the
 # day it was written, so a person reading the intentional-break log years
 # later knows when the break happened. It measures no interval and times
 # nothing; the timing check is lexical and cannot tell a date from a clock.

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -46,7 +46,7 @@ func main() {
 	}
 	// Warnings are never quiet and never gated on --verbose: a warning nobody
 	// reads is a warning that does not exist. Today they come from the tables
-	// baseline's warn class (SPEC-TABLES.md §16).
+	// baseline's warn class (SPEC-TABLES.md §18.2).
 	c.OnWarn = func(msg string) { fmt.Fprintln(os.Stderr, "warning: "+msg) }
 
 	switch os.Args[1] {
@@ -75,7 +75,7 @@ func main() {
 		unit := loadUnit(c, os.Args[2:])
 		fmt.Print(ir.WireProjection(unit))
 	case "tables-baseline":
-		// The TABLES BASELINE (SPEC-TABLES.md §16). Printing is the default:
+		// The TABLES BASELINE (SPEC-TABLES.md §18). Printing is the default:
 		// the same canonical projection the committed file holds, so a
 		// pipeline can diff without writing anything. --update moves the file
 		// and records WHY in its history — and never without --reason,

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -4,6 +4,7 @@
 //	schema generate   --lang cpp --out <dir> [dir]   emit generated code
 //	schema id         [dir|files...]                 print the protocol id
 //	schema projection [dir|files...]                 print the wire shape the id hashes
+//	schema tables-baseline [--update --reason "..."]  print or move the tables baseline
 //	schema fmt        [dir|files...]                 canonicalize schema files in place
 //	schema version                                   print the build identity
 //
@@ -43,6 +44,10 @@ func main() {
 			fmt.Printf("formatted %s\n", path)
 		}
 	}
+	// Warnings are never quiet and never gated on --verbose: a warning nobody
+	// reads is a warning that does not exist. Today they come from the tables
+	// baseline's warn class (SPEC-TABLES.md §16).
+	c.OnWarn = func(msg string) { fmt.Fprintln(os.Stderr, "warning: "+msg) }
 
 	switch os.Args[1] {
 	// Accept every spelling a newcomer will try. `--version` costs nothing to
@@ -55,6 +60,7 @@ func main() {
 		fs := flag.NewFlagSet("check", flag.ExitOnError)
 		fs.BoolVar(&verbose, "verbose", false, "report the package and protocol id on success")
 		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
+		c.TablesBaseline = true
 		unit := loadUnit(c, fs.Args())
 		if verbose {
 			fmt.Printf("ok: package %s, protocol id 0x%016x\n", unit.Package, unit.ProtocolId)
@@ -68,6 +74,48 @@ func main() {
 		// and that is a review question, not an implementation detail.
 		unit := loadUnit(c, os.Args[2:])
 		fmt.Print(ir.WireProjection(unit))
+	case "tables-baseline":
+		// The TABLES BASELINE (SPEC-TABLES.md §16). Printing is the default:
+		// the same canonical projection the committed file holds, so a
+		// pipeline can diff without writing anything. --update moves the file
+		// and records WHY in its history — and never without --reason,
+		// because an intentional break that nobody declared is the failure
+		// this file exists to prevent.
+		//
+		// Neither mode runs the baseline check on load: --update is the tool
+		// for moving a baseline the check is refusing, and it cannot be
+		// blocked by the refusal it exists to resolve.
+		fs := flag.NewFlagSet("tables-baseline", flag.ExitOnError)
+		update := fs.Bool("update", false, "rewrite the unit's tables.baseline and record the move in its history")
+		reason := fs.String("reason", "", "why the baseline moves — mandatory with --update, and written into the file's history")
+		fs.BoolVar(&verbose, "verbose", false, "name the file written")
+		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
+		paths, err := compiler.GatherPaths(fs.Args())
+		if err != nil {
+			fail(err)
+		}
+		u, err := c.Load(paths)
+		if err != nil {
+			fail(err)
+		}
+		if !*update {
+			if *reason != "" {
+				fatalf("--reason belongs with --update: it records why a baseline MOVED")
+			}
+			fmt.Print(compiler.TablesBaselineText(u))
+			break
+		}
+		path, rewrote, err := compiler.UpdateTablesBaseline(u, paths, *reason)
+		if err != nil {
+			fail(err)
+		}
+		if verbose {
+			if rewrote {
+				fmt.Printf("wrote %s\n", path)
+			} else {
+				fmt.Printf("%s is already current\n", path)
+			}
+		}
 	case "fmt":
 		// standalone formatting; check/generate/id already format before
 		// processing, so this exists for editors and pre-commit hooks
@@ -99,6 +147,7 @@ func main() {
 		out := fs.String("out", "generated", "output directory")
 		fs.BoolVar(&verbose, "verbose", false, "list the files emitted")
 		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
+		c.TablesBaseline = true
 		unit := loadUnit(c, fs.Args())
 		files, err := c.Generate(unit, *lang, compiler.Options{})
 		if err != nil {
@@ -133,6 +182,7 @@ func usage() {
   schema generate   [--lang c|cpp|cs|dart|elixir|go|java|js|rust] [--out generated] [--verbose] [dir|files...]
   schema id         [dir|files...]
   schema projection [dir|files...]
+  schema tables-baseline [--update --reason "..."] [--verbose] [dir|files...]
   schema fmt        [--verbose] [dir|files...]
   schema version
 

--- a/compiler/baseline.go
+++ b/compiler/baseline.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
-// TablesBaselineText renders the unit's TABLES BASELINE (SPEC-TABLES.md §16):
+// TablesBaselineText renders the unit's TABLES BASELINE (SPEC-TABLES.md §18.1):
 // a canonical text projection of its table closure — every closure member's
 // fields with their wire ids, kinds, array shapes, evaluated defaults and
 // `was` aliases, and every enum, flags and union it reaches. One fact per

--- a/compiler/baseline.go
+++ b/compiler/baseline.go
@@ -1,0 +1,34 @@
+package compiler
+
+import (
+	"github.com/mas-bandwidth/schema/v2/internal/baseline"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// TablesBaselineText renders the unit's TABLES BASELINE (SPEC-TABLES.md §16):
+// a canonical text projection of its table closure — every closure member's
+// fields with their wire ids, kinds, array shapes, evaluated defaults and
+// `was` aliases, and every enum, flags and union it reaches. One fact per
+// line, stable and diffable, exactly as `schema tables-baseline` prints it.
+//
+// It carries no history: the history section belongs to the committed file,
+// and [UpdateTablesBaseline] is what writes it.
+func TablesBaselineText(u *ir.Unit) string {
+	return baseline.Render(u).Text()
+}
+
+// UpdateTablesBaseline rewrites the unit's committed baseline — the
+// tables.baseline beside its schema files — and appends a dated entry to the
+// history section inside it naming every edit that changed what already-written
+// data means, and the reason.
+//
+// The reason is mandatory: moving the baseline is the declaration that a break
+// is intentional, and an undeclared move would defeat the whole point of
+// keeping the file. It is idempotent — when the projection has not moved, the
+// file is untouched and rewrote is false.
+//
+// paths are the unit's *.schema files, as [GatherPaths] returns them; the
+// baseline lives in their directory.
+func UpdateTablesBaseline(u *ir.Unit, paths []string, reason string) (path string, rewrote bool, err error) {
+	return baseline.Update(u, paths, reason)
+}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -50,7 +50,7 @@ type Compiler struct {
 	// stage the file, or fail the build.
 	OnFormat func(path string)
 
-	// TablesBaseline turns on the TABLES BASELINE check (SPEC-TABLES.md §16):
+	// TablesBaseline turns on the TABLES BASELINE check (SPEC-TABLES.md §18.2):
 	// when a tables.baseline sits in the unit's directory, Load diffs the
 	// unit's table closure against it and REFUSES the edits the table wire
 	// cannot report — a changed specified default, a moved flags bit, a

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mas-bandwidth/schema/v2/internal/baseline"
 	"github.com/mas-bandwidth/schema/v2/internal/check"
 	"github.com/mas-bandwidth/schema/v2/internal/format"
 	"github.com/mas-bandwidth/schema/v2/internal/parser"
@@ -48,6 +49,20 @@ type Compiler struct {
 	// actually rewrote. The CLI prints "formatted <path>"; a build tool might
 	// stage the file, or fail the build.
 	OnFormat func(path string)
+
+	// TablesBaseline turns on the TABLES BASELINE check (SPEC-TABLES.md §16):
+	// when a tables.baseline sits in the unit's directory, Load diffs the
+	// unit's table closure against it and REFUSES the edits the table wire
+	// cannot report — a changed specified default, a moved flags bit, a
+	// changed field kind. No file means no check. The CLI sets it for `check`
+	// and `generate`.
+	TablesBaseline bool
+
+	// OnWarn, when set, receives each non-fatal report a load produced — the
+	// baseline's warn class (a shrunk bound, a removed enum variant or union
+	// arm): data survives, something is lost, and the runtime read report
+	// counts it. The CLI writes them to stderr.
+	OnWarn func(msg string)
 
 	gens      map[string]Generator // every accepted --lang spelling
 	canonical []string             // one per registered generator, its first name
@@ -127,6 +142,17 @@ func (c *Compiler) Load(paths []string) (*ir.Unit, error) {
 	u, cerrs := check.Unit(files)
 	if len(cerrs) > 0 {
 		return nil, Diagnostics(cerrs)
+	}
+	if c.TablesBaseline {
+		warns, berrs := baseline.Check(u, paths)
+		for _, w := range warns {
+			if c.OnWarn != nil {
+				c.OnWarn(w)
+			}
+		}
+		if len(berrs) > 0 {
+			return nil, Diagnostics(berrs)
+		}
 	}
 	return u, nil
 }

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -171,6 +171,15 @@ func Render(u *ir.Unit) *Unit {
 		// the branch structure is deliberately not a fact here.
 		for _, f := range st.Fields {
 			t.Fields = append(t.Fields, renderField(f))
+			// an ENUM-KEYED array's key enum is a vocabulary on the wire, not
+			// just a spelling: its slots ride under their variants' NAME ids
+			// (SPEC-TABLES.md §3.2), so its variants are covered exactly as an
+			// enum-typed field's are. It reaches the closure through KeyEnum,
+			// never through the field's own type.
+			if f.KeyEnumRef != nil && !seenEnum[f.KeyEnumRef.Name] {
+				seenEnum[f.KeyEnumRef.Name] = true
+				out.Enums = append(out.Enums, renderEnum(f.KeyEnumRef))
+			}
 			switch ref := f.Type.Ref.(type) {
 			case *ir.Enum:
 				if !seenEnum[ref.Name] {
@@ -241,11 +250,25 @@ func renderField(f *ir.Field) Field {
 			add("type", f.Type.Name)
 		}
 	}
-	switch f.Array {
-	case ir.ArrayFixed:
+	// PRESENCE IS RECORDED AND JUDGED ON NOTHING (SPEC-TABLES.md §18.1): a
+	// field moving between T, ?T and *T moves no byte (§3.1), so the fact is
+	// here to be read in a diff and nowhere in the policy.
+	if f.Type.Optional {
+		add("optional", "true")
+	}
+	switch {
+	case f.KeyEnum != "":
+		// an enum-keyed array is its own wire kind (§3.2) and its slots ride
+		// under their variants' NAME ids, so the key enum is a referent like
+		// any other — and the keyed and positional bodies can never be
+		// decoded as one another, which the kind fact already says.
+		add("array", "keyed")
+		add("bound", strconv.FormatInt(f.ArrayBound, 10))
+		add("key", f.KeyEnum)
+	case f.Array == ir.ArrayFixed:
 		add("array", "fixed")
 		add("bound", strconv.FormatInt(f.ArrayBound, 10))
-	case ir.ArrayCounted:
+	case f.Array == ir.ArrayCounted:
 		add("array", "bounded")
 		add("bound", strconv.FormatInt(f.ArrayBound, 10))
 	}

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -44,8 +44,11 @@ import (
 
 // Version is the baseline RENDERING's own version, on the file's first line —
 // the same discipline ir.ProjectionVersion keeps for the protocol id. Bumping
-// it makes every committed baseline stale at once, deliberately and visibly.
-const Version = 1
+// it makes every committed baseline stale at once, deliberately and visibly:
+// an older file gets the "regenerate it" refusal, and `--update` regenerates
+// it with its history intact, instead of a flood of diffs against facts this
+// rendering spells differently.
+const Version = 2
 
 // FileName is the baseline's name in the unit directory. Its presence is what
 // turns the check on: no file, no check.

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -1,4 +1,4 @@
-// Package baseline is the TABLES BASELINE (SPEC-TABLES.md §16): an optional
+// Package baseline is the TABLES BASELINE (SPEC-TABLES.md §18): an optional
 // committed projection of a unit's table closure, and the check that refuses
 // the edits the table wire cannot report.
 //
@@ -48,7 +48,14 @@ import (
 // an older file gets the "regenerate it" refusal, and `--update` regenerates
 // it with its history intact, instead of a flood of diffs against facts this
 // rendering spells differently.
-const Version = 2
+//
+// THE RULE FOR BUMPING IT: any NEW JUDGED TOKEN bumps the version. A token
+// this rendering emits and an older one did not reads as an ADDITION to every
+// older file, and the added-token branch of the diff refuses an addition on
+// every judged row — so an unbumped rendering greets an untouched schema with
+// a refusal per field. Recording a fact nothing judges (an `optional`) does
+// not need a bump; adding a rule does.
+const Version = 3
 
 // FileName is the baseline's name in the unit directory. Its presence is what
 // turns the check on: no file, no check.

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -221,8 +221,22 @@ func renderField(f *ir.Field) Field {
 	if elem := ir.TableElemKind(f); elem != 0 {
 		add("elem", strconv.Itoa(elem))
 	}
+	// the referent rides under a key that says WHAT it names, because the two
+	// are judged differently: a table's fields ride by id inside their own
+	// body, and a vocabulary's do not ride at all (SPEC-TABLES.md §4 — an
+	// enum field and a plain uint16 field are both kind 7, so the runtime
+	// cannot report an edit between them). See DefaultTokenPolicy.
 	if f.Type.Kind == ir.TNamed {
-		add("type", f.Type.Name)
+		switch f.Type.Ref.(type) {
+		case *ir.Enum:
+			add("enum", f.Type.Name)
+		case *ir.Flags:
+			add("flags", f.Type.Name)
+		case *ir.Union:
+			add("union", f.Type.Name)
+		default:
+			add("type", f.Type.Name)
+		}
 	}
 	switch f.Array {
 	case ir.ArrayFixed:
@@ -231,10 +245,6 @@ func renderField(f *ir.Field) Field {
 	case ir.ArrayCounted:
 		add("array", "bounded")
 		add("bound", strconv.FormatInt(f.ArrayBound, 10))
-		// ENUM-KEYED ARRAYS, when the construct lands: one line here —
-		//     add("key", f.ArrayKeyEnum)
-		// — and the `key` row already sitting in DefaultTokenPolicy makes
-		// swapping the key enum a refusal.
 	}
 	if f.Type.Size != 0 {
 		add("size", strconv.FormatInt(f.Type.Size, 10))
@@ -331,14 +341,14 @@ func Parse(path string, data []byte) (*Unit, error) {
 
 	head := strings.Fields(lines[0])
 	if len(head) != 2 || head[0] != magic {
-		return nil, fmt.Errorf("%s: not a schema tables baseline (its first line must read %q) — regenerate it with: schema tables-baseline --update --reason \"...\"", path, magic+" "+strconv.Itoa(Version))
+		return nil, fmt.Errorf("%s: not a schema tables baseline (its first line must read %q)", path, magic+" "+strconv.Itoa(Version))
 	}
 	v, err := strconv.Atoi(head[1])
 	if err != nil {
 		return nil, fmt.Errorf("%s: unreadable baseline version %q", path, head[1])
 	}
 	if v != Version {
-		return nil, fmt.Errorf("%s: baseline version %d, this compiler writes %d — regenerate it with: schema tables-baseline --update --reason \"...\"", path, v, Version)
+		return nil, fmt.Errorf("%s: baseline version %d, this compiler writes %d", path, v, Version)
 	}
 	u.Version = v
 
@@ -396,6 +406,7 @@ func (u *Unit) parseMemberLine(path string, lineno int, section string, fields [
 			return bad()
 		}
 		f := Field{Name: fields[1]}
+		var haveId bool
 		for _, tok := range fields[2:] {
 			k, val, ok := strings.Cut(tok, "=")
 			if !ok {
@@ -406,10 +417,16 @@ func (u *Unit) parseMemberLine(path string, lineno int, section string, fields [
 				if err != nil {
 					return bad()
 				}
-				f.Id = uint16(id)
+				f.Id, haveId = uint16(id), true
 				continue
 			}
 			f.Tokens = append(f.Tokens, Token{Key: k, Value: val})
+		}
+		// the wire id is the field's IDENTITY here — a line without one names
+		// nothing the diff can match, and a file that carries such a line is
+		// reported rather than half-read
+		if !haveId {
+			return fmt.Errorf("%s:%d: field %s carries no id= — the wire id is a field's identity in this file", path, lineno, fields[1])
 		}
 		t := &u.Tables[len(u.Tables)-1]
 		t.Fields = append(t.Fields, f)
@@ -438,10 +455,24 @@ func (u *Unit) parseMemberLine(path string, lineno int, section string, fields [
 		un := &u.Unions[len(u.Unions)-1]
 		un.Arms = append(un.Arms, v)
 	case "flags":
-		if fields[0] != "variant" || len(u.Flags) == 0 {
+		if fields[0] != "variant" || len(u.Flags) == 0 || len(fields) != 3 {
 			return bad()
 		}
 		fl := &u.Flags[len(u.Flags)-1]
+		// LINE ORDER IS THE FACT, and `bit=` states it in the file so a human
+		// reading a diff does not have to count. The parser holds the two to
+		// each other: a hand-edit that moves a line without moving its bit is
+		// a file this parser cannot read, and it says so rather than guessing
+		// which half the author meant.
+		k, val, ok := strings.Cut(fields[2], "=")
+		if !ok || k != "bit" {
+			return bad()
+		}
+		bit, err := strconv.Atoi(val)
+		if err != nil || bit != len(fl.Variants) {
+			return fmt.Errorf("%s:%d: flags variant %s is written at bit=%s but stands at position %d — bit position is line order here, and the two disagree",
+				path, lineno, fields[1], val, len(fl.Variants))
+		}
 		fl.Variants = append(fl.Variants, fields[1])
 	default:
 		return bad()

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -1,0 +1,460 @@
+// Package baseline is the TABLES BASELINE (SPEC-TABLES.md §16): an optional
+// committed projection of a unit's table closure, and the check that refuses
+// the edits the table wire cannot report.
+//
+// # WHY IT EXISTS
+//
+// The table wire is evolution-tolerant by construction (SPEC-TABLES.md §4):
+// fields may be added, removed and reordered, variants inserted anywhere,
+// bounds grown, names changed under `was`. Every one of those edits is
+// invisible to a reader in the good sense — nothing is lost and nothing is
+// misread. Two edits are invisible in the bad sense, and they are the reason
+// this file exists:
+//
+//   - A SPECIFIED DEFAULT is part of the wire contract. A field holding its
+//     default is elided, so the reader's declared default is what the absence
+//     MEANS. Change it and every file already written changes meaning, with no
+//     report event, because nothing was lost or skipped.
+//   - A FLAGS variant is positional. A mask carries bits, not names, so
+//     inserting or reordering a variant silently remaps every stored file.
+//
+// The compiler retains no history and cannot see either edit on its own. The
+// baseline is that history, kept where a human can read it: a text file in the
+// unit directory, diffed on every check.
+//
+// # THE SHAPE OF THE ANSWER
+//
+// One representation serves rendering, parsing and diffing: a member is a list
+// of fields, and a field is its name, its wire id and an ORDERED LIST OF
+// TOKENS — `kind=4`, `default=21`, `bound=8`. The whole compatibility policy
+// is then one table, [DefaultTokenPolicy], mapping a token key to what a
+// change of it means. Adding a fact to the projection is a line in the
+// renderer plus a row in that table, which is what keeps the enum-keyed array
+// hook (`key=`) a one-line addition the day the construct lands.
+package baseline
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// Version is the baseline RENDERING's own version, on the file's first line —
+// the same discipline ir.ProjectionVersion keeps for the protocol id. Bumping
+// it makes every committed baseline stale at once, deliberately and visibly.
+const Version = 1
+
+// FileName is the baseline's name in the unit directory. Its presence is what
+// turns the check on: no file, no check.
+const FileName = "tables.baseline"
+
+// HistoryHeading opens the intentional-break log inside the file. Everything
+// from this line to the end of the file is history, preserved verbatim by
+// every update.
+const HistoryHeading = "## history"
+
+const magic = "schema-tables-baseline"
+
+// A Unit is one baseline: the projection of a unit's table closure, plus the
+// history the file carries.
+type Unit struct {
+	Version int
+	Package string
+	Tables  []Table
+	Enums   []Enum
+	Flags   []Flags
+	Unions  []Union
+
+	// History is the `## history` section's lines, verbatim and in file
+	// order. Rendering writes them back untouched; an update appends.
+	History []string
+}
+
+// A Table is one member of the table closure: a `table` declaration, or a
+// `type` reached from one. The two are one thing on the table wire — the
+// keyword that declared it changes no byte — so the baseline spells both
+// `table`.
+type Table struct {
+	Name   string
+	Fields []Field
+}
+
+// A Field is one field of a closure member: its declared name, its EFFECTIVE
+// table-wire id (the `was` alias applied), and the wire facts as ordered
+// tokens.
+type Field struct {
+	Name   string
+	Id     uint16
+	Tokens []Token
+}
+
+// A Token is one `key=value` wire fact on a field's line. The key is what
+// [DefaultTokenPolicy] judges.
+type Token struct {
+	Key   string
+	Value string
+}
+
+// Get returns the value of one token and whether the field carries it.
+func (f Field) Get(key string) (string, bool) {
+	for _, t := range f.Tokens {
+		if t.Key == key {
+			return t.Value, true
+		}
+	}
+	return "", false
+}
+
+// An Enum is one enum in the closure: variants in declaration order, each with
+// the wire id it rides under.
+type Enum struct {
+	Name     string
+	Variants []Variant
+}
+
+// A Variant is one enum variant or union arm, with its name-hash id.
+type Variant struct {
+	Name    string
+	Id      uint16
+	Payload string // union arms only
+}
+
+// A Flags is one flags declaration in the closure. The ORDER IS THE FACT:
+// bit i is variant i, and no name rides on the wire at all.
+type Flags struct {
+	Name     string
+	Variants []string
+}
+
+// A Union is one union in the closure: arms in declaration order, each with
+// its name-hash id and its payload type.
+type Union struct {
+	Name string
+	Arms []Variant
+}
+
+// Render projects a checked unit's table closure. The result is exactly what
+// [Unit.Text] writes and what the check diffs against; it carries no history
+// (the file's own history is merged in by the update path).
+func Render(u *ir.Unit) *Unit {
+	out := &Unit{Version: Version, Package: u.Package}
+
+	closure := ir.TableClosure(u)
+	names := make([]string, 0, len(closure))
+	for name := range closure {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	seenEnum := map[string]bool{}
+	seenFlags := map[string]bool{}
+	seenUnion := map[string]bool{}
+
+	for _, name := range names {
+		st := u.Tables[name]
+		if st == nil {
+			st = u.Structs[name]
+		}
+		if st == nil {
+			continue
+		}
+		t := Table{Name: name}
+		// DECLARATION ORDER: st.Fields is the flattened body, branch fields
+		// included. A guard removes a field from the bytes exactly as a
+		// default does, and both are absorbed by the reader's default — so
+		// the branch structure is deliberately not a fact here.
+		for _, f := range st.Fields {
+			t.Fields = append(t.Fields, renderField(f))
+			switch ref := f.Type.Ref.(type) {
+			case *ir.Enum:
+				if !seenEnum[ref.Name] {
+					seenEnum[ref.Name] = true
+					out.Enums = append(out.Enums, renderEnum(ref))
+				}
+			case *ir.Flags:
+				if !seenFlags[ref.Name] {
+					seenFlags[ref.Name] = true
+					out.Flags = append(out.Flags, Flags{Name: ref.Name, Variants: append([]string(nil), ref.Variants...)})
+				}
+			case *ir.Union:
+				if !seenUnion[ref.Name] {
+					seenUnion[ref.Name] = true
+					out.Unions = append(out.Unions, renderUnion(ref))
+				}
+			}
+		}
+		out.Tables = append(out.Tables, t)
+	}
+
+	sort.Slice(out.Enums, func(i, j int) bool { return out.Enums[i].Name < out.Enums[j].Name })
+	sort.Slice(out.Flags, func(i, j int) bool { return out.Flags[i].Name < out.Flags[j].Name })
+	sort.Slice(out.Unions, func(i, j int) bool { return out.Unions[i].Name < out.Unions[j].Name })
+	return out
+}
+
+func renderEnum(e *ir.Enum) Enum {
+	out := Enum{Name: e.Name}
+	for _, v := range e.Variants {
+		out.Variants = append(out.Variants, Variant{Name: v, Id: ir.VariantId(v)})
+	}
+	return out
+}
+
+func renderUnion(un *ir.Union) Union {
+	out := Union{Name: un.Name}
+	for _, v := range un.Variants {
+		out.Arms = append(out.Arms, Variant{Name: v.Name, Id: ir.VariantId(v.Name), Payload: v.Type})
+	}
+	return out
+}
+
+// renderField lists a field's wire facts. The token ORDER here is the file's
+// column order; every key it can emit has a row in [DefaultTokenPolicy].
+func renderField(f *ir.Field) Field {
+	out := Field{Name: f.Name, Id: ir.TableFieldId(f)}
+	add := func(k, v string) { out.Tokens = append(out.Tokens, Token{Key: k, Value: v}) }
+
+	add("kind", strconv.Itoa(ir.TableFieldKind(f)))
+	if elem := ir.TableElemKind(f); elem != 0 {
+		add("elem", strconv.Itoa(elem))
+	}
+	if f.Type.Kind == ir.TNamed {
+		add("type", f.Type.Name)
+	}
+	switch f.Array {
+	case ir.ArrayFixed:
+		add("array", "fixed")
+		add("bound", strconv.FormatInt(f.ArrayBound, 10))
+	case ir.ArrayCounted:
+		add("array", "bounded")
+		add("bound", strconv.FormatInt(f.ArrayBound, 10))
+		// ENUM-KEYED ARRAYS, when the construct lands: one line here —
+		//     add("key", f.ArrayKeyEnum)
+		// — and the `key` row already sitting in DefaultTokenPolicy makes
+		// swapping the key enum a refusal.
+	}
+	if f.Type.Size != 0 {
+		add("size", strconv.FormatInt(f.Type.Size, 10))
+	}
+	if f.HasDefault {
+		add("default", DefaultText(f))
+	}
+	if f.WasName != "" {
+		add("was", f.WasName)
+	}
+	return out
+}
+
+// DefaultText renders a specified default as exact canonical text — the
+// EVALUATED value, never the author's spelling, so a constant that moved
+// through an expression into a default shows up as the value it now produces.
+func DefaultText(f *ir.Field) string {
+	switch {
+	case f.DefVariant != "":
+		return f.DefVariant
+	case f.DefInt != nil:
+		return f.DefInt.String()
+	case f.Type.Kind == ir.TBool:
+		return strconv.FormatBool(f.DefBool)
+	default:
+		// shortest round-tripping form: exact, and stable across builds. The
+		// trailing ".0" is put back on a whole number so a float default
+		// never reads as an integer one.
+		s := strconv.FormatFloat(f.DefFloat, 'g', -1, 64)
+		if !strings.ContainsAny(s, ".eEnN") {
+			s += ".0"
+		}
+		return s
+	}
+}
+
+// Text renders the baseline as the committed file: the projection, then the
+// history section verbatim.
+func (u *Unit) Text() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %d\n", magic, u.Version)
+	fmt.Fprintf(&b, "package %s\n", u.Package)
+
+	for _, t := range u.Tables {
+		fmt.Fprintf(&b, "\ntable %s\n", t.Name)
+		for _, f := range t.Fields {
+			fmt.Fprintf(&b, "    field %s id=0x%04x", f.Name, f.Id)
+			for _, tok := range f.Tokens {
+				fmt.Fprintf(&b, " %s=%s", tok.Key, tok.Value)
+			}
+			b.WriteString("\n")
+		}
+	}
+	for _, e := range u.Enums {
+		fmt.Fprintf(&b, "\nenum %s\n", e.Name)
+		for _, v := range e.Variants {
+			fmt.Fprintf(&b, "    variant %s id=0x%04x\n", v.Name, v.Id)
+		}
+	}
+	for _, f := range u.Flags {
+		fmt.Fprintf(&b, "\nflags %s\n", f.Name)
+		for i, v := range f.Variants {
+			fmt.Fprintf(&b, "    variant %s bit=%d\n", v, i)
+		}
+	}
+	for _, un := range u.Unions {
+		fmt.Fprintf(&b, "\nunion %s\n", un.Name)
+		for _, a := range un.Arms {
+			fmt.Fprintf(&b, "    arm %s id=0x%04x payload=%s\n", a.Name, a.Id, a.Payload)
+		}
+	}
+	if len(u.History) > 0 {
+		fmt.Fprintf(&b, "\n%s\n", HistoryHeading)
+		for _, line := range u.History {
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// Parse reads a committed baseline file. It is deliberately strict: a file
+// this parser cannot read is reported rather than guessed at, because a
+// misread baseline is a check that lies.
+func Parse(path string, data []byte) (*Unit, error) {
+	u := &Unit{}
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("%s: empty", path)
+	}
+
+	head := strings.Fields(lines[0])
+	if len(head) != 2 || head[0] != magic {
+		return nil, fmt.Errorf("%s: not a schema tables baseline (its first line must read %q) — regenerate it with: schema tables-baseline --update --reason \"...\"", path, magic+" "+strconv.Itoa(Version))
+	}
+	v, err := strconv.Atoi(head[1])
+	if err != nil {
+		return nil, fmt.Errorf("%s: unreadable baseline version %q", path, head[1])
+	}
+	if v != Version {
+		return nil, fmt.Errorf("%s: baseline version %d, this compiler writes %d — regenerate it with: schema tables-baseline --update --reason \"...\"", path, v, Version)
+	}
+	u.Version = v
+
+	var cur string // the open section's kind
+	for i := 1; i < len(lines); i++ {
+		line := lines[i]
+		if line == HistoryHeading {
+			u.History = append(u.History, lines[i+1:]...)
+			for len(u.History) > 0 && strings.TrimSpace(u.History[0]) == "" {
+				u.History = u.History[1:]
+			}
+			break
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if !strings.HasPrefix(line, " ") {
+			// a section opener
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("%s:%d: unreadable section line %q", path, i+1, line)
+			}
+			switch fields[0] {
+			case "package":
+				u.Package = fields[1]
+			case "table":
+				u.Tables = append(u.Tables, Table{Name: fields[1]})
+			case "enum":
+				u.Enums = append(u.Enums, Enum{Name: fields[1]})
+			case "flags":
+				u.Flags = append(u.Flags, Flags{Name: fields[1]})
+			case "union":
+				u.Unions = append(u.Unions, Union{Name: fields[1]})
+			default:
+				return nil, fmt.Errorf("%s:%d: unknown section %q", path, i+1, fields[0])
+			}
+			cur = fields[0]
+			continue
+		}
+		if err := u.parseMemberLine(path, i+1, cur, fields); err != nil {
+			return nil, err
+		}
+	}
+	return u, nil
+}
+
+func (u *Unit) parseMemberLine(path string, lineno int, section string, fields []string) error {
+	bad := func() error { return fmt.Errorf("%s:%d: unreadable %s line", path, lineno, section) }
+	if len(fields) < 2 {
+		return bad()
+	}
+	switch section {
+	case "table":
+		if fields[0] != "field" || len(u.Tables) == 0 {
+			return bad()
+		}
+		f := Field{Name: fields[1]}
+		for _, tok := range fields[2:] {
+			k, val, ok := strings.Cut(tok, "=")
+			if !ok {
+				return bad()
+			}
+			if k == "id" {
+				id, err := strconv.ParseUint(strings.TrimPrefix(val, "0x"), 16, 16)
+				if err != nil {
+					return bad()
+				}
+				f.Id = uint16(id)
+				continue
+			}
+			f.Tokens = append(f.Tokens, Token{Key: k, Value: val})
+		}
+		t := &u.Tables[len(u.Tables)-1]
+		t.Fields = append(t.Fields, f)
+	case "enum", "union":
+		id, err := parseIdToken(fields)
+		if err != nil {
+			return bad()
+		}
+		v := Variant{Name: fields[1], Id: id}
+		if section == "enum" {
+			if fields[0] != "variant" || len(u.Enums) == 0 {
+				return bad()
+			}
+			e := &u.Enums[len(u.Enums)-1]
+			e.Variants = append(e.Variants, v)
+			return nil
+		}
+		if fields[0] != "arm" || len(u.Unions) == 0 {
+			return bad()
+		}
+		for _, tok := range fields[2:] {
+			if k, val, ok := strings.Cut(tok, "="); ok && k == "payload" {
+				v.Payload = val
+			}
+		}
+		un := &u.Unions[len(u.Unions)-1]
+		un.Arms = append(un.Arms, v)
+	case "flags":
+		if fields[0] != "variant" || len(u.Flags) == 0 {
+			return bad()
+		}
+		fl := &u.Flags[len(u.Flags)-1]
+		fl.Variants = append(fl.Variants, fields[1])
+	default:
+		return bad()
+	}
+	return nil
+}
+
+func parseIdToken(fields []string) (uint16, error) {
+	for _, tok := range fields[2:] {
+		if k, val, ok := strings.Cut(tok, "="); ok && k == "id" {
+			id, err := strconv.ParseUint(strings.TrimPrefix(val, "0x"), 16, 16)
+			return uint16(id), err
+		}
+	}
+	return 0, fmt.Errorf("no id")
+}

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -98,6 +98,8 @@ table Config
     swap_grade Grade
     swap_perks Perks
     swap Buff
+    per_grade [Grade]int32
+    gunner ?Buff
 }
 `
 
@@ -319,6 +321,25 @@ func TestRefusals(t *testing.T) {
 			control: replace(t, "    buff   Buff\n", "    buff   BuffPlus\n"),
 		},
 		{
+			// the keyed body and the positional body are different wire kinds
+			// (SPEC-TABLES.md §3.2), so a reader meeting the other skips —
+			// and the values are silently gone
+			name:    "an array changed from the keyed spelling to the positional one",
+			edited:  replace(t, "    per_grade [Grade]int32", "    per_grade [4]int32"),
+			where:   "Config.per_grade",
+			what:    "wire kind 16 -> 14",
+			token:   "kind",
+			control: replace(t, "    per_grade [Grade]int32", "    per_grade [Grade]int32\n    per_tier  [Tier]int32"),
+		},
+		{
+			name:    "an enum-keyed array's KEY enum swapped for another",
+			edited:  replace(t, "    per_grade [Grade]int32", "    per_grade [Tier]int32"),
+			where:   "Config.per_grade",
+			what:    "array key enum Grade -> Tier",
+			token:   "key",
+			control: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Argent, Silver, Gold }"),
+		},
+		{
 			name:    "a flags variant inserted",
 			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Hardened, Cloaked, Turbo }"),
 			where:   "flags Perks",
@@ -476,7 +497,7 @@ func TestVanishedMembers(t *testing.T) {
 			edited: strings.NewReplacer("table Config", "table Ship",
 				"damage  float32 = 21.0", "damage  float32 = 25.0").Replace(baseSrc),
 			warnAt:   "table Config",
-			warnWhat: "Ship carries 13 of its 13 identities",
+			warnWhat: "Ship carries 15 of its 15 identities",
 			verdict:  baseline.Refuse,
 			where:    "Ship.damage",
 			what:     "specified default 21.0 -> 25.0",
@@ -498,7 +519,8 @@ func TestVanishedMembers(t *testing.T) {
 			edited: strings.NewReplacer(
 				"enum Grade { Bronze, Silver, Gold }", "enum Rank { Bronze, Silver }",
 				"grade   Grade = Silver", "grade   Rank = Silver",
-				"swap_grade Grade", "swap_grade Rank").Replace(baseSrc),
+				"swap_grade Grade", "swap_grade Rank",
+				"per_grade [Grade]int32", "per_grade [Rank]int32").Replace(baseSrc),
 			warnAt:   "enum Grade",
 			warnWhat: "Rank carries 2 of its 3 identities",
 			verdict:  baseline.Warn,
@@ -552,7 +574,8 @@ func TestPairedRenameDoesNotRaiseTheVerdict(t *testing.T) {
 			renamed: strings.NewReplacer(
 				"enum Grade { Bronze, Silver, Gold }", "enum Rank { Bronze, Silver }",
 				"grade   Grade = Silver", "grade   Rank = Silver",
-				"swap_grade Grade", "swap_grade Rank").Replace(baseSrc),
+				"swap_grade Grade", "swap_grade Rank",
+				"per_grade [Grade]int32", "per_grade [Rank]int32").Replace(baseSrc),
 			where: "variant Gold removed",
 			what:  "Gold",
 		},
@@ -597,7 +620,8 @@ func TestBelowThresholdRenameIsARepoint(t *testing.T) {
 	renamed := strings.NewReplacer(
 		"enum Grade { Bronze, Silver, Gold }", "enum Rank { Silver }",
 		"grade   Grade = Silver", "grade   Rank = Silver",
-		"swap_grade Grade", "swap_grade Rank").Replace(baseSrc)
+		"swap_grade Grade", "swap_grade Rank",
+		"per_grade [Grade]int32", "per_grade [Rank]int32").Replace(baseSrc)
 	got := diff(t, renamed, baseline.DefaultTokenPolicy)
 	if !find(got, baseline.Refuse, "Config.swap_grade", "enum Grade -> Rank") {
 		t.Fatalf("below the threshold the change of referent is judged as a repoint, got:%s", summary(got))
@@ -791,6 +815,13 @@ func TestAbsorbedEdits(t *testing.T) {
 		{"a bounded array made fixed", replace(t, "slots   [..Slots]int32", "slots   [Slots]int32")},
 		{"a field moved under a guard", replace(t, "    hits    int32", "    guard   bool\n    if guard\n    {\n        hits int32\n    }")},
 		{"a table added", baseSrc + "\ntable Extra\n{\n    x int32 = 1\n}\n"},
+		// T, ?T and *T are one framing (SPEC-TABLES.md §3.1): presence is
+		// recorded in the file and judged on nothing
+		{"a field made optional", replace(t, "    boost   Buff", "    boost   ?Buff")},
+		{"an optional field made plain", replace(t, "    gunner ?Buff", "    gunner Buff")},
+		// a keyed array's bound is its enum's size: growing the enum grows the
+		// array, and the slots ride by variant NAME, so nothing moves
+		{"a keyed array's enum grown", replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Silver, Gold, Platinum }")},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -801,27 +832,47 @@ func TestAbsorbedEdits(t *testing.T) {
 	}
 }
 
-// TestEnumKeyedArrayHook is the enum-keyed array's rule, live before the
-// construct is: the day `[E]T` lands the renderer emits one `key=` token and
-// swapping the key enum is a refusal, because the policy row is already here.
-// Synthesised, since no schema can spell the construct yet.
-func TestEnumKeyedArrayHook(t *testing.T) {
-	member := func(key string) *baseline.Unit {
-		return &baseline.Unit{
-			Version: baseline.Version,
-			Package: "fixture",
-			Tables: []baseline.Table{{Name: "Config", Fields: []baseline.Field{{
-				Name: "slots", Id: 0x1234,
-				Tokens: []baseline.Token{{Key: "kind", Value: "14"}, {Key: "elem", Value: "4"}, {Key: "key", Value: key}},
-			}}}},
-		}
+// TestKeyEnumIsCovered: an enum-keyed array's key enum reaches the closure
+// only through the array, never through a field's own type — and its variants
+// are wire identities all the same, because the slots ride under their name
+// ids (SPEC-TABLES.md §3.2). A projection that forgot it would leave every
+// keyed collection's vocabulary uncovered.
+func TestKeyEnumIsCovered(t *testing.T) {
+	const src = `package keyed
+
+enum Slot { Head, Chest, Legs }
+
+type Piece
+{
+    armour int32 = 1
+}
+
+table Loadout
+{
+    pieces [Slot]Piece
+}
+`
+	b := committed(t, src)
+	var names []string
+	for _, e := range b.Enums {
+		names = append(names, e.Name)
 	}
-	got := baseline.Diff(member("Grade"), member("Tier"), baseline.DefaultTokenPolicy)
-	if !find(got, baseline.Refuse, "Config.slots", "array key enum Grade -> Tier") {
-		t.Fatalf("swapping an enum-keyed array's enum must be refused, got:%s", summary(got))
+	if len(names) != 1 || names[0] != "Slot" {
+		t.Fatalf("the key enum must be projected, got %v", names)
 	}
-	if got := baseline.Diff(member("Grade"), member("Tier"), without("key")); len(got) != 0 {
-		t.Errorf("with the \"key\" rule removed the edit should pass, got:%s", summary(got))
+
+	dropped := strings.Replace(src, "enum Slot { Head, Chest, Legs }", "enum Slot { Head, Chest }", 1)
+	got := baseline.Diff(b, baseline.Render(unit(t, dropped)), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "enum Slot", "variant Legs removed") {
+		t.Errorf("dropping a key enum variant loses those slots and must warn, got:%s", summary(got))
+	}
+	if got := baseline.Diff(b, baseline.Render(unit(t, dropped)), without("enum-variant")); find(got, baseline.Warn, "enum Slot", "variant Legs removed") {
+		t.Errorf("with the \"enum-variant\" rule removed the warning should be gone, got:%s", summary(got))
+	}
+	// growing it is absorbed: a new variant is a new slot nothing has written
+	grown := strings.Replace(src, "enum Slot { Head, Chest, Legs }", "enum Slot { Head, Chest, Legs, Boots }", 1)
+	if got := baseline.Diff(b, baseline.Render(unit(t, grown)), baseline.DefaultTokenPolicy); len(got) != 0 {
+		t.Errorf("growing a key enum is absorbed, got:%s", summary(got))
 	}
 }
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1,0 +1,554 @@
+// The tables baseline's gate (SPEC-TABLES.md §16): one fixture pair per
+// refusal class and per warn class, each with its negative controls.
+//
+// TWO KINDS OF NEGATIVE CONTROL, because a gate can be wrong in two ways.
+//
+//   - The DISCRIMINATION control: the same field, the same vocabulary, edited
+//     in the direction the wire absorbs — a bound grown instead of shrunk, a
+//     flags variant appended instead of inserted, a field added instead of a
+//     default changed. A gate that fires on those is a gate nobody will keep.
+//   - The ATTRIBUTION control: the very same edit, re-judged with that one row
+//     removed from the policy table, must pass. That is what proves the
+//     refusal came from the check under test and not from something else in
+//     the walk — an oracle that shares the code's own transformation cannot
+//     tell you which check fired.
+package baseline_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/baseline"
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// baseSrc is the fixture unit every case edits: one table whose closure
+// reaches an enum, a flags, a union and two plain types, so every vocabulary
+// the baseline records is live.
+const baseSrc = `package fixture
+
+const Slots = 8
+
+enum Grade { Bronze, Silver, Gold }
+
+flags Perks { Shielded, Cloaked, Turbo }
+
+type Buff
+{
+    multiplier float32 = 1.0
+}
+
+type Debuff
+{
+    amount int32 = 0
+}
+
+union Effect
+{
+    buff   Buff
+    debuff Debuff
+}
+
+table Config
+{
+    damage  float32 = 21.0
+    heading int16
+    homing  bool
+    hits    int32
+    grade   Grade = Silver
+    perks   Perks
+    name    string(32)
+    slots   [..Slots]int32
+    effect  Effect
+}
+`
+
+func unit(t *testing.T, src string) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse("Fixture.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "Fixture.schema", Name: "Fixture.schema", Base: "Fixture", Bytes: []byte(src), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	return u
+}
+
+// committed renders a unit and takes it through the file's own text form, so
+// every diff in this file runs against a PARSED baseline exactly as a check
+// against a committed file does.
+func committed(t *testing.T, src string) *baseline.Unit {
+	t.Helper()
+	text := baseline.Render(unit(t, src)).Text()
+	b, err := baseline.Parse("tables.baseline", []byte(text))
+	if err != nil {
+		t.Fatalf("a rendered baseline does not parse: %v\n%s", err, text)
+	}
+	return b
+}
+
+// diff judges an edit of baseSrc under the shipping policy.
+func diff(t *testing.T, edited string, policy map[string]baseline.TokenRule) []baseline.Finding {
+	t.Helper()
+	return baseline.Diff(committed(t, baseSrc), baseline.Render(unit(t, edited)), policy)
+}
+
+// replace is the fixture edit: exactly one substitution, or the test is lying
+// about what it changed.
+func replace(t *testing.T, old, new string) string {
+	t.Helper()
+	if strings.Count(baseSrc, old) != 1 {
+		t.Fatalf("fixture edit %q does not appear exactly once in the base schema", old)
+	}
+	return strings.Replace(baseSrc, old, new, 1)
+}
+
+// find reports whether a finding of this verdict mentions both fragments.
+func find(fs []baseline.Finding, v baseline.Verdict, where, what string) bool {
+	for _, f := range fs {
+		if f.Verdict == v && strings.Contains(f.Where, where) && strings.Contains(f.What, what) {
+			return true
+		}
+	}
+	return false
+}
+
+func summary(fs []baseline.Finding) string {
+	if len(fs) == 0 {
+		return "(no findings)"
+	}
+	var b strings.Builder
+	for _, f := range fs {
+		b.WriteString("\n  [" + f.Verdict.String() + "] " + f.String())
+	}
+	return b.String()
+}
+
+// without returns the shipping policy with one row removed — the attribution
+// control's instrument.
+func without(keys ...string) map[string]baseline.TokenRule {
+	p := map[string]baseline.TokenRule{}
+	for k, v := range baseline.DefaultTokenPolicy {
+		p[k] = v
+	}
+	for _, k := range keys {
+		delete(p, k)
+	}
+	return p
+}
+
+// TestRefusals is one case per refusal class: the edits that change what data
+// already written MEANS, with nothing on the wire to report them.
+func TestRefusals(t *testing.T) {
+	cases := []struct {
+		name    string
+		edited  string
+		where   string
+		what    string
+		token   string // the policy row that must be the cause (empty: not a token rule)
+		control string // an edit of the same shape the wire absorbs
+	}{
+		{
+			name:    "a specified default changed",
+			edited:  replace(t, "damage  float32 = 21.0", "damage  float32 = 25.0"),
+			where:   "Config.damage",
+			what:    "specified default 21.0 -> 25.0",
+			token:   "default",
+			control: replace(t, "damage  float32 = 21.0", "damage  float32 = 21.0 | min = 0.0, max = 100.0, resolution = 0.01"),
+		},
+		{
+			name:    "a specified default removed",
+			edited:  replace(t, "damage  float32 = 21.0", "damage  float32"),
+			where:   "Config.damage",
+			what:    "specified default 21.0 removed",
+			token:   "default",
+			control: replace(t, "damage  float32 = 21.0", "damage  float32 = 21.0\n    extra   int32"),
+		},
+		{
+			name:    "a specified default added",
+			edited:  replace(t, "homing  bool", "homing  bool = true"),
+			where:   "Config.homing",
+			what:    "specified default true added",
+			token:   "default",
+			control: replace(t, "homing  bool", "homing  bool\n    extra   bool = true"),
+		},
+		{
+			name:    "an enum default renamed to another variant",
+			edited:  replace(t, "grade   Grade = Silver", "grade   Grade = Gold"),
+			where:   "Config.grade",
+			what:    "specified default Silver -> Gold",
+			token:   "default",
+			control: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Silver, Gold, Platinum }"),
+		},
+		{
+			name:    "a field's kind changed",
+			edited:  replace(t, "heading int16", "heading int32"),
+			where:   "Config.heading",
+			what:    "wire kind 3 -> 4",
+			token:   "kind",
+			// the absorbed edit of the same shape: a NEW field of the changed
+			// type beside the old one, which is the migration the wire wants
+			control: replace(t, "heading int16", "heading int16\n    heading_wide int32"),
+		},
+		{
+			name:    "an array's element kind changed",
+			edited:  replace(t, "slots   [..Slots]int32", "slots   [..Slots]int64"),
+			where:   "Config.slots",
+			what:    "array element kind 4 -> 5",
+			token:   "elem",
+			control: replace(t, "slots   [..Slots]int32", "slots   [Slots]int32"), // fixed vs bounded frames identically
+		},
+		{
+			name:    "a flags variant inserted",
+			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Hardened, Cloaked, Turbo }"),
+			where:   "flags Perks",
+			what:    "variant Cloaked moved from bit 1 to bit 2",
+			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
+		},
+		{
+			name:    "a flags variant reordered",
+			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Cloaked, Shielded, Turbo }"),
+			where:   "flags Perks",
+			what:    "variant Shielded moved from bit 0 to bit 1",
+			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
+		},
+		{
+			name:    "a flags variant removed",
+			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Turbo }"),
+			where:   "flags Perks",
+			what:    "variant Cloaked removed from bit 1",
+			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diff(t, tc.edited, baseline.DefaultTokenPolicy)
+			if !find(got, baseline.Refuse, tc.where, tc.what) {
+				t.Fatalf("the edit was not refused; wanted %s: %s, got:%s", tc.where, tc.what, summary(got))
+			}
+			// the DISCRIMINATION control: the absorbed edit of the same shape
+			if ctrl := diff(t, tc.control, baseline.DefaultTokenPolicy); len(ctrl) != 0 {
+				t.Errorf("the control edit should be absorbed by the wire, got:%s", summary(ctrl))
+			}
+			// the ATTRIBUTION control: with that policy row gone, the same
+			// edit passes — the refusal came from this check and no other
+			if tc.token == "" {
+				return
+			}
+			if got := diff(t, tc.edited, without(tc.token)); len(got) != 0 {
+				t.Errorf("with the %q rule removed the edit should pass, got:%s", tc.token, summary(got))
+			}
+		})
+	}
+}
+
+// TestWarnings is one case per warn class: the edits that lose something the
+// runtime read report already counts, so the compiler reports rather than
+// refuses.
+func TestWarnings(t *testing.T) {
+	cases := []struct {
+		name    string
+		edited  string
+		where   string
+		what    string
+		token   string
+		control string
+	}{
+		{
+			name: "an array bound shrunk, through the constant it is declared with",
+			// the bound is EVALUATED: the array declaration never moves, the
+			// const does, and the baseline sees the value
+			edited:  replace(t, "const Slots = 8", "const Slots = 4"),
+			where:   "Config.slots",
+			what:    "array bound 8 -> 4",
+			token:   "bound",
+			control: replace(t, "const Slots = 8", "const Slots = 16"),
+		},
+		{
+			name:    "a string capacity shrunk",
+			edited:  replace(t, "name    string(32)", "name    string(16)"),
+			where:   "Config.name",
+			what:    "capacity 32 -> 16",
+			token:   "size",
+			control: replace(t, "name    string(32)", "name    string(64)"),
+		},
+		{
+			name:    "an enum variant removed",
+			edited:  replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Silver }"),
+			where:   "enum Grade",
+			what:    "variant Gold removed",
+			control: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Argent, Silver, Gold }"),
+		},
+		{
+			name:    "a union arm removed",
+			edited:  replace(t, "    buff   Buff\n    debuff Debuff\n", "    buff   Buff\n"),
+			where:   "union Effect",
+			what:    "arm debuff removed",
+			control: replace(t, "    buff   Buff\n    debuff Debuff\n", "    buff   Buff\n    debuff Debuff\n    curse  Buff\n"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diff(t, tc.edited, baseline.DefaultTokenPolicy)
+			if !find(got, baseline.Warn, tc.where, tc.what) {
+				t.Fatalf("the edit did not warn; wanted %s: %s, got:%s", tc.where, tc.what, summary(got))
+			}
+			if refusals, _ := baseline.Split(got); len(refusals) != 0 {
+				t.Errorf("a warn-class edit must not refuse, got:%s", summary(refusals))
+			}
+			if ctrl := diff(t, tc.control, baseline.DefaultTokenPolicy); len(ctrl) != 0 {
+				t.Errorf("the control edit should be absorbed by the wire, got:%s", summary(ctrl))
+			}
+			if tc.token == "" {
+				return
+			}
+			if got := diff(t, tc.edited, without(tc.token)); len(got) != 0 {
+				t.Errorf("with the %q rule removed the edit should pass, got:%s", tc.token, summary(got))
+			}
+		})
+	}
+}
+
+// TestAbsorbedEdits is the other half of the gate: everything the table wire
+// handles on its own must pass in SILENCE. A baseline that cries wolf is a
+// baseline someone deletes.
+func TestAbsorbedEdits(t *testing.T) {
+	cases := []struct{ name, edited string }{
+		{"a field added", replace(t, "    hits    int32", "    hits    int32\n    added   int32")},
+		{"a field removed", replace(t, "    hits    int32\n", "")},
+		{"fields reordered", replace(t, "    damage  float32 = 21.0\n    heading int16", "    heading int16\n    damage  float32 = 21.0")},
+		{"a field renamed under was", replace(t, "hits    int32", "strikes int32 | was = \"hits\"")},
+		{"a flags variant appended", replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }")},
+		{"an enum variant inserted in the middle", replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Argent, Silver, Gold }")},
+		{"an array bound grown", replace(t, "const Slots = 8", "const Slots = 64")},
+		{"a string capacity grown", replace(t, "name    string(32)", "name    string(128)")},
+		{"a bounded array made fixed", replace(t, "slots   [..Slots]int32", "slots   [Slots]int32")},
+		{"a field moved under a guard", replace(t, "    hits    int32", "    guard   bool\n    if guard\n    {\n        hits int32\n    }")},
+		{"a table added", baseSrc + "\ntable Extra\n{\n    x int32 = 1\n}\n"},
+		{"a whole table removed from the closure", strings.Replace(baseSrc, "    effect  Effect\n", "", 1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := diff(t, tc.edited, baseline.DefaultTokenPolicy); len(got) != 0 {
+				t.Errorf("the wire absorbs this edit; the baseline must be silent, got:%s", summary(got))
+			}
+		})
+	}
+}
+
+// TestEnumKeyedArrayHook is the enum-keyed array's rule, live before the
+// construct is: the day `[E]T` lands the renderer emits one `key=` token and
+// swapping the key enum is a refusal, because the policy row is already here.
+// Synthesised, since no schema can spell the construct yet.
+func TestEnumKeyedArrayHook(t *testing.T) {
+	member := func(key string) *baseline.Unit {
+		return &baseline.Unit{
+			Version: baseline.Version,
+			Package: "fixture",
+			Tables: []baseline.Table{{Name: "Config", Fields: []baseline.Field{{
+				Name: "slots", Id: 0x1234,
+				Tokens: []baseline.Token{{Key: "kind", Value: "14"}, {Key: "elem", Value: "4"}, {Key: "key", Value: key}},
+			}}}},
+		}
+	}
+	got := baseline.Diff(member("Grade"), member("Tier"), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Refuse, "Config.slots", "array key enum Grade -> Tier") {
+		t.Fatalf("swapping an enum-keyed array's enum must be refused, got:%s", summary(got))
+	}
+	if got := baseline.Diff(member("Grade"), member("Tier"), without("key")); len(got) != 0 {
+		t.Errorf("with the \"key\" rule removed the edit should pass, got:%s", summary(got))
+	}
+}
+
+// TestRenderIsIdempotent: the text form round-trips through the parser with
+// no drift, which is what makes `--update` byte-stable and the file diffable.
+func TestRenderIsIdempotent(t *testing.T) {
+	first := baseline.Render(unit(t, baseSrc)).Text()
+	parsed, err := baseline.Parse("tables.baseline", []byte(first))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second := parsed.Text(); second != first {
+		t.Errorf("render -> parse -> render is not the identity:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// ---- the file side: when the check runs, and what --update writes ----
+
+// writeUnit lays a one-file unit down in a temp directory and returns the
+// paths the compiler would gather.
+func writeUnit(t *testing.T, src string) (dir string, paths []string) {
+	t.Helper()
+	dir = t.TempDir()
+	p := filepath.Join(dir, "Fixture.schema")
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir, []string{p}
+}
+
+// TestNoFileNoCheck: the baseline is opt-in. A unit that never committed one
+// is untouched by any of this.
+func TestNoFileNoCheck(t *testing.T) {
+	_, paths := writeUnit(t, baseSrc)
+	warns, errs := baseline.Check(unit(t, baseSrc), paths)
+	if len(warns) != 0 || len(errs) != 0 {
+		t.Fatalf("a unit with no baseline must be checked against nothing: %v %v", warns, errs)
+	}
+}
+
+// TestUpdateRefusesWithoutReason is the owner's ruling made mechanical: an
+// intentional break is declared, or it does not happen.
+func TestUpdateRefusesWithoutReason(t *testing.T) {
+	dir, paths := writeUnit(t, baseSrc)
+	for _, reason := range []string{"", "   "} {
+		if _, _, err := baseline.Update(unit(t, baseSrc), paths, reason); err == nil {
+			t.Fatalf("--update with reason %q must be refused", reason)
+		} else if !strings.Contains(err.Error(), "--reason") {
+			t.Errorf("the refusal must name --reason, got: %v", err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, baseline.FileName)); !os.IsNotExist(err) {
+		t.Error("a refused --update must write nothing")
+	}
+}
+
+// TestUpdateWritesAndIsIdempotent: the first update creates the file and says
+// what it does not cover; a second update over an unmoved unit writes nothing
+// at all, so the committed file is byte-stable.
+func TestUpdateWritesAndIsIdempotent(t *testing.T) {
+	dir, paths := writeUnit(t, baseSrc)
+	u := unit(t, baseSrc)
+
+	path, rewrote, err := baseline.Update(u, paths, "the first baseline")
+	if err != nil || !rewrote {
+		t.Fatalf("first update: %v (rewrote=%v)", err, rewrote)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(first), baseline.HistoryHeading) {
+		t.Error("a created baseline carries a history section")
+	}
+	if !strings.Contains(string(first), "the first baseline") {
+		t.Error("the reason must land in the history")
+	}
+	if !strings.Contains(string(first), "data written BEFORE this point is not covered") {
+		t.Error("a created baseline says what it does not cover")
+	}
+
+	_, rewrote, err = baseline.Update(u, paths, "again, with nothing to record")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewrote {
+		t.Error("an update over an unmoved unit must write nothing")
+	}
+	second, err := os.ReadFile(filepath.Join(dir, baseline.FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(second) != string(first) {
+		t.Errorf("the baseline is not byte-stable under a second update:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+// TestUpdateRecordsTheBreak: the whole point of --reason. The history entry
+// names what moved, old to new, beside why.
+func TestUpdateRecordsTheBreak(t *testing.T) {
+	dir, paths := writeUnit(t, baseSrc)
+	if _, _, err := baseline.Update(unit(t, baseSrc), paths, "the first baseline"); err != nil {
+		t.Fatal(err)
+	}
+
+	edited := replace(t, "damage  float32 = 21.0", "damage  float32 = 25.0")
+	if err := os.WriteFile(paths[0], []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	live := unit(t, edited)
+
+	// before the override, the check refuses and names the edit
+	_, errs := baseline.Check(live, paths)
+	if len(errs) != 1 {
+		t.Fatalf("the edit must be refused exactly once, got %v", errs)
+	}
+	for _, want := range []string{"Config.damage", "specified default 21.0 -> 25.0", "--update --reason"} {
+		if !strings.Contains(errs[0].Error(), want) {
+			t.Errorf("the refusal must mention %q, got: %v", want, errs[0])
+		}
+	}
+
+	// the override records it
+	if _, _, err := baseline.Update(live, paths, "damage rebalanced for season 2; old saves read the new value"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, baseline.FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"the first baseline",
+		"damage rebalanced for season 2",
+		"- Config.damage: specified default 21.0 -> 25.0 [refuse]",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("the history must carry %q:\n%s", want, data)
+		}
+	}
+	// and the check is silent again
+	if warns, errs := baseline.Check(live, paths); len(warns) != 0 || len(errs) != 0 {
+		t.Errorf("after the override the check must pass: %v %v", warns, errs)
+	}
+}
+
+// TestCheckReportsWarningsWithoutRefusing: the warn class reaches the caller
+// as text, and the load still succeeds.
+func TestCheckReportsWarningsWithoutRefusing(t *testing.T) {
+	_, paths := writeUnit(t, baseSrc)
+	if _, _, err := baseline.Update(unit(t, baseSrc), paths, "the first baseline"); err != nil {
+		t.Fatal(err)
+	}
+	edited := replace(t, "const Slots = 8", "const Slots = 4")
+	if err := os.WriteFile(paths[0], []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	warns, errs := baseline.Check(unit(t, edited), paths)
+	if len(errs) != 0 {
+		t.Fatalf("a shrunk bound warns, it does not refuse: %v", errs)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "array bound 8 -> 4") {
+		t.Fatalf("wanted one bound warning, got %v", warns)
+	}
+}
+
+// TestCheckRefusesAForeignBaseline: a baseline belongs to the unit it sits
+// beside, and a misread one is a check that lies.
+func TestCheckRefusesAForeignBaseline(t *testing.T) {
+	dir, paths := writeUnit(t, baseSrc)
+	for _, tc := range []struct{ name, data, want string }{
+		{"not a baseline at all", "hello\n", "not a schema tables baseline"},
+		{"a future rendering version", "schema-tables-baseline 99\npackage fixture\n", "this compiler writes"},
+		{"another unit's baseline", "schema-tables-baseline 1\npackage elsewhere\n", "baseline is for package elsewhere"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(filepath.Join(dir, baseline.FileName), []byte(tc.data), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, errs := baseline.Check(unit(t, baseSrc), paths)
+			if len(errs) != 1 || !strings.Contains(errs[0].Error(), tc.want) {
+				t.Fatalf("wanted a refusal mentioning %q, got %v", tc.want, errs)
+			}
+		})
+	}
+}

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -537,12 +537,14 @@ func TestVanishedMembers(t *testing.T) {
 	}
 }
 
-// TestRenamingDoesNotRaiseTheVerdict: the same wire loss must draw the same
-// verdict whether or not the author also renamed the declaration. A paired
-// rename is the declaration under a new name, so its own walk judges it and
-// the referent rule stays out — otherwise repointing a field at "the same
-// thing, renamed" would refuse what an in-place edit only warns about.
-func TestRenamingDoesNotRaiseTheVerdict(t *testing.T) {
+// TestPairedRenameDoesNotRaiseTheVerdict: a rename the pairing RECOGNISES —
+// one that keeps at least half the declaration's identities — must draw the
+// same verdict the same wire loss draws without it. A paired rename is the
+// declaration under a new name, so its own walk judges it and the referent rule
+// stays out; otherwise repointing a field at "the same thing, renamed" would
+// refuse what an in-place edit only warns about. Below the threshold the rule
+// is deliberately different, and TestBelowThresholdRenameIsARepoint states it.
+func TestPairedRenameDoesNotRaiseTheVerdict(t *testing.T) {
 	cases := []struct{ name, alone, renamed, where, what string }{
 		{
 			name:  "an enum variant dropped",
@@ -578,6 +580,33 @@ func TestRenamingDoesNotRaiseTheVerdict(t *testing.T) {
 	}
 }
 
+// TestBelowThresholdRenameIsARepoint is the stated exception to the test above.
+// A declaration that keeps too little of its identity is not recognisable as a
+// rename — no evidence says the new name is the old declaration — so it is
+// judged as what it is indistinguishable from: a field repointed at a different
+// declaration. That refuses where the in-place edit only warns, and the warning
+// says the pairing did not happen, so the harsher verdict is never silent.
+func TestBelowThresholdRenameIsARepoint(t *testing.T) {
+	// two of three variants dropped: below the half a rename needs. The
+	// defaulted variant survives, so the ONLY edit is the loss.
+	dropped := replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Silver }")
+	if refusals, warns := baseline.Split(diff(t, dropped, baseline.DefaultTokenPolicy)); len(refusals) != 0 || len(warns) == 0 {
+		t.Fatalf("dropping variants in place warns and does not refuse, got:%s", summary(append(refusals, warns...)))
+	}
+
+	renamed := strings.NewReplacer(
+		"enum Grade { Bronze, Silver, Gold }", "enum Rank { Silver }",
+		"grade   Grade = Silver", "grade   Rank = Silver",
+		"swap_grade Grade", "swap_grade Rank").Replace(baseSrc)
+	got := diff(t, renamed, baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Refuse, "Config.swap_grade", "enum Grade -> Rank") {
+		t.Fatalf("below the threshold the change of referent is judged as a repoint, got:%s", summary(got))
+	}
+	if !find(got, baseline.Warn, "enum Grade", "below the half needed to call it a rename") {
+		t.Errorf("and the warning must say the pairing did not happen, got:%s", summary(got))
+	}
+}
+
 // TestUnpairedVanishedMemberNamesWhatItFound: on the unpaired path the warning
 // is the ONLY thing between a reader and the coverage hole, so it says what it
 // actually found rather than asserting nothing was close.
@@ -605,6 +634,126 @@ func TestUnpairedVanishedMemberNamesWhatItFound(t *testing.T) {
 	gone := strings.Replace(baseSrc, "    effect  Effect\n", "", 1)
 	if got := diff(t, gone, baseline.DefaultTokenPolicy); !find(got, baseline.Warn, "union Effect", "no declaration carries any of its identities") {
 		t.Errorf("wanted the zero-overlap wording, got:%s", summary(got))
+	}
+}
+
+// pairSrc is a standalone unit for the pairing fixtures: one root table
+// nesting A, so A is in the closure and vanishes when it is renamed.
+const pairSrc = `package pairing
+
+type A
+{
+    x int32 = 1
+    y int32 = 2
+    z int32 = 3
+    w int32 = 4
+}
+
+table Holder
+{
+    a A
+}
+`
+
+// TestPairingWillNotGuessBetweenCandidates is the reviewer's mis-pair shape.
+// `A` is renamed to `A2`, which drops one of its four fields; an UNRELATED new
+// declaration `B` reuses all four field names, so identity overlap alone scores
+// the stranger higher than the real rename. Pairing with the stranger would
+// attribute four confident refusals to edits nobody made — so when more than
+// one candidate reaches the threshold, the pairing asks a second question
+// (whose own facts are closest) and pairs only on a candidate that wins both.
+// Here it wins neither pair of answers together, so nothing is paired and the
+// warning names both.
+func TestPairingWillNotGuessBetweenCandidates(t *testing.T) {
+	edited := `package pairing
+
+type A2
+{
+    x int32 = 1
+    y int32 = 2
+    z int32 = 3
+}
+
+type B
+{
+    x int32 = 77
+    y int32 = 88
+    z int32 = 99
+    w int32 = 66
+}
+
+table Holder
+{
+    a A2
+    b B
+}
+`
+	got := baseline.Diff(committed(t, pairSrc), baseline.Render(unit(t, edited)), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "table A", "A2 and B each carry enough of its 4 identities") {
+		t.Fatalf("an undecidable rename must name its contenders, got:%s", summary(got))
+	}
+	for _, f := range got {
+		if f.Verdict == baseline.Refuse && strings.HasPrefix(f.Where, "B.") {
+			t.Errorf("B is brand new; no edit inside it ever happened, got: %s", f)
+		}
+	}
+	// the repoint is still judged, which is what keeps the loss visible
+	if !find(got, baseline.Refuse, "Holder.a", "nested table A -> A2") {
+		t.Errorf("the field repointed at A2 must still be judged, got:%s", summary(got))
+	}
+}
+
+// TestPairingTieNamesTheTie: two candidates carrying EVERY identity cannot be
+// told apart, and the message must not blame a threshold the numbers in the
+// same sentence disprove.
+func TestPairingTieNamesTheTie(t *testing.T) {
+	edited := `package pairing
+
+type A2
+{
+    x int32 = 1
+    y int32 = 2
+    z int32 = 3
+    w int32 = 4
+}
+
+type A3
+{
+    x int32 = 1
+    y int32 = 2
+    z int32 = 3
+    w int32 = 4
+}
+
+table Holder
+{
+    a A2
+    b A3
+}
+`
+	got := baseline.Diff(committed(t, pairSrc), baseline.Render(unit(t, edited)), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "table A", "A2 and A3 each carry enough of its 4 identities") {
+		t.Fatalf("a tie must be reported as a tie, got:%s", summary(got))
+	}
+	if find(got, baseline.Warn, "table A", "below the half needed") {
+		t.Errorf("4 of 4 is not below half — the reason must not contradict the numbers, got:%s", summary(got))
+	}
+}
+
+// TestPairingTakesTheRenameWhenItIsTheOnlyCandidate: the tiebreak must not cost
+// the ordinary case. One candidate reaching the threshold is paired, and the
+// semantic edit inside the rename is caught.
+func TestPairingTakesTheRenameWhenItIsTheOnlyCandidate(t *testing.T) {
+	edited := strings.NewReplacer(
+		"type A\n", "type A2\n",
+		"    x int32 = 1", "    x int32 = 11",
+		"    a A", "    a A2").Replace(pairSrc)
+	got := baseline.Diff(committed(t, pairSrc), baseline.Render(unit(t, edited)), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "table A", "A2 carries 4 of its 4 identities") {
+		t.Fatalf("the only candidate must be paired, got:%s", summary(got))
+	}
+	if !find(got, baseline.Refuse, "A2.x", "specified default 1 -> 11") {
+		t.Errorf("the edit inside the rename must be judged under the new name, got:%s", summary(got))
 	}
 }
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1,4 +1,4 @@
-// The tables baseline's gate (SPEC-TABLES.md §16): one fixture pair per
+// The tables baseline's gate (SPEC-TABLES.md §18.6): one fixture pair per
 // refusal class and per warn class, each with its negative controls.
 //
 // TWO KINDS OF NEGATIVE CONTROL, because a gate can be wrong in two ways.
@@ -873,6 +873,38 @@ table Loadout
 	grown := strings.Replace(src, "enum Slot { Head, Chest, Legs }", "enum Slot { Head, Chest, Legs, Boots }", 1)
 	if got := baseline.Diff(b, baseline.Render(unit(t, grown)), baseline.DefaultTokenPolicy); len(got) != 0 {
 		t.Errorf("growing a key enum is absorbed, got:%s", summary(got))
+	}
+}
+
+// TestKeyedBoundIsNotJudgedAsAnExtent: a keyed array's bound IS its key
+// enum's size, and its slots ride under variant name ids (SPEC-TABLES.md
+// §3.2) — an unknown key is skipped and counted `unknown`, with no bounded
+// prefix and nothing clamped. The enum walk already says what went and by
+// name, so the extent row must not say it a second time in the wrong words.
+func TestKeyedBoundIsNotJudgedAsAnExtent(t *testing.T) {
+	const src = `package keyed
+
+enum Slot { Head, Chest, Legs }
+
+table Loadout
+{
+    pieces  [Slot]int32
+    spares  [..3]int32
+}
+`
+	dropped := strings.Replace(src, "enum Slot { Head, Chest, Legs }", "enum Slot { Head, Chest }", 1)
+	got := baseline.Diff(committed(t, src), baseline.Render(unit(t, dropped)), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "enum Slot", "variant Legs removed") {
+		t.Fatalf("the enum walk must report the lost slot by name, got:%s", summary(got))
+	}
+	if find(got, baseline.Warn, "Loadout.pieces", "array bound") {
+		t.Errorf("a keyed array's bound must not be judged as an extent — nothing clamps, and the enum walk already said it, got:%s", summary(got))
+	}
+	// the POSITIONAL sibling still warns on a shrunk extent: this is a
+	// discrimination, not a blanket exemption
+	shrunk := strings.Replace(src, "spares  [..3]int32", "spares  [..2]int32", 1)
+	if got := baseline.Diff(committed(t, src), baseline.Render(unit(t, shrunk)), baseline.DefaultTokenPolicy); !find(got, baseline.Warn, "Loadout.spares", "array bound 3 -> 2") {
+		t.Errorf("a positional array's shrunk bound still warns, got:%s", summary(got))
 	}
 }
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -37,7 +37,13 @@ const Slots = 8
 
 enum Grade { Bronze, Silver, Gold }
 
+// declared and unreferenced: a different vocabulary, for the referent fixtures
+enum Tier { Copper, Brass }
+
 flags Perks { Shielded, Cloaked, Turbo }
+
+// declared and unreferenced: Perks' three names at different bits
+flags Traits { Turbo, Shielded, Cloaked }
 
 type Buff
 {
@@ -49,11 +55,26 @@ type Debuff
     amount int32 = 0
 }
 
-// same field ids as Buff, plus one: the referent rule's "the ids ride" side
+// same field ids as Buff, plus one, under identical facts: a declaration that
+// really can stand in for Buff
 type BuffPlus
 {
     multiplier float32 = 1.0
     stacks     int32 = 1
+}
+
+// Buff's TWIN: the same field id under a different specified default. Id
+// membership alone would let this through, and every stored body's elided
+// multiplier would quietly mean 7.0
+type Boon
+{
+    multiplier float32 = 7.0
+}
+
+// the same twin under a different wire kind
+type BoonWide
+{
+    multiplier float64 = 1.0
 }
 
 union Effect
@@ -74,6 +95,9 @@ table Config
     slots   [..Slots]int32
     boost   Buff
     effect  Effect
+    swap_grade Grade
+    swap_perks Perks
+    swap Buff
 }
 `
 
@@ -214,18 +238,20 @@ func TestRefusals(t *testing.T) {
 			control: replace(t, "slots   [..Slots]int32", "slots   [Slots]int32"), // fixed vs bounded frames identically
 		},
 		{
-			name: "a field's flags TYPE swapped for a differently-ordered flags declaration",
-			edited: replace(t, "    perks   Perks",
-				"    perks   Traits") + "\nflags Traits { Turbo, Shielded, Cloaked }\n",
-			where:   "Config.perks",
+			// the ORIGINAL stays referenced, so nothing vanishes and no rename
+			// pairing fires: this is a field repointed at a different
+			// declaration, which is what the referent rule is for
+			name:    "a field's flags TYPE swapped for a differently-ordered declaration",
+			edited:  replace(t, "    swap_perks Perks", "    swap_perks Traits"),
+			where:   "Config.swap_perks",
 			what:    "flags Perks -> Traits",
 			token:   "flags",
-			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
+			control: replace(t, "flags Traits { Turbo, Shielded, Cloaked }", "flags Traits { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 		{
 			name:    "a field's enum TYPE swapped for another vocabulary",
-			edited:  replace(t, "    grade   Grade = Silver", "    grade   Tier = Copper") + "\nenum Tier { Copper, Brass }\n",
-			where:   "Config.grade",
+			edited:  replace(t, "    swap_grade Grade", "    swap_grade Tier"),
+			where:   "Config.swap_grade",
 			what:    "enum Grade -> Tier",
 			token:   "enum",
 			control: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Argent, Silver, Gold }"),
@@ -251,19 +277,46 @@ func TestRefusals(t *testing.T) {
 		},
 		{
 			name:    "a nested table swapped for one whose ids do not ride",
-			edited:  replace(t, "    boost   Buff", "    boost   Debuff"),
-			where:   "Config.boost",
-			what:    "nested table Buff -> Debuff",
+			edited:  replace(t, "    swap Buff", "    swap Debuff"),
+			where:   "Config.swap",
+			what:    "nested table Buff -> Debuff, and 1 of 1 field ids do not ride",
 			token:   "type",
-			control: replace(t, "    boost   Buff", "    boost   BuffPlus"), // every id rides
+			control: replace(t, "    swap Buff", "    swap BuffPlus"), // stands in: every id, same facts
+		},
+		{
+			// THE TWIN. Every id rides and the declaration is still not
+			// substitutable, because the fact under the shared id moved: every
+			// stored body's elided multiplier now means 7.0.
+			name:    "a nested table swapped for a twin carrying the same id under a different default",
+			edited:  replace(t, "    swap Buff", "    swap Boon"),
+			where:   "Config.swap",
+			what:    "nested table Buff -> Boon, and multiplier's specified default 1.0 -> 7.0",
+			token:   "default",
+			control: replace(t, "    swap Buff", "    swap BuffPlus"),
+		},
+		{
+			name:    "a nested table swapped for a twin carrying the same id under a different kind",
+			edited:  replace(t, "    swap Buff", "    swap BoonWide"),
+			where:   "Config.swap",
+			what:    "nested table Buff -> BoonWide, and multiplier's wire kind 10 -> 11",
+			token:   "kind",
+			control: replace(t, "    swap Buff", "    swap BuffPlus"),
 		},
 		{
 			name:    "a union arm's payload swapped for one whose ids do not ride",
 			edited:  replace(t, "    buff   Buff\n", "    buff   Debuff\n"),
 			where:   "union Effect.buff",
-			what:    "arm payload Buff -> Debuff",
+			what:    "arm payload Buff -> Debuff, and 1 of 1 field ids do not ride",
 			token:   "payload",
-			control: replace(t, "    buff   Buff\n", "    buff   BuffPlus\n"), // every id rides
+			control: replace(t, "    buff   Buff\n", "    buff   BuffPlus\n"),
+		},
+		{
+			name:    "a union arm's payload swapped for a twin carrying the same id under a different default",
+			edited:  replace(t, "    buff   Buff\n", "    buff   Boon\n"),
+			where:   "union Effect.buff",
+			what:    "arm payload Buff -> Boon, and multiplier's specified default 1.0 -> 7.0",
+			token:   "default",
+			control: replace(t, "    buff   Buff\n", "    buff   BuffPlus\n"),
 		},
 		{
 			name:    "a flags variant inserted",
@@ -423,7 +476,7 @@ func TestVanishedMembers(t *testing.T) {
 			edited: strings.NewReplacer("table Config", "table Ship",
 				"damage  float32 = 21.0", "damage  float32 = 25.0").Replace(baseSrc),
 			warnAt:   "table Config",
-			warnWhat: "Ship carries 10 of its 10 identities",
+			warnWhat: "Ship carries 13 of its 13 identities",
 			verdict:  baseline.Refuse,
 			where:    "Ship.damage",
 			what:     "specified default 21.0 -> 25.0",
@@ -431,19 +484,21 @@ func TestVanishedMembers(t *testing.T) {
 		{
 			name: "a flags declaration renamed, and its bits reordered with it",
 			edited: strings.NewReplacer(
-				"flags Perks { Shielded, Cloaked, Turbo }", "flags Traits { Cloaked, Shielded, Turbo }",
-				"perks   Perks", "perks   Traits").Replace(baseSrc),
+				"flags Perks { Shielded, Cloaked, Turbo }", "flags Boons { Cloaked, Shielded, Turbo }",
+				"perks   Perks", "perks   Boons",
+				"swap_perks Perks", "swap_perks Boons").Replace(baseSrc),
 			warnAt:   "flags Perks",
-			warnWhat: "Traits carries 3 of its 3 identities",
+			warnWhat: "Boons carries 3 of its 3 identities",
 			verdict:  baseline.Refuse,
-			where:    "flags Traits",
+			where:    "flags Boons",
 			what:     "variant Shielded moved from bit 0 to bit 1",
 		},
 		{
 			name: "an enum renamed, and a variant dropped with it",
 			edited: strings.NewReplacer(
 				"enum Grade { Bronze, Silver, Gold }", "enum Rank { Bronze, Silver }",
-				"grade   Grade = Silver", "grade   Rank = Silver").Replace(baseSrc),
+				"grade   Grade = Silver", "grade   Rank = Silver",
+				"swap_grade Grade", "swap_grade Rank").Replace(baseSrc),
 			warnAt:   "enum Grade",
 			warnWhat: "Rank carries 2 of its 3 identities",
 			verdict:  baseline.Warn,
@@ -479,6 +534,77 @@ func TestVanishedMembers(t *testing.T) {
 				t.Errorf("with the %q rule removed the finding should be gone, got:%s", "member", summary(got))
 			}
 		})
+	}
+}
+
+// TestRenamingDoesNotRaiseTheVerdict: the same wire loss must draw the same
+// verdict whether or not the author also renamed the declaration. A paired
+// rename is the declaration under a new name, so its own walk judges it and
+// the referent rule stays out — otherwise repointing a field at "the same
+// thing, renamed" would refuse what an in-place edit only warns about.
+func TestRenamingDoesNotRaiseTheVerdict(t *testing.T) {
+	cases := []struct{ name, alone, renamed, where, what string }{
+		{
+			name:  "an enum variant dropped",
+			alone: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Silver }"),
+			renamed: strings.NewReplacer(
+				"enum Grade { Bronze, Silver, Gold }", "enum Rank { Bronze, Silver }",
+				"grade   Grade = Silver", "grade   Rank = Silver",
+				"swap_grade Grade", "swap_grade Rank").Replace(baseSrc),
+			where: "variant Gold removed",
+			what:  "Gold",
+		},
+		{
+			name:  "a union arm dropped",
+			alone: replace(t, "    buff   Buff\n    debuff Debuff\n", "    buff   Buff\n"),
+			renamed: strings.NewReplacer(
+				"union Effect\n{\n    buff   Buff\n    debuff Debuff\n}", "union Outcome\n{\n    buff   Buff\n}",
+				"effect  Effect", "effect  Outcome").Replace(baseSrc),
+			where: "arm debuff removed",
+			what:  "debuff",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			aloneRefusals, _ := baseline.Split(diff(t, tc.alone, baseline.DefaultTokenPolicy))
+			renamedRefusals, _ := baseline.Split(diff(t, tc.renamed, baseline.DefaultTokenPolicy))
+			if len(aloneRefusals) != 0 {
+				t.Fatalf("the edit alone must not refuse, got:%s", summary(aloneRefusals))
+			}
+			if len(renamedRefusals) != 0 {
+				t.Errorf("the same edit plus a declaration rename must not refuse either — a rename moves no byte, got:%s", summary(renamedRefusals))
+			}
+		})
+	}
+}
+
+// TestUnpairedVanishedMemberNamesWhatItFound: on the unpaired path the warning
+// is the ONLY thing between a reader and the coverage hole, so it says what it
+// actually found rather than asserting nothing was close.
+func TestUnpairedVanishedMemberNamesWhatItFound(t *testing.T) {
+	// a root table renamed with most of its fields dropped: too little in
+	// common to call it a rename, and something in common all the same
+	edited := strings.NewReplacer(
+		"table Config", "table Archive",
+		"    heading int16\n", "",
+		"    homing  bool\n", "",
+		"    hits    int32\n", "",
+		"    grade   Grade = Silver\n", "",
+		"    swap_grade Grade\n", "",
+		"    name    string(32)\n", "",
+		"    slots   [..Slots]int32\n", "",
+		"    swap Buff\n", "").Replace(baseSrc)
+	got := diff(t, edited, baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "table Config", "below the half needed to call it a rename") {
+		t.Fatalf("the unpaired warning must say what it found, got:%s", summary(got))
+	}
+	if find(got, baseline.Warn, "table Config", "no declaration carries any of its identities") {
+		t.Errorf("a candidate DID carry some identities; the message must not deny it, got:%s", summary(got))
+	}
+	// and the zero-overlap wording is still reachable, on a member nothing resembles
+	gone := strings.Replace(baseSrc, "    effect  Effect\n", "", 1)
+	if got := diff(t, gone, baseline.DefaultTokenPolicy); !find(got, baseline.Warn, "union Effect", "no declaration carries any of its identities") {
+		t.Errorf("wanted the zero-overlap wording, got:%s", summary(got))
 	}
 }
 
@@ -793,7 +919,7 @@ func TestCheckRefusesAForeignBaseline(t *testing.T) {
 	for _, tc := range []struct{ name, data, want string }{
 		{"not a baseline at all", "hello\n", "not a schema tables baseline"},
 		{"a future rendering version", "schema-tables-baseline 99\npackage fixture\n", "this compiler writes"},
-		{"another unit's baseline", "schema-tables-baseline 1\npackage elsewhere\n", "baseline is for package elsewhere"},
+		{"another unit's baseline", fmt.Sprintf("schema-tables-baseline %d\npackage elsewhere\n", baseline.Version), "baseline is for package elsewhere"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, baseline.FileName), []byte(tc.data), 0o644); err != nil {

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -15,6 +15,7 @@
 package baseline_test
 
 import (
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
@@ -48,6 +49,13 @@ type Debuff
     amount int32 = 0
 }
 
+// same field ids as Buff, plus one: the referent rule's "the ids ride" side
+type BuffPlus
+{
+    multiplier float32 = 1.0
+    stacks     int32 = 1
+}
+
 union Effect
 {
     buff   Buff
@@ -64,6 +72,7 @@ table Config
     perks   Perks
     name    string(32)
     slots   [..Slots]int32
+    boost   Buff
     effect  Effect
 }
 `
@@ -205,10 +214,63 @@ func TestRefusals(t *testing.T) {
 			control: replace(t, "slots   [..Slots]int32", "slots   [Slots]int32"), // fixed vs bounded frames identically
 		},
 		{
+			name: "a field's flags TYPE swapped for a differently-ordered flags declaration",
+			edited: replace(t, "    perks   Perks",
+				"    perks   Traits") + "\nflags Traits { Turbo, Shielded, Cloaked }\n",
+			where:   "Config.perks",
+			what:    "flags Perks -> Traits",
+			token:   "flags",
+			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
+		},
+		{
+			name:    "a field's enum TYPE swapped for another vocabulary",
+			edited:  replace(t, "    grade   Grade = Silver", "    grade   Tier = Copper") + "\nenum Tier { Copper, Brass }\n",
+			where:   "Config.grade",
+			what:    "enum Grade -> Tier",
+			token:   "enum",
+			control: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Argent, Silver, Gold }"),
+		},
+		{
+			// SPEC-TABLES.md §4 states outright that this edit is NOT a kind
+			// mismatch — both ride as kind 7 — so the runtime cannot report
+			// it, which is the definition of this baseline's job
+			name:    "an enum-typed field replaced by its raw storage integer",
+			edited:  replace(t, "    grade   Grade = Silver", "    grade   uint16"),
+			where:   "Config.grade",
+			what:    "enum Grade removed",
+			token:   "enum",
+			control: replace(t, "    grade   Grade = Silver", "    grade   Grade = Silver\n    tier    uint16"),
+		},
+		{
+			name:    "a raw integer field given an enum type",
+			edited:  replace(t, "heading int16", "heading Grade"),
+			where:   "Config.heading",
+			what:    "enum Grade added",
+			token:   "enum",
+			control: replace(t, "heading int16", "heading int16\n    tier    Grade"),
+		},
+		{
+			name:    "a nested table swapped for one whose ids do not ride",
+			edited:  replace(t, "    boost   Buff", "    boost   Debuff"),
+			where:   "Config.boost",
+			what:    "nested table Buff -> Debuff",
+			token:   "type",
+			control: replace(t, "    boost   Buff", "    boost   BuffPlus"), // every id rides
+		},
+		{
+			name:    "a union arm's payload swapped for one whose ids do not ride",
+			edited:  replace(t, "    buff   Buff\n", "    buff   Debuff\n"),
+			where:   "union Effect.buff",
+			what:    "arm payload Buff -> Debuff",
+			token:   "payload",
+			control: replace(t, "    buff   Buff\n", "    buff   BuffPlus\n"), // every id rides
+		},
+		{
 			name:    "a flags variant inserted",
 			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Hardened, Cloaked, Turbo }"),
 			where:   "flags Perks",
 			what:    "variant Cloaked moved from bit 1 to bit 2",
+			token:   "flags-position",
 			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 		{
@@ -216,6 +278,7 @@ func TestRefusals(t *testing.T) {
 			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Cloaked, Shielded, Turbo }"),
 			where:   "flags Perks",
 			what:    "variant Shielded moved from bit 0 to bit 1",
+			token:   "flags-position",
 			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 		{
@@ -223,6 +286,7 @@ func TestRefusals(t *testing.T) {
 			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Stealth, Turbo }"),
 			where:   "flags Perks",
 			what:    "bit 1 was Cloaked and is now Stealth",
+			token:   "flags-position",
 			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 		{
@@ -230,6 +294,7 @@ func TestRefusals(t *testing.T) {
 			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Turbo }"),
 			where:   "flags Perks",
 			what:    "variant Turbo moved from bit 2 to bit 1",
+			token:   "flags-position",
 			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 		{
@@ -237,6 +302,7 @@ func TestRefusals(t *testing.T) {
 			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked }"),
 			where:   "flags Perks",
 			what:    "variant Turbo removed from bit 2",
+			token:   "flags-position",
 			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 	}
@@ -251,13 +317,16 @@ func TestRefusals(t *testing.T) {
 			if ctrl := diff(t, tc.control, baseline.DefaultTokenPolicy); len(ctrl) != 0 {
 				t.Errorf("the control edit should be absorbed by the wire, got:%s", summary(ctrl))
 			}
-			// the ATTRIBUTION control: with that policy row gone, the same
-			// edit passes — the refusal came from this check and no other
+			// the ATTRIBUTION control: with that policy row gone, this
+			// finding is gone — it came from THAT check and no other. (An
+			// edit can trip more than one row at once: replacing an
+			// enum-typed field with its raw storage integer also drops the
+			// default, and both refusals are correct.)
 			if tc.token == "" {
 				return
 			}
-			if got := diff(t, tc.edited, without(tc.token)); len(got) != 0 {
-				t.Errorf("with the %q rule removed the edit should pass, got:%s", tc.token, summary(got))
+			if got := diff(t, tc.edited, without(tc.token)); find(got, baseline.Refuse, tc.where, tc.what) {
+				t.Errorf("with the %q rule removed the refusal should be gone, got:%s", tc.token, summary(got))
 			}
 		})
 	}
@@ -298,6 +367,7 @@ func TestWarnings(t *testing.T) {
 			edited:  replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Silver }"),
 			where:   "enum Grade",
 			what:    "variant Gold removed",
+			token:   "enum-variant",
 			control: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Argent, Silver, Gold }"),
 		},
 		{
@@ -305,6 +375,7 @@ func TestWarnings(t *testing.T) {
 			edited:  replace(t, "    buff   Buff\n    debuff Debuff\n", "    buff   Buff\n"),
 			where:   "union Effect",
 			what:    "arm debuff removed",
+			token:   "union-arm",
 			control: replace(t, "    buff   Buff\n    debuff Debuff\n", "    buff   Buff\n    debuff Debuff\n    curse  Buff\n"),
 		},
 	}
@@ -324,10 +395,108 @@ func TestWarnings(t *testing.T) {
 			if tc.token == "" {
 				return
 			}
-			if got := diff(t, tc.edited, without(tc.token)); len(got) != 0 {
-				t.Errorf("with the %q rule removed the edit should pass, got:%s", tc.token, summary(got))
+			if got := diff(t, tc.edited, without(tc.token)); find(got, baseline.Warn, tc.where, tc.what) {
+				t.Errorf("with the %q rule removed the warning should be gone, got:%s", tc.token, summary(got))
 			}
 		})
+	}
+}
+
+// TestVanishedMembers is finding 1 of the review, made a gate: a DECLARATION
+// rename moves no byte, so the wire absorbs it — but it must not take
+// everything inside the declaration out of coverage with it. A vanished
+// baseline name warns, and where a same-shaped declaration appears the
+// contents are judged under its new name, so a rename plus a semantic edit in
+// one commit is still caught.
+func TestVanishedMembers(t *testing.T) {
+	cases := []struct {
+		name     string
+		edited   string
+		warnAt   string
+		warnWhat string
+		verdict  baseline.Verdict
+		where    string // the edit that must still be judged through the rename
+		what     string
+	}{
+		{
+			name: "a table renamed, and a specified default changed with it",
+			edited: strings.NewReplacer("table Config", "table Ship",
+				"damage  float32 = 21.0", "damage  float32 = 25.0").Replace(baseSrc),
+			warnAt:   "table Config",
+			warnWhat: "Ship carries 10 of its 10 identities",
+			verdict:  baseline.Refuse,
+			where:    "Ship.damage",
+			what:     "specified default 21.0 -> 25.0",
+		},
+		{
+			name: "a flags declaration renamed, and its bits reordered with it",
+			edited: strings.NewReplacer(
+				"flags Perks { Shielded, Cloaked, Turbo }", "flags Traits { Cloaked, Shielded, Turbo }",
+				"perks   Perks", "perks   Traits").Replace(baseSrc),
+			warnAt:   "flags Perks",
+			warnWhat: "Traits carries 3 of its 3 identities",
+			verdict:  baseline.Refuse,
+			where:    "flags Traits",
+			what:     "variant Shielded moved from bit 0 to bit 1",
+		},
+		{
+			name: "an enum renamed, and a variant dropped with it",
+			edited: strings.NewReplacer(
+				"enum Grade { Bronze, Silver, Gold }", "enum Rank { Bronze, Silver }",
+				"grade   Grade = Silver", "grade   Rank = Silver").Replace(baseSrc),
+			warnAt:   "enum Grade",
+			warnWhat: "Rank carries 2 of its 3 identities",
+			verdict:  baseline.Warn,
+			where:    "enum Rank",
+			what:     "variant Gold removed",
+		},
+		{
+			name: "a union renamed, and an arm dropped with it",
+			edited: strings.NewReplacer(
+				"union Effect\n{\n    buff   Buff\n    debuff Debuff\n}", "union Outcome\n{\n    buff   Buff\n}",
+				"effect  Effect", "effect  Outcome").Replace(baseSrc),
+			warnAt:   "union Effect",
+			warnWhat: "Outcome carries 1 of its 2 identities",
+			verdict:  baseline.Warn,
+			where:    "union Outcome",
+			what:     "arm debuff removed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diff(t, tc.edited, baseline.DefaultTokenPolicy)
+			if !find(got, baseline.Warn, tc.warnAt, tc.warnWhat) {
+				t.Errorf("a vanished member must warn, naming where it went; wanted %s: %s, got:%s", tc.warnAt, tc.warnWhat, summary(got))
+			}
+			if !find(got, tc.verdict, tc.where, tc.what) {
+				t.Fatalf("the edit inside the renamed declaration must still be judged; wanted %s: %s, got:%s", tc.where, tc.what, summary(got))
+			}
+			// the ATTRIBUTION control: without the member row there is no
+			// pairing, and the edit inside the rename goes unseen — which is
+			// exactly the hole this test closes
+			if got := diff(t, tc.edited, without("member")); find(got, tc.verdict, tc.where, tc.what) {
+				t.Errorf("with the %q rule removed the finding should be gone, got:%s", "member", summary(got))
+			}
+		})
+	}
+}
+
+// TestVanishedMemberWithNoSuccessor: a member that really is gone warns too —
+// removals stay legal, and a coverage hole is never invisible.
+func TestVanishedMemberWithNoSuccessor(t *testing.T) {
+	edited := strings.Replace(baseSrc, "    effect  Effect\n", "", 1)
+	got := diff(t, edited, baseline.DefaultTokenPolicy)
+	for _, want := range []string{"union Effect", "table Debuff"} {
+		if !find(got, baseline.Warn, want, "no longer in the closure") {
+			t.Errorf("wanted a coverage warning for %s, got:%s", want, summary(got))
+		}
+	}
+	if refusals, _ := baseline.Split(got); len(refusals) != 0 {
+		t.Errorf("removing a member is legal — it warns, it does not refuse, got:%s", summary(refusals))
+	}
+	if got := diff(t, edited, without("member")); len(got) != 0 {
+		t.Errorf("with the \"member\" rule removed the removal should be silent, got:%s", summary(got))
 	}
 }
 
@@ -347,7 +516,6 @@ func TestAbsorbedEdits(t *testing.T) {
 		{"a bounded array made fixed", replace(t, "slots   [..Slots]int32", "slots   [Slots]int32")},
 		{"a field moved under a guard", replace(t, "    hits    int32", "    guard   bool\n    if guard\n    {\n        hits int32\n    }")},
 		{"a table added", baseSrc + "\ntable Extra\n{\n    x int32 = 1\n}\n"},
-		{"a whole table removed from the closure", strings.Replace(baseSrc, "    effect  Effect\n", "", 1)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -541,6 +709,80 @@ func TestCheckReportsWarningsWithoutRefusing(t *testing.T) {
 	}
 	if len(warns) != 1 || !strings.Contains(warns[0], "array bound 8 -> 4") {
 		t.Fatalf("wanted one bound warning, got %v", warns)
+	}
+}
+
+// TestUpdateSalvagesHistoryFromAnUnreadableBaseline is the review's finding 3
+// made a gate: every parse refusal names `--update --reason` as the remedy, so
+// that command has to WORK on a baseline the parser rejects — and it must not
+// cost the one artifact in the file that cannot be regenerated. The
+// version-bump case is the one that matters, because a Version bump puts every
+// committed baseline in the estate on exactly this path.
+func TestUpdateSalvagesHistoryFromAnUnreadableBaseline(t *testing.T) {
+	history := []string{
+		"### 2024-01-01 — the break we are never allowed to forget",
+		"- Config.damage: specified default 10.0 -> 21.0 [refuse]",
+	}
+	cases := []struct{ name, head string }{
+		{"a rendering version this compiler does not write", fmt.Sprintf("schema-tables-baseline %d\npackage fixture\n", baseline.Version+1)},
+		{"a file that is not a baseline at all", "hello world\n"},
+		{"a member line this parser cannot read", "schema-tables-baseline 1\npackage fixture\n\ntable Config\n    field ???\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, paths := writeUnit(t, baseSrc)
+			path := filepath.Join(dir, baseline.FileName)
+			stale := tc.head + "\n" + baseline.HistoryHeading + "\n" + strings.Join(history, "\n") + "\n"
+			if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			// the check refuses and names the remedy
+			_, errs := baseline.Check(unit(t, baseSrc), paths)
+			if len(errs) != 1 || !strings.Contains(errs[0].Error(), "--update --reason") {
+				t.Fatalf("wanted one refusal naming the remedy, got %v", errs)
+			}
+			// and the remedy runs
+			if _, rewrote, err := baseline.Update(unit(t, baseSrc), paths, "regenerating as instructed"); err != nil || !rewrote {
+				t.Fatalf("the advertised remedy must work: %v (rewrote=%v)", err, rewrote)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range append(history,
+				"regenerating as instructed",
+				"baseline REGENERATED over an unreadable one",
+				"table Config") {
+				if !strings.Contains(string(data), want) {
+					t.Errorf("the regenerated baseline must carry %q:\n%s", want, data)
+				}
+			}
+			// and the file it produced is one the check accepts
+			if warns, errs := baseline.Check(unit(t, baseSrc), paths); len(warns) != 0 || len(errs) != 0 {
+				t.Errorf("after the regeneration the check must pass: %v %v", warns, errs)
+			}
+		})
+	}
+}
+
+// TestParseHoldsBitPositionToLineOrder: `bit=` states in the file what line
+// order already decides, and the parser holds the two to each other rather
+// than guessing which half a hand-edit meant.
+func TestParseHoldsBitPositionToLineOrder(t *testing.T) {
+	text := baseline.Render(unit(t, baseSrc)).Text()
+	scrambled := strings.Replace(text,
+		"    variant Shielded bit=0\n    variant Cloaked bit=1\n",
+		"    variant Cloaked bit=1\n    variant Shielded bit=0\n", 1)
+	if scrambled == text {
+		t.Fatal("the fixture edit did not apply")
+	}
+	_, err := baseline.Parse("tables.baseline", []byte(scrambled))
+	if err == nil {
+		t.Fatal("two variant lines swapped without their bit= values is a file this parser must refuse")
+	}
+	if !strings.Contains(err.Error(), "bit position is line order here") {
+		t.Errorf("the refusal must say why, got: %v", err)
 	}
 }
 

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -219,10 +219,24 @@ func TestRefusals(t *testing.T) {
 			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 		{
-			name:    "a flags variant removed",
+			name:    "a flags variant renamed in place — a rename, or a spent bit reclaimed",
+			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Stealth, Turbo }"),
+			where:   "flags Perks",
+			what:    "bit 1 was Cloaked and is now Stealth",
+			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
+		},
+		{
+			name:    "a flags variant removed from the middle — every bit above it slides down",
 			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Turbo }"),
 			where:   "flags Perks",
-			what:    "variant Cloaked removed from bit 1",
+			what:    "variant Turbo moved from bit 2 to bit 1",
+			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
+		},
+		{
+			name:    "the last flags variant removed — the bit is freed, and a spent bit stays spent",
+			edited:  replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked }"),
+			where:   "flags Perks",
+			what:    "variant Turbo removed from bit 2",
 			control: replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }"),
 		},
 	}

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -15,6 +15,7 @@
 package baseline_test
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,10 +136,7 @@ func summary(fs []baseline.Finding) string {
 // without returns the shipping policy with one row removed — the attribution
 // control's instrument.
 func without(keys ...string) map[string]baseline.TokenRule {
-	p := map[string]baseline.TokenRule{}
-	for k, v := range baseline.DefaultTokenPolicy {
-		p[k] = v
-	}
+	p := maps.Clone(baseline.DefaultTokenPolicy)
 	for _, k := range keys {
 		delete(p, k)
 	}

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -189,11 +189,11 @@ func TestRefusals(t *testing.T) {
 			control: replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Silver, Gold, Platinum }"),
 		},
 		{
-			name:    "a field's kind changed",
-			edited:  replace(t, "heading int16", "heading int32"),
-			where:   "Config.heading",
-			what:    "wire kind 3 -> 4",
-			token:   "kind",
+			name:   "a field's kind changed",
+			edited: replace(t, "heading int16", "heading int32"),
+			where:  "Config.heading",
+			what:   "wire kind 3 -> 4",
+			token:  "kind",
 			// the absorbed edit of the same shape: a NEW field of the changed
 			// type beside the old one, which is the migration the wire wants
 			control: replace(t, "heading int16", "heading int16\n    heading_wide int32"),

--- a/internal/baseline/corpus_test.go
+++ b/internal/baseline/corpus_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mas-bandwidth/schema/v2/internal/baseline"
 )
 
-// the tables corpora, from this package's directory
+// the tables corpora, from this package's directory.
 var corpora = []string{"../../tables/examples", "../../tables/pointers"}
 
 // TestCorpusBaselinesAreCurrent regenerates each committed baseline and

--- a/internal/baseline/corpus_test.go
+++ b/internal/baseline/corpus_test.go
@@ -1,0 +1,75 @@
+// The committed baselines are pinned like any other golden: the tables
+// corpora carry a tables.baseline, and regenerating it must reproduce the
+// committed bytes exactly. A drift here means the projection moved under an
+// unchanged corpus, which is a review question, not a re-pin.
+package baseline_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/internal/baseline"
+)
+
+// the tables corpora, from this package's directory
+var corpora = []string{"../../tables/examples", "../../tables/pointers"}
+
+// TestCorpusBaselinesAreCurrent regenerates each committed baseline and
+// compares byte for byte — the idempotence the `--update` path promises,
+// measured on the corpus rather than a fixture.
+func TestCorpusBaselinesAreCurrent(t *testing.T) {
+	for _, dir := range corpora {
+		t.Run(filepath.Base(dir), func(t *testing.T) {
+			path := filepath.Join(dir, baseline.FileName)
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("the tables corpus carries a committed baseline: %v", err)
+			}
+			committedFile, err := baseline.Parse(path, want)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			paths, err := compiler.GatherPaths([]string{dir})
+			if err != nil {
+				t.Fatal(err)
+			}
+			u, err := compiler.New().Load(paths)
+			if err != nil {
+				t.Fatalf("the corpus does not compile: %v", err)
+			}
+			live := baseline.Render(u)
+			live.History = committedFile.History
+			if live.Text() != string(want) {
+				t.Errorf("%s is stale — regenerate it deliberately:\n  ./bin/schema tables-baseline --update --reason \"...\" %s\n--- committed ---\n%s\n--- current ---\n%s",
+					path, dir, want, live.Text())
+			}
+		})
+	}
+}
+
+// TestCorpusPassesItsOwnCheck is the whole feature end to end over real
+// schemas: the driver's baseline policy on, the committed file diffed, and
+// silence.
+func TestCorpusPassesItsOwnCheck(t *testing.T) {
+	for _, dir := range corpora {
+		t.Run(filepath.Base(dir), func(t *testing.T) {
+			paths, err := compiler.GatherPaths([]string{dir})
+			if err != nil {
+				t.Fatal(err)
+			}
+			c := compiler.New()
+			c.TablesBaseline = true
+			var warns []string
+			c.OnWarn = func(msg string) { warns = append(warns, msg) }
+			if _, err := c.Load(paths); err != nil {
+				t.Fatalf("the corpus must pass its own baseline: %v", err)
+			}
+			if len(warns) != 0 {
+				t.Errorf("the corpus must warn about nothing: %v", warns)
+			}
+		})
+	}
+}

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -22,6 +22,14 @@
 // rename (see pairMembers) is left to the walk — otherwise the same wire loss
 // would draw a harsher verdict merely because the author also renamed.
 //
+// The split is deliberately ASYMMETRIC ON FIELD REMOVAL, and the asymmetry is
+// the point rather than an oversight: dropping a field from a declaration —
+// renamed or not — is absorbed, because a reader defaults what a writer no
+// longer sends, while repointing a field at a declaration that never had that
+// field refuses, because nothing says the author knew what the old bodies
+// carried. The first is the schema evolving; the second is a substitution
+// claiming to be equivalent, and only the second makes that claim.
+//
 // ONE TABLE IS THE WHOLE POLICY. [DefaultTokenPolicy] maps a field token's key
 // to what a change of it means, and it carries a row for each of the four
 // vocabulary walks too — the ones with no token of their own. Every walk is
@@ -34,6 +42,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // A Verdict is what a difference means for data already written.
@@ -137,10 +146,14 @@ func (f Finding) String() string { return f.Where + ": " + f.What }
 func Diff(base, live *Unit, policy map[string]TokenRule) []Finding {
 	d := &differ{base: base, live: live, policy: policy, visiting: map[string]bool{}}
 	renames := policy["member"] == RuleLoss
-	d.tables = pairMembers(tableIdents(base), tableIdents(live), renames)
-	d.enums = pairMembers(enumIdents(base), enumIdents(live), renames)
-	d.unions = pairMembers(unionIdents(base), unionIdents(live), renames)
-	d.flags = pairMembers(flagsIdents(base), flagsIdents(live), renames)
+	// only tables carry per-member facts to compare; the vocabularies answer 0
+	// for every candidate, so a contest among them is never separated by facts
+	// and is reported as the contest it is.
+	none := func(string, string) int { return 0 }
+	d.tables = pairMembers(tableIdents(base), tableIdents(live), renames, d.factDistance)
+	d.enums = pairMembers(enumIdents(base), enumIdents(live), renames, none)
+	d.unions = pairMembers(unionIdents(base), unionIdents(live), renames, none)
+	d.flags = pairMembers(flagsIdents(base), flagsIdents(live), renames, none)
 
 	var out []Finding
 	out = append(out, d.diffTables()...)
@@ -177,13 +190,14 @@ type idents struct {
 // to and, when it is not a plain namesake, how much of its identity that
 // declaration actually carries.
 type match struct {
-	name      string // the live declaration, "" when nothing was close enough
-	closest   string // the best candidate considered, paired or not
-	carried   int    // identities of this member the candidate carries
-	total     int    // identities this member had
-	renamed   bool   // matched across a rename rather than by name
-	vanished  bool   // the baseline name is gone from the live projection
-	unmatched bool   // vanished, and no candidate reached the threshold
+	name       string   // the live declaration, "" when nothing was close enough
+	closest    string   // the best candidate considered, paired or not
+	carried    int      // identities of this member the candidate carries
+	total      int      // identities this member had
+	renamed    bool     // matched across a rename rather than by name
+	vanished   bool     // the baseline name is gone from the live projection
+	unmatched  bool     // vanished, and no candidate was chosen
+	contenders []string // two or more candidates the evidence could not separate
 }
 
 type pairing map[string]match
@@ -209,7 +223,14 @@ type pairing map[string]match
 // Pairing rides the `member` policy row with the warning, because they are one
 // feature: without the row there is no rename matching and no report of the
 // hole, which is the behaviour the row exists to replace.
-func pairMembers(base, live idents, allowRenames bool) pairing {
+// closeness measures how far a candidate's own facts sit from the vanished
+// member's, under the ids they share. It is the second question the pairing
+// asks — the first, identity overlap, is blind to a brand-new declaration that
+// happens to carry the same field names — and it returns 0 for the
+// vocabularies, which carry no per-variant facts to compare.
+type closeness func(baseName, candidate string) int
+
+func pairMembers(base, live idents, allowRenames bool, near closeness) pairing {
 	out := pairing{}
 	liveHas := map[string]bool{}
 	for _, n := range live.names {
@@ -241,27 +262,74 @@ func pairMembers(base, live idents, allowRenames bool) pairing {
 
 	for _, o := range orphans {
 		want := base.sets[o]
-		best, bestScore, tie := "", 0, false
+
+		// every unmatched candidate, scored on identity overlap; the best of
+		// them is what an unpaired warning reports, whether or not it reached
+		// the threshold
+		best, bestScore := "", 0
+		var reached []string
 		for _, c := range candidates {
 			if taken[c] {
 				continue
 			}
 			score := carried(want, live.sets[c])
-			switch {
-			case score > bestScore:
-				best, bestScore, tie = c, score, false
-			case score == bestScore && score > 0:
-				tie = true
+			if score > bestScore || (score == bestScore && score > 0 && c < best) {
+				best, bestScore = c, score
+			}
+			if score > 0 && score*2 >= len(want) {
+				reached = append(reached, c)
 			}
 		}
-		m := match{closest: best, carried: bestScore, total: len(want), vanished: true}
-		if allowRenames && bestScore > 0 && !tie && bestScore*2 >= len(want) {
-			m.name, m.renamed = best, true
-			taken[best] = true
-		} else {
-			m.unmatched = true
+
+		m := match{closest: best, carried: bestScore, total: len(want), vanished: true, unmatched: true}
+		if !allowRenames || len(reached) == 0 {
+			out[o] = m
+			continue
 		}
+		pick := reached[0]
+		if len(reached) > 1 {
+			// MORE THAN ONE CANDIDATE COULD BE THE RENAME. Identity overlap
+			// alone cannot separate them — an unrelated new declaration that
+			// happens to carry the same field names outscores the real rename
+			// that dropped one — so the tiebreak asks the second question:
+			// whose own FACTS under the shared ids are closest. A candidate is
+			// chosen only when it wins BOTH, strictly. Otherwise nothing is
+			// paired and the warning names the contenders, because a warning
+			// must never assert a rename the evidence cannot distinguish.
+			pick = ""
+			topScore, topFacts := -1, -1
+			var scoreTie, factTie bool
+			for _, c := range reached {
+				score, facts := carried(want, live.sets[c]), near(o, c)
+				switch {
+				case score > topScore:
+					topScore, scoreTie = score, false
+				case score == topScore:
+					scoreTie = true
+				}
+				switch {
+				case topFacts < 0 || facts < topFacts:
+					topFacts, factTie = facts, false
+				case facts == topFacts:
+					factTie = true
+				}
+			}
+			if !scoreTie && !factTie {
+				for _, c := range reached {
+					if carried(want, live.sets[c]) == topScore && near(o, c) == topFacts {
+						pick = c
+					}
+				}
+			}
+			if pick == "" {
+				m.contenders = append([]string(nil), reached...)
+				out[o] = m
+				continue
+			}
+		}
+		m.name, m.renamed, m.unmatched = pick, true, false
 		out[o] = m
+		taken[pick] = true
 	}
 	return out
 }
@@ -276,6 +344,11 @@ func vanishedFinding(what, name string, m match) Finding {
 		return Finding{Warn, where, fmt.Sprintf(
 			"no longer in the closure under that name; %s carries %d of its %d identities, so it is judged as the rename it looks like",
 			m.name, m.carried, m.total)}
+	}
+	if len(m.contenders) > 0 {
+		return Finding{Warn, where, fmt.Sprintf(
+			"no longer in the closure — %s each carry enough of its %d identities to be the rename and the evidence does not separate them, so nothing is paired and this baseline no longer covers it",
+			strings.Join(m.contenders, " and "), m.total)}
 	}
 	if m.carried > 0 {
 		return Finding{Warn, where, fmt.Sprintf(
@@ -307,6 +380,46 @@ func (d *differ) vanished(what string, p pairing, names []string) []Finding {
 		}
 	}
 	return out
+}
+
+// factDistance counts the facts that MOVED between a baseline table and a
+// candidate live one, under the ids they share. Referent tokens are skipped:
+// judging one needs the pairings this measurement is being taken to decide, and
+// a candidate's own kinds, defaults and bounds are enough to tell a renamed
+// declaration from a stranger that reuses its field names.
+func (d *differ) factDistance(baseName, candidate string) int {
+	before, after := findTable(d.base, baseName), findTable(d.live, candidate)
+	if before == nil || after == nil {
+		return 0
+	}
+	liveFields := map[uint16]Field{}
+	for _, f := range after.Fields {
+		liveFields[f.Id] = f
+	}
+	n := 0
+	for _, bf := range before.Fields {
+		lf, ok := liveFields[bf.Id]
+		if !ok {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, bt := range bf.Tokens {
+			seen[bt.Key] = true
+			rule := d.policy[bt.Key]
+			if rule == RulePass || rule == RuleRefs {
+				continue
+			}
+			if lv, present := lf.Get(bt.Key); !present || lv != bt.Value {
+				n++
+			}
+		}
+		for _, lt := range lf.Tokens {
+			if !seen[lt.Key] && d.policy[lt.Key] == RuleFixed {
+				n++
+			}
+		}
+	}
+	return n
 }
 
 // ---- the four walks ----

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -269,6 +269,13 @@ func diffFlags(base, live *Unit) []Finding {
 		for i, v := range bf.Variants {
 			j, ok := pos[v]
 			switch {
+			case !ok && i < len(lf.Variants):
+				// the bit is still declared, under another name. The compiler
+				// cannot tell a rename (which moves no byte) from a new
+				// meaning claimed on a spent bit (which remaps every stored
+				// file), so it refuses and makes the author say which.
+				out = append(out, Finding{Refuse, "flags " + bf.Name,
+					fmt.Sprintf("bit %d was %s and is now %s — a spent bit stays spent; if that is a rename it moves no byte, and if bit %d now means something else every stored file is remapped", i, v, lf.Variants[i], i)})
 			case !ok:
 				out = append(out, Finding{Refuse, "flags " + bf.Name,
 					fmt.Sprintf("variant %s removed from bit %d — a spent bit stays spent; retire the name and keep the position", v, i)})

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -89,10 +89,6 @@ const (
 )
 
 // DefaultTokenPolicy is the WHOLE compatibility policy, one row per fact.
-//
-// The `key` row is the enum-keyed array's rule. No construct spells one today,
-// which is why no renderer emits the token; the rule lives here because this
-// table describes the FACT SET, not the grammar (SPEC-TABLES.md §15).
 var DefaultTokenPolicy = map[string]TokenRule{
 	// ---- a field's own facts ----
 	"kind":    RuleFixed,  // a changed kind is skipped by every old reader, and the value is silently gone
@@ -100,9 +96,11 @@ var DefaultTokenPolicy = map[string]TokenRule{
 	"default": RuleFixed,  // an elided field MEANS the reader's default (SPEC-TABLES.md §4)
 	"bound":   RuleShrink, // a count past the reader's bound keeps the prefix and counts clamped
 	"size":    RuleShrink, // a string/bytes capacity is a bound like any other
-	"key":     RuleFixed,  // an enum-keyed array: swapping the key enum remaps every stored element
 	"array":   RulePass,   // fixed and bounded frame identically on the wire (SPEC-TABLES.md §3)
 	"was":     RulePass,   // `was` is the rename that PRESERVES identity — that is its whole job
+	// PRESENCE IS RECORDED AND JUDGED ON NOTHING: T, ?T and *T are one
+	// framing, so a field moving between them moves no byte (§3.1, §18.1)
+	"optional": RulePass,
 
 	// ---- a field's REFERENT, split by what it names ----
 	//
@@ -115,6 +113,11 @@ var DefaultTokenPolicy = map[string]TokenRule{
 	"union":   RuleRefs,
 	"type":    RuleRefs,
 	"payload": RuleRefs, // a union arm's payload is a nested table, one level in
+	// an ENUM-KEYED array's KEY enum is a referent too, and an enum's one: its
+	// slots ride under their variants' name ids (§3.2), so it stands in
+	// exactly when those names survive. The keyed and positional spellings
+	// are different wire kinds, so THAT move is caught by the `kind` row.
+	"key": RuleRefs,
 
 	// ---- the vocabulary walks, which have no token of their own ----
 	"member":         RuleLoss,  // a closure member that is no longer covered by this baseline
@@ -554,7 +557,7 @@ func (d *differ) refsFindings(where, key, was, now string, present bool) []Findi
 func (d *differ) pairedRename(key, was string) string {
 	var p pairing
 	switch key {
-	case "enum":
+	case "enum", "key":
 		p = d.enums
 	case "flags":
 		p = d.flags
@@ -583,11 +586,13 @@ func (d *differ) pairedRename(key, was string) string {
 //   - a UNION body opens with its arm NAME hash, same rule;
 //   - a FLAGS mask is POSITIONAL and carries no names at all, so it stands in
 //     only when the old declaration's variants sit at the same bits.
+//   - an ENUM-KEYED array's KEY enum is judged as an enum: its slots ride
+//     under their variants' name ids (SPEC-TABLES.md §3.2).
 func (d *differ) substitutable(key, was, now string) []Finding {
 	switch key {
 	case "flags":
 		return bitsRide(flagsVariants(d.base, was), flagsVariants(d.live, now), now)
-	case "enum":
+	case "enum", "key":
 		return namesRide(enumNames(d.base, was), enumNames(d.live, now), now,
 			"variant name", "stored values naming them read as None")
 	case "union":
@@ -730,6 +735,8 @@ func tokenNoun(key string) string {
 		return "capacity"
 	case "key":
 		return "array key enum"
+	case "optional":
+		return "presence"
 	case "type":
 		return "nested table"
 	case "payload":

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -1,0 +1,284 @@
+// The DIFF: live projection against committed baseline, and the judgment on
+// every way they can differ (SPEC-TABLES.md §16).
+//
+// The three verdicts, and the one question that assigns them: what does an
+// old file MEAN to a new reader?
+//
+//   - REFUSE — the meaning changed and nothing on the wire says so. A
+//     specified default, a flags variant's bit position, a field's kind.
+//   - WARN — the data survives but something is lost, and the read report
+//     says so at runtime (clamped, unknown). A shrunk bound, a removed enum
+//     variant or union arm.
+//   - PASS — the wire absorbs it. Fields added, removed, reordered or
+//     renamed under `was`; variants appended; bounds grown.
+package baseline
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// A Verdict is what a difference means for data already written.
+type Verdict int
+
+const (
+	// Pass — the wire absorbs the edit; no reader is affected.
+	Pass Verdict = iota
+	// Warn — data survives, something is lost, and the read report counts it.
+	Warn
+	// Refuse — an old file's meaning changed, silently.
+	Refuse
+)
+
+func (v Verdict) String() string {
+	switch v {
+	case Refuse:
+		return "refuse"
+	case Warn:
+		return "warn"
+	}
+	return "pass"
+}
+
+// A TokenRule says how a change to one field token is judged.
+type TokenRule int
+
+const (
+	// RulePass — the token is recorded as a fact and judged on nothing.
+	RulePass TokenRule = iota
+	// RuleFixed — any change, addition or removal is a refusal.
+	RuleFixed
+	// RuleShrink — a smaller value warns; a larger one passes.
+	RuleShrink
+)
+
+// DefaultTokenPolicy is the WHOLE compatibility policy for a field's facts,
+// one row per token key. It is the file to edit when the projection learns a
+// new fact — and the `key` row is the enum-keyed array hook: the construct is
+// a named follow-on (SPEC-TABLES.md §15), the rule for it is already here, and
+// the renderer needs one line the day it lands.
+var DefaultTokenPolicy = map[string]TokenRule{
+	"kind":    RuleFixed,  // a changed kind is skipped by every old reader, and the value is silently gone
+	"elem":    RuleFixed,  // an array's element kind is that same fact, one level in
+	"default": RuleFixed,  // an elided field MEANS the reader's default (SPEC-TABLES.md §4)
+	"bound":   RuleShrink, // a count past the reader's bound keeps the prefix and counts clamped
+	"size":    RuleShrink, // a string/bytes capacity is a bound like any other
+	"key":     RuleFixed,  // enum-keyed arrays: swapping the key enum remaps every stored element
+	"type":    RulePass,   // the nested member has its own section; its fields ride by id
+	"array":   RulePass,   // fixed and bounded frame identically on the wire (SPEC-TABLES.md §3)
+	"was":     RulePass,   // `was` is the rename that PRESERVES identity — that is its whole job
+}
+
+// A Finding is one difference between the committed baseline and the unit as
+// it stands now.
+type Finding struct {
+	Verdict Verdict
+	Where   string // "WeaponConfig.damage", "flags Perks", "enum Grade"
+	What    string // "specified default 21 -> 25"
+}
+
+func (f Finding) Error() string { return f.String() }
+
+func (f Finding) String() string { return f.Where + ": " + f.What }
+
+// Diff judges the live projection against the committed baseline under a token
+// policy. Findings come back in a stable order — members sorted, fields in
+// declaration order — so a diff never shuffles run to run.
+//
+// The policy is a parameter, not a constant, because that is what makes the
+// negative controls honest: a test drops one row and proves the edit then
+// passes, which shows the refusal came from THAT check and not from something
+// else in the walk.
+func Diff(base, live *Unit, policy map[string]TokenRule) []Finding {
+	var out []Finding
+
+	liveTables := map[string]Table{}
+	for _, t := range live.Tables {
+		liveTables[t.Name] = t
+	}
+	for _, bt := range base.Tables {
+		lt, ok := liveTables[bt.Name]
+		if !ok {
+			// the member left the closure: every field of it went with it,
+			// which is the removal case, and removals are absorbed
+			continue
+		}
+		liveFields := map[uint16]Field{}
+		for _, f := range lt.Fields {
+			liveFields[f.Id] = f
+		}
+		for _, bf := range bt.Fields {
+			// FIELDS MATCH BY WIRE ID, not by name: the id is the identity a
+			// reader keys on, and `was` is exactly the tool for keeping it
+			// through a rename. A field whose id is gone was removed, and a
+			// removal is absorbed — the reader defaults it.
+			lf, ok := liveFields[bf.Id]
+			if !ok {
+				continue
+			}
+			where := bt.Name + "." + lf.Name
+			out = append(out, diffTokens(where, bf, lf, policy)...)
+		}
+	}
+
+	out = append(out, diffEnums(base, live)...)
+	out = append(out, diffFlags(base, live)...)
+	out = append(out, diffUnions(base, live)...)
+	return out
+}
+
+func diffTokens(where string, bf, lf Field, policy map[string]TokenRule) []Finding {
+	var out []Finding
+	seen := map[string]bool{}
+	for _, bt := range bf.Tokens {
+		seen[bt.Key] = true
+		rule := policy[bt.Key]
+		lv, present := lf.Get(bt.Key)
+		switch rule {
+		case RuleFixed:
+			switch {
+			case !present:
+				out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s removed", tokenNoun(bt.Key), bt.Value)})
+			case lv != bt.Value:
+				out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s -> %s", tokenNoun(bt.Key), bt.Value, lv)})
+			}
+		case RuleShrink:
+			if !present || lv == bt.Value {
+				continue
+			}
+			was, err1 := strconv.ParseInt(bt.Value, 10, 64)
+			now, err2 := strconv.ParseInt(lv, 10, 64)
+			if err1 != nil || err2 != nil || now >= was {
+				continue
+			}
+			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s -> %s (a count past the new bound keeps the prefix and counts clamped)", tokenNoun(bt.Key), bt.Value, lv)})
+		}
+	}
+	// a fact the live projection carries and the baseline does not: only the
+	// fixed rules care, and only because ADDING a default is as much a
+	// semantic edit as changing one
+	for _, lt := range lf.Tokens {
+		if seen[lt.Key] || policy[lt.Key] != RuleFixed {
+			continue
+		}
+		out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s added", tokenNoun(lt.Key), lt.Value)})
+	}
+	return out
+}
+
+// tokenNoun names a token in a diagnostic the way a person would say it.
+func tokenNoun(key string) string {
+	switch key {
+	case "kind":
+		return "wire kind"
+	case "elem":
+		return "array element kind"
+	case "default":
+		return "specified default"
+	case "bound":
+		return "array bound"
+	case "size":
+		return "capacity"
+	case "key":
+		return "array key enum"
+	}
+	return key
+}
+
+func diffEnums(base, live *Unit) []Finding {
+	var out []Finding
+	liveEnums := map[string]Enum{}
+	for _, e := range live.Enums {
+		liveEnums[e.Name] = e
+	}
+	for _, be := range base.Enums {
+		le, ok := liveEnums[be.Name]
+		if !ok {
+			continue
+		}
+		have := map[string]bool{}
+		for _, v := range le.Variants {
+			have[v.Name] = true
+		}
+		for _, v := range be.Variants {
+			if !have[v.Name] {
+				// stored values naming it now read as None and count unknown
+				out = append(out, Finding{Warn, "enum " + be.Name,
+					fmt.Sprintf("variant %s removed — stored values naming it read as None and count unknown", v.Name)})
+			}
+		}
+	}
+	return out
+}
+
+func diffUnions(base, live *Unit) []Finding {
+	var out []Finding
+	liveUnions := map[string]Union{}
+	for _, u := range live.Unions {
+		liveUnions[u.Name] = u
+	}
+	for _, bu := range base.Unions {
+		lu, ok := liveUnions[bu.Name]
+		if !ok {
+			continue
+		}
+		have := map[string]bool{}
+		for _, a := range lu.Arms {
+			have[a.Name] = true
+		}
+		for _, a := range bu.Arms {
+			if !have[a.Name] {
+				out = append(out, Finding{Warn, "union " + bu.Name,
+					fmt.Sprintf("arm %s removed — stored bodies naming it are skipped and count unknown", a.Name)})
+			}
+		}
+	}
+	return out
+}
+
+// diffFlags is the one vocabulary with no names on the wire: bit i is variant
+// i, so the ORDER is the fact and APPEND AT THE END is the only safe edit
+// (SPEC-TABLES.md §4).
+func diffFlags(base, live *Unit) []Finding {
+	var out []Finding
+	liveFlags := map[string]Flags{}
+	for _, f := range live.Flags {
+		liveFlags[f.Name] = f
+	}
+	for _, bf := range base.Flags {
+		lf, ok := liveFlags[bf.Name]
+		if !ok {
+			continue
+		}
+		pos := map[string]int{}
+		for i, v := range lf.Variants {
+			pos[v] = i
+		}
+		for i, v := range bf.Variants {
+			j, ok := pos[v]
+			switch {
+			case !ok:
+				out = append(out, Finding{Refuse, "flags " + bf.Name,
+					fmt.Sprintf("variant %s removed from bit %d — a spent bit stays spent; retire the name and keep the position", v, i)})
+			case j != i:
+				out = append(out, Finding{Refuse, "flags " + bf.Name,
+					fmt.Sprintf("variant %s moved from bit %d to bit %d — every stored file's bits are remapped, and nothing on the wire says so", v, i, j)})
+			}
+		}
+	}
+	return out
+}
+
+// Split separates findings into the ones that stop a build and the ones that
+// only report.
+func Split(findings []Finding) (refusals, warnings []Finding) {
+	for _, f := range findings {
+		switch f.Verdict {
+		case Refuse:
+			refusals = append(refusals, f)
+		case Warn:
+			warnings = append(warnings, f)
+		}
+	}
+	return refusals, warnings
+}

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -5,16 +5,25 @@
 // old file MEAN to a new reader?
 //
 //   - REFUSE — the meaning changed and nothing on the wire says so. A
-//     specified default, a flags variant's bit position, a field's kind.
+//     specified default, a flags variant's bit position, a field's kind, a
+//     field's vocabulary swapped for another.
 //   - WARN — the data survives but something is lost, and the read report
 //     says so at runtime (clamped, unknown). A shrunk bound, a removed enum
-//     variant or union arm.
+//     variant or union arm, a closure member that is no longer covered.
 //   - PASS — the wire absorbs it. Fields added, removed, reordered or
 //     renamed under `was`; variants appended; bounds grown.
+//
+// ONE TABLE IS THE WHOLE POLICY. [DefaultTokenPolicy] maps a field token's key
+// to what a change of it means, and it carries a row for each of the four
+// vocabulary walks too — the ones with no token of their own. Every walk is
+// gated on its row, so dropping a row disables exactly that check: that is the
+// seam the attribution controls in the test file ablate through, and it is why
+// every class here has one.
 package baseline
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 )
 
@@ -40,40 +49,70 @@ func (v Verdict) String() string {
 	return "pass"
 }
 
-// A TokenRule says how a change to one field token is judged.
+// A TokenRule says how one difference is judged. The zero value is RulePass,
+// so a key absent from a policy is judged on nothing — which is what makes an
+// ablation control a one-line change.
 type TokenRule int
 
 const (
-	// RulePass — the token is recorded as a fact and judged on nothing.
+	// RulePass — recorded as a fact and judged on nothing.
 	RulePass TokenRule = iota
 	// RuleFixed — any change, addition or removal is a refusal.
 	RuleFixed
 	// RuleShrink — a smaller value warns; a larger one passes.
 	RuleShrink
+	// RuleLoss — something present in the baseline is gone; it warns.
+	RuleLoss
+	// RuleRefs — the token names another declaration in this file. Renaming
+	// that declaration moves no byte, so the edit is absorbed exactly when the
+	// new referent's IDENTITIES RIDE; otherwise stored data means something
+	// else under it and that is a refusal. What "ride" means is the referent's
+	// own identity rule (see identitiesRide).
+	RuleRefs
 )
 
-// DefaultTokenPolicy is the WHOLE compatibility policy for a field's facts,
-// one row per token key. It is the file to edit when the projection learns a
-// new fact — and the `key` row is the enum-keyed array hook: the construct is
-// a named follow-on (SPEC-TABLES.md §15), the rule for it is already here, and
-// the renderer needs one line the day it lands.
+// DefaultTokenPolicy is the WHOLE compatibility policy, one row per fact.
+//
+// The `key` row is the enum-keyed array's rule. No construct spells one today,
+// which is why no renderer emits the token; the rule lives here because this
+// table describes the FACT SET, not the grammar (SPEC-TABLES.md §15).
 var DefaultTokenPolicy = map[string]TokenRule{
+	// ---- a field's own facts ----
 	"kind":    RuleFixed,  // a changed kind is skipped by every old reader, and the value is silently gone
 	"elem":    RuleFixed,  // an array's element kind is that same fact, one level in
 	"default": RuleFixed,  // an elided field MEANS the reader's default (SPEC-TABLES.md §4)
 	"bound":   RuleShrink, // a count past the reader's bound keeps the prefix and counts clamped
 	"size":    RuleShrink, // a string/bytes capacity is a bound like any other
-	"key":     RuleFixed,  // enum-keyed arrays: swapping the key enum remaps every stored element
-	"type":    RulePass,   // the nested member has its own section; its fields ride by id
+	"key":     RuleFixed,  // an enum-keyed array: swapping the key enum remaps every stored element
 	"array":   RulePass,   // fixed and bounded frame identically on the wire (SPEC-TABLES.md §3)
 	"was":     RulePass,   // `was` is the rename that PRESERVES identity — that is its whole job
+
+	// ---- a field's REFERENT, split by what it names ----
+	//
+	// A referent is judged on whether the DECLARATION IT NAMES still carries
+	// what the old one carried (RuleRefs). Dropping the referent entirely —
+	// an enum-typed field spelled as its raw uint16 — is always a refusal:
+	// SPEC-TABLES.md §4 states outright that an enum field and a plain uint16
+	// field are both kind 7, so the runtime cannot report the edit, which is
+	// the definition of this file's job.
+	"enum":    RuleRefs,
+	"flags":   RuleRefs,
+	"union":   RuleRefs,
+	"type":    RuleRefs,
+	"payload": RuleRefs, // a union arm's payload is a nested table, one level in
+
+	// ---- the vocabulary walks, which have no token of their own ----
+	"member":         RuleLoss,  // a closure member that is no longer covered by this baseline
+	"flags-position": RuleFixed, // bit i is variant i, and the order IS the fact
+	"enum-variant":   RuleLoss,  // stored values naming a dropped variant read as None
+	"union-arm":      RuleLoss,  // stored bodies naming a dropped arm are skipped
 }
 
 // A Finding is one difference between the committed baseline and the unit as
 // it stands now.
 type Finding struct {
 	Verdict Verdict
-	Where   string // "WeaponConfig.damage", "flags Perks", "enum Grade"
+	Where   string // "WeaponConfig.damage", "flags Perks", "table Weapon"
 	What    string // "specified default 21 -> 25"
 }
 
@@ -81,7 +120,7 @@ func (f Finding) Error() string { return f.String() }
 
 func (f Finding) String() string { return f.Where + ": " + f.What }
 
-// Diff judges the live projection against the committed baseline under a token
+// Diff judges the live projection against the committed baseline under a
 // policy. Findings come back in a stable order — members sorted, fields in
 // declaration order — so a diff never shuffles run to run.
 //
@@ -91,16 +130,159 @@ func (f Finding) String() string { return f.Where + ": " + f.What }
 // else in the walk.
 func Diff(base, live *Unit, policy map[string]TokenRule) []Finding {
 	var out []Finding
+	out = append(out, diffTables(base, live, policy)...)
+	out = append(out, diffEnums(base, live, policy)...)
+	out = append(out, diffFlags(base, live, policy)...)
+	out = append(out, diffUnions(base, live, policy)...)
+	return out
+}
 
+// ---- matching members across a rename ----
+
+// idents is one vocabulary's members and the identities each one carries: a
+// table's field wire ids, an enum's or a union's variant ids, a flags'
+// variant names (a mask carries no ids at all).
+type idents struct {
+	names []string
+	sets  map[string]map[string]bool
+}
+
+// pairMembers matches baseline members onto live ones. Names first — the
+// ordinary case, and a declaration name is not on the wire. Then THE RENAME
+// RULE, which exists because a declaration rename is absorbed by the wire and
+// must not take everything inside the declaration out of coverage with it:
+//
+//	a baseline member with no live namesake is paired with the unmatched live
+//	member of the same vocabulary that carries the MOST of its identities,
+//	provided that is at least half of them and no other candidate carries as
+//	many.
+//
+// Half is what separates a rename from an unrelated declaration that happens
+// to share a field called `name`, and it is not stricter than half because a
+// rename that also drops one of two arms is exactly the commit this rule
+// exists to catch; the uniqueness requirement keeps a tie from picking
+// arbitrarily. A member that pairs is judged in full under its new name. A
+// member that does not is a coverage loss, and either way vanished names it,
+// because a hole in the coverage has to be visible.
+//
+// Pairing rides the `member` policy row with the warning, because they are one
+// feature: without the row there is no rename matching and no report of the
+// hole, which is the behaviour the row exists to replace.
+func pairMembers(base, live idents, allowRenames bool) (pair map[string]string, vanished []string) {
+	pair = map[string]string{}
+	liveHas := map[string]bool{}
+	for _, n := range live.names {
+		liveHas[n] = true
+	}
+	baseHas := map[string]bool{}
+	for _, n := range base.names {
+		baseHas[n] = true
+	}
+
+	taken := map[string]bool{}
+	var orphans []string
+	for _, n := range base.names {
+		if liveHas[n] {
+			pair[n] = n
+			taken[n] = true
+			continue
+		}
+		orphans = append(orphans, n)
+	}
+	var candidates []string
+	for _, n := range live.names {
+		if !baseHas[n] {
+			candidates = append(candidates, n)
+		}
+	}
+	sort.Strings(orphans)
+	sort.Strings(candidates)
+
+	for _, o := range orphans {
+		vanished = append(vanished, o)
+		want := base.sets[o]
+		best, bestScore, tie := "", 0, false
+		for _, c := range candidates {
+			if taken[c] {
+				continue
+			}
+			score := 0
+			for id := range want {
+				if live.sets[c][id] {
+					score++
+				}
+			}
+			switch {
+			case score > bestScore:
+				best, bestScore, tie = c, score, false
+			case score == bestScore && score > 0:
+				tie = true
+			}
+		}
+		if allowRenames && bestScore > 0 && !tie && bestScore*2 >= len(want) {
+			pair[o] = best
+			taken[best] = true
+		}
+	}
+	return pair, vanished
+}
+
+// vanishedFinding reports a baseline member that is no longer in the closure
+// under its own name — paired with the declaration that looks like its rename,
+// or unpaired and therefore out of coverage entirely.
+func vanishedFinding(what, name, paired string, carried, total int) Finding {
+	if paired == "" {
+		return Finding{Warn, what + " " + name,
+			"no longer in the closure — nothing left carries its identities, so this baseline no longer covers it"}
+	}
+	return Finding{Warn, what + " " + name,
+		fmt.Sprintf("no longer in the closure under that name; %s carries %d of its %d identities, so it is judged as the rename it looks like", paired, carried, total)}
+}
+
+func carried(want, have map[string]bool) int {
+	n := 0
+	for id := range want {
+		if have[id] {
+			n++
+		}
+	}
+	return n
+}
+
+// ---- the four walks ----
+
+func tableIdents(u *Unit) idents {
+	out := idents{sets: map[string]map[string]bool{}}
+	for _, t := range u.Tables {
+		out.names = append(out.names, t.Name)
+		set := map[string]bool{}
+		for _, f := range t.Fields {
+			set[fmt.Sprintf("%04x", f.Id)] = true
+		}
+		out.sets[t.Name] = set
+	}
+	return out
+}
+
+func diffTables(base, live *Unit, policy map[string]TokenRule) []Finding {
+	var out []Finding
 	liveTables := map[string]Table{}
 	for _, t := range live.Tables {
 		liveTables[t.Name] = t
 	}
+	baseIdents, liveIdents := tableIdents(base), tableIdents(live)
+	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
+
+	if policy["member"] == RuleLoss {
+		for _, name := range vanished {
+			out = append(out, vanishedFinding("table", name, pair[name],
+				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
+		}
+	}
+
 	for _, bt := range base.Tables {
-		lt, ok := liveTables[bt.Name]
+		lt, ok := liveTables[pair[bt.Name]]
 		if !ok {
-			// the member left the closure: every field of it went with it,
-			// which is the removal case, and removals are absorbed
 			continue
 		}
 		liveFields := map[uint16]Field{}
@@ -116,25 +298,19 @@ func Diff(base, live *Unit, policy map[string]TokenRule) []Finding {
 			if !ok {
 				continue
 			}
-			where := bt.Name + "." + lf.Name
-			out = append(out, diffTokens(where, bf, lf, policy)...)
+			out = append(out, diffTokens(lt.Name+"."+lf.Name, bf, lf, base, live, policy)...)
 		}
 	}
-
-	out = append(out, diffEnums(base, live)...)
-	out = append(out, diffFlags(base, live)...)
-	out = append(out, diffUnions(base, live)...)
 	return out
 }
 
-func diffTokens(where string, bf, lf Field, policy map[string]TokenRule) []Finding {
+func diffTokens(where string, bf, lf Field, base, live *Unit, policy map[string]TokenRule) []Finding {
 	var out []Finding
 	seen := map[string]bool{}
 	for _, bt := range bf.Tokens {
 		seen[bt.Key] = true
-		rule := policy[bt.Key]
 		lv, present := lf.Get(bt.Key)
-		switch rule {
+		switch policy[bt.Key] {
 		case RuleFixed:
 			switch {
 			case !present:
@@ -152,18 +328,125 @@ func diffTokens(where string, bf, lf Field, policy map[string]TokenRule) []Findi
 				continue
 			}
 			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s -> %s (%s)", tokenNoun(bt.Key), bt.Value, lv, shrinkNote(bt.Key))})
+		case RuleRefs:
+			if f, moved := refsFinding(where, bt.Key, bt.Value, lv, present, base, live); moved {
+				out = append(out, f)
+			}
 		}
 	}
 	// a fact the live projection carries and the baseline does not: only the
-	// fixed rules care, and only because ADDING a default is as much a
+	// refusing rules care, and only because ADDING a default is as much a
 	// semantic edit as changing one
 	for _, lt := range lf.Tokens {
-		if seen[lt.Key] || policy[lt.Key] != RuleFixed {
+		if seen[lt.Key] {
 			continue
 		}
-		out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s added", tokenNoun(lt.Key), lt.Value)})
+		switch policy[lt.Key] {
+		case RuleFixed, RuleRefs:
+			out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s added", tokenNoun(lt.Key), lt.Value)})
+		}
 	}
 	return out
+}
+
+// refsFinding judges a token that NAMES another declaration. Renaming a
+// declaration moves no byte, so the question is never the name: it is whether
+// the new referent still carries what stored data was written against.
+func refsFinding(where, key, was, now string, present bool, base, live *Unit) (Finding, bool) {
+	if !present {
+		return Finding{Refuse, where, fmt.Sprintf("%s %s removed — the field keeps its wire kind, so no reader can report the change (SPEC-TABLES.md §4)", tokenNoun(key), was)}, true
+	}
+	if now == was {
+		return Finding{}, false
+	}
+	if why, rides := identitiesRide(key, was, now, base, live); !rides {
+		return Finding{Refuse, where, fmt.Sprintf("%s %s -> %s, and %s", tokenNoun(key), was, now, why)}, true
+	}
+	return Finding{}, false
+}
+
+// identitiesRide answers, per vocabulary, whether stored data written against
+// `was` still means the same thing under `now`. Each answer is that
+// vocabulary's own wire identity (SPEC-TABLES.md §3):
+//
+//   - a TABLE (a nested field, a union arm's payload) decodes by field id, so
+//     it rides when every field id the old table carried is still carried;
+//   - an ENUM value is its variant NAME hash, so it rides when every variant
+//     name survives;
+//   - a UNION body opens with its arm NAME hash, same rule;
+//   - a FLAGS mask is POSITIONAL and carries no names at all, so it rides only
+//     when the old declaration's variants sit at the same bits — a prefix.
+func identitiesRide(key, was, now string, base, live *Unit) (why string, rides bool) {
+	switch key {
+	case "flags":
+		var oldBits, newBits []string
+		for _, f := range base.Flags {
+			if f.Name == was {
+				oldBits = f.Variants
+			}
+		}
+		for _, f := range live.Flags {
+			if f.Name == now {
+				newBits = f.Variants
+			}
+		}
+		for i, v := range oldBits {
+			if i >= len(newBits) {
+				return fmt.Sprintf("%s declares no bit %d — every stored mask above bit %d loses its meaning, and nothing on the wire says so", now, i, i-1), false
+			}
+			if newBits[i] != v {
+				return fmt.Sprintf("bit %d was %s and is %s under %s — a mask carries bits, not names, so every stored file is remapped silently", i, v, newBits[i], now), false
+			}
+		}
+		return "", true
+	case "enum":
+		return ridesBySet(enumNames(base, was), enumNames(live, now), now,
+			"variant name", "stored values naming them read as None")
+	case "union":
+		return ridesBySet(armNames(base, was), armNames(live, now), now,
+			"arm name", "stored bodies naming them are skipped")
+	default: // "type", "payload" — a table body, decoded by field id
+		return ridesBySet(tableIdents(base).sets[was], tableIdents(live).sets[now], now,
+			"field id", "that much of every stored body reads back as declared defaults")
+	}
+}
+
+func ridesBySet(want, have map[string]bool, now, noun, consequence string) (string, bool) {
+	if have == nil {
+		return fmt.Sprintf("%s is not described by this baseline", now), false
+	}
+	if missing := len(want) - carried(want, have); missing > 0 {
+		return fmt.Sprintf("%d of %d %ss do not ride — %s", missing, len(want), noun, consequence), false
+	}
+	return "", true
+}
+
+func enumNames(u *Unit, name string) map[string]bool {
+	for _, e := range u.Enums {
+		if e.Name != name {
+			continue
+		}
+		set := map[string]bool{}
+		for _, v := range e.Variants {
+			set[v.Name] = true
+		}
+		return set
+	}
+	return nil
+}
+
+func armNames(u *Unit, name string) map[string]bool {
+	for _, un := range u.Unions {
+		if un.Name != name {
+			continue
+		}
+		set := map[string]bool{}
+		for _, a := range un.Arms {
+			set[a.Name] = true
+		}
+		return set
+	}
+	return nil
 }
 
 // shrinkNote says what a reader loses when one of the shrinkable extents
@@ -193,18 +476,47 @@ func tokenNoun(key string) string {
 		return "capacity"
 	case "key":
 		return "array key enum"
+	case "type":
+		return "nested table"
+	case "payload":
+		return "arm payload"
 	}
 	return key
 }
 
-func diffEnums(base, live *Unit) []Finding {
+func enumIdents(u *Unit) idents {
+	out := idents{sets: map[string]map[string]bool{}}
+	for _, e := range u.Enums {
+		out.names = append(out.names, e.Name)
+		set := map[string]bool{}
+		for _, v := range e.Variants {
+			set[fmt.Sprintf("%04x", v.Id)] = true
+		}
+		out.sets[e.Name] = set
+	}
+	return out
+}
+
+func diffEnums(base, live *Unit, policy map[string]TokenRule) []Finding {
 	var out []Finding
 	liveEnums := map[string]Enum{}
 	for _, e := range live.Enums {
 		liveEnums[e.Name] = e
 	}
+	baseIdents, liveIdents := enumIdents(base), enumIdents(live)
+	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
+
+	if policy["member"] == RuleLoss {
+		for _, name := range vanished {
+			out = append(out, vanishedFinding("enum", name, pair[name],
+				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
+		}
+	}
+	if policy["enum-variant"] != RuleLoss {
+		return out
+	}
 	for _, be := range base.Enums {
-		le, ok := liveEnums[be.Name]
+		le, ok := liveEnums[pair[be.Name]]
 		if !ok {
 			continue
 		}
@@ -214,8 +526,7 @@ func diffEnums(base, live *Unit) []Finding {
 		}
 		for _, v := range be.Variants {
 			if !have[v.Name] {
-				// stored values naming it now read as None and count unknown
-				out = append(out, Finding{Warn, "enum " + be.Name,
+				out = append(out, Finding{Warn, "enum " + le.Name,
 					fmt.Sprintf("variant %s removed — stored values naming it read as None and count unknown", v.Name)})
 			}
 		}
@@ -223,27 +534,76 @@ func diffEnums(base, live *Unit) []Finding {
 	return out
 }
 
-func diffUnions(base, live *Unit) []Finding {
+func unionIdents(u *Unit) idents {
+	out := idents{sets: map[string]map[string]bool{}}
+	for _, un := range u.Unions {
+		out.names = append(out.names, un.Name)
+		set := map[string]bool{}
+		for _, a := range un.Arms {
+			set[fmt.Sprintf("%04x", a.Id)] = true
+		}
+		out.sets[un.Name] = set
+	}
+	return out
+}
+
+func diffUnions(base, live *Unit, policy map[string]TokenRule) []Finding {
 	var out []Finding
 	liveUnions := map[string]Union{}
 	for _, u := range live.Unions {
 		liveUnions[u.Name] = u
 	}
+	baseIdents, liveIdents := unionIdents(base), unionIdents(live)
+	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
+
+	if policy["member"] == RuleLoss {
+		for _, name := range vanished {
+			out = append(out, vanishedFinding("union", name, pair[name],
+				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
+		}
+	}
 	for _, bu := range base.Unions {
-		lu, ok := liveUnions[bu.Name]
+		lu, ok := liveUnions[pair[bu.Name]]
 		if !ok {
 			continue
 		}
-		have := map[string]bool{}
+		arms := map[string]Variant{}
 		for _, a := range lu.Arms {
-			have[a.Name] = true
+			arms[a.Name] = a
 		}
 		for _, a := range bu.Arms {
-			if !have[a.Name] {
-				out = append(out, Finding{Warn, "union " + bu.Name,
-					fmt.Sprintf("arm %s removed — stored bodies naming it are skipped and count unknown", a.Name)})
+			la, still := arms[a.Name]
+			if !still {
+				if policy["union-arm"] == RuleLoss {
+					out = append(out, Finding{Warn, "union " + lu.Name,
+						fmt.Sprintf("arm %s removed — stored bodies naming it are skipped and count unknown", a.Name)})
+				}
+				continue
+			}
+			// an arm's PAYLOAD is a reference like a nested table's, judged
+			// the same way: the arm id still selects the arm, and what rides
+			// inside it is decided by whether the field ids ride
+			if policy["payload"] == RuleRefs {
+				if f, moved := refsFinding("union "+lu.Name+"."+a.Name, "payload", a.Payload, la.Payload, la.Payload != "", base, live); moved {
+					out = append(out, f)
+				}
 			}
 		}
+	}
+	return out
+}
+
+func flagsIdents(u *Unit) idents {
+	out := idents{sets: map[string]map[string]bool{}}
+	for _, f := range u.Flags {
+		out.names = append(out.names, f.Name)
+		set := map[string]bool{}
+		for _, v := range f.Variants {
+			// a mask carries no ids at all (SPEC-TABLES.md §3), so a flags
+			// declaration's identity is the set of variant NAMES it declares
+			set[v] = true
+		}
+		out.sets[f.Name] = set
 	}
 	return out
 }
@@ -251,14 +611,26 @@ func diffUnions(base, live *Unit) []Finding {
 // diffFlags is the one vocabulary with no names on the wire: bit i is variant
 // i, so the ORDER is the fact and APPEND AT THE END is the only safe edit
 // (SPEC-TABLES.md §4).
-func diffFlags(base, live *Unit) []Finding {
+func diffFlags(base, live *Unit, policy map[string]TokenRule) []Finding {
 	var out []Finding
 	liveFlags := map[string]Flags{}
 	for _, f := range live.Flags {
 		liveFlags[f.Name] = f
 	}
+	baseIdents, liveIdents := flagsIdents(base), flagsIdents(live)
+	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
+
+	if policy["member"] == RuleLoss {
+		for _, name := range vanished {
+			out = append(out, vanishedFinding("flags", name, pair[name],
+				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
+		}
+	}
+	if policy["flags-position"] != RuleFixed {
+		return out
+	}
 	for _, bf := range base.Flags {
-		lf, ok := liveFlags[bf.Name]
+		lf, ok := liveFlags[pair[bf.Name]]
 		if !ok {
 			continue
 		}
@@ -274,13 +646,13 @@ func diffFlags(base, live *Unit) []Finding {
 				// cannot tell a rename (which moves no byte) from a new
 				// meaning claimed on a spent bit (which remaps every stored
 				// file), so it refuses and makes the author say which.
-				out = append(out, Finding{Refuse, "flags " + bf.Name,
+				out = append(out, Finding{Refuse, "flags " + lf.Name,
 					fmt.Sprintf("bit %d was %s and is now %s — a spent bit stays spent; if that is a rename it moves no byte, and if bit %d now means something else every stored file is remapped", i, v, lf.Variants[i], i)})
 			case !ok:
-				out = append(out, Finding{Refuse, "flags " + bf.Name,
+				out = append(out, Finding{Refuse, "flags " + lf.Name,
 					fmt.Sprintf("variant %s removed from bit %d — a spent bit stays spent; retire the name and keep the position", v, i)})
 			case j != i:
-				out = append(out, Finding{Refuse, "flags " + bf.Name,
+				out = append(out, Finding{Refuse, "flags " + lf.Name,
 					fmt.Sprintf("variant %s moved from bit %d to bit %d — every stored file's bits are remapped, and nothing on the wire says so", v, i, j)})
 			}
 		}

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -1,5 +1,5 @@
 // The DIFF: live projection against committed baseline, and the judgment on
-// every way they can differ (SPEC-TABLES.md §16).
+// every way they can differ (SPEC-TABLES.md §18.2).
 //
 // The three verdicts, and the one question that assigns them: what does an
 // old file MEAN to a new reader?
@@ -491,6 +491,15 @@ func (d *differ) diffTokens(where string, bf, lf Field) []Finding {
 			}
 		case RuleShrink:
 			if !present || lv == bt.Value {
+				continue
+			}
+			// A KEYED ARRAY'S BOUND IS ITS KEY ENUM'S SIZE, and its slots ride
+			// under variant name ids (SPEC-TABLES.md §3.2): an unknown key is
+			// skipped and counted `unknown`, so there is no bounded prefix and
+			// nothing is clamped. The enum walk already reports each variant
+			// that went, correctly and by name — this row would say the wrong
+			// thing and say it a second time.
+			if shape, _ := bf.Get("array"); shape == "keyed" {
 				continue
 			}
 			was, err1 := strconv.ParseInt(bt.Value, 10, 64)

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -151,7 +151,7 @@ func diffTokens(where string, bf, lf Field, policy map[string]TokenRule) []Findi
 			if err1 != nil || err2 != nil || now >= was {
 				continue
 			}
-			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s -> %s (a count past the new bound keeps the prefix and counts clamped)", tokenNoun(bt.Key), bt.Value, lv)})
+			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s -> %s (%s)", tokenNoun(bt.Key), bt.Value, lv, shrinkNote(bt.Key))})
 		}
 	}
 	// a fact the live projection carries and the baseline does not: only the
@@ -164,6 +164,18 @@ func diffTokens(where string, bf, lf Field, policy map[string]TokenRule) []Findi
 		out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s added", tokenNoun(lt.Key), lt.Value)})
 	}
 	return out
+}
+
+// shrinkNote says what a reader loses when one of the shrinkable extents
+// shrinks — the runtime event is the same (clamped), the loss is not.
+func shrinkNote(key string) string {
+	switch key {
+	case "bound":
+		return "a stored count past the new bound keeps the bounded prefix and counts clamped"
+	case "size":
+		return "a stored value longer than the new capacity is truncated and counts clamped"
+	}
+	return "stored values past the new limit are clamped"
 }
 
 // tokenNoun names a token in a diagnostic the way a person would say it.

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -6,12 +6,21 @@
 //
 //   - REFUSE — the meaning changed and nothing on the wire says so. A
 //     specified default, a flags variant's bit position, a field's kind, a
-//     field's vocabulary swapped for another.
+//     field pointed at a declaration that cannot stand in for the old one.
 //   - WARN — the data survives but something is lost, and the read report
 //     says so at runtime (clamped, unknown). A shrunk bound, a removed enum
 //     variant or union arm, a closure member that is no longer covered.
 //   - PASS — the wire absorbs it. Fields added, removed, reordered or
 //     renamed under `was`; variants appended; bounds grown.
+//
+// TWO KINDS OF EDIT, AND THEY MUST NOT DOUBLE-JUDGE EACH OTHER. A declaration
+// edited IN PLACE is judged by its own walk, where the verdicts follow what
+// the runtime can report. A field REPOINTED at a different declaration is
+// judged by the referent rule, where the question is substitutability: can the
+// new declaration stand in for the old one for data already written? Renaming
+// a declaration is the first kind wearing the second's clothes, so a paired
+// rename (see pairMembers) is left to the walk — otherwise the same wire loss
+// would draw a harsher verdict merely because the author also renamed.
 //
 // ONE TABLE IS THE WHOLE POLICY. [DefaultTokenPolicy] maps a field token's key
 // to what a change of it means, and it carries a row for each of the four
@@ -63,11 +72,10 @@ const (
 	RuleShrink
 	// RuleLoss — something present in the baseline is gone; it warns.
 	RuleLoss
-	// RuleRefs — the token names another declaration in this file. Renaming
-	// that declaration moves no byte, so the edit is absorbed exactly when the
-	// new referent's IDENTITIES RIDE; otherwise stored data means something
-	// else under it and that is a refusal. What "ride" means is the referent's
-	// own identity rule (see identitiesRide).
+	// RuleRefs — the token names another declaration. Dropping it refuses;
+	// changing it to the declaration a rename paired it with is left to that
+	// declaration's own walk; changing it to any other is judged on whether
+	// the new one can STAND IN for the old (see substitutable).
 	RuleRefs
 )
 
@@ -89,12 +97,10 @@ var DefaultTokenPolicy = map[string]TokenRule{
 
 	// ---- a field's REFERENT, split by what it names ----
 	//
-	// A referent is judged on whether the DECLARATION IT NAMES still carries
-	// what the old one carried (RuleRefs). Dropping the referent entirely —
-	// an enum-typed field spelled as its raw uint16 — is always a refusal:
-	// SPEC-TABLES.md §4 states outright that an enum field and a plain uint16
-	// field are both kind 7, so the runtime cannot report the edit, which is
-	// the definition of this file's job.
+	// Dropping the referent — an enum-typed field respelled as its raw uint16
+	// — is always a refusal: SPEC-TABLES.md §4 states outright that both ride
+	// as kind 7, so the runtime cannot report the edit, which is the
+	// definition of this file's job.
 	"enum":    RuleRefs,
 	"flags":   RuleRefs,
 	"union":   RuleRefs,
@@ -129,12 +135,32 @@ func (f Finding) String() string { return f.Where + ": " + f.What }
 // passes, which shows the refusal came from THAT check and not from something
 // else in the walk.
 func Diff(base, live *Unit, policy map[string]TokenRule) []Finding {
+	d := &differ{base: base, live: live, policy: policy, visiting: map[string]bool{}}
+	renames := policy["member"] == RuleLoss
+	d.tables = pairMembers(tableIdents(base), tableIdents(live), renames)
+	d.enums = pairMembers(enumIdents(base), enumIdents(live), renames)
+	d.unions = pairMembers(unionIdents(base), unionIdents(live), renames)
+	d.flags = pairMembers(flagsIdents(base), flagsIdents(live), renames)
+
 	var out []Finding
-	out = append(out, diffTables(base, live, policy)...)
-	out = append(out, diffEnums(base, live, policy)...)
-	out = append(out, diffFlags(base, live, policy)...)
-	out = append(out, diffUnions(base, live, policy)...)
+	out = append(out, d.diffTables()...)
+	out = append(out, d.diffEnums()...)
+	out = append(out, d.diffFlags()...)
+	out = append(out, d.diffUnions()...)
 	return out
+}
+
+// a differ carries the two projections, the policy and the member pairings
+// through one diff — plus the set of referent comparisons currently open, so a
+// chain of simultaneous renames cannot walk in a circle.
+type differ struct {
+	base, live *Unit
+	policy     map[string]TokenRule
+	tables     pairing
+	enums      pairing
+	unions     pairing
+	flags      pairing
+	visiting   map[string]bool
 }
 
 // ---- matching members across a rename ----
@@ -146,6 +172,21 @@ type idents struct {
 	names []string
 	sets  map[string]map[string]bool
 }
+
+// a match is what became of one baseline member: the live declaration it maps
+// to and, when it is not a plain namesake, how much of its identity that
+// declaration actually carries.
+type match struct {
+	name      string // the live declaration, "" when nothing was close enough
+	closest   string // the best candidate considered, paired or not
+	carried   int    // identities of this member the candidate carries
+	total     int    // identities this member had
+	renamed   bool   // matched across a rename rather than by name
+	vanished  bool   // the baseline name is gone from the live projection
+	unmatched bool   // vanished, and no candidate reached the threshold
+}
+
+type pairing map[string]match
 
 // pairMembers matches baseline members onto live ones. Names first — the
 // ordinary case, and a declaration name is not on the wire. Then THE RENAME
@@ -162,14 +203,14 @@ type idents struct {
 // rename that also drops one of two arms is exactly the commit this rule
 // exists to catch; the uniqueness requirement keeps a tie from picking
 // arbitrarily. A member that pairs is judged in full under its new name. A
-// member that does not is a coverage loss, and either way vanished names it,
-// because a hole in the coverage has to be visible.
+// member that does not is a coverage loss, and either way the vanished name is
+// reported, because a hole in the coverage has to be visible.
 //
 // Pairing rides the `member` policy row with the warning, because they are one
 // feature: without the row there is no rename matching and no report of the
 // hole, which is the behaviour the row exists to replace.
-func pairMembers(base, live idents, allowRenames bool) (pair map[string]string, vanished []string) {
-	pair = map[string]string{}
+func pairMembers(base, live idents, allowRenames bool) pairing {
+	out := pairing{}
 	liveHas := map[string]bool{}
 	for _, n := range live.names {
 		liveHas[n] = true
@@ -183,7 +224,7 @@ func pairMembers(base, live idents, allowRenames bool) (pair map[string]string, 
 	var orphans []string
 	for _, n := range base.names {
 		if liveHas[n] {
-			pair[n] = n
+			out[n] = match{name: n, closest: n, carried: len(base.sets[n]), total: len(base.sets[n])}
 			taken[n] = true
 			continue
 		}
@@ -199,19 +240,13 @@ func pairMembers(base, live idents, allowRenames bool) (pair map[string]string, 
 	sort.Strings(candidates)
 
 	for _, o := range orphans {
-		vanished = append(vanished, o)
 		want := base.sets[o]
 		best, bestScore, tie := "", 0, false
 		for _, c := range candidates {
 			if taken[c] {
 				continue
 			}
-			score := 0
-			for id := range want {
-				if live.sets[c][id] {
-					score++
-				}
-			}
+			score := carried(want, live.sets[c])
 			switch {
 			case score > bestScore:
 				best, bestScore, tie = c, score, false
@@ -219,24 +254,36 @@ func pairMembers(base, live idents, allowRenames bool) (pair map[string]string, 
 				tie = true
 			}
 		}
+		m := match{closest: best, carried: bestScore, total: len(want), vanished: true}
 		if allowRenames && bestScore > 0 && !tie && bestScore*2 >= len(want) {
-			pair[o] = best
+			m.name, m.renamed = best, true
 			taken[best] = true
+		} else {
+			m.unmatched = true
 		}
+		out[o] = m
 	}
-	return pair, vanished
+	return out
 }
 
 // vanishedFinding reports a baseline member that is no longer in the closure
-// under its own name — paired with the declaration that looks like its rename,
-// or unpaired and therefore out of coverage entirely.
-func vanishedFinding(what, name, paired string, carried, total int) Finding {
-	if paired == "" {
-		return Finding{Warn, what + " " + name,
-			"no longer in the closure — nothing left carries its identities, so this baseline no longer covers it"}
+// under its own name. The unpaired message states what was actually found —
+// the closest candidate and its score — because on that path the message is
+// the only thing standing between a reader and the coverage hole.
+func vanishedFinding(what, name string, m match) Finding {
+	where := what + " " + name
+	if m.renamed {
+		return Finding{Warn, where, fmt.Sprintf(
+			"no longer in the closure under that name; %s carries %d of its %d identities, so it is judged as the rename it looks like",
+			m.name, m.carried, m.total)}
 	}
-	return Finding{Warn, what + " " + name,
-		fmt.Sprintf("no longer in the closure under that name; %s carries %d of its %d identities, so it is judged as the rename it looks like", paired, carried, total)}
+	if m.carried > 0 {
+		return Finding{Warn, where, fmt.Sprintf(
+			"no longer in the closure — the closest declaration, %s, carries %d of its %d identities, below the half needed to call it a rename, so this baseline no longer covers it",
+			m.closest, m.carried, m.total)}
+	}
+	return Finding{Warn, where,
+		"no longer in the closure — no declaration carries any of its identities, so this baseline no longer covers it"}
 }
 
 func carried(want, have map[string]bool) int {
@@ -247,6 +294,19 @@ func carried(want, have map[string]bool) int {
 		}
 	}
 	return n
+}
+
+func (d *differ) vanished(what string, p pairing, names []string) []Finding {
+	if d.policy["member"] != RuleLoss {
+		return nil
+	}
+	var out []Finding
+	for _, name := range names {
+		if m := p[name]; m.vanished {
+			out = append(out, vanishedFinding(what, name, m))
+		}
+	}
+	return out
 }
 
 // ---- the four walks ----
@@ -264,24 +324,19 @@ func tableIdents(u *Unit) idents {
 	return out
 }
 
-func diffTables(base, live *Unit, policy map[string]TokenRule) []Finding {
-	var out []Finding
+func (d *differ) diffTables() []Finding {
 	liveTables := map[string]Table{}
-	for _, t := range live.Tables {
+	for _, t := range d.live.Tables {
 		liveTables[t.Name] = t
 	}
-	baseIdents, liveIdents := tableIdents(base), tableIdents(live)
-	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
-
-	if policy["member"] == RuleLoss {
-		for _, name := range vanished {
-			out = append(out, vanishedFinding("table", name, pair[name],
-				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
-		}
+	names := make([]string, 0, len(d.base.Tables))
+	for _, t := range d.base.Tables {
+		names = append(names, t.Name)
 	}
+	out := d.vanished("table", d.tables, names)
 
-	for _, bt := range base.Tables {
-		lt, ok := liveTables[pair[bt.Name]]
+	for _, bt := range d.base.Tables {
+		lt, ok := liveTables[d.tables[bt.Name].name]
 		if !ok {
 			continue
 		}
@@ -298,19 +353,19 @@ func diffTables(base, live *Unit, policy map[string]TokenRule) []Finding {
 			if !ok {
 				continue
 			}
-			out = append(out, diffTokens(lt.Name+"."+lf.Name, bf, lf, base, live, policy)...)
+			out = append(out, d.diffTokens(lt.Name+"."+lf.Name, bf, lf)...)
 		}
 	}
 	return out
 }
 
-func diffTokens(where string, bf, lf Field, base, live *Unit, policy map[string]TokenRule) []Finding {
+func (d *differ) diffTokens(where string, bf, lf Field) []Finding {
 	var out []Finding
 	seen := map[string]bool{}
 	for _, bt := range bf.Tokens {
 		seen[bt.Key] = true
 		lv, present := lf.Get(bt.Key)
-		switch policy[bt.Key] {
+		switch d.policy[bt.Key] {
 		case RuleFixed:
 			switch {
 			case !present:
@@ -329,9 +384,7 @@ func diffTokens(where string, bf, lf Field, base, live *Unit, policy map[string]
 			}
 			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s -> %s (%s)", tokenNoun(bt.Key), bt.Value, lv, shrinkNote(bt.Key))})
 		case RuleRefs:
-			if f, moved := refsFinding(where, bt.Key, bt.Value, lv, present, base, live); moved {
-				out = append(out, f)
-			}
+			out = append(out, d.refsFindings(where, bt.Key, bt.Value, lv, present)...)
 		}
 	}
 	// a fact the live projection carries and the baseline does not: only the
@@ -341,7 +394,7 @@ func diffTokens(where string, bf, lf Field, base, live *Unit, policy map[string]
 		if seen[lt.Key] {
 			continue
 		}
-		switch policy[lt.Key] {
+		switch d.policy[lt.Key] {
 		case RuleFixed, RuleRefs:
 			out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s added", tokenNoun(lt.Key), lt.Value)})
 		}
@@ -349,76 +402,164 @@ func diffTokens(where string, bf, lf Field, base, live *Unit, policy map[string]
 	return out
 }
 
-// refsFinding judges a token that NAMES another declaration. Renaming a
-// declaration moves no byte, so the question is never the name: it is whether
-// the new referent still carries what stored data was written against.
-func refsFinding(where, key, was, now string, present bool, base, live *Unit) (Finding, bool) {
+// refsFindings judges a token that NAMES another declaration.
+//
+//   - Dropped entirely — refused: the field keeps its wire kind, so no reader
+//     can report it (SPEC-TABLES.md §4).
+//   - Changed to the declaration the RENAME PAIRING matched the old one with —
+//     silent here. It is the same declaration under a new name, and its own
+//     walk judges what changed inside it. Judging it twice would make the same
+//     wire loss draw a harsher verdict merely because the author also renamed.
+//   - Changed to anything else — the new declaration has to be able to STAND
+//     IN for the old one for data already written (see substitutable).
+func (d *differ) refsFindings(where, key, was, now string, present bool) []Finding {
 	if !present {
-		return Finding{Refuse, where, fmt.Sprintf("%s %s removed — the field keeps its wire kind, so no reader can report the change (SPEC-TABLES.md §4)", tokenNoun(key), was)}, true
+		return []Finding{{Refuse, where, fmt.Sprintf(
+			"%s %s removed — the field keeps its wire kind, so no reader can report the change (SPEC-TABLES.md §4)", tokenNoun(key), was)}}
 	}
-	if now == was {
-		return Finding{}, false
+	if now == was || d.pairedRename(key, was) == now {
+		return nil
 	}
-	if why, rides := identitiesRide(key, was, now, base, live); !rides {
-		return Finding{Refuse, where, fmt.Sprintf("%s %s -> %s, and %s", tokenNoun(key), was, now, why)}, true
+	// a chain of simultaneous renames must not walk in a circle
+	visit := key + ":" + was + "->" + now
+	if d.visiting[visit] {
+		return nil
 	}
-	return Finding{}, false
+	d.visiting[visit] = true
+	defer delete(d.visiting, visit)
+
+	found := d.substitutable(key, was, now)
+	out := make([]Finding, 0, len(found))
+	for _, f := range found {
+		out = append(out, Finding{f.Verdict, where, fmt.Sprintf("%s %s -> %s, and %s", tokenNoun(key), was, now, f.What)})
+	}
+	return out
 }
 
-// identitiesRide answers, per vocabulary, whether stored data written against
-// `was` still means the same thing under `now`. Each answer is that
-// vocabulary's own wire identity (SPEC-TABLES.md §3):
+// pairedRename reports the live declaration a vanished baseline declaration
+// was matched to, or "" when it was not matched across a rename.
+func (d *differ) pairedRename(key, was string) string {
+	var p pairing
+	switch key {
+	case "enum":
+		p = d.enums
+	case "flags":
+		p = d.flags
+	case "union":
+		p = d.unions
+	default:
+		p = d.tables
+	}
+	if m := p[was]; m.renamed {
+		return m.name
+	}
+	return ""
+}
+
+// substitutable asks whether `now` can stand in for `was` for data already
+// written, and answers in that vocabulary's own terms (SPEC-TABLES.md §3):
 //
-//   - a TABLE (a nested field, a union arm's payload) decodes by field id, so
-//     it rides when every field id the old table carried is still carried;
-//   - an ENUM value is its variant NAME hash, so it rides when every variant
-//     name survives;
+//   - a TABLE (a nested field, a union arm's payload) is read by field id, so
+//     it stands in when every id the old one carried is still carried AND THE
+//     FACTS UNDER THOSE IDS ARE UNCHANGED. Id membership alone is not enough:
+//     a twin declaration carrying the same id under a different specified
+//     default rewrites the meaning of every stored body, which is the flagship
+//     class this whole file exists to refuse.
+//   - an ENUM value is its variant NAME hash, so it stands in when every
+//     variant name survives;
 //   - a UNION body opens with its arm NAME hash, same rule;
-//   - a FLAGS mask is POSITIONAL and carries no names at all, so it rides only
-//     when the old declaration's variants sit at the same bits — a prefix.
-func identitiesRide(key, was, now string, base, live *Unit) (why string, rides bool) {
+//   - a FLAGS mask is POSITIONAL and carries no names at all, so it stands in
+//     only when the old declaration's variants sit at the same bits.
+func (d *differ) substitutable(key, was, now string) []Finding {
 	switch key {
 	case "flags":
-		var oldBits, newBits []string
-		for _, f := range base.Flags {
-			if f.Name == was {
-				oldBits = f.Variants
-			}
-		}
-		for _, f := range live.Flags {
-			if f.Name == now {
-				newBits = f.Variants
-			}
-		}
-		for i, v := range oldBits {
-			if i >= len(newBits) {
-				return fmt.Sprintf("%s declares no bit %d — every stored mask above bit %d loses its meaning, and nothing on the wire says so", now, i, i-1), false
-			}
-			if newBits[i] != v {
-				return fmt.Sprintf("bit %d was %s and is %s under %s — a mask carries bits, not names, so every stored file is remapped silently", i, v, newBits[i], now), false
-			}
-		}
-		return "", true
+		return bitsRide(flagsVariants(d.base, was), flagsVariants(d.live, now), now)
 	case "enum":
-		return ridesBySet(enumNames(base, was), enumNames(live, now), now,
+		return namesRide(enumNames(d.base, was), enumNames(d.live, now), now,
 			"variant name", "stored values naming them read as None")
 	case "union":
-		return ridesBySet(armNames(base, was), armNames(live, now), now,
+		return namesRide(armNames(d.base, was), armNames(d.live, now), now,
 			"arm name", "stored bodies naming them are skipped")
-	default: // "type", "payload" — a table body, decoded by field id
-		return ridesBySet(tableIdents(base).sets[was], tableIdents(live).sets[now], now,
-			"field id", "that much of every stored body reads back as declared defaults")
+	default: // "type", "payload" — a table body, read by field id
+		return d.bodyRides(was, now)
 	}
 }
 
-func ridesBySet(want, have map[string]bool, now, noun, consequence string) (string, bool) {
+// bodyRides compares two table declarations as a reader would meet them: the
+// ids that stop riding, then EVERY FACT the policy judges under the ids that
+// do. It reuses diffTokens, so the referent path and the in-place path can
+// never disagree about what a field fact means.
+func (d *differ) bodyRides(was, now string) []Finding {
+	before, after := findTable(d.base, was), findTable(d.live, now)
+	if after == nil {
+		return []Finding{{Refuse, "", now + " is not described by this baseline"}}
+	}
+	if before == nil {
+		return nil
+	}
+	liveFields := map[uint16]Field{}
+	for _, f := range after.Fields {
+		liveFields[f.Id] = f
+	}
+	var out []Finding
+	missing := 0
+	for _, bf := range before.Fields {
+		lf, ok := liveFields[bf.Id]
+		if !ok {
+			missing++
+			continue
+		}
+		for _, f := range d.diffTokens("", bf, lf) {
+			out = append(out, Finding{f.Verdict, "", fmt.Sprintf("%s's %s", bf.Name, f.What)})
+		}
+	}
+	if missing > 0 {
+		out = append(out, Finding{Refuse, "", fmt.Sprintf(
+			"%d of %d field ids do not ride — that much of every stored body reads back as declared defaults", missing, len(before.Fields))})
+	}
+	return out
+}
+
+func namesRide(want, have map[string]bool, now, noun, consequence string) []Finding {
 	if have == nil {
-		return fmt.Sprintf("%s is not described by this baseline", now), false
+		return []Finding{{Refuse, "", now + " is not described by this baseline"}}
 	}
 	if missing := len(want) - carried(want, have); missing > 0 {
-		return fmt.Sprintf("%d of %d %ss do not ride — %s", missing, len(want), noun, consequence), false
+		return []Finding{{Refuse, "", fmt.Sprintf("%d of %d %ss do not ride — %s", missing, len(want), noun, consequence)}}
 	}
-	return "", true
+	return nil
+}
+
+func bitsRide(oldBits, newBits []string, now string) []Finding {
+	for i, v := range oldBits {
+		if i >= len(newBits) {
+			return []Finding{{Refuse, "", fmt.Sprintf(
+				"%s declares no bit %d — every stored mask above bit %d loses its meaning, and nothing on the wire says so", now, i, i-1)}}
+		}
+		if newBits[i] != v {
+			return []Finding{{Refuse, "", fmt.Sprintf(
+				"bit %d was %s and is %s under %s — a mask carries bits, not names, so every stored file is remapped silently", i, v, newBits[i], now)}}
+		}
+	}
+	return nil
+}
+
+func findTable(u *Unit, name string) *Table {
+	for i := range u.Tables {
+		if u.Tables[i].Name == name {
+			return &u.Tables[i]
+		}
+	}
+	return nil
+}
+
+func flagsVariants(u *Unit, name string) []string {
+	for _, f := range u.Flags {
+		if f.Name == name {
+			return f.Variants
+		}
+	}
+	return nil
 }
 
 func enumNames(u *Unit, name string) map[string]bool {
@@ -497,26 +638,21 @@ func enumIdents(u *Unit) idents {
 	return out
 }
 
-func diffEnums(base, live *Unit, policy map[string]TokenRule) []Finding {
-	var out []Finding
+func (d *differ) diffEnums() []Finding {
 	liveEnums := map[string]Enum{}
-	for _, e := range live.Enums {
+	for _, e := range d.live.Enums {
 		liveEnums[e.Name] = e
 	}
-	baseIdents, liveIdents := enumIdents(base), enumIdents(live)
-	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
-
-	if policy["member"] == RuleLoss {
-		for _, name := range vanished {
-			out = append(out, vanishedFinding("enum", name, pair[name],
-				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
-		}
+	names := make([]string, 0, len(d.base.Enums))
+	for _, e := range d.base.Enums {
+		names = append(names, e.Name)
 	}
-	if policy["enum-variant"] != RuleLoss {
+	out := d.vanished("enum", d.enums, names)
+	if d.policy["enum-variant"] != RuleLoss {
 		return out
 	}
-	for _, be := range base.Enums {
-		le, ok := liveEnums[pair[be.Name]]
+	for _, be := range d.base.Enums {
+		le, ok := liveEnums[d.enums[be.Name].name]
 		if !ok {
 			continue
 		}
@@ -547,23 +683,19 @@ func unionIdents(u *Unit) idents {
 	return out
 }
 
-func diffUnions(base, live *Unit, policy map[string]TokenRule) []Finding {
-	var out []Finding
+func (d *differ) diffUnions() []Finding {
 	liveUnions := map[string]Union{}
-	for _, u := range live.Unions {
+	for _, u := range d.live.Unions {
 		liveUnions[u.Name] = u
 	}
-	baseIdents, liveIdents := unionIdents(base), unionIdents(live)
-	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
-
-	if policy["member"] == RuleLoss {
-		for _, name := range vanished {
-			out = append(out, vanishedFinding("union", name, pair[name],
-				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
-		}
+	names := make([]string, 0, len(d.base.Unions))
+	for _, u := range d.base.Unions {
+		names = append(names, u.Name)
 	}
-	for _, bu := range base.Unions {
-		lu, ok := liveUnions[pair[bu.Name]]
+	out := d.vanished("union", d.unions, names)
+
+	for _, bu := range d.base.Unions {
+		lu, ok := liveUnions[d.unions[bu.Name].name]
 		if !ok {
 			continue
 		}
@@ -574,7 +706,7 @@ func diffUnions(base, live *Unit, policy map[string]TokenRule) []Finding {
 		for _, a := range bu.Arms {
 			la, still := arms[a.Name]
 			if !still {
-				if policy["union-arm"] == RuleLoss {
+				if d.policy["union-arm"] == RuleLoss {
 					out = append(out, Finding{Warn, "union " + lu.Name,
 						fmt.Sprintf("arm %s removed — stored bodies naming it are skipped and count unknown", a.Name)})
 				}
@@ -582,11 +714,9 @@ func diffUnions(base, live *Unit, policy map[string]TokenRule) []Finding {
 			}
 			// an arm's PAYLOAD is a reference like a nested table's, judged
 			// the same way: the arm id still selects the arm, and what rides
-			// inside it is decided by whether the field ids ride
-			if policy["payload"] == RuleRefs {
-				if f, moved := refsFinding("union "+lu.Name+"."+a.Name, "payload", a.Payload, la.Payload, la.Payload != "", base, live); moved {
-					out = append(out, f)
-				}
+			// inside it is a table body read by field id
+			if d.policy["payload"] == RuleRefs {
+				out = append(out, d.refsFindings("union "+lu.Name+"."+a.Name, "payload", a.Payload, la.Payload, la.Payload != "")...)
 			}
 		}
 	}
@@ -611,26 +741,21 @@ func flagsIdents(u *Unit) idents {
 // diffFlags is the one vocabulary with no names on the wire: bit i is variant
 // i, so the ORDER is the fact and APPEND AT THE END is the only safe edit
 // (SPEC-TABLES.md §4).
-func diffFlags(base, live *Unit, policy map[string]TokenRule) []Finding {
-	var out []Finding
+func (d *differ) diffFlags() []Finding {
 	liveFlags := map[string]Flags{}
-	for _, f := range live.Flags {
+	for _, f := range d.live.Flags {
 		liveFlags[f.Name] = f
 	}
-	baseIdents, liveIdents := flagsIdents(base), flagsIdents(live)
-	pair, vanished := pairMembers(baseIdents, liveIdents, policy["member"] == RuleLoss)
-
-	if policy["member"] == RuleLoss {
-		for _, name := range vanished {
-			out = append(out, vanishedFinding("flags", name, pair[name],
-				carried(baseIdents.sets[name], liveIdents.sets[pair[name]]), len(baseIdents.sets[name])))
-		}
+	names := make([]string, 0, len(d.base.Flags))
+	for _, f := range d.base.Flags {
+		names = append(names, f.Name)
 	}
-	if policy["flags-position"] != RuleFixed {
+	out := d.vanished("flags", d.flags, names)
+	if d.policy["flags-position"] != RuleFixed {
 		return out
 	}
-	for _, bf := range base.Flags {
-		lf, ok := liveFlags[pair[bf.Name]]
+	for _, bf := range d.base.Flags {
+		lf, ok := liveFlags[d.flags[bf.Name].name]
 		if !ok {
 			continue
 		}

--- a/internal/baseline/file.go
+++ b/internal/baseline/file.go
@@ -1,5 +1,5 @@
 // The FILE side: where the baseline lives, when the check runs, and how
-// `--update` moves it (SPEC-TABLES.md §16).
+// `--update` moves it (SPEC-TABLES.md §18.1, §18.2, §18.4).
 package baseline
 
 import (
@@ -79,7 +79,7 @@ func Check(u *ir.Unit, paths []string) (warnings []string, errs []error) {
 	if err != nil {
 		// EVERY parse refusal names the remedy, in one place, and the remedy
 		// works: Update parses leniently and salvages the history section.
-		return nil, []error{fmt.Errorf("%w — regenerate it with: schema tables-baseline --update --reason \"...\", which preserves the %s section (SPEC-TABLES.md §16)", err, HistoryHeading)}
+		return nil, []error{fmt.Errorf("%w — regenerate it with: schema tables-baseline --update --reason \"...\", which preserves the %s section (SPEC-TABLES.md §18.4)", err, HistoryHeading)}
 	}
 	if base.Package != u.Package {
 		return nil, []error{fmt.Errorf("%s: baseline is for package %s, this unit is package %s — the baseline belongs to the unit it sits beside", path, base.Package, u.Package)}
@@ -90,7 +90,7 @@ func Check(u *ir.Unit, paths []string) (warnings []string, errs []error) {
 		warnings = append(warnings, fmt.Sprintf("%s: %s", path, w))
 	}
 	for _, r := range refusals {
-		errs = append(errs, fmt.Errorf("%s: %w — this edit changes what data already written MEANS, and no reader can report it; if you mean it, record it: schema tables-baseline --update --reason \"...\" (SPEC-TABLES.md §16)", path, r))
+		errs = append(errs, fmt.Errorf("%s: %w — this edit changes what data already written MEANS, and no reader can report it; if you mean it, record it: schema tables-baseline --update --reason \"...\" (SPEC-TABLES.md §18)", path, r))
 	}
 	return warnings, errs
 }
@@ -109,7 +109,7 @@ func Update(u *ir.Unit, paths []string, reason string) (path string, rewrote boo
 // update is Update with the date supplied, so tests are not dated by the clock.
 func update(u *ir.Unit, paths []string, reason, date string) (string, bool, error) {
 	if strings.TrimSpace(reason) == "" {
-		return "", false, fmt.Errorf("--update needs --reason: moving the baseline declares an intentional break with data already written, and the reason is what a person reads years later when an old file refuses (SPEC-TABLES.md §16)")
+		return "", false, fmt.Errorf("--update needs --reason: moving the baseline declares an intentional break with data already written, and the reason is what a person reads years later when an old file refuses (SPEC-TABLES.md §18.4)")
 	}
 	dirs := map[string]bool{}
 	var dir string

--- a/internal/baseline/file.go
+++ b/internal/baseline/file.go
@@ -137,9 +137,12 @@ func update(u *ir.Unit, paths []string, reason, date string) (string, bool, erro
 		base, err := Parse(path, data)
 		if err != nil {
 			live.History = salvageHistory(data)
+			// the committed file carries no machine paths: the reader of this
+			// history is on another machine, years later
 			entry = []string{
 				fmt.Sprintf("### %s — %s", date, reason),
-				fmt.Sprintf("- baseline REGENERATED over an unreadable one (%v); the projection is this unit as it stands and the history above is preserved, but the previous projection could not be diffed, so no per-edit lines follow", err),
+				fmt.Sprintf("- baseline REGENERATED over an unreadable one (%s); the projection is this unit as it stands and the history above is preserved, but the previous projection could not be diffed, so no per-edit lines follow",
+					strings.TrimPrefix(err.Error(), path+": ")),
 			}
 			break
 		}

--- a/internal/baseline/file.go
+++ b/internal/baseline/file.go
@@ -85,7 +85,7 @@ func Check(u *ir.Unit, paths []string) (warnings []string, errs []error) {
 
 	refusals, warns := Split(Diff(base, Render(u), DefaultTokenPolicy))
 	for _, w := range warns {
-		warnings = append(warnings, fmt.Sprintf("%s: %s (%s)", path, w, FileName))
+		warnings = append(warnings, fmt.Sprintf("%s: %s", path, w))
 	}
 	for _, r := range refusals {
 		errs = append(errs, fmt.Errorf("%s: %s — this edit changes what data already written MEANS, and no reader can report it; if you mean it, record it: schema tables-baseline --update --reason \"...\" (SPEC-TABLES.md §16)", path, r))
@@ -134,9 +134,13 @@ func update(u *ir.Unit, paths []string, reason, date string) (string, bool, erro
 		}
 		entry = historyEntry(date, reason, Diff(base, live, DefaultTokenPolicy))
 	} else if os.IsNotExist(readErr) {
+		noun := "tables"
+		if len(live.Tables) == 1 {
+			noun = "table"
+		}
 		entry = []string{
 			fmt.Sprintf("### %s — %s", date, reason),
-			fmt.Sprintf("- baseline created over %d tables — data written BEFORE this point is not covered by it", len(live.Tables)),
+			fmt.Sprintf("- baseline created over %d %s — data written BEFORE this point is not covered by it", len(live.Tables), noun),
 		}
 	} else {
 		return "", false, readErr

--- a/internal/baseline/file.go
+++ b/internal/baseline/file.go
@@ -1,0 +1,169 @@
+// The FILE side: where the baseline lives, when the check runs, and how
+// `--update` moves it (SPEC-TABLES.md §16).
+package baseline
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// Locate finds the unit's baseline file from the unit's source paths. A unit
+// is one directory (SPEC §3.2), so the answer is normally that directory's
+// tables.baseline.
+//
+// Two honest answers besides a path. When the paths span several directories
+// and NONE of them holds a baseline, there is nothing to check and ok is
+// false. When several of them do, the unit has no single baseline to diff
+// against and that is an error rather than a silent skip — a check that
+// quietly picks one would be a check that lies.
+func Locate(paths []string) (path string, ok bool, err error) {
+	seen := map[string]bool{}
+	var dirs []string
+	for _, p := range paths {
+		d := filepath.Dir(p)
+		if !seen[d] {
+			seen[d] = true
+			dirs = append(dirs, d)
+		}
+	}
+	sort.Strings(dirs)
+	if len(dirs) == 1 {
+		return filepath.Join(dirs[0], FileName), true, nil
+	}
+	var found []string
+	for _, d := range dirs {
+		p := filepath.Join(d, FileName)
+		if _, statErr := os.Stat(p); statErr == nil {
+			found = append(found, p)
+		}
+	}
+	switch len(found) {
+	case 0:
+		return "", false, nil
+	case 1:
+		return found[0], true, nil
+	default:
+		return "", false, fmt.Errorf("this unit's files span %d directories and %d of them hold a %s (%s) — a unit has one baseline; compile the unit as one directory (SPEC §3.2)",
+			len(dirs), len(found), FileName, strings.Join(found, ", "))
+	}
+}
+
+// Check diffs a checked unit against its committed baseline, when it has one.
+// No file means no check: the baseline is opt-in, and a unit that never
+// committed one is unaffected by any of this.
+//
+// Refusals come back as errors — they fail the compile — and warnings as text
+// for the caller's own reporting.
+func Check(u *ir.Unit, paths []string) (warnings []string, errs []error) {
+	path, ok, err := Locate(paths)
+	if err != nil {
+		return nil, []error{err}
+	}
+	if !ok {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	base, err := Parse(path, data)
+	if err != nil {
+		return nil, []error{err}
+	}
+	if base.Package != u.Package {
+		return nil, []error{fmt.Errorf("%s: baseline is for package %s, this unit is package %s — the baseline belongs to the unit it sits beside", path, base.Package, u.Package)}
+	}
+
+	refusals, warns := Split(Diff(base, Render(u), DefaultTokenPolicy))
+	for _, w := range warns {
+		warnings = append(warnings, fmt.Sprintf("%s: %s (%s)", path, w, FileName))
+	}
+	for _, r := range refusals {
+		errs = append(errs, fmt.Errorf("%s: %s — this edit changes what data already written MEANS, and no reader can report it; if you mean it, record it: schema tables-baseline --update --reason \"...\" (SPEC-TABLES.md §16)", path, r))
+	}
+	return warnings, errs
+}
+
+// Update rewrites the unit's baseline and appends a dated entry to its history
+// naming every edit it recorded and the reason for them. The reason is
+// MANDATORY — the owner's ruling: an intentional break is declared, never
+// slipped in — and Update refuses without one.
+//
+// It is idempotent: when the projection has not moved, the file is left
+// exactly as it sits and no history entry is written.
+func Update(u *ir.Unit, paths []string, reason string) (path string, rewrote bool, err error) {
+	return update(u, paths, reason, time.Now().UTC().Format("2006-01-02"))
+}
+
+// update is Update with the date supplied, so tests are not dated by the clock.
+func update(u *ir.Unit, paths []string, reason, date string) (string, bool, error) {
+	if strings.TrimSpace(reason) == "" {
+		return "", false, fmt.Errorf("--update needs --reason: moving the baseline declares an intentional break with data already written, and the reason is what a person reads years later when an old file refuses (SPEC-TABLES.md §16)")
+	}
+	dirs := map[string]bool{}
+	var dir string
+	for _, p := range paths {
+		dir = filepath.Dir(p)
+		dirs[dir] = true
+	}
+	if len(dirs) != 1 {
+		return "", false, fmt.Errorf("this unit's files span %d directories — a baseline belongs to one unit directory (SPEC §3.2); compile the unit as one directory", len(dirs))
+	}
+	path := filepath.Join(dir, FileName)
+
+	live := Render(u)
+	data, readErr := os.ReadFile(path)
+	var entry []string
+	if readErr == nil {
+		base, err := Parse(path, data)
+		if err != nil {
+			return "", false, err
+		}
+		live.History = base.History
+		if live.Text() == string(data) {
+			return path, false, nil
+		}
+		entry = historyEntry(date, reason, Diff(base, live, DefaultTokenPolicy))
+	} else if os.IsNotExist(readErr) {
+		entry = []string{
+			fmt.Sprintf("### %s — %s", date, reason),
+			fmt.Sprintf("- baseline created over %d tables — data written BEFORE this point is not covered by it", len(live.Tables)),
+		}
+	} else {
+		return "", false, readErr
+	}
+
+	if len(live.History) > 0 {
+		live.History = append(live.History, "")
+	}
+	live.History = append(live.History, entry...)
+	if err := os.WriteFile(path, []byte(live.Text()), 0o644); err != nil {
+		return "", false, err
+	}
+	return path, true, nil
+}
+
+// historyEntry is the intentional-break log's one entry: the date, the reason,
+// and one line per edit that changed what stored data means or loses. Edits the
+// wire absorbs are not listed — the projection above already records them, and
+// a history of them would bury the breaks it exists to show.
+func historyEntry(date, reason string, findings []Finding) []string {
+	entry := []string{fmt.Sprintf("### %s — %s", date, reason)}
+	refusals, warns := Split(findings)
+	for _, f := range append(refusals, warns...) {
+		entry = append(entry, fmt.Sprintf("- %s: %s [%s]", f.Where, f.What, f.Verdict))
+	}
+	if len(refusals) == 0 && len(warns) == 0 {
+		entry = append(entry, "- no compatibility-affecting edits; the wire absorbs the rest")
+	}
+	return entry
+}

--- a/internal/baseline/file.go
+++ b/internal/baseline/file.go
@@ -88,7 +88,7 @@ func Check(u *ir.Unit, paths []string) (warnings []string, errs []error) {
 		warnings = append(warnings, fmt.Sprintf("%s: %s", path, w))
 	}
 	for _, r := range refusals {
-		errs = append(errs, fmt.Errorf("%s: %s — this edit changes what data already written MEANS, and no reader can report it; if you mean it, record it: schema tables-baseline --update --reason \"...\" (SPEC-TABLES.md §16)", path, r))
+		errs = append(errs, fmt.Errorf("%s: %w — this edit changes what data already written MEANS, and no reader can report it; if you mean it, record it: schema tables-baseline --update --reason \"...\" (SPEC-TABLES.md §16)", path, r))
 	}
 	return warnings, errs
 }
@@ -123,7 +123,8 @@ func update(u *ir.Unit, paths []string, reason, date string) (string, bool, erro
 	live := Render(u)
 	data, readErr := os.ReadFile(path)
 	var entry []string
-	if readErr == nil {
+	switch {
+	case readErr == nil:
 		base, err := Parse(path, data)
 		if err != nil {
 			return "", false, err
@@ -133,7 +134,7 @@ func update(u *ir.Unit, paths []string, reason, date string) (string, bool, erro
 			return path, false, nil
 		}
 		entry = historyEntry(date, reason, Diff(base, live, DefaultTokenPolicy))
-	} else if os.IsNotExist(readErr) {
+	case os.IsNotExist(readErr):
 		noun := "tables"
 		if len(live.Tables) == 1 {
 			noun = "table"
@@ -142,7 +143,7 @@ func update(u *ir.Unit, paths []string, reason, date string) (string, bool, erro
 			fmt.Sprintf("### %s — %s", date, reason),
 			fmt.Sprintf("- baseline created over %d %s — data written BEFORE this point is not covered by it", len(live.Tables), noun),
 		}
-	} else {
+	default:
 		return "", false, readErr
 	}
 

--- a/internal/baseline/file.go
+++ b/internal/baseline/file.go
@@ -77,7 +77,9 @@ func Check(u *ir.Unit, paths []string) (warnings []string, errs []error) {
 	}
 	base, err := Parse(path, data)
 	if err != nil {
-		return nil, []error{err}
+		// EVERY parse refusal names the remedy, in one place, and the remedy
+		// works: Update parses leniently and salvages the history section.
+		return nil, []error{fmt.Errorf("%w — regenerate it with: schema tables-baseline --update --reason \"...\", which preserves the %s section (SPEC-TABLES.md §16)", err, HistoryHeading)}
 	}
 	if base.Package != u.Package {
 		return nil, []error{fmt.Errorf("%s: baseline is for package %s, this unit is package %s — the baseline belongs to the unit it sits beside", path, base.Package, u.Package)}
@@ -125,9 +127,21 @@ func update(u *ir.Unit, paths []string, reason, date string) (string, bool, erro
 	var entry []string
 	switch {
 	case readErr == nil:
+		// UPDATE PARSES LENIENTLY, and it has to: every parse refusal names
+		// this command as the remedy, so a baseline the parser rejects — a
+		// corrupt file, another tool's file, or one written by a compiler
+		// whose rendering version has since moved — must be repairable
+		// WITHOUT deleting the one artifact that cannot be regenerated. The
+		// projection is regenerated from the unit either way; the history is
+		// salvaged verbatim.
 		base, err := Parse(path, data)
 		if err != nil {
-			return "", false, err
+			live.History = salvageHistory(data)
+			entry = []string{
+				fmt.Sprintf("### %s — %s", date, reason),
+				fmt.Sprintf("- baseline REGENERATED over an unreadable one (%v); the projection is this unit as it stands and the history above is preserved, but the previous projection could not be diffed, so no per-edit lines follow", err),
+			}
+			break
 		}
 		live.History = base.History
 		if live.Text() == string(data) {
@@ -155,6 +169,28 @@ func update(u *ir.Unit, paths []string, reason, date string) (string, bool, erro
 		return "", false, err
 	}
 	return path, true, nil
+}
+
+// salvageHistory lifts the `## history` lines out of a baseline the parser
+// cannot read. It looks for the heading and nothing else, which is exactly why
+// it works on a file whose projection is unreadable: the history is prose the
+// compiler never interprets.
+func salvageHistory(data []byte) []string {
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	for i, line := range lines {
+		if line != HistoryHeading {
+			continue
+		}
+		history := lines[i+1:]
+		for len(history) > 0 && strings.TrimSpace(history[0]) == "" {
+			history = history[1:]
+		}
+		for len(history) > 0 && strings.TrimSpace(history[len(history)-1]) == "" {
+			history = history[:len(history)-1]
+		}
+		return history
+	}
+	return nil
 }
 
 // historyEntry is the intentional-break log's one entry: the date, the reason,

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -24,93 +24,32 @@ import (
 	"github.com/mas-bandwidth/schema/v2/ir"
 )
 
-// table-wire kinds (SPEC-TABLES.md) — the whole vocabulary of the neutral
-// wire: plain little-endian scalars, length-prefixed strings/bytes/tables.
+// table-wire kinds (SPEC-TABLES.md §3), named locally over the one
+// target-independent definition in ir — the vocabulary is wire law, and the
+// baseline projection reads the same mapping this emitter writes.
 const (
-	tkBool   = 1
-	tkI8     = 2
-	tkI16    = 3
-	tkI32    = 4
-	tkI64    = 5
-	tkU8     = 6
-	tkU16    = 7
-	tkU32    = 8
-	tkU64    = 9
-	tkF32    = 10
-	tkF64    = 11
-	tkString = 12
-	tkTable  = 13
-	tkArray  = 14
-	tkUnion  = 15
+	tkBool   = ir.TableKindBool
+	tkI8     = ir.TableKindI8
+	tkI16    = ir.TableKindI16
+	tkI32    = ir.TableKindI32
+	tkI64    = ir.TableKindI64
+	tkU8     = ir.TableKindU8
+	tkU16    = ir.TableKindU16
+	tkU32    = ir.TableKindU32
+	tkU64    = ir.TableKindU64
+	tkF32    = ir.TableKindF32
+	tkF64    = ir.TableKindF64
+	tkString = ir.TableKindString
+	tkTable  = ir.TableKindTable
+	tkArray  = ir.TableKindArray
+	tkUnion  = ir.TableKindUnion
 	// an ENUM-KEYED array body is its OWN kind (SPEC-TABLES.md §3.2): the
 	// positional array body and the keyed one are incompatible, so a reader
 	// meeting the other must see a KIND MISMATCH and skip, never misdecode.
-	tkKeyed = 16
+	tkKeyed = ir.TableKindKeyed
 )
 
-func tableScalarKind(f *ir.Field) int {
-	switch f.Type.Kind {
-	case ir.TBool:
-		return tkBool
-	case ir.TInt:
-		if f.Type.Signed {
-			switch f.Type.Width {
-			case 8:
-				return tkI8
-			case 16:
-				return tkI16
-			case 32:
-				return tkI32
-			default:
-				return tkI64
-			}
-		}
-		switch f.Type.Width {
-		case 8:
-			return tkU8
-		case 16:
-			return tkU16
-		case 32:
-			return tkU32
-		default:
-			return tkU64
-		}
-	case ir.TBits:
-		switch {
-		case f.Type.Width <= 8:
-			return tkU8
-		case f.Type.Width <= 16:
-			return tkU16
-		case f.Type.Width <= 32:
-			return tkU32
-		default:
-			return tkU64
-		}
-	case ir.TFloat32:
-		return tkF32
-	case ir.TFloat64:
-		return tkF64
-	case ir.TString:
-		return tkString
-	case ir.TBytes:
-		return tkArray
-	case ir.TNamed:
-		switch f.Type.Ref.(type) {
-		case *ir.Enum:
-			// an enum value rides as the u16 hash of its VARIANT NAME, whatever
-			// the declaration-side storage width (SPEC-TABLES.md §5): identity
-			// is the name here, exactly as it is for a field
-			return tkU16
-		case *ir.Flags:
-			return tkU64
-		case *ir.Struct:
-			return tkTable
-		case *ir.Union:
-			return tkUnion
-		}
-	}
-	return 0
-}
+func tableScalarKind(f *ir.Field) int { return ir.TableScalarKind(f) }
 
 func tableKindWidth(kind int) int {
 	switch kind {

--- a/internal/publicapi/publicapi_test.go
+++ b/internal/publicapi/publicapi_test.go
@@ -45,7 +45,7 @@ const (
 	corpusDir    = "../../examples"
 	corpus128Dir = "../../examples128"
 	// the tables corpora: the only ones that declare tables, and so the only
-	// ones the tables baseline has anything to say about
+	// ones the tables baseline has anything to say about.
 	tablesDir         = "../../tables/examples"
 	tablesPointersDir = "../../tables/pointers"
 )

--- a/internal/publicapi/publicapi_test.go
+++ b/internal/publicapi/publicapi_test.go
@@ -140,7 +140,7 @@ func TestExternalModuleBuildsTheCLI(t *testing.T) {
 		}
 	}
 
-	// the tables baseline (SPEC-TABLES.md §16) reads a corpus with tables in
+	// the tables baseline (SPEC-TABLES.md §18) reads a corpus with tables in
 	// it, so it runs over the tables corpora rather than the packet ones.
 	// Printing only: --update writes to the input tree, and this test measures
 	// the API, not the filesystem.

--- a/internal/publicapi/publicapi_test.go
+++ b/internal/publicapi/publicapi_test.go
@@ -44,6 +44,10 @@ import (
 const (
 	corpusDir    = "../../examples"
 	corpus128Dir = "../../examples128"
+	// the tables corpora: the only ones that declare tables, and so the only
+	// ones the tables baseline has anything to say about
+	tablesDir         = "../../tables/examples"
+	tablesPointersDir = "../../tables/pointers"
 )
 
 // repoRoot is the module root, absolute — the external module replaces the
@@ -133,6 +137,18 @@ func TestExternalModuleBuildsTheCLI(t *testing.T) {
 		}
 		if out := run(t, inRepo, "check", corpus); out != "" {
 			t.Errorf("check %s: success is silent by default, printed %q", corpus, out)
+		}
+	}
+
+	// the tables baseline (SPEC-TABLES.md §16) reads a corpus with tables in
+	// it, so it runs over the tables corpora rather than the packet ones.
+	// Printing only: --update writes to the input tree, and this test measures
+	// the API, not the filesystem.
+	for _, corpus := range []string{tablesDir, tablesPointersDir} {
+		want := run(t, inRepo, "tables-baseline", corpus)
+		got := run(t, external, "tables-baseline", corpus)
+		if got != want {
+			t.Errorf("tables-baseline %s diverged\n in-repo: %q\nexternal: %q", corpus, want, got)
 		}
 	}
 

--- a/ir/tablekind.go
+++ b/ir/tablekind.go
@@ -1,0 +1,129 @@
+// The TABLE-WIRE KIND vocabulary (SPEC-TABLES.md §3): the closed set of kind
+// bytes the neutral table wire carries, and the mapping from a declaration's
+// type onto it.
+//
+// It lives here, beside FieldId, because it is target-independent wire law:
+// the C++ backend emits it into codecs and descriptors, and the tables
+// baseline (internal/baseline) records it as the fact a reader keys a field's
+// payload on. Two copies of this mapping would be two wires.
+package ir
+
+// The kind numbers are WIRE FORMAT — frozen (SPEC-TABLES.md §3).
+const (
+	TableKindBool   = 1
+	TableKindI8     = 2
+	TableKindI16    = 3
+	TableKindI32    = 4
+	TableKindI64    = 5
+	TableKindU8     = 6
+	TableKindU16    = 7
+	TableKindU32    = 8
+	TableKindU64    = 9
+	TableKindF32    = 10
+	TableKindF64    = 11
+	TableKindString = 12
+	TableKindTable  = 13
+	TableKindArray  = 14
+	TableKindUnion  = 15
+	// an ENUM-KEYED array body is its OWN kind (SPEC-TABLES.md §3.2): the
+	// positional array body and the keyed one are incompatible, so a reader
+	// meeting the other must see a KIND MISMATCH and skip, never misdecode.
+	TableKindKeyed = 16
+)
+
+// TableScalarKind is the kind a field's ELEMENT rides under: the field's own
+// kind when it is not an array, and the element kind when it is. `bytes(N)`
+// answers TableKindArray, because it rides as an array of u8 and its element
+// kind is [TableElemKind]'s answer, not this one. A field whose type has no
+// table-wire kind (int128, fixed — refused in a table closure) answers 0.
+func TableScalarKind(f *Field) int {
+	switch f.Type.Kind {
+	case TBool:
+		return TableKindBool
+	case TInt:
+		if f.Type.Signed {
+			switch f.Type.Width {
+			case 8:
+				return TableKindI8
+			case 16:
+				return TableKindI16
+			case 32:
+				return TableKindI32
+			default:
+				return TableKindI64
+			}
+		}
+		switch f.Type.Width {
+		case 8:
+			return TableKindU8
+		case 16:
+			return TableKindU16
+		case 32:
+			return TableKindU32
+		default:
+			return TableKindU64
+		}
+	case TBits:
+		switch {
+		case f.Type.Width <= 8:
+			return TableKindU8
+		case f.Type.Width <= 16:
+			return TableKindU16
+		case f.Type.Width <= 32:
+			return TableKindU32
+		default:
+			return TableKindU64
+		}
+	case TFloat32:
+		return TableKindF32
+	case TFloat64:
+		return TableKindF64
+	case TString:
+		return TableKindString
+	case TBytes:
+		return TableKindArray
+	case TNamed:
+		switch f.Type.Ref.(type) {
+		case *Enum:
+			// an enum value rides as the u16 hash of its VARIANT NAME, whatever
+			// the declaration-side storage width (SPEC-TABLES.md §5): identity
+			// is the name here, exactly as it is for a field
+			return TableKindU16
+		case *Flags:
+			return TableKindU64
+		case *Struct:
+			return TableKindTable
+		case *Union:
+			return TableKindUnion
+		}
+	}
+	return 0
+}
+
+// TableFieldKind is the kind byte written for the FIELD itself: an
+// enum-keyed array is TableKindKeyed, any other array is TableKindArray, and
+// everything else is its scalar kind. An OPTIONAL field rides under the kind
+// of the value it holds — absence is the absence of the field, not a kind of
+// its own — which is what keeps `T` and `?T` wire-identical.
+func TableFieldKind(f *Field) int {
+	if f.KeyEnum != "" {
+		return TableKindKeyed
+	}
+	if f.Array != ArrayNone {
+		return TableKindArray
+	}
+	return TableScalarKind(f)
+}
+
+// TableElemKind is the element kind an array field's body opens with, and 0
+// for a field that is not an array on the wire. `bytes(N)` is an array of u8
+// (SPEC-TABLES.md §3) even though it declares no array bound.
+func TableElemKind(f *Field) int {
+	if f.Type.Kind == TBytes {
+		return TableKindU8
+	}
+	if f.Array != ArrayNone {
+		return TableScalarKind(f)
+	}
+	return 0
+}

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -16,10 +16,10 @@ table Debuff
     field amount id=0x39cc kind=4 default=0
 
 table LoadoutConfig
-    field grade id=0xd272 kind=7 type=Grade default=Silver
-    field grades id=0x301a kind=14 elem=7 type=Grade array=bounded bound=4
-    field podium id=0x088a kind=14 elem=7 type=Grade array=fixed bound=3
-    field perks id=0x2fc5 kind=9 type=Perks
+    field grade id=0xd272 kind=7 enum=Grade default=Silver
+    field grades id=0x301a kind=14 elem=7 enum=Grade array=bounded bound=4
+    field podium id=0x088a kind=14 elem=7 enum=Grade array=fixed bound=3
+    field perks id=0x2fc5 kind=9 flags=Perks
     field primary id=0x05f7 kind=13 type=WeaponConfig
     field backups id=0x1647 kind=14 elem=13 type=WeaponConfig array=fixed bound=2
     field attachments id=0x44d5 kind=14 elem=13 type=Attachment array=bounded bound=8
@@ -50,7 +50,7 @@ table WeaponConfig
     field penetration id=0x6557 kind=4 default=1
     field channel id=0x7366 kind=6
     field homing id=0xab40 kind=1
-    field effect id=0xe33a kind=15 type=Effect
+    field effect id=0xe33a kind=15 union=Effect
 
 table WideBlob
     field label id=0xe16a kind=12 size=70000

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -1,0 +1,76 @@
+schema-tables-baseline 1
+package tabledemo
+
+table ArchiveConfig
+    field root id=0x2eb8 kind=13 type=RootConfig
+    field count id=0xe445 kind=4 default=1
+
+table Attachment
+    field slot id=0x37e4 kind=4 default=0
+    field power id=0xd609 kind=10 default=1.0
+
+table Buff
+    field multiplier id=0x32e0 kind=10 default=1.0
+
+table Debuff
+    field amount id=0x39cc kind=4 default=0
+
+table LoadoutConfig
+    field grade id=0xd272 kind=7 type=Grade default=Silver
+    field grades id=0x301a kind=14 elem=7 type=Grade array=bounded bound=4
+    field podium id=0x088a kind=14 elem=7 type=Grade array=fixed bound=3
+    field perks id=0x2fc5 kind=9 type=Perks
+    field primary id=0x05f7 kind=13 type=WeaponConfig
+    field backups id=0x1647 kind=14 elem=13 type=WeaponConfig array=fixed bound=2
+    field attachments id=0x44d5 kind=14 elem=13 type=Attachment array=bounded bound=8
+
+table ProfileConfig
+    field name id=0x30df kind=12 size=32
+    field icon id=0xf3b0 kind=14 elem=6 size=16
+    field experience id=0x61d8 kind=8 default=0
+    field tilt id=0x023c kind=2
+    field heading id=0x885d kind=3
+    field timestamp id=0x67a0 kind=5
+    field badge id=0xb71c kind=6
+    field port id=0x6942 kind=7
+    field epoch id=0xf4bd kind=9
+    field precision id=0x96e0 kind=11
+    field ratings id=0x97dd kind=14 elem=10 array=fixed bound=4
+    field has_loadout id=0xb4db kind=1
+    field loadout id=0x9f78 kind=13 type=LoadoutConfig
+
+table RootConfig
+    field version_note id=0xe726 kind=12 size=16
+    field weapons id=0x91cd kind=14 elem=13 type=WeaponConfig array=bounded bound=8
+    field profiles id=0x73fd kind=14 elem=13 type=ProfileConfig array=bounded bound=4
+
+table WeaponConfig
+    field damage id=0x15a9 kind=10 default=21.0
+    field speed id=0x2e46 kind=10 default=500.0 was=velocity
+    field penetration id=0x6557 kind=4 default=1
+    field channel id=0x7366 kind=6
+    field homing id=0xab40 kind=1
+    field effect id=0xe33a kind=15 type=Effect
+
+table WideBlob
+    field label id=0xe16a kind=12 size=70000
+    field payload id=0x44aa kind=14 elem=6 size=70000
+    field samples id=0xaf9a kind=14 elem=7 array=bounded bound=70000
+
+enum Grade
+    variant Bronze id=0x3407
+    variant Silver id=0xa3e7
+    variant Gold id=0xda27
+
+flags Perks
+    variant Shielded bit=0
+    variant Cloaked bit=1
+    variant Turbo bit=2
+
+union Effect
+    arm buff id=0xeae6 payload=Buff
+    arm debuff id=0xb0d3 payload=Debuff
+
+## history
+### 2026-09-02 — the first baseline over the tables corpus
+- baseline created over 9 tables — data written BEFORE this point is not covered by it

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -15,6 +15,20 @@ table Buff
 table Debuff
     field amount id=0x39cc kind=4 default=0
 
+table GunnerConfig
+    field reaction id=0x900f kind=10 default=0.2
+    field tracking id=0x53d5 kind=1
+
+table HullConfig
+    field health id=0x8617 kind=10 default=100.0
+    field mass id=0xe7a6 kind=10 default=1.0
+    field turrets id=0x48ad kind=16 elem=13 type=TurretConfig array=keyed bound=4 key=Weapon
+
+table KeyedConfig
+    field teams id=0x9ae1 kind=16 elem=13 type=TeamConfig array=keyed bound=4 key=Team
+    field hulls id=0xeff5 kind=16 elem=13 type=HullConfig array=keyed bound=4 key=Hull
+    field scores id=0xdcf3 kind=13 type=ScoreBoard
+
 table LoadoutConfig
     field grade id=0xd272 kind=7 enum=Grade default=Silver
     field grades id=0x301a kind=14 elem=7 enum=Grade array=bounded bound=4
@@ -44,6 +58,18 @@ table RootConfig
     field weapons id=0x91cd kind=14 elem=13 type=WeaponConfig array=bounded bound=8
     field profiles id=0x73fd kind=14 elem=13 type=ProfileConfig array=bounded bound=4
 
+table ScoreBoard
+    field per_team id=0x443f kind=16 elem=4 array=keyed bound=4 key=Team
+
+table TeamConfig
+    field spawn_count id=0x3668 kind=4 default=4
+    field banner id=0x80e4 kind=12 size=16
+
+table TurretConfig
+    field damage id=0x15a9 kind=10 default=10.0
+    field cooldown id=0x2230 kind=10 default=0.5
+    field gunner id=0x2bc9 kind=13 type=GunnerConfig optional=true
+
 table WeaponConfig
     field damage id=0x15a9 kind=10 default=21.0
     field speed id=0x2e46 kind=10 default=500.0 was=velocity
@@ -62,6 +88,21 @@ enum Grade
     variant Silver id=0xa3e7
     variant Gold id=0xda27
 
+enum Hull
+    variant Interceptor id=0xf0f0
+    variant Gunship id=0xb534
+    variant Freighter id=0xb617
+
+enum Team
+    variant Red id=0xbb03
+    variant Blue id=0xf630
+    variant Green id=0x6e0f
+
+enum Weapon
+    variant Cannon id=0xf055
+    variant Missile id=0x16b3
+    variant Mine id=0x61bf
+
 flags Perks
     variant Shielded bit=0
     variant Cloaked bit=1
@@ -73,4 +114,4 @@ union Effect
 
 ## history
 ### 2026-09-02 — the first baseline over the tables corpus
-- baseline created over 9 tables — data written BEFORE this point is not covered by it
+- baseline created over 15 tables — data written BEFORE this point is not covered by it

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -1,4 +1,4 @@
-schema-tables-baseline 1
+schema-tables-baseline 2
 package tabledemo
 
 table ArchiveConfig

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -1,4 +1,4 @@
-schema-tables-baseline 2
+schema-tables-baseline 3
 package tabledemo
 
 table ArchiveConfig

--- a/tables/pointers/tables.baseline
+++ b/tables/pointers/tables.baseline
@@ -14,6 +14,12 @@ table Colour
     field g id=0xc40a kind=6
     field b id=0xcae9 kind=6
 
+table Depot
+    field name id=0x30df kind=12 size=12
+    field banks id=0x7f34 kind=16 elem=13 type=Layer array=keyed bound=3 key=Tier
+    field spare id=0x3a4f kind=13 type=Meta optional=true
+    field head id=0x79aa kind=13 type=ListNode
+
 table Layer
     field depth id=0x609f kind=4 default=0
     field head id=0x79aa kind=13 type=ListNode
@@ -58,6 +64,10 @@ table TreeNode
     field left id=0xfe3a kind=13 type=TreeNode
     field right id=0x5506 kind=13 type=TreeNode
 
+enum Tier
+    variant Low id=0x24fc
+    variant High id=0xb817
+
 ## history
 ### 2026-09-02 — the first baseline over the pointers corpus
-- baseline created over 11 tables — data written BEFORE this point is not covered by it
+- baseline created over 12 tables — data written BEFORE this point is not covered by it

--- a/tables/pointers/tables.baseline
+++ b/tables/pointers/tables.baseline
@@ -1,4 +1,4 @@
-schema-tables-baseline 1
+schema-tables-baseline 2
 package graphdemo
 
 table Album

--- a/tables/pointers/tables.baseline
+++ b/tables/pointers/tables.baseline
@@ -1,4 +1,4 @@
-schema-tables-baseline 2
+schema-tables-baseline 3
 package graphdemo
 
 table Album

--- a/tables/pointers/tables.baseline
+++ b/tables/pointers/tables.baseline
@@ -1,0 +1,63 @@
+schema-tables-baseline 1
+package graphdemo
+
+table Album
+    field name id=0x30df kind=12 size=16
+    field tint id=0x82b9 kind=13 type=Colour
+    field stamp id=0x0dc6 kind=13 type=Stamp
+    field marker id=0x866f kind=13 type=Marker
+    field pin id=0x69d5 kind=13 type=Marker
+    field head id=0x79aa kind=13 type=ListNode
+
+table Colour
+    field r id=0xb019 kind=6
+    field g id=0xc40a kind=6
+    field b id=0xcae9 kind=6
+
+table Layer
+    field depth id=0x609f kind=4 default=0
+    field head id=0x79aa kind=13 type=ListNode
+
+table ListNode
+    field value id=0x9194 kind=4
+    field name id=0x30df kind=12 size=12
+    field next id=0xd15e kind=13 type=ListNode
+
+table Marker
+    field label id=0xe16a kind=12 size=8
+    field note id=0x9da7 kind=13 type=Tally
+
+table Meta
+    field build id=0x3138 kind=4 default=1
+    field tag id=0xbc64 kind=12 size=8
+
+table Scene
+    field name id=0x30df kind=12 size=24
+    field version id=0xe8e6 kind=4 default=1
+    field head id=0x79aa kind=13 type=ListNode
+    field tree id=0x595e kind=13 type=TreeNode
+    field settings id=0x130e kind=13 type=Settings
+    field alias id=0xfc71 kind=13 type=ListNode
+    field ground id=0x5bdf kind=13 type=Layer
+    field layers id=0x1ee8 kind=14 elem=13 type=Layer array=bounded bound=4
+    field meta id=0xcea6 kind=13 type=Meta
+
+table Settings
+    field quality id=0xcaf3 kind=4 default=2
+    field label id=0xe16a kind=12 size=16
+
+table Stamp
+    field tag id=0xbc64 kind=12 size=8
+    field seq id=0xc29b kind=4 default=0
+
+table Tally
+    field hits id=0xb723 kind=4 default=0
+
+table TreeNode
+    field label id=0xe16a kind=12 size=12
+    field left id=0xfe3a kind=13 type=TreeNode
+    field right id=0x5506 kind=13 type=TreeNode
+
+## history
+### 2026-09-02 — the first baseline over the pointers corpus
+- baseline created over 11 tables — data written BEFORE this point is not covered by it


### PR DESCRIPTION
Closes #256. **Rebased onto `85becbf`, docs from main** — `SPEC.md`,
`SPEC-TABLES.md` and `USAGE.md` are byte-identical to main's, and this branch
touches no other doc but `VERSIONING.md`'s export note. The page's §18 carries
the policy; this is the implementation of it.

Two edits to a table schema change what data ALREADY WRITTEN means, and
neither one can be reported by any reader:

- **A specified default.** A field holding its default is elided
  (SPEC-TABLES.md §3), so the reader's declared default is what the absence
  MEANS. Change it and every stored file changes meaning — no report event
  fires, because nothing was lost or skipped.
- **A flags variant's position.** A mask carries bits, not names, so
  inserting or reordering a variant silently remaps every stored file.

The compiler retains no history and cannot see either edit on its own. This
PR gives it one, on the owner's terms: optional, diffable, and never moved
without a recorded reason.

## What lands

**`schema tables-baseline <unit>`** prints a canonical text projection of the
unit's table closure — members sorted, fields in declaration order, one fact
per line: name, wire id, kind, array shape with the bound's EVALUATED value,
string/bytes capacity, the specified default as exact canonical text
(evaluated, so a constant that moved through an expression into a default
shows up as the value it now produces), and the `was` alias; then each enum's
variants in order with their ids, each flags' variants positionally, and each
union's arms in order with their ids and payloads.

**`tables.baseline` in the unit directory turns the check on**, and nothing
else does — no file, no check. `schema check` (and so `schema generate`) then
diffs live against committed:

- **REFUSE, naming table.field and the edit** — a specified default changed,
  added or removed; a flags variant inserted, removed, reordered or RENAMED IN
  PLACE (a rename moves no byte, a new meaning on a spent bit remaps every
  stored file, and nothing distinguishes them — so the author says which); a
  field's wire kind or an array's element kind changed; a field's referent
  dropped or swapped for one whose identities do not ride; an enum-keyed
  array's key enum swapped, the day that construct exists.
- **WARN** — a bound or a capacity shrunk; an enum variant or union arm
  removed; a DECLARATION renamed, or otherwise no longer in the closure under
  its baseline name (a paired rename names what carries it on; an unpaired one
  names the closest candidate and its score). The runtime read report already
  counts what is lost (`clamped`, `unknown`), so this reports rather than
  stops.
- **PASS, in silence** — everything the wire absorbs: fields added, removed,
  reordered or renamed under `was`; variants added anywhere; flags variants
  APPENDED; bounds and capacities grown; bounded made fixed or the reverse.

**`schema tables-baseline --update --reason "<text>" <unit>`** rewrites the
file and appends a dated entry to the `## history` section inside it, naming
every edit it recorded, old value to new, beside the reason. `--update`
without `--reason` is refused. That history is the one record the wire lacks —
the log of every intentional break — and it is what a person consults years
later when an old save or an old tool file reads back wrong. It is idempotent:
a unit that has not moved rewrites nothing.

The type wire, the wire-shape projection and the protocol id are untouched
(§10); `TestTablesMoveNoProtocolId` is green.

## Design notes

- **One representation** serves rendering, parsing and diffing: a field is its
  name, its wire id and an ordered list of `key=value` tokens. The whole
  compatibility policy is then one table, `DefaultTokenPolicy`, mapping a
  token key to what a change of it means.
- **A declaration rename is followed, not lost.** A declaration name is not on
  the wire, so renaming one is absorbed — but it must not take everything
  inside the declaration out of coverage for that commit. Members match by
  name first, then across a rename by identity overlap: at least half of the
  vanished member's identities, uniquely. The vanished name warns either way,
  so a coverage hole is never invisible.
- **A field's referent must be able to STAND IN for the one it replaces**, and
  each vocabulary's standard is its own. A table body — and a union arm's
  payload, the same fact one level in — is read by field id, so it stands in
  when every id still rides AND THE FACTS UNDER THOSE IDS ARE UNCHANGED: a
  twin declaration carrying the same id under a different specified default
  rewrites the meaning of every stored body, and id membership alone would let
  it through. Those facts are judged by `diffTokens` itself, so the referent
  path and the in-place path cannot disagree about what a field fact means. An
  enum value is its variant name hash and a union body opens with its arm name
  hash, so those stand in when the names survive; a flags mask carries no names
  at all, so it stands in only when the old variants sit at the same bits.
  Dropping the referent — an enum-typed field respelled as its raw `uint16` —
  always refuses: SPEC-TABLES §4 says both ride as kind 7, so no reader can
  report it.
- **Two kinds of edit, and they never judge each other.** A declaration edited
  IN PLACE is judged by its own walk, where verdicts follow what the runtime
  can report; a field REPOINTED at a different declaration is judged by the
  referent rule, which asks about substitutability. A rename is the first
  wearing the second's clothes, so a PAIRED rename is left to the walk — the
  same wire loss draws the same verdict whether or not the author also
  renamed, and a test holds the two equal.
- **`--update` repairs a baseline the checker cannot read**, salvaging the
  `## history` section verbatim. Every parse refusal names that command as the
  remedy, so the remedy has to run — and the history is the one part of the
  file nothing can regenerate.
- **The constructs #265 landed are facts here too.** `?T` renders
  `optional=true` and is judged on NOTHING — T, ?T and *T are one framing
  (§3.1), so §18.1's "recorded and judged on nothing" is mechanical. `[E]T`
  renders `array=keyed bound=N key=E` under its own wire kind 16, so a
  keyed/positional spelling change refuses through the `kind` row, and swapping
  the key enum is judged by the referent rule under the ENUM standard, because a
  keyed array's slots ride under their variants' name ids (§3.2).
- **A key enum reaches the closure only through the array**, never through a
  field's own type, so the projection had to learn to walk `KeyEnumRef` — without
  it `Team`, `Hull` and `Weapon` were absent from the corpus baseline and every
  keyed collection's vocabulary was uncovered. Found by the fixtures, held by
  `TestKeyEnumIsCovered`.
- **A keyed array's bound is not an extent.** It IS the key enum's size, and the
  slots ride under variant name ids (§3.2): an unknown key is skipped and counted
  `unknown`, with no bounded prefix and nothing clamped. The extent row stands
  aside for a keyed shape — the enum walk already reports each variant that went,
  by name, once — while a positional array's shrunk bound still warns.
- **Fields match by WIRE ID, not by name.** The id is the identity a reader
  keys on, which is what makes a `was` rename pass and a bare rename read as
  the remove-plus-add that it is.
- **The table-wire kind mapping moved to `ir`.** The C++ backend held the only
  copy of SPEC-TABLES §3's kind vocabulary and the baseline records the same
  fact — two copies of a wire mapping are two wires. `cpptable` now names the
  one definition.

## Gates

- One fixture pair **per refusal class and per warn class**, each with two
  negative controls: the DISCRIMINATION control (the same field edited in the
  direction the wire absorbs — a bound grown, a flags variant appended, a field
  added) and the ATTRIBUTION control (the same edit re-judged with that one
  policy row removed, which must no longer produce that finding — what proves
  it came from the check under test and not from something else in the walk).
  Every class has both now: the four vocabulary walks are gated on their own
  policy rows (`member`, `flags-position`, `enum-variant`, `union-arm`), which
  is the seam the earlier revision's flags cases had no way to ablate through.
- Twelve absorbed edits that must pass in **silence** — a baseline that cries
  wolf is a baseline someone deletes.
- The committed corpus baselines (`tables/examples`, `tables/pointers`) pinned
  as goldens: regeneration must reproduce them byte for byte.
- `--update` without `--reason` refused; a foreign, unreadable or
  future-version baseline refused by name.
- `tables-baseline` added to the public-API command matrix, so the external
  module that rebuilds the CLI proves the new command too.
- Full battery, the zero-cost gate and the independence test green.

## Judgment calls, labelled

- **String/bytes capacity is in the warn class** beside the array bound. The
  issue named "a bound shrunk"; a capacity is a bound, and shrinking one
  truncates stored values exactly as a shrunk count clamps them.
- **Value ranges (`min`/`max`) are deliberately NOT recorded.** Tightening one
  clamps and the read report counts it, and the fact set the issue enumerated
  is the spec — the docs say so rather than leaving the omission silent.
- **A `type` in a table closure renders as `table`.** On the table wire the
  keyword that declared a closure member changes no byte.
- **A union arm's payload swap and a nested-table swap are one rule, not two.**
  The review filed the payload comparison separately; both are a table body
  read by field id, so both go through the same substitutability check rather
  than two rules that could drift apart.
- **The rendering `Version` is 3, and the rule for bumping it is written down.**
  ANY NEW JUDGED TOKEN BUMPS IT: a token this rendering emits and an older one
  did not reads as an ADDITION to every older file, and the added-token branch
  refuses an addition on every judged row — so an unbumped rendering greets an
  untouched schema with a refusal per field. Recording a fact nothing judges
  (an `optional`) does not need a bump; adding a rule (`key`, and earlier the
  `enum=`/`flags=`/`union=` split) does. A file at an older rendering gets one
  clean "regenerate it" refusal and keeps its history through `--update`. No
  released build has ever written a baseline, so the only files this has ever
  exposed are this branch's own intermediates.
- **The hook is on the driver, not in `check`.** `Compiler.TablesBaseline` +
  `Compiler.OnWarn` are the two new policy fields; `internal/check` is
  untouched, which keeps this rebasing cleanly under the other branches in
  flight.

## Open for the owner

**A removed FIELD passes in silence; a removed enum variant or union arm
WARNS** — and both produce the same runtime event, one `unknown` count
(SPEC-TABLES §4). Both readings are faithful to #256's own text, and the
rationale in §16 does not currently discriminate between them. Left as it
stands, flagged for a ruling rather than decided here.

## What the page states, and what the implementation also does

Two behaviours exist in the code that §18 does not describe. Both were added in
response to review and neither is in the spec text; flagging rather than
editing, since the docs come from main wholesale:

1. **The tie and the second question.** §18.3 says a vanished name is matched to
   the candidate carrying the most of its identities "when that is at least half
   of them **and unique**". The implementation goes further: when more than one
   candidate reaches that bar it decides on a second question — whose own facts
   under the shared ids are closest — and takes a candidate only when it wins
   both, strictly. Without that, a brand-new declaration reusing four field names
   outscores the real rename that dropped one, and collects four confident
   refusals for edits nobody made.
2. **A third unpaired message.** §18.3 lists two ("a paired one naming the
   declaration that carries it on, an unpaired one naming the closest candidate
   and its score"). There is a third: when two candidates cannot be separated,
   the warning names both. Under the two-message text a tie falls into the
   below-half wording and prints "carries 4 of its 4 identities, below the half
   needed" — a reason the numbers in the same sentence disprove.

Neither changes a verdict on data; both change what a person is told. A sentence
each in §18.3 would close the gap.

## Section numbering

Numbering follows the spec-of-record: this is `SPEC-TABLES.md §18` (§16 is the
JSON walk, §17 the packer). Every citation in the code names the subsection it
means — the check §18.2, the file §18.1, the override and its history §18.4, the
gate §18.6 — and `grep -rn "§16" --exclude='SPEC*.md' --exclude=USAGE.md` over the
tree comes back empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





