### PR TITLE
SPEC-TABLES: the design of record for the tables campaign — spec first (#248)

### DIFF
--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -15,24 +15,70 @@ arena, read through a region and a root pointer, never held by value).
 A fixed-size table pays for none of the variable-length machinery: that
 property is a gate, held by test, not an intention (§2.2).
 
-Tables are schema's declarations for **data that crosses builds**: config
-files, asset archives, tool output, editor state — and just as much,
-**messages**: bytes produced by one build of one program and consumed by
-another build of another, whether the trip is a disk file read years later
-or a datagram read milliseconds later by a peer that deployed last week.
-The hardcoded wire (`type`, SPEC.md) is the same-build contract, guarded by
-the protocol id: same-or-refuse. Packets are its loudest user, not its
-definition — any data whose writer and reader share a schema build belongs
-there. The table wire is the opposite contract: **any reader reads any
-data**, and the differences are reported, never fatal.
+Tables are schema's declarations for **data that outlives the build that
+wrote it**: config files, asset archives, tool output, editor state,
+**save games** — a file written by a build nobody has any more and read by
+a build its writer never saw, years apart — and just as much, **messages**:
+bytes produced by one build of one program and consumed by another build of
+another, whether the trip is a disk file read years later or a datagram
+read milliseconds later by a peer that deployed last week. Save games and
+tool output are one case, not two, and the whole of this document serves
+it. The hardcoded wire (`type`, SPEC.md) is the same-build contract,
+guarded by the protocol id: same-or-refuse. Packets are its loudest user,
+not its definition — any data whose writer and reader share a schema build
+belongs there. The table wire is the opposite contract: **any reader reads
+any data**, and the differences are reported, never fatal.
 
 The two contracts never mix. Flatbuffers- and protobuf-class evolution
 ideas apply here, to tables — they do not apply to `type`, whose wire is
 hardcoded under the protocol id, and nothing in this document changes that.
 
+## The performance ladder
+
+**Tables are LESS performant than types**, and that is the trade they exist
+to make: types buy speed with a hardcoded, same-build wire; tables buy
+tolerance, reflection and evolution with a neutral byte wire, length
+prefixes and — in one narrow case — an allocation. A chosen cost is
+licensed. Unexplained slowness is still a defect, in every rung.
+
+- **A type is a raw struct.** Its generated storage IS the struct a person
+  would have written, and its codec is measured against a hand-written
+  serialize of that struct. The fastest-correct mission applies to types
+  without qualification, and the standing ledger holds them to it.
+- **A fixed-size table is a raw struct with a tolerant byte codec around
+  it**, and is expected to run as close to its equivalent type as the
+  neutral wire allows. That is a bench obligation, not an intention: a
+  fixed table sits beside its equivalent type on the ledger, and the gap
+  is explained or closed. The zero-cost gate (§2.2) holds the storage
+  half of it; the bench leg holds the codec half.
+- **The variable-length class pays for exactly what it buys** — pointers,
+  an arena on the building side, a region on the reading side, a
+  reference indirection per edge. This is where "less performant" lives,
+  and it is deliberate.
+
+## What allocates, and what never does
+
+- **A type never allocates**, in any backend, on any path. This rung does
+  not move.
+- **A fixed-size table with no union allocates nowhere, in any backend.**
+  It is a struct; measure, save and load work over caller-owned buffers.
+- **A fixed-size table WITH a union may allocate for the arm, and only
+  where the LANGUAGE needs it.** The carve-out is keyed on the backend
+  language, never on the table's class: a backend with no native union
+  builds a pseudo-union — one reference per arm, the set arm non-null,
+  allocated on read and write — and a backend with a native union (C++)
+  allocates nothing for the same declaration.
+- **The variable-length class allocates by nature**, and assuming
+  otherwise is foolish: the arena on build, the region on load. C++ keeps
+  the caller-owned form — `LoadMeasure` sizes the region and the caller
+  supplies it, `Builder` grows storage the caller owns — which is
+  allocation with the caller holding the pointer, not its absence. Other
+  backends allocate inside their runtime and say so. No port contorts
+  itself toward zero allocation for a variable-length table.
+
 **Backend status: C++.** Every other backend refuses a unit that declares
 tables, by name, with this document cited. Per-language backends are named
-follow-ons.
+follow-ons (§15).
 
 ## 1. Purpose
 
@@ -72,7 +118,7 @@ table ShipConfig
 A table body is a type body — the field grammar of SPEC §4.2, hosted by
 `table`: bare and ranged integers, `bits(N)`, `bool`, floats and
 compressed floats, enums, flags, strings, bytes, bounded arrays, unions,
-`if` branches, and declared types as field groups. Two additions:
+`if` branches, and declared types as field groups. Six additions:
 
 - **Tables nest.** A named table is a field type (above); nesting is by
   value, and a bounded array of tables is a collection. A table may not
@@ -83,6 +129,14 @@ compressed floats, enums, flags, strings, bytes, bounded arrays, unions,
 - **Tables point** (§2.1). `next *Node` declares a POINTER to a table.
   Recursion THROUGH a pointer edge is legal and expected — the by-value
   cycle rule exempts pointer edges, because a pointer carries no size.
+- **Fields may be OPTIONAL** (§2.3). `settings ?GunnerSettings` is present
+  or absent by value, with no pointer and no change of mode.
+- **An array may be ENUM-KEYED** (§2.4). `ships [ShipType]ShipConfig` has
+  exactly one slot per variant, indexed by the variant.
+- **A blob is a node** (§2.5). `data *bytes` declares an unbounded byte
+  buffer at exactly its used size, and `*string` is its sibling.
+- **A union arm may be a table** (§2.6), which is what makes an evolvable
+  message set expressible.
 - **`was` — the rename attribute** (§5).
 
 ### 2.1 Pointers
@@ -104,22 +158,16 @@ table Scene
 **A pointer is for recursion, sharing and size — not for optionality.**
 Every field on this wire is already optional: absence is the reader's
 default (§4), so nothing has to be pointed at to be left out. The spelling
-for an OPTIONAL SECTION is the guarded field:
+for an OPTIONAL SECTION is `?T` (§2.3):
 
 ```
 table Scene
 {
-    has_settings bool
-    if has_settings
-    {
-        settings Settings   // an optional section: off the wire when the guard is false
-    }
+    settings ?Settings   // an optional section: off the wire when it is absent
 }
 ```
 
