### PR TITLE
SPEC: the view — one file per unit carrying every declaration, on the side, for editors and debug builds (#157, spec-first)

### DIFF
--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1988,6 +1988,29 @@ were never checked for collisions (§5's refusal is scoped to the closure, as
 one id and a text-form key for a text form that does not exist. A type
 inside a closure carries both as it always did.
 
+**The same rule governs EVERY id column the view carries, for the same
+reason.** §5's refusals are scoped to the closure throughout: the variant
+refusal reaches a vocabulary through a closure member's field, and through
+the KEY of a closure member's keyed array, so a declaration no table closure
+reaches has ids nothing ever checked. So **an enum, a flags or a union no
+table closure reaches carries `id = 0` on every variant row** — the
+registry's `ViewVariant.id` (§8.3) and a descriptor's `variant_id()`
+function (§8.1) alike — and **an enum-keyed array whose KEY enum no table
+closure reaches carries `key_id( slot )` of `0` in every slot**. `0` is the
+reserved id no declared name folds to (§5), and it already spells "no
+table-wire identity here" in the two places the columns state it: a flags
+bit's id, and slot 0 of a keyed array. A vocabulary a closure reaches
+carries its checked ids exactly as it did before.
+
+**The compiler is unchanged, and is right to be.** Inside a closure it
+refuses a collision by name; outside one it accepts the unit, because the
+packet wire identifies a variant by its ORDINAL and carries no name hash
+(§5) — an enum nothing in a table reaches keeps every spelling it ever had,
+and widening the refusal unit-wide would reject a packet-only schema over an
+identity its wire does not have. The consequence is the rule above, stated
+so a tool never has to know it: **outside a table closure an id is not
+unique**, and the view hands out none.
+
 **The vocabulary keeps its `Table` spellings** — `TableFieldInfo`,
 `TableTypeInfo`, `<Name>TableType()` — in a unit that declares no table at
 all — and every unit now has a view, so every unit spells them. They are one
@@ -2018,10 +2041,13 @@ struct ViewVariant          // one enum variant, one flags bit, one union arm
 {
     uint64_t value;         // an enum's value, a flags BIT INDEX, a union's tag
     const char * name;
-    uint16_t id;            // the table-wire id (§5); 0 for a flags bit
+    uint16_t id;            // the table-wire id (§5); 0 for a flags bit, and 0
+                            // throughout a vocabulary no table closure reaches
+                            // (§8.2)
     const char * payload_name;      // a union arm's payload TYPE name, else NULL
-    const TableTypeInfo * payload;  // that payload's descriptor where it has a
-                                    // view (§8.2), else NULL
+    const TableTypeInfo * payload;  // that payload's descriptor — never NULL for
+                                    // a declared payload (§8.2); NULL on tag 0
+                                    // and on an enum or flags row
 };
 
 struct ViewVocabulary       // an enum, a flags or a union declaration
@@ -2034,7 +2060,7 @@ struct ViewVocabulary       // an enum, a flags or a union declaration
     const ViewVariant * variants;
 };
 
-struct ViewType             // a type with a view, or a table
+struct ViewType             // one declaration: a type, or a table
 {
     const char * name;
     const char * file;
@@ -2070,9 +2096,11 @@ const UnitViewInfo * UnitView();
   registry.
 - **An ENUM lists its NAMED values in order, beside its `max`.** Row 0 is
   `None`, the reserved id (§5), then the variants in declared order with the
-  wire id each rides under. A value inside `[0, max]` that no row names is
-  `| max = K` headroom (SPEC §4.2), and a tool that shows such a value
-  unnamed is showing the truth rather than inventing a name for it.
+  wire id each rides under — `0` throughout where no table closure reaches
+  the enum, because nothing checked those ids (§8.2). A value inside
+  `[0, max]` that no row names is `| max = K` headroom (SPEC §4.2), and a
+  tool that shows such a value unnamed is showing the truth rather than
+  inventing a name for it.
 - **A FLAGS row's `value` is a BIT INDEX and its `id` is 0**, because a
   mask's variants ride by position and have no per-variant wire id (§4) —
   the same rule §8.1's columns state, in data rather than in functions.
@@ -2220,23 +2248,38 @@ applied to reflection). The scope is per backend because acceptance already
 is: C# refuses a pointered unit by name (§11), and a gate cannot ask a
 backend for a listing of a unit it declines to emit at all. Completeness is
 the count the pin carries: every declaration, every field of every type,
-every variant of every enum, flags and union, and every constant, in the
-schema's own order. How the compiler produces its half is the
-implementation's business — a test that walks the checked unit is enough,
-and nothing in this section asks for a new command.
+every variant of every enum, flags and union, and every constant, each set
+in DECLARATION-NAME order (§8.3) — a variant list keeps its declared order,
+which is the one order that is a property of the declaration itself. How the
+compiler produces its half is the implementation's business — a test that
+walks the checked unit is enough, and nothing in this section asks for a new
+command.
 
 **A gate that cannot go red proves nothing.** Dropping one declaration, one
 property, one variant or one constant from an emitter's registry turns the
 corpus gate red, and that is established by doing it rather than assumed.
 
 **The INDEPENDENCE gate, and it is what the whole section rests on.** The
-view adds a file and moves nothing else: for every corpus unit, every
-generated file other than `<Package>View.*` is byte-identical to what the
-same unit emitted before the view existed, and `schema id` reports the same
-protocol id. That is what proves reflection costs the type wire's generated
-code not one byte — §10's independence, claimed for a table edit, holding
-for a view. Beside it, the containment gate of §8.4: not one of the six
-registry symbols appears in any generated file but the view pair.
+view adds a file and moves nothing else: every generated file other than
+`<Package>View.*` is byte-identical to what the same unit emitted before the
+view existed, and `schema id` reports the same protocol id. That is what
+proves reflection costs the type wire's generated code not one byte — §10's
+independence, claimed for a table edit, holding for a view.
+
+**Its left-hand side is the RECORDED SOURCE GOLDENS**, because with nothing
+selecting the view there is no second generate to compare against: "before
+the view existed" is a snapshot, and the repo keeps one — the source goldens
+pin every backend's generated text byte for byte, with the protocol id
+beside them, so the gate reduces to "landing the view moves nothing in the
+recorded goldens", which is mechanical and already red-capable. Today those
+goldens cover the `examples` and `examples128` units, and **extending them
+to the two TABLE corpora is a named follow-on (§15)** — that is the half
+where movement is plausible, since §8.5 draws the boundary between the table
+header and the view file straight through `<Base>Table.h`, and until the
+snapshot exists the gate has no referent for those units.
+
+Beside it, the containment gate of §8.4: not one of the six registry symbols
+appears in any generated file but the view pair.
 
 ## 9. Relocatable, and built wide
 
@@ -2925,8 +2968,8 @@ Owner rulings, 2026-09-02, in the order given.
 - **The question that opened it, and both halves are yes**: "We should
   revisit the 'view' concept. Does a type have a view generated for it,
   alongside it, and a table has the view built in?" A table's descriptors
-  are built in (§8.1); a type's view is generated alongside it when asked
-  (§8.2). That is the section's whole shape.
+  are built in (§8.1); a type's view is generated alongside it, for every
+  type, always (§8.2). That is the section's whole shape.
 - **What has to be walkable, beyond fields**: "I would find it valuable to
   be able to walk enums, constants at runtime via some reflection." Constants
   had no runtime surface at all before §8.3, and enums had one only through
@@ -3380,6 +3423,14 @@ pre-empted here.
   per table: walk the registry, print or compare every declaration, with the
   instance-level walk of §8.1 underneath it. The listing §8.7's gate already
   produces is the dump half of it in embryo.
+- **THE SOURCE GOLDENS EXTENDED TO THE TABLE CORPORA.** §8.7's independence
+  gate compares against a recorded snapshot of generated text, and the
+  snapshot covers the `examples` and `examples128` units only — nothing
+  records what the two table corpora emit, so for exactly the units whose
+  table headers the view's boundary runs through, the gate has nothing to
+  compare. It is the same harness pointed at two more directories, and it
+  belongs with the emitters rather than with this page, because a snapshot
+  taken before the code that could move it is a snapshot of nothing.
 - **The view in a ported backend** — C++ and C# carry it; every other
   backend emits no view file until it emits the same registry against the
   same pin (§8.7). Nothing is refused meanwhile, because nothing in a schema

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -104,6 +104,15 @@ variable-length table's block form is (§19). C++ and C# take it together,
 because the form is an ABI between two languages and one language alone
 cannot hold the gate it exists for (§12.1).
 
+**The VIEW's type half and unit registry (§8.2–§8.7) are specified and
+unimplemented.** What ships today is §8.1: a table's descriptors, built in,
+and the same descriptors for every type a table reaches. No backend emits a
+view file yet, so a declaration carrying `| view` and a request for
+`--views all` are refused by name with §8 cited, never accepted and ignored;
+the default over a unit that marks nothing asks for no view file and is
+unaffected. C++ and C# take it together, because the gate it exists for is
+one listing both backends reproduce.
+
 ## 1. Purpose
 
 - **Users build their own formats.** A table declaration plus nesting is a
@@ -1767,7 +1776,26 @@ builder with a serialization point in it, whatever the read side costs. A
 cook does not answer it either — a cook is produced from a builder by a
 single-threaded `Lock` (§6.2), which is exactly the shape that lost.
 
-## 8. Reflection
+## 8. Reflection: the view
+
+**One vocabulary, one walker, three things it describes.** A TABLE carries
+its descriptors BUILT IN, always — they are what the table runtime, the text
+form (§16) and the block form's read side (§19.2) are written against. A
+TYPE gets the SAME descriptors generated ALONGSIDE it when something asks:
+a `| view` marker on the declaration (§8.2), or a table reaching it. And a
+UNIT gets a REGISTRY (§8.3) — one entry point listing every declaration in
+the build, so a tool that knows the unit and nothing else enumerates the
+types, the tables, the enums, the flags, the unions and the constants, and
+walks each one's properties with no schema files on hand.
+
+The registry and the type views are emitted ON THE SIDE (§8.5): one
+generated file per unit that an editor or a debug build links and a game
+build never compiles. Which of them exists is decided by WHO ASKS (§8.4) —
+a build flag and a declaration marker, never a change to what a table
+carries. Nothing here rides a wire: `| view` moves no protocol id, no
+generated wire byte and no baseline row (§10, §18).
+
+### 8.1 The descriptors
 
 For every table in the unit's closure the generated header carries static
 descriptors: field name, type name, wire id and kind, storage offset and
@@ -1879,6 +1907,277 @@ could not have been written both race-free and recursion-safe, and no
 mutable state anywhere on the surface. This is the surface
 editors and tools build on — walk properties by name, print a value, diff
 two, bind a property grid — with no RTTI and no schema files at runtime.
+
+### 8.2 The type view: `| view`, and what a table reaches
+
+**A type has a view when something asks for one**, and there are three
+askers: the declaration itself, marked `| view` (SPEC §4.2); a TABLE that
+reaches it, as today — a walk must be able to enter a nested type, so every
+type in a table's closure has had a view all along; and the build, asking
+for every declaration at once (§8.4). A type no asker names has no
+descriptor emitted, is absent from the registry, and costs nothing. The
+packet-only path is unchanged by this section.
+
+**The view IS §8.1's surface.** `<Name>TableType()` returns the same
+`TableTypeInfo`, with the same columns, filled by the same rules. There is
+no second vocabulary and no second walker: a printer, a differ or a property
+grid written against §8.1 walks a viewed type without being told it is not a
+table. That is the whole of the answer to "a view on that type" — the view
+of a type is the descriptor surface a table carries, generated for a
+declaration that carries no table wire.
+
+**A view describes; it does not add a wire.** A viewed type gains no codec,
+no `Measure`/`Save`/`Load`, no text form and no baseline row. `| view` says
+what may be inspected, and nothing about what may be written.
+
+**A field with no table-wire kind is DESCRIBED, never refused.**
+`fixed`/`ufixed` and the 128-bit family have no table kind and are refused
+inside a table body (§2, §11) — but a `type` outside every table closure
+declares them freely, and a view over such a type describes them: `kind` is
+`0`, the reserved "no table-wire kind" value; `type_name` carries the
+declared spelling (`fixed(2, 30)`, `uint128`); and the range columns carry
+the declared bounds, which those kinds always have (SPEC §4.3). A build that
+asks for a view over a whole unit never fails because a declaration is
+packet-only — the corpus's fixed-point and 128-bit unit is exactly that
+case, and the view over it is a listing, not a refusal.
+
+**The vocabulary keeps its `Table` spellings** — `TableFieldInfo`,
+`TableTypeInfo`, `<Name>TableType()` — in a unit that declares no table at
+all. They are one surface, and renaming them for the view would fork the
+walker every tool is already written against. A unit whose view exists
+without tables carries the descriptor primitives in the view file behind the
+same include guard the table headers use, so a unit that has both carries
+one definition of them.
+
+### 8.3 The unit registry
+
+**`UnitView()` is the entry point, and it returns constant data.** One
+function per unit, name-first in the unit's own namespace beside
+`ProtocolId` (SPEC §6.1), answering with the set of everything the build
+declared:
+
+```cpp
+struct ViewConstant
+{
+    const char * name;
+    const char * file;       // the declaring schema file's basename
+    const char * type_name;  // declared storage: "int64", "float64", "int32", ...
+    bool is_float;
+    int64_t int_value;       // the folded value; float_value when is_float
+    double float_value;
+};
+
+struct ViewVariant          // one enum variant, one flags bit, one union arm
+{
+    uint64_t value;         // an enum's value, a flags BIT INDEX, a union's tag
+    const char * name;
+    uint16_t id;            // the table-wire id (§5); 0 for a flags bit
+    const char * payload_name;      // a union arm's payload TYPE name, else NULL
+    const TableTypeInfo * payload;  // that payload's descriptor where it has a
+                                    // view (§8.2), else NULL
+};
+
+struct ViewVocabulary       // an enum, a flags or a union declaration
+{
+    const char * name;
+    const char * file;
+    int64_t max;            // highest value / highest bit index / highest tag
+    int32_t storage_bits;
+    int32_t num_variants;
+    const ViewVariant * variants;
+};
+
+struct ViewType             // a type with a view, or a table
+{
+    const char * name;
+    const char * file;
+    bool table;                     // declared `table`
+    const TableTypeInfo * type;     // §8.1's descriptor: the properties
+    int32_t num_tags;               // the declaration's type tags (SPEC §4.2)
+    const char * const * tags;
+};
+
+struct UnitViewInfo
+{
+    const char * package;
+    uint64_t protocol_id;
+    int32_t num_types;      const ViewType * types;
+    int32_t num_tables;     const ViewType * tables;
+    int32_t num_enums;      const ViewVocabulary * enums;
+    int32_t num_flags;      const ViewVocabulary * flags;
+    int32_t num_unions;     const ViewVocabulary * unions;
+    int32_t num_constants;  const ViewConstant * constants;
+};
+
+const UnitViewInfo * UnitView();
+```
+
+- **TYPES and TABLES are two sets, walked separately**, because they are two
+  wires and a tool acts differently on each: a table can be loaded from a
+  file, a type cannot. `types` holds exactly the types with a view (§8.2);
+  `tables` holds every table in the unit, always, because a table's view is
+  built in. Each entry's `type` is the descriptor §8.1 already specifies —
+  the properties, their kinds, their bounds and their nested descriptors —
+  so walking a declaration's properties is one dereference from the
+  registry.
+- **An ENUM lists its NAMED values in order, beside its `max`.** Row 0 is
+  `None`, the reserved id (§5), then the variants in declared order with the
+  wire id each rides under. A value inside `[0, max]` that no row names is
+  `| max = K` headroom (SPEC §4.2), and a tool that shows such a value
+  unnamed is showing the truth rather than inventing a name for it.
+- **A FLAGS row's `value` is a BIT INDEX and its `id` is 0**, because a
+  mask's variants ride by position and have no per-variant wire id (§4) —
+  the same rule §8.1's columns state, in data rather than in functions.
+- **A UNION lists tag 0, the empty arm, then its arms in declared order**
+  (SPEC §4.8), each with its payload type's NAME always and that payload's
+  descriptor where the payload has a view. Under a build that views
+  everything the descriptor is always there; under a narrower one a NULL
+  descriptor beside a named payload says "declared, not viewed here", and
+  the arm's name, tag and id stay walkable.
+- **A CONSTANT carries its name, its declared storage and its folded
+  value** — the one declaration kind with no runtime surface of its own
+  before this section. An implicitly typed constant reports the storage it
+  folded to (`int64`, `float64`), a declared one reports what it declared
+  (SPEC §4.2).
+- **Every entry names the schema FILE it was declared in**, by basename, as
+  every generated file already names its source (SPEC §6.1) — a tool
+  grouping a build's declarations the way a person navigates them needs no
+  second table to do it.
+- **The order is the schema's own**, within each set: files by basename,
+  then declaration order within a file — the order the generated files are
+  emitted in (SPEC §6.1). A listing produced from the registry is therefore
+  stable across builds and diffable between them, which is what makes
+  §8.7's gate a byte comparison.
+- **It is constant data.** In C++ the whole registry is constant-initialised
+  and `UnitView()` returns its address: a lookup, never a parse, and no
+  mutable state on the surface — the property §8.1 already holds for
+  descriptors, carried up to the unit. In C# the registry is a static
+  instance on `Schema` and a `ViewType`'s descriptor is held behind a
+  factory, exactly as §8.1's `TableRef` is and for the same
+  initialization-order reason; the entry point is `Schema.UnitView()`.
+
+### 8.4 Who asks: `--views`
+
+**Zero cost is resolved by who asks, not by what is declared.** The same
+declarations serve an editor and a game; the generate request decides what
+the build pays for:
+
+- **`--views declared`** — the default. A type marked `| view` gets one, a
+  table's descriptors are built in as they always were, and a unit in which
+  nothing is marked emits no view file at all. This is today's behaviour for
+  every unit that adds no marker.
+- **`--views all`** — every declaration in the unit gets a view: every type,
+  and therefore a registry that reaches everything. An editor or a debug
+  build asks for this, and it is the mode §8.7's gate is held in.
+- **`--views none`** — no view file, whatever the declarations say. A game
+  build asks for this and pays nothing for markers a tools build wanted.
+
+`--views` is a generate option (SPEC §6.1), carried on the request rather
+than in the schema, so a marked declaration never forces cost on a build
+that did not ask. A backend with no view emitter refuses a request for one
+by name with this section cited, and never emits a unit with the registry
+missing (§11) — the same shape every unimplemented surface here takes.
+
+**The zero-cost gate holds, and is stated as a gate** (§2.2): a unit that
+asks for nothing emits NO view file — not an empty one — and not one symbol
+of the registry appears in any other generated file. The build fails if a
+spelling of the view surfaces in a unit that asked for none, exactly as it
+fails on a pointer symbol in a pointer-free unit.
+
+### 8.5 On the side
+
+**The view is one generated file per UNIT, not per schema file** —
+`<Package>View.h` and `<Package>View.cpp` in C++, `<Package>View.cs` in C#,
+the package name spelled as that target spells it in a file name
+(`TabledemoView.h`). The registry is a unit-level fact, the set of
+everything declared, and a per-file split would leave it homeless or force
+one file to reach across the others and back. **The name is the UNIT's
+because two units may generate into one directory** — one package per unit
+(SPEC §3.2), two units side by side in one output tree is a layout the
+corpus itself uses — and a fixed name would collide there while every
+per-schema-file name does not.
+
+- **The header declares, the translation unit holds the data.** The header
+  declares `UnitView()`, the registry's structs and the `<Name>TableType()`
+  of every type the view adds; the `.cpp` holds the definitions. That is
+  §13.5's ruling applied where it applies again —
+  an editor compiles one translation unit, and an including translation unit
+  carries no descriptor table it does not use.
+- **It sits at the LEAF of the unit's include graph.** It includes the
+  unit's data headers `<Base>.h` and its table headers `<Base>Table.h`, and
+  nothing includes it — so it introduces no cross-file cycle (§11), and it
+  pulls no WIRE header: a tool that walks declarations never inherits the
+  serialize runtime it does not use, which is the reason SPEC §6.1 splits
+  data from wire in the first place.
+- **A descriptor a TABLE needs stays where the table is** (§8.1). A table's
+  descriptor names its nested types' descriptors, so a type a table reaches
+  keeps its `<Name>TableType()` in the table header, where a game that loads
+  tables links it and where it is today. The view file adds the types no
+  table reached, plus the registry that lists everything; it duplicates
+  nothing and moves nothing.
+- **The text form's walker stays in `<Base>Table.cpp`** where §13.5 put it.
+  The view file is a second on-the-side file for the same reason and with no
+  relationship to the first: a project compiles either, both or neither.
+
+### 8.6 What the view does not carry
+
+- **No semantics.** A type tag is an identifier the language assigns no
+  meaning (SPEC §4.2); the registry lists a declaration's tags because they
+  are part of what was declared, and claims nothing about them. A claiming
+  pass that gives a tag meaning changes what a consumer does with the
+  listing, never the listing.
+- **No UI hints.** Names, kinds, ids, bounds, extents, offsets, presence
+  companions and key vocabularies — the facts the declaration states, and
+  those alone. No widget, no grouping, no ordering hint, no unit of measure.
+- **No description strings, and no `| doc` attribute.** Doc comments are
+  deferred with their design pinned (SPEC §4.1, §9 q5); when they land the
+  view carries them as one more column. A second spelling for the same text
+  is not introduced ahead of them.
+- **No per-field default VALUE.** A walker that fills a value establishes
+  defaults through the descriptor's `reset` hook (§8.1) — one instance put
+  back at its declared defaults, which is what a filler actually needs and
+  what the wire's read path itself does. A per-field default column would be
+  a second spelling of one fact.
+- **No packet-wire layout.** Bit offsets, field widths and `MaxBits` are the
+  hardcoded wire's business (SPEC §6.1); the descriptors describe
+  DECLARATIONS. A view over the packet encoding itself is a named follow-on
+  (§15).
+- **No build identity beyond the unit's own.** The registry carries the
+  package name and the protocol id, and nothing else about the build that
+  produced it.
+
+### 8.7 Held by test
+
+**The editor gate, and it is a dogfood rather than a thought
+experiment** — the shape §12's gates take. A test program that has the
+generated view file and NOTHING ELSE — no schema files on disk, no
+compiler, no knowledge of a single declaration's name — calls `UnitView()`
+and prints the whole build: every constant with its value, every enum and
+flags and union with its variants in order, every type and every table with
+every property, recursing through each property's nested descriptor. If it
+cannot reach a declaration or a property of one, the view is incomplete and
+the gate says so.
+
+**The corpus gate makes that mechanical.** For every unit in the corpus,
+generated under `--views all`, the listing the generated program prints is
+byte-identical to the listing the compiler produces from its own IR. The
+compiler's listing is the PIN — the IR is what was declared — and every
+backend's program byte-compares against it, so C++ and C# are one view the
+way they are one wire (§16's goldens, applied to reflection). Completeness
+is the count the pin carries: every declaration, every field of every viewed
+type, every variant of every enum, flags and union, and every constant, in
+the schema's own order. How the compiler produces its half is the
+implementation's business — a test that walks the checked unit is enough,
+and nothing in this section asks for a new command.
+
+**A gate that cannot go red proves nothing.** Dropping one declaration, one
+property, one variant or one constant from an emitter's registry turns the
+corpus gate red, and that is established by doing it rather than assumed.
+
+**The zero-cost gate** (§8.4) is held the way §2.2's is: a unit generated
+with `--views none`, and a unit with no marker under the default, emit no
+view file and not one registry symbol anywhere else, and the build fails if
+one appears.
 
 ## 9. Relocatable, and built wide
 
@@ -2008,6 +2307,21 @@ lockstep redeploy by a table edit. This independence is held by test.
   payload. Its BY-VALUE form is an ordinary fixed table and behaves like one
   everywhere; only its block form requires a base, exactly as a cooked file's
   does.
+- **The view** (§8), each refusal naming the declaration at fault:
+  - **`| view` on a `table`** — a table's view is built in (§8.1), and an
+    attribute that changes nothing is a lie about the declaration, exactly
+    as `| stride` is;
+  - **`| view` on an `enum`, `flags`, `union` or `const` declaration** — the
+    registry catalogues every one of them whenever it exists (§8.3): they
+    are unit-level vocabulary, they cost names and values, and a build that
+    could see only some of them would be useless to the editor §8.7's gate
+    describes. There is nothing for a marker to select;
+  - **`| view` on a FIELD** — it qualifies a declaration, not a member; a
+    type is viewed whole or not at all;
+  - **`| view`, or a `--views` request, under a backend that carries no view
+    emitter** — refused with §8 cited and never emitted with the registry
+    missing. A generate option a target cannot honor is an error rather than
+    a silent fallback (SPEC §6.1).
 - **A `table` union arm outside a table closure** (§2.6) — a union declared
   for the type wire takes `type` payloads only, because types are value
   semantics.
@@ -2068,6 +2382,20 @@ lockstep redeploy by a table edit. This independence is held by test.
   free yesterday must not become a collision tomorrow. The nine block
   spellings are claimed on the same terms and for a stronger reason: every
   fixed table has a block form (§2.7), so every fixed table claims them.
+
+  **`TableType` is claimed one step wider still: for EVERY declaration in
+  every unit**, closure member or not. A view gives any type that accessor
+  (§8.2), and `--views all` gives it to every declaration at once — so a
+  name that is legal without views and refused with them would make a
+  GENERATE FLAG change what the language accepts, which no flag may do. The
+  claim is unconditional for the same reason the other 36 are.
+
+  **The view's own unit-scope spellings are refused as declaration names in
+  every unit, always** (§8.3): `UnitView`, `UnitViewInfo`, `ViewType`,
+  `ViewVocabulary`, `ViewVariant` and `ViewConstant`. They belong to the
+  unit rather than to a declaration, so they are claimed once at unit scope,
+  as `ProtocolId` is (SPEC §6.1), and on the same
+  it-must-not-depend-on-a-flag terms as `TableType` above.
 
   **A FIXED TABLE claims two more per out-of-line array, because its
   row accessors are named after its fields.** `<Table>` followed by the
@@ -2797,6 +3125,40 @@ have added one are priced here.
   consumer's own constant, which is the difference between absorbing a grown
   row and refusing one (§19.4).
 
+**The view's shape** (§8). Four models were weighed against the owner's
+picture of it — an editor that inspects everything in the schema built,
+paid for by whoever asks:
+
+1. **A SECOND descriptor vocabulary for types — REJECTED.** A `type` is not
+   a table, so a type-shaped `TypeFieldInfo` beside `TableFieldInfo` looked
+   tidy. It is two vocabularies, therefore two walkers, therefore every
+   printer, differ and property grid written twice — and the JSON walker
+   (§16) and the block form's reflective read (§19.2) are already written
+   against the first one. One surface, filled by the same rules, is what
+   makes a viewed type walkable by code that was never told about views.
+2. **Views always on — REJECTED.** It is the simplest rule and it breaks
+   §2.2's gate at the level above tables: a packet-only unit would carry a
+   descriptor table per declaration, in every game build, for a surface no
+   game build calls. The flag exists so the gate survives contact with a
+   feature whose whole point is completeness.
+3. **A view file per SCHEMA FILE — REJECTED.** It mirrors §6.1's
+   one-file-per-schema-file layout and leaves the registry homeless: the
+   registry is the set of everything the UNIT declares, so it would either
+   live in one arbitrarily chosen file's output or force each file's view to
+   reach into the others and back — the cross-file cycle §11 refuses. A
+   unit-level fact gets a unit-level file.
+4. **A unit-level registry in one on-the-side file, opt-in — THE DESIGN OF
+   RECORD.** One `UnitView()` over constant data, the type views beside it,
+   `<Name>TableType()` unchanged for anything a table already reached, and a
+   file an editor links and a game never compiles.
+
+**Why the marker sits on types and nowhere else.** Enums, flags, unions and
+constants are catalogued unconditionally wherever a registry exists, because
+what they cost is names and values — while a TYPE costs a descriptor table
+per declaration, which is the cost worth a marker. The asymmetry is the
+price list, not a taste, and §11 refuses `| view` on the free kinds rather
+than accepting an attribute that would select nothing.
+
 **No decision here knowingly costs TIME.** The `u64` type id and the
 repeating node-table field cost BYTES and nothing else — the record scan
 is linear either way, and a wider id compares no slower than a narrow
@@ -2894,7 +3256,23 @@ pre-empted here.
 - **Cross-endian blocks.** A block carries its byte order in its magic and
   refuses a foreign one, exactly as a cook does; swapping one would be the
   cook's cross-endian follow-on applied to a flatter shape.
-- A generic dump/diff tool over the reflection surface.
+- **A generic dump/diff tool over the reflection surface** — and the unit
+  registry (§8.3) is what makes it a tool over a whole BUILD rather than one
+  per table: walk the registry, print or compare every declaration, with the
+  instance-level walk of §8.1 underneath it. The listing §8.7's gate already
+  produces is the dump half of it in embryo.
+- **The view in a ported backend** — C++ and C# carry it; every other
+  backend refuses a `--views` request by name (§11) until it emits the same
+  registry against the same pin (§8.7).
+- **DOC STRINGS in the view.** Doc comments are deferred with their design
+  pinned (SPEC §4.1, §9 q5); when they land they become one more descriptor
+  column and one more registry column, and nothing else about §8 moves. No
+  competing `| doc = "..."` attribute is introduced ahead of them.
+- **A view over the PACKET wire's own layout** — bit offsets, field widths
+  and the compressed-float parameters a `type` rides under (SPEC §6.1),
+  beside the declaration facts §8 carries. It is what a packet inspector
+  would want and what a table-shaped descriptor cannot express; the
+  no-table-wire-kind fields of §8.2 are exactly the ones it would fill in.
 - Keyed lookup conveniences over loaded collections (library-side, never
   stored semantics).
 - Arrays of unions in table bodies.

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -113,6 +113,15 @@ the default over a unit that marks nothing asks for no view file and is
 unaffected. C++ and C# take it together, because the gate it exists for is
 one listing both backends reproduce.
 
+**Two front-end changes come BEFORE any emitter, and the refusal above is
+one of them.** `view` is reserved out of the type-tag namespace (SPEC §4.2,
+§4.11) — until it is, `| view` parses as a TAG named `view` and is carried
+through inertly, which is accepted-and-ignored wearing the marker's clothes.
+And the generated table runtime's names are claimed in every unit rather
+than only in a unit that declares a table (§11), because the view file
+defines them in units that declare none. Neither waits for a view file to
+exist; both are what makes the refusal above true rather than aspirational.
+
 ## 1. Purpose
 
 - **Users build their own formats.** A table declaration plus nesting is a
@@ -1918,6 +1927,16 @@ for every declaration at once (§8.4). A type no asker names has no
 descriptor emitted, is absent from the registry, and costs nothing. The
 packet-only path is unchanged by this section.
 
+**`| view` is CLOSURE-TRANSITIVE, on the reason a table's reach already
+is.** A marked type's by-value closure is viewed with it: every type it
+nests, every element of an array it declares, every arm's payload of a union
+it names. The rule is the one §2.2 derives a table's closure with, and the
+reason is the sentence above — a walk that enters a nested type needs that
+type's descriptor, so a view whose nested column is NULL one level down is
+not a view of that type, it is a view of its first level. `types` therefore
+lists a marked type AND its closure, and a walker that recurses through the
+nested column never meets a NULL it cannot explain.
+
 **The view IS §8.1's surface.** `<Name>TableType()` returns the same
 `TableTypeInfo`, with the same columns, filled by the same rules. There is
 no second vocabulary and no second walker: a printer, a differ or a property
@@ -1930,16 +1949,49 @@ declaration that carries no table wire.
 no `Measure`/`Save`/`Load`, no text form and no baseline row. `| view` says
 what may be inspected, and nothing about what may be written.
 
-**A field with no table-wire kind is DESCRIBED, never refused.**
-`fixed`/`ufixed` and the 128-bit family have no table kind and are refused
-inside a table body (§2, §11) — but a `type` outside every table closure
-declares them freely, and a view over such a type describes them: `kind` is
-`0`, the reserved "no table-wire kind" value; `type_name` carries the
-declared spelling (`fixed(2, 30)`, `uint128`); and the range columns carry
-the declared bounds, which those kinds always have (SPEC §4.3). A build that
-asks for a view over a whole unit never fails because a declaration is
-packet-only — the corpus's fixed-point and 128-bit unit is exactly that
-case, and the view over it is a listing, not a refusal.
+**A field with no table-wire kind is DESCRIBED, never refused.** The
+no-table-wire-kind set is `fixed`, `ufixed` AND the 128-bit family
+(`int128`, `uint128`) — the exclusions §2 names, refused inside a table body
+(§11) and declared freely by a `type` outside every table closure. A view
+over such a type describes them: `kind` is `0`, the reserved value no
+declared kind spells; `type_name` carries the declared spelling
+(`fixed(2, 30)`, `uint128`); and `offset` and `elem_size` locate the storage.
+A build that asks for a view over a whole unit never fails because a
+declaration is packet-only — the corpus's fixed-point and 128-bit unit is 27
+such fields, and the view over it is a listing, not a refusal.
+
+**The kind function must be corrected before it can answer that, and the
+correction belongs with the view.** The rule that fills the kind column
+dispatches an integer on its width and lets the widths it does not name fall
+to the 64-bit answer — correct while every caller was a table body, where a
+128-bit field cannot appear, and wrong the moment a view over a packet-only
+type calls it: eight fields of the corpus's 128-bit unit answer a 64-bit
+kind today, each describing a 16-byte field as an 8-byte one. The view is
+what makes that path reachable, so `0` for the whole set above is this
+section's rule, and the emitters' shared kind function names 128 explicitly
+rather than defaulting it.
+
+**Kind 0 DESCRIBES; it does not decode.** What a kind-0 field hands a
+generic walker is its name, its declared spelling as text, its offset, its
+size and its declared range as two `double`s — enough to LIST the field and
+show where it lives, and not enough to read or write its value. There is no
+numeric-shape column: no signedness, no `I`, no `F`, no storage width, so
+nothing decodes those bytes without parsing `type_name`, which is a schema
+file in disguise. The range columns do not close it either: they are
+`double`s, so a bound past 2^53 — a `uint128`'s declared maximum, say — does
+not survive the column, and it rounds UP, which is the one direction an
+editor must never clamp to. So: a kind-0 field is DESCRIBABLE and is not
+generically readable or writable, and the typed descriptor form that would
+close it is a named follow-on (§15). Nothing in this section claims
+sufficiency for it.
+
+**A field of a type NO TABLE CLOSURE REACHES carries no table-wire
+identity**: its `id` column is `0` and its `json` column is NULL. Those two
+columns describe the table wire, and such a type has none — its field ids
+were never checked for collisions (§5's refusal is scoped to the closure, as
+§16.4's key refusal is), so filling them would hand a tool two fields under
+one id and a text-form key for a text form that does not exist. A viewed
+type inside a closure carries both as it always did.
 
 **The vocabulary keeps its `Table` spellings** — `TableFieldInfo`,
 `TableTypeInfo`, `<Name>TableType()` — in a unit that declares no table at
@@ -2014,9 +2066,11 @@ const UnitViewInfo * UnitView();
 
 - **TYPES and TABLES are two sets, walked separately**, because they are two
   wires and a tool acts differently on each: a table can be loaded from a
-  file, a type cannot. `types` holds exactly the types with a view (§8.2);
-  `tables` holds every table in the unit, always, because a table's view is
-  built in. Each entry's `type` is the descriptor §8.1 already specifies —
+  file, a type cannot. `types` holds exactly the types with a view (§8.2) —
+  the marked ones and their closures, the ones tables reach, or every type
+  in the unit under `--views all`; `tables` holds every table in the unit,
+  always, because a table's view is built in. Each entry's `type` is the
+  descriptor §8.1 already specifies —
   the properties, their kinds, their bounds and their nested descriptors —
   so walking a declaration's properties is one dereference from the
   registry.
@@ -2043,18 +2097,22 @@ const UnitViewInfo * UnitView();
   every generated file already names its source (SPEC §6.1) — a tool
   grouping a build's declarations the way a person navigates them needs no
   second table to do it.
-- **The order is the schema's own**, within each set: files by basename,
-  then declaration order within a file — the order the generated files are
-  emitted in (SPEC §6.1). A listing produced from the registry is therefore
-  stable across builds and diffable between them, which is what makes
-  §8.7's gate a byte comparison.
+- **Each set is ordered by DECLARATION NAME**, and deliberately not by where
+  the declaration lives. File layout and declaration order move nothing in
+  this language — not an id, not a wire byte (SPEC §3.2) — so a listing that
+  reordered when a file was renamed or a declaration moved between files
+  would be the one artifact in the tree that did. Name order is stable under
+  both, it is still one byte comparison for §8.7, and grouping a listing by
+  file stays one pass over the `file` column.
 - **It is constant data.** In C++ the whole registry is constant-initialised
   and `UnitView()` returns its address: a lookup, never a parse, and no
   mutable state on the surface — the property §8.1 already holds for
   descriptors, carried up to the unit. In C# the registry is a static
-  instance on `Schema` and a `ViewType`'s descriptor is held behind a
-  factory, exactly as §8.1's `TableRef` is and for the same
-  initialization-order reason; the entry point is `Schema.UnitView()`.
+  instance on `Schema`, and a `ViewType`'s descriptor is reached through a
+  factory rather than held as a value, because C# gives no initialization
+  order across a partial class's files and a registry names every
+  declaration in the unit — the same reason the C# field descriptor reaches
+  its nested table through one. The entry point is `Schema.UnitView()`.
 
 ### 8.4 Who asks: `--views`
 
@@ -2062,10 +2120,15 @@ const UnitViewInfo * UnitView();
 declarations serve an editor and a game; the generate request decides what
 the build pays for:
 
-- **`--views declared`** — the default. A type marked `| view` gets one, a
-  table's descriptors are built in as they always were, and a unit in which
-  nothing is marked emits no view file at all. This is today's behaviour for
-  every unit that adds no marker.
+- **`--views declared`** — the default. A type marked `| view` gets one,
+  with its closure (§8.2); a table's descriptors are built in as they always
+  were; and a unit in which nothing is marked emits no view file at all.
+  This is today's behaviour for every unit that adds no marker. **The
+  default honors the marker rather than ignoring it**, and that is the
+  reason it is the default: a marker that did nothing until a flag was
+  passed would be an attribute accepted and inert, which this document
+  refuses for `| stride` in the same words — an inert attribute is a lie
+  about the declaration.
 - **`--views all`** — every declaration in the unit gets a view: every type,
   and therefore a registry that reaches everything. An editor or a debug
   build asks for this, and it is the mode §8.7's gate is held in.
@@ -2074,23 +2137,38 @@ the build pays for:
 
 `--views` is a generate option (SPEC §6.1), carried on the request rather
 than in the schema, so a marked declaration never forces cost on a build
-that did not ask. A backend with no view emitter refuses a request for one
-by name with this section cited, and never emits a unit with the registry
-missing (§11) — the same shape every unimplemented surface here takes.
+that did not ask.
+
+**Every backend KNOWS the key: it honors the request or refuses it, and no
+backend ignores it.** A generator ignores option keys it does not know —
+which is why `views` may not be left unknown to the backends that emit no
+view file: silence there would hand a build that asked for a registry a
+tree without one and say nothing. So a target with no view emitter refuses
+any request that would need one, by name, with this section cited (§11),
+and never emits a unit with the registry missing — the same shape every
+unimplemented surface here takes.
 
 **The zero-cost gate holds, and is stated as a gate** (§2.2): a unit that
-asks for nothing emits NO view file — not an empty one — and not one symbol
-of the registry appears in any other generated file. The build fails if a
-spelling of the view surfaces in a unit that asked for none, exactly as it
-fails on a pointer symbol in a pointer-free unit.
+asks for nothing emits NO view file — not an empty one — and not one
+REGISTRY symbol anywhere else in its generated output. The registry's
+symbols are the six §8.3 names — `UnitView`, `UnitViewInfo`, `ViewType`,
+`ViewVocabulary`, `ViewVariant`, `ViewConstant` — and nothing else: the
+descriptor vocabulary a table carries is §8.1's and rides in every table
+unit whatever `--views` says, so the gate asks "did the registry leak in?",
+never "is there a descriptor here?" — the distinction §2.2 already draws
+between machinery and columns.
 
 ### 8.5 On the side
 
 **The view is one generated file per UNIT, not per schema file** —
-`<Package>View.h` and `<Package>View.cpp` in C++, `<Package>View.cs` in C#,
-the package name spelled as that target spells it in a file name
-(`TabledemoView.h`). The registry is a unit-level fact, the set of
-everything declared, and a per-file split would leave it homeless or force
+`<Package>View.h` and `<Package>View.cpp` in C++, `<Package>View.cs` in C#.
+**The name is `capitalize(package)` followed by `View`** in every target
+that emits one: `package tabledemo` gives `TabledemoView.h`. It is a FILE
+name, and generated file names are basename-shaped in every target, so it
+takes the same shape here even where the language spells the package
+itself verbatim — C++ emits `TabledemoView.h` and, inside it,
+`namespace tabledemo` unchanged. The registry is a unit-level fact, the set
+of everything declared, and a per-file split would leave it homeless or force
 one file to reach across the others and back. **The name is the UNIT's
 because two units may generate into one directory** — one package per unit
 (SPEC §3.2), two units side by side in one output tree is a layout the
@@ -2144,7 +2222,8 @@ per-schema-file name does not.
   (§15).
 - **No build identity beyond the unit's own.** The registry carries the
   package name and the protocol id, and nothing else about the build that
-  produced it.
+  produced it; what else might identify a build is a named follow-on (§15),
+  so the two pages meet there rather than each inventing a column.
 
 ### 8.7 Held by test
 
@@ -2161,9 +2240,13 @@ the gate says so.
 **The corpus gate makes that mechanical.** For every unit in the corpus,
 generated under `--views all`, the listing the generated program prints is
 byte-identical to the listing the compiler produces from its own IR. The
-compiler's listing is the PIN — the IR is what was declared — and every
-backend's program byte-compares against it, so C++ and C# are one view the
-way they are one wire (§16's goldens, applied to reflection). Completeness
+compiler's listing is the PIN — the IR is what was declared — and each
+backend's program byte-compares against it FOR THE UNITS THAT BACKEND
+ACCEPTS, so two backends that both carry a unit produce one view of it the
+way they produce one wire (§16's goldens, applied to reflection). The scope
+is per backend because acceptance already is: C# refuses a pointered unit by
+name (§11), and a gate cannot ask a backend for a listing of a unit it
+declines to emit at all. Completeness
 is the count the pin carries: every declaration, every field of every viewed
 type, every variant of every enum, flags and union, and every constant, in
 the schema's own order. How the compiler produces its half is the
@@ -2176,8 +2259,19 @@ corpus gate red, and that is established by doing it rather than assumed.
 
 **The zero-cost gate** (§8.4) is held the way §2.2's is: a unit generated
 with `--views none`, and a unit with no marker under the default, emit no
-view file and not one registry symbol anywhere else, and the build fails if
-one appears.
+view file and not one of the six registry symbols anywhere else, and the
+build fails if one appears.
+
+**The INDEPENDENCE gate, which is the one the whole section rests on.**
+Zero-cost says a build that asks for nothing gets nothing; independence says
+a build that asks for EVERYTHING moves nothing else. Every corpus unit is
+generated three times — `--views none`, `--views declared`, `--views all` —
+into three trees, and: every file other than `<Package>View.*` is
+byte-identical across all three; `schema id` reports the same protocol id
+for all three; and no `<Package>View.*` exists in the `none` tree. That is
+what proves a view costs the type wire's generated code not one byte, which
+§10's independence claims for a table edit and this section claims for a
+reflection request.
 
 ## 9. Relocatable, and built wide
 
@@ -2320,8 +2414,12 @@ lockstep redeploy by a table edit. This independence is held by test.
     type is viewed whole or not at all;
   - **`| view`, or a `--views` request, under a backend that carries no view
     emitter** — refused with §8 cited and never emitted with the registry
-    missing. A generate option a target cannot honor is an error rather than
-    a silent fallback (SPEC §6.1).
+    missing. Every backend knows the key: it honors the request or refuses
+    it, and none ignores it (§8.4, SPEC §6.1);
+  - **a type TAG spelled `view`** — the marker owns the spelling, so the tag
+    namespace loses it (SPEC §4.2, §4.11). It is a language change, and the
+    one this section's refusal above rests on: without it `| view` parses as
+    an inert tag rather than reaching any refusal at all.
 - **A `table` union arm outside a table closure** (§2.6) — a union declared
   for the type wire takes `type` payloads only, because types are value
   semantics.
@@ -2383,19 +2481,43 @@ lockstep redeploy by a table edit. This independence is held by test.
   spellings are claimed on the same terms and for a stronger reason: every
   fixed table has a block form (§2.7), so every fixed table claims them.
 
-  **`TableType` is claimed one step wider still: for EVERY declaration in
-  every unit**, closure member or not. A view gives any type that accessor
-  (§8.2), and `--views all` gives it to every declaration at once — so a
-  name that is legal without views and refused with them would make a
-  GENERATE FLAG change what the language accepts, which no flag may do. The
-  claim is unconditional for the same reason the other 36 are.
+  **THE DESCRIPTOR SURFACE'S CLAIMS ARE UNCONDITIONAL — every declaration,
+  every unit, tables or not.** A generate flag may not change what the
+  language accepts: a name legal without views and colliding with them would
+  make `--views all` turn a legal unit's generated code into code that does
+  not compile, which is precisely the defect the claim exists to prevent.
+  Two sets follow from it, and both are FRONT-END LAW rather than one
+  target's inventory:
+
+  - **The three per-declaration spellings the descriptors emit** —
+    `<Name>TableFields`, `<Name>TableInfo` and `<Name>TableType` — claimed
+    for every declaration in every unit. All three are in the 36 above and
+    are claimed today only for closure members; the descriptor emission
+    spells all three per declaration, so widening one of them would leave
+    two open.
+  - **The unit-level TABLE-RUNTIME names**, claimed in every unit rather
+    than only in a unit that declares a table: the descriptor primitives
+    `TableTypeInfo` and `TableFieldInfo` at their head, and beside them the
+    rest of the one registry the checker and the emitters share —
+    `TableKeyed` (an enum-keyed array's storage, and a keyed array occurs in
+    a `type` body: this document's own `ScoreBoard` declares one),
+    `TableRef`, `TableReport`, `TableWriter`, `TableReader`, `TableEnumId`,
+    `TableEnumValue` and the rest of that list. §8.2 has a table-free unit's
+    view file DEFINING those primitives, so a unit that declares no table
+    can no longer be allowed to declare their names.
 
   **The view's own unit-scope spellings are refused as declaration names in
   every unit, always** (§8.3): `UnitView`, `UnitViewInfo`, `ViewType`,
   `ViewVocabulary`, `ViewVariant` and `ViewConstant`. They belong to the
   unit rather than to a declaration, so they are claimed once at unit scope,
-  as `ProtocolId` is (SPEC §6.1), and on the same
-  it-must-not-depend-on-a-flag terms as `TableType` above.
+  as `ProtocolId` is (SPEC §6.1), on the same terms as everything above.
+
+  **A schema file whose generated name would be the view file's is refused**
+  (§8.5): a file named `<capitalize(package)>View.schema` — `TabledemoView`
+  in `package tabledemo` — emits `TabledemoView.h` from two sources at once.
+  It is a file-name collision rather than a declaration collision, so it is
+  refused naming the FILE, and it is stated here because the view is what
+  introduces a generated name that is not derived from a schema file's own.
 
   **A FIXED TABLE claims two more per out-of-line array, because its
   row accessors are named after its fields.** `<Table>` followed by the
@@ -2844,6 +2966,39 @@ Owner rulings, 2026-09-02, in the order given.
   was buying. §2.7 declares nothing at all now, and §14's decision below
   records what the marker cost.
 
+### 13.7 The view, ruled
+
+Owner rulings, 2026-09-02, in the order given.
+
+- **The question that opened it, and both halves are yes**: "We should
+  revisit the 'view' concept. Does a type have a view generated for it,
+  alongside it, and a table has the view built in?" A table's descriptors
+  are built in (§8.1); a type's view is generated alongside it when asked
+  (§8.2). That is the section's whole shape.
+- **What has to be walkable, beyond fields**: "I would find it valuable to
+  be able to walk enums, constants at runtime via some reflection." Constants
+  had no runtime surface at all before §8.3, and enums had one only through
+  the field that named them.
+- **Per enum, and then the sets**: "I would find it valuable to be able to
+  walk per-enum the set of values and names." / "I would find it valuable to
+  be able to walk the set of types." / "And the set of tables." The registry
+  is those three sentences: a vocabulary's values and names in order, the set
+  of types, the set of tables (§8.3).
+- **Down into each, and the qualification that decided the design**: "And
+  then be able to walk each table set of properties." / "And be able to walk
+  types and properties too!" / **"(but with a view on that type?)"** — which
+  is why a type's view is the SAME descriptor surface a table carries rather
+  than a second vocabulary (§8.2, §14).
+- **The acceptance test, in his own framing**: "Let's imagine you were an
+  editor and you wanted to just be able to inspect everything that was in
+  the schema built." §8.7's gate is that sentence made mechanical — a
+  program that knows only the unit, reaching every declaration and every
+  property of each.
+- **And what it is for**: "Walk it and display it somehow."
+- **The placement, granted rather than argued for**: "This can be *on the
+  side* if you want." §8.5 takes the grant literally — one file per unit
+  that an editor links and a game build never compiles.
+
 ## 14. Design notes: the models weighed
 
 Recorded because the rejected options are the useful part.
@@ -3271,8 +3426,23 @@ pre-empted here.
 - **A view over the PACKET wire's own layout** — bit offsets, field widths
   and the compressed-float parameters a `type` rides under (SPEC §6.1),
   beside the declaration facts §8 carries. It is what a packet inspector
-  would want and what a table-shaped descriptor cannot express; the
-  no-table-wire-kind fields of §8.2 are exactly the ones it would fill in.
+  would want and what a table-shaped descriptor cannot express.
+- **THE TYPED DESCRIPTOR FORM for the kind-0 set** (§8.2), which is what
+  would turn describing a `fixed`, `ufixed` or 128-bit field into reading
+  and writing one. Three things it needs, and none is decided here: the
+  numeric SHAPE as columns rather than as text — signedness, `I`, `F` and
+  the storage width, so a walker decodes the bytes without parsing
+  `type_name`; BOUNDS that survive the value — the range columns are
+  `double`s, and a 128-bit bound is not representable in one, so the pair
+  either widens or grows a second form; and a decision about whether the
+  same columns serve the packet wire's own kinds, which is the follow-on
+  above. Until it lands, §8.2's rule stands as written: kind 0 describes,
+  and does not decode.
+- **BUILD IDENTITY in the registry** (§8.6). It carries the unit's package
+  and protocol id and nothing else about the build that produced it; what
+  else identifies a build — a compiler version, a build stamp — is settled
+  where build versioning is settled, and the registry gains a column then
+  rather than inventing one first.
 - Keyed lookup conveniences over loaded collections (library-side, never
   stored semantics).
 - Arrays of unions in table bodies.

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -107,20 +107,17 @@ cannot hold the gate it exists for (§12.1).
 **The VIEW's type half and unit registry (§8.2–§8.7) are specified and
 unimplemented.** What ships today is §8.1: a table's descriptors, built in,
 and the same descriptors for every type a table reaches. No backend emits a
-view file yet, so a declaration carrying `| view` and a request for
-`--views all` are refused by name with §8 cited, never accepted and ignored;
-the default over a unit that marks nothing asks for no view file and is
-unaffected. C++ and C# take it together, because the gate it exists for is
-one listing both backends reproduce.
+view file yet; a backend that does not emit one simply does not have it,
+because nothing in a schema requests it and no flag selects it (§8.4). C++
+and C# take it together, because the gate it exists for is one listing both
+backends reproduce, and the remaining backends are a named follow-on (§15).
 
-**Two front-end changes come BEFORE any emitter, and the refusal above is
-one of them.** `view` is reserved out of the type-tag namespace (SPEC §4.2,
-§4.11) — until it is, `| view` parses as a TAG named `view` and is carried
-through inertly, which is accepted-and-ignored wearing the marker's clothes.
-And the generated table runtime's names are claimed in every unit rather
-than only in a unit that declares a table (§11), because the view file
-defines them in units that declare none. Neither waits for a view file to
-exist; both are what makes the refusal above true rather than aspirational.
+**One front-end change comes BEFORE any emitter.** The generated table
+runtime's names are claimed in every unit rather than only in a unit that
+declares a table (§11), because the view file defines them in units that
+declare none. It does not wait for a view file to exist: a name a unit may
+legally declare today must not become a collision the day its view is
+emitted.
 
 ## 1. Purpose
 
@@ -1790,19 +1787,19 @@ single-threaded `Lock` (§6.2), which is exactly the shape that lost.
 **One vocabulary, one walker, three things it describes.** A TABLE carries
 its descriptors BUILT IN, always — they are what the table runtime, the text
 form (§16) and the block form's read side (§19.2) are written against. A
-TYPE gets the SAME descriptors generated ALONGSIDE it when something asks:
-a `| view` marker on the declaration (§8.2), or a table reaching it. And a
-UNIT gets a REGISTRY (§8.3) — one entry point listing every declaration in
-the build, so a tool that knows the unit and nothing else enumerates the
-types, the tables, the enums, the flags, the unions and the constants, and
-walks each one's properties with no schema files on hand.
+TYPE gets the SAME descriptors generated ALONGSIDE it, for every type, in
+every unit (§8.2). And a UNIT gets a REGISTRY (§8.3) — one entry point
+listing every declaration in the build, so a tool that knows the unit and
+nothing else enumerates the types, the tables, the enums, the flags, the
+unions and the constants, and walks each one's properties with no schema
+files on hand.
 
-The registry and the type views are emitted ON THE SIDE (§8.5): one
-generated file per unit that an editor or a debug build links and a game
-build never compiles. Which of them exists is decided by WHO ASKS (§8.4) —
-a build flag and a declaration marker, never a change to what a table
-carries. Nothing here rides a wire: `| view` moves no protocol id, no
-generated wire byte and no baseline row (§10, §18).
+**Nothing selects any of it.** There is no attribute, no generate flag and
+no mode: the registry and the type views are emitted ON THE SIDE (§8.5) —
+one generated file per unit, carrying everything — and what a build pays is
+decided by whether it COMPILES that file (§8.4). An editor does; a game
+build never includes it. Nothing here rides a wire either: the view moves no
+protocol id, no generated wire byte and no baseline row (§10, §18).
 
 ### 8.1 The descriptors
 
@@ -1917,25 +1914,23 @@ mutable state anywhere on the surface. This is the surface
 editors and tools build on — walk properties by name, print a value, diff
 two, bind a property grid — with no RTTI and no schema files at runtime.
 
-### 8.2 The type view: `| view`, and what a table reaches
+### 8.2 The type view: every type, on the side
 
-**A type has a view when something asks for one**, and there are three
-askers: the declaration itself, marked `| view` (SPEC §4.2); a TABLE that
-reaches it, as today — a walk must be able to enter a nested type, so every
-type in a table's closure has had a view all along; and the build, asking
-for every declaration at once (§8.4). A type no asker names has no
-descriptor emitted, is absent from the registry, and costs nothing. The
-packet-only path is unchanged by this section.
+**Every type in the unit has a view, and nothing declares it.** A `type` a
+table reaches has carried these descriptors all along — a walk must be able
+to enter a nested type — and a `type` no table reaches now carries them too,
+in the view file rather than beside the table runtime (§8.5). There is no
+marker: an editor that must inspect everything in the build cannot be served
+by a set someone remembered to mark, and a set that is complete needs no
+spelling to select it. The cost question the marker would have answered is
+answered by placement instead (§8.4), and answered better, because a game
+build then pays nothing for a type a tools build views.
 
-**`| view` is CLOSURE-TRANSITIVE, on the reason a table's reach already
-is.** A marked type's by-value closure is viewed with it: every type it
-nests, every element of an array it declares, every arm's payload of a union
-it names. The rule is the one §2.2 derives a table's closure with, and the
-reason is the sentence above — a walk that enters a nested type needs that
-type's descriptor, so a view whose nested column is NULL one level down is
-not a view of that type, it is a view of its first level. `types` therefore
-lists a marked type AND its closure, and a walker that recurses through the
-nested column never meets a NULL it cannot explain.
+That also settles the questions a partial rule would have raised and this
+one does not: nothing is closure-transitive, because there is no subset for
+a closure to be taken of; a union arm's payload always has a descriptor; and
+a walker recursing through the nested column never meets a NULL where a
+declared type stands.
 
 **The view IS §8.1's surface.** `<Name>TableType()` returns the same
 `TableTypeInfo`, with the same columns, filled by the same rules. There is
@@ -1945,9 +1940,9 @@ table. That is the whole of the answer to "a view on that type" — the view
 of a type is the descriptor surface a table carries, generated for a
 declaration that carries no table wire.
 
-**A view describes; it does not add a wire.** A viewed type gains no codec,
-no `Measure`/`Save`/`Load`, no text form and no baseline row. `| view` says
-what may be inspected, and nothing about what may be written.
+**A view describes; it does not add a wire.** A type gains no codec, no
+`Measure`/`Save`/`Load`, no text form and no baseline row from having one.
+The view says what may be inspected, and nothing about what may be written.
 
 **A field with no table-wire kind is DESCRIBED, never refused.** The
 no-table-wire-kind set is `fixed`, `ufixed` AND the 128-bit family
@@ -1956,9 +1951,9 @@ no-table-wire-kind set is `fixed`, `ufixed` AND the 128-bit family
 over such a type describes them: `kind` is `0`, the reserved value no
 declared kind spells; `type_name` carries the declared spelling
 (`fixed(2, 30)`, `uint128`); and `offset` and `elem_size` locate the storage.
-A build that asks for a view over a whole unit never fails because a
-declaration is packet-only — the corpus's fixed-point and 128-bit unit is 27
-such fields, and the view over it is a listing, not a refusal.
+A unit generates its view whatever it declares, so a packet-only declaration
+is a listing rather than a refusal — the corpus's fixed-point and 128-bit
+unit is 27 such fields.
 
 **The kind function must be corrected before it can answer that, and the
 correction belongs with the view.** The rule that fills the kind column
@@ -1990,16 +1985,16 @@ identity**: its `id` column is `0` and its `json` column is NULL. Those two
 columns describe the table wire, and such a type has none — its field ids
 were never checked for collisions (§5's refusal is scoped to the closure, as
 §16.4's key refusal is), so filling them would hand a tool two fields under
-one id and a text-form key for a text form that does not exist. A viewed
-type inside a closure carries both as it always did.
+one id and a text-form key for a text form that does not exist. A type
+inside a closure carries both as it always did.
 
 **The vocabulary keeps its `Table` spellings** — `TableFieldInfo`,
 `TableTypeInfo`, `<Name>TableType()` — in a unit that declares no table at
-all. They are one surface, and renaming them for the view would fork the
-walker every tool is already written against. A unit whose view exists
-without tables carries the descriptor primitives in the view file behind the
-same include guard the table headers use, so a unit that has both carries
-one definition of them.
+all — and every unit now has a view, so every unit spells them. They are one
+surface, and renaming them for the view would fork the walker every tool is
+already written against. A table-free unit carries the descriptor primitives
+in its view file behind the same include guard the table headers use, so a
+unit that has both carries one definition of them.
 
 ### 8.3 The unit registry
 
@@ -2066,11 +2061,10 @@ const UnitViewInfo * UnitView();
 
 - **TYPES and TABLES are two sets, walked separately**, because they are two
   wires and a tool acts differently on each: a table can be loaded from a
-  file, a type cannot. `types` holds exactly the types with a view (§8.2) —
-  the marked ones and their closures, the ones tables reach, or every type
-  in the unit under `--views all`; `tables` holds every table in the unit,
-  always, because a table's view is built in. Each entry's `type` is the
-  descriptor §8.1 already specifies —
+  file, a type cannot. `types` holds every `type` the unit declares and
+  `tables` every `table` — both complete, because completeness is what an
+  editor inspecting a build needs and nothing selects a subset (§8.2). Each
+  entry's `type` is the descriptor §8.1 already specifies —
   the properties, their kinds, their bounds and their nested descriptors —
   so walking a declaration's properties is one dereference from the
   registry.
@@ -2083,11 +2077,10 @@ const UnitViewInfo * UnitView();
   mask's variants ride by position and have no per-variant wire id (§4) —
   the same rule §8.1's columns state, in data rather than in functions.
 - **A UNION lists tag 0, the empty arm, then its arms in declared order**
-  (SPEC §4.8), each with its payload type's NAME always and that payload's
-  descriptor where the payload has a view. Under a build that views
-  everything the descriptor is always there; under a narrower one a NULL
-  descriptor beside a named payload says "declared, not viewed here", and
-  the arm's name, tag and id stay walkable.
+  (SPEC §4.8), each with its payload type's name and that payload's own
+  descriptor. The descriptor is never NULL for a declared payload: every
+  type in the unit has a view (§8.2), so an arm is walkable to its bottom.
+  Tag 0 carries no payload and says so with both columns NULL.
 - **A CONSTANT carries its name, its declared storage and its folded
   value** — the one declaration kind with no runtime surface of its own
   before this section. An implicitly typed constant reports the storage it
@@ -2114,49 +2107,29 @@ const UnitViewInfo * UnitView();
   declaration in the unit — the same reason the C# field descriptor reaches
   its nested table through one. The entry point is `Schema.UnitView()`.
 
-### 8.4 Who asks: `--views`
+### 8.4 What it costs: the include rule
 
-**Zero cost is resolved by who asks, not by what is declared.** The same
-declarations serve an editor and a game; the generate request decides what
-the build pays for:
+**Nothing selects the view, so nothing has to decide what a build deserves.**
+The file is emitted for every unit and carries every declaration; what a
+build pays is what it COMPILES. A tool that walks declarations includes the
+header and compiles the source. A game includes neither, and its binary
+carries not one descriptor the type wire did not already need — which is a
+stronger answer than a flag, because it is per CONSUMER rather than per
+generate: one unit's output serves the editor and the game at once, with no
+second generate and no second tree to keep in step.
 
-- **`--views declared`** — the default. A type marked `| view` gets one,
-  with its closure (§8.2); a table's descriptors are built in as they always
-  were; and a unit in which nothing is marked emits no view file at all.
-  This is today's behaviour for every unit that adds no marker. **The
-  default honors the marker rather than ignoring it**, and that is the
-  reason it is the default: a marker that did nothing until a flag was
-  passed would be an attribute accepted and inert, which this document
-  refuses for `| stride` in the same words — an inert attribute is a lie
-  about the declaration.
-- **`--views all`** — every declaration in the unit gets a view: every type,
-  and therefore a registry that reaches everything. An editor or a debug
-  build asks for this, and it is the mode §8.7's gate is held in.
-- **`--views none`** — no view file, whatever the declarations say. A game
-  build asks for this and pays nothing for markers a tools build wanted.
+That is the same trade §13.5 already made for the text form's walker, and it
+is why this file exists rather than a header addition (§8.5): a translation
+unit nobody compiles costs a build nothing, while a header everybody
+includes costs every one of them.
 
-`--views` is a generate option (SPEC §6.1), carried on the request rather
-than in the schema, so a marked declaration never forces cost on a build
-that did not ask.
-
-**Every backend KNOWS the key: it honors the request or refuses it, and no
-backend ignores it.** A generator ignores option keys it does not know —
-which is why `views` may not be left unknown to the backends that emit no
-view file: silence there would hand a build that asked for a registry a
-tree without one and say nothing. So a target with no view emitter refuses
-any request that would need one, by name, with this section cited (§11),
-and never emits a unit with the registry missing — the same shape every
-unimplemented surface here takes.
-
-**The zero-cost gate holds, and is stated as a gate** (§2.2): a unit that
-asks for nothing emits NO view file — not an empty one — and not one
-REGISTRY symbol anywhere else in its generated output. The registry's
-symbols are the six §8.3 names — `UnitView`, `UnitViewInfo`, `ViewType`,
-`ViewVocabulary`, `ViewVariant`, `ViewConstant` — and nothing else: the
-descriptor vocabulary a table carries is §8.1's and rides in every table
-unit whatever `--views` says, so the gate asks "did the registry leak in?",
-never "is there a descriptor here?" — the distinction §2.2 already draws
-between machinery and columns.
+**The gate, in §2.2's shape**: not one REGISTRY symbol appears in any
+generated file except the view pair. The registry's symbols are the six
+§8.3 names — `UnitView`, `UnitViewInfo`, `ViewType`, `ViewVocabulary`,
+`ViewVariant`, `ViewConstant` — and nothing else, because the descriptor
+vocabulary a table carries is §8.1's and rides where it always did. The gate
+asks "did the registry leak out of its file?", never "is there a descriptor
+here?" — §2.2's own distinction between machinery and columns.
 
 ### 8.5 On the side
 
@@ -2177,7 +2150,7 @@ per-schema-file name does not.
 
 - **The header declares, the translation unit holds the data.** The header
   declares `UnitView()`, the registry's structs and the `<Name>TableType()`
-  of every type the view adds; the `.cpp` holds the definitions. That is
+  of every type outside the table closure; the `.cpp` holds the definitions. That is
   §13.5's ruling applied where it applies again —
   an editor compiles one translation unit, and an including translation unit
   carries no descriptor table it does not use.
@@ -2237,19 +2210,18 @@ every property, recursing through each property's nested descriptor. If it
 cannot reach a declaration or a property of one, the view is incomplete and
 the gate says so.
 
-**The corpus gate makes that mechanical.** For every unit in the corpus,
-generated under `--views all`, the listing the generated program prints is
-byte-identical to the listing the compiler produces from its own IR. The
-compiler's listing is the PIN — the IR is what was declared — and each
-backend's program byte-compares against it FOR THE UNITS THAT BACKEND
-ACCEPTS, so two backends that both carry a unit produce one view of it the
-way they produce one wire (§16's goldens, applied to reflection). The scope
-is per backend because acceptance already is: C# refuses a pointered unit by
-name (§11), and a gate cannot ask a backend for a listing of a unit it
-declines to emit at all. Completeness
-is the count the pin carries: every declaration, every field of every viewed
-type, every variant of every enum, flags and union, and every constant, in
-the schema's own order. How the compiler produces its half is the
+**The corpus gate makes that mechanical.** For every unit in the corpus the
+listing the generated program prints is byte-identical to the listing the
+compiler produces from its own IR. The compiler's listing is the PIN — the
+IR is what was declared — and each backend's program byte-compares against
+it FOR THE UNITS THAT BACKEND ACCEPTS, so two backends that both carry a
+unit produce one view of it the way they produce one wire (§16's goldens,
+applied to reflection). The scope is per backend because acceptance already
+is: C# refuses a pointered unit by name (§11), and a gate cannot ask a
+backend for a listing of a unit it declines to emit at all. Completeness is
+the count the pin carries: every declaration, every field of every type,
+every variant of every enum, flags and union, and every constant, in the
+schema's own order. How the compiler produces its half is the
 implementation's business — a test that walks the checked unit is enough,
 and nothing in this section asks for a new command.
 
@@ -2257,21 +2229,14 @@ and nothing in this section asks for a new command.
 property, one variant or one constant from an emitter's registry turns the
 corpus gate red, and that is established by doing it rather than assumed.
 
-**The zero-cost gate** (§8.4) is held the way §2.2's is: a unit generated
-with `--views none`, and a unit with no marker under the default, emit no
-view file and not one of the six registry symbols anywhere else, and the
-build fails if one appears.
-
-**The INDEPENDENCE gate, which is the one the whole section rests on.**
-Zero-cost says a build that asks for nothing gets nothing; independence says
-a build that asks for EVERYTHING moves nothing else. Every corpus unit is
-generated three times — `--views none`, `--views declared`, `--views all` —
-into three trees, and: every file other than `<Package>View.*` is
-byte-identical across all three; `schema id` reports the same protocol id
-for all three; and no `<Package>View.*` exists in the `none` tree. That is
-what proves a view costs the type wire's generated code not one byte, which
-§10's independence claims for a table edit and this section claims for a
-reflection request.
+**The INDEPENDENCE gate, and it is what the whole section rests on.** The
+view adds a file and moves nothing else: for every corpus unit, every
+generated file other than `<Package>View.*` is byte-identical to what the
+same unit emitted before the view existed, and `schema id` reports the same
+protocol id. That is what proves reflection costs the type wire's generated
+code not one byte — §10's independence, claimed for a table edit, holding
+for a view. Beside it, the containment gate of §8.4: not one of the six
+registry symbols appears in any generated file but the view pair.
 
 ## 9. Relocatable, and built wide
 
@@ -2401,25 +2366,12 @@ lockstep redeploy by a table edit. This independence is held by test.
   payload. Its BY-VALUE form is an ordinary fixed table and behaves like one
   everywhere; only its block form requires a base, exactly as a cooked file's
   does.
-- **The view** (§8), each refusal naming the declaration at fault:
-  - **`| view` on a `table`** — a table's view is built in (§8.1), and an
-    attribute that changes nothing is a lie about the declaration, exactly
-    as `| stride` is;
-  - **`| view` on an `enum`, `flags`, `union` or `const` declaration** — the
-    registry catalogues every one of them whenever it exists (§8.3): they
-    are unit-level vocabulary, they cost names and values, and a build that
-    could see only some of them would be useless to the editor §8.7's gate
-    describes. There is nothing for a marker to select;
-  - **`| view` on a FIELD** — it qualifies a declaration, not a member; a
-    type is viewed whole or not at all;
-  - **`| view`, or a `--views` request, under a backend that carries no view
-    emitter** — refused with §8 cited and never emitted with the registry
-    missing. Every backend knows the key: it honors the request or refuses
-    it, and none ignores it (§8.4, SPEC §6.1);
-  - **a type TAG spelled `view`** — the marker owns the spelling, so the tag
-    namespace loses it (SPEC §4.2, §4.11). It is a language change, and the
-    one this section's refusal above rests on: without it `| view` parses as
-    an inert tag rather than reaching any refusal at all.
+- **The view** (§8) refuses nothing a schema can write, and that is a
+  property of it rather than an omission: no attribute selects it, no flag
+  configures it and no declaration can ask for it wrongly, so there is no
+  spelling left to refuse. What the view does add to this section is the two
+  name claims below — which are refusals of a NAME, not of a construct — and
+  one file-name collision, and nothing else.
 - **A `table` union arm outside a table closure** (§2.6) — a union declared
   for the type wire takes `type` payloads only, because types are value
   semantics.
@@ -2482,12 +2434,12 @@ lockstep redeploy by a table edit. This independence is held by test.
   fixed table has a block form (§2.7), so every fixed table claims them.
 
   **THE DESCRIPTOR SURFACE'S CLAIMS ARE UNCONDITIONAL — every declaration,
-  every unit, tables or not.** A generate flag may not change what the
-  language accepts: a name legal without views and colliding with them would
-  make `--views all` turn a legal unit's generated code into code that does
-  not compile, which is precisely the defect the claim exists to prevent.
-  Two sets follow from it, and both are FRONT-END LAW rather than one
-  target's inventory:
+  every unit, tables or not.** Every unit emits a view file and that file
+  defines the descriptor surface (§8.2), so a name a table-free unit may
+  declare today would collide with its own generated code the day its view
+  is emitted — a legal schema whose generated code does not compile, which
+  is the one defect this whole list exists to prevent. Two sets follow, and
+  both are FRONT-END LAW rather than one target's inventory:
 
   - **The three per-declaration spellings the descriptors emit** —
     `<Name>TableFields`, `<Name>TableInfo` and `<Name>TableType` — claimed
@@ -2998,6 +2950,13 @@ Owner rulings, 2026-09-02, in the order given.
 - **The placement, granted rather than argued for**: "This can be *on the
   side* if you want." §8.5 takes the grant literally — one file per unit
   that an editor links and a game build never compiles.
+- **And then the subtraction, which is the ruling that shaped the rest.**
+  The marker and the generate flag are gone: the view file carries
+  everything, for every unit, always, and a consumer pays by compiling it.
+  The grant above is what makes that free, and completeness is what the
+  editor sentence above asks for — so the attribute, the three-valued flag,
+  the reserved word they needed, and every refusal they brought with them
+  went out together (§8.4, §14).
 
 ## 14. Design notes: the models weighed
 
@@ -3281,8 +3240,7 @@ have added one are priced here.
   row and refusing one (§19.4).
 
 **The view's shape** (§8). Four models were weighed against the owner's
-picture of it — an editor that inspects everything in the schema built,
-paid for by whoever asks:
+picture of it — an editor that inspects everything in the schema built:
 
 1. **A SECOND descriptor vocabulary for types — REJECTED.** A `type` is not
    a table, so a type-shaped `TypeFieldInfo` beside `TableFieldInfo` looked
@@ -3290,29 +3248,35 @@ paid for by whoever asks:
    printer, differ and property grid written twice — and the JSON walker
    (§16) and the block form's reflective read (§19.2) are already written
    against the first one. One surface, filled by the same rules, is what
-   makes a viewed type walkable by code that was never told about views.
-2. **Views always on — REJECTED.** It is the simplest rule and it breaks
-   §2.2's gate at the level above tables: a packet-only unit would carry a
-   descriptor table per declaration, in every game build, for a surface no
-   game build calls. The flag exists so the gate survives contact with a
-   feature whose whole point is completeness.
+   makes a type walkable by code that was never told about views.
+2. **A MARKER on the declaration plus a generate flag to select what is
+   viewed — REJECTED, and this is the subtraction the design turns on.** It
+   was the shape this section was first written in: `| view` on a type, a
+   three-valued `--views`, a closure rule for what a marker reaches, a
+   refusal for each declaration kind the marker does not fit, a reserved
+   word taken out of the type-tag namespace to make the marker parse, and a
+   gate proving the flag moved nothing. All of it existed to answer one
+   question — what does this build pay for — that placement answers by
+   itself (§8.4): the file is on the side, a consumer that does not compile
+   it pays nothing, and a consumer that does wants everything anyway. Every
+   one of those constructs went with the question.
 3. **A view file per SCHEMA FILE — REJECTED.** It mirrors §6.1's
    one-file-per-schema-file layout and leaves the registry homeless: the
    registry is the set of everything the UNIT declares, so it would either
    live in one arbitrarily chosen file's output or force each file's view to
    reach into the others and back — the cross-file cycle §11 refuses. A
    unit-level fact gets a unit-level file.
-4. **A unit-level registry in one on-the-side file, opt-in — THE DESIGN OF
-   RECORD.** One `UnitView()` over constant data, the type views beside it,
-   `<Name>TableType()` unchanged for anything a table already reached, and a
-   file an editor links and a game never compiles.
+4. **One unit-level file carrying everything, always — THE DESIGN OF
+   RECORD.** One `UnitView()` over constant data, every declaration's view
+   beside it, `<Name>TableType()` unchanged for anything a table already
+   reached, and a file an editor links and a game never compiles.
 
-**Why the marker sits on types and nowhere else.** Enums, flags, unions and
-constants are catalogued unconditionally wherever a registry exists, because
-what they cost is names and values — while a TYPE costs a descriptor table
-per declaration, which is the cost worth a marker. The asymmetry is the
-price list, not a taste, and §11 refuses `| view` on the free kinds rather
-than accepting an attribute that would select nothing.
+**Completeness is what an editor needs, and a subset is what a marker
+sells.** A tool that inspects a build cannot be served by the declarations
+someone remembered to mark — the one it needs is the one nobody marked. So
+the registry is complete by construction, and the price of completeness is
+paid where it is cheap: in a translation unit a build either compiles or
+does not.
 
 **No decision here knowingly costs TIME.** The `u64` type id and the
 repeating node-table field cost BYTES and nothing else — the record scan
@@ -3417,8 +3381,10 @@ pre-empted here.
   instance-level walk of §8.1 underneath it. The listing §8.7's gate already
   produces is the dump half of it in embryo.
 - **The view in a ported backend** — C++ and C# carry it; every other
-  backend refuses a `--views` request by name (§11) until it emits the same
-  registry against the same pin (§8.7).
+  backend emits no view file until it emits the same registry against the
+  same pin (§8.7). Nothing is refused meanwhile, because nothing in a schema
+  asks for one (§8.4): a backend without the emitter is a backend whose
+  users have no registry, and the status paragraph says so.
 - **DOC STRINGS in the view.** Doc comments are deferred with their design
   pinned (SPEC §4.1, §9 q5); when they land they become one more descriptor
   column and one more registry column, and nothing else about §8 moves. No

--- a/SPEC.md
+++ b/SPEC.md
@@ -284,7 +284,7 @@ Enum        = "enum" ident ( VariantList
             | AttrSection NL VariantList ) NL .
 VariantList = "{" [ ident { "," ident } [ "," ] ] "}" .            // commas; trailing comma OK
 TypeDecl    = "type" ident ( Block
-            | AttrSection NL Block ) NL .               // qualifiers = the type TAG, the
+            | AttrSection NL Block ) NL .               // qualifiers = the type TAG and the
                                                         // cpp_* pair, §4.2
 TableDecl   = "table" ident ( Block
             | AttrSection NL Block ) NL .               // the TABLE wire, SPEC-TABLES.md —
@@ -542,7 +542,7 @@ sequence    uint16
   vocabulary: integers take `min`/`max` (both together or neither); `float32`
   takes `min`/`max`/`resolution` (all three together — §4.3: this IS the
   compressed float); `fixed`/`ufixed`/`int128` take `min`/`max` (required —
-  §4.3); enum declarations take `max`; type declarations take a tag, the
+  §4.3); enum declarations take `max`; type declarations take a tag and the
   `cpp_native`/`cpp_include` pair (below); a field of a **table** body takes
   `was` (below); and a **table declaration** takes none.
 - **`was = "old_name"` — the rename attribute, table bodies only**

--- a/SPEC.md
+++ b/SPEC.md
@@ -547,7 +547,18 @@ sequence    uint16
   **table** body takes `was` (below); and a **table declaration** takes
   none.
 - **`view` — reflection over a type, type declarations only**
-  (SPEC-TABLES.md §8.2). A valueless marker: `type ShipState | view`. It
+  (SPEC-TABLES.md §8.2). A valueless marker, and **`view` is reserved out of
+  the type-tag namespace to make it one**: a type declaration's qualification
+  section takes bare identifiers as TAGS (below), so without the reservation
+  `| view` would parse as a tag named `view` and be carried into the IR as
+  one — accepted and inert, which is the outcome an attribute may never
+  have. `view` is therefore an ATTRIBUTE everywhere it appears, and a type
+  tagged `view` is refused by name (§4.11). That is a **language change**:
+  a declaration reading `type Camera | view` meant "tagged view" and now
+  means "reflected", and one that meant the tag has no spelling for it any
+  more. It moves no id — tags never enter the wire-shape projection (§3.1),
+  so no unit's `ProtocolId` moves either way. The marker itself:
+  `type ShipState | view`. It
   declares nothing and changes no field, no storage and no wire byte — it
   says the type gets the reflection descriptors a table carries built in, so
   a tool walks its properties by name at runtime with no schema files on
@@ -599,6 +610,13 @@ type Quat | quat4
   and checked. **In v1 a tag is inert**: parsed, carried through the IR,
   emitted as an annotation on the generated type, and it changes zero
   generated code.
+- **The namespace has ONE hole in it, and every valueless attribute a type
+  declaration takes must cut the same one: `view` is not a tag** (§4.11). A
+  bare identifier in a type's qualification section is a tag unless the
+  attribute vocabulary claims it, and a claimed spelling cannot also be a
+  tag — the same identifier cannot be both a marker the compiler acts on and
+  a string it carries through inertly. So the vocabulary's valueless markers
+  are refused as tags by name, `view` being the one that exists.
 - **Meaning arrives by claiming.** A future pass — the delta pass first —
   claims a tag and assigns its semantics and generated actions
   (interpolation, prediction, normalization, render mapping). Claiming is an
@@ -1172,6 +1190,13 @@ NAME rather than falling into a generic parse error:
   of the language; every field of a type is identical on every peer.
 - **`round`** (the attribute) — rounding is not an attribute: it is the one
   fixed-point rule, half away from zero, everywhere (§4.3).
+- **`view` as a TYPE TAG** — `view` is an attribute (§4.2, SPEC-TABLES.md
+  §8.2), so a type tagged `view` is refused naming the declaration rather
+  than carried through the IR as an inert string. A tag and a marker cannot
+  share a spelling: one is acted on and the other is not, and a reader of the
+  line could not tell which they wrote. Tags are excluded from the wire-shape
+  projection (§3.1), so the refusal moves no unit's `ProtocolId` — it costs a
+  rename in a schema that spelled the tag, and nothing on any wire.
 
 The projection (§3.1) keeps FROZEN tokens — `table=false message=false` on
 every type line, `round=nearest` on every compressed-float field line — so
@@ -1336,9 +1361,16 @@ reflection descriptors, and a unit that marks nothing emits no view file),
 debug build asks for), or `--views none` (no view file, whatever the
 declarations say — what a game build asks for). The request is carried as a
 generate option, never in the schema, so the same declarations serve both
-builds and a marker costs a build that did not ask for it nothing. A target
-with no view emitter refuses the request by name rather than ignoring it.
-The surface it emits, and the gates it is held to, are SPEC-TABLES.md §8.
+builds and a marker costs a build that did not ask for it nothing.
+
+**`views` is a key EVERY target knows.** A generator ignores option keys it
+does not know — that is the option contract, and it is exactly why the key
+cannot be left unknown to the seven backends that emit no view: ignoring it
+is silent, and a build that asked for a registry would get none without
+being told. So every target either HONORS `views` or REFUSES it by name,
+and refusing is what a target with no view emitter does for any value but
+`none` and an unmarked `declared`. The surface a target that honors it
+emits, and the gates it is held to, are SPEC-TABLES.md §8.
 
 **Output layout.** Each target emits one generated file per schema file —
 `examples/Constants.schema` → `generated/cpp/Constants.h` — so the generated

--- a/SPEC.md
+++ b/SPEC.md
@@ -285,7 +285,7 @@ Enum        = "enum" ident ( VariantList
 VariantList = "{" [ ident { "," ident } [ "," ] ] "}" .            // commas; trailing comma OK
 TypeDecl    = "type" ident ( Block
             | AttrSection NL Block ) NL .               // qualifiers = the type TAG, the
-                                                        // cpp_* pair and `view`, §4.2
+                                                        // cpp_* pair, §4.2
 TableDecl   = "table" ident ( Block
             | AttrSection NL Block ) NL .               // the TABLE wire, SPEC-TABLES.md —
                                                         // a type body, plus pointers and `was`.
@@ -543,34 +543,8 @@ sequence    uint16
   takes `min`/`max`/`resolution` (all three together — §4.3: this IS the
   compressed float); `fixed`/`ufixed`/`int128` take `min`/`max` (required —
   §4.3); enum declarations take `max`; type declarations take a tag, the
-  `cpp_native`/`cpp_include` pair (below) and `view` (below); a field of a
-  **table** body takes `was` (below); and a **table declaration** takes
-  none.
-- **`view` — reflection over a type, type declarations only**
-  (SPEC-TABLES.md §8.2). A valueless marker, and **`view` is reserved out of
-  the type-tag namespace to make it one**: a type declaration's qualification
-  section takes bare identifiers as TAGS (below), so without the reservation
-  `| view` would parse as a tag named `view` and be carried into the IR as
-  one — accepted and inert, which is the outcome an attribute may never
-  have. `view` is therefore an ATTRIBUTE everywhere it appears, and a type
-  tagged `view` is refused by name (§4.11). That is a **language change**:
-  a declaration reading `type Camera | view` meant "tagged view" and now
-  means "reflected", and one that meant the tag has no spelling for it any
-  more. It moves no id — tags never enter the wire-shape projection (§3.1),
-  so no unit's `ProtocolId` moves either way. The marker itself:
-  `type ShipState | view`. It
-  declares nothing and changes no field, no storage and no wire byte — it
-  says the type gets the reflection descriptors a table carries built in, so
-  a tool walks its properties by name at runtime with no schema files on
-  hand, and it appears in the unit's registry (SPEC-TABLES.md §8.3). A type
-  a TABLE reaches has those descriptors already and needs no marker; a
-  marked type pays only in the build that asks for views (`--views`, §6.1),
-  and a game build that asks for none pays nothing for the marker. Refused
-  on a `table` (its view is built in), on an `enum`, `flags`, `union` or
-  `const` declaration (the registry catalogues those unconditionally), and
-  on a field. **It never enters the wire-shape projection** (§3.1): marking
-  a type moves no `ProtocolId`, exactly as a type tag does not, so the same
-  declarations serve an editor build and a game build.
+  `cpp_native`/`cpp_include` pair (below); a field of a **table** body takes
+  `was` (below); and a **table declaration** takes none.
 - **`was = "old_name"` — the rename attribute, table bodies only**
   (SPEC-TABLES.md §5). A table field's wire id is the hash of its name, so a
   bare rename would orphan every byte ever written under the old one; `was`
@@ -610,13 +584,6 @@ type Quat | quat4
   and checked. **In v1 a tag is inert**: parsed, carried through the IR,
   emitted as an annotation on the generated type, and it changes zero
   generated code.
-- **The namespace has ONE hole in it, and every valueless attribute a type
-  declaration takes must cut the same one: `view` is not a tag** (§4.11). A
-  bare identifier in a type's qualification section is a tag unless the
-  attribute vocabulary claims it, and a claimed spelling cannot also be a
-  tag — the same identifier cannot be both a marker the compiler acts on and
-  a string it carries through inertly. So the vocabulary's valueless markers
-  are refused as tags by name, `view` being the one that exists.
 - **Meaning arrives by claiming.** A future pass — the delta pass first —
   claims a tag and assigns its semantics and generated actions
   (interpolation, prediction, normalization, render mapping). Claiming is an
@@ -1190,13 +1157,6 @@ NAME rather than falling into a generic parse error:
   of the language; every field of a type is identical on every peer.
 - **`round`** (the attribute) — rounding is not an attribute: it is the one
   fixed-point rule, half away from zero, everywhere (§4.3).
-- **`view` as a TYPE TAG** — `view` is an attribute (§4.2, SPEC-TABLES.md
-  §8.2), so a type tagged `view` is refused naming the declaration rather
-  than carried through the IR as an inert string. A tag and a marker cannot
-  share a spelling: one is acted on and the other is not, and a reader of the
-  line could not tell which they wrote. Tags are excluded from the wire-shape
-  projection (§3.1), so the refusal moves no unit's `ProtocolId` — it costs a
-  rename in a schema that spelled the tag, and nothing on any wire.
 
 The projection (§3.1) keeps FROZEN tokens — `table=false message=false` on
 every type line, `round=nearest` on every compressed-float field line — so
@@ -1354,23 +1314,12 @@ size regression.
 correct at any entry offset; the same type works standalone and nested.
 `MaxBits` covers the worst case.
 
-**Reflection is asked for, per generate request: `--views`.** A generate
-takes `--views declared` (the default: a type marked `| view` gets
-reflection descriptors, and a unit that marks nothing emits no view file),
-`--views all` (every declaration in the unit is viewed — what an editor or a
-debug build asks for), or `--views none` (no view file, whatever the
-declarations say — what a game build asks for). The request is carried as a
-generate option, never in the schema, so the same declarations serve both
-builds and a marker costs a build that did not ask for it nothing.
-
-**`views` is a key EVERY target knows.** A generator ignores option keys it
-does not know — that is the option contract, and it is exactly why the key
-cannot be left unknown to the seven backends that emit no view: ignoring it
-is silent, and a build that asked for a registry would get none without
-being told. So every target either HONORS `views` or REFUSES it by name,
-and refusing is what a target with no view emitter does for any value but
-`none` and an unmarked `declared`. The surface a target that honors it
-emits, and the gates it is held to, are SPEC-TABLES.md §8.
+**Reflection is emitted, never requested.** Every unit gets one view file
+carrying the reflection descriptors of every declaration and the registry
+over them; nothing in the schema asks for it and no flag selects it. A
+project that walks declarations compiles that file; a project that does not
+never includes it and pays nothing for it. The surface it carries, and the
+gates it is held to, are SPEC-TABLES.md §8.
 
 **Output layout.** Each target emits one generated file per schema file —
 `examples/Constants.schema` → `generated/cpp/Constants.h` — so the generated
@@ -1396,15 +1345,15 @@ tree mirrors the schema tree a person navigates.
   TABLES emits one further pair — `<Base>Table.h` and `<Base>Table.cpp` —
   because the table wire carries a RUNTIME the type wire has no equivalent
   of (SPEC-TABLES.md §6.1, §13.5); it is a table-side file and adds nothing
-  to a table-free unit. **A unit that asks for VIEWS emits one further pair
-  per UNIT** — `<Package>View.h` and `<Package>View.cpp` — carrying the unit
-  registry and the reflection descriptors of every type the request views
-  (SPEC-TABLES.md §8.3, §8.5). It is per unit rather than per schema file
-  because the registry is the set of everything the unit declares, and it is
-  named for the package because two units may share one output directory
-  (§3.2). It includes the unit's DATA headers and no wire header, so a tool
-  that walks declarations inherits no serialize runtime; and a unit that
-  asks for no views emits no such file at all.
+  to a table-free unit. **Every unit emits one further pair per UNIT** —
+  `<Package>View.h` and `<Package>View.cpp` — carrying the unit registry and
+  the reflection descriptors of every declaration (SPEC-TABLES.md §8.3,
+  §8.5). It is per unit rather than per schema file because the registry is
+  the set of everything the unit declares, and it is named for the package
+  because two units may share one output directory (§3.2). It includes the
+  unit's DATA headers and no wire header, so a tool that walks declarations
+  inherits no serialize runtime — and a project that never walks them never
+  includes the header or compiles the source.
 - **C:** the same data/wire header pair per schema file (`<Base>.h` /
   `<Base>Wire.h`), mirroring the C++ split in C's own types.
 - **Go:** one `.go` file per schema file, all in `package <package>` — Go
@@ -1414,8 +1363,8 @@ tree mirrors the schema tree a person navigates.
   `lib.rs` declaring and glob re-exporting them.
 - **C#:** one `.cs` file per schema file, types at namespace level and every
   function and constant on `public static partial class Schema`, in
-  `namespace <Package>`. A unit that asks for views emits one further file
-  per unit, `<Package>View.cs`, on the same terms as the C++ pair above.
+  `namespace <Package>`. Every unit emits one further file per unit,
+  `<Package>View.cs`, on the same terms as the C++ pair above.
 - **JavaScript:** one ES module per schema file, cross-file `import`s derived
   from actual references; classes whose constructors initialize every member
   in declaration order (specified defaults live in construction; `ZeroX` is

--- a/SPEC.md
+++ b/SPEC.md
@@ -284,8 +284,8 @@ Enum        = "enum" ident ( VariantList
             | AttrSection NL VariantList ) NL .
 VariantList = "{" [ ident { "," ident } [ "," ] ] "}" .            // commas; trailing comma OK
 TypeDecl    = "type" ident ( Block
-            | AttrSection NL Block ) NL .               // qualifiers = the type TAG and the
-                                                        // cpp_* pair, §4.2
+            | AttrSection NL Block ) NL .               // qualifiers = the type TAG, the
+                                                        // cpp_* pair and `view`, §4.2
 TableDecl   = "table" ident ( Block
             | AttrSection NL Block ) NL .               // the TABLE wire, SPEC-TABLES.md —
                                                         // a type body, plus pointers and `was`.
@@ -542,9 +542,24 @@ sequence    uint16
   vocabulary: integers take `min`/`max` (both together or neither); `float32`
   takes `min`/`max`/`resolution` (all three together — §4.3: this IS the
   compressed float); `fixed`/`ufixed`/`int128` take `min`/`max` (required —
-  §4.3); enum declarations take `max`; type declarations take a tag and the
-  `cpp_native`/`cpp_include` pair (below); a field of a **table** body takes
-  `was` (below); and a **table declaration** takes none.
+  §4.3); enum declarations take `max`; type declarations take a tag, the
+  `cpp_native`/`cpp_include` pair (below) and `view` (below); a field of a
+  **table** body takes `was` (below); and a **table declaration** takes
+  none.
+- **`view` — reflection over a type, type declarations only**
+  (SPEC-TABLES.md §8.2). A valueless marker: `type ShipState | view`. It
+  declares nothing and changes no field, no storage and no wire byte — it
+  says the type gets the reflection descriptors a table carries built in, so
+  a tool walks its properties by name at runtime with no schema files on
+  hand, and it appears in the unit's registry (SPEC-TABLES.md §8.3). A type
+  a TABLE reaches has those descriptors already and needs no marker; a
+  marked type pays only in the build that asks for views (`--views`, §6.1),
+  and a game build that asks for none pays nothing for the marker. Refused
+  on a `table` (its view is built in), on an `enum`, `flags`, `union` or
+  `const` declaration (the registry catalogues those unconditionally), and
+  on a field. **It never enters the wire-shape projection** (§3.1): marking
+  a type moves no `ProtocolId`, exactly as a type tag does not, so the same
+  declarations serve an editor build and a game build.
 - **`was = "old_name"` — the rename attribute, table bodies only**
   (SPEC-TABLES.md §5). A table field's wire id is the hash of its name, so a
   bare rename would orphan every byte ever written under the old one; `was`
@@ -1314,6 +1329,17 @@ size regression.
 correct at any entry offset; the same type works standalone and nested.
 `MaxBits` covers the worst case.
 
+**Reflection is asked for, per generate request: `--views`.** A generate
+takes `--views declared` (the default: a type marked `| view` gets
+reflection descriptors, and a unit that marks nothing emits no view file),
+`--views all` (every declaration in the unit is viewed — what an editor or a
+debug build asks for), or `--views none` (no view file, whatever the
+declarations say — what a game build asks for). The request is carried as a
+generate option, never in the schema, so the same declarations serve both
+builds and a marker costs a build that did not ask for it nothing. A target
+with no view emitter refuses the request by name rather than ignoring it.
+The surface it emits, and the gates it is held to, are SPEC-TABLES.md §8.
+
 **Output layout.** Each target emits one generated file per schema file —
 `examples/Constants.schema` → `generated/cpp/Constants.h` — so the generated
 tree mirrors the schema tree a person navigates.
@@ -1338,7 +1364,15 @@ tree mirrors the schema tree a person navigates.
   TABLES emits one further pair — `<Base>Table.h` and `<Base>Table.cpp` —
   because the table wire carries a RUNTIME the type wire has no equivalent
   of (SPEC-TABLES.md §6.1, §13.5); it is a table-side file and adds nothing
-  to a table-free unit.
+  to a table-free unit. **A unit that asks for VIEWS emits one further pair
+  per UNIT** — `<Package>View.h` and `<Package>View.cpp` — carrying the unit
+  registry and the reflection descriptors of every type the request views
+  (SPEC-TABLES.md §8.3, §8.5). It is per unit rather than per schema file
+  because the registry is the set of everything the unit declares, and it is
+  named for the package because two units may share one output directory
+  (§3.2). It includes the unit's DATA headers and no wire header, so a tool
+  that walks declarations inherits no serialize runtime; and a unit that
+  asks for no views emits no such file at all.
 - **C:** the same data/wire header pair per schema file (`<Base>.h` /
   `<Base>Wire.h`), mirroring the C++ split in C's own types.
 - **Go:** one `.go` file per schema file, all in `package <package>` — Go
@@ -1348,7 +1382,8 @@ tree mirrors the schema tree a person navigates.
   `lib.rs` declaring and glob re-exporting them.
 - **C#:** one `.cs` file per schema file, types at namespace level and every
   function and constant on `public static partial class Schema`, in
-  `namespace <Package>`.
+  `namespace <Package>`. A unit that asks for views emits one further file
+  per unit, `<Package>View.cs`, on the same terms as the C++ pair above.
 - **JavaScript:** one ES module per schema file, cross-file `import`s derived
   from actual references; classes whose constructors initialize every member
   in declaration order (specified defaults live in construction; `ZeroX` is

--- a/USAGE.md
+++ b/USAGE.md
@@ -1329,6 +1329,86 @@ a unit that declares them, by name. What stays off the table wire: `fixed`,
 no wire ceiling: string and bytes byte lengths and array counts ride in
 uint32, so the only limit is the language's own int32 storage cap.
 
+### Inspecting a whole build: the view
+
+The descriptors above answer "what is in this table". The **view** answers
+"what is in this build" — every declaration the schema made, walkable by a
+tool that has the generated code and no schema files at all. Ask for it at
+generate time:
+
+```
+schema generate --lang cpp --views all --out generated tables/examples
+```
+
+That adds one file to the unit — `TabledemoView.h` and `TabledemoView.cpp`,
+named for the unit's package, one pair for the whole unit — holding a
+registry of everything the schema declared. An
+editor or a debug build compiles it; a game build generates with the default
+(or `--views none`) and never sees it. Marking one type instead of the whole
+unit is `| view` on the declaration:
+
+```
+type ShipState | view
+{
+    position Vec3
+    health   int16 | min = 0, max = 1000
+}
+```
+
+A type a TABLE reaches needs no marker — it has had descriptors all along.
+
+```cpp
+#include "TabledemoView.h"
+
+const UnitViewInfo * unit = UnitView();
+printf( "package %s  protocol 0x%016llx\n",
+        unit->package, (unsigned long long) unit->protocol_id );
+
+for ( int32_t i = 0; i < unit->num_constants; i++ )
+{
+    const ViewConstant & c = unit->constants[i];
+    if ( c.is_float ) printf( "const %s %s = %g\n", c.type_name, c.name, c.float_value );
+    else              printf( "const %s %s = %lld\n", c.type_name, c.name, (long long) c.int_value );
+}
+
+for ( int32_t i = 0; i < unit->num_enums; i++ )    // flags and unions walk the same way
+{
+    const ViewVocabulary & e = unit->enums[i];
+    printf( "enum %s (max %lld)\n", e.name, (long long) e.max );
+    for ( int32_t v = 0; v < e.num_variants; v++ ) // row 0 is None, then declared order
+        printf( "    %llu %s  id 0x%04x\n",
+                (unsigned long long) e.variants[v].value, e.variants[v].name, e.variants[v].id );
+}
+
+for ( int32_t i = 0; i < unit->num_tables; i++ )   // then unit->types, the same shape
+{
+    const ViewType & entry = unit->tables[i];
+    printf( "table %s  (%s)\n", entry.name, entry.file );
+    const TableTypeInfo * type = entry.type;
+    for ( int32_t f = 0; f < type->num_fields; f++ )
+    {
+        const TableFieldInfo & field = type->fields[f];
+        printf( "    %s %s", field.type_name, field.name );
+        if ( field.is_array )  printf( "[%d]", field.array_bound );
+        if ( field.optional )  printf( " ?" );
+        if ( field.has_range ) printf( "  [%g, %g]", field.range_min, field.range_max );
+        if ( field.table )     printf( "  -> %s", field.table->name ); // recurse
+        printf( "\n" );
+    }
+}
+```
+
+`unit->tables` is every table in the unit, always. `unit->types` is the
+types with a view — the marked ones, the ones a table reaches, or all of
+them under `--views all`. Every entry points at the same `TableTypeInfo` the
+section above walks, so one printer serves both. C# is the same registry
+through `Schema.UnitView()`.
+
+Constants, enums, flags and unions are listed whenever the view exists — they
+cost names and values, so nothing marks them. What the view does not carry:
+descriptions, UI hints, semantics for a type tag (the tags are listed; their
+meaning is yours), and the packet wire's bit layout.
+
 ### The text form: JSON in and out of one table
 
 The same descriptors drive a JSON text form, so every table reads from and

--- a/USAGE.md
+++ b/USAGE.md
@@ -1331,34 +1331,26 @@ uint32, so the only limit is the language's own int32 storage cap.
 
 ### Inspecting a whole build: the view
 
+*Specified, not yet implemented — no backend emits the view file yet
+(SPEC-TABLES.md §8). The per-table descriptors above are live today.*
+
 The descriptors above answer "what is in this table". The **view** answers
 "what is in this build" — every declaration the schema made, walkable by a
-tool that has the generated code and no schema files at all. Ask for it at
-generate time:
+tool that has the generated code and no schema files at all. Nothing asks
+for it: every unit generates one more pair of files beside the rest,
 
 ```
-schema generate --lang cpp --views all --out generated tables/examples
+generated/TabledemoView.h
+generated/TabledemoView.cpp
 ```
 
-That adds one pair of files to the unit — `TabledemoView.h` and
-`TabledemoView.cpp`, named for the unit's package, one pair for the whole
-unit however many schema files it has — holding a registry of everything the
-schema declared. An editor or a debug build compiles it; a game build
-generates with the default (or `--views none`) and never sees it. Marking one
-type instead of the whole unit is `| view` on the declaration:
-
-```
-type ShipState | view
-{
-    position Vec3
-    health   int16 | min = 0, max = 1000
-}
-```
-
-Marking `ShipState` views `Vec3` too: a marker takes the type's whole
-by-value closure, so the recursion below never dead-ends inside a type you
-marked. A type a TABLE reaches needs no marker — it has had descriptors all
-along.
+named for the unit's package, one pair for the whole unit however many
+schema files it has, holding a registry of every type, table, enum, flags,
+union and constant the schema declared. **You pay for it by compiling it.**
+An editor, an inspector or a debug build includes the header and compiles
+the source; a game does neither and carries none of it. There is no flag and
+no marker on a declaration — a tool that inspects a build wants everything
+in it, and the one declaration it needs is the one nobody would have marked.
 
 ```cpp
 #include "TabledemoView.h"
@@ -1401,16 +1393,13 @@ for ( int32_t i = 0; i < unit->num_tables; i++ )   // then unit->types, the same
 }
 ```
 
-`unit->tables` is every table in the unit, always. `unit->types` is the
-types with a view — the marked ones, the ones a table reaches, or all of
-them under `--views all`. Every entry points at the same `TableTypeInfo` the
+`unit->tables` is every table in the unit and `unit->types` every type —
+both complete, and every entry points at the same `TableTypeInfo` the
 section above walks, so one printer serves both. C# is the same registry
 through `Schema.UnitView()`.
 
-Constants, enums, flags and unions are listed whenever the view exists — they
-cost names and values, so nothing marks them. Each set is ordered by
-declaration name, so a listing does not churn when a file is renamed or a
-declaration moves between files.
+Each set is ordered by declaration name, so a listing does not churn when a
+file is renamed or a declaration moves between files.
 
 What the view does not carry: descriptions, UI hints, semantics for a type
 tag (the tags are listed; their meaning is yours), and the packet wire's bit

--- a/USAGE.md
+++ b/USAGE.md
@@ -1340,12 +1340,12 @@ generate time:
 schema generate --lang cpp --views all --out generated tables/examples
 ```
 
-That adds one file to the unit — `TabledemoView.h` and `TabledemoView.cpp`,
-named for the unit's package, one pair for the whole unit — holding a
-registry of everything the schema declared. An
-editor or a debug build compiles it; a game build generates with the default
-(or `--views none`) and never sees it. Marking one type instead of the whole
-unit is `| view` on the declaration:
+That adds one pair of files to the unit — `TabledemoView.h` and
+`TabledemoView.cpp`, named for the unit's package, one pair for the whole
+unit however many schema files it has — holding a registry of everything the
+schema declared. An editor or a debug build compiles it; a game build
+generates with the default (or `--views none`) and never sees it. Marking one
+type instead of the whole unit is `| view` on the declaration:
 
 ```
 type ShipState | view
@@ -1355,7 +1355,10 @@ type ShipState | view
 }
 ```
 
-A type a TABLE reaches needs no marker — it has had descriptors all along.
+Marking `ShipState` views `Vec3` too: a marker takes the type's whole
+by-value closure, so the recursion below never dead-ends inside a type you
+marked. A type a TABLE reaches needs no marker — it has had descriptors all
+along.
 
 ```cpp
 #include "TabledemoView.h"
@@ -1405,9 +1408,16 @@ section above walks, so one printer serves both. C# is the same registry
 through `Schema.UnitView()`.
 
 Constants, enums, flags and unions are listed whenever the view exists — they
-cost names and values, so nothing marks them. What the view does not carry:
-descriptions, UI hints, semantics for a type tag (the tags are listed; their
-meaning is yours), and the packet wire's bit layout.
+cost names and values, so nothing marks them. Each set is ordered by
+declaration name, so a listing does not churn when a file is renamed or a
+declaration moves between files.
+
+What the view does not carry: descriptions, UI hints, semantics for a type
+tag (the tags are listed; their meaning is yours), and the packet wire's bit
+layout. And one field kind is listed but not decodable: `fixed`, `ufixed`,
+`int128` and `uint128` have no table-wire kind, so they arrive with
+`kind == 0` — name, declared spelling, offset and size, enough to show the
+field and not enough to read or write its value generically.
 
 ### The text form: JSON in and out of one table
 


### PR DESCRIPTION
Spec-only, per #157's spec-first step: SPEC-TABLES.md §8, SPEC.md §4.2 and §6.1, USAGE.md. No compiler code, no corpus change — `| view` and a `--views all` request are stated as refused-by-name today, the way `| block` is.

## Placement decision: §8 rewritten, not a new section

§8 becomes **"Reflection: the view"** and today's descriptor text becomes **§8.1 The descriptors**, unchanged in substance. Every existing `§8` citation — §16's walk, §19.2's reflective read, §11, and a dozen comments in `internal/codegen/*` — still lands on the section that carries the columns, so nothing has to be re-cited. A separate §20 would have put the view a document away from the vocabulary it *is*: the owner's "(but with a view on that type?)" asks for the same surface, not a second one.

## What the page now says

- **§8.2 The type view.** Three askers: `| view` on the declaration, a table reaching the type (as today), or a build viewing everything. The view IS §8.1's `TableTypeInfo` — one vocabulary, one walker — so a printer written against tables walks a viewed type without being told. A field with **no table-wire kind** (`fixed`, `ufixed`, the 128-bit family) is **described at kind 0**, not refused: `examples128` has 19 such fields, and `--views all` over that unit must produce a listing rather than a diagnostic.
- **§8.3 The unit registry.** `UnitView()` returning constant data: `types` (those with a view), `tables` (always), `enums`, `flags`, `unions`, `constants`. Enum rows are the named values in order beside `max`; a flags row's value is a bit index with id 0; a union lists tag 0 then its arms with payload name always and payload descriptor where the payload is viewed; a constant carries name, declared storage and folded value. Every entry names its schema file; order is files-by-basename then declaration order, which is what makes §8.7 a byte comparison.
- **§8.4 Who asks.** `--views declared` (default) / `all` / `none`, carried as a generate option — the `compiler.Options` contract already says a target that cannot honor a key errors rather than falling back, which is exactly the refusal this needs. §2.2's zero-cost gate is restated: a unit that asks for nothing emits no view file, not an empty one.
- **§8.5 On the side.** One `<Package>View.h`/`<Package>View.cpp` per unit (`<Package>View.cs` for C#), at the **leaf** of the include graph, pulling data headers and no wire header. Data in the `.cpp` per §13.5. Descriptors a table needs stay in the table header — a table's descriptor points at its nested types', so a game that loads tables must keep linking them.
- **§8.6 What it does not carry**, **§8.7 Held by test** (the editor gate, the corpus pin, the red-gate check, the zero-cost gate).
- **§11** gains the view's refusals, and claims `TableType` plus `UnitView`/`UnitViewInfo`/`ViewType`/`ViewVocabulary`/`ViewVariant`/`ViewConstant` unconditionally — a generate flag must never change what the language accepts. **§14** records the four models weighed; **§15** the follow-ons.
- **SPEC.md** §4.2: the `| view` attribute, type declarations only, excluded from the wire-shape projection (no `ProtocolId` moves, exactly as a type tag does not). §6.1: the `--views` request and the per-unit view file, C++ and C#.
- **USAGE.md**: "Inspecting a whole build: the view" — an editor-shaped walk over `UnitView()`, printing constants, vocabularies and every declaration's properties.

## Decisions taken (each open to the owner)

1. **§8 rewritten in place** rather than a new section — citation compatibility and one vocabulary. 
2. **Entry point `UnitView()`**, in the unit's own namespace beside `ProtocolId`; no package baked into the identifier.
3. **File named `<Package>View.*`, per unit.** A fixed name would collide: the bench corpus generates **two units into one directory** (`generated/bench/cpp`), which the Makefile calls out.
4. **A viewed type's accessor is `<Name>TableType()`** — already in §11's claimed 36 suffixes, so the view adds no new per-declaration spelling. The `Table*` names are kept even in a table-free unit: renaming them forks the walker.
5. **`| view` marks types only.** Enums, flags, unions and constants are catalogued unconditionally wherever a registry exists — they cost names and values, a type costs a descriptor table. §11 refuses the marker on the free kinds rather than accepting one that selects nothing.
6. **`| doc` is NOT introduced.** Doc comments are already deferred with a pinned design (SPEC §4.1, §9 q5); when they land the view carries them as a column. Listed in §15 rather than invented here.
7. **Type TAGS are carried** in the registry (data, no meaning attached) — `Vec3 | vec3` exists in the corpus and an editor wants it.
8. **The editor gate lives in §8.7, not as a third §12 gate.** §12's two gates are expressiveness gates; this one is reflection completeness. §12 is untouched.
9. **Three `--views` modes.** `none` exists so a game build pays nothing for markers a tools build wanted — the "same declarations serve both" property.
10. **The corpus pin is the compiler's IR listing**, with each backend's generated program byte-comparing against it, so C++ and C# are one view the way they are one wire. The spec explicitly does not ask for a new CLI verb.

## Open for the owner

- The `Table*` spellings in a table-free unit (`TableFieldInfo` describing a packet-only type) — kept for one-vocabulary reasons; aliases are cheap if he dislikes the read.
- Whether the default should be `declared` or `none` — I chose `declared` so a marker works without a flag; `none` as default would make the marker inert until asked for.
- Whether registry entries should carry the source file basename at all (three extra pointers) — kept because "everything that was in the schema built" includes where it was declared.
- Build identity in the registry (package + protocol id only today) — deliberately silent, since the build-version work is in flight elsewhere.

Not touched: SPEC §3.3/§7 (#292 in flight), §12, the block-form sections beyond citations, and anything in `internal/`.

Refs #157