### PR TITLE
Tables JSON: a keyed object's repeated key is counted, not just last-wins (#253)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,22 @@ tables-cs-refuses-pointers: bin/schema
 	@grep -q "variable class is a named follow-on" build/tables-cs-refusal.log || \
 		{ echo "REFUSAL GATE FAILED: the refusal does not name the follow-on"; cat build/tables-cs-refusal.log; exit 1; }
 	@echo "tables C# refusal gate: a pointered unit is refused by name"
+# The NEGATIVE CONTROL for a KEYED object's duplicate counting
+# (SPEC-TABLES.md §16.2). Last-wins inside a keyed object was already true, so
+# the missing count was invisible to every round-trip test — the value was
+# right and only the ledger was wrong. This sabotage removes the increment and
+# the fixture must go red; without it, nothing in the suite could see the
+# defect the pack engine's two-sided gate found.
+.PHONY: tables-json-keyed-dup-negative-control
+tables-json-keyed-dup-negative-control: bin/schema test/tables/json_keyed_dup_negative_main.cpp
+	@rm -rf build/json-dup-sabotage && mkdir -p build/json-dup-sabotage
+	./bin/schema generate --lang cpp --out build/json-dup-sabotage tables/examples
+	@sed -i.bak 's|if ( ( seen\[slot >> 6\] \& bit ) != 0 ) { in.report->duplicate++; }|if ( ( seen[slot >> 6] \& bit ) != 0 ) { /* sabotaged: no count */ }|' build/json-dup-sabotage/KeyedTable.h
+	@grep -q 'sabotaged: no count' build/json-dup-sabotage/KeyedTable.h || { echo "NEGATIVE CONTROL: the sabotage did not apply"; exit 1; }
+	@mkdir -p build
+	$(CXX) -std=c++17 -Wall -Wextra -Werror -ffp-contract=off \
+		-Ibuild/json-dup-sabotage test/tables/json_keyed_dup_negative_main.cpp -o build/schema_test_json_keyed_dup_negative
+	./build/schema_test_json_keyed_dup_negative
 
 # Deliberately compiled WITHOUT -I$(SERIALIZE): the generated Table headers
 # carry no serialize dependency, and this build proves it stays that way.
@@ -480,6 +496,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/t
 	$(MAKE) tables-cs-standalone
 	$(MAKE) tables-cs-refuses-pointers
 	cd test/cs-tables && dotnet run
+	$(MAKE) tables-json-keyed-dup-negative-control
 	./build/schema_test_random
 	./build/schema_test_ludicrous
 	cd test/c && ../../build/schema_test_c

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1748,7 +1748,7 @@ Per kind:
 | flags | array of variant names | `["Shielded", "Turbo"]`; an empty mask writes as `[]`; an unknown name is skipped, counted |
 | `[N]T` fixed array | array | fewer elements pad with defaults; more are dropped, counted |
 | `[..N]T` bounded array | array | count = length; more than N are dropped, counted |
-| `[E]T` enum-keyed array | object keyed by VARIANT NAME | `{ "Fighter": {...}, "Bomber": {...} }`; an absent key keeps that slot's defaults; an unknown key is skipped and counted, and **`"None"` is such a key** — it names no slot (§2.4) |
+| `[E]T` enum-keyed array | object keyed by VARIANT NAME | `{ "Fighter": {...}, "Bomber": {...} }`; an absent key keeps that slot's defaults; a **repeated variant key is last-wins and counted**, as any duplicate key is; an unknown key is skipped and counted, and **`"None"` is such a key** — it names no slot (§2.4) |
 | nested `type` / `table` | object | the same walk, recursively |
 | `?T` optional | the value, or the key absent | **presence of the KEY is presence**: a key present sets the field present, whatever its value; an absent key leaves it absent. `ToJson` writes present optionals only |
 | union | object with ONE key, the arm name | `{ "buff": { "multiplier": 2.0 } }`; `None` writes as `{}`; `{}` or absent reads as None; two keys is malformed. A `table` arm (§2.6) is the same object form |