-The guard is a field like any other, the section rides only when it is
-true, and a reader whose writer left it out gets the declared defaults —
-with no pointer, no allocation and no change of mode. Reach for `*` when
+No pointer, no allocation and no change of mode. Reach for `*` when
 the structure genuinely needs it: a table that refers to ITSELF (a chain, a
 tree), a large subtree you would rather not carry by value, or one node
 several parents name (sharing is a named follow-on, §15 — v1 writes a
@@ -130,8 +178,10 @@ choice is a real one.
 The spelling is C's, deliberately: it reads as what it is. The rules,
 each refused by name (§11):
 
-- **A pointer targets a `table`, and only a `table`.** `*SomeType`,
-  `*SomeEnum`, `*SomeUnion` are refused: value-semantics data has no
+- **A pointer targets a `table`, or one of the two buffer primitives.**
+  `*Node` names a declared table; `*bytes` and `*string` name an unbounded
+  buffer at its used size (§2.5). Everything else is refused — `*SomeType`,
+  `*SomeEnum`, `*SomeUnion` — because value-semantics data has no
   independent identity to point at. Nest it by value instead.
 - **A pointer is declared inside a table body, and nowhere else.** A
   `type` body refuses one: types remain value semantics, and that is the
@@ -151,22 +201,32 @@ pointers in the struct. Its meaning depends on the form it sits in
 The compiler works out which class a table belongs to; the schema never
 says. The rule is a least-fixed-point over BY-VALUE edges:
 
-- A table is **VARIABLE-LENGTH** if it declares a pointer, or if anything
-  it nests by value — directly, or as a bounded array — is
-  variable-length.
+- A table is **VARIABLE-LENGTH** if it declares a pointer — including
+  `*bytes` and `*string` (§2.5) — or if anything it nests by value is
+  variable-length. "Nests by value" reaches through every by-value edge
+  there is: a plain nested table, an element of a bounded array, an
+  element of an enum-keyed array, a member of a guarded (`if`) group, an
+  optional's value (§2.3), and a UNION ARM that is a table (§2.6).
 - Every other table is **FIXED-SIZE**.
 
 Pointer edges do not propagate the mode: a table that is merely POINTED
 AT stays fixed-size if it holds no pointer of its own. It gains an
 allocation and a resolution entry, and nothing else.
 
-**A fixed-size table pays nothing for any of this**, and that is a gate,
-not a hope: for a unit whose tables are all fixed-size, the generated
-output is byte-for-byte what it was before pointers existed — no
-builder, no arena, no reference type, no lifecycle surface, not one extra
-descriptor column, not one extra branch in a codec, not one extra
-`#include`. The build fails if a single symbol of the pointer machinery
-appears in a pointer-free unit's generated header.
+**A fixed-size table pays nothing for the VARIABLE-LENGTH machinery**, and
+that is a gate, not a hope: in a unit whose tables are all fixed-size the
+generated output carries no builder, no arena, no reference type, no
+lifecycle surface, not one descriptor column that exists to describe a
+pointer, not one branch in a codec that exists to follow one, and not one
+extra `#include`. The build fails if a single symbol of the pointer
+machinery appears in a pointer-free unit's generated header.
+
+The gate is scoped to that machinery and to nothing else. A LANGUAGE
+FEATURE the fixed class itself can use — an optional's presence companion,
+an enum-keyed array's key columns, the wire id a variant rides under — is
+emitted in every unit, whatever its mode, because a fixed-size table can
+declare it and a tool walking a fixed-size table has to find it. The gate
+asks "did the pointer world leak in?", never "did the descriptor grow?".
 
 The assumption behind the split, stated so nobody quietly designs against
 it: size and mode correlate in practice. Value-only tables are assumed
@@ -182,6 +242,184 @@ follow-on. **Extents have no wire ceiling**: lengths and counts ride as u32
 (§3), so the only limit is the language's own — a string, bytes or array
 extent lives in int32 storage (SPEC §4.3), and that cap is what a too-large
 extent is refused against.
+
+### 2.3 Optional fields: `settings ?GunnerSettings`
+
+```
+table ShipConfig
+{
+    health   float32 = 100.0
+    settings ?GunnerSettings   // present or absent, by value
+    tier     ?int32            // scalars too: present, and the value
+}
+```
+
+`?T` declares a field that is PRESENT or ABSENT. Its storage is the value
+plus a generated `<field>_present` bool, so the holder stays FIXED-SIZE:
+an optional costs one bool, one branch and no allocation, and a table of
+optionals is still a plain struct (§2.2's gate is untouched).
+
+**PRESENCE decides whether the field rides, never content.** An absent
+optional is not written; a present one is ALWAYS written, even when its
+value is entirely default — the pointer's rule (§3.1), for the same
+reason: otherwise "absent" and "present with nothing to say" would be one
+value on the wire. On load, a field that rode sets `present = true`; a
+field that did not leaves `present = false` with the value at its declared
+defaults.
+
+The framing is exactly the non-optional field's, which makes `?T`, `*T`
+and a plain `T` nesting **one field on the wire**: a schema may move a
+field among the three and no byte moves, in either direction. The corpus
+holds all six directions and the byte-identity of the three writers.
+
+`?` applies to a nested table, a nested `type`, an enum, a `flags` mask
+and any scalar. It is refused, by name, on:
+
+- **a `type` body** — a type's wire is positional and every field always
+  rides, so there is no absence to express;
+- **a pointer** — a pointer is already optional, and null rides exactly
+  as an absent optional does;
+- **a union** — its `None` arm IS the absence, and an empty union already
+  elides;
+- **an array, a string or `bytes`** — each already carries a count or
+  length whose zero is emptiness, and a second presence bit beside it
+  would be two answers to one question. Wrap it in a table and make that
+  optional; the general form is a named follow-on (§15).
+- **a specified default** — presence is the only default an optional has.
+
+### 2.4 Enum-keyed arrays: `ships [ShipType]ShipConfig`
+
+```
+enum ShipType { Fighter, Bomber, Scout }
+
+table Fleet
+{
+    ships [ShipType]ShipConfig   // one slot per variant, indexed by the variant
+}
+```
+
+An array bound that NAMES A DECLARED ENUM is an enum-keyed array. The two
+spellings never overlap, because an enum is declared: `[Name]` naming a
+constant is the fixed array it has always been, and `[Name]` naming an
+enum is keyed.
+
+- **Storage** is `T ships[ShipType.Max + 1]`, indexed directly by the enum
+  value — slot 0 is `None`'s. Every slot exists, so there is no count
+  companion, and `ships[int( ShipType::Bomber )]` just works.
+- **On the TABLE wire the slots ride by NAME** (§3.2): the array body
+  carries `(variant id, element)` pairs, so inserting, removing or
+  reordering variants leaves every surviving slot in its own home. This is
+  the whole point of the construct: an ordinal-indexed array is the last
+  positional vocabulary the table wire had, and it failed silently.
+- **On the TYPE wire the spelling IS `[E.Max + 1]T`** — positional,
+  bitpacked, same-build, the protocol id moving exactly as that spelling
+  moves it. One construct, two wires, the same rule every kind follows.
+  The two spellings project identically and share one protocol id, and
+  that is held by test.
+- **Fixed-size when `T` is**, so the zero-cost gate holds.
+
+Refused by name: a bound naming a `flags` declaration (a mask holds any
+set of bits at once, so it names no single slot); a bounded keyed array,
+`[..E]` or `[A..E]` (a keyed array is COMPLETE by construction); and an
+element that is a pointer, as for any array (§15).
+
+### 2.5 Byte buffers: `data *bytes`
+
+```
+table Asset
+{
+    format  AssetFormat
+    data    *bytes        // an unbounded blob, stored at exactly its used size
+    label   *string       // the sibling: a string node at its used length
+}
+```
+
+`bytes(N)` is fixed inline storage of N bytes in every instance. `*bytes`
+is a POINTER to a byte buffer that has no declared bound and occupies
+exactly the size it is given. The distinction is what makes large content
+expressible: in a table of a million nodes, a `bytes(65536)` field costs
+64 KB per node whether it is used or not, because the region packs storage
+verbatim, while a `*bytes` field costs the four-byte reference plus what
+each node actually holds.
+
+- **Storage** is the four-byte relocatable reference (§2.1) beside a u32
+  used length. Declaring one makes the holder VARIABLE-LENGTH (§2.2), like
+  any other pointer.
+- **In the arena**, `builder.AllocBytes( n )` returns a node of exactly `n`
+  bytes; `builder.AllocString( n )` is the sibling.
+- **In a region** it is packed at its used length, its reference
+  self-relative like every other (§6.3).
+- **On the wire it is framed exactly as `bytes(N)` is** — kind `14`, an
+  array of element kind `6` (u8) at its used count — and `*string` is
+  framed exactly as `string(N)` is, kind `12`. No new kind, no new skip
+  rule, and one useful consequence: `bytes(N)` and `*bytes` are ONE FIELD
+  ON THE WIRE, as `T`, `?T` and `*T` are (§3.1), so a field that outgrows
+  its inline bound moves to a blob and no byte changes. A null blob is
+  absent, exactly as a null pointer is.
+- **In the cooked form**, `Open`'s walk bounds the blob by its length as it
+  bounds every node, so a pointer into a mapped file IS the asset: no copy,
+  no parse (§7).
+
+Two sentences that must travel together: **a tolerant wire load COPIES the
+blob** — a gigabyte on the wire path is a gigabyte read — and **the cooked
+path is the zero-copy one.** Both are true and neither is the whole story.
+
+schema does not interpret the bytes. A format tag beside the blob is an
+ordinary field the user declares. A pattern falls out and is worth naming
+though it is no construct: a sub-document, or a rarely needed arm, can be
+stored as its own wire bytes inside a `*bytes` and decoded only when
+something asks for it — which keeps a very large file's resident memory
+proportional to what is touched rather than to what exists.
+
+Refused by name: `*bytes` or `*string` outside a table body; a specified
+default on one (a fresh reference is null); an array of them, as for any
+pointer (§15); `?` on one, because null already IS absence (§2.3).
+
+### 2.6 Union arms may be tables
+
+Inside a TABLE closure a union's arm may name a `table`, not only a
+declared `type`:
+
+```
+table OpenDocument  { path string(256), line uint32 }
+table SaveDocument  { path string(256), force bool   }
+
+union ToolBody
+{
+    open OpenDocument
+    save SaveDocument
+}
+
+table ToolMessage
+{
+    sequence uint32
+    body     ToolBody
+}
+```
+
+That is an evolvable MESSAGE SET by construction, and it is the case this
+document's opening promises. Arms ride under their own name hashes (§5),
+so adding a message is adding an arm; a reader that lacks the arm reads
+the union as empty, skips the body by its length and counts `unknown`
+(§4); arms may be removed and reordered freely. A message may therefore
+carry a nested table, a collection, or anything else a table body holds —
+which is what a message set of documents needs and what a `type`-only
+payload could never express.
+
+- **A union declared for the TYPE wire keeps refusing table arms.** Types
+  are value semantics and their wire is positional; a table arm is a
+  table-closure construct and is refused by name outside one.
+- **Mode derivation runs through arms** (§2.2): an arm that is a
+  variable-length table makes the union's holder variable-length. A union
+  of fixed-size table arms leaves its holder fixed-size, and the zero-cost
+  gate holds.
+- **On the wire an arm's body is framed exactly as a nested table's is**
+  (§3, kind `15`): `arm id (u16)`, then `L`, then `L` bytes of table body.
+  A `type` arm and a `table` arm are the same three bytes of framing, so a
+  reader needs no new rule and an arm may change between the two forms
+  without the framing moving.
+- **A backend without a native union may allocate for the arm** (the
+  ladder, above): the carve-out is the language's, not the table's.
 
 ## 3. The wire
 
@@ -210,11 +448,22 @@ schema's codebase:
   | `12` string | `L`, then `L` bytes. No terminator; no encoding imposed |
   | `13` table | `L`, then `L` bytes of table body (fields, then the u16 zero terminator) |
   | `14` array | `L`, then the array body: `element kind (u8)`, `N`, then the elements |
-  | `15` union | `arm id (u16)`, and when it is not 0, `L` then `L` bytes of table body |
+  | `14` array, ENUM-KEYED | `L`, then the array body: `element kind (u8)`, `N` = the number of SLOTS PRESENT, then N pairs of `variant id (u16)`, `L (u32)`, `L` bytes of element (§3.2) |
+  | `15` union | `arm id (u16)`, and when it is not 0, `L` then `L` bytes of arm body |
 
   **The union carries NO outer length** — its `arm id` sits where the other
   three containers put theirs, and the length that follows frames the arm
   alone. It is the one payload whose framing a skipper has to know (below).
+  An arm's body is a table body whether the arm names a declared `type` or
+  a `table` (§2.6): fields, then the u16 zero terminator, the same bytes a
+  kind `13` payload carries.
+
+  **Three spellings that add no row.** A `?T` optional field is framed
+  exactly as the non-optional `T` (§2.3); `*T` is framed exactly as a
+  by-value `T` (§3.1); and `*bytes` and `*string` are framed exactly as
+  `bytes(N)` and `string(N)` (§2.5). Each family is ONE FIELD ON THE WIRE
+  under several declaration spellings, which is what lets a schema move a
+  field among them without moving a byte.
   - **Array elements.** For a scalar element kind the elements sit back to
     back at that kind's fixed width. For element kind `13` (table) each
     element is preceded by its own `L`. `bytes(N)` rides as an array of
@@ -240,10 +489,17 @@ schema's codebase:
 - **Writers elide what readers default**: a field holding its default, an
   empty string or array, an all-default FIXED array, an empty union and an
   all-default nested table are not written at all (fixed arrays of tables
-  keep their elements — position is identity there). Elision is why old
-  readers and new writers meet cleanly, and why measure and save agree byte
-  for byte (§7). Elision makes the DECLARED DEFAULT part of the wire
-  contract: see §4.
+  keep their elements — position is identity there; an ENUM-KEYED array
+  elides per slot instead, because identity there is the key, §3.2).
+  Elision is why old readers and new writers meet cleanly, and why measure
+  and save agree byte for byte (§7). Elision makes the DECLARED DEFAULT
+  part of the wire contract: see §4.
+  **PRESENCE, not content, decides the three pointer-shaped spellings.** An
+  absent `?T`, a null `*T` and a null `*bytes` are not written; a present
+  optional, a non-null pointer and a non-null blob are ALWAYS written, even
+  when the value is entirely default and even when the blob is zero bytes
+  long — otherwise "absent" and "present with nothing to say" would be one
+  value on the wire (§2.3, §2.5, §3.1).
 - Schema's declaration-side types map onto the neutral kinds: a ranged
   integer rides as its storage-width integer kind, `bits(N)` as the
   narrowest unsigned kind that holds it, compressed floats as f32, and a
@@ -274,10 +530,12 @@ Three consequences, all deliberate:
 - **A non-null pointer ALWAYS rides**, even when its pointee is entirely
   default. Elision is decided by presence, not by content — otherwise
   null and "points at an empty node" would be one value on the wire.
-- **A pointer field and a by-value nesting are wire-identical.** A schema
-  may change one into the other and no byte moves: old readers take the
-  first body by value; new readers allocate one node from it. The corpus
-  holds that as a both-directions evolution test.
+- **A pointer field, an OPTIONAL field and a by-value nesting are
+  wire-identical** — one field on the wire with three spellings (§2.3). A
+  schema may change any of them into any other and no byte moves: old
+  readers take the first body by value, pointer readers allocate one node
+  from it, optional readers mark it present. The corpus holds all six
+  directions, and the byte-identity of the three writers.
 
 **Wire v1 is a TREE, and identity is not preserved.** Two pointers to one
 node write two bodies and load as two nodes. Aliasing, sharing and DAG
@@ -309,11 +567,46 @@ The cap in force:
 Wide structures are unbounded; deep ones are capped. Lifting the cap
 wants a flat, indexed node encoding — a named follow-on (§15).
 
+### 3.2 Enum-keyed arrays on the wire: slots by name
+
+An enum-keyed array (§2.4) rides as kind `14`, and its body opens exactly
+as any array's does — `element kind (u8)`, then a u32 count. What differs
+is what the count counts and what each element carries:
+
+- **`N` is the number of SLOTS PRESENT**, not the array's extent. A slot
+  whose element holds its default is elided, exactly as a defaulted field
+  is; `None`'s slot rides only when it is non-default; and an array with no
+  present slot is not written at all.
+- **Each element is a pair**: `variant id (u16)`, then `L (u32)`, then `L`
+  bytes of element. The variant id is the key's name hash, folded exactly as
+  a field id is (§5). The length rides for EVERY element kind, scalars
+  included, so one rule skips an unknown key whatever the element is.
+- **On load, each pair is placed by its variant id.** A key this reader can
+  name lands in that variant's slot; a key it cannot name is skipped by its
+  length and counted `unknown`; a slot the writer never sent keeps its
+  declared default. Insert a variant, remove one, reorder them — every
+  surviving slot still finds its home, in both directions.
+- **A repeated key is legal input and the last occurrence wins**, the
+  field-level rule (§3) applied inside the body.
+- **A key with no name on the WRITING side is a save error**, not a silent
+  `None`: measure and save return failure, exactly as they refuse an
+  unnameable enum value or an out-of-range union tag (§5).
+
+The contrast is the point. A plain `[E.Max + 1]T` array is POSITIONAL:
+insert a variant in the middle and every later slot lands one place off,
+with nothing on the wire to say so and no report event that could fire.
+The keyed spelling costs `2 + 4` bytes per present slot and closes that
+class. The corpus holds it with a middle insert and a removal in one
+generation step, and the negative control — encoding the slots
+positionally — turns the middle-insert test red.
+
 The same bytes serve every use: a file on disk, a blob in memory, a
 payload handed from a tool to a game, a message between services whose
 deploys never align. Save and load are symmetric over caller-provided
-buffers — message-ready by construction; generated code allocates
-nothing on the reading path.
+buffers — message-ready by construction; generated code allocates nothing
+on the reading path, with the two carve-outs the ladder names: the
+variable-length class allocates by nature, and a union arm may allocate in
+a backend whose language has no native union.
 
 ## 4. Versioning is wire tolerance
 
@@ -324,11 +617,18 @@ tolerance is the versioning model:
 - **Unknown field** (newer writer): skipped by its length, counted.
 - **Absent field** (older writer): the reader's value takes the field's
   default — the specified default, else zero.
-- **Unknown enum variant or union arm** (a name this reader does not have):
-  the enum value reads as `None`, the union reads as empty, the arm's body
-  is skipped by its length, and the event is counted as **unknown** —
-  the same counter an unknown field id uses, because it is the same event:
-  the writer named something this reader cannot name.
+- **Unknown enum variant, union arm or KEYED SLOT** (a name this reader
+  does not have): the enum value reads as `None`, the union reads as empty,
+  a keyed array's slot is dropped and the rest of its slots land normally,
+  the body is skipped by its length, and the event is counted as
+  **unknown** — the same counter an unknown field id uses, because it is
+  the same event: the writer named something this reader cannot name.
+- **A keyed slot this reader has but the writer never sent**: the slot
+  keeps its declared default, exactly as an absent field does (§3.2).
+- **An OPTIONAL field the writer did not send** reads as ABSENT, with the
+  value at its declared defaults; one that rode reads as PRESENT, whatever
+  the content (§2.3). A field moved between `?T`, `*T` and a plain nesting
+  is not an evolution event at all — the bytes do not move (§3.1).
 - **Kind mismatch** (a field changed type between builds): skipped, never
   misdecoded, counted. The kinds are a coarser vocabulary than the
   declaration side, so this catches a change of KIND, not every change of
@@ -398,6 +698,38 @@ fires, because nothing was lost or skipped. **A default change is a
 semantic edit to every stored file**, and `was` does not cover it: `was`
 preserves an identity, not a value. Change a default the way you would
 change data, or add a new field and leave the old one alone.
+
+### 4.1 The silent class, in full
+
+Almost every edit lands in the read report. **Exactly two do not**, and
+naming the whole set is the point of this subsection — a person reading a
+save game that came back wrong needs to know there is no third:
+
+1. **A specified DEFAULT changed, added or removed.** An elided field means
+   "the reader's declared default", so the same bytes now mean something
+   else. Nothing was lost or skipped, so no counter can fire.
+2. **A FLAGS variant inserted, removed, reordered, or renamed in place.** A
+   mask is the wire's one positional vocabulary (§3), so a variant's
+   identity is its bit position; moving one remaps every stored file and
+   the wire carries nothing that could say so.
+
+Everything else is either reported or safe. Fields may be added, removed,
+reordered and renamed under `was`; enum variants and union arms may be
+added anywhere, removed and reordered; array bounds may move; a field may
+change between `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes` —
+all of it either invisible to the wire or counted in the report. **The last
+positional vocabulary besides flags was the enum-ordinal-indexed array, and
+`[E]T` (§2.4) closes it**: keyed slots ride by name, so a middle insert
+moves no slot.
+
+Each of the two has its own answer:
+
+- **Flags** are answered by DISCIPLINE, stated as law: **append at the end,
+  never insert or reorder**, and retire a name in place rather than freeing
+  its bit.
+- **Both** are answered by MACHINERY, opt-in: the committed tables baseline
+  (§18) is the history the compiler does not keep, and it refuses either
+  edit until the baseline moves with a recorded reason.
 
 ## 5. Identity: the name hash, `was`, and the collision refusal
 
@@ -564,7 +896,19 @@ The builder is designed to go wide, lock-free by ownership:
   fresh builder, so loaded data can be edited and locked again.
 
 Contract split, stated once: the AUTHORING path (builder growth, `Lock`)
-may allocate; the reading path never does.
+may allocate; the reading path allocates nothing of its own — the caller
+owns the region, and `LoadMeasure` exists so it can.
+
+**The one carve-out, and it belongs to the LANGUAGE, not to the table.** A
+UNION inside a table may allocate per arm, on read and on write, in a
+backend whose language has no native union: the arm becomes a pseudo-union
+— one reference per arm, the set arm non-null, allocated when it is read
+or written. C++ has a native union and allocates nothing for the same
+declaration; a backend that has one must not allocate either. The rule is
+stated here once and inherited by every port rather than rediscovered as a
+per-backend accident, and it does not widen: the type wire allocates
+nowhere, in any language, and a fixed-size table with no union allocates
+nowhere either.
 
 ## 7. The cooked form
 
@@ -659,18 +1003,47 @@ element size, array bound and count-companion offset, declared bounds,
 branch guards, and the nested table's descriptor. `<Name>TableType()`
 returns that table's descriptor.
 
+**An optional field carries its presence companion.** `optional` marks the
+field and `present_offset` names the `<field>_present` bool, exactly as
+`counted` and `count_offset` name a count companion — so a walker can read
+and write presence without knowing the spelling that produced it, and can
+tell "absent" from "present and default" (§2.3).
+
+**An enum-keyed array carries its KEY's vocabulary.** `key_type_name` names
+the keying enum, and `key_name` and `key_id` map a slot index to that
+variant's name and to the wire id it rides under — so a tool prints
+`ships[Bomber]` rather than `ships[2]`, with no schema files on hand. The
+element's own vocabulary columns are unaffected: a keyed array OF enums
+carries both (§2.4). A positional array leaves all three NULL.
+
 **A vocabulary field carries its vocabulary and the ids it rides under.**
 An enum field and a union field both describe a named set indexed by
 `[0, enum_max]` — an enum's values, a union's arms — with a value→name
 function beside a **value→wire-id** function, so a tool can enumerate the
-names AND the ids without the schema files (§5). For every other kind those
-columns are absent: a flags field carries none, because its variants have
-no per-variant wire id to carry (§4).
+names AND the ids without the schema files (§5).
+
+**A union field also names each arm's PAYLOAD**, by that type's descriptor,
+whether the arm is a declared `type` or a `table` (§2.6). Without it a
+walker can name the arm a value holds and cannot enter it, which stops
+every generic walk — the text form (§16) among them — at the union.
+
+**A flags field carries its BIT NAMES**: a bit-index→name function and the
+bit count, as an enum carries its value→name. It carries no per-variant
+wire id, because a mask's variants ride by position and have none (§4).
+
+**A `*bytes` or `*string` field** carries its used-length companion's
+offset beside the reference, so a walker reads the blob's extent the way
+it reads an array's count (§2.5).
+
+These columns exist in every unit, whatever its mode — they describe the
+LANGUAGE, and a fixed-size table can declare all of them. Only the two
+POINTER columns below are conditional (§2.2).
 
 A unit that has pointers carries two more facts, and a unit that has none
 carries neither (§2.2): a field's **`is_pointer`** flag — whose `table`
-member then names the TARGET table's descriptor, and whose `elem_size` is
-the reference slot's width — and a type's derived **`variable`** mode, so
+member then names the TARGET table's descriptor, NULL for a `*bytes` or
+`*string` because a buffer is not a declared table, and whose `elem_size`
+is the reference slot's width — and a type's derived **`variable`** mode, so
 a tool can tell at runtime which of §6's two lives a table has without
 being told. A self-referential pointer resolves to its own type's
 descriptor. Where pointers exist the descriptors are CONSTANT-INITIALISED
@@ -741,6 +1114,30 @@ lockstep redeploy by a table edit. This independence is held by test.
   value-semantics data has no identity to point at; a pointer declared
   outside a table body; an array of pointers (§15); a specified default
   on a pointer field.
+- **Optional fields** (§2.3): `?T` outside a table body; `?` on a pointer
+  (already optional); `?` on a union (its `None` IS the absence); `?` on an
+  array, a string or `bytes` (a named follow-on, §15 — the count or length
+  already carries emptiness); a specified default on an optional; and a
+  field whose name collides with an optional's `<field>_present` companion.
+- **Enum-keyed arrays** (§2.4): a bound naming a `flags` declaration (a mask
+  names no single slot); a bounded keyed array, `[..E]` or `[A..E]` (a keyed
+  array is complete by construction); an element that is a pointer, as for
+  any array (§15). A slot value no variant names is a SAVE failure, not a
+  silent `None` (§3.2).
+- **Byte buffers** (§2.5): `*bytes` or `*string` outside a table body; a
+  specified default on one; an array of them (§15); `?` on one, because a
+  null reference already IS absence.
+- **A `table` union arm outside a table closure** (§2.6) — a union declared
+  for the type wire takes `type` payloads only, because types are value
+  semantics.
+- **The text form's key** (§16): `json = "..."` on a field no table closure
+  reaches — keys are a table-wire construct; and two fields of one table
+  whose JSON keys collide, naming both, as wire ids do (§5).
+- **An edit the committed TABLES BASELINE forbids** (§18), when a unit has
+  one: a specified default changed, added or removed; a flags variant
+  inserted, removed, reordered or renamed in place; a field's wire kind
+  changed; an enum-keyed array's key enum swapped. Overridden only by
+  moving the baseline with a recorded reason.
 - **A save-time data cycle or over-deep graph** (§3.1): measure, save,
   cook and `Lock` all return failure. Nothing recurses away.
 - **A read-time nesting past the depth cap** (§3.1): the subtree is
@@ -754,7 +1151,7 @@ lockstep redeploy by a table edit. This independence is held by test.
   types share one symbol table (§13.1), which is what makes the generated
   surface unprefixed and collision-free — so every name a closure member
   claims is refused to everything else. A member `X` claims `X` followed by
-  each of these **23 suffixes**, and a declaration spelling one of them is
+  each of these **26 suffixes**, and a declaration spelling one of them is
   refused naming the collision:
 
   ```
@@ -762,6 +1159,7 @@ lockstep redeploy by a table edit. This independence is held by test.
   LoadMeasure  LoadMeasureBody  LoadBuilder  TableType  Builder
   At  Root  Emplace  Pack  PackMeasure  OpenWalk
   Cook  CookMeasure  Open  LayoutId  TableFields  TableInfo
+  FromJson  ToJson  ToJsonMeasure
   ```
 
   The set is claimed for EVERY closure member, not only pointer-bearing
@@ -784,11 +1182,28 @@ lockstep redeploy by a table edit. This independence is held by test.
 
 ## 12. The expressiveness gate
 
-The feature's acceptance test: a real game's binary config and asset
-archive formats — a root table of nested collections of typed records,
-built by tools, loaded by the game — must be expressible as declared
-tables with nothing left over, without schema prescribing any of their
-structure. The corpus carries a config-format example holding that gate.
+The feature's acceptance test is a DOGFOOD, not a thought experiment: a
+real game's binary config and asset archive formats — a root table of
+nested collections of typed records, built by tools, loaded by the game —
+must be expressible as declared tables with nothing left over, and without
+schema prescribing any of their structure. The corpus carries a
+config-format example holding that gate.
+
+**The shape the gate is held to.** `Config.bin` and `Assets.bin` are each
+ONE root table, and each root is FIXED-SIZE down to the leaves: no pointer
+anywhere in the closure. That is expressible because the constructs that
+used to force a pointer no longer do — `?T` (§2.3) gives an optional
+section by value, and `[E]T` (§2.4) gives the enum-keyed collection those
+formats always were, as language rather than as convention. A fixed root
+is the strong form of the gate: it says the whole content pipeline runs
+on the ladder's second rung, with no arena, no region and no allocation
+on either side.
+
+**The gate is a per-language obligation, not a one-language one.** A game
+whose engine runtime is not the language its tools are written in has to
+read the same bytes from the same declarations, with the same report, on
+both sides — so a backend clears the gate only in its own language, and
+the per-language backends are named follow-ons (§15).
 
 ## 13. Rulings, recorded
 
@@ -859,6 +1274,59 @@ draft this document previously carried is dead; these replace it.
   a big file and point at its root, without copying it and without
   parsing the whole thing.
 
+### 13.2 Cost and allocation, ruled
+
+The performance ladder and the allocation rules in this document's opening
+are these rulings, in the owner's words:
+
+- **The trade**: "Tables are 'less' performant than types."
+- **The top rung**: "Types are expected to match the equivalent of raw
+  structs."
+- **The second rung**: "Fixed tables should be as performant, when
+  possible…" — which this document reads as a bench obligation, a fixed
+  table beside its equivalent type on the ledger.
+- **The union carve-out, keyed on the LANGUAGE**: "but for example, if
+  fixed with a union, it's OK to alloc (if the language needs it)"; and
+  for the ported backends, "I have no problem for the message and table
+  case (not types) if you do some allocations while you read or write for
+  unions, this way you can have a pseudo-union in golang."
+- **The closing rung**: "variable tables, you'll obviously need to alloc
+  and assuming otherwise is foolish."
+- **Why very large tables want a blob node** (§2.5): "the key with variable
+  tables is imagine they could be very large, like a gigabyte. you'd not in
+  that case want to blow out memory with extra union tables you don't need
+  and so on" — and the primitive itself, "yes, I like byte buffer as
+  primitive", so that "we can include say, images or assets inside them."
+
+### 13.3 The fixed-class constructs, ruled
+
+- **Optional fields** (§2.3): "If you want to have optional fields without
+  needing pointers too, and that's elegant, then go for it" — and, once
+  they existed, "it's cool to keep the Config.bin and Assets.bin fixed
+  tables, for now. No pointers", which is the fixed-down-to-root shape §12
+  holds the gate to.
+- **Enum-keyed arrays** (§2.4): "I like the enum keyed arrays. That is
+  cool… It's a really good, unique language feature, that is optional."
+  Optional is part of the design: `[E.Max + 1]T` stays legal and
+  positional; `[E]T` is the keyed form a user chooses.
+- **Union arms as tables** (§2.6): "if you had a set of messages for
+  tooling, you'd want to safely evolve those tables / messages."
+- **The text form** (§16): "the general idea of reading JSON file into a
+  table can move into schema… that's not opinionated. but only one table at
+  a time?" — one table, one text, and the linking left outside.
+- **Packing** (§17): "It also may make it possible to move the table
+  reading and packing entirely down into schema now… which is a WIN", with
+  the directory rule taken as it stands and revisited against a real packed
+  corpus rather than in advance.
+- **The baseline** (§18): "Practically, consider the save game example.
+  You'd have to just be careful, and if the compiler helped you be careful
+  -- that would be good"; the invariant, "the save games would have to not
+  ever break compatibility with stuff already written"; the same for tool
+  output, "same for example, for tooling"; and the override, "or
+  *explicitly* override it, saying, ok fine, from this version on, we
+  intentionally break compat and that's OK" — which is why `--update`
+  without `--reason` is refused.
+
 ## 14. Design notes: the models weighed
 
 Recorded because the rejected options are the useful part.
@@ -917,32 +1385,319 @@ together.
 
 ## 15. Named follow-ons
 
-- Per-language backends beyond C++ (the refusal in §11 names this).
-- **Graph and DAG identity**: preserving aliasing and sharing across the
-  wire, so two references to one node stay one node. Wire v1 is a tree
-  (§3.1) and says so.
-- **Arrays of pointers** (§2.1).
-- **Lifting the depth cap** with a flat, indexed node encoding, so a
-  pointer chain's length stops being a nesting depth (§3.1).
+- **TABLE WIRE V2 — the flat indexed node encoding.** One design answers
+  three of the entries that follow it: a pointered root writes every
+  reachable node ONCE into a node table and a pointer field rides as an
+  index into it, which lifts the depth cap, preserves DAG identity, and
+  makes an array of pointers an array of indices. It reaches past §3.1 into
+  the region and the cooked form, and it is drafted spec-first, ahead of
+  any emitter, because it changes what the bytes mean wherever a pointer
+  appears. **The pointer-free classes are untouched by it**, byte for byte,
+  so nothing in the fixed class waits on it.
+  - **Graph and DAG identity**: preserving aliasing and sharing across the
+    wire, so two references to one node stay one node. Wire v1 is a tree
+    (§3.1) and says so.
+  - **Lifting the depth cap**, so a pointer chain's length stops being a
+    nesting depth (§3.1).
+  - **Arrays of pointers** (§2.1).
+- **Per-language backends beyond C++** (the refusal in §11 names this). The
+  first is C#, because the dogfood's game engine reads the same config and
+  asset bytes the C++ tools write (§12), and the FIXED class is what that
+  needs: storage structs, measure/save/load over caller-owned buffers, the
+  report, the reflection descriptors, `?T`, `[E]T`, name-hashed vocabularies
+  and the text form. A port mirrors this document and invents no contract of
+  its own; where a language forces a shape — a pseudo-union for a language
+  with no native union — the ladder above already says what is licensed.
+- **The variable class in a ported backend** — the arena, the region, the
+  cooked form and the pointer surface — after that port's fixed class.
+- **`?` on an array, a string or `bytes`** (§2.3): a presence bit beside an
+  existing count or length wants a decision about what the pair means before
+  it becomes wire. Wrap the field in a table and make that optional today.
+- **An array of `?T`** — the same question one level down: an element's
+  presence bit beside the array's own count.
 - **Cross-endian `Open`**: an in-place, descriptor-driven byte-swap pass
   sharing `Open`'s existing traversal — the same nodes and fields are
   already visited, and kinds and offsets are already in the descriptors.
   v1 refuses a foreign byte order instead (§7).
 - **A hash-guarded fallback loader** — open the cooked form, else load
   the wire — as a convenience helper.
-- **A generic JSON walk over the reflection descriptors.** A text
-  authoring form is a pattern the owner described from practice: humans
-  and tools edit text, a build cooks it, the runtime points at the
-  result. Because the descriptors carry every field's name, kind and
-  offset, that walk is ONE implementation over the reflection surface —
-  no per-table codecs — which is what makes it worth doing as its own
-  round. It pairs with the field-level name-mapping attribute already
-  filed below.
 - A generic dump/diff tool over the reflection surface.
 - Keyed lookup conveniences over loaded collections (library-side, never
   stored semantics).
 - Arrays of unions in table bodies.
 - `fixed` and 128-bit table-wire kinds, if a need ever materializes.
-- A field-level name-mapping attribute for text-format tooling (the
-  JSON-authoring surface real pipelines pair with binary tables) —
-  tool-side, never wire.
+- **An `--envelope` shape for `schema pack`** (§17), if one recurring
+  wrapper — a magic, a content hash, a protocol id — earns being schema's
+  rather than each caller's.
+
+## 16. The text form: JSON in and out of one table
+
+Reading a JSON text into a table, and writing one out, is not an opinion:
+it is one table, one text, one walk over the reflection descriptors (§8),
+the same for every table in the closure. schema owns it. Everything AROUND
+it is an opinion and belongs to whatever tool holds it — which file goes
+with which instance, what key an instance is filed under, how instances are
+linked into a root table's collections, what envelope wraps the bytes. A
+packer (§17) calls this section once per text and does the rest itself.
+
+### 16.1 The surface
+
+For every table in a unit's closure, name first, C++:
+
+```cpp
+TableReport report;
+ShipConfig ship;
+if ( !ShipConfigFromJson( ship, text, text_bytes, &report ) )
+{
+    // the text is not JSON, or a value cannot be placed at all
+    // (report.malformed) — the instance holds what was placed before the stop
+}
+
+int64_t size = ShipConfigToJsonMeasure( ship );      // exact bytes, writes nothing
+ShipConfigToJson( ship, buffer, size );              // returns size; -1 = too small
+```
+
+- **`FromJson` fills ONE instance from ONE text.** The instance is the
+  caller's; the read path allocates nothing beyond it. Fields the text does
+  not mention keep their storage defaults (SPEC §4.2: zero, or the
+  specified default), exactly as an absent field on the wire does (§4).
+- **`ToJson` writes ONE instance as ONE text**, every field, in declaration
+  order, defaults included — a text is for people and tools, and a text
+  that elides is a text a reader has to know the schema to complete.
+  Measure and write agree byte for byte, the wire's invariant (§9) carried
+  across.
+- **Both are ONE generic walk.** No per-table codec is emitted: the
+  generated header carries the descriptors and one walker over them. That
+  is the property that makes this schema's rather than a packer's, and it
+  is a gate: the walker's source is the same bytes in every generated
+  header of the corpus.
+
+### 16.2 The mapping, field kind by field kind
+
+The JSON form of a table is an object whose keys are field names. Per kind:
+
+| declaration | JSON | notes |
+|---|---|---|
+| integers, `bits(N)` | number | integral; a fraction is malformed |
+| `float32`, `float64`, compressed floats | number | |
+| `bool` | `true` / `false` | |
+| `string(N)`, `*string` | string | UTF-8; longer than N is CLAMPED to N bytes at a code point boundary, counted (a `*string` has no bound to clamp against) |
+| `bytes(N)`, `*bytes` | string, base64 | longer than N is clamped, counted (a `*bytes` has no bound to clamp against) |
+| enum | string, the variant NAME | `"Silver"`; an unknown name → None, counted |
+| flags | array of variant names | `["Shielded", "Turbo"]`; an unknown name is skipped, counted |
+| `[N]T` fixed array | array | fewer elements pad with defaults; more are dropped, counted |
+| `[..N]T` bounded array | array | count = length; more than N are dropped, counted |
+| `[E]T` enum-keyed array | object keyed by VARIANT NAME | `{ "Fighter": {...}, "Bomber": {...} }`; an absent key keeps that slot's defaults; an unknown key is skipped, counted; a duplicate key is last-wins, counted |
+| nested `type` / `table` | object | the same walk, recursively |
+| `?T` optional | the value, or the key absent | **presence of the KEY is presence**: a key present sets the field present, whatever its value; an absent key leaves it absent. `ToJson` writes present optionals only |
+| union | object with ONE key, the arm name | `{ "buff": { "multiplier": 2.0 } }`; `{}` or absent = None; two keys is malformed. A `table` arm (§2.6) is the same object form |
+| pointer `*T` | object, or `null` | the pointee's object in place; a variable-length table reads through its builder (§6.5), so `FromJson` for one takes the builder: `SceneFromJson( builder, text, bytes, &report )` |
+
+**Guarded fields** (`if guard { ... }`): a guarded group's fields are placed
+only when the guard reads true, and the guard is an ordinary bool field in
+the text — it is written and read like any other field, and the walk infers
+nothing from the presence of the group. A field that is genuinely present
+or absent is `?T`, which the walk does model, and that is the difference
+between the two constructs.
+
+**Bounds.** A number outside a field's declared `[min, max]` is clamped and
+counted, never refused — the wire's rule (§4), so a text and a wire loaded
+from the same data land the same instance.
+
+**Unknown keys** are skipped and counted in `report.unknown`. **Duplicate
+keys**: last wins, counted. **Trailing commas** in objects and arrays are
+accepted on read — the authoring files this section exists for carry them —
+and never written. Comments are not JSON and are refused.
+
+**The report is the wire's report** (§4): `unknown`, `kind_mismatch` (a key
+present with the wrong JSON type — a string where a number was declared —
+is skipped, never coerced), `clamped`, `malformed`. Silence means the text
+matched the schema exactly.
+
+### 16.3 The key: `json`
+
+A field's JSON key is its name. The one attribute this form adds lets a
+declaration meet an existing text:
+
+```
+ship_type ShipType | json = "type"
+```
+
+The field reads from and writes to `"type"`. Two fields of one table whose
+keys collide are refused at compile time, naming both, as wire ids are
+(§5); `json` on a field no table closure reaches is refused (§11). **The
+attribute changes no byte on the wire**: keys are the text's business, ids
+are the wire's, and a schema may add, change or remove a `json` key without
+touching a stored file.
+
+### 16.4 Held by test
+
+- Every table in the corpus round-trips `ToJson` → `FromJson` → `Save` and
+  byte-matches the wire of the original instance.
+- A hostile battery: wrong JSON types at every kind, overflow at every
+  integer width, nesting past the depth cap, unknown keys, duplicate keys,
+  clamped strings at a multi-byte boundary, a union with two keys, an
+  enum-keyed object with a name the enum lacks.
+- **Negative control:** with the walker's offset arithmetic sabotaged by
+  one field, the round-trip goes red on the first table that has two
+  fields.
+- The generic-walk gate: the walker's source is identical in every
+  generated header of the corpus.
+
+### 16.5 What this is not
+
+Not a file format, not a directory layout, not a manifest, not an envelope.
+Those are a packer's business; §17 is one packer, and it is a TOOL over
+this section rather than a second definition of it.
+
+## 17. Packing: a directory tree that mirrors a root table
+
+`schema pack` assembles ONE table instance from a directory tree and writes
+the root's wire bytes. It adds no format: the tree is the table, the text
+in it is §16's, and the output is §3's.
+
+```
+schema pack   --root Config --out Config.bin  configs/
+schema unpack --root Config --in  Config.bin  configs/
+```
+
+### 17.1 The directory rule
+
+The tree MIRRORS the root table's shape, and nothing else:
+
+- a **directory named after a field** holds that field's value;
+- for an **enum-keyed array** (§2.4), one file per variant,
+  `<Variant>.json`;
+- for a **bounded array**, files in name order become the elements, or one
+  `<field>.json` holds the whole array;
+- for a **nested table**, either `<field>.json` or a directory of its
+  fields;
+- a plain **`<field>.json` at any level** is that field's value verbatim;
+- the **root may simply be one `<Root>.json`**.
+
+Each file's content is read by §16's walk, so every rule about kinds,
+presence, clamping and the report is that section's and is not restated
+here. The tree rule is structural only — it says where a value lives, never
+what a value means — which is what keeps a packer out of the format.
+
+### 17.2 What comes out
+
+**The output is the root table's wire bytes and nothing else**: no magic,
+no content hash, no protocol id, no length prefix around the whole. A
+caller that wants an envelope writes its own few lines around these bytes,
+which is §1's promise that schema imposes no envelope. `unpack` is the
+inverse — it writes the tree back out of a `.bin` through `ToJson`, which
+is the tool round trip §1 promises, and `unpack` → `pack` is byte-stable.
+
+### 17.3 Refusals and the report
+
+A tree that does not mirror the table is reported rather than guessed at: a
+directory or file naming no field, two files claiming one enum-keyed slot,
+a variant name the enum does not have, a file that is not JSON. Everything
+§16 counts is counted here too, aggregated across the tree, so a pack of a
+hundred files reports once.
+
+### 17.4 Held by test
+
+A directory corpus packs to bytes identical to `Save` of the same instance
+built by hand; `unpack` → `pack` is byte-stable; and the hostile tree above
+is refused or counted per §16's rules.
+
+## 18. The tables baseline
+
+**An optional committed projection of a unit's table closure, and the check
+that refuses the edits the wire cannot report.** §4.1 names those edits:
+exactly two, a changed specified default and a moved flags variant. The
+compiler retains no history and cannot see either on its own. The baseline
+IS that history, in a text file a person can read in a diff.
+
+The motivating case is a SAVE GAME — a file written by a build the reader
+no longer has, read by a build the writer never saw, years apart — and tool
+output is the same case, not a second one: data that outlives the build
+that wrote it. The invariant the check protects is the plain one: **no edit
+may make data already written unreadable, or quietly change what it
+means.**
+
+### 18.1 The file
+
+**It is `tables.baseline`, in the unit directory, and it is opt-in: no
+file, no check.** It is a canonical text projection of the closure — the
+members sorted, each member's fields in declaration order, one fact per
+line: name, wire id, kind, array shape (fixed, bounded or enum-keyed, with
+the bound's EVALUATED value), string and bytes capacity, presence of an
+optional, the specified default as exact canonical text, and the `was`
+alias; then each enum's variants in order with their ids, each flags'
+variants in positional order, and each union's arms in order with their ids
+and payloads.
+
+**The values are EVALUATED**, not the source text: a constant that moves
+and flows through an expression into a default shows up as the value it now
+produces, which is the whole point — the projection records what data will
+mean, not how it was spelled.
+
+It carries no protocol id and no packet fact: the type wire, the wire-shape
+projection and the protocol id are untouched by all of it (§10).
+
+```
+schema-tables-baseline 1
+package shipdemo
+
+table ShipConfig
+    field damage id=0x15a9 kind=10 default=21.0
+    field speed id=0x2e46 kind=10 default=500.0 was=velocity
+    field name id=0x30df kind=12 size=32
+
+## history
+### 2026-09-02 — first baseline before 1.0 ships
+- baseline created over 1 table — data written BEFORE this point is not covered by it
+```
+
+### 18.2 The check
+
+`schema tables-baseline <unit>` prints the projection. `schema check` — and
+therefore every `schema generate` — diffs the live closure against the
+committed file whenever one is there, and:
+
+- **REFUSES, naming `table.field` and the edit** — a specified default
+  changed, added or removed; a flags variant inserted, removed, reordered,
+  or RENAMED IN PLACE (a rename moves no byte, and a new meaning on a spent
+  bit remaps every stored file; nothing distinguishes the two, so the
+  author says which); a field's wire kind or an array's element kind
+  changed; an enum-keyed array's key enum swapped for another.
+- **WARNS** — an array bound or a string/bytes capacity shrunk; an enum
+  variant or a union arm removed. The data survives and the read report
+  already counts what is lost (`clamped`, `unknown`), so this reports
+  rather than stops.
+- **PASSES, in silence** — everything the wire absorbs: fields added,
+  removed, reordered or renamed under `was`; enum variants and union arms
+  added anywhere; flags variants APPENDED at the end; bounds and capacities
+  grown; a bounded array made fixed or the reverse; a field moved between
+  `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes`.
+
+### 18.3 Moving it is an explicit act
+
+```
+schema tables-baseline --update --reason "damage rebalanced in 2.0; saves from 1.x read the new value" configs/
+```
+
+`--update` rewrites the file AND appends a dated entry to the `## history`
+section inside it, naming every edit it recorded, old value to new, beside
+the reason. **`--update` without `--reason` is refused.** The history is
+therefore the one record the wire lacks — the log of every intentional
+break — and it is what a person consults when an old save or an old tool
+file reads back wrong. The update is idempotent: a unit that has not moved
+rewrites nothing.
+
+### 18.4 What it does not cover
+
+**The first baseline covers only what comes after it.** It is a snapshot of
+whatever the schema is on the day it is written; data written before that
+day was written against a shape nobody recorded, and no check can speak for
+it. The created file says so in its own first history entry.
+
+### 18.5 Held by test
+
+Each refusal class has a fixture pair and its negative control — remove the
+check and the edit passes. The projection over the corpus regenerates
+byte-identical. The warn class warns and does not refuse. `--update`
+without `--reason` refuses.

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -268,9 +268,19 @@ field that did not leaves `present = false` with the value at its declared
 defaults.
 
 The framing is exactly the non-optional field's, which makes `?T`, `*T`
-and a plain `T` nesting **one field on the wire**: a schema may move a
-field among the three and no byte moves, in either direction. The corpus
-holds all six directions and the byte-identity of the three writers.
+and a plain `T` nesting **one framing with three spellings**: for any value
+that is not entirely default, a schema may move a field among the three and
+no byte moves, in either direction.
+
+**The one difference is at the empty end**, and it follows from the two
+elision rules above: a plain `T` holding nothing but defaults is not
+written at all, while a PRESENT `?T` and a non-null `*T` are written even
+then. No direction misdecodes — an absent field reads as the declared
+default by value, as null through a pointer, and as absent through an
+optional, each of which is the right answer — but the bytes are not
+identical for an all-default value, and an implementer should not be
+promised that they are. The corpus holds all six directions, and the
+byte-identity of the three writers **over non-default content**.
 
 `?` applies to a nested table, a nested `type`, an enum, a `flags` mask
 and any scalar. It is refused, by name, on:
@@ -304,24 +314,40 @@ constant is the fixed array it has always been, and `[Name]` naming an
 enum is keyed.
 
 - **Storage** is `T ships[ShipType.Max + 1]`, indexed directly by the enum
-  value — slot 0 is `None`'s. Every slot exists, so there is no count
-  companion, and `ships[int( ShipType::Bomber )]` just works.
-- **On the TABLE wire the slots ride by NAME** (§3.2): the array body
-  carries `(variant id, element)` pairs, so inserting, removing or
-  reordering variants leaves every surviving slot in its own home. This is
-  the whole point of the construct: an ordinal-indexed array is the last
-  positional vocabulary the table wire had, and it failed silently.
+  value. Every slot exists, so there is no count companion, and
+  `ships[ShipType::Bomber]` reads with no biased arithmetic.
+- **SLOT 0 EXISTS AND IS NEVER VALID.** `None` is the enum's null, so it
+  keys nothing: only `E.Max` slots can ever hold data. Slot 0 is kept in
+  storage so indexing stays unbiased, and reaching it is an ERROR —
+  a compile-time refusal where the language can express one (a
+  `static_assert` on a constant index in C++), an assert otherwise —
+  through the generated keyed type's `operator[]( E )`. The wire enforces
+  the same thing from the other side: a `None` key never rides (§3.2).
+- **On the TABLE wire the slots ride by NAME** (§3.2): the body carries
+  `(variant id, element)` pairs, so inserting, removing or reordering
+  variants leaves every surviving slot in its own home. This is the whole
+  point of the construct: an ordinal-indexed array is the last positional
+  vocabulary the table wire had, and it failed silently.
 - **On the TYPE wire the spelling IS `[E.Max + 1]T`** — positional,
   bitpacked, same-build, the protocol id moving exactly as that spelling
-  moves it. One construct, two wires, the same rule every kind follows.
-  The two spellings project identically and share one protocol id, and
-  that is held by test.
+  moves it. The two spellings project identically and share one protocol
+  id, and that is held by test.
 - **Fixed-size when `T` is**, so the zero-cost gate holds.
+
+**The two spellings are ONE FIELD on the type wire and TWO DIFFERENT
+ENCODINGS on the table wire.** `[E]T` is kind `16` and `[E.Max + 1]T` is
+kind `14` (§3), so changing a TABLE field from one spelling to the other
+is a wire break, not a refactor: an old file read under the new spelling
+is a kind mismatch — skipped, counted, never misdecoded (§4) — and the
+committed baseline refuses the edit at compile time (§18.2). Giving the
+keyed body its own kind is what buys that; the two encodings are not
+mutually decodable and nothing should let them be tried.
 
 Refused by name: a bound naming a `flags` declaration (a mask holds any
 set of bits at once, so it names no single slot); a bounded keyed array,
-`[..E]` or `[A..E]` (a keyed array is COMPLETE by construction); and an
-element that is a pointer, as for any array (§15).
+`[..E]` or `[A..E]` (a keyed array is COMPLETE by construction); an
+element that is a pointer, as for any array (§15); and an index of
+`E::None`, which names no slot.
 
 ### 2.5 Byte buffers: `data *bytes`
 
@@ -352,10 +378,14 @@ each node actually holds.
 - **On the wire it is framed exactly as `bytes(N)` is** — kind `14`, an
   array of element kind `6` (u8) at its used count — and `*string` is
   framed exactly as `string(N)` is, kind `12`. No new kind, no new skip
-  rule, and one useful consequence: `bytes(N)` and `*bytes` are ONE FIELD
-  ON THE WIRE, as `T`, `?T` and `*T` are (§3.1), so a field that outgrows
-  its inline bound moves to a blob and no byte changes. A null blob is
-  absent, exactly as a null pointer is.
+  rule, and one useful consequence: `bytes(N)` and `*bytes` share one
+  framing, as `T`, `?T` and `*T` do (§3.1), so a field that outgrows its
+  inline bound moves to a blob and no byte changes **for any non-empty
+  value**. The one difference is the empty end, the same asymmetry the
+  other family has: an empty `bytes(N)` elides, while a non-null
+  ZERO-LENGTH `*bytes` writes an empty payload, because presence decides
+  for a pointer-shaped spelling. A null blob is absent, exactly as a null
+  pointer is.
 - **In the cooked form**, `Open`'s walk bounds the blob by its length as it
   bounds every node, so a pointer into a mapped file IS the asset: no copy,
   no parse (§7).
@@ -435,7 +465,8 @@ schema's codebase:
   0 mapping to 1 so the terminator can never collide (§5).
 - **The kinds are a closed set**, and these are their numbers: `1` bool,
   `2` i8, `3` i16, `4` i32, `5` i64, `6` u8, `7` u16, `8` u32, `9` u64,
-  `10` f32, `11` f64, `12` string, `13` table, `14` array, `15` union.
+  `10` f32, `11` f64, `12` string, `13` table, `14` array, `15` union,
+  `16` enum-keyed array.
 - **Payloads**, one row per kind. `L` is a u32 byte length; `N` is a u32
   element count. Nothing is aligned and nothing is padded.
 
@@ -448,8 +479,8 @@ schema's codebase:
   | `12` string | `L`, then `L` bytes. No terminator; no encoding imposed |
   | `13` table | `L`, then `L` bytes of table body (fields, then the u16 zero terminator) |
   | `14` array | `L`, then the array body: `element kind (u8)`, `N`, then the elements |
-  | `14` array, ENUM-KEYED | `L`, then the array body: `element kind (u8)`, `N` = the number of SLOTS PRESENT, then N pairs of `variant id (u16)`, `L (u32)`, `L` bytes of element (§3.2) |
   | `15` union | `arm id (u16)`, and when it is not 0, `L` then `L` bytes of arm body |
+  | `16` enum-keyed array | `L`, then the body: `element kind (u8)`, `N` = the number of SLOTS PRESENT, then N pairs of `variant id (u16)`, `L (u32)`, `L` bytes of element (§3.2) |
 
   **The union carries NO outer length** — its `arm id` sits where the other
   three containers put theirs, and the length that follows frames the arm
@@ -458,12 +489,23 @@ schema's codebase:
   a `table` (§2.6): fields, then the u16 zero terminator, the same bytes a
   kind `13` payload carries.
 
-  **Three spellings that add no row.** A `?T` optional field is framed
-  exactly as the non-optional `T` (§2.3); `*T` is framed exactly as a
-  by-value `T` (§3.1); and `*bytes` and `*string` are framed exactly as
-  `bytes(N)` and `string(N)` (§2.5). Each family is ONE FIELD ON THE WIRE
-  under several declaration spellings, which is what lets a schema move a
-  field among them without moving a byte.
+  **Spellings that add no row, and the one way they differ.** A `?T`
+  optional field is framed exactly as the non-optional `T` (§2.3); `*T` is
+  framed exactly as a by-value `T` (§3.1); and `*bytes` and `*string` are
+  framed exactly as `bytes(N)` and `string(N)` (§2.5). Each family is ONE
+  FRAMING under several declaration spellings.
+
+  **What differs inside a family is ELISION, and only at the empty end.**
+  Content decides for the by-value spellings and presence decides for the
+  pointer-shaped ones (above), so a by-value `T` at its defaults writes
+  nothing while a present `?T` at its defaults writes its body, and an
+  empty `bytes(N)` writes nothing while a non-null zero-length `*bytes`
+  writes an empty payload. **For any content that is not entirely default,
+  the spellings in a family are byte-identical**, and that is the scope of
+  the claim: a schema may move a field among them and no byte moves for
+  such a value. At the empty end the bytes differ and no reader
+  misdecodes — an elided field reads as absent (`?T`), null (`*T`) or the
+  declared default (`T`), which is correct in every direction.
   - **Array elements.** For a scalar element kind the elements sit back to
     back at that kind's fixed width. For element kind `13` (table) each
     element is preceded by its own `L`. `bytes(N)` rides as an array of
@@ -475,9 +517,12 @@ schema's codebase:
     reader accepts it.
 - **Skipping a field you cannot name** needs the kind byte and nothing
   else, which is what makes an unknown field survivable (§4). Three rules
-  cover the set: kinds `1`–`11` skip their fixed width; kinds `12`, `13`
-  and `14` read `L` and skip `L` bytes; kind `15` reads the `u16` arm id
-  and stops there if it is 0, else reads `L` and skips `L` bytes.
+  cover the set: kinds `1`–`11` skip their fixed width; kinds `12`, `13`,
+  `14` and `16` read `L` and skip `L` bytes; kind `15` reads the `u16` arm
+  id and stops there if it is 0, else reads `L` and skips `L` bytes.
+  **A kind a reader does not know at all is not skippable** and is framing
+  damage, which is why the set is closed and why a new kind is a wire
+  change rather than an addition.
 - **Field ORDER within a body is not part of the contract.** This
   implementation writes fields in declaration order, and a reader must not
   rely on it: every field is found by its id, so any order decodes the same
@@ -530,12 +575,17 @@ Three consequences, all deliberate:
 - **A non-null pointer ALWAYS rides**, even when its pointee is entirely
   default. Elision is decided by presence, not by content — otherwise
   null and "points at an empty node" would be one value on the wire.
-- **A pointer field, an OPTIONAL field and a by-value nesting are
-  wire-identical** — one field on the wire with three spellings (§2.3). A
-  schema may change any of them into any other and no byte moves: old
-  readers take the first body by value, pointer readers allocate one node
-  from it, optional readers mark it present. The corpus holds all six
-  directions, and the byte-identity of the three writers.
+- **A pointer field, an OPTIONAL field and a by-value nesting share one
+  framing** — three spellings of one field (§2.3). A schema may change any
+  of them into any other and, for content that is not entirely default, no
+  byte moves: old readers take the first body by value, pointer readers
+  allocate one node from it, optional readers mark it present. **At the
+  empty end they differ**, because content decides elision by value and
+  presence decides it here: an all-default `T` writes nothing, a present
+  `?T` and a non-null `*T` write a body. Every direction still reads
+  correctly; only the byte-identity claim is scoped. The corpus holds all
+  six directions, and the byte-identity of the three writers over
+  non-default content.
 
 **Wire v1 is a TREE, and identity is not preserved.** Two pointers to one
 node write two bodies and load as two nodes. Aliasing, sharing and DAG
@@ -569,14 +619,30 @@ wants a flat, indexed node encoding — a named follow-on (§15).
 
 ### 3.2 Enum-keyed arrays on the wire: slots by name
 
-An enum-keyed array (§2.4) rides as kind `14`, and its body opens exactly
-as any array's does — `element kind (u8)`, then a u32 count. What differs
-is what the count counts and what each element carries:
+An enum-keyed array (§2.4) rides as **kind `16`, its own kind**, and its
+body opens as an array's does — `element kind (u8)`, then a u32 count.
+Kind `16` exists so that the keyed and the positional spellings cannot be
+mistaken for one another: they are different encodings, a reader meeting
+the wrong one reports a kind mismatch instead of decoding a body under the
+wrong rule, and no reader ever has to guess which layout a `14` carries.
+What differs from a plain array is what the count counts and what each
+element carries:
 
 - **`N` is the number of SLOTS PRESENT**, not the array's extent. A slot
   whose element holds its default is elided, exactly as a defaulted field
-  is; `None`'s slot rides only when it is non-default; and an array with no
-  present slot is not written at all.
+  is, and an array with no present slot is not written at all. The upper
+  bound on `N` is therefore `E.Max`, never `E.Max + 1`.
+- **A `None` key NEVER RIDES.** `None` is the enum's null and keys no slot
+  (§2.4), so slot 0 is not written whatever it holds, and **a stored key of
+  `0` is MALFORMED** — not an unknown variant, because `0` is the reserved
+  id no declared name can ever fold to (§5), so a body carrying one is
+  damaged rather than merely foreign. The reader stops that body, keeps
+  what it decoded, and flags malformed (§4).
+- **Slots are written in ascending variant ordinal**, and a reader must
+  not rely on it — the field-order rule (§3) one level down. Every slot is
+  found by its key, so any order decodes the same value; byte-identical
+  output against this implementation requires matching the ascending order
+  as well as the framing.
 - **Each element is a pair**: `variant id (u16)`, then `L (u32)`, then `L`
   bytes of element. The variant id is the key's name hash, folded exactly as
   a field id is (§5). The length rides for EVERY element kind, scalars
@@ -599,6 +665,13 @@ The keyed spelling costs `2 + 4` bytes per present slot and closes that
 class. The corpus holds it with a middle insert and a removal in one
 generation step, and the negative control — encoding the slots
 positionally — turns the middle-insert test red.
+
+**And the two spellings do not decode each other.** A `16` body read as a
+`14`, or the reverse, would take keys for values and values for keys — the
+same silent corruption in a different costume — so the distinct kind is
+what makes changing spelling a REPORTED edit (§4) rather than a quiet one.
+A reader meeting the other kind skips the field, counts `kind_mismatch`,
+and leaves the array at its declared defaults.
 
 The same bytes serve every use: a file on disk, a blob in memory, a
 payload handed from a tool to a game, a message between services whose
@@ -634,7 +707,10 @@ tolerance is the versioning model:
   declaration side, so this catches a change of KIND, not every change of
   type: an enum field and a plain `uint16` field are both kind `7`, so an
   edit between the two is not a kind mismatch — the raw value is read as a
-  variant hash, and lands on `None` unless it happens to name one.
+  variant hash, and lands on `None` unless it happens to name one. **An
+  array changed between the keyed and the positional spelling IS a kind
+  mismatch** (`16` against `14`, §3.2), which is exactly why the keyed body
+  has a kind of its own.
 - **A changed array BOUND** (a literal, a constant, or an `E.Max + 1`
   expression that moved): the array still loads, and the bound is not part
   of identity — a field is its name hash and its kind, and neither carries
@@ -653,13 +729,20 @@ tolerance is the versioning model:
   bounds**: a count the body cannot cover yields the bounded prefix and
   the malformed flag, never values fabricated from a neighbor's bytes.
 
-Every event lands in the **read report** — unknown, kind_mismatch,
-clamped, malformed. `unknown` counts every id this reader cannot name: a
-field id, an enum variant id, a union arm id. Silence (all zero) means the
-data matched this reader's schema exactly. Tools surface the report; games decide their own
-policy over it. Nothing crashes on data from a different schema version,
-in either direction, and that property is held by a both-directions
-evolution test in the corpus.
+Every event lands in the **read report**, whose counters are `unknown`,
+`kind_mismatch`, `clamped`, `duplicate` and the `malformed` flag.
+`unknown` counts every id this reader cannot name: a field id, an enum
+variant id, a union arm id, a keyed slot's key. Silence (all zero) means
+the data matched this reader's schema exactly. Tools surface the report;
+games decide their own policy over it. Nothing crashes on data from a
+different schema version, in either direction, and that property is held by
+a both-directions evolution test in the corpus.
+
+**`duplicate` is the TEXT FORM's counter and the wire never raises it**
+(§16.2). It rides on the same report struct because a caller has one report
+type, not two — so every backend carries the counter, and a wire read
+always leaves it zero: a body carrying an id twice is legal input whose
+last occurrence wins, silently, by §3.
 
 Fields may be added anywhere, removed freely, and reordered freely —
 identity is the name, not the position. **So may an enum's variants and a
@@ -717,19 +800,30 @@ Everything else is either reported or safe. Fields may be added, removed,
 reordered and renamed under `was`; enum variants and union arms may be
 added anywhere, removed and reordered; array bounds may move; a field may
 change between `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes` —
-all of it either invisible to the wire or counted in the report. **The last
-positional vocabulary besides flags was the enum-ordinal-indexed array, and
-`[E]T` (§2.4) closes it**: keyed slots ride by name, so a middle insert
-moves no slot.
+all of it either invisible to the wire or counted in the report.
 
-Each of the two has its own answer:
+**Two edits that would otherwise be silent are made REPORTABLE by
+construction, and it is worth saying how, because the claim above depends
+on it.**
+
+- **An enum-ordinal-indexed array** was the last positional vocabulary
+  besides flags: insert a variant in the middle and every later slot lands
+  one place off. `[E]T` (§2.4) closes it — keyed slots ride by name, so a
+  middle insert moves no slot.
+- **Changing a table field between `[E]T` and `[E.Max + 1]T`** would then
+  have replaced it: two encodings under one kind would have let a reader
+  decode keys as values and report nothing. The keyed body's own kind `16`
+  (§3.2) turns that edit into a kind mismatch, counted like any other.
+
+Each of the two real ones has its own answer:
 
 - **Flags** are answered by DISCIPLINE, stated as law: **append at the end,
   never insert or reorder**, and retire a name in place rather than freeing
   its bit.
 - **Both** are answered by MACHINERY, opt-in: the committed tables baseline
   (§18) is the history the compiler does not keep, and it refuses either
-  edit until the baseline moves with a recorded reason.
+  edit until the baseline moves with a recorded reason. It refuses the
+  spelling change above too, at compile time, ahead of the reader's report.
 
 ## 5. Identity: the name hash, `was`, and the collision refusal
 
@@ -1003,6 +1097,22 @@ element size, array bound and count-companion offset, declared bounds,
 branch guards, and the nested table's descriptor. `<Name>TableType()`
 returns that table's descriptor.
 
+**A type descriptor also carries a RESET hook** — put one instance back at
+its declared defaults, in place. A generic walker that FILLS a value has to
+be able to establish the defaults an absent field takes, and it holds no
+type to spell; this is the one thing the columns cannot express without a
+function. It does what the wire's read path does, with no temporary.
+
+**A field carries its TEXT KEY** beside its name — the `json = "..."`
+attribute's value, else the field's own name (§16.3) — so a walker over the
+text form spells keys without a second table.
+
+**A `bits(N)` field carries its IMPLIED RANGE.** `bits(N)` declares
+`[0, 2^N − 1]` by its width rather than by an attribute, and the codec has
+always clamped to it (§4); carrying it in the descriptor is what lets a
+generic walker apply the same bound without re-deriving it from a type
+name.
+
 **An optional field carries its presence companion.** `optional` marks the
 field and `present_offset` names the `<field>_present` bool, exactly as
 `counted` and `count_offset` name a count companion — so a walker can read
@@ -1023,13 +1133,22 @@ function beside a **value→wire-id** function, so a tool can enumerate the
 names AND the ids without the schema files (§5).
 
 **A union field also names each arm's PAYLOAD**, by that type's descriptor,
-whether the arm is a declared `type` or a `table` (§2.6). Without it a
-walker can name the arm a value holds and cannot enter it, which stops
-every generic walk — the text form (§16) among them — at the union.
+whether the arm is a declared `type` or a `table` (§2.6), **beside the
+TAG's own offset and width** and each arm's offset within the union
+storage. Without those a walker can name the arm a value holds and can
+neither read the tag nor enter the payload, which stops every generic
+walk — the text form (§16) among them — at the union. Arms are indexed
+`[0, enum_max]`, and index 0 is the EMPTY arm, which carries no payload.
 
-**A flags field carries its BIT NAMES**: a bit-index→name function and the
-bit count, as an enum carries its value→name. It carries no per-variant
-wire id, because a mask's variants ride by position and have none (§4).
+**A flags field carries its BIT NAMES**: a bit-index→name function bounded
+by **the highest declared BIT INDEX** — not a count, so a walker loops
+`[0, enum_max]` inclusive, exactly as it does for an enum's values and a
+union's arms. It carries no per-variant wire id, because a mask's variants
+ride by position and have none (§4); a null id function beside a non-null
+name function is what identifies a flags field.
+
+**An enum-keyed array's slot 0 is marked invalid** (§2.4), so a walker
+enumerating slots skips it rather than printing a `None` row.
 
 **A `*bytes` or `*string` field** carries its used-length companion's
 offset beside the reference, so a walker reads the blob's extent the way
@@ -1135,9 +1254,11 @@ lockstep redeploy by a table edit. This independence is held by test.
   whose JSON keys collide, naming both, as wire ids do (§5).
 - **An edit the committed TABLES BASELINE forbids** (§18), when a unit has
   one: a specified default changed, added or removed; a flags variant
-  inserted, removed, reordered or renamed in place; a field's wire kind
-  changed; an enum-keyed array's key enum swapped. Overridden only by
-  moving the baseline with a recorded reason.
+  inserted, removed, reordered or renamed in place; a field's wire kind or
+  an array's ELEMENT kind changed; an array changed between the keyed and
+  the positional spelling; an enum-keyed array's key enum swapped; a
+  field's referent dropped, or swapped for one whose identities do not
+  ride. Overridden only by moving the baseline with a recorded reason.
 - **A save-time data cycle or over-deep graph** (§3.1): measure, save,
   cook and `Lock` all return failure. Nothing recurses away.
 - **A read-time nesting past the depth cap** (§3.1): the subtree is
@@ -1191,13 +1312,12 @@ config-format example holding that gate.
 
 **The shape the gate is held to.** `Config.bin` and `Assets.bin` are each
 ONE root table, and each root is FIXED-SIZE down to the leaves: no pointer
-anywhere in the closure. That is expressible because the constructs that
-used to force a pointer no longer do — `?T` (§2.3) gives an optional
-section by value, and `[E]T` (§2.4) gives the enum-keyed collection those
-formats always were, as language rather than as convention. A fixed root
-is the strong form of the gate: it says the whole content pipeline runs
-on the ladder's second rung, with no arena, no region and no allocation
-on either side.
+anywhere in the closure. `?T` (§2.3) expresses an optional section by
+value and `[E]T` (§2.4) expresses the enum-keyed collection as language
+rather than as convention, so neither forces a pointer. A fixed root is
+the strong form of the gate: it says the whole content pipeline runs on
+the ladder's second rung, with no arena, no region and no allocation on
+either side.
 
 **The gate is a per-language obligation, not a one-language one.** A game
 whose engine runtime is not the language its tools are written in has to
@@ -1207,8 +1327,7 @@ the per-language backends are named follow-ons (§15).
 
 ## 13. Rulings, recorded
 
-Owner rulings, 2026-09-01, in the order given. The fenced/append-only
-draft this document previously carried is dead; these replace it.
+Owner rulings, 2026-09-01, in the order given.
 
 - **The model**: "wire itself being evolution tolerant is what I thought
   versioning was … when you consider the wire also being save/load to
@@ -1313,7 +1432,10 @@ are these rulings, in the owner's words:
   tooling, you'd want to safely evolve those tables / messages."
 - **The text form** (§16): "the general idea of reading JSON file into a
   table can move into schema… that's not opinionated. but only one table at
-  a time?" — one table, one text, and the linking left outside.
+  a time? So we separate packing from table reading JSON, the actual
+  linking up by enums has to be replicant only since that is opinionated."
+  One table, one text; the ruling's second half is what §17 answers, and it
+  answers it by removing the opinion rather than by keeping the tool out.
 - **Packing** (§17): "It also may make it possible to move the table
   reading and packing entirely down into schema now… which is a WIN", with
   the directory rule taken as it stands and revisited against a real packed
@@ -1440,21 +1562,42 @@ with which instance, what key an instance is filed under, how instances are
 linked into a root table's collections, what envelope wraps the bytes. A
 packer (§17) calls this section once per text and does the rest itself.
 
+**This section states RULES, not one implementation.** A generic walk over
+the descriptors is what makes the form cheap enough to exist at all, and
+the C++ backend holds it as one walker whose source is byte-identical in
+every generated header — but that is C++'s way of meeting the rules, not
+the definition of them. Another backend, and the compiler's own packer
+(§17), implement the same rules over the same IR, and goldens are what make
+the implementations one form: for every instance in the corpus, every
+implementation's text is byte-identical and every implementation's read of
+that text produces the same wire bytes.
+
+**The walk rides in every table closure's header, the fixed class
+included.** It is not gated on a unit's mode, because a fixed-size table is
+exactly the kind a tool authors as text; there is no opt-out.
+
 ### 16.1 The surface
 
-For every table in a unit's closure, name first, C++:
+For every FIXED-SIZE table in a unit's closure, name first, C++:
 
 ```cpp
 TableReport report;
 ShipConfig ship;
 if ( !ShipConfigFromJson( ship, text, text_bytes, &report ) )
 {
-    // the text is not JSON, or a value cannot be placed at all
-    // (report.malformed) — the instance holds what was placed before the stop
+    // the text is not JSON (report.malformed) — the instance holds what
+    // was placed before the stop
 }
 
 int64_t size = ShipConfigToJsonMeasure( ship );      // exact bytes, writes nothing
-ShipConfigToJson( ship, buffer, size );              // returns size; -1 = too small
+ShipConfigToJson( ship, buffer, size );              // returns size; -1 = refused
+```
+
+A VARIABLE-LENGTH table reads through its builder, because that is where
+its storage comes from (§6.5):
+
+```cpp
+SceneFromJson( builder, text, text_bytes, &report );
 ```
 
 - **`FromJson` fills ONE instance from ONE text.** The instance is the
@@ -1466,11 +1609,12 @@ ShipConfigToJson( ship, buffer, size );              // returns size; -1 = too s
   that elides is a text a reader has to know the schema to complete.
   Measure and write agree byte for byte, the wire's invariant (§9) carried
   across.
-- **Both are ONE generic walk.** No per-table codec is emitted: the
-  generated header carries the descriptors and one walker over them. That
-  is the property that makes this schema's rather than a packer's, and it
-  is a gate: the walker's source is the same bytes in every generated
-  header of the corpus.
+- **`ToJson` is PRETTY-PRINTED**, and the shape is part of the contract:
+  one entry per line, two-space indent per nesting level. Measure must
+  equal write byte for byte and `unpack` → `pack` must be byte-stable
+  (§17.2), and neither is checkable while the shape is unstated. It is the
+  form's one formatting opinion, and it is held because a text these files
+  exist for is read and diffed by people.
 
 ### 16.2 The mapping, field kind by field kind
 
@@ -1478,43 +1622,100 @@ The JSON form of a table is an object whose keys are field names. Per kind:
 
 | declaration | JSON | notes |
 |---|---|---|
-| integers, `bits(N)` | number | integral; a fraction is malformed |
-| `float32`, `float64`, compressed floats | number | |
+| integers, `bits(N)` | number | see **Numbers** below; a `bits(N)` value over its implied `[0, 2^N − 1]` clamps and counts |
+| `float32`, `float64`, compressed floats | number | a value a float32 field cannot hold is `kind_mismatch`, never stored as infinity |
 | `bool` | `true` / `false` | |
-| `string(N)`, `*string` | string | UTF-8; longer than N is CLAMPED to N bytes at a code point boundary, counted (a `*string` has no bound to clamp against) |
-| `bytes(N)`, `*bytes` | string, base64 | longer than N is clamped, counted (a `*bytes` has no bound to clamp against) |
-| enum | string, the variant NAME | `"Silver"`; an unknown name → None, counted |
-| flags | array of variant names | `["Shielded", "Turbo"]`; an unknown name is skipped, counted |
+| `string(N)`, `*string` | string | longer than N is CLAMPED to N bytes at a code point boundary, counted (`*string` has no bound to clamp against) |
+| `bytes(N)`, `*bytes` | string, base64 | standard alphabet, PADDED on write; padded and unpadded both read. Longer than N is clamped, counted |
+| enum | string, the variant NAME | `"Silver"`; `None` writes as `"None"`; an unknown name → None, counted |
+| flags | array of variant names | `["Shielded", "Turbo"]`; an empty mask writes as `[]`; an unknown name is skipped, counted |
 | `[N]T` fixed array | array | fewer elements pad with defaults; more are dropped, counted |
 | `[..N]T` bounded array | array | count = length; more than N are dropped, counted |
-| `[E]T` enum-keyed array | object keyed by VARIANT NAME | `{ "Fighter": {...}, "Bomber": {...} }`; an absent key keeps that slot's defaults; an unknown key is skipped, counted; a duplicate key is last-wins, counted |
+| `[E]T` enum-keyed array | object keyed by VARIANT NAME | `{ "Fighter": {...}, "Bomber": {...} }`; an absent key keeps that slot's defaults; an unknown key is skipped and counted, and **`"None"` is such a key** — it names no slot (§2.4) |
 | nested `type` / `table` | object | the same walk, recursively |
 | `?T` optional | the value, or the key absent | **presence of the KEY is presence**: a key present sets the field present, whatever its value; an absent key leaves it absent. `ToJson` writes present optionals only |
-| union | object with ONE key, the arm name | `{ "buff": { "multiplier": 2.0 } }`; `{}` or absent = None; two keys is malformed. A `table` arm (§2.6) is the same object form |
-| pointer `*T` | object, or `null` | the pointee's object in place; a variable-length table reads through its builder (§6.5), so `FromJson` for one takes the builder: `SceneFromJson( builder, text, bytes, &report )` |
+| union | object with ONE key, the arm name | `{ "buff": { "multiplier": 2.0 } }`; `None` writes as `{}`; `{}` or absent reads as None; two keys is malformed. A `table` arm (§2.6) is the same object form |
+| pointer `*T` | object, or `null` | the pointee's object in place; `null` is a null pointer |
 
-**Guarded fields** (`if guard { ... }`): a guarded group's fields are placed
-only when the guard reads true, and the guard is an ordinary bool field in
-the text — it is written and read like any other field, and the walk infers
-nothing from the presence of the group. A field that is genuinely present
-or absent is `?T`, which the walk does model, and that is the difference
-between the two constructs.
+**Numbers.** JSON has ONE number type, so an integer field accepts any
+token whose VALUE is integral — `2`, `2.0` and `1e3` are the integers 2, 2
+and 1000 — because that is how every library that round-trips numbers
+through a double writes them, and meeting an existing text is what §16.3
+exists for. A token with a genuinely fractional value in an integer field
+is `kind_mismatch`, skipped and counted. A value outside the field's
+declared or implied range clamps and counts (**Bounds**, below); a float
+value the field's width cannot represent is `kind_mismatch`, so an
+infinity is never stored. **A token that is not a JSON number at all** —
+`1-2`, `5+`, `1.2.3`, `--3` — is `malformed`: the token grammar is RFC
+8259's, and a typo in an authoring file is a diagnostic, never a clamped
+value.
+
+**`null`** is `kind_mismatch` for every kind except the two where absence
+is a value: a `?T` reads `null` as ABSENT, and a pointer reads it as null.
+
+**Guarded fields** (`if guard { ... }`) are ordinary fields, and the walk
+infers nothing from them:
+
+- **Writing** elides a field whose guard is false, exactly as the wire does
+  (§3), so a text and a wire of the same instance describe the same fields.
+- **Reading** places every key it can name, in whatever order the text
+  gives them, and never lets a guard's position in the object decide
+  whether a key is honoured. A field placed under a false guard is elided
+  again on the way out, so the wire never sees it.
+
+That order-independence is the whole reason the rule is stated this way: a
+text whose guard key follows the fields it guards must not silently lose
+them. A field that is genuinely present-or-absent is `?T`, which the walk
+DOES model, and that is the difference between the two constructs.
 
 **Bounds.** A number outside a field's declared `[min, max]` is clamped and
 counted, never refused — the wire's rule (§4), so a text and a wire loaded
 from the same data land the same instance.
 
 **Unknown keys** are skipped and counted in `report.unknown`. **Duplicate
-keys**: last wins, counted. **Trailing commas** in objects and arrays are
-accepted on read — the authoring files this section exists for carry them —
-and never written. Comments are not JSON and are refused.
+keys**: the last occurrence wins and the repeat is counted in
+`report.duplicate` (§4). Last-wins applies to a WHOLE value: a repeated
+array key replaces the array outright rather than overlaying a prefix on
+what the first occurrence left, and a repeated table or union key
+re-establishes the whole value at its defaults before placing it.
+**Trailing commas** in objects and arrays are accepted on read — the
+authoring files this section exists for carry them — and never written.
+Comments are not JSON and are refused.
 
-**The report is the wire's report** (§4): `unknown`, `kind_mismatch` (a key
-present with the wrong JSON type — a string where a number was declared —
-is skipped, never coerced), `clamped`, `malformed`. Silence means the text
-matched the schema exactly.
+**The report** (§4): `unknown`, `kind_mismatch` (a key present with the
+wrong JSON type — a string where a number was declared — is skipped, never
+coerced), `clamped`, `duplicate`, `malformed`. Silence means the text
+matched the schema exactly, and it means it honestly: no value a read calls
+clean can be one the writer would refuse.
 
