### PR TITLE
test: capture spare_present before Lock() — a use-after-free the sanitizer found

### DIFF
--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -2602,8 +2602,13 @@ static void test_keyed_variable_oracle()
         name[name_len] = 0;
         set_string( root->name, root->name_length, name );
 
-        root->spare_present = ( oracle_rand( state ) & 1 ) != 0;
-        if ( root->spare_present ) root->spare.build = (int32_t) ( oracle_rand( state ) % 1001 );
+        // CAPTURED BEFORE Lock(), exactly as name, depths[] and chains[] are:
+        // Lock() compacts the arena into the region and releases the mutable
+        // life, so `root` dangles from that point on (SPEC-TABLES.md §6.2).
+        // Every value an assertion below compares against has to outlive it.
+        const bool spare_present = ( oracle_rand( state ) & 1 ) != 0;
+        root->spare_present = spare_present;
+        if ( spare_present ) root->spare.build = (int32_t) ( oracle_rand( state ) % 1001 );
 
         int32_t depths[8] = {};
         int32_t chains[8] = {};
@@ -2639,7 +2644,7 @@ static void test_keyed_variable_oracle()
         CHECK( loaded != NULL );
         CHECK( !report.malformed && report.unknown == 0 && report.kind_mismatch == 0 && report.clamped == 0 );
         CHECK( strcmp( loaded->name, name ) == 0 );
-        CHECK( loaded->spare_present == root->spare_present );
+        CHECK( loaded->spare_present == spare_present );
         for ( int32_t slot = 1; slot < 3; slot++ )
         {
             CHECK( loaded->banks.slots[slot].depth == depths[slot] );


### PR DESCRIPTION
`test_keyed_variable_oracle` took `root = builder.GetRoot()` before `Lock()` and then compared `loaded->spare_present == root->spare_present` after it. `Lock()` compacts the arena into the region and releases the mutable life (SPEC-TABLES.md §6.2), so `root` dangles from that point on and the compare reads freed memory.

Found by the #267 worker's sanitizer run, reproduced here on `main`:

```
==15163==ERROR: AddressSanitizer: heap-use-after-free on address 0x00010b2d4848
READ of size 1 at 0x00010b2d4848 thread T0
    #0 test_keyed_variable_oracle() main.cpp:2642
    #1 main main.cpp:2750

0x00010b2d4848 is located 72 bytes inside of 4194304-byte region
freed by thread T0 here:
    #0 free
    #1 graphdemo::TableArenaShutdown(graphdemo::TableArena&) MarksTable.h:322
    #2 graphdemo::DepotBuilder::Lock() GraphTable.h:4733
    #3 test_keyed_variable_oracle() main.cpp:2628
```

**The defect is the test's alone.** The generated code is correct and the arena lifetime is exactly what §6.2 documents: `Lock()` is one-way and it IS the compaction. The test already captured every other value its assertions compare against — `name`, `depths[]`, `chains[]` — before locking; `spare_present` was the one that was not. It is now captured the same way, and nothing reads `root` after `Lock()`.

The pinned twin, `test_keyed_and_optional_in_a_variable_table`, was checked and is clean: it never touches `root` after `Lock()`.

## Verification

Same sanitizer build, before and after this commit:

```
before: ERROR: AddressSanitizer: heap-use-after-free ... main.cpp:2642
after : tables test passed        (exit 0, ASan + UBSan, 30000 oracle shapes)
```

Ordinary build green too, plus `make tables-zero-cost` and `go test ./...`.

## Why CI did not catch it

**CI does not build the tables leg — or any C++ leg — under sanitizers.** `make test` compiles `build/schema_test_tables` with `-Wall -Wextra -Werror` and no `-fsanitize`, so a dangling read that happens to return the right byte passes silently, which is exactly what it did: the assertion compared equal 30000 times out of 30000. Filed as #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