--- a/internal/codegen/cpptable/json.go
+++ b/internal/codegen/cpptable/json.go
@@ -1402,6 +1402,12 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
             else { memset( slot, 0, (size_t) f->elem_size ); }
         }
         char shape = TableJsonElementShape( f );
+        // A KEYED OBJECT'S KEYS ARE KEYS: a variant named twice is a duplicate
+        // key like any other, last-wins and counted (§16.2). Tracked the way
+        // a table's own field keys are — a bounded, allocation-free bitmask;
+        // a vocabulary wider than this still reads, its repeats simply stop
+        // being counted.
+        uint64_t seen[8] = {};
         for ( ;; )
         {
             char c = TableJsonPeek( in );
@@ -1420,6 +1426,12 @@ inline bool TableJsonReadField( TableJsonIn & in, void * base, const TableFieldI
                 // unknown key like any other name this reader cannot place
                 if ( !TableJsonKeyedSlotValid( f, v ) ) { continue; }
                 if ( strcmp( f->key_name( (uint64_t) v ), key ) == 0 ) { slot = v; break; }
+            }
+            if ( slot >= 0 && slot < 512 )
+            {
+                uint64_t bit = uint64_t( 1 ) << ( slot & 63 );
+                if ( ( seen[slot >> 6] & bit ) != 0 ) { in.report->duplicate++; }
+                seen[slot >> 6] |= bit;
             }
             if ( slot < 0 )
             {

--- a/test/tables/json_keyed_dup_negative_main.cpp
+++ b/test/tables/json_keyed_dup_negative_main.cpp
@@ -1,0 +1,48 @@
+// The NEGATIVE CONTROL for a keyed object's duplicate counting
+// (SPEC-TABLES.md §16.2).
+//
+// A keyed object's keys ARE keys, so a variant named twice is last-wins AND
+// counted. Last-wins was already true — the slot is re-established before
+// each placement — which is exactly why the missing count was invisible to
+// every round-trip test: the VALUE was right and only the ledger was wrong.
+// A test that can only see values could never have caught it.
+//
+// This binary is built against a walker whose duplicate increment has been
+// deliberately removed, and it PASSES only when the count comes back wrong.
+
+#include <cstdio>
+#include <cstring>
+
+#include "KeyedTable.h"
+
+int main()
+{
+    tabledemo::KeyedConfig value;
+    tabledemo::TableReport report;
+    const char * text = "{ \"teams\": { \"Red\": { \"spawn_count\": 5 }, \"Red\": { \"spawn_count\": 9 } } }";
+    if ( !tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) )
+    {
+        printf( "keyed duplicate negative control: the sabotaged walker would not read at all — red\n" );
+        return 0;
+    }
+
+    // last-wins must STILL hold: the sabotage removes the ledger entry, not
+    // the re-establishment, and a control that passed for the wrong reason
+    // would prove nothing
+    if ( value.teams[tabledemo::Team::Red].spawn_count != 9 )
+    {
+        printf( "keyed duplicate negative control: last-wins broke as well — red, but for the wrong reason\n" );
+        return 0;
+    }
+
+    if ( report.duplicate == 0 )
+    {
+        printf( "keyed duplicate negative control: the repeat went uncounted — red, as required\n" );
+        return 0;
+    }
+
+    printf( "FAIL keyed duplicate negative control: a walker with its duplicate increment\n"
+            "      removed still reported duplicate=%d. The suite cannot see an uncounted\n"
+            "      repeat inside a keyed object.\n", report.duplicate );
+    return 1;
+}

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -4864,6 +4864,129 @@ static void test_golden_seams()
     }
 }
 