-### 16.3 The key: `json`
+### 16.3 What the writer refuses
+
+`ToJsonMeasure` and `ToJson` return **-1** rather than write a text that
+does not say what the instance holds. This is §5's save-failure rule
+carried across: an unnameable value is refused on the way out rather than
+written as something else.
+
+- **An enum value no variant names**, and **a set flags bit no variant
+  names** — refused by the NAME, not by a bound, so a vocabulary that
+  disagrees with its own extent cannot slip through as a placeholder.
+- **A union tag outside its arm range.**
+- **A non-finite float.** The read path cannot produce one (above), so an
+  instance that came from a text is always writable; one built in code with
+  an infinity in it is refused, and says so.
+
+`-1` therefore has two meanings on `ToJson` — a buffer too small, and a
+value that cannot be written — and a caller that distinguishes them calls
+`ToJsonMeasure` first, which fails only for the second reason.
+
+**The writer always emits valid JSON and valid UTF-8.** A stored byte
+sequence that is not well-formed UTF-8 — which the storage permits, and
+which a text can introduce through a lone surrogate escape — is written as
+the replacement character `U+FFFD`, one per ill-formed sequence, rather
+than passed through. RFC 8259 requires a JSON text to be valid UTF-8, and a
+text this form emits must be readable by any conforming parser, not only by
+schema's own reader.
+
+### 16.4 The key: `json`
 
 A field's JSON key is its name. The one attribute this form adds lets a
 declaration meet an existing text:
