### PR TITLE
SPEC: four honesty notes — nine languages; status on §2.6 and §3.1; §12's corpus wording (#296)

### DIFF
--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -542,6 +542,15 @@ carry a nested table, a collection, or anything else a table body holds —
 which is what a message set of documents needs and what a `type`-only
 payload could never express.
 
+**Backend status for this section: no backend, and no declaration reaches
+it.** A union arm naming a `table` is refused by the checker, before any
+emitter sees it — `<Name> is a table, not a union payload` — so a unit
+declaring the form above does not compile today and no generated code
+carries an arm that is a table. The construct is stated here rather than
+withheld because the framing it lands under is already the framing a `type`
+arm rides (below), so what lands is the checker's refusal lifting, not a
+second decision about the wire; it is tracked as schema#258.
+
 - **A union declared for the TYPE wire keeps refusing table arms.** Types
   are value semantics and their wire is positional; a table arm is a
   table-closure construct and is refused by name outside one.
@@ -772,6 +781,21 @@ length is not a depth; two references to one node are one node; and an
 array of pointers is an array of indices. It moves not one byte of a
 value-only table: a fixed-size table has no pointer, therefore no node
 table, therefore exactly the bytes §3 already describes.
+
+**Backend status for this section: spec ahead of the emitter.** This
+section is the landed law; no backend writes it yet. What a reader of
+today's generated code finds instead is the earlier NESTED form: the C++
+table backend — the only one that accepts a pointered unit, since C# refuses
+one by name (§11) — writes a pointer field's pointee inline as a nested
+table body under kind `13`, not as a `u32` index under kind `17`. Kind `17`
+is not in the kind vocabulary any backend emits, and no node table rides.
+Three consequences follow, and they are the reasons the flat form is the
+law: a node two parents name is written once per parent and reads back as
+that many nodes, so identity does not survive a save; a pointer chain IS a
+nesting depth; and that depth is therefore bounded, by a generated
+`kTableMaxDepth` of 128, with a graph past the cap — or a data cycle —
+refused by measure and save rather than written. Moving the emitter to the
+flat node table is tracked as schema#251.
 
 **Kind `17` costs nothing and closes an edit that would otherwise be
 silent.** A node index is four bytes and so is a `uint32`, so under a
@@ -2135,8 +2159,17 @@ The feature's acceptance test is a DOGFOOD, not a thought experiment: a
 real game's binary config and asset archive formats — a root table of
 nested collections of typed records, built by tools, loaded by the game —
 must be expressible as declared tables with nothing left over, and without
-schema prescribing any of their structure. The corpus carries a
-config-format example holding that gate.
+schema prescribing any of their structure.
+
+**Where the gate is held.** The corpus half is a config format declared and
+packed end to end: `tables/examples/Pack.schema` is the root — an
+enum-keyed collection of records, an optional section inside a record, a
+global block nested by value, a bounded array of records and a keyed array
+of scalars, fixed-size down to the leaves — and `tables/pack/config/` is the
+directory tree `schema pack` assembles into it and `unpack` writes back out
+(§17), byte-stable in both directions under `make`. That half proves the
+form; it does not prove the game. The dogfood half is **space#443**, where a
+real game takes its config on this wire.
 
 **The shape the gate is held to.** `Config.bin` and `Assets.bin` are each
 ONE root table, and each root is FIXED-SIZE down to the leaves: no pointer

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,21 +8,27 @@ document disagree, one of them is a bug (see VERSIONING.md).
 
 **schema** is a small language for describing bitpacked network data, and a
 compiler — written in Go — that translates `*.schema` files into generated C,