+// ---- a keyed object's keys ARE keys (SPEC-TABLES.md §16.2) ---------------
+//
+// Last-wins inside a keyed object was always true — each placement
+// re-establishes the slot — so the VALUE was right and only the ledger was
+// wrong, which is precisely why no round-trip test could see the repeat go
+// uncounted. It took the pack engine's two-sided gate to find it.
+
+static void test_json_keyed_duplicate_keys()
+{
+    // one variant named twice: last wins, and the repeat is COUNTED
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Red\": { \"spawn_count\": 5 }, \"Red\": { \"spawn_count\": 9 } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.teams[tabledemo::Team::Red].spawn_count == 9 );
+        CHECK( report.duplicate == 1 );
+        CHECK( report.unknown == 0 && report.kind_mismatch == 0 && !report.malformed );
+    }
+
+    // every repeat past the first counts, across variants
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Red\": {}, \"Red\": {}, \"Red\": {}, \"Blue\": {}, \"Blue\": {} } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.duplicate == 3 ); // two extra Reds, one extra Blue
+    }
+
+    // DISTINCT variants are not duplicates — the whole point of the key
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Red\": {}, \"Blue\": {}, \"Green\": {} } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.duplicate == 0 );
+    }
+
+    // a repeated key that names NO slot is unknown twice, never a duplicate:
+    // it was never placed, so there is nothing for a second one to replace
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Violet\": {}, \"Violet\": {}, \"None\": {}, \"None\": {} } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.unknown == 4 && report.duplicate == 0 );
+    }
+
+    // last-wins is a WHOLE-VALUE replacement here too: the second occurrence
+    // does not overlay the first, it re-establishes the slot
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"teams\": { \"Red\": { \"spawn_count\": 9, \"banner\": \"first\" },"
+                            "              \"Red\": { \"spawn_count\": 2 } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.teams[tabledemo::Team::Red].spawn_count == 2 );
+        CHECK( value.teams[tabledemo::Team::Red].banner_length == 0 ); // nothing of the first survives
+        CHECK( report.duplicate == 1 );
+
+        // and the instance is the one the SECOND occurrence alone describes
+        tabledemo::KeyedConfig once;
+        const char * single = "{ \"teams\": { \"Red\": { \"spawn_count\": 2 } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( once, single, (int64_t) strlen( single ), &report ) );
+        uint8_t a[4096], b[4096];
+        int64_t na = tabledemo::KeyedConfigSave( value, a, sizeof( a ) );
+        int64_t nb = tabledemo::KeyedConfigSave( once, b, sizeof( b ) );
+        CHECK( na > 0 && na == nb && memcmp( a, b, (size_t) na ) == 0 );
+    }
+
+    // a keyed array of SCALARS counts the same way
+    {
+        tabledemo::ScoreBoard value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"per_team\": { \"Blue\": 1, \"Blue\": 2, \"Blue\": 3 } }";
+        CHECK( tabledemo::ScoreBoardFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.per_team[(int) tabledemo::Team::Blue] == 3 );
+        CHECK( report.duplicate == 2 );
+    }
+
+    // a repeat NESTED one keyed object down still counts
+    {
+        tabledemo::KeyedConfig value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"hulls\": { \"Gunship\": { \"turrets\": {"
+                            "   \"Missile\": { \"damage\": 1 }, \"Missile\": { \"damage\": 2 } } } } }";
+        CHECK( tabledemo::KeyedConfigFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( value.hulls[tabledemo::Hull::Gunship].turrets[tabledemo::Weapon::Missile].damage == 2.0f );
+        CHECK( report.duplicate == 1 );
+    }
+
+    // the PINNED TEXT: a repeated key is a READ-side event only, so what the
+    // writer emits for the instance it lands on carries each variant exactly
+    // once — the repeat leaves no trace in the text, only in the ledger
+    {
+        tabledemo::ScoreBoard value;
+        tabledemo::TableReport report;
+        const char * text = "{ \"per_team\": { \"Red\": 4, \"Green\": 7, \"Green\": 9 } }";
+        CHECK( tabledemo::ScoreBoardFromJson( value, text, (int64_t) strlen( text ), &report ) );
+        CHECK( report.duplicate == 1 );
+
+        static const char * expected =
+            "{\n"
+            "  \"per_team\": {\n"
+            "    \"Red\": 4,\n"
+            "    \"Blue\": 0,\n"
+            "    \"Green\": 9\n"
+            "  }\n"
+            "}";
+        int64_t size = tabledemo::ScoreBoardToJsonMeasure( value );
+        if ( size < 0 ) { printf( "FAIL json keyed duplicate pinned text: refused\n" ); failures++; return; }
+        std::vector<char> out( (size_t) size + 1 );
+        CHECK( tabledemo::ScoreBoardToJson( value, out.data(), size ) == size );
+        out[(size_t) size] = 0;
+        if ( strcmp( out.data(), expected ) != 0 )
+        {
+            printf( "FAIL json keyed duplicate pinned text\n--- got ---\n%s\n--- want ---\n%s\n",
+                    out.data(), expected );
+            failures++;
+        }
+    }
+}
+
 int main()
 {
     test_golden_wire();
@@ -4944,6 +5067,7 @@ int main()
     test_json_keyed_and_optional_round_trip();
     test_json_optional_presence();
     test_json_keyed_arrays();
+    test_json_keyed_duplicate_keys();
     test_json_pinned_keyed_and_optional();
     test_json_pinned_text();
     test_json_fuzz_tokenizer();


### PR DESCRIPTION
Follow-up to #267, found by the pack engine's two-sided gate (#272).

The generated C++ walk placed a repeated variant key inside an **enum-keyed
object** last-wins but never counted it, while §16.2 says duplicate keys are
last-wins **and** counted. A keyed object's keys are keys.

```
{ "teams": { "Red": { "spawn_count": 5 }, "Red": { "spawn_count": 9 } } }
   before:  spawn_count = 9   duplicate = 0     <- last-wins right, ledger wrong
   after:   spawn_count = 9   duplicate = 1
```

## Why the existing battery could not see it

Last-wins was already true — each placement re-establishes the slot before
writing it — so the **value** was right and only the **ledger** was wrong. Every
test in the §16 battery reads a value back, and a round trip cannot see a
miscount. It is the same blind spot the pinned text was added to close on the
vocabulary side, one column over.

## What changed

- The walk counts `duplicate` for a repeated variant key, tracked exactly as a
  table's own field keys are: a bounded, allocation-free bitmask. A vocabulary
  wider than the mask still reads; its repeats simply stop being counted, which
  is the same bound and the same wording the field path already carries.
- A **repeated key that names no slot** — `"Violet"`, or `"None"` — stays
  `unknown` twice and is never a duplicate. It was never placed, so there is
  nothing for a second one to replace.

## Held by test

One variant twice; every repeat past the first across variants; distinct
variants counting nothing; a repeated unknown key; a nested keyed object one
level down; a keyed array of scalars; whole-value replacement byte-matching the
wire of the second occurrence alone; and a **pinned text** showing the repeat
leaves no trace in what the writer emits — only in the ledger.

**Negative control** (`make tables-json-keyed-dup-negative-control`, wired into
`make test`): with the increment removed the fixture goes red, and it asserts
last-wins **still** holds so the control cannot pass for the wrong reason. Built
against the honest walker it fails, checked by hand. Whole suite clean under
`-fsanitize=address,undefined -fno-sanitize-recover=all`; the one-walk gate is
still byte-identical across all 14 headers.

## Page

**SPEC-TABLES.md §16.2's `[E]T` row gains one clause** — *"a repeated variant key
is last-wins and counted, as any duplicate key is"*. It states what the section
already implies for every other kind of key rather than adding a rule, which is
why it rides with the fix instead of waiting for a page round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
