### PR TITLE
tables: regenerate the corpus baseline for table Patrol — main is red

### DIFF
--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -38,6 +38,14 @@ table LoadoutConfig
     field backups id=0x1647 kind=14 elem=13 type=WeaponConfig array=fixed bound=2
     field attachments id=0x44d5 kind=14 elem=13 type=Attachment array=bounded bound=8
 
+table Patrol
+    field active id=0x405a kind=1
+    field speed id=0xbc00 kind=10 default=1.0
+    field has_target id=0xb0a7 kind=1
+    field target_id id=0xdf6a kind=4 default=0
+    field wander id=0x832f kind=10 default=0.5
+    field note id=0x9da7 kind=12 size=8
+
 table ProfileConfig
     field name id=0x30df kind=12 size=32
     field icon id=0xf3b0 kind=14 elem=6 size=16
@@ -115,3 +123,6 @@ union Effect
 ## history
 ### 2026-09-02 — the first baseline over the tables corpus
 - baseline created over 15 tables — data written BEFORE this point is not covered by it
+
+### 2026-09-02 — table Patrol joined the corpus with the text form's guard coverage (#267); the baseline was written before it (#263) and the two landed in sequence
+- no compatibility-affecting edits; the wire absorbs the rest


### PR DESCRIPTION
**Main is red, and has been since 0762afb.** Not a defect in either PR that caused it — a merge-order collision, with the baseline's own gate catching it one commit late.

## What happened

- **#263** (526239c) committed `tables/examples/tables.baseline`.
- **#267** (0762afb) then added `table Patrol` to the same corpus, for the nested-guard coverage its adversarial review asked for (F12).

Each was green on its own base and neither could see the other's change, so `TestCorpusBaselinesAreCurrent` fails on main:

```
corpus_test.go:46: ../../tables/examples/tables.baseline is stale — regenerate it deliberately
```

The whole diff is one absent `table Patrol` block.

## Why this is safe to just regenerate

`schema check tables/examples` **reports no finding** (exit 0). A new closure member is in the PASS class, so there is no compatibility decision here and nothing is being papered over — only the committed artifact was out of date. The regenerated diff is purely additive: the `Patrol` block, plus a history entry reading *"no compatibility-affecting edits; the wire absorbs the rest."*

Done through the documented remedy (`tables-baseline --update --reason "…"`) rather than by hand, so the file records why it moved — which is the point of the file.

`go test ./...` green locally.

## Worth a look separately

Two PRs can each be green and land a red main this way. A rebase-and-verify on the second merge would have caught it; so would a `make test` on main after each merge, which the CI split already runs — it just runs *after* the merge rather than gating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
