### PR TITLE
Tables: JSON in and out of one table over the reflection descriptors — §16 (#253)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ build/schema_test_guard: build/guard-generated/.stamp test/guard/main.cpp
 # The tables corpus (SPEC-TABLES.md): the tabledemo unit plus the
 # two-generation evolution pair (tblv1/tblv2), generated at build time into
 # build/ — test-only, never part of the committed generated/ tree.
-build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P2.schema test/tables/P3.schema
+build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P2.schema test/tables/P3.schema test/tables/JsonKeys.schema
 	@mkdir -p build/tables-generated
 	./bin/schema generate --lang cpp --out build/tables-generated/examples tables/examples
 	./bin/schema generate --lang cpp --out build/tables-generated/pointers tables/pointers
@@ -208,6 +208,7 @@ build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POI
 	./bin/schema generate --lang cpp --out build/tables-generated/p1 test/tables/P1.schema
 	./bin/schema generate --lang cpp --out build/tables-generated/p2 test/tables/P2.schema
 	./bin/schema generate --lang cpp --out build/tables-generated/p3 test/tables/P3.schema
+	./bin/schema generate --lang cpp --out build/tables-generated/jsonkeys test/tables/JsonKeys.schema
 	@touch $@
 
 # The ZERO-COST GATE (SPEC-TABLES.md): a table with no pointer in its by-value
@@ -227,6 +228,45 @@ tables-zero-cost: build/tables-generated/.stamp
 	done
 	@echo "tables zero-cost gate: value-only tables carry no pointer machinery"
 
+# The GENERIC-WALK GATE (SPEC-TABLES.md §16): the text form is ONE walk over
+# the reflection descriptors, not a per-table codec — that is the property
+# which makes it schema's rather than a packer's. The walker's source must
+# therefore be the SAME BYTES in every generated header of the corpus, whose
+# units disagree about packages, tables, kinds and pointer modes. The package
+# name lives in the guard and the namespace, outside the markers, so this is a
+# strict byte comparison with nothing normalised away.
+.PHONY: tables-json-walk
+tables-json-walk: build/tables-generated/.stamp
+	@rm -rf build/json-walk && mkdir -p build/json-walk
+	@for f in build/tables-generated/*/*Table.h; do \
+		out=build/json-walk/$$(echo $$f | tr / _); \
+		awk '/---- json walk: begin ----/,/---- json walk: end ----/' $$f > $$out; \
+		if [ ! -s $$out ]; then echo "GENERIC-WALK GATE FAILED: no walker in $$f"; exit 1; fi; \
+	done
+	@first=""; for f in build/json-walk/*; do \
+		if [ -z "$$first" ]; then first=$$f; else \
+			cmp -s $$first $$f || { echo "GENERIC-WALK GATE FAILED: the walker in $$f is not the walker in $$first"; exit 1; }; \
+		fi; \
+	done
+	@echo "tables generic-walk gate: one walker, byte-identical in $$(ls build/json-walk | wc -l | tr -d ' ') generated headers"
+
+# The NEGATIVE CONTROL for the walk (SPEC-TABLES.md §16.5). A green round-trip
+# suite proves nothing until the suite is shown capable of going red: the
+# walker's field-offset arithmetic is sabotaged by one field width, and the
+# round trip must FAIL on the first table with two fields. Attachment is that
+# table — two four-byte fields at offsets 0 and 4 — so the sabotage swaps them
+# and stays inside the struct.
+.PHONY: tables-json-negative-control
+tables-json-negative-control: bin/schema test/tables/json_negative_main.cpp
+	@rm -rf build/json-sabotage && mkdir -p build/json-sabotage
+	./bin/schema generate --lang cpp --out build/json-sabotage tables/examples
+	@sed -i.bak 's|const uint8_t \* storage = (const uint8_t \*) base + f->offset;|const uint8_t * storage = (const uint8_t *) base + ( f->offset ^ 4 );|' build/json-sabotage/TablesTable.h
+	@grep -q 'f->offset ^ 4' build/json-sabotage/TablesTable.h || { echo "NEGATIVE CONTROL: the sabotage did not apply"; exit 1; }
+	@mkdir -p build
+	$(CXX) -std=c++17 -Wall -Wextra -Werror -ffp-contract=off \
+		-Ibuild/json-sabotage test/tables/json_negative_main.cpp -o build/schema_test_json_negative
+	./build/schema_test_json_negative
+
 # Deliberately compiled WITHOUT -I$(SERIALIZE): the generated Table headers
 # carry no serialize dependency, and this build proves it stays that way.
 build/schema_test_tables: build/tables-generated/.stamp test/tables/main.cpp
@@ -235,6 +275,7 @@ build/schema_test_tables: build/tables-generated/.stamp test/tables/main.cpp
 		-Ibuild/tables-generated/examples -Ibuild/tables-generated/pointers -Itest/tables \
 		-Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
 		-Ibuild/tables-generated/p1 -Ibuild/tables-generated/p2 -Ibuild/tables-generated/p3 \
+		-Ibuild/tables-generated/jsonkeys \
 		test/tables/main.cpp -o $@
 
 build/schema_test_random: generated/cpp/.stamp test/random_main.cpp
@@ -390,6 +431,8 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	./build/schema_test_guard
 	./build/schema_test_tables
 	$(MAKE) tables-zero-cost
+	$(MAKE) tables-json-walk
+	$(MAKE) tables-json-negative-control
 	./build/schema_test_random
 	./build/schema_test_ludicrous
 	cd test/c && ../../build/schema_test_c

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -145,8 +145,12 @@ func TestGeneratedTableCodeAllocatesNothing(t *testing.T) {
 			t.Errorf("generated table code contains %q — generated codecs must not allocate", banned)
 		}
 	}
+	// every `new` in the header is a PLACEMENT new — `new ( address ) T{}`,
+	// which allocates nothing: the read path's in-place prefill, and the
+	// descriptor's reset hook (SPEC-TABLES.md §8) which is the same prefill
+	// behind a function pointer. An allocating new has no parenthesis after it.
 	for line := range strings.SplitSeq(table, "\n") {
-		if found := strings.Contains(line, "new "); found && !strings.Contains(line, "new ( &") && !strings.Contains(line, "<new>") {
+		if found := strings.Contains(line, "new "); found && !strings.Contains(line, "new (") && !strings.Contains(line, "<new>") {
 			t.Errorf("generated table code contains a non-placement new: %q", line)
 		}
 	}
@@ -213,17 +217,23 @@ func tableHeader(t *testing.T, src string) string {
 
 // TestZeroCostForValueOnlyTables is the mode's whole justification, at the
 // grain the property actually holds: a UNIT whose tables are all fixed-size
-// emits none of the pointer machinery — no builder, no arena, no reference
+// emits none of the POINTER machinery — no builder, no arena, no reference
 // type, no lifecycle surface, not one extra descriptor column, not one extra
 // include (SPEC-TABLES.md §2.2). Per TABLE the guarantee is narrower and
 // TestPointerSurfaceEmitted states it exactly.
+//
+// What the gate is NOT about: the reflection surface and the text form that
+// walks it ride in every table closure's header by design, fixed class
+// included (SPEC-TABLES.md §16.1), and <cstdlib> is one of the text form's
+// three number-conversion includes rather than the arena's — which is why it
+// left this list when the walk landed.
 func TestZeroCostForValueOnlyTables(t *testing.T) {
 	header := tableHeader(t, tableSrc)
 	for _, leak := range []string{
 		"TableArena", "TableSlot", "TableWorker", "TableRef", "TableRegion",
 		"kTableSegment", "kTableSlab", "kTableMaxDepth", "is_pointer", "variable",
 		"Builder", "LayoutId", "OpenWalk", "PackMeasure", "LoadMeasure",
-		"Cook", "Open", "<atomic>", "<cstdlib>", "template",
+		"Cook", "Open", "<atomic>", "template",
 	} {
 		if strings.Contains(header, leak) {
 			t.Errorf("pointer machinery leaked into a value-only unit: %q", leak)

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -508,6 +508,7 @@ var valuedAttr = map[string]bool{
 	"max":        true,
 	"resolution": true,
 	"was":        true,
+	"json":       true,
 }
 
 func (c *checker) enumMax(e *ast.MaxExpr) (*big.Int, bool) {
@@ -1151,6 +1152,9 @@ func (c *checker) resolveField(owner string, f *ast.Field, inTable bool) *ir.Fie
 		c.errf(f.Pos, "field %s: was is a table-wire concept — it aliases a renamed field's wire id, and only table fields have wire ids; a `type`'s wire is positional, so a rename there moves no bit (SPEC-TABLES.md)", f.Name)
 		return nil
 	}
+	// `json` outside a table CLOSURE is refused in checkTables, where the
+	// closure is known: a `type` a table reaches has a text form and may
+	// carry the attribute, and only membership decides it.
 
 	// the fixed and 128-bit families mirror serialize's own surface exactly
 	// (SPEC §4.3, runtime-first): fixed(I, F) and int128 are RANGED — the
@@ -1339,6 +1343,21 @@ func (c *checker) resolveAttrs(f *ast.Field, out *ir.Field) {
 				continue
 			}
 			out.WasName = lit.Value
+		case "json":
+			// the text form's key (SPEC-TABLES.md §16.3): the one attribute
+			// the JSON walk adds, so a declaration can meet an existing text.
+			// Table fields only — enforced below, where the owner's kind is
+			// known — and it moves no wire byte.
+			lit, ok := a.Value.(*ast.StringLit)
+			if !ok {
+				c.errf(a.Pos, `json takes the field's text key as a quoted string, e.g. json = "type" (SPEC-TABLES.md §16.3)`)
+				continue
+			}
+			if lit.Value == "" {
+				c.errf(a.Pos, "json = \"\" names nothing — json records the key this field reads and writes in the text form (SPEC-TABLES.md §16.3)")
+				continue
+			}
+			out.JsonKey = lit.Value
 		case "round":
 			// refused by name: rounding is not an attribute — it is the one
 			// fixed-point rule, half away from zero, everywhere (SPEC §4.3)
@@ -1726,6 +1745,22 @@ func (c *checker) checkTables() {
 			c.errf(pos, "table %s: the name collides with a member of the generated %sBuilder — a member function hides the type name it shares, and the header would not compile; rename the table (SPEC-TABLES.md §6.2)",
 				name, name)
 		}
+		// the TEXT form's keys (SPEC-TABLES.md §16.3): two fields of one
+		// closure member whose keys collide are indistinguishable in a JSON
+		// object, exactly as colliding ids are on the wire — refused once,
+		// naming both, whether the collision comes from a `json` attribute
+		// or from an attribute meeting a plain field name.
+		seenKey := map[string]*ir.Field{}
+		for _, f := range st.Fields {
+			key := ir.TableFieldJsonKey(f)
+			if prev, dup := seenKey[key]; dup {
+				c.errf(pos, "%s %s: fields %s and %s collide on the JSON key %q — rename one, or give one a different json key (SPEC-TABLES.md §16.3)",
+					what, name, describeTableJsonField(prev), describeTableJsonField(f), key)
+				continue
+			}
+			seenKey[key] = f
+		}
+
 		seen := map[uint16]*ir.Field{}
 		for _, f := range st.Fields {
 			if f.Type.Pointer {
@@ -1774,6 +1809,30 @@ func (c *checker) checkTables() {
 		}
 	}
 	c.checkTableVariantIdentity(names)
+	c.checkJsonKeysInClosure()
+}
+
+// checkJsonKeysInClosure refuses `json = "key"` on a field no table closure
+// reaches (SPEC-TABLES.md §16.3). The text form is the table closure's — a
+// `type` a table nests has one and may carry the attribute; a type nothing in
+// a closure reaches has no text form for a key to name.
+func (c *checker) checkJsonKeysInClosure() {
+	for _, name := range sortedKeys(c.structs) {
+		if c.tableClosure[name] {
+			continue
+		}
+		st := c.structs[name]
+		pos := ast.Pos{}
+		if d, ok := c.astDecls[name]; ok {
+			pos = d.DeclPos()
+		}
+		for _, f := range st.Fields {
+			if f.JsonKey != "" {
+				c.errf(pos, "type %s: field %s carries json = %q, but no table reaches %s — the text form is the table closure's, and a type outside one has none (SPEC-TABLES.md §16.3)",
+					name, f.Name, f.JsonKey, name)
+			}
+		}
+	}
 }
 
 // sortedKeys gives a map's keys in a stable order, so diagnostics do not
@@ -2039,6 +2098,15 @@ func declKindName(d ast.Decl) string {
 func describeTableField(f *ir.Field) string {
 	if f.WasName != "" {
 		return fmt.Sprintf("%s (was %q)", f.Name, f.WasName)
+	}
+	return f.Name
+}
+
+// describeTableJsonField names a field in a text-key diagnostic, showing the
+// `json` attribute where one carries the key.
+func describeTableJsonField(f *ir.Field) string {
+	if f.JsonKey != "" {
+		return fmt.Sprintf("%s (json %q)", f.Name, f.JsonKey)
 	}
 	return f.Name
 }

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2538,6 +2538,7 @@ var tableGeneratedVerbs = []string{
 	"LoadMeasure", "LoadMeasureBody", "LoadBuilder", "TableType", "Builder",
 	"At", "Root", "Emplace", "Pack", "PackMeasure", "OpenWalk",
 	"Cook", "CookMeasure", "Open", "LayoutId", "TableFields", "TableInfo",
+	"FromJson", "ToJson", "ToJsonMeasure",
 }
 
 // tableBuilderMembers are the member names of a generated <Name>Builder. A

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -43,6 +43,16 @@ func TestTableRefusals(t *testing.T) {
 			src: "package t\ntable Tab { speed float32 | was = \"\" }\n"},
 		{name: "was takes a quoted string", want: "was takes the field's old name as a quoted string",
 			src: "package t\ntable Tab { speed float32 | was = velocity }\n"},
+		{name: "json outside a table closure is refused by name", want: "the text form is the table closure's",
+			src: "package t\ntype P { a int32 | json = \"b\" }\n"},
+		{name: "json keys collide inside one table", want: "collide on the JSON key",
+			src: "package t\ntable Tab {\n    a int32 | json = \"b\"\n    b int32\n}\n"},
+		{name: "two json attributes naming one key", want: "collide on the JSON key",
+			src: "package t\ntable Tab {\n    a int32 | json = \"k\"\n    b int32 | json = \"k\"\n}\n"},
+		{name: "json takes a quoted string", want: "json takes the field's text key as a quoted string",
+			src: "package t\ntable Tab { a int32 | json = b }\n"},
+		{name: "json with an empty string", want: "json = \"\" names nothing",
+			src: "package t\ntable Tab { a int32 | json = \"\" }\n"},
 		{name: "effective wire ids collide (was aliases a live sibling)", want: "collide on table-wire id",
 			src: "package t\ntable Tab {\n    a int32 | was = \"b\"\n    b int32\n}\n"},
 		{name: "a table nesting itself is a composition cycle", want: "type composition cycle",
@@ -301,6 +311,63 @@ table Config
 	}
 	if base.ProtocolId != keyed.ProtocolId {
 		t.Fatalf("an optional field or a keyed array moved the protocol id %#x -> %#x", base.ProtocolId, keyed.ProtocolId)
+	}
+}
+
+// TestJsonKeyMovesNoWire is §16.3's independence requirement: the text form's
+// key is the TEXT's vocabulary and the wire id is the WIRE's, so declaring a
+// json key moves no byte on either wire — not a table field's id, not the
+// packet projection, not the protocol id. Keys are the text's business.
+func TestJsonKeyMovesNoWire(t *testing.T) {
+	plain := tablelessSrc + `
+table Config
+{
+    ship_type int32
+    label     string(32)
+}
+type Keyed
+{
+    weight float32
+}
+`
+	keyed := tablelessSrc + `
+table Config
+{
+    ship_type int32      | json = "type"
+    label     string(32) | json = "name"
+}
+type Keyed
+{
+    weight float32
+}
+`
+	before := buildUnit(t, plain)
+	after := buildUnit(t, keyed)
+
+	if ir.WireProjection(before) != ir.WireProjection(after) {
+		t.Fatalf("a json key changed the wire projection:\n--- without ---\n%s\n--- with ---\n%s",
+			ir.WireProjection(before), ir.WireProjection(after))
+	}
+	if before.ProtocolId != after.ProtocolId {
+		t.Fatalf("a json key moved the protocol id %#x -> %#x", before.ProtocolId, after.ProtocolId)
+	}
+	for i, f := range after.Tables["Config"].Fields {
+		was := before.Tables["Config"].Fields[i]
+		if ir.TableFieldId(f) != ir.TableFieldId(was) {
+			t.Errorf("field %s: a json key moved the table-wire id %#04x -> %#04x",
+				f.Name, ir.TableFieldId(was), ir.TableFieldId(f))
+		}
+		if ir.TableFieldId(f) != ir.FieldId(f.Name) {
+			t.Errorf("field %s: the wire id is not the hash of the SCHEMA name", f.Name)
+		}
+	}
+	// and the key itself is what the walk reads and writes under
+	if got := ir.TableFieldJsonKey(after.Tables["Config"].Fields[0]); got != "type" {
+		t.Errorf("json key = %q, want %q", got, "type")
+	}
+	// a field with no attribute keys under its own name
+	if got := ir.TableFieldJsonKey(before.Tables["Config"].Fields[0]); got != "ship_type" {
+		t.Errorf("default json key = %q, want the field name", got)
 	}
 }
 

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -1099,6 +1099,33 @@ func unionArmLambda(un *ir.Union, result string, arm func(ir.UnionVariant) strin
 	return b.String()
 }
 
+// resetLambda renders a type descriptor's reset column: placement-new
+// value-init, the same in-place prefill the read path uses, behind a
+// captureless lambda so the descriptor stays constant-initialisable.
+func resetLambda(name string) string {
+	return fmt.Sprintf("+[]( void * p ) { new ( p ) %s{}; }", name)
+}
+
+// unionArmsLambda renders a union field's arms column: a captureless lambda
+// whose function-pointer conversion is a constant expression, so a descriptor
+// that names it stays constant-initialised (SPEC-TABLES.md §8). The arms table
+// is a static inside it — no namespace-scope name to claim, and no first-use
+// state on the surface a caller sees.
+func (g *tableGen) unionArmsLambda(un *ir.Union, hoisted bool) string {
+	var b strings.Builder
+	b.WriteString("+[]() -> const TableUnionInfo * { static const TableUnionArmInfo arms[] = { { 0, NULL },")
+	for _, v := range un.Variants {
+		table := v.Type + "TableType()"
+		if hoisted {
+			table = "&" + v.Type + "TableInfo"
+		}
+		fmt.Fprintf(&b, " { (uint32_t) offsetof( %s, %s ), %s },", un.Name, v.Name, table)
+	}
+	fmt.Fprintf(&b, " }; static const TableUnionInfo info = { (uint32_t) offsetof( %s, type ), (uint32_t) sizeof( %s{}.type ), arms }; return &info; }",
+		un.Name, un.Name)
+	return b.String()
+}
+
 // bigToDouble renders a big.Int as a C++ double literal for the descriptor's
 // range fields (precision past 2^53 is documented as lost).
 func bigToDouble(v *big.Int) string {
@@ -1211,18 +1238,30 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 				rangeMin, rangeMax = formatFloat(f.FMin, false), formatFloat(f.FMax, false)
 			}
 
-			// the VOCABULARY columns: an enum's values and a union's arms are
-			// both a named set indexed by [0, enum_max], and each name carries
-			// the table-wire id it rides under (SPEC-TABLES.md §5, §8)
+			// the VOCABULARY columns: an enum's values, a union's arms and a
+			// flags field's BITS are each a named set indexed by
+			// [0, enum_max]. An enum's and a union's names carry the
+			// table-wire id they ride under; a flags variant has none, and
+			// that missing id is what tells the two apart at runtime
+			// (SPEC-TABLES.md §4, §5, §8).
 			enumMax := "-1"
 			enumName := "NULL"
 			variantId := "NULL"
+			arms := "NULL"
 			switch ref := f.Type.Ref.(type) {
 			case *ir.Enum:
 				if f.Type.Kind == ir.TNamed {
 					enumMax = fmt.Sprintf("%d", ref.Max)
 					enumName = fmt.Sprintf("+[]( uint64_t v ) { return EnumName( %s( v ) ); }", f.Type.Name)
 					variantId = fmt.Sprintf("+[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( %s( v ), id ); return id; }", f.Type.Name)
+				}
+			case *ir.Flags:
+				if f.Type.Kind == ir.TNamed {
+					// a flags mask is the wire's one POSITIONAL vocabulary
+					// (SPEC-TABLES.md §4): its variants are BIT POSITIONS, so
+					// the descriptor names bits, and there is no variant id.
+					enumMax = fmt.Sprintf("%d", len(ref.Variants)-1)
+					enumName = fmt.Sprintf("+[]( uint64_t v ) { return FlagName%s( (int) v ); }", f.Type.Name)
 				}
 			case *ir.Union:
 				if f.Type.Kind == ir.TNamed && f.Array == ir.ArrayNone {
@@ -1233,6 +1272,10 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 					variantId = unionArmLambda(ref, "uint16_t", func(v ir.UnionVariant) string {
 						return fmt.Sprintf("0x%04x", ir.VariantId(v.Name))
 					}, "0", "0")
+					arms = g.unionArmsLambda(ref, hoisted)
+					for _, v := range ref.Variants {
+						g.noteRef(v.Type)
+					}
 				}
 			}
 
@@ -1256,27 +1299,27 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 			if g.anyVariable {
 				pointerColumn = fmt.Sprintf("%v, ", f.Type.Pointer)
 			}
-			g.pf("%s    { \"%s\", \"%s\", 0x%04x, %d, %v, %s%v, %v, %d, (uint32_t) offsetof( %s, %s ), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, \"%s\" },\n",
-				indent, f.Name, tableFieldTypeName(f), id, kind, isArray, pointerColumn, counted, f.Type.Optional, bound,
+			g.pf("%s    { \"%s\", \"%s\", \"%s\", 0x%04x, %d, %v, %s%v, %v, %d, (uint32_t) offsetof( %s, %s ), %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, \"%s\" },\n",
+				indent, f.Name, ir.TableFieldJsonKey(f), tableFieldTypeName(f), id, kind, isArray, pointerColumn, counted, f.Type.Optional, bound,
 				st.Name, f.Name, elemSize, countOffset, presentOffset, table,
 				hasRange, rangeMin, rangeMax, enumMax, enumName, variantId,
-				keyTypeName, keyName, keyId, guards[f.Name])
+				keyTypeName, keyName, keyId, arms, guards[f.Name])
 		}
 		if hoisted {
 			g.pf("};\n")
-			g.pf("inline const TableTypeInfo %sTableInfo = { \"%s\", (uint32_t) sizeof( %s ), %d, %sTableFields%s };\n",
-				st.Name, st.Name, st.Name, len(st.Fields), st.Name, g.modeColumn(st))
+			g.pf("inline const TableTypeInfo %sTableInfo = { \"%s\", (uint32_t) sizeof( %s ), %d, %sTableFields, %s%s };\n",
+				st.Name, st.Name, st.Name, len(st.Fields), st.Name, resetLambda(st.Name), g.modeColumn(st))
 		} else {
 			g.pf("    };\n")
-			g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), %d, fields%s };\n",
-				infoQualifier, st.Name, st.Name, len(st.Fields), g.modeColumn(st))
+			g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), %d, fields, %s%s };\n",
+				infoQualifier, st.Name, st.Name, len(st.Fields), resetLambda(st.Name), g.modeColumn(st))
 		}
 	case hoisted:
-		g.pf("inline const TableTypeInfo %sTableInfo = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL%s };\n",
-			st.Name, st.Name, st.Name, g.modeColumn(st))
+		g.pf("inline const TableTypeInfo %sTableInfo = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL, %s%s };\n",
+			st.Name, st.Name, st.Name, resetLambda(st.Name), g.modeColumn(st))
 	default:
-		g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL%s };\n",
-			infoQualifier, st.Name, st.Name, g.modeColumn(st))
+		g.pf("    %s TableTypeInfo info = { \"%s\", (uint32_t) sizeof( %s ), 0, NULL, %s%s };\n",
+			infoQualifier, st.Name, st.Name, resetLambda(st.Name), g.modeColumn(st))
 	}
 	if hoisted {
 		g.pf("inline const TableTypeInfo * %sTableType() { return &%sTableInfo; }\n\n", st.Name, st.Name)

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -1230,6 +1230,15 @@ func (g *tableGen) emitTableDescriptor(st *ir.Struct) {
 
 			hasRange := "false"
 			rangeMin, rangeMax := "0.0", "0.0"
+			if f.Type.Kind == ir.TBits && !f.HasIntRange {
+				// bits(N) declares its range by its WIDTH: [0, 2^N - 1]. The
+				// codec has always clamped a read to it (SPEC-TABLES.md §4);
+				// carrying it here is what lets a generic walker apply the
+				// same bound without re-deriving it from the type name.
+				max := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), uint(f.Type.Width)), big.NewInt(1))
+				hasRange = "true"
+				rangeMin, rangeMax = "0.0", bigToDouble(max)
+			}
 			if f.HasIntRange {
 				hasRange = "true"
 				rangeMin, rangeMax = bigToDouble(f.IntMin), bigToDouble(f.IntMax)

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -298,9 +298,29 @@ struct TableReport
 
 struct TableTypeInfo;
 
+// One arm of a union field: where its payload sits inside the union's storage
+// and what its payload looks like. The arm's NAME and its table-wire id come
+// from the field's enum_name/variant_id functions at the same tag, so nothing
+// is spelled twice (SPEC-TABLES.md §8).
+struct TableUnionArmInfo
+{
+    uint32_t offset;             // offsetof the arm's payload within the union storage
+    const TableTypeInfo * table; // the arm payload's descriptor
+};
+
+// A union field's shape: the tag, and the arms indexed by it. Arms run
+// [0, enum_max]; index 0 is the EMPTY arm and carries no payload.
+struct TableUnionInfo
+{
+    uint32_t tag_offset; // offsetof the tag within the union storage
+    uint32_t tag_size;   // sizeof the tag
+    const TableUnionArmInfo * arms;
+};
+
 struct TableFieldInfo
 {
     const char * name;      // schema field name, e.g. "health"
+    const char * json;      // the TEXT form's key: the json = "key" attribute, else name (§16.3)
     const char * type_name; // schema type name, e.g. "float32", "Grade"
     uint16_t id;            // table-wire field id (name hash; the was alias's hash after a rename)
     uint8_t kind;           // table-wire kind; for arrays/strings/bytes, the ELEMENT kind
@@ -317,12 +337,18 @@ struct TableFieldInfo
     double range_min;       // NOTE: int64 ranges beyond 2^53 lose precision here
     double range_max;
     int64_t enum_max;       // enums: highest valid value (None = 0 always valid);
-                            // unions: the arm count (tag range [0, enum_max]); else -1
-    const char * (*enum_name)( uint64_t value ); // enums: value -> name; unions: tag -> arm name; else NULL
+                            // unions: the arm count (tag range [0, enum_max]);
+                            // flags: the highest declared BIT INDEX; else -1
+    // the vocabulary's names, indexed the same way enum_max bounds: an enum's
+    // value -> name, a union's tag -> arm name, a FLAGS field's bit index ->
+    // variant name. NULL for every other kind.
+    const char * (*enum_name)( uint64_t value );
     // the TABLE-WIRE id of one variant (SPEC-TABLES.md §5): for an enum, the
     // hash of the variant's name; for a union, the hash of the arm's name.
     // 0 is the reserved id — an enum's None, a union's empty. NULL for every
-    // other kind. Walk [0, enum_max] to enumerate a vocabulary and its ids.
+    // other kind — a FLAGS field's variants have no per-variant wire id (§4),
+    // so a NULL here beside a non-NULL enum_name is what says "flags".
+    // Walk [0, enum_max] to enumerate a vocabulary and its ids.
     uint16_t (*variant_id)( uint64_t value );
     // an ENUM-KEYED array (SPEC-TABLES.md §2.4): the array has one slot per
     // variant of key_type_name, indexed by the variant's value, and its slots
@@ -332,6 +358,11 @@ struct TableFieldInfo
     const char * key_type_name;
     const char * (*key_name)( uint64_t value );
     uint16_t (*key_id)( uint64_t value );
+    // union fields: the tag and its arms, behind a function so the whole
+    // descriptor stays CONSTANT-INITIALISED (a captureless lambda converts to
+    // a function pointer at compile time; the arms themselves are a static
+    // inside it). NULL for every other kind.
+    const TableUnionInfo * (*arms)();
     const char * guard;     // branch guard, e.g. "at_rest" or "!at_rest"; "" if unguarded
 };
 
@@ -340,7 +371,13 @@ struct TableTypeInfo
     const char * name;   // schema type name
     uint32_t size;       // sizeof the storage struct
     int32_t num_fields;
-    const TableFieldInfo * fields;` + pointerTypeMember + `
+    const TableFieldInfo * fields;
+    // put one instance back at its declared defaults, in place. A generic
+    // walker that fills a value has to be able to establish the defaults an
+    // absent field takes, and it holds no type to spell — this is the one
+    // thing the descriptors could not express without it. Placement-new
+    // value-init, exactly what the wire's read path does, and no temporary.
+    void (*reset)( void * storage );` + pointerTypeMember + `
 };
 
 struct TableWriter

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -286,6 +286,10 @@ struct TableReport
     int32_t unknown = 0;       // unknown field ids skipped (newer data)
     int32_t kind_mismatch = 0; // known id, changed type — skipped, never misdecoded
     int32_t clamped = 0;       // out-of-range values clamped to declared bounds
+    // a key the TEXT form saw twice: last wins, and the repeat is counted
+    // (SPEC-TABLES.md §16.2). The wire never raises it — a body carrying an
+    // id twice is legal input whose last occurrence wins, silently (§3).
+    int32_t duplicate = 0;
     bool malformed = false;    // framing damage; decode stopped, partial result kept
 };
 
@@ -532,6 +536,15 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 				g.owner = st
 				g.emitTableDescriptor(st)
 			}
+			// the TEXT form's surface (SPEC-TABLES.md §16), emitted AFTER the
+			// descriptors it names: three thin wrappers per fixed-size member
+			// over the one generic walk. No per-table codec, which is the
+			// property that makes the text form schema's rather than a
+			// packer's — and the gate that holds it.
+			g.pf("// ---- the text form (SPEC-TABLES.md §16) ----\n\n")
+			for _, st := range members {
+				g.emitJsonSurface(st)
+			}
 		} else {
 			g.pf("// no tables declared or referenced in this file — codecs are emitted\n")
 			g.pf("// for the table closure only (`table` declarations and what they reach)\n")
@@ -542,10 +555,14 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		h.WriteString("// The TABLE wire (evolution-tolerant, SPEC-TABLES.md): no serialize\n")
 		h.WriteString("// dependency — includable from any TU.\n\n")
 		h.WriteString("#pragma once\n\n#include <cstdint>\n#include <cstring>\n#include <cstddef> // offsetof, for the reflection descriptors\n#include <new> // in-place prefill (placement new): no giant stack temporaries\n#include <type_traits> // the enforced relocatability asserts\n")
+		// the TEXT form (SPEC-TABLES.md §16) rides in every table header, as
+		// the reflection surface does — it is one generic walk over those same
+		// descriptors, and a closure that carries the descriptors carries the
+		// walk. Number conversion is its only runtime dependency.
+		h.WriteString("#include <cstdio> // the text form: number formatting\n#include <cstdlib> // the text form: exact number conversion\n#include <clocale> // the text form: the runtime's decimal point\n")
 		if anyVariable {
 			// VARIABLE-LENGTH tables only: a unit of pointer-free tables pays
 			// for neither header (SPEC-TABLES.md §2, the zero-cost gate)
-			h.WriteString("#include <cstdlib> // the arena's segments (the AUTHORING path may allocate)\n")
 			h.WriteString("#include <atomic> // one atomic per slab: the arena is lock-free by ownership\n")
 		}
 		if anyKeyed {
@@ -572,6 +589,8 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		}
 		h.WriteString("\n")
 		h.WriteString(tablePrimitives(u.Package, anyVariable, anyKeyed))
+		h.WriteString("\n")
+		h.WriteString(tableJsonWalk(u.Package))
 		if anyVariable {
 			h.WriteString("\n")
 			h.WriteString(tableArenaRuntime(u.Package))

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -423,9 +423,10 @@ inline bool TableJsonWriteScalar( TableJsonOut & out, const void * storage, cons
         {
             return false; // a tag no arm names, exactly as measure refuses it
         }
+        const char * arm = f->enum_name( tag );
         out.put( '{' );
         out.line( depth + 1 );
-        TableJsonWriteString( out, f->enum_name( tag ), (int32_t) strlen( f->enum_name( tag ) ) );
+        TableJsonWriteString( out, arm, (int32_t) strlen( arm ) );
         out.raw( ": ", 2 );
         if ( !TableJsonWriteValue( out, (const uint8_t *) storage + arms->arms[tag].offset, arms->arms[tag].table, depth + 1 ) )
         {
@@ -904,14 +905,21 @@ inline bool TableJsonSkipValue( TableJsonIn & in, int32_t depth )
         case 0:   in.bad = true; return false;
         default:
         {
-            char token[kTableJsonMaxNumber];
-            int32_t length = 0;
-            bool integral = false;
-            if ( !TableJsonScanNumber( in, token, kTableJsonMaxNumber, &length, &integral ) )
+            // consumed, never converted: skipping needs no buffer, and this
+            // is the one walk a hostile text drives to the depth cap
+            TableJsonSpace( in );
+            int64_t start = in.pos;
+            bool digits = false;
+            while ( in.pos < in.size )
             {
-                in.bad = true;
-                return false;
+                char n = in.text[in.pos];
+                bool numeric = ( n >= '0' && n <= '9' ) || n == '-' || n == '+' ||
+                               n == '.' || n == 'e' || n == 'E';
+                if ( !numeric ) { break; }
+                if ( n >= '0' && n <= '9' ) { digits = true; }
+                in.pos++;
             }
+            if ( in.pos == start || !digits ) { in.bad = true; return false; }
             return true;
         }
     }

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -96,6 +96,22 @@ inline char TableJsonDecimalPoint()
 // ---- storage is the HOST's, so every load and store goes through a width
 // ---- switch rather than a memcpy into the low bytes of a wider word
 
+// finite: not a NaN, not an infinity. Written without <cmath> — the walk's
+// runtime surface stays the handful of functions it already names.
+// A vocabulary entry the descriptor could not spell. The generated name
+// functions answer "???" for a value outside the declared set, and that is
+// not a name — writing it would put a spelling in the text that the reader
+// then counts as unknown, turning a refusal into a silent loss.
+inline bool TableJsonNamed( const char * name )
+{
+    return name != NULL && strcmp( name, "???" ) != 0;
+}
+
+inline bool TableJsonFinite( double v )
+{
+    return v == v && v <= 1.7976931348623157e308 && v >= -1.7976931348623157e308;
+}
+
 inline uint64_t TableJsonGetRaw( const void * storage, uint32_t width )
 {
     switch ( width )
@@ -301,6 +317,43 @@ inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int3
     out.put( '"' );
 }
 
+// One UTF-8 sequence at s, or -1 when the bytes there are not one. Rejects
+// the lot: a stray continuation, an overlong form, a surrogate half, and
+// anything past U+10FFFF.
+inline int32_t TableJsonUtf8( const char * s, int32_t remaining, int32_t * width )
+{
+    unsigned char lead = (unsigned char) s[0];
+    int32_t want = 0;
+    int32_t code = 0;
+    if ( lead < 0x80 ) { *width = 1; return lead; }
+    else if ( lead >= 0xc2 && lead <= 0xdf ) { want = 2; code = lead & 0x1f; }
+    else if ( lead >= 0xe0 && lead <= 0xef ) { want = 3; code = lead & 0x0f; }
+    else if ( lead >= 0xf0 && lead <= 0xf4 ) { want = 4; code = lead & 0x07; }
+    else { return -1; }
+    if ( remaining < want ) { return -1; }
+    for ( int32_t i = 1; i < want; i++ )
+    {
+        unsigned char next = (unsigned char) s[i];
+        if ( ( next & 0xc0 ) != 0x80 ) { return -1; }
+        code = ( code << 6 ) | ( next & 0x3f );
+    }
+    if ( want == 3 && code < 0x800 ) { return -1; }          // overlong
+    if ( want == 4 && code < 0x10000 ) { return -1; }        // overlong
+    if ( code >= 0xd800 && code <= 0xdfff ) { return -1; }   // a surrogate half
+    if ( code > 0x10ffff ) { return -1; }
+    *width = want;
+    return code;
+}
+
+// A JSON text MUST be valid UTF-8 (RFC 8259 §8.1). The read path is
+// byte-transparent — the wire imposes no encoding (§3) and a string may hold
+// anything — so the WRITER is where that obligation is met: a byte that is
+// not part of a well-formed sequence is written as U+FFFD, one per bad byte,
+// and never raw. A text this walk writes is therefore readable by any
+// conforming parser, which a raw byte would not be. The cost is stated
+// plainly: for a string holding invalid UTF-8, the round trip is NOT
+// byte-identical, because the alternative is emitting a text that is not
+// JSON.
 inline void TableJsonWriteString( TableJsonOut & out, const char * s, int32_t length )
 {
     static const char hex[] = "0123456789abcdef";
@@ -323,11 +376,22 @@ inline void TableJsonWriteString( TableJsonOut & out, const char * s, int32_t le
                     char escape[6] = { '\\', 'u', '0', '0', hex[ c >> 4 ], hex[ c & 0xf ] };
                     out.raw( escape, 6 );
                 }
+                else if ( c < 0x80 )
+                {
+                    out.put( (char) c );
+                }
                 else
                 {
-                    // UTF-8 rides as its own bytes: the wire imposes no
-                    // encoding and neither does the text (SPEC-TABLES.md §3)
-                    out.put( (char) c );
+                    int32_t width = 0;
+                    if ( TableJsonUtf8( s + i, length - i, &width ) < 0 )
+                    {
+                        out.raw( "\xef\xbf\xbd", 3 ); // U+FFFD, one per bad byte
+                    }
+                    else
+                    {
+                        out.raw( s + i, width );
+                        i += width - 1;
+                    }
                 }
                 break;
         }
@@ -367,10 +431,7 @@ inline void TableJsonWriteSigned( TableJsonOut & out, int64_t value )
 // already apply to an enum value no variant names (§5).
 inline bool TableJsonWriteFloat( TableJsonOut & out, double value, bool single )
 {
-    if ( !( value == value ) || value > 1.7976931348623157e308 || value < -1.7976931348623157e308 )
-    {
-        return false;
-    }
+    if ( !TableJsonFinite( value ) ) { return false; }
     char text[64];
     int low = single ? 6 : 15;
     int high = single ? 9 : 17;
@@ -424,6 +485,11 @@ inline bool TableJsonWriteScalar( TableJsonOut & out, const void * storage, cons
             return false; // a tag no arm names, exactly as measure refuses it
         }
         const char * arm = f->enum_name( tag );
+        // and refuse on the NAME, not merely on the bound: §16.2 says a value
+        // no variant NAMES is refused, so the check is the name. Writing
+        // whatever came back would emit "???", a spelling the reader counts
+        // as unknown — a silent round-trip loss in place of a refusal.
+        if ( !TableJsonNamed( arm ) ) { return false; }
         out.put( '{' );
         out.line( depth + 1 );
         TableJsonWriteString( out, arm, (int32_t) strlen( arm ) );
@@ -449,6 +515,7 @@ inline bool TableJsonWriteScalar( TableJsonOut & out, const void * storage, cons
         if ( (int64_t) value > f->enum_max ) { return false; }
         if ( value != 0 && f->variant_id( value ) == 0 ) { return false; }
         const char * name = f->enum_name( value );
+        if ( !TableJsonNamed( name ) ) { return false; }
         TableJsonWriteString( out, name, (int32_t) strlen( name ) );
         return true;
     }
@@ -469,10 +536,11 @@ inline bool TableJsonWriteScalar( TableJsonOut & out, const void * storage, cons
             {
                 return false; // a bit no variant names has no text spelling
             }
+            const char * name = f->enum_name( (uint64_t) bit );
+            if ( !TableJsonNamed( name ) ) { return false; }
             if ( !first ) { out.put( ',' ); }
             first = false;
             out.line( depth + 1 );
-            const char * name = f->enum_name( (uint64_t) bit );
             TableJsonWriteString( out, name, (int32_t) strlen( name ) );
         }
         out.line( depth );
@@ -730,6 +798,11 @@ inline bool TableJsonScanString( TableJsonIn & in, char * out, int32_t capacity,
                             in.pos = mark; // a lone lead surrogate rides as itself
                         }
                     }
+                    // a surrogate half that never found its partner has no
+                    // UTF-8 encoding: encoding it anyway would manufacture
+                    // CESU-8 — invalid UTF-8 — out of input that was valid
+                    // JSON, so it reads as the replacement character
+                    if ( code >= 0xd800 && code <= 0xdfff ) { code = 0xfffd; }
                     unit_length = TableJsonEncodeUtf8( code, unit );
                     break;
                 }
@@ -781,30 +854,71 @@ inline bool TableJsonScanString( TableJsonIn & in, char * out, int32_t capacity,
 }
 
 // the numeric token at the cursor, copied out whole; false = not a number
+// Scan one number, to JSON's OWN grammar (RFC 8259 §6) and not to a run of
+// number-ish characters:
+//
+//     number = [ "-" ] int [ frac ] [ exp ]
+//     int    = "0" / ( digit1-9 *digit )
+//     frac   = "." 1*digit
+//     exp    = ( "e" / "E" ) [ "-" / "+" ] 1*digit
+//
+// Scanning the production is what makes a typo in an authoring file a
+// DIAGNOSTIC rather than a value: "1-2" scans as 1 and leaves "-2" where the
+// object expects a comma, so the text is malformed — which is what §16.2
+// already promises. A permissive scan would hand "1-2" to a digit loop and
+// report a clamp, and a config pipeline would never hear about it. Leading
+// "+", leading zeros, ".5" and "3." are not JSON either.
+inline bool TableJsonWalkNumber( TableJsonIn & in, bool * integral )
+{
+    TableJsonSpace( in );
+    bool whole = true;
+    if ( in.pos < in.size && in.text[in.pos] == '-' ) { in.pos++; }
+    // int: a lone zero, or a non-zero digit and any digits after it
+    if ( in.pos >= in.size ) { return false; }
+    if ( in.text[in.pos] == '0' )
+    {
+        in.pos++;
+    }
+    else if ( in.text[in.pos] >= '1' && in.text[in.pos] <= '9' )
+    {
+        while ( in.pos < in.size && in.text[in.pos] >= '0' && in.text[in.pos] <= '9' ) { in.pos++; }
+    }
+    else
+    {
+        return false;
+    }
+    // frac
+    if ( in.pos < in.size && in.text[in.pos] == '.' )
+    {
+        in.pos++;
+        if ( in.pos >= in.size || in.text[in.pos] < '0' || in.text[in.pos] > '9' ) { return false; }
+        while ( in.pos < in.size && in.text[in.pos] >= '0' && in.text[in.pos] <= '9' ) { in.pos++; }
+        whole = false;
+    }
+    // exp
+    if ( in.pos < in.size && ( in.text[in.pos] == 'e' || in.text[in.pos] == 'E' ) )
+    {
+        in.pos++;
+        if ( in.pos < in.size && ( in.text[in.pos] == '-' || in.text[in.pos] == '+' ) ) { in.pos++; }
+        if ( in.pos >= in.size || in.text[in.pos] < '0' || in.text[in.pos] > '9' ) { return false; }
+        while ( in.pos < in.size && in.text[in.pos] >= '0' && in.text[in.pos] <= '9' ) { in.pos++; }
+        whole = false;
+    }
+    *integral = whole;
+    return true;
+}
+
+// the same production, with the token kept for conversion
 inline bool TableJsonScanNumber( TableJsonIn & in, char * token, int32_t capacity, int32_t * length, bool * integral )
 {
     TableJsonSpace( in );
     int64_t start = in.pos;
-    bool whole = true;
-    while ( in.pos < in.size )
-    {
-        char c = in.text[in.pos];
-        bool numeric = ( c >= '0' && c <= '9' ) || c == '-' || c == '+' || c == '.' || c == 'e' || c == 'E';
-        if ( !numeric ) { break; }
-        if ( c == '.' || c == 'e' || c == 'E' ) { whole = false; }
-        in.pos++;
-    }
-    bool digits = false;
-    for ( int64_t i = start; i < in.pos; i++ )
-    {
-        if ( in.text[i] >= '0' && in.text[i] <= '9' ) { digits = true; break; }
-    }
+    if ( !TableJsonWalkNumber( in, integral ) ) { return false; }
     int64_t count = in.pos - start;
-    if ( count <= 0 || count >= capacity || !digits ) { return false; }
+    if ( count <= 0 || count >= capacity ) { return false; }
     memcpy( token, in.text + start, (size_t) count );
     token[count] = 0;
     *length = (int32_t) count;
-    *integral = whole;
     return true;
 }
 
@@ -908,20 +1022,11 @@ inline bool TableJsonSkipValue( TableJsonIn & in, int32_t depth )
         default:
         {
             // consumed, never converted: skipping needs no buffer, and this
-            // is the one walk a hostile text drives to the depth cap
-            TableJsonSpace( in );
-            int64_t start = in.pos;
-            bool digits = false;
-            while ( in.pos < in.size )
-            {
-                char n = in.text[in.pos];
-                bool numeric = ( n >= '0' && n <= '9' ) || n == '-' || n == '+' ||
-                               n == '.' || n == 'e' || n == 'E';
-                if ( !numeric ) { break; }
-                if ( n >= '0' && n <= '9' ) { digits = true; }
-                in.pos++;
-            }
-            if ( in.pos == start || !digits ) { in.bad = true; return false; }
+            // is the one walk a hostile text drives to the depth cap. It is
+            // the SAME production the value path scans, so an unknown key
+            // cannot smuggle past a number a named key would refuse.
+            bool integral = false;
+            if ( !TableJsonWalkNumber( in, &integral ) ) { in.bad = true; return false; }
             return true;
         }
     }
@@ -1057,6 +1162,18 @@ inline bool TableJsonReadScalar( TableJsonIn & in, void * storage, const TableFi
     {
         bool single = f->kind == 10;
         double value = TableJsonTokenDouble( token, length, single );
+        // A magnitude the field's format cannot hold is the WRONG SHAPE for
+        // the kind, and it never reaches storage: 1e400 is not a float64 and
+        // 1e300 is not a float32. Storing the infinity the conversion
+        // produced would leave an instance this walk called CLEAN that
+        // ToJsonMeasure then refuses forever (a non-finite float has no JSON
+        // spelling), and §16.1's one invariant is that a text which reads
+        // clean writes back.
+        if ( !TableJsonFinite( value ) )
+        {
+            in.report->kind_mismatch++;
+            return true;
+        }
         if ( f->has_range )
         {
             if ( value < f->range_min ) { value = f->range_min; in.report->clamped++; }
@@ -1065,6 +1182,11 @@ inline bool TableJsonReadScalar( TableJsonIn & in, void * storage, const TableFi
         if ( single )
         {
             float narrow = (float) value;
+            if ( !TableJsonFinite( (double) narrow ) )
+            {
+                in.report->kind_mismatch++;
+                return true;
+            }
             memcpy( storage, &narrow, sizeof( narrow ) );
         }
         else
@@ -1073,17 +1195,48 @@ inline bool TableJsonReadScalar( TableJsonIn & in, void * storage, const TableFi
         }
         return true;
     }
-    if ( !integral )
-    {
-        // a fraction where an integer is declared is the WRONG SHAPE for the
-        // kind, not framing damage: skipped and counted, never rounded into
-        // place (§16.2)
-        in.report->kind_mismatch++;
-        return true;
-    }
+    // JSON HAS ONE NUMBER TYPE. 2.0 IS the integer 2 and 1e3 IS 1000, and a
+    // library that round-trips numbers through a double emits them that way —
+    // this walker's own float writer emits 1e+21. So an integer field takes
+    // any number whose VALUE is integral, however it was spelled; only a
+    // genuinely fractional value is the wrong shape for it.
     bool is_signed = f->kind >= 2 && f->kind <= 5;
     bool saturated = false;
-    int64_t value = TableJsonTokenInteger( token, length, is_signed, &saturated );
+    int64_t value = 0;
+    if ( integral )
+    {
+        value = TableJsonTokenInteger( token, length, is_signed, &saturated );
+    }
+    else
+    {
+        double d = TableJsonTokenDouble( token, length, false );
+        if ( !TableJsonFinite( d ) )
+        {
+            in.report->kind_mismatch++;
+            return true;
+        }
+        if ( is_signed )
+        {
+            if ( d >= 9223372036854775808.0 ) { value = INT64_MAX; saturated = true; }
+            else if ( d < -9223372036854775808.0 ) { value = INT64_MIN; saturated = true; }
+            else if ( d != (double) (int64_t) d ) { in.report->kind_mismatch++; return true; }
+            else { value = (int64_t) d; }
+        }
+        else
+        {
+            if ( d < 0.0 )
+            {
+                // a negative for an unsigned field clamps to zero, as the
+                // exact digit path already does
+                if ( d != (double) (int64_t) d ) { in.report->kind_mismatch++; return true; }
+                value = 0;
+                saturated = true;
+            }
+            else if ( d >= 18446744073709551616.0 ) { value = (int64_t) UINT64_MAX; saturated = true; }
+            else if ( d != (double) (uint64_t) d ) { in.report->kind_mismatch++; return true; }
+            else { value = (int64_t) (uint64_t) d; }
+        }
+    }
     if ( saturated ) { in.report->clamped++; }
     if ( f->has_range )
     {
@@ -1135,6 +1288,8 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
         // backslash in one is simply not an alphabet character.
         if ( TableJsonPeek( in ) != '"' ) { in.bad = true; return false; }
         in.pos++;
+        memset( storage, 0, (size_t) f->array_bound );
+        TableJsonSetCount( base, f, 0 );
         const char * alphabet = TableJsonBase64Alphabet();
         int32_t placed = 0;
         uint32_t accumulator = 0;
@@ -1179,6 +1334,26 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
     {
         if ( TableJsonPeek( in ) != '[' ) { in.bad = true; return false; }
         in.pos++;
+        // LAST WINS has to be true of a repeated ARRAY key too, and it is
+        // wire-visible: a fixed array writes every slot, so a second, shorter
+        // occurrence overlaying a prefix would leave the first occurrence's
+        // tail standing. The field goes back to its declared defaults before
+        // this occurrence's elements are placed — the re-establishment a nested
+        // table and a union arm already get. A table element's defaults are
+        // its own (the reset hook); every other element kind's storage
+        // default is zero, which is what the generated array declares.
+        if ( f->kind == 13 )
+        {
+            for ( int32_t i = 0; i < f->array_bound; i++ )
+            {
+                f->table->reset( storage + (int64_t) i * f->elem_size );
+            }
+        }
+        else
+        {
+            memset( storage, 0, (size_t) f->array_bound * (size_t) f->elem_size );
+        }
+        TableJsonSetCount( base, f, 0 );
         int32_t placed = 0;
         char shape = TableJsonElementShape( f );
         for ( ;; )

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -192,6 +192,22 @@ inline bool TableJsonIsBytes( const TableFieldInfo * f )
     return f->is_array && f->kind == 6 && strcmp( f->type_name, "bytes" ) == 0;
 }
 
+// An ENUM-KEYED array (SPEC-TABLES.md §2.4): its JSON form is an OBJECT
+// keyed by variant name, not a positional array, because that is what the
+// storage is — one slot per variant, addressed by the variant.
+inline bool TableJsonIsKeyed( const TableFieldInfo * f )
+{
+    return f->key_name != NULL;
+}
+
+// SLOT 0 IS NONE'S AND NAMES NOTHING (§2.4, §8): its key id is 0, the
+// reserved id no declared name can fold to, so a walk enumerating
+// [0, array_bound) skips it without needing any rule about slot indices.
+inline bool TableJsonKeyedSlotValid( const TableFieldInfo * f, int64_t slot )
+{
+    return f->key_id( (uint64_t) slot ) != 0;
+}
+
 inline bool TableJsonIsFlags( const TableFieldInfo * f )
 {
     return f->enum_name != NULL && f->variant_id == NULL;
@@ -206,6 +222,7 @@ inline char TableJsonShape( const TableFieldInfo * f )
 {
     if ( f->kind == 12 ) return 's';           // string
     if ( TableJsonIsBytes( f ) ) return 's';   // bytes: base64
+    if ( TableJsonIsKeyed( f ) ) return 'o';   // an object keyed by variant NAME
     if ( f->is_array ) return 'a';
     if ( f->arms != NULL ) return 'o';         // union: an object with ONE key
     if ( f->kind == 13 ) return 'o';           // nested table or type
@@ -586,6 +603,32 @@ inline bool TableJsonWriteField( TableJsonOut & out, const void * base, const Ta
         TableJsonWriteBase64( out, storage, TableJsonCount( base, f ) );
         return true;
     }
+    if ( TableJsonIsKeyed( f ) )
+    {
+        // one entry per SLOT, keyed by the variant that owns it, so inserting
+        // a variant next season moves nothing in the text either. Slot 0 is
+        // None's and names nothing, so it is skipped by its reserved key id.
+        out.put( '{' );
+        bool first = true;
+        for ( int64_t slot = 0; slot < f->array_bound; slot++ )
+        {
+            if ( !TableJsonKeyedSlotValid( f, slot ) ) { continue; }
+            if ( !first ) { out.put( ',' ); }
+            first = false;
+            out.line( depth + 1 );
+            const char * key = f->key_name( (uint64_t) slot );
+            TableJsonWriteString( out, key, (int32_t) strlen( key ) );
+            out.raw( ": ", 2 );
+            if ( !TableJsonWriteScalar( out, storage + slot * f->elem_size, f, depth + 1 ) )
+            {
+                return false;
+            }
+        }
+        if ( first ) { out.raw( "}", 1 ); return true; }
+        out.line( depth );
+        out.put( '}' );
+        return true;
+    }
     if ( f->is_array )
     {
         int32_t count = TableJsonCount( base, f );
@@ -621,6 +664,14 @@ inline bool TableJsonWriteValue( TableJsonOut & out, const void * base, const Ta
     {
         const TableFieldInfo * f = &info->fields[i];
         if ( f->guard[0] != 0 && !TableJsonGuardHolds( base, info, f->guard ) ) { continue; }
+        // an ABSENT optional writes no key: presence of the key IS the
+        // presence (§16.2), so an absent field is an absent key and nothing
+        // else would read back as absent
+        if ( f->optional &&
+             TableJsonGetRaw( (const uint8_t *) base + f->present_offset, 1 ) == 0 )
+        {
+            continue;
+        }
         // ---- SEAM (schema#260): an OPTIONAL field writes its key only when
         // ---- present — skip here on !optional_present, since presence is the
         // ---- presence and an absent key is the absence. The enum-keyed half
@@ -1332,6 +1383,61 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
         TableJsonSetCount( base, f, placed );
         return true;
     }
+    if ( TableJsonIsKeyed( f ) )
+    {
+        if ( TableJsonPeek( in ) != '{' ) { in.bad = true; return false; }
+        in.pos++;
+        // every slot back to its declared defaults first, so a key the text
+        // omits keeps them and a repeated field key cannot leave an earlier
+        // occurrence's slots standing
+        for ( int32_t i = 0; i < f->array_bound; i++ )
+        {
+            void * slot = storage + (int64_t) i * f->elem_size;
+            if ( f->kind == 13 ) { f->table->reset( slot ); }
+            else { memset( slot, 0, (size_t) f->elem_size ); }
+        }
+        char shape = TableJsonElementShape( f );
+        for ( ;; )
+        {
+            char c = TableJsonPeek( in );
+            if ( c == '}' ) { in.pos++; break; }
+            if ( c == 0 ) { in.bad = true; return false; }
+            char key[kTableJsonMaxKey];
+            int32_t key_length = 0;
+            if ( !TableJsonScanString( in, key, kTableJsonMaxKey - 1, &key_length ) ) { return false; }
+            key[key_length] = 0;
+            if ( TableJsonPeek( in ) != ':' ) { in.bad = true; return false; }
+            in.pos++;
+            int64_t slot = -1;
+            for ( int64_t v = 0; v < f->array_bound; v++ )
+            {
+                // slot 0 names nothing, so "None" finds no slot and is an
+                // unknown key like any other name this reader cannot place
+                if ( !TableJsonKeyedSlotValid( f, v ) ) { continue; }
+                if ( strcmp( f->key_name( (uint64_t) v ), key ) == 0 ) { slot = v; break; }
+            }
+            if ( slot < 0 )
+            {
+                in.report->unknown++;
+                if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+            }
+            else if ( TableJsonValueShape( in ) != shape )
+            {
+                in.report->kind_mismatch++;
+                if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+            }
+            else if ( !TableJsonReadScalar( in, storage + slot * f->elem_size, f, depth + 1 ) )
+            {
+                return false;
+            }
+            c = TableJsonPeek( in );
+            if ( c == ',' ) { in.pos++; continue; } // a trailing comma is accepted
+            if ( c == '}' ) { in.pos++; break; }
+            in.bad = true;
+            return false;
+        }
+        return true;
+    }
     if ( f->is_array )
     {
         if ( TableJsonPeek( in ) != '[' ) { in.bad = true; return false; }
@@ -1437,21 +1543,36 @@ inline bool TableJsonReadTable( TableJsonIn & in, void * base, const TableTypeIn
                 if ( ( seen[index >> 6] & bit ) != 0 ) { in.report->duplicate++; }
                 seen[index >> 6] |= bit;
             }
-            // ---- SEAM (schema#260): an OPTIONAL field sets its presence
-            // ---- companion here, because reaching this line IS the key being
-            // ---- present. The enum-keyed half (schema#255) is not here: it
-            // ---- is a shape, and lands in TableJsonShape and
-            // ---- TableJsonReadField, matching each key against the key
-            // ---- vocabulary rather than counting positions.
-            if ( TableJsonValueShape( in ) != TableJsonShape( f ) )
+            // PRESENCE OF THE KEY IS THE PRESENCE (§16.2): reaching this line
+            // is the key being present, so an optional is set present
+            // whatever its value — with one exception the page names: a JSON
+            // null, which reads as ABSENT rather than as a value.
+            char got = TableJsonValueShape( in );
+            if ( f->optional && got == 'z' )
             {
-                // the wrong JSON type for the kind: skipped, never coerced
-                in.report->kind_mismatch++;
-                if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+                if ( !TableJsonLiteral( in, "null" ) ) { return false; }
+                // absent, and back at its defaults: a repeated key whose last
+                // occurrence is null must not leave an earlier value standing
+                if ( f->table != NULL ) { f->table->reset( (uint8_t *) base + f->offset ); }
+                else { memset( (uint8_t *) base + f->offset, 0, (size_t) f->elem_size ); }
+                TableJsonSetRaw( (uint8_t *) base + f->present_offset, 1, 0 );
             }
-            else if ( !TableJsonReadField( in, base, f, depth ) )
+            else
             {
-                return false;
+                if ( got != TableJsonShape( f ) )
+                {
+                    // the wrong JSON type for the kind: skipped, never coerced
+                    in.report->kind_mismatch++;
+                    if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+                }
+                else if ( !TableJsonReadField( in, base, f, depth ) )
+                {
+                    return false;
+                }
+                if ( f->optional )
+                {
+                    TableJsonSetRaw( (uint8_t *) base + f->present_offset, 1, 1 );
+                }
             }
         }
         c = TableJsonPeek( in );

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -1,0 +1,1311 @@
+// The TEXT form: JSON in and out of one table, driven by the reflection
+// descriptors (SPEC-TABLES.md §16).
+//
+// ONE generic walk, emitted once per generated header behind the same macro
+// guard the primitives use — not a per-table codec. That is the property
+// which makes the text form schema's rather than a packer's, and it is a
+// gate: the walker's source is the SAME BYTES in every generated header of
+// the corpus (`make tables-json-walk`). Everything a walk needs about a
+// table is already in §8's descriptors; the per-table surface is three thin
+// wrappers that name a descriptor and nothing else.
+package cpptable
+
+import (
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// tableJsonWalk wraps the walker in its package guard. The package name is in
+// the guard and the namespace and NOWHERE inside the markers, so the gate
+// between them is a strict byte comparison across every header of the corpus.
+func tableJsonWalk(pkg string) string {
+	guard := strings.ToUpper(pkg) + "_SCHEMA_TABLE_JSON"
+	return "#ifndef " + guard + "\n#define " + guard + "\n\nnamespace " + pkg + " {\n\n" +
+		tableJsonWalkSource +
+		"\n} // namespace " + pkg + "\n\n#endif // " + guard + "\n"
+}
+
+// emitJsonSurface emits one closure member's text-form surface: three thin
+// wrappers over the generic walk. FIXED-SIZE members only — a
+// VARIABLE-LENGTH table is never held by value, and reading one from a text
+// wants the builder and the two reference encodings (§6.3) threaded through
+// a descriptor-driven walk, which is a named follow-on (§16.6), not a cheap
+// add-on. The refusal is by absence and it is loud: no <Name>FromJson exists
+// to call.
+func (g *tableGen) emitJsonSurface(st *ir.Struct) {
+	if g.isVar(st.Name) {
+		g.pf("// %s is VARIABLE-LENGTH: its text form reads through the builder and is\n", st.Name)
+		g.pf("// a named follow-on (SPEC-TABLES.md §16.6). No %sFromJson is emitted.\n\n", st.Name)
+		return
+	}
+	g.pf("// %s in and out of a JSON text — one instance, one text, the generic walk\n", st.Name)
+	g.pf("// over this type's descriptors (SPEC-TABLES.md §16).\n")
+	g.pf("inline bool %sFromJson( %s & value, const char * text, int64_t bytes, TableReport * report )\n{\n", st.Name, st.Name)
+	g.pf("    return TableJsonRead( &value, %sTableType(), text, bytes, report );\n}\n\n", st.Name)
+	g.pf("inline int64_t %sToJsonMeasure( const %s & value )\n{\n", st.Name, st.Name)
+	g.pf("    return TableJsonWrite( &value, %sTableType(), NULL, 0 );\n}\n\n", st.Name)
+	g.pf("inline int64_t %sToJson( const %s & value, char * buffer, int64_t capacity )\n{\n", st.Name, st.Name)
+	g.pf("    return TableJsonWrite( &value, %sTableType(), buffer, capacity );\n}\n\n", st.Name)
+}
+
+// tableJsonWalkSource is the walker. It reads and writes ONLY the columns
+// every generated header carries, so its text never varies with the unit —
+// which is what the generic-walk gate asserts.
+const tableJsonWalkSource = `// ---- json walk: begin ----
+//
+// The TEXT form (SPEC-TABLES.md §16): one table, one text, one walk over the
+// reflection descriptors (§8). Reading fills ONE caller-owned instance and
+// allocates nothing beyond it; writing targets a caller buffer with the
+// wire's measure/write symmetry. Everything AROUND this — which file goes
+// with which instance, what key an instance is filed under, how instances
+// link into a root table's collections — is a packer's opinion and stays
+// with the tool that holds it.
+//
+// The dialect: trailing commas are accepted on read (the authoring files
+// this exists for carry them) and never written; comments are not JSON and
+// are refused; unknown keys are skipped and counted; a duplicate key is
+// last-wins and counted; a key present with the wrong JSON type is skipped
+// and counted, never coerced.
+
+constexpr int32_t kTableJsonMaxDepth = 128;
+
+// A key longer than this cannot name a field, so it is skipped as unknown.
+constexpr int32_t kTableJsonMaxKey = 256;
+
+// The longest numeric token the walk will convert. Anything longer is a
+// value no field can hold and counts as a kind mismatch.
+constexpr int32_t kTableJsonMaxNumber = 512;
+
+// The decimal point the C runtime is CURRENTLY using. Number conversion is
+// the one locale-sensitive corner of the grammar — JSON's point is always
+// '.', the runtime's is whatever the program set — so every number crosses
+// this one character on the way out and on the way back in. Nothing else in
+// the walk consults the locale.
+inline char TableJsonDecimalPoint()
+{
+    const struct lconv * conv = localeconv();
+    if ( conv != NULL && conv->decimal_point != NULL && conv->decimal_point[0] != 0 )
+    {
+        return conv->decimal_point[0];
+    }
+    return '.';
+}
+
+// ---- storage access: the descriptors give an offset and a width, and the
+// ---- storage is the HOST's, so every load and store goes through a width
+// ---- switch rather than a memcpy into the low bytes of a wider word
+
+inline uint64_t TableJsonGetRaw( const void * storage, uint32_t width )
+{
+    switch ( width )
+    {
+        case 1: { uint8_t v = 0;  memcpy( &v, storage, 1 ); return v; }
+        case 2: { uint16_t v = 0; memcpy( &v, storage, 2 ); return v; }
+        case 4: { uint32_t v = 0; memcpy( &v, storage, 4 ); return v; }
+        case 8: { uint64_t v = 0; memcpy( &v, storage, 8 ); return v; }
+    }
+    return 0;
+}
+
+inline void TableJsonSetRaw( void * storage, uint32_t width, uint64_t value )
+{
+    switch ( width )
+    {
+        case 1: { uint8_t v = (uint8_t) value;   memcpy( storage, &v, 1 ); break; }
+        case 2: { uint16_t v = (uint16_t) value; memcpy( storage, &v, 2 ); break; }
+        case 4: { uint32_t v = (uint32_t) value; memcpy( storage, &v, 4 ); break; }
+        case 8: { uint64_t v = value;            memcpy( storage, &v, 8 ); break; }
+    }
+}
+
+inline int64_t TableJsonGetSigned( const void * storage, uint32_t width )
+{
+    uint64_t raw = TableJsonGetRaw( storage, width );
+    if ( width < 8 )
+    {
+        uint64_t sign = uint64_t( 1 ) << ( width * 8 - 1 );
+        if ( ( raw & sign ) != 0 )
+        {
+            raw |= ~( ( sign << 1 ) - 1 );
+        }
+    }
+    return (int64_t) raw;
+}
+
+// a counted field's companion: a string's length, a bytes' length, a counted
+// array's count. Bounded by the declared extent on the way out, so a storage
+// invariant a caller broke cannot walk off the end of the array.
+inline int32_t TableJsonCount( const void * base, const TableFieldInfo * f )
+{
+    if ( !f->counted )
+    {
+        return f->array_bound;
+    }
+    int32_t count = 0;
+    memcpy( &count, (const uint8_t *) base + f->count_offset, sizeof( count ) );
+    if ( count < 0 ) { count = 0; }
+    if ( count > f->array_bound ) { count = f->array_bound; }
+    return count;
+}
+
+inline void TableJsonSetCount( void * base, const TableFieldInfo * f, int32_t count )
+{
+    if ( f->counted )
+    {
+        memcpy( (uint8_t *) base + f->count_offset, &count, sizeof( count ) );
+    }
+}
+
+// ---- what a field's kind expects to see in the text ----
+//
+// One classifier, consulted by both directions, so a reader and a writer can
+// never disagree about a kind's JSON form. 'o' object, 'a' array, 's'
+// string, 'n' number, 'b' boolean.
+//
+// A vocabulary field is spelled by NAME: an enum is one name, a flags mask
+// is the array of the names of its set bits. The two are told apart by the
+// id column — an enum variant rides under a wire id, a flags BIT never does
+// (SPEC-TABLES.md §4), so a name function with no id function is flags.
+//
+// bytes(N) is the one kind whose element kind does not decide its form: it
+// shares u8 with a plain array of u8, and rides as base64. The schema type
+// name settles it, and "bytes" is a keyword no declaration can claim.
+inline bool TableJsonIsBytes( const TableFieldInfo * f )
+{
+    return f->is_array && f->kind == 6 && strcmp( f->type_name, "bytes" ) == 0;
+}
+
+inline bool TableJsonIsFlags( const TableFieldInfo * f )
+{
+    return f->enum_name != NULL && f->variant_id == NULL;
+}
+
+inline bool TableJsonIsEnum( const TableFieldInfo * f )
+{
+    return f->variant_id != NULL && f->arms == NULL;
+}
+
+inline char TableJsonShape( const TableFieldInfo * f )
+{
+    if ( f->kind == 12 ) return 's';           // string
+    if ( TableJsonIsBytes( f ) ) return 's';   // bytes: base64
+    if ( f->is_array ) return 'a';
+    if ( f->arms != NULL ) return 'o';         // union: an object with ONE key
+    if ( f->kind == 13 ) return 'o';           // nested table or type
+    if ( TableJsonIsEnum( f ) ) return 's';
+    if ( TableJsonIsFlags( f ) ) return 'a';
+    if ( f->kind == 1 ) return 'b';
+    return 'n';
+}
+
+// the ELEMENT shape of an array field — the same classifier one level down
+inline char TableJsonElementShape( const TableFieldInfo * f )
+{
+    if ( f->kind == 13 ) return 'o';
+    if ( TableJsonIsEnum( f ) ) return 's';
+    if ( TableJsonIsFlags( f ) ) return 'a';
+    if ( f->kind == 1 ) return 'b';
+    return 'n';
+}
+
+// A guarded group rides only when its guard reads true — the wire's own
+// elision (§4), carried into the text so a text and a wire written from one
+// instance say the same thing. The guard is spelled as its branch condition
+// over bool fields of the SAME type ("at_rest", "!at_rest",
+// "active && has_target"), so evaluating it is a walk of the same
+// descriptor. Nothing is inferred in the other direction: reading places
+// every key it can name, and the guard is a plain bool key (§16.2).
+inline bool TableJsonGuardHolds( const void * base, const TableTypeInfo * info, const char * guard )
+{
+    const char * p = guard;
+    for ( ;; )
+    {
+        while ( *p == ' ' || *p == '&' ) { p++; }
+        if ( *p == 0 ) { return true; }
+        bool want = true;
+        if ( *p == '!' ) { want = false; p++; }
+        const char * start = p;
+        while ( *p != 0 && *p != ' ' && *p != '&' ) { p++; }
+        size_t length = (size_t) ( p - start );
+        bool value = false;
+        for ( int32_t i = 0; i < info->num_fields; i++ )
+        {
+            const TableFieldInfo * f = &info->fields[i];
+            if ( strlen( f->name ) == length && strncmp( f->name, start, length ) == 0 )
+            {
+                value = TableJsonGetRaw( (const uint8_t *) base + f->offset, f->elem_size ) != 0;
+                break;
+            }
+        }
+        if ( value != want ) { return false; }
+    }
+}
+
+// ---- writing ----
+
+// The writer sink MEASURES when the buffer is NULL and WRITES when it is
+// not, over one code path — so measure and write agree byte for byte, the
+// wire's invariant (§9) carried across.
+struct TableJsonOut
+{
+    char * buffer;
+    int64_t capacity;
+    int64_t offset;
+    bool overflow;
+
+    void raw( const char * data, int64_t count )
+    {
+        if ( buffer != NULL )
+        {
+            if ( offset + count > capacity ) { overflow = true; return; }
+            memcpy( buffer + offset, data, (size_t) count );
+        }
+        offset += count;
+    }
+    void put( char c ) { raw( &c, 1 ); }
+    void text( const char * s ) { raw( s, (int64_t) strlen( s ) ); }
+    void line( int32_t depth )
+    {
+        put( '\n' );
+        for ( int32_t i = 0; i < depth; i++ ) { raw( "  ", 2 ); }
+    }
+};
+
+inline const char * TableJsonBase64Alphabet()
+{
+    return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+}
+
+inline void TableJsonWriteBase64( TableJsonOut & out, const uint8_t * data, int32_t length )
+{
+    const char * alphabet = TableJsonBase64Alphabet();
+    out.put( '"' );
+    int32_t i = 0;
+    for ( ; i + 3 <= length; i += 3 )
+    {
+        uint32_t triple = ( uint32_t( data[i] ) << 16 ) | ( uint32_t( data[i+1] ) << 8 ) | uint32_t( data[i+2] );
+        char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ],
+                         alphabet[ ( triple >> 6 ) & 0x3f ], alphabet[ triple & 0x3f ] };
+        out.raw( quad, 4 );
+    }
+    if ( i < length )
+    {
+        int32_t left = length - i;
+        uint32_t triple = uint32_t( data[i] ) << 16;
+        if ( left == 2 ) { triple |= uint32_t( data[i+1] ) << 8; }
+        char quad[4] = { alphabet[ ( triple >> 18 ) & 0x3f ], alphabet[ ( triple >> 12 ) & 0x3f ], '=', '=' };
+        if ( left == 2 ) { quad[2] = alphabet[ ( triple >> 6 ) & 0x3f ]; }
+        out.raw( quad, 4 );
+    }
+    out.put( '"' );
+}
+
+inline void TableJsonWriteString( TableJsonOut & out, const char * s, int32_t length )
+{
+    static const char hex[] = "0123456789abcdef";
+    out.put( '"' );
+    for ( int32_t i = 0; i < length; i++ )
+    {
+        unsigned char c = (unsigned char) s[i];
+        switch ( c )
+        {
+            case '"':  out.raw( "\\\"", 2 ); break;
+            case '\\': out.raw( "\\\\", 2 ); break;
+            case '\b': out.raw( "\\b", 2 ); break;
+            case '\f': out.raw( "\\f", 2 ); break;
+            case '\n': out.raw( "\\n", 2 ); break;
+            case '\r': out.raw( "\\r", 2 ); break;
+            case '\t': out.raw( "\\t", 2 ); break;
+            default:
+                if ( c < 0x20 )
+                {
+                    char escape[6] = { '\\', 'u', '0', '0', hex[ c >> 4 ], hex[ c & 0xf ] };
+                    out.raw( escape, 6 );
+                }
+                else
+                {
+                    // UTF-8 rides as its own bytes: the wire imposes no
+                    // encoding and neither does the text (SPEC-TABLES.md §3)
+                    out.put( (char) c );
+                }
+                break;
+        }
+    }
+    out.put( '"' );
+}
+
+inline void TableJsonWriteUnsigned( TableJsonOut & out, uint64_t value )
+{
+    char digits[24];
+    int32_t n = 0;
+    do
+    {
+        digits[n++] = (char) ( '0' + (int) ( value % 10 ) );
+        value /= 10;
+    } while ( value != 0 );
+    char text[24];
+    for ( int32_t i = 0; i < n; i++ ) { text[i] = digits[n - 1 - i]; }
+    out.raw( text, n );
+}
+
+inline void TableJsonWriteSigned( TableJsonOut & out, int64_t value )
+{
+    if ( value < 0 )
+    {
+        out.put( '-' );
+        TableJsonWriteUnsigned( out, uint64_t( 0 ) - (uint64_t) value );
+        return;
+    }
+    TableJsonWriteUnsigned( out, (uint64_t) value );
+}
+
+// A float writes at the SHORTEST precision that reads back as the same value
+// at the field's own width, so a round trip is exact and a text stays
+// readable. Non-finite values have no JSON spelling at all, and the writer
+// REFUSES rather than losing one silently — the same rule measure and save
+// already apply to an enum value no variant names (§5).
+inline bool TableJsonWriteFloat( TableJsonOut & out, double value, bool single )
+{
+    if ( !( value == value ) || value > 1.7976931348623157e308 || value < -1.7976931348623157e308 )
+    {
+        return false;
+    }
+    char text[64];
+    int low = single ? 6 : 15;
+    int high = single ? 9 : 17;
+    int length = 0;
+    for ( int digits = low; ; digits++ )
+    {
+        length = snprintf( text, sizeof( text ), "%.*g", digits, value );
+        if ( length <= 0 || length >= (int) sizeof( text ) ) { return false; }
+        if ( digits >= high ) { break; }
+        // the round-trip check runs BEFORE the decimal point is normalised:
+        // the token still carries whatever point snprintf just produced
+        if ( single )
+        {
+            if ( (double) strtof( text, NULL ) == value ) { break; }
+        }
+        else
+        {
+            if ( strtod( text, NULL ) == value ) { break; }
+        }
+    }
+    char point = TableJsonDecimalPoint();
+    if ( point != '.' )
+    {
+        for ( int i = 0; i < length; i++ )
+        {
+            if ( text[i] == point ) { text[i] = '.'; }
+        }
+    }
+    out.raw( text, length );
+    return true;
+}
+
+inline bool TableJsonWriteValue( TableJsonOut & out, const void * base, const TableTypeInfo * info, int32_t depth );
+
+// one scalar, at one storage address: a nested object, a union, a
+// vocabulary, or a number
+inline bool TableJsonWriteScalar( TableJsonOut & out, const void * storage, const TableFieldInfo * f, int32_t depth )
+{
+    if ( f->arms != NULL )
+    {
+        // a union is an object with ONE key, the arm's name; None is {}
+        const TableUnionInfo * arms = f->arms();
+        uint64_t tag = TableJsonGetRaw( (const uint8_t *) storage + arms->tag_offset, arms->tag_size );
+        if ( tag == 0 )
+        {
+            out.raw( "{}", 2 );
+            return true;
+        }
+        if ( (int64_t) tag > f->enum_max )
+        {
+            return false; // a tag no arm names, exactly as measure refuses it
+        }
+        out.put( '{' );
+        out.line( depth + 1 );
+        TableJsonWriteString( out, f->enum_name( tag ), (int32_t) strlen( f->enum_name( tag ) ) );
+        out.raw( ": ", 2 );
+        if ( !TableJsonWriteValue( out, (const uint8_t *) storage + arms->arms[tag].offset, arms->arms[tag].table, depth + 1 ) )
+        {
+            return false;
+        }
+        out.line( depth );
+        out.put( '}' );
+        return true;
+    }
+    if ( f->kind == 13 )
+    {
+        return TableJsonWriteValue( out, storage, f->table, depth );
+    }
+    if ( TableJsonIsEnum( f ) )
+    {
+        uint64_t value = TableJsonGetRaw( storage, f->elem_size );
+        // a value no variant names has no text spelling, exactly as it has no
+        // wire identity: the writer REFUSES rather than writing None over it,
+        // the rule measure and save already apply (SPEC-TABLES.md §5)
+        if ( (int64_t) value > f->enum_max ) { return false; }
+        if ( value != 0 && f->variant_id( value ) == 0 ) { return false; }
+        const char * name = f->enum_name( value );
+        TableJsonWriteString( out, name, (int32_t) strlen( name ) );
+        return true;
+    }
+    if ( TableJsonIsFlags( f ) )
+    {
+        uint64_t bits = TableJsonGetRaw( storage, f->elem_size );
+        if ( bits == 0 )
+        {
+            out.raw( "[]", 2 );
+            return true;
+        }
+        out.put( '[' );
+        bool first = true;
+        for ( int64_t bit = 0; bit < 64; bit++ )
+        {
+            if ( ( bits & ( uint64_t( 1 ) << bit ) ) == 0 ) { continue; }
+            if ( bit > f->enum_max )
+            {
+                return false; // a bit no variant names has no text spelling
+            }
+            if ( !first ) { out.put( ',' ); }
+            first = false;
+            out.line( depth + 1 );
+            const char * name = f->enum_name( (uint64_t) bit );
+            TableJsonWriteString( out, name, (int32_t) strlen( name ) );
+        }
+        out.line( depth );
+        out.put( ']' );
+        return true;
+    }
+    switch ( f->kind )
+    {
+        case 1:
+            out.text( TableJsonGetRaw( storage, f->elem_size ) != 0 ? "true" : "false" );
+            return true;
+        case 10:
+        {
+            float v = 0.0f;
+            memcpy( &v, storage, sizeof( v ) );
+            return TableJsonWriteFloat( out, (double) v, true );
+        }
+        case 11:
+        {
+            double v = 0.0;
+            memcpy( &v, storage, sizeof( v ) );
+            return TableJsonWriteFloat( out, v, false );
+        }
+        case 2: case 3: case 4: case 5:
+            TableJsonWriteSigned( out, TableJsonGetSigned( storage, f->elem_size ) );
+            return true;
+        default:
+            TableJsonWriteUnsigned( out, TableJsonGetRaw( storage, f->elem_size ) );
+            return true;
+    }
+}
+
+inline bool TableJsonWriteField( TableJsonOut & out, const void * base, const TableFieldInfo * f, int32_t depth )
+{
+    const uint8_t * storage = (const uint8_t *) base + f->offset;
+    if ( f->kind == 12 )
+    {
+        TableJsonWriteString( out, (const char *) storage, TableJsonCount( base, f ) );
+        return true;
+    }
+    if ( TableJsonIsBytes( f ) )
+    {
+        TableJsonWriteBase64( out, storage, TableJsonCount( base, f ) );
+        return true;
+    }
+    if ( f->is_array )
+    {
+        int32_t count = TableJsonCount( base, f );
+        if ( count == 0 )
+        {
+            out.raw( "[]", 2 );
+            return true;
+        }
+        out.put( '[' );
+        for ( int32_t i = 0; i < count; i++ )
+        {
+            if ( i > 0 ) { out.put( ',' ); }
+            out.line( depth + 1 );
+            if ( !TableJsonWriteScalar( out, storage + (int64_t) i * f->elem_size, f, depth + 1 ) )
+            {
+                return false;
+            }
+        }
+        out.line( depth );
+        out.put( ']' );
+        return true;
+    }
+    return TableJsonWriteScalar( out, storage, f, depth );
+}
+
+// One instance, every field, in DECLARATION ORDER, defaults included — a
+// text is for people and tools, and a text that elides is a text a reader
+// has to know the schema to complete.
+inline bool TableJsonWriteValue( TableJsonOut & out, const void * base, const TableTypeInfo * info, int32_t depth )
+{
+    bool any = false;
+    for ( int32_t i = 0; i < info->num_fields; i++ )
+    {
+        const TableFieldInfo * f = &info->fields[i];
+        if ( f->guard[0] != 0 && !TableJsonGuardHolds( base, info, f->guard ) ) { continue; }
+        // ---- SEAM: optional fields (schema#260) write their key only when
+        // ---- present; enum-keyed arrays (schema#255) write an object keyed
+        // ---- by variant name instead of a positional array. Both land here.
+        if ( !any ) { out.put( '{' ); }
+        else { out.put( ',' ); }
+        any = true;
+        out.line( depth + 1 );
+        TableJsonWriteString( out, f->json, (int32_t) strlen( f->json ) );
+        out.raw( ": ", 2 );
+        if ( !TableJsonWriteField( out, base, f, depth + 1 ) ) { return false; }
+    }
+    if ( !any )
+    {
+        out.raw( "{}", 2 );
+        return true;
+    }
+    out.line( depth );
+    out.put( '}' );
+    return true;
+}
+
+// ---- reading ----
+
+struct TableJsonIn
+{
+    const char * text;
+    int64_t size;
+    int64_t pos;
+    TableReport * report;
+    bool bad; // the text is not JSON: the walk stops and keeps what it placed
+};
+
+inline void TableJsonSpace( TableJsonIn & in )
+{
+    while ( in.pos < in.size )
+    {
+        char c = in.text[in.pos];
+        if ( c == ' ' || c == '\t' || c == '\n' || c == '\r' ) { in.pos++; continue; }
+        // comments are not JSON, and a walk that guessed at one would be
+        // reading a dialect nobody wrote down
+        if ( c == '/' ) { in.bad = true; }
+        return;
+    }
+}
+
+inline char TableJsonPeek( TableJsonIn & in )
+{
+    TableJsonSpace( in );
+    return in.pos < in.size ? in.text[in.pos] : 0;
+}
+
+// the shape of the value sitting at the cursor, without consuming it
+inline char TableJsonValueShape( TableJsonIn & in )
+{
+    char c = TableJsonPeek( in );
+    switch ( c )
+    {
+        case '{': return 'o';
+        case '[': return 'a';
+        case '"': return 's';
+        case 't': case 'f': return 'b';
+        case 'n': return 'z';
+        case 0: return 0;
+        default: return 'n';
+    }
+}
+
+inline bool TableJsonLiteral( TableJsonIn & in, const char * word )
+{
+    int64_t length = (int64_t) strlen( word );
+    if ( in.pos + length > in.size || memcmp( in.text + in.pos, word, (size_t) length ) != 0 )
+    {
+        in.bad = true;
+        return false;
+    }
+    in.pos += length;
+    return true;
+}
+
+// one \uXXXX escape body; -1 when the four hex digits are not there
+inline int TableJsonHex4( TableJsonIn & in )
+{
+    if ( in.pos + 4 > in.size ) { return -1; }
+    int value = 0;
+    for ( int i = 0; i < 4; i++ )
+    {
+        char c = in.text[in.pos + i];
+        int digit;
+        if ( c >= '0' && c <= '9' ) { digit = c - '0'; }
+        else if ( c >= 'a' && c <= 'f' ) { digit = c - 'a' + 10; }
+        else if ( c >= 'A' && c <= 'F' ) { digit = c - 'A' + 10; }
+        else { return -1; }
+        value = ( value << 4 ) | digit;
+    }
+    in.pos += 4;
+    return value;
+}
+
+inline int32_t TableJsonEncodeUtf8( uint32_t code, char * unit )
+{
+    if ( code < 0x80 ) { unit[0] = (char) code; return 1; }
+    if ( code < 0x800 )
+    {
+        unit[0] = (char) ( 0xc0 | ( code >> 6 ) );
+        unit[1] = (char) ( 0x80 | ( code & 0x3f ) );
+        return 2;
+    }
+    if ( code < 0x10000 )
+    {
+        unit[0] = (char) ( 0xe0 | ( code >> 12 ) );
+        unit[1] = (char) ( 0x80 | ( ( code >> 6 ) & 0x3f ) );
+        unit[2] = (char) ( 0x80 | ( code & 0x3f ) );
+        return 3;
+    }
+    unit[0] = (char) ( 0xf0 | ( code >> 18 ) );
+    unit[1] = (char) ( 0x80 | ( ( code >> 12 ) & 0x3f ) );
+    unit[2] = (char) ( 0x80 | ( ( code >> 6 ) & 0x3f ) );
+    unit[3] = (char) ( 0x80 | ( code & 0x3f ) );
+    return 4;
+}
+
+// Scan one JSON string into a caller buffer. Bytes are appended ONE CODE
+// POINT AT A TIME — an escape's encoding, or a UTF-8 sequence read whole —
+// so a string longer than the field is clamped AT A CODE POINT BOUNDARY and
+// never cut through a multi-byte character. Clamping is counted, never
+// fatal, exactly as it is on the wire (§4). A NULL destination scans past a
+// string without keeping it.
+inline bool TableJsonScanString( TableJsonIn & in, char * out, int32_t capacity, int32_t * length )
+{
+    if ( TableJsonPeek( in ) != '"' ) { in.bad = true; return false; }
+    in.pos++;
+    int32_t placed = 0;
+    bool clamped = false;
+    for ( ;; )
+    {
+        if ( in.pos >= in.size ) { in.bad = true; return false; }
+        char c = in.text[in.pos];
+        if ( c == '"' ) { in.pos++; break; }
+        char unit[4];
+        int32_t unit_length = 0;
+        if ( c == '\\' )
+        {
+            in.pos++;
+            if ( in.pos >= in.size ) { in.bad = true; return false; }
+            char escape = in.text[in.pos++];
+            switch ( escape )
+            {
+                case '"':  unit[0] = '"';  unit_length = 1; break;
+                case '\\': unit[0] = '\\'; unit_length = 1; break;
+                case '/':  unit[0] = '/';  unit_length = 1; break;
+                case 'b':  unit[0] = '\b'; unit_length = 1; break;
+                case 'f':  unit[0] = '\f'; unit_length = 1; break;
+                case 'n':  unit[0] = '\n'; unit_length = 1; break;
+                case 'r':  unit[0] = '\r'; unit_length = 1; break;
+                case 't':  unit[0] = '\t'; unit_length = 1; break;
+                case 'u':
+                {
+                    int high = TableJsonHex4( in );
+                    if ( high < 0 ) { in.bad = true; return false; }
+                    uint32_t code = (uint32_t) high;
+                    if ( high >= 0xd800 && high <= 0xdbff && in.pos + 2 <= in.size &&
+                         in.text[in.pos] == '\\' && in.text[in.pos + 1] == 'u' )
+                    {
+                        int64_t mark = in.pos;
+                        in.pos += 2;
+                        int low = TableJsonHex4( in );
+                        if ( low >= 0xdc00 && low <= 0xdfff )
+                        {
+                            code = 0x10000 + ( ( (uint32_t) high - 0xd800 ) << 10 ) + ( (uint32_t) low - 0xdc00 );
+                        }
+                        else
+                        {
+                            in.pos = mark; // a lone lead surrogate rides as itself
+                        }
+                    }
+                    unit_length = TableJsonEncodeUtf8( code, unit );
+                    break;
+                }
+                default: in.bad = true; return false;
+            }
+        }
+        else if ( (unsigned char) c < 0x20 )
+        {
+            in.bad = true; // a raw control character is not a JSON string body
+            return false;
+        }
+        else
+        {
+            // a UTF-8 sequence read WHOLE, so the clamp below can only land
+            // between code points
+            unsigned char lead = (unsigned char) c;
+            int32_t want = 1;
+            if ( ( lead & 0xe0 ) == 0xc0 ) { want = 2; }
+            else if ( ( lead & 0xf0 ) == 0xe0 ) { want = 3; }
+            else if ( ( lead & 0xf8 ) == 0xf0 ) { want = 4; }
+            for ( int32_t i = 0; i < want; i++ )
+            {
+                if ( in.pos >= in.size ) { in.bad = true; return false; }
+                unit[i] = in.text[in.pos++];
+            }
+            unit_length = want;
+        }
+        if ( out != NULL )
+        {
+            if ( placed + unit_length <= capacity )
+            {
+                memcpy( out + placed, unit, (size_t) unit_length );
+                placed += unit_length;
+            }
+            else
+            {
+                clamped = true;
+            }
+        }
+    }
+    if ( clamped ) { in.report->clamped++; }
+    if ( length != NULL ) { *length = placed; }
+    return true;
+}
+
+// the numeric token at the cursor, copied out whole; false = not a number
+inline bool TableJsonScanNumber( TableJsonIn & in, char * token, int32_t capacity, int32_t * length, bool * integral )
+{
+    TableJsonSpace( in );
+    int64_t start = in.pos;
+    bool whole = true;
+    while ( in.pos < in.size )
+    {
+        char c = in.text[in.pos];
+        bool numeric = ( c >= '0' && c <= '9' ) || c == '-' || c == '+' || c == '.' || c == 'e' || c == 'E';
+        if ( !numeric ) { break; }
+        if ( c == '.' || c == 'e' || c == 'E' ) { whole = false; }
+        in.pos++;
+    }
+    bool digits = false;
+    for ( int64_t i = start; i < in.pos; i++ )
+    {
+        if ( in.text[i] >= '0' && in.text[i] <= '9' ) { digits = true; break; }
+    }
+    int64_t count = in.pos - start;
+    if ( count <= 0 || count >= capacity || !digits ) { return false; }
+    memcpy( token, in.text + start, (size_t) count );
+    token[count] = 0;
+    *length = (int32_t) count;
+    *integral = whole;
+    return true;
+}
+
+// the token's exact double, through the runtime's own converter — which
+// speaks the LOCALE's decimal point, so the token crosses back over that
+// character on its way in
+inline double TableJsonTokenDouble( const char * token, int32_t length, bool single )
+{
+    char work[kTableJsonMaxNumber];
+    memcpy( work, token, (size_t) length );
+    work[length] = 0;
+    char point = TableJsonDecimalPoint();
+    if ( point != '.' )
+    {
+        for ( int32_t i = 0; i < length; i++ )
+        {
+            if ( work[i] == '.' ) { work[i] = point; }
+        }
+    }
+    if ( single ) { return (double) strtof( work, NULL ); }
+    return strtod( work, NULL );
+}
+
+// the token's exact integer, parsed digit by digit so no width and no
+// locale can move it. Saturation is reported as a clamp, the wire's rule for
+// a value outside what the reader can hold (§4).
+inline int64_t TableJsonTokenInteger( const char * token, int32_t length, bool is_signed, bool * saturated )
+{
+    int32_t i = 0;
+    bool negative = false;
+    if ( i < length && ( token[i] == '-' || token[i] == '+' ) )
+    {
+        negative = token[i] == '-';
+        i++;
+    }
+    uint64_t magnitude = 0;
+    bool over = false;
+    for ( ; i < length; i++ )
+    {
+        uint64_t digit = (uint64_t) ( token[i] - '0' );
+        if ( magnitude > ( UINT64_MAX - digit ) / 10 ) { over = true; break; }
+        magnitude = magnitude * 10 + digit;
+    }
+    if ( !is_signed )
+    {
+        if ( negative ) { *saturated = true; return 0; }
+        if ( over ) { *saturated = true; return (int64_t) UINT64_MAX; }
+        *saturated = false;
+        return (int64_t) magnitude;
+    }
+    if ( negative )
+    {
+        if ( over || magnitude > ( uint64_t( 1 ) << 63 ) ) { *saturated = true; return INT64_MIN; }
+        *saturated = false;
+        if ( magnitude == ( uint64_t( 1 ) << 63 ) ) { return INT64_MIN; }
+        return -(int64_t) magnitude;
+    }
+    if ( over || magnitude > (uint64_t) INT64_MAX ) { *saturated = true; return INT64_MAX; }
+    *saturated = false;
+    return (int64_t) magnitude;
+}
+
+inline bool TableJsonSkipValue( TableJsonIn & in, int32_t depth );
+
+inline bool TableJsonSkipContainer( TableJsonIn & in, char close, int32_t depth )
+{
+    if ( depth > kTableJsonMaxDepth ) { in.bad = true; return false; }
+    in.pos++; // the opening bracket
+    for ( ;; )
+    {
+        char c = TableJsonPeek( in );
+        if ( c == close ) { in.pos++; return true; }
+        if ( c == 0 ) { in.bad = true; return false; }
+        if ( close == '}' )
+        {
+            if ( !TableJsonScanString( in, NULL, 0, NULL ) ) { return false; }
+            if ( TableJsonPeek( in ) != ':' ) { in.bad = true; return false; }
+            in.pos++;
+        }
+        if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+        c = TableJsonPeek( in );
+        if ( c == ',' ) { in.pos++; continue; }   // a trailing comma is accepted
+        if ( c == close ) { in.pos++; return true; }
+        in.bad = true;
+        return false;
+    }
+}
+
+inline bool TableJsonSkipValue( TableJsonIn & in, int32_t depth )
+{
+    char c = TableJsonPeek( in );
+    switch ( c )
+    {
+        case '{': return TableJsonSkipContainer( in, '}', depth );
+        case '[': return TableJsonSkipContainer( in, ']', depth );
+        case '"': return TableJsonScanString( in, NULL, 0, NULL );
+        case 't': return TableJsonLiteral( in, "true" );
+        case 'f': return TableJsonLiteral( in, "false" );
+        case 'n': return TableJsonLiteral( in, "null" );
+        case 0:   in.bad = true; return false;
+        default:
+        {
+            char token[kTableJsonMaxNumber];
+            int32_t length = 0;
+            bool integral = false;
+            if ( !TableJsonScanNumber( in, token, kTableJsonMaxNumber, &length, &integral ) )
+            {
+                in.bad = true;
+                return false;
+            }
+            return true;
+        }
+    }
+}
+
+inline bool TableJsonReadTable( TableJsonIn & in, void * base, const TableTypeInfo * info, int32_t depth );
+
+// place one scalar at one storage address
+inline bool TableJsonReadScalar( TableJsonIn & in, void * storage, const TableFieldInfo * f, int32_t depth )
+{
+    if ( f->arms != NULL )
+    {
+        // a union is an object with ONE key, the arm's name; {} is None, and
+        // two keys is a text this walk will not guess at
+        const TableUnionInfo * arms = f->arms();
+        if ( TableJsonPeek( in ) != '{' ) { in.bad = true; return false; }
+        in.pos++;
+        TableJsonSetRaw( (uint8_t *) storage + arms->tag_offset, arms->tag_size, 0 );
+        if ( TableJsonPeek( in ) == '}' ) { in.pos++; return true; }
+        char key[kTableJsonMaxKey];
+        int32_t key_length = 0;
+        if ( !TableJsonScanString( in, key, kTableJsonMaxKey - 1, &key_length ) ) { return false; }
+        key[key_length] = 0;
+        if ( TableJsonPeek( in ) != ':' ) { in.bad = true; return false; }
+        in.pos++;
+        int64_t tag = 0;
+        for ( int64_t t = 1; t <= f->enum_max; t++ )
+        {
+            if ( strcmp( f->enum_name( (uint64_t) t ), key ) == 0 ) { tag = t; break; }
+        }
+        if ( tag == 0 )
+        {
+            in.report->unknown++;
+            if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+        }
+        else
+        {
+            void * payload = (uint8_t *) storage + arms->arms[tag].offset;
+            arms->arms[tag].table->reset( payload );
+            if ( !TableJsonReadTable( in, payload, arms->arms[tag].table, depth + 1 ) ) { return false; }
+            TableJsonSetRaw( (uint8_t *) storage + arms->tag_offset, arms->tag_size, (uint64_t) tag );
+        }
+        char c = TableJsonPeek( in );
+        if ( c == ',' ) { in.pos++; c = TableJsonPeek( in ); }
+        if ( c == '}' ) { in.pos++; return true; }
+        in.bad = true; // a second key: a one-of with two arms is not a value
+        return false;
+    }
+    if ( f->kind == 13 )
+    {
+        f->table->reset( storage );
+        return TableJsonReadTable( in, storage, f->table, depth + 1 );
+    }
+    if ( TableJsonIsEnum( f ) )
+    {
+        char name[kTableJsonMaxKey];
+        int32_t name_length = 0;
+        if ( !TableJsonScanString( in, name, kTableJsonMaxKey - 1, &name_length ) ) { return false; }
+        name[name_length] = 0;
+        for ( int64_t v = 0; v <= f->enum_max; v++ )
+        {
+            if ( strcmp( f->enum_name( (uint64_t) v ), name ) == 0 )
+            {
+                TableJsonSetRaw( storage, f->elem_size, (uint64_t) v );
+                return true;
+            }
+        }
+        // a name this build cannot name reads as None and counts as unknown,
+        // exactly as an unknown variant id does on the wire (§4)
+        TableJsonSetRaw( storage, f->elem_size, 0 );
+        in.report->unknown++;
+        return true;
+    }
+    if ( TableJsonIsFlags( f ) )
+    {
+        if ( TableJsonPeek( in ) != '[' ) { in.bad = true; return false; }
+        in.pos++;
+        uint64_t bits = 0;
+        for ( ;; )
+        {
+            char c = TableJsonPeek( in );
+            if ( c == ']' ) { in.pos++; break; }
+            if ( c == 0 ) { in.bad = true; return false; }
+            if ( c != '"' )
+            {
+                in.report->kind_mismatch++;
+                if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+            }
+            else
+            {
+                char name[kTableJsonMaxKey];
+                int32_t name_length = 0;
+                if ( !TableJsonScanString( in, name, kTableJsonMaxKey - 1, &name_length ) ) { return false; }
+                name[name_length] = 0;
+                bool found = false;
+                for ( int64_t bit = 0; bit <= f->enum_max; bit++ )
+                {
+                    if ( strcmp( f->enum_name( (uint64_t) bit ), name ) == 0 )
+                    {
+                        bits |= uint64_t( 1 ) << bit;
+                        found = true;
+                        break;
+                    }
+                }
+                if ( !found ) { in.report->unknown++; }
+            }
+            c = TableJsonPeek( in );
+            if ( c == ',' ) { in.pos++; continue; }
+            if ( c == ']' ) { in.pos++; break; }
+            in.bad = true;
+            return false;
+        }
+        TableJsonSetRaw( storage, f->elem_size, bits );
+        return true;
+    }
+    if ( f->kind == 1 )
+    {
+        char c = TableJsonPeek( in );
+        if ( c == 't' ) { if ( !TableJsonLiteral( in, "true" ) ) { return false; } TableJsonSetRaw( storage, f->elem_size, 1 ); return true; }
+        if ( !TableJsonLiteral( in, "false" ) ) { return false; }
+        TableJsonSetRaw( storage, f->elem_size, 0 );
+        return true;
+    }
+    char token[kTableJsonMaxNumber];
+    int32_t length = 0;
+    bool integral = false;
+    if ( !TableJsonScanNumber( in, token, kTableJsonMaxNumber, &length, &integral ) )
+    {
+        in.bad = true;
+        return false;
+    }
+    if ( f->kind == 10 || f->kind == 11 )
+    {
+        bool single = f->kind == 10;
+        double value = TableJsonTokenDouble( token, length, single );
+        if ( f->has_range )
+        {
+            if ( value < f->range_min ) { value = f->range_min; in.report->clamped++; }
+            else if ( value > f->range_max ) { value = f->range_max; in.report->clamped++; }
+        }
+        if ( single )
+        {
+            float narrow = (float) value;
+            memcpy( storage, &narrow, sizeof( narrow ) );
+        }
+        else
+        {
+            memcpy( storage, &value, sizeof( value ) );
+        }
+        return true;
+    }
+    if ( !integral )
+    {
+        // a fraction where an integer is declared is the WRONG SHAPE for the
+        // kind, not framing damage: skipped and counted, never rounded into
+        // place (§16.2)
+        in.report->kind_mismatch++;
+        return true;
+    }
+    bool is_signed = f->kind >= 2 && f->kind <= 5;
+    bool saturated = false;
+    int64_t value = TableJsonTokenInteger( token, length, is_signed, &saturated );
+    if ( saturated ) { in.report->clamped++; }
+    if ( f->has_range )
+    {
+        if ( (double) value < f->range_min ) { value = (int64_t) f->range_min; in.report->clamped++; }
+        else if ( (double) value > f->range_max ) { value = (int64_t) f->range_max; in.report->clamped++; }
+    }
+    // the field's own storage width is the last bound: a value past it
+    // clamps rather than wrapping, which is what the wire does too
+    if ( f->elem_size < 8 )
+    {
+        if ( is_signed )
+        {
+            int64_t high = ( int64_t( 1 ) << ( f->elem_size * 8 - 1 ) ) - 1;
+            int64_t low = -high - 1;
+            if ( value > high ) { value = high; in.report->clamped++; }
+            else if ( value < low ) { value = low; in.report->clamped++; }
+        }
+        else
+        {
+            uint64_t high = ( uint64_t( 1 ) << ( f->elem_size * 8 ) ) - 1;
+            if ( value < 0 ) { value = 0; in.report->clamped++; }
+            else if ( (uint64_t) value > high ) { value = (int64_t) high; in.report->clamped++; }
+        }
+    }
+    // at eight bytes the storage IS the parser's width, and an unsigned value
+    // past INT64_MAX rides here as a negative int64 by design — the token
+    // parser already turned a NEGATIVE token for an unsigned field into a
+    // clamped zero, so there is nothing left to bound.
+    TableJsonSetRaw( storage, f->elem_size, (uint64_t) value );
+    return true;
+}
+
+inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldInfo * f, int32_t depth )
+{
+    uint8_t * storage = (uint8_t *) base + f->offset;
+    if ( f->kind == 12 )
+    {
+        int32_t length = 0;
+        if ( !TableJsonScanString( in, (char *) storage, f->array_bound, &length ) ) { return false; }
+        storage[length] = 0;
+        TableJsonSetCount( base, f, length );
+        return true;
+    }
+    if ( TableJsonIsBytes( f ) )
+    {
+        char encoded[kTableJsonMaxKey];
+        int32_t encoded_length = 0;
+        // base64 is scanned into a bounded window: a body longer than the
+        // window cannot fit the field either, so the excess clamps
+        if ( !TableJsonScanString( in, encoded, kTableJsonMaxKey, &encoded_length ) ) { return false; }
+        int32_t placed = 0;
+        uint32_t accumulator = 0;
+        int32_t held = 0;
+        bool malformed = false;
+        for ( int32_t i = 0; i < encoded_length; i++ )
+        {
+            char c = encoded[i];
+            if ( c == '=' ) { break; }
+            const char * alphabet = TableJsonBase64Alphabet();
+            const char * at = strchr( alphabet, c );
+            if ( at == NULL || c == 0 ) { malformed = true; break; }
+            accumulator = ( accumulator << 6 ) | (uint32_t) ( at - alphabet );
+            held += 6;
+            if ( held >= 8 )
+            {
+                held -= 8;
+                if ( placed < f->array_bound )
+                {
+                    storage[placed++] = (uint8_t) ( ( accumulator >> held ) & 0xff );
+                }
+                else
+                {
+                    in.report->clamped++;
+                    break;
+                }
+            }
+        }
+        if ( malformed )
+        {
+            // a body that is not base64 is the wrong shape for the kind: the
+            // field keeps its default and the event is counted
+            in.report->kind_mismatch++;
+            return true;
+        }
+        TableJsonSetCount( base, f, placed );
+        return true;
+    }
+    if ( f->is_array )
+    {
+        if ( TableJsonPeek( in ) != '[' ) { in.bad = true; return false; }
+        in.pos++;
+        int32_t placed = 0;
+        char shape = TableJsonElementShape( f );
+        for ( ;; )
+        {
+            char c = TableJsonPeek( in );
+            if ( c == ']' ) { in.pos++; break; }
+            if ( c == 0 ) { in.bad = true; return false; }
+            if ( placed >= f->array_bound )
+            {
+                // more elements than the reader's bound: the bounded prefix
+                // is kept and the excess counts, the wire's rule (§4)
+                in.report->clamped++;
+                if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+            }
+            else if ( TableJsonValueShape( in ) != shape )
+            {
+                in.report->kind_mismatch++;
+                if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+                placed++;
+            }
+            else
+            {
+                if ( !TableJsonReadScalar( in, storage + (int64_t) placed * f->elem_size, f, depth + 1 ) ) { return false; }
+                placed++;
+            }
+            c = TableJsonPeek( in );
+            if ( c == ',' ) { in.pos++; continue; }
+            if ( c == ']' ) { in.pos++; break; }
+            in.bad = true;
+            return false;
+        }
+        // a fixed array's tail keeps the defaults the prefill left there,
+        // exactly as a short wire count does
+        TableJsonSetCount( base, f, placed );
+        return true;
+    }
+    return TableJsonReadScalar( in, storage, f, depth );
+}
+
+// ONE table object: keys are field keys, unknown ones are skipped and
+// counted, a repeated key is last-wins and counted. The instance is already
+// at its declared defaults when this is entered, so a key the text never
+// mentions keeps the default an absent field takes on the wire (§4).
+inline bool TableJsonReadTable( TableJsonIn & in, void * base, const TableTypeInfo * info, int32_t depth )
+{
+    if ( depth > kTableJsonMaxDepth ) { in.bad = true; return false; }
+    if ( TableJsonPeek( in ) != '{' ) { in.bad = true; return false; }
+    in.pos++;
+    // duplicate tracking, bounded and allocation-free: a table with more
+    // fields than this still reads, its repeats simply stop being counted
+    uint64_t seen[8] = {};
+    for ( ;; )
+    {
+        char c = TableJsonPeek( in );
+        if ( c == '}' ) { in.pos++; return true; }
+        if ( c == 0 ) { in.bad = true; return false; }
+        char key[kTableJsonMaxKey];
+        int32_t key_length = 0;
+        if ( !TableJsonScanString( in, key, kTableJsonMaxKey - 1, &key_length ) ) { return false; }
+        key[key_length] = 0;
+        if ( TableJsonPeek( in ) != ':' ) { in.bad = true; return false; }
+        in.pos++;
+        int32_t index = -1;
+        for ( int32_t i = 0; i < info->num_fields; i++ )
+        {
+            if ( strcmp( info->fields[i].json, key ) == 0 ) { index = i; break; }
+        }
+        if ( index < 0 )
+        {
+            in.report->unknown++;
+            if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+        }
+        else
+        {
+            const TableFieldInfo * f = &info->fields[index];
+            if ( index < 512 )
+            {
+                uint64_t bit = uint64_t( 1 ) << ( index & 63 );
+                if ( ( seen[index >> 6] & bit ) != 0 ) { in.report->duplicate++; }
+                seen[index >> 6] |= bit;
+            }
+            // ---- SEAM: an optional field (schema#260) sets its presence
+            // ---- companion here, by the key's PRESENCE; an enum-keyed array
+            // ---- (schema#255) reads an object keyed by variant name instead
+            // ---- of a positional array.
+            if ( TableJsonValueShape( in ) != TableJsonShape( f ) )
+            {
+                // the wrong JSON type for the kind: skipped, never coerced
+                in.report->kind_mismatch++;
+                if ( !TableJsonSkipValue( in, depth + 1 ) ) { return false; }
+            }
+            else if ( !TableJsonReadField( in, base, f, depth ) )
+            {
+                return false;
+            }
+        }
+        c = TableJsonPeek( in );
+        if ( c == ',' ) { in.pos++; continue; } // a trailing comma is accepted
+        if ( c == '}' ) { in.pos++; return true; }
+        in.bad = true;
+        return false;
+    }
+}
+
+// ---- the two entry points the per-table wrappers name ----
+
+inline bool TableJsonRead( void * value, const TableTypeInfo * info, const char * text, int64_t bytes, TableReport * report )
+{
+    TableReport ignored;
+    TableJsonIn in;
+    in.text = text;
+    in.size = bytes;
+    in.pos = 0;
+    in.report = report != NULL ? report : &ignored;
+    in.bad = false;
+    info->reset( value );
+    if ( text == NULL || bytes < 0 )
+    {
+        in.report->malformed = true;
+        return false;
+    }
+    bool ok = TableJsonReadTable( in, value, info, 0 );
+    if ( ok )
+    {
+        TableJsonSpace( in );
+        if ( in.pos != in.size ) { in.bad = true; } // trailing rubbish is not one text
+    }
+    if ( in.bad || !ok )
+    {
+        in.report->malformed = true;
+        return false;
+    }
+    return true;
+}
+
+inline int64_t TableJsonWrite( const void * value, const TableTypeInfo * info, char * buffer, int64_t capacity )
+{
+    TableJsonOut out;
+    out.buffer = buffer;
+    out.capacity = capacity;
+    out.offset = 0;
+    out.overflow = false;
+    if ( !TableJsonWriteValue( out, value, info, 0 ) ) { return -1; }
+    if ( out.overflow ) { return -1; }
+    return out.offset;
+}
+
+// ---- json walk: end ----
+`

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -35,8 +35,13 @@ func tableJsonWalk(pkg string) string {
 // to call.
 func (g *tableGen) emitJsonSurface(st *ir.Struct) {
 	if g.isVar(st.Name) {
-		g.pf("// %s is VARIABLE-LENGTH: its text form reads through the builder and is\n", st.Name)
-		g.pf("// a named follow-on (SPEC-TABLES.md §16.6). No %sFromJson is emitted.\n\n", st.Name)
+		// SPEC-TABLES.md §16.1 states the builder surface for this class —
+		// <Name>FromJson( builder, ... ) — and this backend does not carry it
+		// yet. The refusal is by ABSENCE and it is loud: there is no function
+		// to call, so nothing silently reads a pointered table as an empty one.
+		g.pf("// %s is VARIABLE-LENGTH. Its text form reads through the builder\n", st.Name)
+		g.pf("// (SPEC-TABLES.md §16.1), which this backend does not emit yet:\n")
+		g.pf("// no %sFromJson and no %sToJson exist to call.\n\n", st.Name, st.Name)
 		return
 	}
 	g.pf("// %s in and out of a JSON text — one instance, one text, the generic walk\n", st.Name)

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -741,18 +741,23 @@ inline bool TableJsonScanString( TableJsonIn & in, char * out, int32_t capacity,
         else
         {
             // a UTF-8 sequence read WHOLE, so the clamp below can only land
-            // between code points
+            // between code points. Only bytes that ACTUALLY look like
+            // continuations are taken: the wire imposes no encoding (§3), so
+            // a string may legitimately hold a stray lead byte, and one at
+            // the end of a text must not swallow the closing quote.
             unsigned char lead = (unsigned char) c;
             int32_t want = 1;
             if ( ( lead & 0xe0 ) == 0xc0 ) { want = 2; }
             else if ( ( lead & 0xf0 ) == 0xe0 ) { want = 3; }
             else if ( ( lead & 0xf8 ) == 0xf0 ) { want = 4; }
-            for ( int32_t i = 0; i < want; i++ )
+            unit[0] = c;
+            in.pos++;
+            unit_length = 1;
+            while ( unit_length < want && in.pos < in.size &&
+                    ( (unsigned char) in.text[in.pos] & 0xc0 ) == 0x80 )
             {
-                if ( in.pos >= in.size ) { in.bad = true; return false; }
-                unit[i] = in.text[in.pos++];
+                unit[unit_length++] = in.text[in.pos++];
             }
-            unit_length = want;
         }
         if ( out != NULL )
         {

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -1114,22 +1114,26 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
     }
     if ( TableJsonIsBytes( f ) )
     {
-        char encoded[kTableJsonMaxKey];
-        int32_t encoded_length = 0;
-        // base64 is scanned into a bounded window: a body longer than the
-        // window cannot fit the field either, so the excess clamps
-        if ( !TableJsonScanString( in, encoded, kTableJsonMaxKey, &encoded_length ) ) { return false; }
+        // base64 decodes STRAIGHT INTO the field's storage, six bits at a
+        // time — no window, no temporary, so a bytes(N) of any declared
+        // extent reads the same way. A base64 body carries no escapes, so a
+        // backslash in one is simply not an alphabet character.
+        if ( TableJsonPeek( in ) != '"' ) { in.bad = true; return false; }
+        in.pos++;
+        const char * alphabet = TableJsonBase64Alphabet();
         int32_t placed = 0;
         uint32_t accumulator = 0;
         int32_t held = 0;
+        bool clamped = false;
         bool malformed = false;
-        for ( int32_t i = 0; i < encoded_length; i++ )
+        for ( ;; )
         {
-            char c = encoded[i];
-            if ( c == '=' ) { break; }
-            const char * alphabet = TableJsonBase64Alphabet();
-            const char * at = strchr( alphabet, c );
-            if ( at == NULL || c == 0 ) { malformed = true; break; }
+            if ( in.pos >= in.size ) { in.bad = true; return false; }
+            char c = in.text[in.pos++];
+            if ( c == '"' ) { break; }
+            if ( c == '=' || malformed ) { continue; }
+            const char * at = c != 0 ? strchr( alphabet, c ) : NULL;
+            if ( at == NULL ) { malformed = true; continue; }
             accumulator = ( accumulator << 6 ) | (uint32_t) ( at - alphabet );
             held += 6;
             if ( held >= 8 )
@@ -1141,8 +1145,7 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
                 }
                 else
                 {
-                    in.report->clamped++;
-                    break;
+                    clamped = true;
                 }
             }
         }
@@ -1153,6 +1156,7 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
             in.report->kind_mismatch++;
             return true;
         }
+        if ( clamped ) { in.report->clamped++; }
         TableJsonSetCount( base, f, placed );
         return true;
     }

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -553,9 +553,11 @@ inline bool TableJsonWriteValue( TableJsonOut & out, const void * base, const Ta
     {
         const TableFieldInfo * f = &info->fields[i];
         if ( f->guard[0] != 0 && !TableJsonGuardHolds( base, info, f->guard ) ) { continue; }
-        // ---- SEAM: optional fields (schema#260) write their key only when
-        // ---- present; enum-keyed arrays (schema#255) write an object keyed
-        // ---- by variant name instead of a positional array. Both land here.
+        // ---- SEAM (schema#260): an OPTIONAL field writes its key only when
+        // ---- present — skip here on !optional_present, since presence is the
+        // ---- presence and an absent key is the absence. The enum-keyed half
+        // ---- (schema#255) is not here: an object keyed by variant name is a
+        // ---- SHAPE, so it lands in TableJsonShape and TableJsonWriteField.
         if ( !any ) { out.put( '{' ); }
         else { out.put( ',' ); }
         any = true;
@@ -1258,10 +1260,12 @@ inline bool TableJsonReadTable( TableJsonIn & in, void * base, const TableTypeIn
                 if ( ( seen[index >> 6] & bit ) != 0 ) { in.report->duplicate++; }
                 seen[index >> 6] |= bit;
             }
-            // ---- SEAM: an optional field (schema#260) sets its presence
-            // ---- companion here, by the key's PRESENCE; an enum-keyed array
-            // ---- (schema#255) reads an object keyed by variant name instead
-            // ---- of a positional array.
+            // ---- SEAM (schema#260): an OPTIONAL field sets its presence
+            // ---- companion here, because reaching this line IS the key being
+            // ---- present. The enum-keyed half (schema#255) is not here: it
+            // ---- is a shape, and lands in TableJsonShape and
+            // ---- TableJsonReadField, matching each key against the key
+            // ---- vocabulary rather than counting positions.
             if ( TableJsonValueShape( in ) != TableJsonShape( f ) )
             {
                 // the wrong JSON type for the kind: skipped, never coerced

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -964,7 +964,9 @@ inline int64_t TableJsonTokenInteger( const char * token, int32_t length, bool i
     }
     if ( !is_signed )
     {
-        if ( negative ) { *saturated = true; return 0; }
+        // -0 IS zero, and clamping it would report an event that did not
+        // happen; only a real negative magnitude is out of range here
+        if ( negative ) { *saturated = magnitude != 0; return 0; }
         if ( over ) { *saturated = true; return (int64_t) UINT64_MAX; }
         *saturated = false;
         return (int64_t) magnitude;

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -193,6 +193,13 @@ type Field struct {
 	// identity survives a rename. Table fields only; "" when unset.
 	WasName string
 
+	// JsonKey is the `json = "key"` text-form key (SPEC-TABLES.md §16.3): the
+	// key the JSON walk reads and writes this field under, so a declaration
+	// can meet an existing text. Table fields only; "" means the field's own
+	// name is the key. It moves no wire byte — keys are the text's business,
+	// ids are the wire's.
+	JsonKey string
+
 	Array      ArrayKind
 	ArrayBound int64
 	ArrayExpr  Expr  // the declared bound expression, for rendering

--- a/ir/table.go
+++ b/ir/table.go
@@ -36,6 +36,17 @@ func TableFieldId(f *Field) uint16 {
 	return FieldId(f.Name)
 }
 
+// TableFieldJsonKey is a field's key in the text form (SPEC-TABLES.md §16.3):
+// the `json = "key"` attribute where one is declared, and the field's own name
+// otherwise. Independent of the wire id — a `was` rename and a `json` key are
+// two different vocabularies over one field.
+func TableFieldJsonKey(f *Field) string {
+	if f.JsonKey != "" {
+		return f.JsonKey
+	}
+	return f.Name
+}
+
 // VariableTables derives the table MODE — the compiler works it out; nobody
 // declares it (the owner's ruling: "i wouldn't want to manually have to
 // specify this… the compiler can work it out"). A closure member is

--- a/tables/examples/Guarded.schema
+++ b/tables/examples/Guarded.schema
@@ -1,0 +1,28 @@
+// Guarded.schema — nested and negated branches, the shape the flat
+// `if has_loadout` in Tables.schema does not reach. A guard's condition is
+// composed from the branch tree ("active && !has_target"), and both the wire
+// codecs and the text walk (SPEC-TABLES.md §16.2) have to evaluate the same
+// composition and agree about which fields ride.
+package tabledemo
+
+table Patrol
+{
+    active bool
+    if active
+    {
+        speed      float32 = 1.0
+        has_target bool
+        if has_target
+        {
+            target_id int32 = 0 | min = 0, max = 1000
+        }
+        else
+        {
+            wander float32 = 0.5
+        }
+    }
+    else
+    {
+        note string(8)
+    }
+}

--- a/test/tables/JsonKeys.schema
+++ b/test/tables/JsonKeys.schema
@@ -1,0 +1,14 @@
+// JsonKeys.schema — the `json = "key"` attribute (SPEC-TABLES.md §16.3): a
+// declaration meeting a text that already exists. The keys differ from the
+// schema names, and no wire byte moves — a field's wire id is still the hash
+// of its own name, so this file's wire is exactly what it would be with the
+// attribute deleted. The corpus holds both halves.
+package jsonkeys
+
+table Ship
+{
+    ship_type  int32       | json = "type"
+    name       string(24)  | json = "label"
+    hit_points int32 = 100 | json = "hp", min = 0, max = 1000
+    shielded   bool
+}

--- a/test/tables/json_negative_main.cpp
+++ b/test/tables/json_negative_main.cpp
@@ -1,0 +1,62 @@
+// The NEGATIVE CONTROL for the text form (SPEC-TABLES.md §16.5).
+//
+// A green round-trip suite is worth nothing until the suite has been shown
+// capable of going red. This binary is built against a DELIBERATELY SABOTAGED
+// walker — the field-offset arithmetic shifted by one field width, applied by
+// the Makefile to a throwaway copy of the generated header — and it PASSES
+// only when the round trip fails.
+//
+// Attachment is the smallest table with two fields (slot at offset 0, power
+// at offset 4, both four bytes), so the sabotage swaps exactly two fields and
+// reads nothing outside the struct.
+
+#include <cstdio>
+#include <cstring>
+
+#include "TablesTable.h"
+
+int main()
+{
+    tabledemo::Attachment value;
+    value.slot = 5;
+    value.power = 2.5f;
+
+    int64_t size = tabledemo::AttachmentToJsonMeasure( value );
+    if ( size <= 0 )
+    {
+        printf( "json negative control: the sabotaged writer refused outright — red, as required\n" );
+        return 0;
+    }
+    char text[512];
+    if ( size > (int64_t) sizeof( text ) )
+    {
+        printf( "FAIL json negative control: the text does not fit the fixture buffer\n" );
+        return 1;
+    }
+    if ( tabledemo::AttachmentToJson( value, text, size ) != size )
+    {
+        printf( "json negative control: the sabotaged writer disagreed with its own measure — red\n" );
+        return 0;
+    }
+
+    tabledemo::Attachment back;
+    tabledemo::TableReport report;
+    if ( !tabledemo::AttachmentFromJson( back, text, size, &report ) )
+    {
+        printf( "json negative control: the sabotaged text would not read back — red\n" );
+        return 0;
+    }
+
+    uint8_t a[256], b[256];
+    int64_t na = tabledemo::AttachmentSave( value, a, sizeof( a ) );
+    int64_t nb = tabledemo::AttachmentSave( back, b, sizeof( b ) );
+    if ( na != nb || na <= 0 || memcmp( a, b, (size_t) na ) != 0 )
+    {
+        printf( "json negative control: the round trip changed the wire — red, as required\n" );
+        return 0;
+    }
+
+    printf( "FAIL json negative control: a walker with its offsets sabotaged still round-tripped\n"
+            "      Attachment byte-identically. The round-trip suite cannot see an offset bug.\n" );
+    return 1;
+}

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -742,7 +742,15 @@ static void test_flags_are_positional()
     CHECK( perks != NULL );
     CHECK( perks->kind == 9 );            // kU64: the mask's raw storage
     CHECK( perks->variant_id == NULL );   // no per-variant wire id exists to carry
-    CHECK( perks->enum_max == -1 );
+    // the bits DO have names, and the descriptor carries them: enum_max is the
+    // highest declared BIT INDEX and enum_name spells one bit (SPEC-TABLES.md
+    // §8). The missing variant_id beside a present enum_name is what says
+    // "positional vocabulary" — a bit has a name, never a wire id.
+    CHECK( perks->enum_max == 2 );
+    CHECK( perks->enum_name != NULL );
+    CHECK( strcmp( perks->enum_name( 0 ), "Shielded" ) == 0 );
+    CHECK( strcmp( perks->enum_name( 1 ), "Cloaked" ) == 0 );
+    CHECK( strcmp( perks->enum_name( 2 ), "Turbo" ) == 0 );
 
     tabledemo::LoadoutConfig loadout;
     loadout.perks = tabledemo::Perks_Cloaked; // bit 1
@@ -985,6 +993,48 @@ static void test_reflection()
     CHECK( strcmp( effect->enum_name( 1 ), "buff" ) == 0 );
     CHECK( effect->variant_id( 0 ) == 0 );
     CHECK( effect->variant_id( 2 ) == field_id( "debuff" ) );
+    // and the arms carry their PAYLOAD: where it sits in the union storage and
+    // what it looks like, so a walker can enter a union with no schema files
+    // (SPEC-TABLES.md §8). Arm 0 is the empty arm and has none.
+    CHECK( effect->arms != NULL );
+    {
+        const tabledemo::TableUnionInfo * arms = effect->arms();
+        CHECK( arms->tag_offset == offsetof( tabledemo::Effect, type ) );
+        CHECK( arms->tag_size == sizeof( tabledemo::Effect{}.type ) );
+        CHECK( arms->arms[0].table == NULL );
+        CHECK( arms->arms[1].table == tabledemo::BuffTableType() );
+        CHECK( arms->arms[1].offset == offsetof( tabledemo::Effect, buff ) );
+        CHECK( arms->arms[2].table == tabledemo::DebuffTableType() );
+
+        // the walk a tool actually does: reach the arm's payload by name
+        tabledemo::WeaponConfig w;
+        w.effect.type = tabledemo::EffectType::Buff;
+        w.effect.buff.multiplier = 3.5f;
+        uint8_t * base = (uint8_t *) &w;
+        uint8_t tag = *( base + effect->offset + arms->tag_offset );
+        CHECK( strcmp( effect->enum_name( tag ), "buff" ) == 0 );
+        const void * payload = base + effect->offset + arms->arms[tag].offset;
+        const tabledemo::TableFieldInfo * mult = demo_field( arms->arms[tag].table, "multiplier" );
+        CHECK( mult != NULL );
+        float read = 0.0f;
+        memcpy( &read, (const uint8_t *) payload + mult->offset, sizeof( read ) );
+        CHECK( read == 3.5f );
+    }
+
+    // reset: a generic walker can put any instance back at its declared
+    // defaults with no type to spell (SPEC-TABLES.md §8)
+    {
+        tabledemo::WeaponConfig w;
+        w.damage = 999.0f;
+        w.homing = true;
+        weapon->reset( &w );
+        CHECK( w.damage == 21.0f ); // the DECLARED default, not zero
+        CHECK( w.homing == false );
+    }
+
+    // the text form's key rides beside the name (SPEC-TABLES.md §16.3); with
+    // no json attribute in the corpus the two are the same string's content
+    CHECK( strcmp( damage->json, "damage" ) == 0 );
     const tabledemo::TableFieldInfo * nameF = demo_field( profileType, "name" );
     CHECK( nameF != NULL && nameF->kind == 12 ); // string
 

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -14,6 +14,7 @@
 #include "KeyedTable.h"
 #include "NestedTable.h"
 #include "WideTable.h"
+#include "GuardedTable.h"
 #include "V1Table.h"
 #include "V2Table.h"
 #include "GraphTable.h"
@@ -4022,6 +4023,85 @@ static void test_json_null_is_a_kind_mismatch()
     }
 }
 
+// ---- composed guards: nested and negated branches ------------------------
+//
+// Tables.schema's only guard is a flat `if has_loadout`, so the composition
+// TableJsonGuardHolds actually has to parse — "active && !has_target" — was
+// never reached by this suite. Patrol reaches all four states.
+
+static void test_json_nested_guards()
+{
+    struct { bool active; bool has_target; } states[] = {
+        { false, false }, { false, true }, { true, false }, { true, true },
+    };
+    for ( const auto & state : states )
+    {
+        tabledemo::Patrol value;
+        value.active = state.active;
+        value.has_target = state.has_target;
+        value.speed = 3.5f;
+        value.target_id = 42;
+        value.wander = 9.5f;
+        set_string( value.note, value.note_length, "patrol" );
+
+        int64_t size = tabledemo::PatrolToJsonMeasure( value );
+        CHECK( size > 0 );
+        std::vector<char> text( (size_t) size + 1 );
+        CHECK( tabledemo::PatrolToJson( value, text.data(), size ) == size );
+        text[(size_t) size] = 0;
+
+        // the text carries exactly the fields the WIRE would carry: a guard
+        // decides both, from one composition
+        CHECK( ( strstr( text.data(), "\"speed\"" ) != NULL ) == state.active );
+        CHECK( ( strstr( text.data(), "\"has_target\"" ) != NULL ) == state.active );
+        CHECK( ( strstr( text.data(), "\"target_id\"" ) != NULL ) == ( state.active && state.has_target ) );
+        CHECK( ( strstr( text.data(), "\"wander\"" ) != NULL ) == ( state.active && !state.has_target ) );
+        CHECK( ( strstr( text.data(), "\"note\"" ) != NULL ) == !state.active );
+        CHECK( strstr( text.data(), "\"active\"" ) != NULL ); // the guard itself is a plain key
+
+        // and the round trip lands the same wire
+        tabledemo::Patrol back;
+        tabledemo::TableReport report;
+        CHECK( tabledemo::PatrolFromJson( back, text.data(), size, &report ) );
+        CHECK( !report.malformed && report.unknown == 0 && report.kind_mismatch == 0 );
+        uint8_t a[512], b[512];
+        int64_t na = tabledemo::PatrolSave( value, a, sizeof( a ) );
+        int64_t nb = tabledemo::PatrolSave( back, b, sizeof( b ) );
+        if ( na <= 0 || na != nb || memcmp( a, b, (size_t) na ) != 0 )
+        {
+            printf( "FAIL json nested guard (active=%d has_target=%d): wire %lld vs %lld\n",
+                    (int) state.active, (int) state.has_target, (long long) na, (long long) nb );
+            failures++;
+        }
+    }
+
+    // reading is ORDER-FREE: every key placed before either guard is named,
+    // and the instance still matches the one built by hand
+    {
+        tabledemo::Patrol value;
+        tabledemo::TableReport report;
+        const char * text =
+            "{ \"target_id\": 7, \"wander\": 1.5, \"note\": \"x\", \"speed\": 2.5,"
+            "  \"has_target\": true, \"active\": true }";
+        CHECK( tabledemo::PatrolFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.active && value.has_target && value.target_id == 7 && value.speed == 2.5f );
+
+        tabledemo::Patrol hand;
+        hand.active = true;
+        hand.has_target = true;
+        hand.target_id = 7;
+        hand.speed = 2.5f;
+        hand.wander = 1.5f;
+        set_string( hand.note, hand.note_length, "x" );
+        uint8_t a[512], b[512];
+        int64_t na = tabledemo::PatrolSave( value, a, sizeof( a ) );
+        int64_t nb = tabledemo::PatrolSave( hand, b, sizeof( b ) );
+        CHECK( na > 0 && na == nb && memcmp( a, b, (size_t) na ) == 0 );
+    }
+
+    JSON_ROUND_TRIP( tabledemo, Patrol, ( []() { tabledemo::Patrol p; p.active = true; p.has_target = false; p.speed = 8.0f; p.wander = 2.5f; return p; }() ) );
+}
+
 int main()
 {
     test_round_trip();
@@ -4096,6 +4176,7 @@ int main()
     test_json_no_infinity_reaches_storage();
     test_json_duplicate_arrays_last_wins();
     test_json_null_is_a_kind_mismatch();
+    test_json_nested_guards();
     test_json_pinned_text();
     test_json_fuzz_tokenizer();
 

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -22,6 +22,7 @@
 #include "P1Table.h"
 #include "P2Table.h"
 #include "P3Table.h"
+#include "JsonKeysTable.h"
 
 static int failures = 0;
 
@@ -51,6 +52,14 @@ static uint16_t field_id( const char * name )
 }
 
 static const tabledemo::TableFieldInfo * demo_field( const tabledemo::TableTypeInfo * type, const char * name )
+{
+    for ( int32_t i = 0; i < type->num_fields; i++ )
+        if ( strcmp( type->fields[i].name, name ) == 0 )
+            return &type->fields[i];
+    return NULL;
+}
+
+static const jsonkeys::TableFieldInfo * jsonkeys_field( const jsonkeys::TableTypeInfo * type, const char * name )
 {
     for ( int32_t i = 0; i < type->num_fields; i++ )
         if ( strcmp( type->fields[i].name, name ) == 0 )
@@ -2769,6 +2778,752 @@ static void test_optional_and_keyed_reflection()
     const tblv1::TableFieldInfo * tally = v1_field( cfg, "tally" );
     CHECK( tally != NULL && tally->is_array );
     CHECK( tally->key_type_name == NULL && tally->key_name == NULL && tally->key_id == NULL );
+// ---- the TEXT form (SPEC-TABLES.md §16) ------------------------------------
+//
+// ONE walk over the reflection descriptors, so these tests are about the
+// WALK, not about any table: what holds for the corpus root holds for every
+// table in the closure by construction, and the round-trip loop below says
+// so table by table anyway.
+
+// the text form's contract in one call: write it, read it back, and prove the
+// instance that came back saves to THE SAME WIRE BYTES as the one that went
+// out. The wire is the arbiter — a text that round-trips through it has lost
+// nothing the wire would have carried.
+template <typename T>
+static void check_json_round_trip( const T & value,
+                                   int64_t ( *measure )( const T & ),
+                                   int64_t ( *to_json )( const T &, char *, int64_t ),
+                                   bool ( *from_json )( T &, const char *, int64_t, tabledemo::TableReport * ),
+                                   int64_t ( *wire_measure )( const T & ),
+                                   int64_t ( *wire_save )( const T &, uint8_t *, int64_t ),
+                                   const char * what )
+{
+    int64_t size = measure( value );
+    if ( size < 0 ) { printf( "FAIL %s: ToJsonMeasure refused\n", what ); failures++; return; }
+
+    // measure == write at EXACT capacity, the wire's invariant carried across
+    std::vector<char> text( (size_t) size );
+    CHECK( to_json( value, text.data(), size ) == size );
+    if ( size > 0 )
+    {
+        std::vector<char> tight( (size_t) size - 1 );
+        CHECK( to_json( value, tight.data(), size - 1 ) == -1 ); // one byte short REFUSES
+    }
+    // and a roomy write produces the same bytes as the exact one
+    std::vector<char> roomy( (size_t) size + 64 );
+    CHECK( to_json( value, roomy.data(), size + 64 ) == size );
+    CHECK( memcmp( roomy.data(), text.data(), (size_t) size ) == 0 );
+
+    T back;
+    tabledemo::TableReport report;
+    if ( !from_json( back, text.data(), size, &report ) )
+    {
+        printf( "FAIL %s: FromJson refused its own text\n", what );
+        failures++;
+        return;
+    }
+    if ( report.unknown != 0 || report.kind_mismatch != 0 || report.clamped != 0 ||
+         report.duplicate != 0 || report.malformed )
+    {
+        printf( "FAIL %s: a text this build wrote reported %d/%d/%d/%d/%d\n", what,
+                report.unknown, report.kind_mismatch, report.clamped, report.duplicate,
+                (int) report.malformed );
+        failures++;
+    }
+
+    int64_t wire_a = wire_measure( value );
+    int64_t wire_b = wire_measure( back );
+    if ( wire_a < 0 || wire_a != wire_b ) { printf( "FAIL %s: wire sizes differ\n", what ); failures++; return; }
+    std::vector<uint8_t> a( (size_t) wire_a ), b( (size_t) wire_b );
+    CHECK( wire_save( value, a.data(), wire_a ) == wire_a );
+    CHECK( wire_save( back, b.data(), wire_b ) == wire_b );
+    if ( memcmp( a.data(), b.data(), (size_t) wire_a ) != 0 )
+    {
+        printf( "FAIL %s: round trip changed the wire\n", what );
+        failures++;
+    }
+}
+
+#define JSON_ROUND_TRIP( ns, type, value )                                    \
+    check_json_round_trip<ns::type>( value, ns::type##ToJsonMeasure,           \
+        ns::type##ToJson, ns::type##FromJson, ns::type##Measure, ns::type##Save, #type )
+
+// a corpus root with every kind of the closure populated away from its
+// default, so nothing round-trips green by riding a default
+static tabledemo::RootConfig json_corpus_root()
+{
+    tabledemo::RootConfig root;
+    set_string( root.version_note, root.version_note_length, "note \"q\"\n" );
+    root.weapons_count = 2;
+    root.weapons[0].damage = 33.5f;
+    root.weapons[0].speed = 0.1f;          // a value no short decimal names exactly
+    root.weapons[0].penetration = 7;
+    root.weapons[0].channel = 63;          // bits(6) at its ceiling
+    root.weapons[0].homing = true;
+    root.weapons[0].effect.type = tabledemo::EffectType::Buff;
+    root.weapons[0].effect.buff.multiplier = 2.25f;
+    root.weapons[1].effect.type = tabledemo::EffectType::Debuff;
+    root.weapons[1].effect.debuff.amount = 99;
+
+    root.profiles_count = 1;
+    tabledemo::ProfileConfig & p = root.profiles[0];
+    set_string( p.name, p.name_length, "Ada \xc3\xa9 \xe2\x9c\x93" ); // multi-byte UTF-8
+    const uint8_t icon[5] = { 0x00, 0x01, 0xfe, 0xff, 0x7f };
+    memcpy( p.icon, icon, sizeof( icon ) );
+    p.icon_length = (int32_t) sizeof( icon );
+    p.experience = 4294967295u;            // u32 at its ceiling
+    p.tilt = -128;                         // i8 at its floor
+    p.heading = 32767;
+    p.timestamp = -9223372036854775807LL - 1; // i64 at its floor
+    p.badge = 255;
+    p.port = 65535;
+    p.epoch = 18446744073709551615ull;     // u64 at its ceiling: past int64
+    p.precision = 0.1;                     // a double no short decimal names exactly
+    p.ratings[0] = 1.5f;
+    p.ratings[3] = -2.25f;
+    p.has_loadout = true;
+    p.loadout.grade = tabledemo::Grade::Gold;
+    p.loadout.grades_count = 3;
+    p.loadout.grades[0] = tabledemo::Grade::Bronze;
+    p.loadout.grades[1] = tabledemo::Grade::None;
+    p.loadout.grades[2] = tabledemo::Grade::Silver;
+    p.loadout.podium[0] = tabledemo::Grade::Silver;
+    p.loadout.podium[2] = tabledemo::Grade::Gold;
+    p.loadout.perks = tabledemo::Perks_Shielded | tabledemo::Perks_Turbo;
+    p.loadout.primary.damage = 12.0f;
+    p.loadout.backups[1].homing = true;
+    p.loadout.attachments_count = 2;
+    p.loadout.attachments[0].slot = 7;
+    p.loadout.attachments[0].power = 3.5f;
+    p.loadout.attachments[1].slot = 0;
+    return root;
+}
+
+// ---- every table in tables/examples round-trips ToJson -> FromJson -> Save,
+// ---- byte-identical to the Save of the instance that went out
+
+static void test_json_corpus_round_trip()
+{
+    tabledemo::RootConfig root = json_corpus_root();
+    JSON_ROUND_TRIP( tabledemo, RootConfig, root );
+    JSON_ROUND_TRIP( tabledemo, WeaponConfig, root.weapons[0] );
+    JSON_ROUND_TRIP( tabledemo, WeaponConfig, root.weapons[1] );
+    JSON_ROUND_TRIP( tabledemo, ProfileConfig, root.profiles[0] );
+    JSON_ROUND_TRIP( tabledemo, LoadoutConfig, root.profiles[0].loadout );
+    JSON_ROUND_TRIP( tabledemo, Attachment, root.profiles[0].loadout.attachments[0] );
+    JSON_ROUND_TRIP( tabledemo, Buff, root.weapons[0].effect.buff );
+    JSON_ROUND_TRIP( tabledemo, Debuff, root.weapons[1].effect.debuff );
+
+    // an ALL-DEFAULT instance: the text carries every field anyway (a text is
+    // for people, and one that elides is one a reader must know the schema to
+    // complete), and the wire it comes back as is the empty one
+    tabledemo::RootConfig empty;
+    JSON_ROUND_TRIP( tabledemo, RootConfig, empty );
+    tabledemo::WeaponConfig plain;
+    JSON_ROUND_TRIP( tabledemo, WeaponConfig, plain );
+
+    // cross-file: ArchiveConfig nests RootConfig from another file
+    tabledemo::ArchiveConfig archive;
+    archive.root = root;
+    archive.count = 42;
+    JSON_ROUND_TRIP( tabledemo, ArchiveConfig, archive );
+
+    // extents past the old 16-bit ceiling ride the text form too
+    tabledemo::WideBlob wide;
+    for ( int32_t i = 0; i < 70000; i++ ) { wide.label[i] = char( 'a' + ( i % 26 ) ); }
+    wide.label[70000] = 0;
+    wide.label_length = 70000;
+    for ( int32_t i = 0; i < 66000; i++ ) { wide.payload[i] = (uint8_t) ( i * 7 ); }
+    wide.payload_length = 66000;
+    wide.samples_count = 70000;
+    for ( int32_t i = 0; i < 70000; i++ ) { wide.samples[i] = (uint16_t) ( i * 3 ); }
+    JSON_ROUND_TRIP( tabledemo, WideBlob, wide );
+
+    // the evolution pair's tables are ordinary tables to the walk
+    tblv1::Cfg cfg;
+    cfg.a = 900;
+    cfg.b = 2.5f;
+    cfg.mode = tblv1::Mode::Alpha;
+    set_string( cfg.name, cfg.name_length, "v1" );
+    cfg.inner.factor = 9.0f;
+    cfg.items_count = 2; cfg.items[0] = 3; cfg.items[1] = 250;
+    cfg.grade = tblv1::Grade::Gold;
+    cfg.effect.type = tblv1::EffectType::Ward;
+    cfg.effect.ward.charge = 0.25f;
+    {
+        int64_t size = tblv1::CfgToJsonMeasure( cfg );
+        CHECK( size > 0 );
+        std::vector<char> text( (size_t) size );
+        CHECK( tblv1::CfgToJson( cfg, text.data(), size ) == size );
+        tblv1::Cfg back;
+        tblv1::TableReport report;
+        CHECK( tblv1::CfgFromJson( back, text.data(), size, &report ) );
+        uint8_t a[4096], b[4096];
+        int64_t na = tblv1::CfgSave( cfg, a, sizeof( a ) );
+        int64_t nb = tblv1::CfgSave( back, b, sizeof( b ) );
+        CHECK( na > 0 && na == nb && memcmp( a, b, (size_t) na ) == 0 );
+    }
+}
+
+// ---- the dialect: what the walk accepts, and what it will not guess at ----
+
+static void test_json_dialect()
+{
+    tabledemo::Attachment value;
+    tabledemo::TableReport report;
+
+    // trailing commas: the authoring files this section exists for carry them
+    const char * trailing = "{ \"slot\": 3, \"power\": 1.5, }";
+    CHECK( tabledemo::AttachmentFromJson( value, trailing, (int64_t) strlen( trailing ), &report ) );
+    CHECK( value.slot == 3 && value.power == 1.5f );
+    CHECK( report.unknown == 0 && !report.malformed );
+
+    // ... in arrays too
+    tabledemo::LoadoutConfig loadout;
+    const char * array_trailing = "{ \"grades\": [ \"Gold\", \"Bronze\", ], }";
+    CHECK( tabledemo::LoadoutConfigFromJson( loadout, array_trailing, (int64_t) strlen( array_trailing ), &report ) );
+    CHECK( loadout.grades_count == 2 && loadout.grades[0] == tabledemo::Grade::Gold );
+
+    // comments are not JSON, and a walk that guessed at one would be reading
+    // a dialect nobody wrote down
+    tabledemo::TableReport comment_report;
+    const char * comment = "{ // a note\n \"slot\": 3 }";
+    CHECK( !tabledemo::AttachmentFromJson( value, comment, (int64_t) strlen( comment ), &comment_report ) );
+    CHECK( comment_report.malformed );
+
+    // whitespace anywhere, and a text that is not an object at all
+    const char * spaced = "  \t\n { \n \"slot\" \t : \n 2 \n } \n ";
+    CHECK( tabledemo::AttachmentFromJson( value, spaced, (int64_t) strlen( spaced ), &report ) );
+    CHECK( value.slot == 2 );
+    tabledemo::TableReport not_object;
+    const char * scalar = "42";
+    CHECK( !tabledemo::AttachmentFromJson( value, scalar, 2, &not_object ) );
+    CHECK( not_object.malformed );
+
+    // trailing rubbish after the one text is not one text
+    tabledemo::TableReport trailing_junk;
+    const char * two = "{ \"slot\": 1 } { \"slot\": 2 }";
+    CHECK( !tabledemo::AttachmentFromJson( value, two, (int64_t) strlen( two ), &trailing_junk ) );
+    CHECK( trailing_junk.malformed );
+
+    // an absent key keeps the field's DECLARED default, exactly as an absent
+    // field does on the wire (SPEC-TABLES.md §4)
+    tabledemo::WeaponConfig weapon;
+    const char * partial = "{ \"homing\": true }";
+    CHECK( tabledemo::WeaponConfigFromJson( weapon, partial, (int64_t) strlen( partial ), &report ) );
+    CHECK( weapon.homing && weapon.damage == 21.0f && weapon.speed == 500.0f );
+
+    // unknown keys are skipped and counted, whatever they carry
+    tabledemo::TableReport unknown;
+    const char * strange = "{ \"nope\": { \"deep\": [ 1, 2, { \"x\": null } ] }, \"slot\": 4, \"also\": \"text\" }";
+    CHECK( tabledemo::AttachmentFromJson( value, strange, (int64_t) strlen( strange ), &unknown ) );
+    CHECK( value.slot == 4 );
+    CHECK( unknown.unknown == 2 && !unknown.malformed );
+
+    // a duplicate key is LAST WINS, and the repeat is counted
+    tabledemo::TableReport duplicate;
+    const char * repeated = "{ \"slot\": 1, \"slot\": 6, \"slot\": 2 }";
+    CHECK( tabledemo::AttachmentFromJson( value, repeated, (int64_t) strlen( repeated ), &duplicate ) );
+    CHECK( value.slot == 2 && duplicate.duplicate == 2 );
+
+    // string escapes both ways, including a surrogate pair
+    tabledemo::ProfileConfig profile;
+    const char * escapes = "{ \"name\": \"a\\\"b\\\\c\\nd\\u00e9e\\ud83d\\ude00\" }";
+    CHECK( tabledemo::ProfileConfigFromJson( profile, escapes, (int64_t) strlen( escapes ), &report ) );
+    CHECK( strcmp( profile.name, "a\"b\\c\nd\xc3\xa9""e\xf0\x9f\x98\x80" ) == 0 );
+}
+
+// ---- hostile: the wrong JSON type at every kind, and every width overflowed
+
+static void test_json_hostile_kinds()
+{
+    // a key present with the WRONG JSON TYPE is skipped and counted, never
+    // coerced: the field keeps its default and the read carries on
+    struct { const char * text; const char * what; } wrong[] = {
+        { "{ \"experience\": \"12\" }",      "string where a number is declared" },
+        { "{ \"experience\": true }",        "bool where a number is declared" },
+        { "{ \"experience\": null }",        "null where a number is declared" },
+        { "{ \"experience\": [ 1 ] }",       "array where a number is declared" },
+        { "{ \"experience\": { \"a\": 1 } }", "object where a number is declared" },
+        { "{ \"name\": 5 }",                 "number where a string is declared" },
+        { "{ \"name\": [ \"a\" ] }",         "array where a string is declared" },
+        { "{ \"icon\": 7 }",                 "number where bytes are declared" },
+        { "{ \"has_loadout\": 1 }",          "number where a bool is declared" },
+        { "{ \"has_loadout\": \"true\" }",   "string where a bool is declared" },
+        { "{ \"ratings\": 3.5 }",            "number where an array is declared" },
+        { "{ \"loadout\": [ ] }",            "array where a table is declared" },
+        { "{ \"precision\": \"1e3\" }",      "string where a float is declared" },
+    };
+    for ( const auto & row : wrong )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        bool ok = tabledemo::ProfileConfigFromJson( value, row.text, (int64_t) strlen( row.text ), &report );
+        if ( !ok || report.kind_mismatch != 1 || report.malformed )
+        {
+            printf( "FAIL json kind mismatch (%s): ok=%d mismatch=%d malformed=%d\n",
+                    row.what, ok, report.kind_mismatch, (int) report.malformed );
+            failures++;
+        }
+        CHECK( value.experience == 0 && value.name_length == 0 && !value.has_loadout );
+    }
+
+    // a vocabulary field wants a NAME, not a number
+    {
+        tabledemo::LoadoutConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"grade\": 3, \"perks\": 5 }";
+        CHECK( tabledemo::LoadoutConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.kind_mismatch == 2 );
+        CHECK( value.grade == tabledemo::Grade::Silver ); // the declared default
+        CHECK( value.perks == 0 );
+    }
+
+    // a name no variant names reads as None and counts as UNKNOWN — the same
+    // event an unknown variant id is on the wire (SPEC-TABLES.md §4)
+    {
+        tabledemo::LoadoutConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"grade\": \"Platinum\", \"perks\": [ \"Turbo\", \"Warp\" ] }";
+        CHECK( tabledemo::LoadoutConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.grade == tabledemo::Grade::None );
+        CHECK( value.perks == tabledemo::Perks_Turbo );
+        CHECK( report.unknown == 2 );
+    }
+
+    // a fraction where an INTEGER is declared is the wrong shape for the kind,
+    // not framing damage: counted and skipped, never rounded into place
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"experience\": 12.5, \"badge\": 3 }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.experience == 0 && value.badge == 3 );
+        CHECK( report.kind_mismatch == 1 && !report.malformed );
+    }
+}
+
+static void test_json_hostile_overflow()
+{
+    // every integer width, over its ceiling and under its floor: CLAMPED and
+    // counted, never wrapped (SPEC-TABLES.md §4)
+    struct { const char * text; const char * field; int64_t expect; } rows[] = {
+        { "{ \"tilt\": 999 }",                          "tilt+",  127 },
+        { "{ \"tilt\": -999 }",                         "tilt-",  -128 },
+        { "{ \"badge\": 300 }",                         "badge",  255 },
+        { "{ \"badge\": -1 }",                          "badge-", 0 },
+        { "{ \"heading\": 40000 }",                     "head+",  32767 },
+        { "{ \"heading\": -40000 }",                    "head-",  -32768 },
+        { "{ \"port\": 70000 }",                        "port",   65535 },
+        { "{ \"experience\": 5000000000 }",             "exp",    4294967295ll },
+        { "{ \"timestamp\": 99999999999999999999 }",    "time+",  9223372036854775807ll },
+        { "{ \"timestamp\": -99999999999999999999 }",   "time-",  -9223372036854775807ll - 1 },
+    };
+    for ( const auto & row : rows )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        CHECK( tabledemo::ProfileConfigFromJson( value, row.text, (int64_t) strlen( row.text ), &report ) );
+        int64_t got = 0;
+        if ( strncmp( row.field, "tilt", 4 ) == 0 ) { got = value.tilt; }
+        else if ( strncmp( row.field, "badge", 5 ) == 0 ) { got = value.badge; }
+        else if ( strncmp( row.field, "head", 4 ) == 0 ) { got = value.heading; }
+        else if ( strncmp( row.field, "port", 4 ) == 0 ) { got = value.port; }
+        else if ( strncmp( row.field, "exp", 3 ) == 0 ) { got = (int64_t) value.experience; }
+        else { got = value.timestamp; }
+        if ( got != row.expect || report.clamped == 0 || report.malformed )
+        {
+            printf( "FAIL json overflow (%s): got %lld want %lld clamped=%d\n",
+                    row.field, (long long) got, (long long) row.expect, report.clamped );
+            failures++;
+        }
+    }
+
+    // u64 past int64 is NOT an overflow — it is the top of the field
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"epoch\": 18446744073709551615 }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.epoch == 18446744073709551615ull && report.clamped == 0 );
+    }
+    // ... and past THAT it saturates at the ceiling
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"epoch\": 99999999999999999999999 }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.epoch == 18446744073709551615ull && report.clamped == 1 );
+    }
+
+    // a DECLARED range clamps before the storage width does
+    {
+        tabledemo::WeaponConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"penetration\": 500, \"channel\": 4000 }";
+        CHECK( tabledemo::WeaponConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.penetration == 10 );  // | min = 0, max = 10
+        CHECK( value.channel == 63 );      // bits(6): the width IS the range
+        CHECK( report.clamped == 2 );
+    }
+
+    // a float range clamps the same way
+    {
+        tabledemo::Attachment value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"slot\": -5 }";
+        CHECK( tabledemo::AttachmentFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.slot == 0 && report.clamped == 1 );
+    }
+}
+
+static void test_json_hostile_extents()
+{
+    // a string longer than the field CLAMPS AT A CODE POINT BOUNDARY: the
+    // storage never holds half a character
+    {
+        tabledemo::RootConfig value;   // version_note is string(16)
+        tabledemo::TableReport report;
+        // 15 ASCII bytes, then a 2-byte character that cannot fit in the 16th
+        const char * text = "{ \"version_note\": \"123456789012345\xc3\xa9\" }";
+        CHECK( tabledemo::RootConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.version_note_length == 15 );
+        CHECK( strcmp( value.version_note, "123456789012345" ) == 0 );
+        CHECK( report.clamped == 1 );
+    }
+    {
+        // and a 3-byte character that WOULD have fit at 14 does
+        tabledemo::RootConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"version_note\": \"1234567890123\xe2\x9c\x93X\" }";
+        CHECK( tabledemo::RootConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.version_note_length == 16 );
+        CHECK( report.clamped == 1 ); // the trailing X did not fit
+    }
+
+    // more array elements than the reader's bound: the bounded prefix is kept
+    // and the excess counts, the wire's rule
+    {
+        tabledemo::LoadoutConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"grades\": [ \"Gold\", \"Gold\", \"Gold\", \"Gold\", \"Gold\", \"Gold\" ] }";
+        CHECK( tabledemo::LoadoutConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.grades_count == 4 && report.clamped == 2 );
+    }
+    // fewer than a FIXED array's extent: the tail keeps its defaults
+    {
+        tabledemo::LoadoutConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"podium\": [ \"Gold\" ] }";
+        CHECK( tabledemo::LoadoutConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.podium[0] == tabledemo::Grade::Gold );
+        CHECK( value.podium[1] == tabledemo::Grade::None && value.podium[2] == tabledemo::Grade::None );
+        CHECK( report.clamped == 0 );
+    }
+
+    // base64 both ways, and a body that is not base64 at all
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"icon\": \"AQID/w==\" }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.icon_length == 4 );
+        CHECK( value.icon[0] == 0x01 && value.icon[1] == 0x02 && value.icon[2] == 0x03 && value.icon[3] == 0xff );
+        CHECK( report.kind_mismatch == 0 );
+    }
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"icon\": \"not base64 at all!\" }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.icon_length == 0 && report.kind_mismatch == 1 && !report.malformed );
+    }
+    {
+        // a base64 body longer than bytes(16) clamps and counts
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"icon\": \"QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=\" }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.icon_length == 16 && report.clamped == 1 );
+    }
+}
+
+static void test_json_hostile_unions()
+{
+    tabledemo::WeaponConfig value;
+    tabledemo::TableReport report;
+
+    // {} and an absent key are both None
+    const char * empty = "{ \"effect\": {} }";
+    CHECK( tabledemo::WeaponConfigFromJson( value, empty, (int64_t) strlen( empty ), &report ) );
+    CHECK( value.effect.type == tabledemo::EffectType::None );
+
+    // ONE key, the arm's name
+    const char * one = "{ \"effect\": { \"debuff\": { \"amount\": 12 } } }";
+    CHECK( tabledemo::WeaponConfigFromJson( value, one, (int64_t) strlen( one ), &report ) );
+    CHECK( value.effect.type == tabledemo::EffectType::Debuff && value.effect.debuff.amount == 12 );
+
+    // an arm this build cannot name reads as None and counts
+    tabledemo::TableReport unknown_arm;
+    const char * strange = "{ \"effect\": { \"hex\": { \"power\": 3 } } }";
+    CHECK( tabledemo::WeaponConfigFromJson( value, strange, (int64_t) strlen( strange ), &unknown_arm ) );
+    CHECK( value.effect.type == tabledemo::EffectType::None && unknown_arm.unknown == 1 );
+
+    // TWO keys is not a one-of, and the walk will not choose for you
+    tabledemo::TableReport two;
+    const char * both = "{ \"effect\": { \"buff\": { \"multiplier\": 2.0 }, \"debuff\": { \"amount\": 1 } } }";
+    CHECK( !tabledemo::WeaponConfigFromJson( value, both, (int64_t) strlen( both ), &two ) );
+    CHECK( two.malformed );
+
+    // a selected arm is RE-ESTABLISHED, never overlaid on the last one: a
+    // repeated key that names a different arm leaves nothing of the first
+    tabledemo::TableReport repeat;
+    const char * again = "{ \"effect\": { \"buff\": { \"multiplier\": 9.0 } }, "
+                         "\"effect\": { \"debuff\": { \"amount\": 4 } } }";
+    CHECK( tabledemo::WeaponConfigFromJson( value, again, (int64_t) strlen( again ), &repeat ) );
+    CHECK( value.effect.type == tabledemo::EffectType::Debuff && value.effect.debuff.amount == 4 );
+    CHECK( repeat.duplicate == 1 );
+}
+
+static void test_json_hostile_framing()
+{
+    tabledemo::Attachment value;
+
+    struct { const char * text; const char * what; } broken[] = {
+        { "",                          "empty" },
+        { "{",                         "unterminated object" },
+        { "{ \"slot\"",                "key with no colon" },
+        { "{ \"slot\": }",             "colon with no value" },
+        { "{ \"slot\" 3 }",            "no colon" },
+        { "{ slot: 3 }",               "unquoted key" },
+        { "{ \"slot\": 3",             "no close" },
+        { "{ \"slot\": [ 1, 2 }",      "array closed as an object" },
+        { "{ \"slot\": \"unterminated }", "unterminated string" },
+        { "{ \"slot\": tru }",         "truncated literal" },
+        { "{ \"slot\": - }",           "a sign with no digits" },
+        { "{ \"slot\": \"\\q\" }",     "an escape that is not one" },
+        { "{ \"slot\": \"\\u00\" }",   "a short unicode escape" },
+    };
+    for ( const auto & row : broken )
+    {
+        tabledemo::TableReport report;
+        bool ok = tabledemo::AttachmentFromJson( value, row.text, (int64_t) strlen( row.text ), &report );
+        if ( ok || !report.malformed )
+        {
+            printf( "FAIL json framing (%s): ok=%d malformed=%d\n", row.what, ok, (int) report.malformed );
+            failures++;
+        }
+    }
+
+    // nesting past the cap is refused rather than run off the C stack
+    {
+        std::vector<char> deep;
+        const char * head = "{ \"nope\": ";
+        deep.insert( deep.end(), head, head + strlen( head ) );
+        for ( int i = 0; i < 400; i++ ) { deep.push_back( '[' ); }
+        for ( int i = 0; i < 400; i++ ) { deep.push_back( ']' ); }
+        deep.push_back( '}' );
+        tabledemo::TableReport report;
+        CHECK( !tabledemo::AttachmentFromJson( value, deep.data(), (int64_t) deep.size(), &report ) );
+        CHECK( report.malformed );
+    }
+    // a nesting the walk CAN take is still taken
+    {
+        std::vector<char> deep;
+        const char * head = "{ \"nope\": ";
+        deep.insert( deep.end(), head, head + strlen( head ) );
+        for ( int i = 0; i < 100; i++ ) { deep.push_back( '[' ); }
+        for ( int i = 0; i < 100; i++ ) { deep.push_back( ']' ); }
+        const char * tail = ", \"slot\": 5 }";
+        deep.insert( deep.end(), tail, tail + strlen( tail ) );
+        tabledemo::TableReport report;
+        CHECK( tabledemo::AttachmentFromJson( value, deep.data(), (int64_t) deep.size(), &report ) );
+        CHECK( value.slot == 5 && report.unknown == 1 && !report.malformed );
+    }
+
+    // a NULL text, and a negative size
+    {
+        tabledemo::TableReport report;
+        CHECK( !tabledemo::AttachmentFromJson( value, NULL, 0, &report ) );
+        CHECK( report.malformed );
+    }
+    // ... and no report at all is legal: the walk owns one when the caller
+    // does not
+    CHECK( !tabledemo::AttachmentFromJson( value, "{", 1, NULL ) );
+}
+
+// ---- the writer refuses what the text cannot name, exactly as measure and
+// ---- save refuse what the wire cannot name (SPEC-TABLES.md §5)
+
+static void test_json_writer_refusals()
+{
+    {
+        tabledemo::LoadoutConfig value;
+        value.grade = (tabledemo::Grade) 9; // no variant names it
+        CHECK( tabledemo::LoadoutConfigToJsonMeasure( value ) == -1 );
+    }
+    {
+        tabledemo::LoadoutConfig value;
+        value.perks = uint64_t( 1 ) << 40; // no variant names that bit
+        CHECK( tabledemo::LoadoutConfigToJsonMeasure( value ) == -1 );
+    }
+    {
+        tabledemo::WeaponConfig value;
+        value.effect.type = (tabledemo::EffectType) 7; // no arm names it
+        CHECK( tabledemo::WeaponConfigToJsonMeasure( value ) == -1 );
+    }
+    {
+        // a non-finite float has no JSON spelling at all, and the writer will
+        // not lose one silently
+        tabledemo::WeaponConfig value;
+        value.damage = 1.0f / 0.0f - 1.0f / 0.0f; // NaN, computed so no literal is needed
+        CHECK( tabledemo::WeaponConfigToJsonMeasure( value ) == -1 );
+        value.damage = 3.4e38f * 10.0f;           // +inf
+        CHECK( tabledemo::WeaponConfigToJsonMeasure( value ) == -1 );
+    }
+}
+
+// ---- guards: the wire's elision, carried into the text (SPEC-TABLES.md §16.2)
+
+static void test_json_guards()
+{
+    tabledemo::ProfileConfig off;
+    off.has_loadout = false;
+    off.loadout.grade = tabledemo::Grade::Gold; // stale, and off the wire
+    int64_t size = tabledemo::ProfileConfigToJsonMeasure( off );
+    CHECK( size > 0 );
+    std::vector<char> text( (size_t) size + 1 );
+    CHECK( tabledemo::ProfileConfigToJson( off, text.data(), size ) == size );
+    text[(size_t) size] = 0;
+    CHECK( strstr( text.data(), "\"loadout\"" ) == NULL ); // guarded off, as on the wire
+    CHECK( strstr( text.data(), "\"has_loadout\"" ) != NULL ); // the guard is a plain key
+
+    tabledemo::ProfileConfig on;
+    on.has_loadout = true;
+    on.loadout.grade = tabledemo::Grade::Gold;
+    size = tabledemo::ProfileConfigToJsonMeasure( on );
+    std::vector<char> text_on( (size_t) size + 1 );
+    CHECK( tabledemo::ProfileConfigToJson( on, text_on.data(), size ) == size );
+    text_on[(size_t) size] = 0;
+    CHECK( strstr( text_on.data(), "\"loadout\"" ) != NULL );
+
+    // reading INFERS NOTHING: the guard is an ordinary bool key, and a guarded
+    // field's key is placed whether or not the guard came first — key order in
+    // an object is nobody's contract
+    tabledemo::ProfileConfig value;
+    tabledemo::TableReport report;
+    const char * after = "{ \"loadout\": { \"grade\": \"Gold\" }, \"has_loadout\": true }";
+    CHECK( tabledemo::ProfileConfigFromJson( value, after, (int64_t) strlen( after ), &report ) );
+    CHECK( value.has_loadout && value.loadout.grade == tabledemo::Grade::Gold );
+
+    // and a guarded field placed with the guard FALSE is elided on the way
+    // out, so the wire never sees it either
+    tabledemo::ProfileConfig ignored;
+    const char * no_guard = "{ \"loadout\": { \"grade\": \"Gold\" } }";
+    CHECK( tabledemo::ProfileConfigFromJson( ignored, no_guard, (int64_t) strlen( no_guard ), &report ) );
+    CHECK( !ignored.has_loadout );
+    uint8_t wire[512];
+    int64_t wrote = tabledemo::ProfileConfigSave( ignored, wire, sizeof( wire ) );
+    tabledemo::ProfileConfig fresh;
+    CHECK( wrote == tabledemo::ProfileConfigMeasure( fresh ) ); // the empty body
+}
+
+// ---- the json = "key" attribute: the text's vocabulary, not the wire's ----
+
+static void test_json_key_attribute()
+{
+    const tabledemo::TableFieldInfo * f = demo_field( tabledemo::WeaponConfigTableType(), "damage" );
+    CHECK( f != NULL && strcmp( f->json, "damage" ) == 0 );
+
+    // jsonkeys::Ship renames two fields in the TEXT and moves no wire byte:
+    // the id is still the hash of the schema name (SPEC-TABLES.md §16.3)
+    const jsonkeys::TableFieldInfo * ship_type = jsonkeys_field( jsonkeys::ShipTableType(), "ship_type" );
+    CHECK( ship_type != NULL );
+    CHECK( strcmp( ship_type->json, "type" ) == 0 );
+    CHECK( ship_type->id == field_id( "ship_type" ) );
+
+    jsonkeys::Ship ship;
+    jsonkeys::TableReport report;
+    const char * text = "{ \"type\": 3, \"label\": \"Hauler\", \"hp\": 250 }";
+    CHECK( jsonkeys::ShipFromJson( ship, text, (int64_t) strlen( text ), &report ) );
+    CHECK( ship.ship_type == 3 && ship.hit_points == 250 );
+    CHECK( strcmp( ship.name, "Hauler" ) == 0 );
+    CHECK( report.unknown == 0 && !report.malformed );
+
+    // the SCHEMA name is not a key: it reads as unknown
+    jsonkeys::Ship other;
+    jsonkeys::TableReport by_name;
+    const char * schema_names = "{ \"ship_type\": 3, \"name\": \"Hauler\" }";
+    CHECK( jsonkeys::ShipFromJson( other, schema_names, (int64_t) strlen( schema_names ), &by_name ) );
+    CHECK( other.ship_type == 0 && by_name.unknown == 2 );
+
+    // and the text the writer produces uses the keys, round-tripping clean
+    int64_t size = jsonkeys::ShipToJsonMeasure( ship );
+    std::vector<char> out( (size_t) size + 1 );
+    CHECK( jsonkeys::ShipToJson( ship, out.data(), size ) == size );
+    out[(size_t) size] = 0;
+    CHECK( strstr( out.data(), "\"type\"" ) != NULL );
+    CHECK( strstr( out.data(), "\"ship_type\"" ) == NULL );
+    jsonkeys::Ship back;
+    CHECK( jsonkeys::ShipFromJson( back, out.data(), size, &report ) );
+    uint8_t a[512], b[512];
+    int64_t na = jsonkeys::ShipSave( ship, a, sizeof( a ) );
+    int64_t nb = jsonkeys::ShipSave( back, b, sizeof( b ) );
+    CHECK( na > 0 && na == nb && memcmp( a, b, (size_t) na ) == 0 );
+}
+
+// ---- the tokenizer under a mutation fuzz: no input, however malformed,
+// ---- may crash, hang, or read past the text it was handed
+
+static void test_json_fuzz_tokenizer()
+{
+    // one seed corpus, mutated deterministically: the point is not coverage
+    // of the schema, it is that the TOKENIZER survives arbitrary bytes
+    static const char * seeds[] = {
+        "{ \"slot\": 3, \"power\": 1.5 }",
+        "{ \"name\": \"a\\u00e9b\", \"icon\": \"AQID\", \"ratings\": [ 1, 2, 3, 4 ] }",
+        "{ \"effect\": { \"buff\": { \"multiplier\": 2.0 } } }",
+        "{ \"grades\": [ \"Gold\", \"Bronze\" ], \"perks\": [ \"Turbo\" ] }",
+        "{ \"loadout\": { \"primary\": { \"damage\": 1e30 } }, \"has_loadout\": true }",
+    };
+    uint64_t state = 0x9e3779b97f4a7c15ull;
+    auto next = [&state]() -> uint32_t
+    {
+        state ^= state << 13; state ^= state >> 7; state ^= state << 17;
+        return (uint32_t) ( state >> 32 );
+    };
+    std::vector<char> work;
+    for ( int iteration = 0; iteration < 20000; iteration++ )
+    {
+        const char * seed = seeds[ next() % ( sizeof( seeds ) / sizeof( seeds[0] ) ) ];
+        work.assign( seed, seed + strlen( seed ) );
+        int mutations = 1 + (int) ( next() % 6 );
+        for ( int m = 0; m < mutations && !work.empty(); m++ )
+        {
+            uint32_t at = next() % (uint32_t) work.size();
+            switch ( next() % 4 )
+            {
+                case 0: work[at] = (char) ( next() & 0xff ); break;      // flip a byte
+                case 1: work.erase( work.begin() + at ); break;          // cut one
+                case 2: work.insert( work.begin() + at, (char) ( next() & 0xff ) ); break;
+                case 3: work.resize( (size_t) at ); break;               // truncate
+            }
+        }
+        // every table the walk can enter, over the same mutated bytes: a
+        // tokenizer defect that only one descriptor shape reaches is still a
+        // defect
+        tabledemo::TableReport report;
+        tabledemo::ProfileConfig profile;
+        tabledemo::ProfileConfigFromJson( profile, work.data(), (int64_t) work.size(), &report );
+        tabledemo::WeaponConfig weapon;
+        tabledemo::WeaponConfigFromJson( weapon, work.data(), (int64_t) work.size(), &report );
+        tabledemo::LoadoutConfig loadout;
+        tabledemo::LoadoutConfigFromJson( loadout, work.data(), (int64_t) work.size(), &report );
+        tabledemo::RootConfig root;
+        tabledemo::RootConfigFromJson( root, work.data(), (int64_t) work.size(), &report );
+        // whatever came back is a legal instance: it must still save
+        CHECK( tabledemo::RootConfigMeasure( root ) > 0 );
+    }
 }
 
 int main()
@@ -2829,6 +3584,18 @@ int main()
     test_open_refuses_dirty_reserved();
     test_descriptors_are_constant();
     test_cross_file_pointer_unit();
+
+    test_json_corpus_round_trip();
+    test_json_dialect();
+    test_json_hostile_kinds();
+    test_json_hostile_overflow();
+    test_json_hostile_extents();
+    test_json_hostile_unions();
+    test_json_hostile_framing();
+    test_json_writer_refusals();
+    test_json_guards();
+    test_json_key_attribute();
+    test_json_fuzz_tokenizer();
 
     if ( failures > 0 )
     {

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -2779,6 +2779,8 @@ static void test_optional_and_keyed_reflection()
     const tblv1::TableFieldInfo * tally = v1_field( cfg, "tally" );
     CHECK( tally != NULL && tally->is_array );
     CHECK( tally->key_type_name == NULL && tally->key_name == NULL && tally->key_id == NULL );
+}
+
 // ---- the TEXT form (SPEC-TABLES.md §16) ------------------------------------
 //
 // ONE walk over the reflection descriptors, so these tests are about the
@@ -3915,6 +3917,24 @@ static void test_json_no_infinity_reaches_storage()
             printf( "FAIL json overflow (%s): the instance can no longer be written\n", row.what );
             failures++;
         }
+    }
+
+    // -0 IS zero for an unsigned field, and reports nothing: a clamp count
+    // is an event, and that event did not happen
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"experience\": -0, \"precision\": -0 }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.experience == 0 && report.clamped == 0 && report.kind_mismatch == 0 );
+    }
+    {
+        // ... while a real negative for an unsigned field does clamp, and says so
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"experience\": -5 }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.experience == 0 && report.clamped == 1 );
     }
 
     // ... and a magnitude that DOES fit still lands exactly

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -3026,6 +3026,28 @@ static void test_json_dialect()
     CHECK( tabledemo::AttachmentFromJson( value, repeated, (int64_t) strlen( repeated ), &duplicate ) );
     CHECK( value.slot == 2 && duplicate.duplicate == 2 );
 
+    // the wire imposes no encoding on a string (SPEC-TABLES.md §3), so the
+    // text must not either: a stray lead byte rides as its own byte and does
+    // NOT swallow the character after it — including the closing quote
+    {
+        tabledemo::ProfileConfig stray;
+        char text[64];
+        int n = snprintf( text, sizeof( text ), "{ \"name\": \"ab\xc3\" }" );
+        CHECK( n > 0 );
+        tabledemo::TableReport raw;
+        CHECK( tabledemo::ProfileConfigFromJson( stray, text, n, &raw ) );
+        CHECK( stray.name_length == 3 && (unsigned char) stray.name[2] == 0xc3 );
+        CHECK( !raw.malformed );
+
+        // and it round-trips: the writer emits the byte, the reader takes it
+        int64_t size = tabledemo::ProfileConfigToJsonMeasure( stray );
+        std::vector<char> out( (size_t) size );
+        CHECK( tabledemo::ProfileConfigToJson( stray, out.data(), size ) == size );
+        tabledemo::ProfileConfig back;
+        CHECK( tabledemo::ProfileConfigFromJson( back, out.data(), size, &raw ) );
+        CHECK( back.name_length == 3 && (unsigned char) back.name[2] == 0xc3 );
+    }
+
     // string escapes both ways, including a surrogate pair
     tabledemo::ProfileConfig profile;
     const char * escapes = "{ \"name\": \"a\\\"b\\\\c\\nd\\u00e9e\\ud83d\\ude00\" }";

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -3039,13 +3039,43 @@ static void test_json_dialect()
         CHECK( stray.name_length == 3 && (unsigned char) stray.name[2] == 0xc3 );
         CHECK( !raw.malformed );
 
-        // and it round-trips: the writer emits the byte, the reader takes it
+        // ... but the WRITER owes a valid JSON text (RFC 8259 §8.1), so the
+        // byte it cannot spell is written as U+FFFD, one per bad byte. The
+        // round trip is therefore NOT byte-identical for invalid UTF-8, and
+        // that is the trade: a text a conforming parser can read, rather than
+        // one only this walk can (SPEC-TABLES.md §16.2).
         int64_t size = tabledemo::ProfileConfigToJsonMeasure( stray );
-        std::vector<char> out( (size_t) size );
+        std::vector<char> out( (size_t) size + 1 );
         CHECK( tabledemo::ProfileConfigToJson( stray, out.data(), size ) == size );
+        out[(size_t) size] = 0;
+        CHECK( strstr( out.data(), "\"ab\xef\xbf\xbd\"" ) != NULL );
         tabledemo::ProfileConfig back;
         CHECK( tabledemo::ProfileConfigFromJson( back, out.data(), size, &raw ) );
-        CHECK( back.name_length == 3 && (unsigned char) back.name[2] == 0xc3 );
+        CHECK( back.name_length == 5 );
+        CHECK( (unsigned char) back.name[2] == 0xef && (unsigned char) back.name[3] == 0xbf &&
+               (unsigned char) back.name[4] == 0xbd );
+        // and the SECOND trip is stable: a text the walk wrote reads back and
+        // writes the same bytes again
+        int64_t again = tabledemo::ProfileConfigToJsonMeasure( back );
+        std::vector<char> twice( (size_t) again );
+        CHECK( tabledemo::ProfileConfigToJson( back, twice.data(), again ) == again );
+        CHECK( again == size && memcmp( twice.data(), out.data(), (size_t) size ) == 0 );
+    }
+
+    // a lone surrogate ESCAPE is valid JSON input with no UTF-8 encoding:
+    // it reads as U+FFFD rather than manufacturing CESU-8 out of it
+    {
+        tabledemo::ProfileConfig lone;
+        tabledemo::TableReport report;
+        const char * text = "{ \"name\": \"\\udc00x\\ud800\" }";
+        CHECK( tabledemo::ProfileConfigFromJson( lone, text, (int64_t) strlen( text ), &report ) );
+        CHECK( lone.name_length == 7 );
+        CHECK( strcmp( lone.name, "\xef\xbf\xbd" "x" "\xef\xbf\xbd" ) == 0 );
+        // ... and a well-formed pair still decodes to the character it names
+        tabledemo::ProfileConfig pair;
+        const char * emoji = "{ \"name\": \"\\ud83d\\ude00\" }";
+        CHECK( tabledemo::ProfileConfigFromJson( pair, emoji, (int64_t) strlen( emoji ), &report ) );
+        CHECK( pair.name_length == 4 && strcmp( pair.name, "\xf0\x9f\x98\x80" ) == 0 );
     }
 
     // string escapes both ways, including a surrogate pair
@@ -3545,6 +3575,450 @@ static void test_json_fuzz_tokenizer()
         tabledemo::RootConfigFromJson( root, work.data(), (int64_t) work.size(), &report );
         // whatever came back is a legal instance: it must still save
         CHECK( tabledemo::RootConfigMeasure( root ) > 0 );
+
+        // AND it must still be WRITABLE as a text. §16.1 sells one invariant —
+        // a text that reads writes back — and the way to lose it is to let a
+        // conversion put something in storage that has no JSON spelling. No
+        // mutated text, however hostile, may reach that state.
+        tabledemo::TableReport clean;
+        tabledemo::ProfileConfig checked;
+        if ( tabledemo::ProfileConfigFromJson( checked, work.data(), (int64_t) work.size(), &clean ) )
+        {
+            if ( tabledemo::ProfileConfigToJsonMeasure( checked ) <= 0 )
+            {
+                printf( "FAIL json fuzz: a text that READ produced an instance that cannot be WRITTEN\n" );
+                failures++;
+                break;
+            }
+        }
+    }
+}
+
+// ---- the PINNED TEXT: what ToJson actually spells ------------------------
+//
+// Every other test in this section round-trips through the writer, so reader
+// and writer share `enum_name` and a vocabulary error cancels itself out: a
+// walker emitting "???" for a bit it cannot name round-trips green. This test
+// is the one that cannot: a known instance against a known LITERAL text, so
+// every spelling the form promises — an enum variant, a flags bit, a union
+// arm name, None, base64, a bool, an integer, a float, the guard's elision
+// and the pretty-printed shape — is pinned to the page rather than to the
+// code's own opinion of itself.
+
+static void test_json_pinned_text()
+{
+    tabledemo::LoadoutConfig loadout;
+    loadout.grade = tabledemo::Grade::Gold;
+    loadout.grades_count = 2;
+    loadout.grades[0] = tabledemo::Grade::Bronze;
+    loadout.grades[1] = tabledemo::Grade::None;
+    loadout.podium[0] = tabledemo::Grade::Silver;
+    loadout.perks = tabledemo::Perks_Shielded | tabledemo::Perks_Turbo;
+    loadout.primary.damage = 2.5f;
+    loadout.primary.effect.type = tabledemo::EffectType::Buff;
+    loadout.primary.effect.buff.multiplier = 4.0f;
+    loadout.backups[0].effect.type = tabledemo::EffectType::Debuff;
+    loadout.backups[0].effect.debuff.amount = 7;
+    loadout.attachments_count = 1;
+    loadout.attachments[0].slot = 3;
+    loadout.attachments[0].power = 1.5f;
+
+    static const char * expected =
+        "{\n"
+        "  \"grade\": \"Gold\",\n"
+        "  \"grades\": [\n"
+        "    \"Bronze\",\n"
+        "    \"None\"\n"
+        "  ],\n"
+        "  \"podium\": [\n"
+        "    \"Silver\",\n"
+        "    \"None\",\n"
+        "    \"None\"\n"
+        "  ],\n"
+        "  \"perks\": [\n"
+        "    \"Shielded\",\n"
+        "    \"Turbo\"\n"
+        "  ],\n"
+        "  \"primary\": {\n"
+        "    \"damage\": 2.5,\n"
+        "    \"speed\": 500,\n"
+        "    \"penetration\": 1,\n"
+        "    \"channel\": 0,\n"
+        "    \"homing\": false,\n"
+        "    \"effect\": {\n"
+        "      \"buff\": {\n"
+        "        \"multiplier\": 4\n"
+        "      }\n"
+        "    }\n"
+        "  },\n"
+        "  \"backups\": [\n"
+        "    {\n"
+        "      \"damage\": 21,\n"
+        "      \"speed\": 500,\n"
+        "      \"penetration\": 1,\n"
+        "      \"channel\": 0,\n"
+        "      \"homing\": false,\n"
+        "      \"effect\": {\n"
+        "        \"debuff\": {\n"
+        "          \"amount\": 7\n"
+        "        }\n"
+        "      }\n"
+        "    },\n"
+        "    {\n"
+        "      \"damage\": 21,\n"
+        "      \"speed\": 500,\n"
+        "      \"penetration\": 1,\n"
+        "      \"channel\": 0,\n"
+        "      \"homing\": false,\n"
+        "      \"effect\": {}\n"
+        "    }\n"
+        "  ],\n"
+        "  \"attachments\": [\n"
+        "    {\n"
+        "      \"slot\": 3,\n"
+        "      \"power\": 1.5\n"
+        "    }\n"
+        "  ]\n"
+        "}";
+
+    int64_t size = tabledemo::LoadoutConfigToJsonMeasure( loadout );
+    if ( size < 0 )
+    {
+        // a refusal here means a spelling the writer could not name: report
+        // it as the failure it is rather than indexing a buffer by -1
+        printf( "FAIL json pinned text: ToJsonMeasure refused an instance the page can spell\n" );
+        failures++;
+        return;
+    }
+    CHECK( size == (int64_t) strlen( expected ) );
+    std::vector<char> text( (size_t) size + 1 );
+    CHECK( tabledemo::LoadoutConfigToJson( loadout, text.data(), size ) == size );
+    text[(size_t) size] = 0;
+    if ( strcmp( text.data(), expected ) != 0 )
+    {
+        printf( "FAIL json pinned text: ToJson does not spell what the page says\n--- got ---\n%s\n--- want ---\n%s\n",
+                text.data(), expected );
+        failures++;
+    }
+
+    // the empty vocabulary spellings, pinned too: an empty flags mask is [],
+    // an empty union is {}, and a defaulted enum is its variant's name
+    tabledemo::LoadoutConfig plain;
+    static const char * plain_head =
+        "{\n"
+        "  \"grade\": \"Silver\",\n"
+        "  \"grades\": [],\n";
+    int64_t plain_size = tabledemo::LoadoutConfigToJsonMeasure( plain );
+    if ( plain_size < 0 ) { printf( "FAIL json pinned text: an all-default instance was refused\n" ); failures++; return; }
+    std::vector<char> plain_text( (size_t) plain_size + 1 );
+    CHECK( tabledemo::LoadoutConfigToJson( plain, plain_text.data(), plain_size ) == plain_size );
+    plain_text[(size_t) plain_size] = 0;
+    CHECK( strncmp( plain_text.data(), plain_head, strlen( plain_head ) ) == 0 );
+    CHECK( strstr( plain_text.data(), "\"perks\": []" ) != NULL );
+    CHECK( strstr( plain_text.data(), "\"effect\": {}" ) != NULL );
+
+    // bytes are base64 AND PADDED on the way out, at all three lengths
+    struct { const uint8_t * bytes; int32_t length; const char * spelling; } base64[] = {
+        { (const uint8_t *) "\x01\x02\x03", 3, "\"icon\": \"AQID\"" },
+        { (const uint8_t *) "\x01\x02",     2, "\"icon\": \"AQI=\"" },
+        { (const uint8_t *) "\x01",         1, "\"icon\": \"AQ==\"" },
+        { (const uint8_t *) "",             0, "\"icon\": \"\"" },
+    };
+    for ( const auto & row : base64 )
+    {
+        tabledemo::ProfileConfig profile;
+        memcpy( profile.icon, row.bytes, (size_t) row.length );
+        profile.icon_length = row.length;
+        int64_t n = tabledemo::ProfileConfigToJsonMeasure( profile );
+        if ( n < 0 ) { printf( "FAIL json pinned base64: refused\n" ); failures++; continue; }
+        std::vector<char> out( (size_t) n + 1 );
+        CHECK( tabledemo::ProfileConfigToJson( profile, out.data(), n ) == n );
+        out[(size_t) n] = 0;
+        if ( strstr( out.data(), row.spelling ) == NULL )
+        {
+            printf( "FAIL json pinned base64: %s not in the text\n", row.spelling );
+            failures++;
+        }
+    }
+    // ... and UNPADDED base64 still reads, so a text from elsewhere lands
+    {
+        tabledemo::ProfileConfig profile;
+        tabledemo::TableReport report;
+        const char * text = "{ \"icon\": \"AQI\" }";
+        CHECK( tabledemo::ProfileConfigFromJson( profile, text, (int64_t) strlen( text ), &report ) );
+        CHECK( profile.icon_length == 2 && profile.icon[0] == 1 && profile.icon[1] == 2 );
+        CHECK( !report.malformed );
+    }
+}
+
+// ---- numbers: JSON has ONE number type, and no value the field cannot hold
+// ---- ever reaches storage (SPEC-TABLES.md §16.2)
+
+static void test_json_number_grammar()
+{
+    // JSON's number production, and nothing else. A typo in an authoring file
+    // is a DIAGNOSTIC, not a value: the worst failure mode for a config
+    // pipeline is a garbled number that arrives as a clamped integer.
+    static const char * not_json[] = {
+        "{ \"heading\": 1-2 }",
+        "{ \"heading\": 5+ }",
+        "{ \"precision\": 1.2.3 }",
+        "{ \"precision\": 1e5e5 }",
+        "{ \"precision\": --3 }",
+        "{ \"heading\": +7 }",
+        "{ \"heading\": 007 }",
+        "{ \"precision\": .5 }",
+        "{ \"precision\": 3. }",
+        "{ \"precision\": 1e }",
+        "{ \"precision\": 1e+ }",
+        "{ \"heading\": - }",
+        "{ \"heading\": 0x10 }",
+    };
+    for ( const char * text : not_json )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        bool ok = tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report );
+        if ( ok || !report.malformed || report.clamped != 0 )
+        {
+            printf( "FAIL json number grammar (%s): ok=%d malformed=%d clamped=%d\n",
+                    text, ok, (int) report.malformed, report.clamped );
+            failures++;
+        }
+    }
+
+    // and the whole production IS accepted
+    struct { const char * text; double expect; } good[] = {
+        { "{ \"precision\": 0 }",        0.0 },
+        { "{ \"precision\": -0 }",       0.0 },
+        { "{ \"precision\": 1e3 }",      1000.0 },
+        { "{ \"precision\": 1E3 }",      1000.0 },
+        { "{ \"precision\": 1e+3 }",     1000.0 },
+        { "{ \"precision\": 1e-3 }",     0.001 },
+        { "{ \"precision\": -2.5 }",     -2.5 },
+        { "{ \"precision\": 0.5 }",      0.5 },
+        { "{ \"precision\": 123456.75 }", 123456.75 },
+    };
+    for ( const auto & row : good )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        CHECK( tabledemo::ProfileConfigFromJson( value, row.text, (int64_t) strlen( row.text ), &report ) );
+        if ( value.precision != row.expect || report.malformed || report.kind_mismatch != 0 )
+        {
+            printf( "FAIL json number accepted (%s): got %g want %g\n", row.text, value.precision, row.expect );
+            failures++;
+        }
+    }
+}
+
+static void test_json_integral_spellings()
+{
+    // JSON has one number type: 2.0 IS the integer 2 and 1e3 IS 1000. A text
+    // written by any library that round-trips numbers through a double spells
+    // integers this way — including this walker's own float writer — and
+    // §16.3 exists so a declaration can meet a text that already exists.
+    struct { const char * text; int64_t expect; } integral[] = {
+        { "{ \"experience\": 1e3 }",     1000 },
+        { "{ \"experience\": 2E0 }",     2 },
+        { "{ \"experience\": 2.0 }",     2 },
+        { "{ \"experience\": 2.00000 }", 2 },
+        { "{ \"experience\": 1.5e3 }",   1500 },
+        { "{ \"experience\": 4 }",       4 },
+        { "{ \"experience\": 1e0 }",     1 },
+    };
+    for ( const auto & row : integral )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        CHECK( tabledemo::ProfileConfigFromJson( value, row.text, (int64_t) strlen( row.text ), &report ) );
+        if ( (int64_t) value.experience != row.expect || report.kind_mismatch != 0 || report.malformed )
+        {
+            printf( "FAIL json integral spelling (%s): got %u want %lld kind=%d\n",
+                    row.text, value.experience, (long long) row.expect, report.kind_mismatch );
+            failures++;
+        }
+    }
+
+    // a GENUINELY fractional value is still the wrong shape for an integer
+    static const char * fractional[] = {
+        "{ \"experience\": 2.5 }",
+        "{ \"experience\": 1e-3 }",
+        "{ \"experience\": 0.1 }",
+        "{ \"experience\": -2.5 }",
+    };
+    for ( const char * text : fractional )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        if ( value.experience != 0 || report.kind_mismatch != 1 || report.malformed )
+        {
+            printf( "FAIL json fraction (%s): experience=%u kind=%d\n", text, value.experience, report.kind_mismatch );
+            failures++;
+        }
+    }
+
+    // an integral spelling still meets the width and the declared range
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"badge\": 3e2 }"; // 300 into a uint8
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.badge == 255 && report.clamped == 1 );
+    }
+    {
+        // signed, negative, and past the width
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"tilt\": -2e3 }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.tilt == -128 && report.clamped == 1 );
+    }
+    {
+        // an integral value past every integer width saturates and counts
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"epoch\": 1e30 }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.epoch == 18446744073709551615ull && report.clamped == 1 );
+    }
+}
+
+static void test_json_no_infinity_reaches_storage()
+{
+    // A magnitude the field's format cannot hold never lands: storing the
+    // infinity the conversion produced would leave an instance this walk
+    // called CLEAN that ToJsonMeasure refuses forever, and §16.1's whole
+    // invariant is that a text which reads clean writes back.
+    struct { const char * text; const char * what; } overflow[] = {
+        { "{ \"precision\": 1e400 }",   "float64 over" },
+        { "{ \"precision\": -1e400 }",  "float64 under" },
+        { "{ \"ratings\": [ 1e400 ] }", "float32 array over" },
+        { "{ \"ratings\": [ -1e400 ] }", "float32 array under" },
+        { "{ \"ratings\": [ 1e300 ] }", "float64 magnitude into a float32" },
+    };
+    for ( const auto & row : overflow )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        bool ok = tabledemo::ProfileConfigFromJson( value, row.text, (int64_t) strlen( row.text ), &report );
+        if ( !ok || report.kind_mismatch != 1 )
+        {
+            printf( "FAIL json overflow (%s): ok=%d kind=%d\n", row.what, ok, report.kind_mismatch );
+            failures++;
+        }
+        // the field kept its default, and the instance is still writable
+        if ( tabledemo::ProfileConfigToJsonMeasure( value ) <= 0 )
+        {
+            printf( "FAIL json overflow (%s): the instance can no longer be written\n", row.what );
+            failures++;
+        }
+    }
+
+    // ... and a magnitude that DOES fit still lands exactly
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"precision\": 1e308, \"ratings\": [ 3.4e38 ] }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.precision == 1e308 && report.kind_mismatch == 0 );
+        CHECK( tabledemo::ProfileConfigToJsonMeasure( value ) > 0 );
+    }
+}
+
+static void test_json_duplicate_arrays_last_wins()
+{
+    // "last wins" has to be true of an ARRAY key too, and it is wire-visible:
+    // a fixed array writes every slot, so a second, shorter occurrence must
+    // not leave the first occurrence's tail standing.
+    {
+        tabledemo::LoadoutConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"podium\": [ \"Bronze\", \"Silver\", \"Gold\" ], \"podium\": [ \"Gold\" ] }";
+        CHECK( tabledemo::LoadoutConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.podium[0] == tabledemo::Grade::Gold );
+        CHECK( value.podium[1] == tabledemo::Grade::None );
+        CHECK( value.podium[2] == tabledemo::Grade::None );
+        CHECK( report.duplicate == 1 );
+
+        // and it matches the instance the SECOND occurrence alone describes
+        tabledemo::LoadoutConfig once;
+        const char * single = "{ \"podium\": [ \"Gold\" ] }";
+        CHECK( tabledemo::LoadoutConfigFromJson( once, single, (int64_t) strlen( single ), &report ) );
+        uint8_t a[1024], b[1024];
+        int64_t na = tabledemo::LoadoutConfigSave( value, a, sizeof( a ) );
+        int64_t nb = tabledemo::LoadoutConfigSave( once, b, sizeof( b ) );
+        CHECK( na > 0 && na == nb && memcmp( a, b, (size_t) na ) == 0 );
+    }
+    {
+        // a counted array, and a fixed array of TABLES (whose elements go back
+        // to their own declared defaults, not to zero)
+        tabledemo::LoadoutConfig value;
+        tabledemo::TableReport report;
+        const char * text =
+            "{ \"grades\": [ \"Gold\", \"Bronze\", \"Silver\" ], \"grades\": [ \"Bronze\" ],"
+            "  \"backups\": [ { \"damage\": 1 }, { \"damage\": 2 } ], \"backups\": [ { \"damage\": 3 } ] }";
+        CHECK( tabledemo::LoadoutConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.grades_count == 1 && value.grades[0] == tabledemo::Grade::Bronze );
+        CHECK( value.backups[0].damage == 3 );     // the SECOND occurrence's element
+        CHECK( value.backups[1].damage == 21.0f ); // the DECLARED default, not 2
+        CHECK( report.duplicate == 2 );
+    }
+    {
+        // bytes too
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"icon\": \"AQIDBAUG\", \"icon\": \"/w==\" }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.icon_length == 1 && value.icon[0] == 0xff );
+        CHECK( report.duplicate == 1 );
+    }
+    {
+        // and a float array, the review's own repro
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"ratings\": [ 1.5, 2.5, 3.5, 4.5 ], \"ratings\": [ 9.5 ] }";
+        CHECK( tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.ratings[0] == 9.5f && value.ratings[1] == 0.0f &&
+               value.ratings[2] == 0.0f && value.ratings[3] == 0.0f );
+    }
+}
+
+static void test_json_null_is_a_kind_mismatch()
+{
+    // null is a JSON value with no field kind to land in — there is no
+    // pointer row on this page — so it is the wrong shape everywhere, and it
+    // is skipped and counted like any other wrong shape.
+    static const char * nulls[] = {
+        "{ \"experience\": null }",
+        "{ \"name\": null }",
+        "{ \"icon\": null }",
+        "{ \"ratings\": null }",
+        "{ \"has_loadout\": null }",
+        "{ \"loadout\": null }",
+        "{ \"precision\": null }",
+    };
+    for ( const char * text : nulls )
+    {
+        tabledemo::ProfileConfig value;
+        tabledemo::TableReport report;
+        bool ok = tabledemo::ProfileConfigFromJson( value, text, (int64_t) strlen( text ), &report );
+        if ( !ok || report.kind_mismatch != 1 || report.malformed )
+        {
+            printf( "FAIL json null (%s): ok=%d kind=%d malformed=%d\n",
+                    text, ok, report.kind_mismatch, (int) report.malformed );
+            failures++;
+        }
+    }
+    // and inside a vocabulary array, and inside a union
+    {
+        tabledemo::LoadoutConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"grades\": [ \"Gold\", null ], \"perks\": [ null ] }";
+        CHECK( tabledemo::LoadoutConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.grades_count == 2 && value.grades[0] == tabledemo::Grade::Gold );
+        CHECK( report.kind_mismatch == 2 );
     }
 }
 
@@ -3617,6 +4091,12 @@ int main()
     test_json_writer_refusals();
     test_json_guards();
     test_json_key_attribute();
+    test_json_number_grammar();
+    test_json_integral_spellings();
+    test_json_no_infinity_reaches_storage();
+    test_json_duplicate_arrays_last_wins();
+    test_json_null_is_a_kind_mismatch();
+    test_json_pinned_text();
     test_json_fuzz_tokenizer();
 
     if ( failures > 0 )

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -15,6 +15,7 @@
 #include "NestedTable.h"
 #include "WideTable.h"
 #include "GuardedTable.h"
+#include "KeyedTable.h"
 #include "V1Table.h"
 #include "V2Table.h"
 #include "GraphTable.h"
@@ -4122,6 +4123,304 @@ static void test_json_nested_guards()
     JSON_ROUND_TRIP( tabledemo, Patrol, ( []() { tabledemo::Patrol p; p.active = true; p.has_target = false; p.speed = 8.0f; p.wander = 2.5f; return p; }() ) );
 }
 
+// ---- the two constructs #265 added, in the text form --------------------
+//
+// `?T` (SPEC-TABLES.md §2.3): PRESENCE OF THE KEY IS THE PRESENCE.
+// `[E]T` (§2.4): an OBJECT KEYED BY VARIANT NAME, because that is what the
+// storage is — one slot per variant, addressed by the variant, and slot 0 is
+// None's and names nothing.
+
+static tabledemo::KeyedConfig json_keyed_instance()
+{
+    tabledemo::KeyedConfig cfg;
+    cfg.teams[tabledemo::Team::Red].spawn_count = 9;
+    set_string( cfg.teams[tabledemo::Team::Blue].banner,
+                cfg.teams[tabledemo::Team::Blue].banner_length, "blue" );
+    cfg.hulls[tabledemo::Hull::Gunship].health = 55.0f;
+    cfg.hulls[tabledemo::Hull::Gunship].turrets[tabledemo::Weapon::Missile].damage = 7.5f;
+    cfg.hulls[tabledemo::Hull::Gunship].turrets[tabledemo::Weapon::Missile].gunner_present = true;
+    cfg.hulls[tabledemo::Hull::Gunship].turrets[tabledemo::Weapon::Missile].gunner.reaction = 0.9f;
+    cfg.hulls[tabledemo::Hull::Gunship].turrets[tabledemo::Weapon::Missile].gunner.tracking = true;
+    cfg.scores.per_team[(int) tabledemo::Team::Green] = 1234;
+    return cfg;
+}
+
+static void test_json_keyed_and_optional_round_trip()
+{
+    tabledemo::KeyedConfig cfg = json_keyed_instance();
+    JSON_ROUND_TRIP( tabledemo, KeyedConfig, cfg );
+    JSON_ROUND_TRIP( tabledemo, HullConfig, cfg.hulls[tabledemo::Hull::Gunship] );
+    JSON_ROUND_TRIP( tabledemo, TeamConfig, cfg.teams[tabledemo::Team::Red] );
+    JSON_ROUND_TRIP( tabledemo, ScoreBoard, cfg.scores );
+    // an optional PRESENT and an optional ABSENT are different values, and
+    // both have to survive the trip
+    JSON_ROUND_TRIP( tabledemo, TurretConfig,
+                     cfg.hulls[tabledemo::Hull::Gunship].turrets[tabledemo::Weapon::Missile] );
+    JSON_ROUND_TRIP( tabledemo, TurretConfig,
+                     cfg.hulls[tabledemo::Hull::Gunship].turrets[tabledemo::Weapon::Cannon] );
+    // ... including a PRESENT optional holding nothing but defaults, which is
+    // the case elision by content would destroy
+    tabledemo::TurretConfig defaulted;
+    defaulted.gunner_present = true;
+    JSON_ROUND_TRIP( tabledemo, TurretConfig, defaulted );
+
+    tabledemo::KeyedConfig empty;
+    JSON_ROUND_TRIP( tabledemo, KeyedConfig, empty );
+}
+
+static void test_json_optional_presence()
+{
+    // an absent optional writes NO KEY: nothing else would read back absent
+    {
+        tabledemo::TurretConfig absent;
+        int64_t size = tabledemo::TurretConfigToJsonMeasure( absent );
+        CHECK( size > 0 );
+        std::vector<char> text( (size_t) size + 1 );
+        CHECK( tabledemo::TurretConfigToJson( absent, text.data(), size ) == size );
+        text[(size_t) size] = 0;
+        CHECK( strstr( text.data(), "\"gunner\"" ) == NULL );
+    }
+    // a present one writes its key, even holding only defaults
+    {
+        tabledemo::TurretConfig present;
+        present.gunner_present = true;
+        int64_t size = tabledemo::TurretConfigToJsonMeasure( present );
+        std::vector<char> text( (size_t) size + 1 );
+        CHECK( tabledemo::TurretConfigToJson( present, text.data(), size ) == size );
+        text[(size_t) size] = 0;
+        CHECK( strstr( text.data(), "\"gunner\"" ) != NULL );
+    }
+
+    // PRESENCE OF THE KEY IS THE PRESENCE — whatever the value
+    struct { const char * text; bool present; int kind_mismatch; const char * what; } rows[] = {
+        { "{ \"gunner\": { \"reaction\": 0.5 } }", true,  0, "a value" },
+        { "{ \"gunner\": {} }",                    true,  0, "an empty object" },
+        { "{ \"damage\": 1 }",                     false, 0, "no key at all" },
+        { "{ \"gunner\": null }",                  false, 0, "null reads as ABSENT" },
+        { "{ \"gunner\": 7 }",                     true,  1, "a wrong-typed value is still a present key" },
+        { "{ \"gunner\": \"x\" }",                 true,  1, "likewise a string" },
+    };
+    for ( const auto & row : rows )
+    {
+        tabledemo::TurretConfig value;
+        tabledemo::TableReport report;
+        bool ok = tabledemo::TurretConfigFromJson( value, row.text, (int64_t) strlen( row.text ), &report );
+        if ( !ok || value.gunner_present != row.present || report.kind_mismatch != row.kind_mismatch )
+        {
+            printf( "FAIL json optional (%s): ok=%d present=%d want %d kind=%d want %d\n",
+                    row.what, ok, (int) value.gunner_present, (int) row.present,
+                    report.kind_mismatch, row.kind_mismatch );
+            failures++;
+        }
+    }
+
+    // null is ABSENT for a ?T and a KIND MISMATCH for everything else
+    {
+        tabledemo::TurretConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"damage\": null, \"gunner\": null }";
+        CHECK( tabledemo::TurretConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.kind_mismatch == 1 );       // damage only
+        CHECK( !value.gunner_present );
+        CHECK( value.damage == 10.0f );           // the declared default
+    }
+
+    // last wins, and a null LAST leaves nothing of the value before it
+    {
+        tabledemo::TurretConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"gunner\": { \"reaction\": 9.5 }, \"gunner\": null }";
+        CHECK( tabledemo::TurretConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( !value.gunner_present && report.duplicate == 1 );
+        CHECK( value.gunner.reaction == 0.2f );   // back at its declared default
+    }
+
+    // an absent optional and a present-all-default one are DIFFERENT wires,
+    // and the text distinguishes them
+    {
+        tabledemo::TurretConfig absent, present;
+        present.gunner_present = true;
+        uint8_t a[512], b[512];
+        int64_t na = tabledemo::TurretConfigSave( absent, a, sizeof( a ) );
+        int64_t nb = tabledemo::TurretConfigSave( present, b, sizeof( b ) );
+        CHECK( na != nb ); // presence is the payload, not content
+    }
+}
+
+static void test_json_keyed_arrays()
+{
+    // an absent key keeps that slot's defaults; the others still land
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Green\": { \"spawn_count\": 7 } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.teams[tabledemo::Team::Green].spawn_count == 7 );
+        CHECK( value.teams[tabledemo::Team::Red].spawn_count == 4 );  // the declared default
+        CHECK( value.teams[tabledemo::Team::Blue].spawn_count == 4 );
+        CHECK( report.unknown == 0 && !report.malformed );
+    }
+
+    // "None" NAMES NO SLOT (§2.4): slot 0 is None's and is never valid, so
+    // the key is unknown like any other name this reader cannot place
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"None\": { \"spawn_count\": 3 }, \"Red\": { \"spawn_count\": 5 } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.unknown == 1 );
+        CHECK( value.teams[tabledemo::Team::Red].spawn_count == 5 );
+    }
+    // ... and the writer never emits it
+    {
+        tabledemo::KeyedConfig value;
+        int64_t size = tabledemo::KeyedConfigToJsonMeasure( value );
+        std::vector<char> text( (size_t) size + 1 );
+        CHECK( tabledemo::KeyedConfigToJson( value, text.data(), size ) == size );
+        text[(size_t) size] = 0;
+        CHECK( strstr( text.data(), "\"None\"" ) == NULL );
+        CHECK( strstr( text.data(), "\"Red\"" ) != NULL );
+    }
+
+    // a variant this build cannot name is skipped and counted
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Violet\": { \"spawn_count\": 3 } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.unknown == 1 && !report.malformed );
+    }
+
+    // a keyed array is an OBJECT: an array is the wrong shape for it
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": [ { \"spawn_count\": 3 } ] }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.kind_mismatch == 1 && !report.malformed );
+    }
+    // ... and a slot whose value is the wrong shape is counted, not coerced
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Red\": 5 } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.kind_mismatch == 1 );
+        CHECK( value.teams[tabledemo::Team::Red].spawn_count == 4 );
+    }
+
+    // last wins for a repeated keyed field: the second object replaces the
+    // first outright rather than overlaying it
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Red\": { \"spawn_count\": 5 }, \"Blue\": { \"spawn_count\": 6 } },"
+                            "  \"teams\": { \"Blue\": { \"spawn_count\": 7 } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.teams[tabledemo::Team::Blue].spawn_count == 7 );
+        CHECK( value.teams[tabledemo::Team::Red].spawn_count == 4 ); // back at its default
+        CHECK( report.duplicate == 1 );
+    }
+
+    // trailing commas inside a keyed object, like everywhere else
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Red\": { \"spawn_count\": 5 }, }, }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.teams[tabledemo::Team::Red].spawn_count == 5 && !report.malformed );
+    }
+
+    // a keyed array of SCALARS, on a plain `type`, keyed the same way
+    {
+        tabledemo::ScoreBoard value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"per_team\": { \"Blue\": 900, \"Green\": 200000 } }";
+        CHECK( tabledemo::ScoreBoardFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.per_team[(int) tabledemo::Team::Blue] == 900 );
+        CHECK( value.per_team[(int) tabledemo::Team::Green] == 100000 ); // clamped to max
+        CHECK( report.clamped == 1 );
+    }
+}
+
+// ---- the pinned texts for both constructs -------------------------------
+
+static void test_json_pinned_keyed_and_optional()
+{
+    // an optional PRESENT, and the object it writes
+    tabledemo::TurretConfig turret;
+    turret.damage = 7.5f;
+    turret.gunner_present = true;
+    turret.gunner.reaction = 0.9f;
+    turret.gunner.tracking = true;
+    static const char * present =
+        "{\n"
+        "  \"damage\": 7.5,\n"
+        "  \"cooldown\": 0.5,\n"
+        "  \"gunner\": {\n"
+        "    \"reaction\": 0.9,\n"
+        "    \"tracking\": true\n"
+        "  }\n"
+        "}";
+    {
+        int64_t size = tabledemo::TurretConfigToJsonMeasure( turret );
+        if ( size < 0 ) { printf( "FAIL json pinned optional: refused\n" ); failures++; return; }
+        std::vector<char> text( (size_t) size + 1 );
+        CHECK( tabledemo::TurretConfigToJson( turret, text.data(), size ) == size );
+        text[(size_t) size] = 0;
+        if ( strcmp( text.data(), present ) != 0 )
+        {
+            printf( "FAIL json pinned optional (present)\n--- got ---\n%s\n--- want ---\n%s\n", text.data(), present );
+            failures++;
+        }
+    }
+    // ... and ABSENT: the key is simply not there
+    static const char * absent =
+        "{\n"
+        "  \"damage\": 10,\n"
+        "  \"cooldown\": 0.5\n"
+        "}";
+    {
+        tabledemo::TurretConfig plain;
+        int64_t size = tabledemo::TurretConfigToJsonMeasure( plain );
+        if ( size < 0 ) { printf( "FAIL json pinned optional: refused\n" ); failures++; return; }
+        std::vector<char> text( (size_t) size + 1 );
+        CHECK( tabledemo::TurretConfigToJson( plain, text.data(), size ) == size );
+        text[(size_t) size] = 0;
+        if ( strcmp( text.data(), absent ) != 0 )
+        {
+            printf( "FAIL json pinned optional (absent)\n--- got ---\n%s\n--- want ---\n%s\n", text.data(), absent );
+            failures++;
+        }
+    }
+
+    // an enum-keyed array of scalars: one entry per SLOT, keyed by the
+    // variant that owns it, and NO "None" row
+    tabledemo::ScoreBoard scores;
+    scores.per_team[(int) tabledemo::Team::Red] = 10;
+    scores.per_team[(int) tabledemo::Team::Green] = 1234;
+    static const char * keyed =
+        "{\n"
+        "  \"per_team\": {\n"
+        "    \"Red\": 10,\n"
+        "    \"Blue\": 0,\n"
+        "    \"Green\": 1234\n"
+        "  }\n"
+        "}";
+    {
+        int64_t size = tabledemo::ScoreBoardToJsonMeasure( scores );
+        if ( size < 0 ) { printf( "FAIL json pinned keyed: refused\n" ); failures++; return; }
+        std::vector<char> text( (size_t) size + 1 );
+        CHECK( tabledemo::ScoreBoardToJson( scores, text.data(), size ) == size );
+        text[(size_t) size] = 0;
+        if ( strcmp( text.data(), keyed ) != 0 )
+        {
+            printf( "FAIL json pinned keyed\n--- got ---\n%s\n--- want ---\n%s\n", text.data(), keyed );
+            failures++;
+        }
+    }
+}
+
 int main()
 {
     test_round_trip();
@@ -4197,6 +4496,10 @@ int main()
     test_json_duplicate_arrays_last_wins();
     test_json_null_is_a_kind_mismatch();
     test_json_nested_guards();
+    test_json_keyed_and_optional_round_trip();
+    test_json_optional_presence();
+    test_json_keyed_arrays();
+    test_json_pinned_keyed_and_optional();
     test_json_pinned_text();
     test_json_fuzz_tokenizer();
 


### PR DESCRIPTION
Closes #253. Gate item for #248.

**Rebased onto 85becbf; SPEC-TABLES.md, SPEC.md and USAGE.md are taken from main
WHOLESALE** — this branch's own §16 and every other doc edit was dropped, and the
three files are byte-identical to main. The page (#269, #273) is the source of the
rules; this PR is the C++ backend meeting them.

One PR: the reflection columns the walk needs, ONE generic walker emitted per
generated header, the `json = "key"` attribute, `?T` and `[E]T` in the text form,
the corpus and hostile batteries, three gates, and a nested-guard corpus table.

## What this implements, against the page

**One walk, not a codec per table.** The header carries §8's descriptors and one
walker over them; `<Name>FromJson`, `<Name>ToJsonMeasure` and `<Name>ToJson` are
wrappers that name a descriptor. `make tables-json-walk` holds it: the walker's
source is byte-identical in all **14** generated headers of the corpus, whose units
disagree about packages, tables, kinds, keyed arrays, optionals and pointer modes.

**Reflection gained** flags bit names, union arm payloads (tag offset/width, each
arm's payload offset and descriptor), a per-type `reset` hook, each field's text
key, and `bits(N)`'s implied range. Merged with #265's `optional`/`present_offset`
and `key_type_name`/`key_name`/`key_id` columns.

**`?T`** — presence of the KEY is the presence. A key sets the field present
whatever its value, including one the walk then counts as a kind mismatch; a JSON
`null` is the exception the page names and reads as ABSENT, putting the value back
at its defaults so a repeated key ending in `null` leaves nothing behind. An absent
optional writes no key; a PRESENT all-default one still writes, because presence is
the payload and not content.

**`[E]T`** — an object keyed by variant NAME. The walk enumerates
`[0, array_bound)` and skips the slot whose key id is `0`, which is exactly the
mechanism §8 states, so `"None"` names no slot, reads as an unknown key, and is
never emitted. An absent key keeps that slot's defaults; a repeated field key
resets every slot first, so last-wins replaces the object outright.

**The `json` key** moves no byte on either wire — `TestJsonKeyMovesNoWire` pins the
projection, the protocol id and every table-wire field id, and the committed
`generated/` tree does not move.

## Where the code does NOT match the page — one gap, and it is the owner's call

**§16.1 states a builder surface for the VARIABLE-LENGTH class**
(`SceneFromJson( builder, text, text_bytes, &report )`), and §16.2 carries a
`pointer *T` row. **This backend does not implement either.** A variable-length
table gets no text form; the refusal is by absence and it is loud — the header
carries a named comment and there is no function to call, so nothing reads a
pointered table as an empty one.

It is implementable, but not as a line item on this PR, and the reason is a
collision between two of this document's own gates:

- the one-walk gate wants a single walker byte-identical in **every** header;
- the zero-cost gate (§2.2) forbids `Builder` / `TableRef` / `TableRegion` from
  appearing in a **pointer-free** header.

A builder-aware walk must name those symbols, so one walker cannot satisfy both.
The way through is a SECOND walker emitted only in `anyVariable` units, plus
conditional descriptor columns carrying per-target `Emplace`/`At` as function
pointers — the same conditional treatment `is_pointer` already gets. That is a
round of roughly the size of this one, not a patch.

**§15 no longer lists it as a follow-on**, so the page currently promises a surface
nothing provides. Either §16.1's builder line and §16.2's pointer row move back to
§15 as a named follow-on, or this work grows the second walker. **Not mine to
decide — flagging the sentence.**

Two further §16.2 rows describe constructs the compiler cannot yet declare, so
there is nothing to implement or test for them: `*string` / `*bytes` (§2.5, refused
by the parser) and a `table` union arm (§2.6, refused by the checker).

## Held by test

`make test` runs all of it, plus three gates: `tables-json-walk` (one walker, 14
headers), `tables-zero-cost` (unchanged and green), `tables-json-negative-control`.

- Every table in `tables/examples` round-trips `ToJson` → `FromJson` → `Save`
  byte-identical to the original's `Save` — the keyed and optional shapes, the
  cross-file nesting, the 70000-element extents, the all-default instance and the
  evolution pair included.
- **Pinned texts** — known instance, known literal text — for the corpus root, and
  for both new constructs. This is the test a round trip cannot replace: reader and
  writer share `enum_name`, so a vocabulary error round-trips green. Verified
  honest by sabotaging bit-name emission.
- Hostile: wrong JSON types at every kind, malformed number tokens, both-direction
  overflow at every integer width, float widths, `bits(N)`, multi-byte string
  clamping, over-long arrays, bad base64, two-key unions, `"None"` as a keyed key,
  lone surrogates, thirteen framing breaks, nesting past the cap.
- Guards in all four states of a nested `if/else` (`Guarded.schema`, added), and a
  text whose keys precede their guards.
- A mutation fuzz asserting the page's honesty clause directly: **no text that
  reads clean may produce an instance the writer would refuse.**
- **Negative control**, checked in both directions — it fails when built against
  the unsabotaged walker, so it cannot pass by accident.

Whole suite clean under `-fsanitize=address,undefined -fno-sanitize-recover=all`.

## Header compile cost, banked

`+11%` to `+15%` on an empty TU including one corpus table header (arm64 clang,
three interleaved same-sitting pairs; an independent reviewer measured +10.9% at an
earlier revision). The three number-conversion includes are ~+2% of it; the walker
body is the rest. One sitting was discarded whole for contamination rather than
averaged in. The page states the walk rides in every table header with no opt-out;
this is what that costs.

## Review

The adversarial review's conditions F1–F12 are all addressed; the response is in
[this comment](https://github.com/mas-bandwidth/schema/pull/267#issuecomment-5503612840)'s
reply and the commits that cite them. F2 (JSON has one number type), F3 (RFC 8259
number grammar) and F5 (valid-UTF-8 output) became rules on the page and are
implemented as the page now states them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