@@ -1530,21 +1731,29 @@ attribute changes no byte on the wire**: keys are the text's business, ids
 are the wire's, and a schema may add, change or remove a `json` key without
 touching a stored file.
 
-### 16.4 Held by test
+### 16.5 Held by test
 
 - Every table in the corpus round-trips `ToJson` → `FromJson` → `Save` and
   byte-matches the wire of the original instance.
-- A hostile battery: wrong JSON types at every kind, overflow at every
-  integer width, nesting past the depth cap, unknown keys, duplicate keys,
+- **A PINNED TEXT.** `ToJson` of a known instance equals a known literal
+  text, checked as bytes. A round trip alone cannot see a vocabulary error
+  — reader and writer share the name function, so a wrong spelling
+  round-trips perfectly — and this is the test that closes that class for
+  enums, flags, union arms and `None`.
+- A hostile battery: wrong JSON types at every kind, malformed number
+  tokens, overflow at every integer width and float width, nesting past the
+  depth cap, unknown keys, duplicate keys at every kind including arrays,
   clamped strings at a multi-byte boundary, a union with two keys, an
-  enum-keyed object with a name the enum lacks.
+  enum-keyed object keyed `"None"`, a lone surrogate.
+- Guards in every configuration, including nested and negated ones, and a
+  text whose keys precede their guards.
 - **Negative control:** with the walker's offset arithmetic sabotaged by
   one field, the round-trip goes red on the first table that has two
   fields.
