### PR TITLE
SPEC-TABLES: index the keyed array's refusals in §11, and say how a walker sees slot 0

### DIFF
--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1226,8 +1226,14 @@ union's arms. It carries no per-variant wire id, because a mask's variants
 ride by position and have none (§4); a null id function beside a non-null
 name function is what identifies a flags field.
 
-**An enum-keyed array's slot 0 is marked invalid** (§2.4), so a walker
-enumerating slots skips it rather than printing a `None` row.
+**An enum-keyed array's slot 0 is marked invalid** (§2.4), and the
+descriptor says so in the column a walker is already reading:
+**`key_id( 0 )` is `0`**, the reserved id no declared name can fold to
+(§5), with `key_name( 0 )` reading `"None"` beside it. So a walker
+enumerating `[0, array_bound)` skips the slot whose key id is 0 rather than
+printing a `None` row, and it needs no rule about slot indices to do it —
+the same reserved id that keeps `None` off the wire keeps it out of a
+listing.
 
 **A `*bytes` or `*string` field** carries its used-length companion's
 offset beside the reference, so a walker reads the blob's extent the way
@@ -1323,8 +1329,13 @@ lockstep redeploy by a table edit. This independence is held by test.
 - **Enum-keyed arrays** (§2.4): a bound naming a `flags` declaration (a mask
   names no single slot); a bounded keyed array, `[..E]` or `[A..E]` (a keyed
   array is complete by construction); an element that is a pointer, as for
-  any array (§15). A slot value no variant names is a SAVE failure, not a
-  silent `None` (§3.2).
+  any array (§15); an index of `E::None`, which names no slot — refused at
+  compile time through the constant accessor (`Slot<Key>()`) and asserted
+  through `operator[]( E )`; and, on the KEY ENUM itself because a key is a
+  reaching edge into the table closure, `| max = K` headroom and variant id
+  collisions, each diagnostic naming the keying field that pulled the enum
+  in. A slot value no variant names is a SAVE failure, not a silent `None`
+  (§3.2).
 - **Byte buffers** (§2.5): `*bytes` or `*string` outside a table body; a
   specified default on one; an array of them (§15); `?` on one, because a
   null reference already IS absence.


### PR DESCRIPTION
Spec only, one file, two sentences. Follow-on to #269 (landed at 9b13893), from what #265's rebase showed the implementation relies on.

## 1. §11's enum-keyed row indexes three of the six refusals §2.4 states

§11 is the index a porter reads for the refusal set, so a refusal that lives only in §2.4's prose is one that half the ports will not have. The three missing ones are exactly the ones most likely to be skipped, because they are not about the array:

- **an index of `E::None`** — compile-time through the constant accessor (`Slot<Key>()`), asserted through `operator[]( E )`;
- **`| max = K` headroom on the KEY ENUM**, and
- **variant id collisions on the key enum** — both because a key is a reaching edge into the table closure, and both with the diagnostic naming the keying field that pulled the enum in.

## 2. §8 says WHICH COLUMN marks slot 0 invalid

It said slot 0 is "marked invalid" and left a walker author to invent a rule about slot indices. The fact is already in the vocabulary the descriptor carries, verified against the shipped emitter:

- `TableEnumId( E::None, id )` sets `id = 0` and returns true → **`key_id( 0 ) == 0`**, the reserved id no declared name can fold to (§5);
- `EnumName( E::None )` returns `"None"` → **`key_name( 0 ) == "None"`** beside it.

So a walker enumerating `[0, array_bound)` skips the slot whose key id is 0, and needs no index rule to do it — the same reserved id that keeps `None` off the wire keeps it out of a listing.

Present-state throughout; no construct changes, no wire byte moves, nothing renumbered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