-C++, C#, Go, JavaScript and Rust source code targeting the serialize family of
-runtime libraries:
+C++, C#, Dart, Elixir, Go, Java, JavaScript and Rust source code. Six of the
+nine targets read and write through a serialize-family runtime library; the
+other three carry the bit reader and writer in the generated code itself and
+need nothing but their own toolchain:
 
 | target | runtime library |
 |---|---|
 | C | [serialize.c](https://github.com/mas-bandwidth/serialize.c) |
 | C++ | [serialize](https://github.com/mas-bandwidth/serialize) |
 | C# | [serialize.cs](https://github.com/mas-bandwidth/serialize.cs) |
+| Dart | none — the generated code is self-contained |
+| Elixir | none — the generated code is self-contained |
 | Go | [serialize.go](https://github.com/mas-bandwidth/serialize.go) |
+| Java | none — the generated code is self-contained |
 | JavaScript | [serialize.js](https://github.com/mas-bandwidth/serialize.js) |
 | Rust | [serialize.rs](https://github.com/mas-bandwidth/serialize.rs) |
 
 The runtimes are bit-for-bit wire compatible, pinned in CI with shared golden
-bytes. schema inherits that foundation: **a type serialized by generated code
-in any target language decodes identically in the others.**
+bytes, and the self-contained targets are held to the same goldens. schema
+inherits that foundation: **a type serialized by generated code in any
+target language decodes identically in the others.**
 
 The idea is extracted from
 [serialize.modern](https://github.com/mas-bandwidth/serialize.modern)'s


### PR DESCRIPTION
Closes #296.

Four places where the page claimed more, or less, than the tree carries. Spec-only, present-state; no source, gate or corpus change.

### SPEC.md §1 — six languages become nine

`internal/codegen` holds nine language backends — `c`, `cpp`, `csharp`, `dart`, `elixir`, `golang`, `java`, `js`, `rust` (`cpptable` and `cstable` are the table backends of two of them, not further languages) — and `make test` generates and gates every one: `generated/{go,rust,cs,js,dart,java,elixir}` stamps beside the C and C++ legs, each byte-comparing the same C++-pinned wire goldens.

The runtime table gains Dart, Java and Elixir. Their entry is `none — the generated code is self-contained`, which is the tree's own fact: CONTRIBUTING.md's clone list says `# no serialize.dart or serialize.java clone: generated Dart and Java are self-contained`, and the generated Dart imports nothing but `dart:typed_data`. The prose now splits the nine into the six that read and write through a serialize-family runtime and the three that carry the bit reader and writer in the generated code, and says the self-contained three are held to the same goldens.

### SPEC-TABLES.md §2.6 — table union arms have no backend, and no declaration

The section states the message-set form as law. `internal/check/check.go:854` refuses it before any emitter sees it:

```
%s is a table, not a union payload — a payload is a declared `type`; tables nest in tables directly
```

Adds a **Backend status** note in the shape §16.1 uses, saying that a unit declaring the form does not compile today, that the construct is stated rather than withheld because it lands under framing a `type` arm already rides, and that it is tracked as schema#258.

### SPEC-TABLES.md §3.1 — the flat node table is spec, the emitter is v1

§3.1 is the flat node table: a pointee written once into a node table, a pointer riding as a `u32` index under kind `17`. The C++ table backend still writes the earlier NESTED form — `internal/codegen/cpptable/codecs.go` emits `w.put16( id ); w.put8( 13 ); // the pointee rides as a nested body` — and `ir/tablekind.go`'s frozen vocabulary stops at `16`, so kind `17` is emitted by nobody.

The note says what a reader of today's generated code will find, and the three things that follow from it, which are also why the flat form is the law: a node two parents name is written once per parent and reads back as that many nodes, so identity does not survive a save; a pointer chain IS a nesting depth; and that depth is therefore bounded, by the generated `kTableMaxDepth` of `128` (`internal/codegen/cpptable/arena.go:54`), with a graph past the cap or a data cycle refused by measure and save rather than written. Cites schema#251. C# is named as refusing a pointered unit outright (§11), so C++ is the only backend the note is about.

### SPEC-TABLES.md §12 — the corpus sentence named nothing

"The corpus carries a config-format example holding that gate" pointed at no file, and nothing in the tree is named `Config.bin`. Replaced with a **Where the gate is held** paragraph naming both halves: the corpus half is `tables/examples/Pack.schema` packed from `tables/pack/config/` — which is exactly what the Makefile runs (`./bin/schema pack --root PackConfig --out build/tables-pack.bin tables/pack/config tables/examples`), byte-stable in both directions per §17.5 — and the dogfood half, which the corpus does not prove, is **space#443**.

### Gates

`make check` green across all eleven corpora. The `Config.bin`/`Assets.bin` naming elsewhere in §12 and §13 is untouched: those name the game's formats as a design target, which is what the rulings quote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