-- The generic-walk gate: the walker's source is identical in every
-  generated header of the corpus.
+- The one-walk gate: within a backend that holds the form as a single
+  walker, that walker's source is identical in every generated header.
 
-### 16.5 What this is not
+### 16.6 What this is not
 
 Not a file format, not a directory layout, not a manifest, not an envelope.
 Those are a packer's business; §17 is one packer, and it is a TOOL over
@@ -1561,13 +1770,45 @@ schema pack   --root Config --out Config.bin  configs/
 schema unpack --root Config --in  Config.bin  configs/
 ```
 
-### 17.1 The directory rule
+**Why this is not the opinion the text form's ruling kept out.** What made
+packing an opinion was linking instances into a collection by an enum key,
+and the key field inside each instance that made the link possible. With
+`[E]T` (§2.4) the link IS the declaration and the key is the slot, so there
+is no manifest, no collection concept and no key field to invent. What is
+left is a structural convention about where a value's text lives, which is
+the part that prescribes nothing about content.
+
+### 17.1 The engine
+
+**`schema pack` carries its own implementation of §16's rules and §3's
+wire**, inside the compiler, driven by the same IR the emitters are driven
+by. It does not call generated code: the compiler is a Go program and the
+generated walk is the target language's, so there is no path from the one
+to the other, and building one would make the compiler depend on a C++
+toolchain to pack a file.
+
+That means the tree holds **two implementations of one wire**, and goldens
+are what make them one:
+
+- for every corpus tree, `schema pack`'s bytes equal a backend's `Save` of
+  the same instance built by hand;
+- `schema pack` → a backend's `Load` → that backend's `ToJson` →
+  `schema unpack` is byte-stable;
+- every text `schema unpack` writes is byte-identical to the one the
+  backend's `ToJson` writes for the same instance.
+
+Every backend that implements the text form inherits that obligation
+against the same corpus, which is what keeps one wire and one text form as
+the number of implementations grows.
+
+### 17.2 The directory rule
 
 The tree MIRRORS the root table's shape, and nothing else:
 
 - a **directory named after a field** holds that field's value;
 - for an **enum-keyed array** (§2.4), one file per variant,
-  `<Variant>.json`;
+  `<Variant>.json` — and there is no `None.json`, because `None` keys no
+  slot;
 - for a **bounded array**, files in name order become the elements, or one
   `<field>.json` holds the whole array;
 - for a **nested table**, either `<field>.json` or a directory of its
@@ -1575,33 +1816,34 @@ The tree MIRRORS the root table's shape, and nothing else:
 - a plain **`<field>.json` at any level** is that field's value verbatim;
 - the **root may simply be one `<Root>.json`**.
 
-Each file's content is read by §16's walk, so every rule about kinds,
-presence, clamping and the report is that section's and is not restated
-here. The tree rule is structural only — it says where a value lives, never
-what a value means — which is what keeps a packer out of the format.
+Each file's content is read under §16's rules, so everything about kinds,
+presence, numbers, clamping and the report is that section's and is not
+restated here. The tree rule is structural only — it says where a value
+lives, never what a value means.
 
-### 17.2 What comes out
+### 17.3 What comes out
 
 **The output is the root table's wire bytes and nothing else**: no magic,
 no content hash, no protocol id, no length prefix around the whole. A
 caller that wants an envelope writes its own few lines around these bytes,
 which is §1's promise that schema imposes no envelope. `unpack` is the
-inverse — it writes the tree back out of a `.bin` through `ToJson`, which
-is the tool round trip §1 promises, and `unpack` → `pack` is byte-stable.
+inverse — it writes the tree back out of a `.bin` — which is the tool round
+trip §1 promises, and `unpack` → `pack` is byte-stable.
 
-### 17.3 Refusals and the report
+### 17.4 Refusals and the report
 
 A tree that does not mirror the table is reported rather than guessed at: a
 directory or file naming no field, two files claiming one enum-keyed slot,
-a variant name the enum does not have, a file that is not JSON. Everything
-§16 counts is counted here too, aggregated across the tree, so a pack of a
-hundred files reports once.
+a variant name the enum does not have, a `None.json`, a file that is not
+JSON. Everything §16 counts is counted here too, aggregated across the
+tree, so a pack of a hundred files reports once.
 
-### 17.4 Held by test
+### 17.5 Held by test
 
 A directory corpus packs to bytes identical to `Save` of the same instance
-built by hand; `unpack` → `pack` is byte-stable; and the hostile tree above
-is refused or counted per §16's rules.
+built by hand; `unpack` → `pack` is byte-stable; the goldens of §17.1 hold
+the engine to every backend that implements the form; and the hostile tree
+above is refused or counted per §16's rules.
 
 ## 18. The tables baseline
 
@@ -1623,17 +1865,28 @@ means.**
 **It is `tables.baseline`, in the unit directory, and it is opt-in: no
 file, no check.** It is a canonical text projection of the closure — the
 members sorted, each member's fields in declaration order, one fact per
-line: name, wire id, kind, array shape (fixed, bounded or enum-keyed, with
-the bound's EVALUATED value), string and bytes capacity, presence of an
+line: name, wire id, kind, an array's ELEMENT kind, array shape (fixed,
+bounded or enum-keyed, with the bound's EVALUATED value and, for a keyed
+array, the KEY enum it names), string and bytes capacity, presence of an
 optional, the specified default as exact canonical text, and the `was`
 alias; then each enum's variants in order with their ids, each flags'
 variants in positional order, and each union's arms in order with their ids
 and payloads.
 
+**A field that names a declaration records WHICH KIND of declaration it
+names** — a table, an `enum`, a `flags` or a `union` — because those four
+are judged by four different identity rules (§18.3).
+
 **The values are EVALUATED**, not the source text: a constant that moves
 and flows through an expression into a default shows up as the value it now
 produces, which is the whole point — the projection records what data will
 mean, not how it was spelled.
+
+**Presence is RECORDED and judged on nothing.** An optional's presence
+companion is a fact in the file so a person reading a diff can see it, but
+a field moving between `T`, `?T` and `*T` moves no byte (§3.1) and passes
+in silence. Recording a fact and judging it are two different things, and
+this one is only recorded.
 
 It carries no protocol id and no packet fact: the type wire, the wire-shape
 projection and the protocol id are untouched by all of it (§10).
@@ -1662,19 +1915,49 @@ committed file whenever one is there, and:
   changed, added or removed; a flags variant inserted, removed, reordered,
   or RENAMED IN PLACE (a rename moves no byte, and a new meaning on a spent
   bit remaps every stored file; nothing distinguishes the two, so the
-  author says which); a field's wire kind or an array's element kind
-  changed; an enum-keyed array's key enum swapped for another.
+  author says which); a field's wire kind or an array's ELEMENT kind
+  changed; an array changed between the keyed and the positional spelling,
+  or an enum-keyed array's KEY enum swapped for another; a field's REFERENT
+  dropped, or swapped for one whose identities do not ride (§18.3).
 - **WARNS** — an array bound or a string/bytes capacity shrunk; an enum
-  variant or a union arm removed. The data survives and the read report
-  already counts what is lost (`clamped`, `unknown`), so this reports
-  rather than stops.
+  variant or a union arm removed; a closure member no longer covered by the
+  baseline (§18.3). The data survives and the read report already counts
+  what is lost (`clamped`, `unknown`), so this reports rather than stops.
 - **PASSES, in silence** — everything the wire absorbs: fields added,
   removed, reordered or renamed under `was`; enum variants and union arms
   added anywhere; flags variants APPENDED at the end; bounds and capacities
   grown; a bounded array made fixed or the reverse; a field moved between
-  `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes`.
+  `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes`; a DECLARATION
+  renamed, whose contents keep being judged under its new name (§18.3).
 
-### 18.3 Moving it is an explicit act
+### 18.3 What a name is worth, and what a referent is worth
+
+**A DECLARATION NAME IS NOT ON THE WIRE, and renaming one must not take its
+contents out of coverage.** Members match by name first; a baseline name
+with no live namesake is then matched to the unmatched live declaration of
+the same kind carrying the most of its identities, when that is at least
+half of them and unique. Either way the vanished name WARNS — a paired one
+saying where it went, an unpaired one saying nothing carries its identities
+any more — so a hole in the coverage is never silent. A removal stays
+legal; it stops being invisible.
+
+**A FIELD'S REFERENT is judged by whether the identities ride**, and each
+vocabulary's identity is its own (§3):
+
+- a **table body** decodes by field id, so a nested table — or a union
+  arm's payload, which is the same fact one level in — rides when every
+  field id the old one carried is still carried;
+- an **enum** value is its variant NAME hash and a **union** body opens
+  with its arm NAME hash, so those ride when the names survive;
+- a **flags** mask carries no names at all, so it rides only when the old
+  variants sit at the same bits.
+
+**Dropping the referent entirely always refuses** — an enum-typed field
+respelled as its raw `uint16`, say. §4 states that both ride as kind `7`,
+so that is precisely the edit no reader can report, which is this file's
+whole job.
+
+### 18.4 Moving it is an explicit act
 
 ```
 schema tables-baseline --update --reason "damage rebalanced in 2.0; saves from 1.x read the new value" configs/
@@ -1688,16 +1971,25 @@ break — and it is what a person consults when an old save or an old tool
 file reads back wrong. The update is idempotent: a unit that has not moved
 rewrites nothing.
 
-### 18.4 What it does not cover
+**`--update` works on a baseline the checker cannot read.** A corrupt file,
+another unit's file, or one written under a rendering version this compiler
+does not write, all refuse on check and name `--update` as the remedy — so
+the remedy runs: it salvages the `## history` lines verbatim, regenerates
+the projection from the unit as it stands, and records in the history that
+the previous projection could not be diffed. The one artifact in the file
+that cannot be regenerated is never the price of repairing it.
+
+### 18.5 What it does not cover
 
 **The first baseline covers only what comes after it.** It is a snapshot of
 whatever the schema is on the day it is written; data written before that
 day was written against a shape nobody recorded, and no check can speak for
 it. The created file says so in its own first history entry.
 
