### PR TITLE
ci: build and run the tables leg under ASan+UBSan (#277)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,14 +313,38 @@ tables-cs-refuses-pointers: bin/schema
 
 # Deliberately compiled WITHOUT -I$(SERIALIZE): the generated Table headers
 # carry no serialize dependency, and this build proves it stays that way.
+#
+# TABLES_INCLUDES is shared with the sanitized twin below, so the two builds
+# can never drift into covering different code.
+TABLES_INCLUDES := -Ibuild/tables-generated/examples -Ibuild/tables-generated/pointers -Itest/tables \
+	-Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
+	-Ibuild/tables-generated/p1 -Ibuild/tables-generated/p2 -Ibuild/tables-generated/p3 \
+	-Ibuild/tables-generated/jsonkeys
+TABLES_CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -pthread
+
 build/schema_test_tables: build/tables-generated/.stamp test/tables/main.cpp
 	@mkdir -p build
-	$(CXX) -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -pthread \
-		-Ibuild/tables-generated/examples -Ibuild/tables-generated/pointers -Itest/tables \
-		-Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
-		-Ibuild/tables-generated/p1 -Ibuild/tables-generated/p2 -Ibuild/tables-generated/p3 \
-		-Ibuild/tables-generated/jsonkeys \
-		test/tables/main.cpp -o $@
+	$(CXX) $(TABLES_CXXFLAGS) $(TABLES_INCLUDES) test/tables/main.cpp -o $@
+
+# The SANITIZED twin (issue #277). The tables leg is where the pointer
+# machinery lives — an arena whose Lock() frees it one way, a packed region
+# read through self-relative deltas, a cooked file Open validates by walking
+# an offset graph, a builder that goes wide across threads — and those are
+# lifetime and bounds questions -Werror cannot see. A heap-use-after-free
+# lived here with CI green over it, because the assertion it corrupted
+# happened to compare equal every time (#276).
+#
+# -fno-sanitize-recover=all is what makes it a GATE: UBSan's default is to
+# print and continue, which exits 0 and proves nothing.
+#
+# Both builds run, and that is not duplication: ASan replaces the allocator,
+# so the two see different addresses and alignments — and this suite refuses
+# unaligned bases and misaligned region references by design. Each build
+# reaches states the other does not.
+build/schema_test_tables_asan: build/tables-generated/.stamp test/tables/main.cpp
+	@mkdir -p build
+	$(CXX) $(TABLES_CXXFLAGS) -fsanitize=address,undefined -fno-sanitize-recover=all \
+		-fno-omit-frame-pointer -g $(TABLES_INCLUDES) test/tables/main.cpp -o $@
 
 build/schema_test_random: generated/cpp/.stamp test/random_main.cpp
 	@mkdir -p build
@@ -470,10 +494,11 @@ build/schema_test_c_ludicrous: generated/c-ludicrous/.stamp test/c-ludicrous/mai
 		-O2 -ffp-contract=off -Igenerated/c-ludicrous -I$(SERIALIZE_C) \
 		test/c-ludicrous/main.c $(SERIALIZE_C)/serialize.c -o $@ -lm
 
-test: build/schema_test build/schema_test_guard build/schema_test_tables build/tables-generated-cs/.stamp build/schema_test_random build/schema_test_ludicrous build/schema_test_c build/schema_test_c_ludicrous build/schema_test_bench build/schema_test_bench_c generated/go/.stamp generated/rust/.stamp generated/cs/.stamp generated/js/.stamp generated/dart/.stamp generated/java/.stamp generated/elixir/.stamp generated/go-ludicrous/.stamp generated/rust-ludicrous/.stamp generated/cs-ludicrous/.stamp generated/js-ludicrous/.stamp generated/dart-ludicrous/.stamp generated/java-ludicrous/.stamp generated/elixir-ludicrous/.stamp generated/bench/go/.stamp generated/bench/rust/.stamp generated/bench/cs/.stamp generated/bench/js/.stamp generated/bench/dart/.stamp generated/bench/java/.stamp generated/bench/elixir/.stamp build/java-test/.stamp build/java-test-ludicrous/.stamp build/java-bench/.stamp
+test: build/schema_test build/schema_test_guard build/schema_test_tables build/schema_test_tables_asan build/tables-generated-cs/.stamp build/schema_test_random build/schema_test_ludicrous build/schema_test_c build/schema_test_c_ludicrous build/schema_test_bench build/schema_test_bench_c generated/go/.stamp generated/rust/.stamp generated/cs/.stamp generated/js/.stamp generated/dart/.stamp generated/java/.stamp generated/elixir/.stamp generated/go-ludicrous/.stamp generated/rust-ludicrous/.stamp generated/cs-ludicrous/.stamp generated/js-ludicrous/.stamp generated/dart-ludicrous/.stamp generated/java-ludicrous/.stamp generated/elixir-ludicrous/.stamp generated/bench/go/.stamp generated/bench/rust/.stamp generated/bench/cs/.stamp generated/bench/js/.stamp generated/bench/dart/.stamp generated/bench/java/.stamp generated/bench/elixir/.stamp build/java-test/.stamp build/java-test-ludicrous/.stamp build/java-bench/.stamp
 	./build/schema_test
 	./build/schema_test_guard
 	./build/schema_test_tables
+	./build/schema_test_tables_asan
 	$(MAKE) tables-zero-cost
 	$(MAKE) tables-json-walk
 	$(MAKE) tables-json-negative-control

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -837,6 +837,8 @@ static void test_wide_extents()
     CHECK( out2.samples_count == 2 );                            // the bounded prefix, nothing fabricated
     CHECK( out2.samples[0] == 11 && out2.samples[1] == 22 );
     CHECK( out2.label_length == 2 && strcmp( out2.label, "ok" ) == 0 ); // the parent read on
+
+    free( buffer );
 }
 
 // ---- clamping: hostile or stale numerics clamp and count ----