-### 18.5 Held by test
+### 18.6 Held by test
 
 Each refusal class has a fixture pair and its negative control — remove the
 check and the edit passes. The projection over the corpus regenerates
 byte-identical. The warn class warns and does not refuse. `--update`
-without `--reason` refuses.
+without `--reason` refuses, and `--update` over an unreadable baseline
+repairs it while keeping every history line.

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -335,11 +335,21 @@ enum is keyed.
   ```
 
   A port provides both wherever its language expresses both, and the
-  runtime half wherever it does not. The wire enforces the same rule from
-  the other side: a `None` key never rides (§3.2).
-- **In a `type` body the same spelling is a plain array** with no wrapper
-  and no accessor — the type wire is positional and has no key to check
-  (below).
+  runtime half wherever it does not. **The compile-time accessor is the
+  form that holds in a release build**: an assert is compiled out under
+  `NDEBUG` and its equivalent elsewhere, so a runtime key carries no guard
+  at all in the configuration a shipped game runs. `Slot<Key>()` costs
+  nothing and cannot be disabled — prefer it wherever the key is written
+  literally, which is most places. The wire enforces the rule from the
+  other side regardless: a `None` key never rides (§3.2).
+- **In a `type` body the same spelling is a PLAIN ARRAY.** `per_team [Team]int32`
+  inside a `type` generates `int32_t per_team[4]` — no wrapper, no keyed
+  accessor, and no `None` guard of any kind. The type wire is positional
+  (below), so there is no key to check and nothing to protect: slot 0 is an
+  ordinary element a `type` may read and write. **The guard exists only
+  where the keyed storage type is generated, which is table bodies**, and
+  only the TABLE-wire ENCODING is keyed. A porter reading this section
+  should not emit the wrapper for a `type`.
 - **On the TABLE wire the slots ride by NAME** (§3.2): the body carries
   `(variant id, element)` pairs, so inserting, removing or reordering
   variants leaves every surviving slot in its own home. This is the whole
@@ -359,6 +369,17 @@ is a kind mismatch — skipped, counted, never misdecoded (§4) — and the
 committed baseline refuses the edit at compile time (§18.2). Giving the
 keyed body its own kind is what buys that; the two encodings are not
 mutually decodable and nothing should let them be tried.
+
+**A KEY ENUM IS IN THE TABLE CLOSURE'S VOCABULARY**, and the closure's
+rules reach it through the keying field. An enum that a table closure
+reaches ONLY as an array key — never as a field type — still rides by
+variant name on this wire (§3.2), so it takes the closure's two vocabulary
+refusals (§5): **`| max = K` headroom is refused**, because a headroom
+value is reserved by number and named by nothing, and **variant id
+collisions are refused**, naming both variants. Both diagnostics name the
+KEYING FIELD as the edge that pulled the enum in, because that edge is the
+only reason the rule applies and a person looking at the enum alone would
+not otherwise see it.
 
 Refused by name: a bound naming a `flags` declaration (a mask holds any
 set of bits at once, so it names no single slot); a bounded keyed array,
@@ -923,9 +944,14 @@ values and a union's arms ride under their own name hashes (§3), so:
   are a compile error naming both** — the field rule, applied to the
   vocabulary. Scoped to the TABLE CLOSURE: the packet wire identifies a
   variant by its ordinal and is untouched.
-- **`| max = K` headroom on an enum in a table closure is refused.** A
-  headroom value is reserved by number and named by nothing, so it has no
-  identity to ride under — and the table wire needs no headroom, because a
+- **A closure is reached by every edge, including an ARRAY KEY.** An enum
+  that a table closure reaches only as an enum-keyed array's key (§2.4)
+  rides by variant name exactly as a field-typed one does, so both rules
+  above apply to it, and the diagnostic names the keying field as the edge
+  that pulled it in.
+- **`| max = K` headroom on an enum in a table closure is refused**, key
+  enums included. A headroom value is reserved by number and named by
+  nothing, so it has no identity to ride under — and the table wire needs no headroom, because a
   variant may be added anywhere. A stored value no variant names is
   likewise refused on the way out: measure and save return failure rather
   than writing `None` over it, exactly as they refuse an out-of-range union
@@ -1277,9 +1303,12 @@ lockstep redeploy by a table edit. This independence is held by test.
 - Id collisions, hash or `was`-induced (§5).
 - `was` outside a table body (§5).
 - **Variant id collisions** — two variants of one enum, or two arms of one
-  union, whose name hashes collide, with both named (§5).
+  union, whose name hashes collide, with both named (§5). An enum reaching
+  the closure only as an ARRAY KEY is in scope, and the diagnostic names
+  the keying field as the reaching edge (§2.4).
 - **`| max = K` headroom on an enum in a table closure** — a headroom value
-  has no name, and the table wire identifies a variant by name (§5).
+  has no name, and the table wire identifies a variant by name (§5). Key
+  enums are in scope on the same terms.
 - Tables under any backend but C++ (status, above) — refused with the
   follow-on named, never silently ignored.
 - **Pointers** (§2.1): `*T` where T is a `type`, enum, flags or union —

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -313,16 +313,33 @@ spellings never overlap, because an enum is declared: `[Name]` naming a
 constant is the fixed array it has always been, and `[Name]` naming an
 enum is keyed.
 
-- **Storage** is `T ships[ShipType.Max + 1]`, indexed directly by the enum
-  value. Every slot exists, so there is no count companion, and
-  `ships[ShipType::Bomber]` reads with no biased arithmetic.
+- **Storage** is a generated KEYED-ARRAY TYPE wrapping `T slots[E.Max + 1]`
+  — one slot per variant, indexed by the enum value, no count companion
+  because every slot exists. The wrapper is what gives the accessors below
+  a home; the array inside it is an ordinary array, so the type stays
+  trivially copyable and standard-layout (§9).
 - **SLOT 0 EXISTS AND IS NEVER VALID.** `None` is the enum's null, so it
   keys nothing: only `E.Max` slots can ever hold data. Slot 0 is kept in
-  storage so indexing stays unbiased, and reaching it is an ERROR —
-  a compile-time refusal where the language can express one (a
-  `static_assert` on a constant index in C++), an assert otherwise —
-  through the generated keyed type's `operator[]( E )`. The wire enforces
-  the same thing from the other side: a `None` key never rides (§3.2).
+  storage so indexing stays unbiased, and reaching it is an ERROR. The two
+  accessors put that error as early as each can:
+  - `operator[]( E )` takes a runtime key and ASSERTS that it is not
+    `None`;
+  - a compile-time accessor beside it — `Slot<Key>()` in C++ — takes the
+    key as a constant and REFUSES `None` with a `static_assert`, so the
+    common case where the key is written literally never reaches a runtime
+    check at all.
+
+  ```cpp
+  fleet.ships[ ShipType::Bomber ]        // runtime key: asserts key != None
+  fleet.ships.Slot<ShipType::Bomber>()   // constant key: static_asserts
+  ```
+
+  A port provides both wherever its language expresses both, and the
+  runtime half wherever it does not. The wire enforces the same rule from
+  the other side: a `None` key never rides (§3.2).
+- **In a `type` body the same spelling is a plain array** with no wrapper
+  and no accessor — the type wire is positional and has no key to check
+  (below).
 - **On the TABLE wire the slots ride by NAME** (§3.2): the body carries
   `(variant id, element)` pairs, so inserting, removing or reordering
   variants leaves every surviving slot in its own home. This is the whole
@@ -482,6 +499,14 @@ schema's codebase:
   | `15` union | `arm id (u16)`, and when it is not 0, `L` then `L` bytes of arm body |
   | `16` enum-keyed array | `L`, then the body: `element kind (u8)`, `N` = the number of SLOTS PRESENT, then N pairs of `variant id (u16)`, `L (u32)`, `L` bytes of element (§3.2) |
 
+  **An array's ELEMENT KIND is part of its identity, not only its framing.**
+  For kinds `14` and `16` a reader compares the element kind it declares
+  against the one in the body and, when they differ, skips the field and
+  counts a kind mismatch (§4) — exactly as it does for the field's own
+  kind. Without that rule a `[3]int32` body would decode into a
+  `[3]float32` field as three reinterpreted bit patterns, reported by
+  nothing: the field-level silent-corruption class, one level down.
+
   **The union carries NO outer length** — its `arm id` sits where the other
   three containers put theirs, and the length that follows frames the arm
   alone. It is the one payload whose framing a skipper has to know (below).
@@ -539,6 +564,11 @@ schema's codebase:
   Elision is why old readers and new writers meet cleanly, and why measure
   and save agree byte for byte (§7). Elision makes the DECLARED DEFAULT
   part of the wire contract: see §4.
+  **A field under a FALSE GUARD is elided too**, whatever its storage
+  holds: an `if` branch that does not run writes none of its fields, so a
+  guarded group rides only when its guard is true. That is what makes a
+  guard an optional SECTION on the wire and not merely in the language, and
+  the text form defers to this rule rather than restating it (§16.2).
   **PRESENCE, not content, decides the three pointer-shaped spellings.** An
   absent `?T`, a null `*T` and a null `*bytes` are not written; a present
   optional, a non-null pointer and a non-null blob are ALWAYS written, even
@@ -710,7 +740,9 @@ tolerance is the versioning model:
   variant hash, and lands on `None` unless it happens to name one. **An
   array changed between the keyed and the positional spelling IS a kind
   mismatch** (`16` against `14`, §3.2), which is exactly why the keyed body
-  has a kind of its own.
+  has a kind of its own — **and so is an array whose ELEMENT kind differs**,
+  which is the same event one level in (§3): `[3]int32` read into a
+  `[3]float32` field is skipped and counted, never reinterpreted.
 - **A changed array BOUND** (a literal, a constant, or an `E.Max + 1`
   expression that moved): the array still loads, and the bound is not part
   of identity — a field is its name hash and its kind, and neither carries
@@ -722,6 +754,15 @@ tolerance is the versioning model:
   bytes do not.
 - **Out-of-range value** (bounds tightened since the writer): clamped to
   the reader's declared bounds, counted.
+- **A GUARD added or removed around an existing field**: the READ is
+  faithful in both directions — a field is found by its id whatever branch
+  now encloses it, so a reader whose build added `if g { x }` still loads
+  `x` out of an old file, with every counter zero and nothing lost. What
+  changes is the WRITE: that reader will elide `x` on its next save if `g`
+  is false (§3), so a load-edit-store cycle drops a value the load itself
+  read correctly. Adding or removing a guard is therefore not a decoding
+  hazard but a ROUND-TRIP one, and it is the one edit whose cost lands on
+  the tool that rewrites the file rather than on the one that reads it.
 - **Framing damage**: decode stops the damaged nesting level, keeps what
   it decoded there, flags malformed, and the parent continues past the
   field's declared length — one bad subtable never takes down the rest
@@ -814,6 +855,18 @@ on it.**
   have replaced it: two encodings under one kind would have let a reader
   decode keys as values and report nothing. The keyed body's own kind `16`
   (§3.2) turns that edit into a kind mismatch, counted like any other.
+
+**One edit is adjacent to this class without belonging to it, and the
+difference is worth stating rather than leaving to the reader.** Adding or
+removing a GUARD around an existing field (§4) reads correctly in both
+directions — the value comes back, the report is silent, and the silence is
+honest, because nothing was lost on the way in. The loss, if it comes, is
+on the way OUT: a reader whose guard is false elides the field on its next
+save. So it is not a silent decoding edit, and the enumeration above stays
+at two; it is a round-trip hazard, and a tool that loads, edits and stores
+a file — the save-game cycle §18 exists for — should be read as carrying
+it. A person whose file came back wrong needs the two above; a person whose
+tool rewrote a file needs this one.
 
 Each of the two real ones has its own answer:
 
@@ -1104,7 +1157,7 @@ type to spell; this is the one thing the columns cannot express without a
 function. It does what the wire's read path does, with no temporary.
 
 **A field carries its TEXT KEY** beside its name — the `json = "..."`
-attribute's value, else the field's own name (§16.3) — so a walker over the
+attribute's value, else the field's own name (§16.4) — so a walker over the
 text form spells keys without a second table.
 
 **A `bits(N)` field carries its IMPLIED RANGE.** `bits(N)` declares
@@ -1618,7 +1671,9 @@ SceneFromJson( builder, text, text_bytes, &report );
 
 ### 16.2 The mapping, field kind by field kind
 
-The JSON form of a table is an object whose keys are field names. Per kind:
+The JSON form of a table is an object whose keys are field KEYS — a
+field's name, or the `json` attribute's value where one is declared (§16.4).
+Per kind:
 
 | declaration | JSON | notes |
 |---|---|---|
@@ -1640,7 +1695,7 @@ The JSON form of a table is an object whose keys are field names. Per kind:
 **Numbers.** JSON has ONE number type, so an integer field accepts any
 token whose VALUE is integral — `2`, `2.0` and `1e3` are the integers 2, 2
 and 1000 — because that is how every library that round-trips numbers
-through a double writes them, and meeting an existing text is what §16.3
+through a double writes them, and meeting an existing text is what §16.4
 exists for. A token with a genuinely fractional value in an integer field
 is `kind_mismatch`, skipped and counted. A value outside the field's
 declared or implied range clamps and counts (**Bounds**, below); a float
@@ -1892,7 +1947,7 @@ It carries no protocol id and no packet fact: the type wire, the wire-shape
 projection and the protocol id are untouched by all of it (§10).
 
 ```
-schema-tables-baseline 1
+schema-tables-baseline 2
 package shipdemo
 
 table ShipConfig
@@ -1918,17 +1973,19 @@ committed file whenever one is there, and:
   author says which); a field's wire kind or an array's ELEMENT kind
   changed; an array changed between the keyed and the positional spelling,
   or an enum-keyed array's KEY enum swapped for another; a field's REFERENT
-  dropped, or swapped for one whose identities do not ride (§18.3).
+  dropped, or replaced by one that cannot STAND IN for it — every identity
+  survives AND, for a table or a union arm's payload, the facts under the
+  shared field ids are unchanged (§18.3).
 - **WARNS** — an array bound or a string/bytes capacity shrunk; an enum
-  variant or a union arm removed; a closure member no longer covered by the
-  baseline (§18.3). The data survives and the read report already counts
-  what is lost (`clamped`, `unknown`), so this reports rather than stops.
+  variant or a union arm removed; a DECLARATION renamed, or otherwise no
+  longer in the closure under its baseline name (§18.3). The data survives
+  and the read report already counts what is lost (`clamped`, `unknown`), so
+  this reports rather than stops.
 - **PASSES, in silence** — everything the wire absorbs: fields added,
   removed, reordered or renamed under `was`; enum variants and union arms
   added anywhere; flags variants APPENDED at the end; bounds and capacities
   grown; a bounded array made fixed or the reverse; a field moved between
-  `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes`; a DECLARATION
-  renamed, whose contents keep being judged under its new name (§18.3).
+  `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes`.
 
 ### 18.3 What a name is worth, and what a referent is worth
 
@@ -1937,20 +1994,34 @@ contents out of coverage.** Members match by name first; a baseline name
 with no live namesake is then matched to the unmatched live declaration of
 the same kind carrying the most of its identities, when that is at least
 half of them and unique. Either way the vanished name WARNS — a paired one
-saying where it went, an unpaired one saying nothing carries its identities
-any more — so a hole in the coverage is never silent. A removal stays
-legal; it stops being invisible.
+naming the declaration that carries it on, an unpaired one naming the
+closest candidate and its score — so a hole in the coverage is never
+silent. A removal stays legal; it stops being invisible.
 
-**A FIELD'S REFERENT is judged by whether the identities ride**, and each
-vocabulary's identity is its own (§3):
+**Two kinds of edit, and they never judge each other.** A declaration
+edited IN PLACE is judged by its own walk, where the verdicts follow what
+the runtime can report. A field REPOINTED at a different declaration is
+judged by the referent rule below. A rename is the first kind wearing the
+second's clothes, so a PAIRED rename is left to the walk: the same wire
+loss draws the same verdict whether or not the author also renamed — an
+enum variant or a union arm dropped from a renamed declaration WARNS,
+exactly as it does when the name did not move.
 
-- a **table body** decodes by field id, so a nested table — or a union
-  arm's payload, which is the same fact one level in — rides when every
-  field id the old one carried is still carried;
-- an **enum** value is its variant NAME hash and a **union** body opens
-  with its arm NAME hash, so those ride when the names survive;
-- a **flags** mask carries no names at all, so it rides only when the old
-  variants sit at the same bits.
+**A FIELD'S REFERENT must be able to STAND IN for the one it replaces**,
+and each vocabulary's standard is its own (§3):
+
+- A **table** — a nested field, or a union arm's payload, which is the
+  same fact one level in — is read by field id, so it stands in when every
+  id the old one carried is still carried AND THE FACTS UNDER THOSE IDS
+  ARE UNCHANGED. Id membership alone is not enough: a twin declaration
+  carrying the same id under a different specified default rewrites the
+  meaning of every stored body, and that is the flagship class this file
+  exists to refuse. The facts are judged by the same rules a field's own
+  facts are, so the two paths cannot disagree.
+- An **enum** value is its variant NAME hash and a **union** body opens
+  with its arm NAME hash, so those stand in when the names survive.
+- A **flags** mask carries no names at all, so it stands in only when the
+  old variants sit at the same bits.
 
 **Dropping the referent entirely always refuses** — an enum-typed field
 respelled as its raw `uint16`, say. §4 states that both ride as kind `7`,

--- a/SPEC.md
+++ b/SPEC.md
@@ -324,8 +324,9 @@ Bound       = IntExpr | ".." IntExpr | IntExpr ".." IntExpr .       // [N] exact
                                                                     // An exact bound NAMING A DECLARED
                                                                     // ENUM is an ENUM-KEYED array: exactly
                                                                     // E.Max + 1 slots, indexed by the
-                                                                    // variant (SPEC-TABLES.md §2.4). On
-                                                                    // this wire it IS [E.Max + 1]T
+                                                                    // variant, of which slot 0 (None) is
+                                                                    // never valid (SPEC-TABLES.md §2.4).
+                                                                    // On this wire it IS [E.Max + 1]T
 
 AttrSection = "|" Attr { "," Attr } .                            // runs to END OF LINE: the newline
                                                                  // or a // comment terminates it —

--- a/SPEC.md
+++ b/SPEC.md
@@ -265,7 +265,11 @@ Flags       = "flags" ident ( VariantList
                                                                    // body opens on the NEXT line
 Union       = "union" ident UnionBlock NL .                        // "union" contextual, §4.8
 UnionBlock  = "{" { UnionVariant } "}" .
-UnionVariant = ident ident NL .                                    // variant name, then its payload type
+UnionVariant = ident ident NL .                                    // variant name, then its payload type.
+                                                                   // A payload naming a TABLE is legal
+                                                                   // inside a table closure only
+                                                                   // (SPEC-TABLES.md §2.6); on the type
+                                                                   // wire a payload is a declared `type`
 Package     = "package" ident NL .
 Const       = "const" ident [ ConstType ] "=" ConstExpr NL .
 ConstType   = IntType | "float32" | "float64" .
@@ -289,7 +293,12 @@ ConstField  = "const" "(" IntExpr "," IntExpr ")" NL .          // (value, bits)
 Reserved    = "reserved" "(" IntExpr ")" NL .
 Align       = "align" NL .
 
-Type        = [ "[" Bound "]" ] Scalar .                         // array bound is a PREFIX, Go's order
+Type        = [ "?" ] [ "[" Bound "]" ] Scalar .                 // array bound is a PREFIX, Go's order.
+                                                                 // "?" is the OPTIONAL prefix
+                                                                 // (SPEC-TABLES.md §2.3): the value plus
+                                                                 // a generated presence bool. TABLE
+                                                                 // BODIES ONLY — a type body refuses one
+                                                                 // by name, as it does a pointer
 Scalar      = IntType
             | "int128" | "uint128"                               // 128-bit integers (§4.3);
                                                                  // field types only, not ConstType
@@ -301,15 +310,22 @@ Scalar      = IntType
                                                                  // the Q format is the type's SHAPE,
                                                                  // so it is positional like bits(N)
             | "ufixed" "(" IntExpr "," IntExpr ")"               // the unsigned sibling (§4.3)
-            | "*" ident                                          // a POINTER to a table
-                                                                 // (SPEC-TABLES.md §2.1);
+            | "*" ( ident | "bytes" | "string" )                 // a POINTER to a table
+                                                                 // (SPEC-TABLES.md §2.1), or to an
+                                                                 // unbounded byte or string buffer
+                                                                 // at its used size (§2.5);
                                                                  // TABLE BODIES ONLY — a type
                                                                  // body refuses one by name
             | ident .                                            // a declared type or enum
 IntType     = "int8" | "int16" | "int32" | "int64"
             | "uint8" | "uint16" | "uint32" | "uint64" .
 Bound       = IntExpr | ".." IntExpr | IntExpr ".." IntExpr .       // [N] exact; [..N] = [0..N],
-                                                                    // "up to N"; [A..B] = count in [A, B]
+                                                                    // "up to N"; [A..B] = count in [A, B].
+                                                                    // An exact bound NAMING A DECLARED
+                                                                    // ENUM is an ENUM-KEYED array: exactly
+                                                                    // E.Max + 1 slots, indexed by the
+                                                                    // variant (SPEC-TABLES.md §2.4). On
+                                                                    // this wire it IS [E.Max + 1]T
 
 AttrSection = "|" Attr { "," Attr } .                            // runs to END OF LINE: the newline
                                                                  // or a // comment terminates it —

--- a/USAGE.md
+++ b/USAGE.md
@@ -724,8 +724,12 @@ written; a present one always is, even at its defaults — so "absent" and
 sees the field sets `_present` whatever it contains.
 
 The framing is the ordinary field's, which makes `?T`, `*T` and a plain `T`
-nesting **one field on the wire**: move a field among the three and no byte
-changes, in either direction.
+nesting **three spellings of one field**: for any value that is not entirely
+default, move a field among the three and no byte changes, in either
+direction. The one difference is at the empty end — a plain `T` holding
+nothing but defaults writes nothing, while a present `?T` and a non-null `*T`
+write a body — and no direction misdecodes: an absent field reads as the
+declared default, as null, or as absent, each of which is right.
 
 `?` goes on nested tables and types, enums, flags and scalars. It is refused
 on a pointer (already optional), a union (`None` is its absence), and on
@@ -743,18 +747,23 @@ enum ShipType { Fighter, Bomber, Scout }
 
 table Fleet
 {
-    ships [ShipType]ShipConfig   // ShipType.Max + 1 slots; slot 0 is None's
+    ships [ShipType]ShipConfig   // one slot per variant, indexed by the variant
 }
 ```
 
 ```cpp
 Fleet fleet;
-fleet.ships[int( ShipType::Bomber )].health = 400.0f;
+fleet.ships[ShipType::Bomber].health = 400.0f;
 ```
 
 Storage is a plain fixed array with no count companion — every slot exists —
 so this is the array you would have written by hand as `[ShipType.Max +
-1]ShipConfig`. **What changes is the wire: the slots ride by NAME.** Each
+1]ShipConfig`. **Slot 0 exists and is never valid**: `None` is the enum's
+null, so it keys nothing and only `ShipType.Max` slots ever hold data. The
+slot is kept so indexing stays unbiased, and reaching it is an error —
+a compile-time refusal on a constant index, an assert otherwise.
+
+**What changes is the wire: the slots ride by NAME.** Each
 present slot carries its variant's id, so inserting a variant in the middle,
 removing one, or reordering them leaves every surviving slot in its own home:
 
@@ -767,10 +776,16 @@ enum ShipType { Fighter, Heavy, Bomber, Scout }    // v2 — every stored Bomber
 Under the positional spelling every slot after the insert would shift one
 place, silently. A slot the writer left at its default is elided; a slot this
 reader has no name for is skipped and counted `unknown`; a slot the writer
-never sent keeps its declared default.
+never sent keeps its declared default. A `None` key never rides at all.
 
 In a `type` body the same spelling is exactly `[E.Max + 1]T` — positional and
 bitpacked, the packet wire as always, with the same protocol id either way.
+
+**On the TABLE wire the two spellings are different encodings**, and changing
+a table field from one to the other is a wire break, not a refactor: the keyed
+body has its own wire kind, so an old file read under the new spelling is
+reported as a kind mismatch rather than decoded with keys taken for values.
+A committed baseline refuses the edit outright.
 
 ### Messages: a union whose arms are tables
 
@@ -900,8 +915,10 @@ const Scene * scene = SceneLoad( region, need, wire, wire_size, &report );
 
 On the wire a pointer rides as its pointee's table body — framing identical
 to a by-value nesting AND to an optional (`?T`), so a field may change among
-the three and no byte moves. Null pointers are simply absent. **Wire v1 is a
-tree**: two pointers to one node write two bodies and load as two nodes.
+the three and no byte moves for any non-default value (at the empty end they
+differ: a by-value `T` at its defaults elides, a non-null pointer does not).
+Null pointers are simply absent. **Wire v1 is a tree**: two pointers to one
+node write two bodies and load as two nodes.
 
 ### Byte buffers: `data *bytes`
 
@@ -928,7 +945,9 @@ In a million-node table a `bytes(65536)` field costs 64 KB a node whether it
 is used or not; a `*bytes` costs the reference plus what each node holds.
 Like any pointer it makes the holder variable-length. On the wire it is
 framed exactly as `bytes(N)` is, so a field that outgrows its inline bound
-moves to a blob and no byte changes.
+moves to a blob and no byte changes for any non-empty value — the same empty-end
+asymmetry as above: an empty `bytes(N)` elides, a non-null zero-length `*bytes`
+writes an empty payload.
 
 Two sentences that go together: **a tolerant wire load COPIES the blob** — a
 gigabyte on the wire path is a gigabyte read — and **the cooked path is the
@@ -1051,11 +1070,15 @@ or it does not happen.
 
 **What refuses, what warns, what passes.** Refused: a specified default
 changed, added or removed; a flags variant inserted, removed, reordered or
-renamed in place; a field's wire kind changed. Warned, because the read
-report already counts what is lost: a bound or a string capacity shrunk, an
-enum variant or a union arm removed. Passed in silence, because the wire
+renamed in place; a field's wire kind or an array's ELEMENT kind changed; an
+array changed between the keyed and positional spellings, or a keyed array's
+key enum swapped; a field's referent dropped, or swapped for one whose
+identities do not ride. Warned, because the read report already counts what is
+lost: a bound or a string capacity shrunk, an enum variant or a union arm
+removed, a declaration no longer covered. Passed in silence, because the wire
 absorbs it: fields added, removed, reordered or renamed under `was`; variants
-added anywhere; flags variants APPENDED; bounds grown.
+added anywhere; flags variants APPENDED; bounds grown; a declaration renamed,
+whose contents keep being judged under the new name.
 
 The whole thing is opt-in — no `tables.baseline`, no check — and the first
 one you write covers only what comes after it: data written before it existed
@@ -1143,15 +1166,24 @@ ShipConfigToJson( ship, buffer, size );
 
 `FromJson` places what the text mentions and leaves the rest at its declared
 defaults, exactly as an absent field on the wire does; unknown keys, wrong
-JSON types and out-of-range numbers land in the same report the wire uses.
-`ToJson` writes every field, defaults included — a text is for people.
+JSON types and out-of-range numbers land in the same report the wire uses,
+plus one counter the wire never raises — `duplicate`, for a key the text gave
+twice. `ToJson` writes every field, defaults included — a text is for people —
+and it is pretty-printed: one entry per line, two-space indent.
 
 The mapping is the obvious one: enums and flags by variant NAME, a union as
 an object with one key, an enum-keyed array as an object keyed by variant
 name, a `?T` optional present exactly when its key is present, `*bytes` as
-base64. Trailing commas are accepted on read and never written. A field can
-meet an existing text with `| json = "type"`, which changes no byte on the
-wire.
+base64. **JSON has one number type**, so `2`, `2.0` and `1e3` all read into an
+integer field; a genuinely fractional value there is a kind mismatch, and a
+token that is not a JSON number at all — `1-2`, `1.2.3` — is malformed rather
+than quietly clamped. Trailing commas are accepted on read and never written.
+A field can meet an existing text with `| json = "type"`, which changes no
+byte on the wire.
+
+**The writer refuses rather than lie**: `ToJson` returns -1 for an enum value
+or a set flags bit no variant names, an invalid union tag, or a non-finite
+float. The text it does emit is always valid JSON and valid UTF-8.
 
 ### Packing a directory into a table
 
@@ -1164,11 +1196,16 @@ $ schema unpack --root Config --in Config.bin configs/
 ```
 
 A directory named after a field holds that field's value; an enum-keyed array
-takes one `<Variant>.json` per variant; a bounded array takes files in name
-order; anything can collapse to a single `<field>.json`. The output is the
-table's wire bytes and **nothing else** — no magic, no hash, no protocol id.
-If you want an envelope, write your own few lines around them. `unpack` is
-the inverse, and `unpack` → `pack` is byte-stable.
+takes one `<Variant>.json` per variant (there is no `None.json` — `None` keys
+no slot); a bounded array takes files in name order; anything can collapse to
+a single `<field>.json`. The output is the table's wire bytes and **nothing
+else** — no magic, no hash, no protocol id. If you want an envelope, write
+your own few lines around them. `unpack` is the inverse, and `unpack` → `pack`
+is byte-stable.
+
+`pack` reads the texts with its own engine inside the compiler rather than by
+calling generated code — the compiler is a Go program — so the tree carries a
+second implementation of the same wire, held to the backends by goldens.
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -553,10 +553,11 @@ find out, once, at connect time, instead of paying for it on every packet.
 ## Tables: data that outlives builds
 
 Packets are for the network: exact-match, bit-packed, same protocol id or
-refuse. **Tables are for data** — tools→game pipelines, editors that walk
-properties by name, save/load to memory or disk — where the writer and the
-reader are routinely DIFFERENT builds and both must cope. Declare one with
-`table`; the body grammar is the type body's:
+refuse. **Tables are for data that outlives the build that wrote it** —
+tools→game pipelines, editors that walk properties by name, save games, tool
+output, save/load to memory or disk — where the writer and the reader are
+routinely DIFFERENT builds and both must cope. Declare one with `table`; the
+body grammar is the type body's:
 
 ```
 table ShipConfig
@@ -567,6 +568,16 @@ table ShipConfig
     name        string(32)
 }
 ```
+
+**What it costs.** Tables are less performant than types, and that is the
+trade: a type is a raw struct with a bit-packed same-build wire, a FIXED-size
+table is a raw struct with a tolerant byte codec around it and runs as close
+to its equivalent type as that wire allows, and the variable-length class
+(pointers, an arena, a region) pays for what it buys. Allocation follows the
+same ladder: types never allocate, a fixed table with no union never
+allocates, a fixed table WITH a union may allocate for the arm in a language
+that has no native union, and a variable-length table allocates by nature —
+in C++ the caller owns it.
 
 A table lives on its own wire — evolution-tolerant TLV, C++ only today. Field
 identity is a hash of the field NAME, so any reader takes any data, both
@@ -686,6 +697,110 @@ schema deliberately does not prescribe one. Tables may also reference plain
 A `type` cannot reference a table (packets stay exact-match), and a table
 cannot nest itself.
 
+### Optional fields: `settings ?GunnerSettings`
+
+A `?` before the type makes a field PRESENT or ABSENT. Storage is the value
+plus a generated `<field>_present` bool, so the table stays a fixed-size
+struct — no pointer, no allocation:
+
+```
+table ShipConfig
+{
+    health   float32 = 100.0
+    settings ?GunnerSettings
+    tier     ?int32            // scalars too
+}
+```
+
+```cpp
+ShipConfig ship;
+ship.settings_present = true;          // absent until you say so
+ship.settings.sensitivity = 0.4f;
+```
+
+**Presence decides whether it rides, not content.** An absent optional is not
+written; a present one always is, even at its defaults — so "absent" and
+"present with nothing to say" stay two different values, and a reader that
+sees the field sets `_present` whatever it contains.
+
+The framing is the ordinary field's, which makes `?T`, `*T` and a plain `T`
+nesting **one field on the wire**: move a field among the three and no byte
+changes, in either direction.
+
+`?` goes on nested tables and types, enums, flags and scalars. It is refused
+on a pointer (already optional), a union (`None` is its absence), and on
+arrays, strings and `bytes` — those already carry a count or length whose
+zero is emptiness; wrap one in a table and make that optional. An optional
+takes no specified default: presence is its only default.
+
+### Enum-keyed arrays: `ships [ShipType]ShipConfig`
+
+An array bound that names a declared ENUM gives you exactly one slot per
+variant, indexed by the variant:
+
+```
+enum ShipType { Fighter, Bomber, Scout }
+
+table Fleet
+{
+    ships [ShipType]ShipConfig   // ShipType.Max + 1 slots; slot 0 is None's
+}
+```
+
+```cpp
+Fleet fleet;
+fleet.ships[int( ShipType::Bomber )].health = 400.0f;
+```
+
+Storage is a plain fixed array with no count companion — every slot exists —
+so this is the array you would have written by hand as `[ShipType.Max +
+1]ShipConfig`. **What changes is the wire: the slots ride by NAME.** Each
+present slot carries its variant's id, so inserting a variant in the middle,
+removing one, or reordering them leaves every surviving slot in its own home:
+
+```
+enum ShipType { Fighter, Bomber, Scout }           // v1
+enum ShipType { Fighter, Heavy, Bomber, Scout }    // v2 — every stored Bomber
+                                                   // slot still loads as Bomber
+```
+
+Under the positional spelling every slot after the insert would shift one
+place, silently. A slot the writer left at its default is elided; a slot this
+reader has no name for is skipped and counted `unknown`; a slot the writer
+never sent keeps its declared default.
+
+In a `type` body the same spelling is exactly `[E.Max + 1]T` — positional and
+bitpacked, the packet wire as always, with the same protocol id either way.
+
+### Messages: a union whose arms are tables
+
+Inside a table closure a union's arm may name a `table`, which is what makes
+a tool message set evolve safely:
+
+```
+table OpenDocument  { path string(256), line uint32 }
+table SaveDocument  { path string(256), force bool   }
+
+union ToolBody
+{
+    open OpenDocument
+    save SaveDocument
+}
+
+table ToolMessage
+{
+    sequence uint32
+    body     ToolBody
+}
+```
+
+Arms ride under their name hash, so adding a message is adding an arm; a
+reader that lacks it reads the union empty, skips the body by its length and
+counts `unknown`; arms may be removed and reordered freely. Unlike a
+`type`-only payload, a message may carry a nested table or a whole
+collection. A union declared for the packet wire still takes `type` payloads
+only — types stay value semantics.
+
 ### Pointers: `next *Node`
 
 Types are value semantics. Tables ALLOW pointer semantics, because a generic
@@ -710,17 +825,13 @@ never a type body. Arrays of pointers, and a specified default on a pointer,
 are refused by name.
 
 **Do not reach for a pointer to make a field optional.** Every field on this
-wire is already optional — absence is the reader's default. The spelling for
-an optional SECTION is a guarded field:
+wire is already optional — absence is the reader's default — and a section
+that is present or absent as a unit is spelled `?T`:
 
 ```
 table Scene
 {
-    has_settings bool
-    if has_settings
-    {
-        settings Settings   // off the wire entirely when the guard is false
-    }
+    settings ?Settings   // off the wire entirely when it is absent
 }
 ```
 
@@ -788,9 +899,40 @@ const Scene * scene = SceneLoad( region, need, wire, wire_size, &report );
 ```
 
 On the wire a pointer rides as its pointee's table body — framing identical
-to a by-value nesting, so a field may change between the two and no byte
-moves. Null pointers are simply absent. **Wire v1 is a tree**: two pointers
-to one node write two bodies and load as two nodes.
+to a by-value nesting AND to an optional (`?T`), so a field may change among
+the three and no byte moves. Null pointers are simply absent. **Wire v1 is a
+tree**: two pointers to one node write two bodies and load as two nodes.
+
+### Byte buffers: `data *bytes`
+
+`bytes(N)` is N bytes of inline storage in every instance. `*bytes` is a
+pointer to a buffer that has no bound and takes exactly the size you give it
+— which is how an image or an asset lives inside a table:
+
+```
+table Asset
+{
+    format AssetFormat
+    data   *bytes        // sized per node, not per declaration
+    label  *string       // the sibling
+}
+```
+
+```cpp
+Asset * asset = builder.Alloc<Asset>();
+asset->data = builder.AllocBytes( png_bytes );
+memcpy( BytesAt( asset->data ), png, png_bytes );
+```
+
+In a million-node table a `bytes(65536)` field costs 64 KB a node whether it
+is used or not; a `*bytes` costs the reference plus what each node holds.
+Like any pointer it makes the holder variable-length. On the wire it is
+framed exactly as `bytes(N)` is, so a field that outgrows its inline bound
+moves to a blob and no byte changes.
+
+Two sentences that go together: **a tolerant wire load COPIES the blob** — a
+gigabyte on the wire path is a gigabyte read — and **the cooked path is the
+zero-copy one**, where a pointer into a mapped file IS the asset.
 
 ### The cooked form: point at a file instead of parsing it
 
@@ -842,6 +984,83 @@ Old files that carry `velocity` load into `speed`; new files keep writing the
 old id. The compiler refuses `was` naming the field's own current name, and
 refuses any two fields of one table whose effective ids collide.
 
+### The tables baseline: catching the edits the wire cannot report
+
+Think of a save game. A player's file was written two years ago by a build
+nobody has any more, and today's build has to read it. Almost every schema
+edit since is safe by construction — fields came and went, an enum grew,
+bounds moved — and the wire reports whatever it cannot use. **Exactly two
+edits are different**: they change what an OLD file MEANS, and nothing on the
+wire can tell you.
+
+```
+table ShipConfig
+{
+    damage float32 = 21.0    // v1 elided this: absence MEANS 21.0
+}
+
+table ShipConfig
+{
+    damage float32 = 25.0    // v2: every stored save now reads 25.0 out of
+}                            // the same bytes, and no report event fires
+```
+
+`flags` has the same shape of hazard one level down: bits carry no names, so
+inserting a variant silently remaps every stored mask.
+
+Commit a baseline and the compiler remembers for you:
+
+```
+$ schema tables-baseline --update --reason "first baseline before 1.0 ships" configs/
+$ ls configs/
+ShipConfig.schema   tables.baseline
+```
+
+`tables.baseline` is a text projection of the unit's whole table closure —
+one fact per line, made to be read in a diff — and from then on `schema
+check`, and so `schema generate`, diffs against it:
+
+```
+$ schema check configs/
+configs/tables.baseline: ShipConfig.damage: specified default 21.0 -> 25.0 — this
+edit changes what data already written MEANS, and no reader can report it; if you
+mean it, record it: schema tables-baseline --update --reason "..." (SPEC-TABLES.md §18)
+schema: 1 error(s)
+```
+
+Sometimes you mean it. The override is one command and it is never silent:
+
+```
+$ schema tables-baseline --update --reason "damage rebalanced in 2.0; saves from 1.x read the new value" configs/
+```
+
+That appends to the file's own history — which is what someone reads years
+later when an old save loads wrong:
+
+```
+## history
+### 2026-09-02 — first baseline before 1.0 ships
+- baseline created over 1 table — data written BEFORE this point is not covered by it
+
+### 2026-11-14 — damage rebalanced in 2.0; saves from 1.x read the new value
+- ShipConfig.damage: specified default 21.0 -> 25.0 [refuse]
+```
+
+`--update` without `--reason` is refused: an intentional break gets declared
+or it does not happen.
+
+**What refuses, what warns, what passes.** Refused: a specified default
+changed, added or removed; a flags variant inserted, removed, reordered or
+renamed in place; a field's wire kind changed. Warned, because the read
+report already counts what is lost: a bound or a string capacity shrunk, an
+enum variant or a union arm removed. Passed in silence, because the wire
+absorbs it: fields added, removed, reordered or renamed under `was`; variants
+added anywhere; flags variants APPENDED; bounds grown.
+
+The whole thing is opt-in — no `tables.baseline`, no check — and the first
+one you write covers only what comes after it: data written before it existed
+was written against a shape nobody recorded.
+
 ### Going wide
 
 Every nested table on the wire is length-prefixed, so building a large file