### PR DESCRIPTION
Closes #277.

`make test` now builds `build/schema_test_tables_asan` beside the plain tables binary and runs both. CI needs no YAML change: the ubuntu job already runs `make test`.

```make
TABLES_INCLUDES := -Ibuild/tables-generated/examples ... -Ibuild/tables-generated/p3
TABLES_CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -pthread

build/schema_test_tables:      $(CXX) $(TABLES_CXXFLAGS) $(TABLES_INCLUDES) ...
build/schema_test_tables_asan: $(CXX) $(TABLES_CXXFLAGS) -fsanitize=address,undefined \
                                 -fno-sanitize-recover=all -fno-omit-frame-pointer -g $(TABLES_INCLUDES) ...
```

The includes and base flags are now shared between the two rules, so they cannot drift into covering different code.

**`-fno-sanitize-recover=all` is what makes it a gate rather than a log.** UBSan's default is to print a diagnostic and continue, which exits 0 — a finding nobody would see. With it, the first violation aborts and `make test` fails.

## Nothing on main is red under ASan or UBSan

Both sanitizers, `-fno-sanitize-recover=all`, whole tables suite including the 30000-shape oracle:

```
./build/schema_test_tables
tables test passed
./build/schema_test_tables_asan
tables test passed
```

Full `make test` green end to end. So this lands as a standing gate, not a repair — and #271 (cooked-region trap representations) is **not** reached by any existing test: it needs a forged cooked file, which the suite does not currently build. That issue stays open on its own merits.

## The gate found a second defect before it landed

CI's ubuntu leg went red on the first run — **LeakSanitizer**, which rides with ASan on Linux and is not supported on arm64 macOS, so my local run was clean and CI was not. The leak was real on both:

```
==5260==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 280033 byte(s) in 1 object(s) allocated from:
    #1 test_wide_extents test/tables/main.cpp:781
SUMMARY: AddressSanitizer: 280033 byte(s) leaked in 1 allocation(s).
```

`test_wide_extents` mallocs a 280KB buffer and returns without freeing it. Every other allocation in the file was already paired — 31 mallocs to 30 frees, and LSan named the one. Fixed in the second commit; the counts are 31/31 now.

That is two defects this gate has found in the file it polices, before it was even merged. Neither was reachable by `-Werror` or by a passing assertion.

## Negative control

Reverted #276's fix in a throwaway worktree and ran the CI-equivalent `make test`. The contrast is the whole argument for the issue:

```
./build/schema_test_tables
tables test passed                         <- the plain leg, GREEN on the defect
./build/schema_test_tables_asan
=================================================================
==20929==ERROR: AddressSanitizer: heap-use-after-free on address 0x0001099c4848
READ of size 1 at 0x0001099c4848 thread T0
    #0 test_keyed_variable_oracle() main.cpp:2642
    #1 main main.cpp:2750
freed by thread T0 here:
    #1 graphdemo::TableArenaShutdown(graphdemo::TableArena&) MarksTable.h:322
    #2 graphdemo::DepotBuilder::Lock() GraphTable.h:4733
    #3 test_keyed_variable_oracle() main.cpp:2628
SUMMARY: AddressSanitizer: heap-use-after-free main.cpp:2642 in test_keyed_variable_oracle()
==20929==ABORTING
make: *** [test] Abort trap: 6
EXIT=2
```

The plain leg passes on the very defect the sanitized leg aborts on.

## Both builds, and the cost

**Kept both.** Measured on an arm64 Mac, median of 3:

| | compile | run |
|---|---|---|
| plain | 0.66s | 1.40s |
| sanitized | 1.74s | 2.59s |

**+4.3s wall** against a job measured at 31–45s — about a tenth of it, comfortably inside the two-minute law, so dropping the plain build buys nothing worth its coverage.

And the two are not redundant: **ASan replaces the allocator**, so the builds see different addresses and alignments — and this suite refuses unaligned bases and misaligned region references *by design* (`SceneOpen( broken + 1, ... )`, the misaligned-reference refusals in `test_cooked_form`). Each build reaches states the other does not. If CI time ever gets tight, the plain build is the one to drop, not the sanitized one.

## Why the tables leg first

It is where the pointer machinery lives: an arena whose `Lock()` frees it one way, a packed region read through self-relative deltas, a cooked file `Open` validates by walking an offset graph, and a builder that goes wide across threads. Every one of those is a lifetime or bounds question `-Werror` cannot see. The C, C++ and ludicrous legs deserve the same treatment; this one had a proven finding behind it.

Windows is unaffected — that job runs `go vet` and `go build` only, no C++.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