@@ -874,8 +1093,11 @@ Every closure type gets a reflection descriptor — name, wire id and kind,
 storage offset, array bounds and count companions, declared ranges, branch
 guards, and for an enum or union field the whole vocabulary: `[0, enum_max]`
 indexed, `enum_name` for each name and `variant_id` for the wire id it rides
-under. Enough to write a generic editor, printer or differ with no RTTI and
-no schema files at runtime:
+under. An optional field carries `optional` and `present_offset`, the
+presence companion's offset, so a walker can read and set presence; an
+enum-keyed array carries `key_type_name`, `key_name` and `key_id`, so it can
+print `ships[Bomber]` instead of `ships[2]`. Enough to write a generic
+editor, printer or differ with no RTTI and no schema files at runtime:
 
 ```cpp
 const TableTypeInfo * type = ShipConfigTableType();
@@ -904,6 +1126,49 @@ a unit that declares them, by name. What stays off the table wire: `fixed`,
 (bit-position constructs — the table wire has no bit positions). Extents have
 no wire ceiling: string and bytes byte lengths and array counts ride in
 uint32, so the only limit is the language's own int32 storage cap.
+
+### The text form: JSON in and out of one table
+
+The same descriptors drive a JSON text form, so every table reads from and
+writes to text with no per-table codec:
+
+```cpp
+TableReport report;
+ShipConfig ship;
+ShipConfigFromJson( ship, text, text_bytes, &report );   // fills ONE instance
+
+int64_t size = ShipConfigToJsonMeasure( ship );          // exact, writes nothing
+ShipConfigToJson( ship, buffer, size );
+```
+
+`FromJson` places what the text mentions and leaves the rest at its declared
+defaults, exactly as an absent field on the wire does; unknown keys, wrong
+JSON types and out-of-range numbers land in the same report the wire uses.
+`ToJson` writes every field, defaults included — a text is for people.
+
+The mapping is the obvious one: enums and flags by variant NAME, a union as
+an object with one key, an enum-keyed array as an object keyed by variant
+name, a `?T` optional present exactly when its key is present, `*bytes` as
+base64. Trailing commas are accepted on read and never written. A field can
+meet an existing text with `| json = "type"`, which changes no byte on the
+wire.
+
+### Packing a directory into a table
+
+`schema pack` builds ONE table instance from a directory tree that mirrors
+the root table, and writes the root's wire bytes:
+
+```
+$ schema pack --root Config --out Config.bin configs/
+$ schema unpack --root Config --in Config.bin configs/
+```
+
+A directory named after a field holds that field's value; an enum-keyed array
+takes one `<Variant>.json` per variant; a bounded array takes files in name
+order; anything can collapse to a single `<field>.json`. The output is the
+table's wire bytes and **nothing else** — no magic, no hash, no protocol id.
+If you want an envelope, write your own few lines around them. `unpack` is
+the inverse, and `unpack` → `pack` is byte-stable.
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -781,7 +781,16 @@ reader has no name for is skipped and counted `unknown`; a slot the writer
 never sent keeps its declared default. A `None` key never rides at all.
 
 In a `type` body the same spelling is exactly `[E.Max + 1]T` — positional and
-bitpacked, the packet wire as always, with the same protocol id either way.
+bitpacked, the packet wire as always, with the same protocol id either way —
+and there the storage is a **plain array**: `per_team [Team]int32` in a `type`
+is `int32_t per_team[4]`, no accessor and no `None` guard, because there is no
+key to check. Only the table wire keys the slots.
+
+Note that the runtime assert goes away under `NDEBUG`, so `Slot<Key>()` is the
+form that still catches a `None` in a release build. And a key enum counts as
+part of the table closure: it rides by variant name, so `| max` headroom and
+colliding variant names are refused for it too, with the diagnostic naming the
+field that keys on it.
 
 **On the TABLE wire the two spellings are different encodings**, and changing
 a table field from one to the other is a wire break, not a refactor: the keyed

--- a/USAGE.md
+++ b/USAGE.md
@@ -753,12 +753,14 @@ table Fleet
 
 ```cpp
 Fleet fleet;
-fleet.ships[ShipType::Bomber].health = 400.0f;
+fleet.ships[ShipType::Bomber].health = 400.0f;   // runtime key: asserts
+fleet.ships.Slot<ShipType::Scout>().health = 90; // constant key: static_asserts
 ```
 
-Storage is a plain fixed array with no count companion — every slot exists —
-so this is the array you would have written by hand as `[ShipType.Max +
-1]ShipConfig`. **Slot 0 exists and is never valid**: `None` is the enum's
+Storage is a generated keyed-array type wrapping a plain `ShipConfig[ShipType.Max
++ 1]` — no count companion, because every slot exists — so the memory is the
+array you would have written by hand, with the two accessors above on top of
+it. **Slot 0 exists and is never valid**: `None` is the enum's
 null, so it keys nothing and only `ShipType.Max` slots ever hold data. The
 slot is kept so indexing stays unbiased, and reaching it is an error —
 a compile-time refusal on a constant index, an assert otherwise.
@@ -1072,13 +1074,23 @@ or it does not happen.
 changed, added or removed; a flags variant inserted, removed, reordered or
 renamed in place; a field's wire kind or an array's ELEMENT kind changed; an
 array changed between the keyed and positional spellings, or a keyed array's
-key enum swapped; a field's referent dropped, or swapped for one whose
-identities do not ride. Warned, because the read report already counts what is
-lost: a bound or a string capacity shrunk, an enum variant or a union arm
-removed, a declaration no longer covered. Passed in silence, because the wire
+key enum swapped; a field pointed at a different enum, flags, union or table
+that cannot stand in for the old one — or at none at all, like an enum-typed
+field respelled as its raw `uint16`, which the runtime cannot report because
+both ride as kind 7. **"Stand in" means every identity survives AND, for a
+table, the facts under the shared field ids are unchanged**: a twin
+declaration carrying the same id under a different default is refused,
+because every stored body's elided value would quietly change meaning.
+Warned, because the read report already counts what is lost: a bound or a
+string capacity shrunk, an enum variant or a union arm removed, a declaration
+renamed or otherwise no longer covered. Passed in silence, because the wire
 absorbs it: fields added, removed, reordered or renamed under `was`; variants
-added anywhere; flags variants APPENDED; bounds grown; a declaration renamed,
-whose contents keep being judged under the new name.
+added anywhere; flags variants APPENDED; bounds grown.
+
+Renaming a declaration never raises a verdict of its own: it warns, saying
+which declaration carries the old one's contents on, and the contents keep
+being judged by their own walk — so a dropped variant draws the same warning
+whether or not its enum was renamed in the same edit.
 
 The whole thing is opt-in — no `tables.baseline`, no check — and the first
 one you write covers only what comes after it: data written before it existed


### PR DESCRIPTION
Spec only, three files — `SPEC-TABLES.md`, `SPEC.md` §4.2's grammar block, `USAGE.md`. No compiler, emitter, corpus or test change, and no generated byte moves.

**Spec first always** (owner, live). The tables campaign written as one language, landing ahead of the implementation PRs rather than trailing them. Every section is meant to be implementable from the page alone by someone who does not have this repo — a property the cold read tested directly by writing a Go encoder from §3/§3.1/§3.2 and matching the generated `Save` byte for byte on the first attempt.

## The load-bearing change: the keyed array body gets its own wire kind

`[E.Max + 1]T` stays legal and positional (the owner's ruling), so a table field can be edited between the two spellings. They were both kind `14` with different layouts. Measured by the cold read, keyed writer → positional reader:

```
Load returns true.  unknown=0 kind_mismatch=0 clamped=0 malformed=0
slots = {262144, 65536, -1157431296}
```

Every counter zero, every value garbage — a silent, data-corrupting edit, and the **third** member of a silent class §4.1 claimed had exactly two. **The keyed body is now kind `16`.** The edit becomes a reported `kind_mismatch`, §4.1's claim becomes true, and §18.2's compile-time refusal is the belt to that braces. §3's skip rules gain `16` (still three rules), and §3.2 states ascending-ordinal write order with readers key-driven.

## Sections added

- **`## The performance ladder` / `## What allocates, and what never does`** (the opening) — the owner's ladder and the language-keyed union carve-out.
- **§2.5 `*bytes`/`*string`**, **§2.6 union arms as tables**, **§4.1 the silent class**, **§13.2/§13.3 rulings in the owner's words**, **§16 the text form**, **§17 packing**, **§18 the baseline**.

## The cold read's ten must-fixes — all closed

| # | fix | where |
|---|---|---|
| D1 | positional↔keyed is a silent corrupting edit | §2.4, §3, §3.2, §4, §4.1, §11, §18.2 — closed by kind `16` |
| D2 | byte-identity claim overbroad | §2.3, §2.5, §3, §3.1 + USAGE — scoped to non-default content, empty-end asymmetry named |
| D3 | §17 not implementable (compiler cannot run generated code) | §17.1 pack's own IR-driven engine + the goldens; §16 preamble states rules, not one implementation |
| D4 | report contradiction on duplicates | `duplicate` counter in §4 and §16.2 |
| D5 | guard rule order-dependent, drops data | §16.2 — write elides, read is order-free and infers nothing |
| J1 | a fraction was "malformed" | §16.2 — `kind_mismatch`; `malformed` reserved for not-JSON |
| J4, J6 | writer refusals and text shape unstated | §16.3 (the `-1` refusals), §16.1 (pretty-print as contract) |
| J7 | §8 missing columns the walk needs | reset hook, text key, `bits(N)` implied range, union tag offset/width; flags bound corrected to **highest declared bit index** |
| O1 | variable-class narrowing | page keeps `SceneFromJson(builder, …)`; §15 does **not** list it as a follow-on; open-for-owner item 1 |
| D6, D7 | §17's licensing sentence, §11's element-kind row, history narration | §13.3 quotes the ruling's second clause; §17 preamble; §11; §12 and §13 de-narrated |

## Owner rulings folded in this pass

- **`[E]T` slot 0** (#255): "the 0th entry in the array is not valid, and is 'null', so you really only store n-1 entries"; and "accessing the 0th entry is an error/assert". Storage stays `E.Max + 1` (owner: "memory is cheap so you could just leave the array as-is, and just put an error/assert on index by zero"), slot 0 exists and is never valid, indexing it is a `static_assert` where expressible and an assert otherwise. `None` never rides; a stored key `0` is **malformed**, not unknown, because `0` is the reserved id no name can fold to. `"None"` is an unknown key in the text form; no `None.json` in pack; §8 marks slot 0 invalid. Unbiased indexing throughout — `ships[ShipType::Bomber]`.

## The delta read's five (`7e54c0d`) — all closed

| # | finding | fix |
|---|---|---|
| N1 | §3's elision list omitted guarded-false fields while §16.2 cited the rule as if §3 carried it — an encoder from §3 alone wrote a field the reference does not | a bullet in §3's elision list; §16.2 now genuinely defers |
| N2 | §4 never said an array's ELEMENT kind is checked, though the code checks it — a faithful reader would decode `[3]int32` into `[3]float32` and report nothing | §3's `14`/`16` rows state element kind is identity, not only framing; §4's kind-mismatch bullet covers it |
| N3 | adding an `if` guard is report-clean and round-trip-lossy, and §4 named guards nowhere | §4 gains the bullet; §4.1 states why it is **not** a third silent edit — see below |
| N4 | two `§16.3` refs stale after §16.3 was inserted; "field names" vs keys | → `§16.4`; §16.2 opens on field KEYS |
| N5 | §2.4 put the `static_assert` in `operator[]( E )`, where a runtime key cannot carry one | storage is a keyed-array type over `T[E.Max + 1]`; `operator[]( E )` asserts, `Slot<Key>()` static_asserts; a two-line snippet shows both |

**N3, the one that needed a call: stated, not made a refusal.** Adding or removing a guard reads correctly in both directions with every counter zero; the loss is on write-back, when the new reader elides the field on its next save. So §4.1's enumeration honestly stays at two — a silent edit is one that *decodes* wrong — and the page says so explicitly rather than leaving a reader to work out why the class is adjacent but not a member: *"A person whose file came back wrong needs the two above; a person whose tool rewrote a file needs this one."* Making it a §18 refusal would be a **new policy row** that no ruling covers, and a guard is a legitimate edit that a blanket refusal would block, so it goes to the owner instead (open item 11) rather than onto the page.

## From the #265 delta read (`817a775`)

Three things §2.4 owed a porter:

- **The type-body carve-out.** `per_team [Team]int32` inside a `type` generates a plain `int32_t per_team[4]` — no wrapper, no keyed accessor, no `None` guard — because the type wire is positional and there is no key to check. Only the TABLE-wire encoding is keyed, and the keyed storage type is generated for table bodies alone. The previous text would have had a porter emit the wrapper for a `type`.
- **A key enum is in the table closure's vocabulary**, even when no field has its type. It rides by variant name like any other, so `| max = K` headroom and variant-id collisions are refused for it — and the diagnostic names the KEYING FIELD as the reaching edge, because that edge is the only reason the rule applies and a person looking at the enum alone would not see it. Stated in §2.4, §5 and §11.
- **`NDEBUG` compiles the runtime guard out.** "Asserted otherwise" was doing too much work: the assert in `operator[]( E )` is absent in exactly the build a shipped game runs. `Slot<Key>()` is the form that holds in release, costs nothing, and cannot be disabled — preferred wherever the key is written literally, which is most places.

## Reconciliations

1. **Two branches both claimed §16** → §16 text form, §17 pack, §18 baseline. §1–§15 frozen (cited from code comments and issues).
2. **#264's `L == 4` union-arm discriminator is NOT here** — a wire-v2 construct; v1 has no node table, so a table arm rides inline in both classes, framed as a `type` arm.
3. **`*bytes` framing pinned to `bytes(N)`'s exactly** (kind `14` u8 array; `*string` kind `12`) — joins the wire-identity family, no new kind.
4. **Backend status stays `C++`** — the cold read judged this right; #266 carries its own status edit.
5. **§2.2's zero-cost gate rescoped to the pointer machinery** (#265 decision 6). The cold read verified the gate empirically: pointer-free unit with `?T` and `[E]T` passes, gaining exactly the five language columns, with `is_pointer`/`variable` absent — so §8's "only the two POINTER columns are conditional" is literally true.
6. **26 suffixes**, matching `tableGeneratedVerbs` — verified identical, same order.
7. **#253's §16.4 folded into §8**; **§16.6's replicant claim superseded by #257**; **guard-presence closed** per #253's own comment.

### Implementation-taught — the page adopted what a branch learned

Each of these is the page catching up to a build, per the gate's own provision:

- **`origin/tables-json-walk` (#267), six places.** A fraction is `kind_mismatch` not `malformed` (malformed stops the whole read — one bad value must not); `duplicate` as a real counter on `TableReport`; the guard rule as shipped (order-free read, eliding write) because the drafted rule silently lost fields whose guard key came later in the object; the writer's `-1` refusals as §5's save-failure rule carried into text; pretty-printing stated because measure==write and `unpack`→`pack` byte-stability are uncheckable without it; and §8's four missing columns plus the flags off-by-one (`enum_max` is the highest bit **index**, so a walker written from the old page looped one short).
- **From the #267 review**, also adopted: JSON has one number type, so `2.0` and `1e3` read into an integer field (the class of existing text §16.3 exists to meet); RFC 8259 number-token validation, so `1-2` is `malformed` rather than a clamp to int16 MAX; last-wins applies to a whole value including arrays; the writer always emits valid JSON/UTF-8; and the four page gaps a from-the-page author had to guess (how `None` writes, what `null` does per kind, base64 padding, empty flags).
- **`origin/tables-baseline` (#263), the repairs.** §18 now matches `DefaultTokenPolicy` row for row, including the referent rule (`RuleRefs` per vocabulary — table bodies by field id, enums and unions by name, flags by bit position), the always-refuse referent drop, the declaration-rename member matching with its warn, and the repairable-baseline behaviour of `--update`. §18.1 states that an optional's presence is **recorded and judged on nothing**, so nobody later adds a `RuleFixed` row and breaks the `T` ↔ `?T` move.
- **`origin/optional-and-enum-keyed` (#265): no divergences.** The cold read found full byte-level agreement with §3/§3.1/§3.2 on both scratch units. Its other seven decisions were checked against the rulings and kept verbatim.

## Open for the owner

1. **The text form's variable-class narrowing.** #267 ships no `FromJson` for a variable-length table — refusal by absence. The ruling was "one table at a time" with **no class restriction**, so the page states the design (`SceneFromJson( builder, … )`) and §15 does not list it as a follow-on. Either the walker builds it or the ruling narrows; the page must not decide it. Already on #248 as item (e). *(Consistency note either way: §16.2 carries rows for `*string`, `*bytes` and pointer `*T`, and a `*bytes` field alone makes its holder variable-length — so under the narrowing those three rows describe a table with no `FromJson` to call, and §17 needs a matching sentence about whether `pack` is fixed-class only.)*
2. **Wire v2's five decisions** (#251 / draft #264) — untouched; the page is v1 throughout.
3. **`*string`** is not ruled; "byte buffer as primitive" was.
4. **`schema pack` carries a second implementation of the wire** — a Go text reader and table-wire encoder inside the compiler, golden-locked to the generated backends. It follows from the codegen philosophy (interpreters stay in tooling) and it is the only way `pack` can exist in a Go compiler, but it is a second implementation of §3 in the tree and every port inherits the goldens obligation.
5. **`duplicate` on `TableReport`** — a new column on the wire's own cross-language report struct, for an event the wire never raises. Nine backends will each carry it; cheaper nodded now than ported nine times and changed.
6. **The text form's writer refusals** (`-1` for an unnameable enum value, an unnamed flags bit, an invalid union tag, a non-finite float).
7. **The lone-surrogate / non-UTF-8 decision.** The review named two options: refuse on read, or drop "UTF-8" from the row and call the form byte-transparent. The page takes a third that keeps both halves — storage stays byte-transparent, and the WRITER substitutes `U+FFFD` for any ill-formed sequence so the emitted text is always valid JSON. Mine, not ruled.
8. **The baseline's new refusal classes** — the positional↔keyed spelling change (from D1), and the flags rename-in-place refusal (from #263's text, not the owner's words directly; it follows the same reasoning as the reorder refusal).
9. **§18's `--reason` flag spelling** is #263's; the ruling was that the update is never bare.
10. **Should adding or removing a GUARD be a baseline finding?** (N3.) It is the one edit that reads clean and loses data on write-back, which is precisely the save-game cycle §18 exists for — but it is a legitimate everyday edit, so a REFUSE would be heavy-handed and a WARN is the proportionate shape. Either way it is a new `DefaultTokenPolicy` row that #263 does not implement, so the page names the hazard (§4, §4.1) and stops there. If you want it, #263 gains the row and the obligation below becomes real.
11. **The text-form walk costs +10.9% header compile time**, unconditional, fixed class included. Measured by the #267 review, interleaved, median of 9, arm64 clang, empty TU including `TablesTable.h`: main 0.0466s → branch 0.0517s. The zero-cost gate is **not** weakened (grep list byte-unchanged and green). But this repo rules header cost on measured evidence — the union-vs-variant precedent, *"0.17 -> 0.27 is not trivial for me"* — so the number is banked here rather than buried. The page states that the walk rides in every table header with no opt-out; whether it should stay unconditional is yours.

## Rebase obligations recorded (not this PR's)

- **#263**: render the `key` token (§18.2's keyed refusal and D1's baseline half both need it) and a presence token; renumber its §16 → §18 in `internal/baseline/diff.go` and `cmd/schema/main.go`. **Also: its own §16 REFUSE list row still reads "swapped for one whose identities do not ride" while the prose below it already states the STAND IN rule** — the list and the prose contradict each other on the branch, and "identities ride" is exactly the weaker test the delta review replaced. One-line repair, and it is the row a reader checks first. *(Conditional, on open item 10: a guard-change policy row.)*
- **#267**: its §16 **replaces** this one wholesale rather than merging; §16.4/§16.5/§16.6 renumber (this page folds "what reflection gains" into §8).
- **#266**: "the 23 name-first suffixes" → 26; the `TableReset` decision is unchanged.
- **#265**: the `[E]T` slot-0 ruling and kind `16` land there.

CI: green (docs-only; nothing in the build reads these files). Head is `817a775`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


