### PR TITLE
SPEC: no block marker — every fixed table has a block form, on the side (#302)

### DIFF
--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -98,8 +98,9 @@ name, with this document cited. The remaining per-language backends are named
 follow-ons (§15).
 
 **The BLOCK FORM (§2.7, §19) is specified and unimplemented.** No backend
-emits it yet: a table marked `| block` is refused by name, with §19 cited,
-never emitted with the block surface missing. C++ and C# take it together,
+emits the Block files yet, so the form is unavailable everywhere: a consumer
+that reaches for it finds nothing to include, which is the same absence a
+variable-length table's block form is (§19). C++ and C# take it together,
 because the form is an ABI between two languages and one language alone
 cannot hold the gate it exists for (§12.1).
 
@@ -162,10 +163,10 @@ compressed floats, enums, flags, strings, bytes, bounded arrays, unions,
   message set expressible.
 - **`was` — the rename attribute** (§5).
 
-And one addition that is not a field spelling at all: **a fixed table may be
-marked `| block`** (§2.7), which gives it a third FORM beside its wire and its
-cook — the same declaration laid out so another language points at its rows
-(§19). It adds no field type, no wire kind and no byte on the wire.
+And one addition that is not a field spelling at all: **every fixed table has
+a BLOCK FORM** (§2.7), a third form beside its wire and its cook — the same
+declaration laid out so another language points at its rows (§19). Nothing
+declares it, and it adds no field type, no wire kind and no byte on the wire.
 
 ### 2.1 Pointers
 
@@ -246,11 +247,12 @@ Pointer edges do not propagate the mode: a table that is merely POINTED
 AT stays fixed-size if it holds no pointer of its own. It gains an
 allocation and a resolution entry, and nothing else.
 
-**`| block` does not enter this derivation at all** (§2.7). A block-form
-table declares nothing new: its fields are the bounded arrays of fixed
-structs it always had, which are by-value edges under the rule above, so it
-derives FIXED by that rule unchanged. The marker selects a FORM, and a form
-is not a mode.
+**The BLOCK FORM does not enter this derivation — it READS it** (§2.7). The
+form declares nothing, so there is nothing for the rule above to take account
+of; the rule instead decides which tables have the form at all. Every FIXED
+table has one and a variable-length table has none, so "which arrays are laid
+out at a fixed pitch" and "which tables can be" are both answered by the mode.
+A form is not a mode, and this one is derived from it.
 
 **A fixed-size table pays nothing for the VARIABLE-LENGTH machinery**, and
 that is a gate, not a hope: in a unit whose tables are all fixed-size the
@@ -267,13 +269,14 @@ emitted in every unit, whatever its mode, because a fixed-size table can
 declare it and a tool walking a fixed-size table has to find it. The gate
 asks "did the pointer world leak in?", never "did the descriptor grow?".
 
-**The BLOCK machinery takes the same gate, on the same terms** (§19): a unit
-in which no table is marked `| block` carries no block storage type, no
-`Begin`, no `Open`, no row iterator and no layout constants — the build fails
-if one symbol of it appears. No marker, not one symbol. The descriptor
-COLUMNS (§8) the block form reads ride in every unit as every other column
-does, because they describe the language. Machinery is gated; columns are
-not, which is the rule the paragraph above already states.
+**The BLOCK machinery takes the same gate, and it is held by SEPARATION**
+(§19): the block storage type, `Begin`, `Open`, the row accessors and the
+layout constants live in a unit's Block files and nowhere else, so a Table
+header is byte-identical whether those files exist or not and the build fails
+if one symbol of them appears in it. The descriptor COLUMNS (§8) the block
+form reads ride in every unit as every other column does, because they
+describe the language. Machinery is gated; columns are not, which is the rule
+the paragraph above already states.
 
 The assumption behind the split, stated so nobody quietly designs against
 it: size and mode correlate in practice. Value-only tables are assumed
@@ -282,15 +285,16 @@ struct and loaded directly, and no large-flat-struct machinery is
 warranted for them without a real case forcing it. Pointer-bearing tables
 are where size lives, and the arena and the region are the size answer.
 
-**`| block` IS a case forcing it, and it declares that it is** (§2.7). A
-block-form table's bounded arrays are storage like any other — `T[N]` inline
-beside an `int32` count — so its BY-VALUE struct is the sum of its declared
-maxima, and for the case this form comes from that is about 7.5 MiB. The
-marker is the author saying so out loud: a table marked `| block` is not
+**LARGE DECLARED MAXIMA ARE a case forcing it, and the declaration is where
+they are visible** (§2.7). A table's bounded arrays are storage like any
+other — `T[N]` inline beside an `int32` count — so its BY-VALUE struct is
+the sum of its declared maxima, and for the case the block form comes from
+that is about 7.5 MiB. Nothing announces it but the maxima themselves, and
+nothing else could: a table that declares megabytes of bounded arrays is not
 covered by the assumption above, and everything about its by-value form
-follows from that rather than from a surprise. §19.1 prices the block form's
-own storage; the by-value form's price is here, where the assumption it
-breaks is stated.
+follows from the numbers in its own declaration rather than from a surprise.
+§19.1 prices the block form's own storage; the by-value form's price is here,
+where the assumption it breaks is stated.
 
 **Three consequences, so a reader meets them here rather than in a profile.**
 A `Load` of such a table needs a destination struct of that size, and the
@@ -566,67 +570,24 @@ second decision about the wire; it is tracked as schema#258.
 - **A backend without a native union may allocate for the arm** (the
   ladder, above): the carve-out is the language's, not the table's.
 
-### 2.7 The block form: `table RenderFrame | block`
+### 2.7 The block form is not declared
 
-```
-table RenderFrame | block
-{
-    version uint64
-    cameras [..1]RenderCamera
-    ships   [..MaxShips]RenderShip
-    lasers  [..MaxLasers]RenderLaser
-}
-```
+**Nothing in a declaration selects it, and nothing is refused for asking.**
+Every FIXED table has a block form — a THIRD projection beside its wire (§3)
+and its cook (§7), in which the table's own bounded arrays are laid out of
+line at a fixed pitch so a consumer in another language points at their rows
+instead of parsing them. A VARIABLE-LENGTH table has none, and the mode (§2.2)
+is the whole of the rule: a pointer anywhere in the closure means no fixed
+pitch anywhere in it.
 
-**`| block` declares no construct.** Every field above is an ordinary field
-of an ordinary fixed table: a scalar and three bounded arrays of structs,
-which this document has always had. The marker says that this table has a
-THIRD FORM beside its wire (§3) and its cook (§7) — one in which its own
-bounded arrays are laid out of line at a fixed pitch, so a consumer in
-another language points at their rows instead of parsing them (§19). One
-declaration, three projections of it.
+**It needs no marker because it costs a declaration nothing.** The form is
+emitted ON THE SIDE, in files of its own, and a consumer that does not include
+them pays for none of it — the same shape §16's text form already takes, one
+step further (§19). What a fixed table's declaration owes the form is two
+names it may not spell, `magic` and `layout_id` (§11), and nothing else.
 
-**The rule, in full, because it is the one thing a reader has to know that
-the declaration does not spell:**
-
-- **DEPTH ONE, BOUNDED ONLY.** In the block form, every **bounded** array
-  field **of the marked table itself** — `[..N]T` — is laid out of line, in
-  declaration order, each at its own pitch. Everything else stays exactly
-  where it is: a fixed `[N]T`, an enum-keyed `[E]T`, and **every array at any
-  depth inside an element**. An element is one flat record or it is not a
-  record another language can point at, and one level is what makes "which
-  arrays move" answerable by reading one declaration.
-- **THE INSTANCE IS WHAT MOVES, not the schema.** The block form generates
-  the table's struct as a PROJECTION: each out-of-line array's inline storage
-  — `T[N]` and its count companion — is replaced, AT THAT FIELD'S POSITION,
-  by `(offset_of u64, count u32, stride u32)`, sixteen bytes with no interior
-  padding. Every other field keeps its by-value storage at its natural offset.
-  That projection is what sits at the front of the block, and nothing declares
-  it: it is what the table already knows about its own rows, written down
-  where the other side can read it.
-- **THE ELEMENTS ARE STRUCTS.** A bounded array takes the out-of-line form
-  only when its element is a fixed-class `table` or a declared `type` — the
-  same thing, semantically (the ladder, above). A variable-length table, a
-  `*T`, a `string` or `bytes` element is refused by name in a block-form table
-  (§11): none of them has a fixed pitch, and striding what has no pitch means
-  nothing.
-- **THE PITCH IS `sizeof`.** A row's stride is the element's `sizeof`, rounded
-  up to its alignment — which for a standard-layout struct (§9) is `sizeof`
-  itself. It is derived, always, and no declaration adjusts it in this
-  version; declared headroom is a named follow-on (§15) with the reason it is
-  not here. The stride still RIDES in the triple, because it is the pitch the
-  consumer indexes with and it must come from the data, never from the
-  consumer's own constant (§19.2).
-- **A TABLE, NOT A NEW KIND OF TABLE.** A block-form table keeps everything
-  an ordinary fixed table has: `Measure`, `Save` and `Load` over the tolerant
-  wire (§3), its cook (§7), its reflection descriptors (§8), its place as a
-  nested field or an array element in someone else's table. `| block` adds a
-  form; it removes nothing. That is what makes "is the render data a table?"
-  answerable with one word.
-
-**`| block` is refused on a `type`, and on a table whose closure is not all
-structs** (§11). A type has no table wire to be a third form beside, and a
-table that reaches a pointer has no fixed pitch anywhere in it.
+The form itself — which arrays move out of line, what the projection is, what
+the pitch is, what it costs and what it refuses — is §19.
 
 ## 3. The wire
 
@@ -721,7 +682,7 @@ schema's codebase:
 - **The BLOCK FORM moves no byte on this wire, and spends no kind** (§2.7,
   §19). A block-form table's bounded arrays ride here exactly as every other
   bounded array of tables does — kind `14`, element kind `13`, the LIVE
-  count — and `| block` is not a wire fact at all: it selects a second
+  count — and the block form is not a wire fact at all: it is a second
   projection of the same declaration, the way a cook (§7) is a third. The
   `(offset_of, count, stride)` triple is a block-form artifact and has
   nothing to ride here, because a wire form has no triple. So a tool can
@@ -1877,16 +1838,16 @@ listing.
 offset beside the reference, so a walker reads the blob's extent the way
 it reads an array's count (§2.5).
 
-**A BLOCK-FORM table carries a second set of positions for the same fields,
-and this is what makes the block form READABLE BY REFLECTION** (§19.2). A
-table's own **`block`** flag says it has the form; each out-of-line array
-field then carries, beside the offset its by-value storage has, the
-**projection offset** of its `(offset_of, count, stride)` triple and the
-offsets of the three members inside it, with the ELEMENT's own descriptor
-already in the column a nested table uses. Every other field carries its
-projection offset too, because the projection is a different struct from the
-by-value one (§19.3) and a walker over a block needs the positions that
-struct actually has.
+**A FIXED table carries a second set of positions for the same fields, and
+this is what makes the block form READABLE BY REFLECTION** (§19.2). No flag
+says it has the form — every fixed table does (§2.7), and the mode is already
+in the descriptors. Each out-of-line array field carries, beside the offset
+its by-value storage has, the **projection offset** of its
+`(offset_of, count, stride)` triple and the offsets of the three members
+inside it, with the ELEMENT's own descriptor already in the column a nested
+table uses. Every other field carries its projection offset too, because the
+projection is a different struct from the by-value one (§19.3) and a walker
+over a block needs the positions that struct actually has.
 
 That is the whole mechanism behind the block form's read side: a consumer
 with the descriptors reads the triples out of an instance and points at rows,
@@ -2026,27 +1987,20 @@ lockstep redeploy by a table edit. This independence is held by test.
   specified default on one; an array of them — a buffer takes no node
   index (§3.1), unlike an array of table pointers, which is legal; `?` on
   one, because a null reference already IS absence.
-- **The block form** (§2.7), each refusal naming the marked table and the
-  field or declaration at fault:
-  - **`| block` on a `type`** — a type has no table wire for the form to sit
-    beside, and the marker's whole meaning is "a third projection of this
-    table";
-  - **`| block` on a VARIABLE-LENGTH table** — a pointer anywhere in the
-    closure means no fixed pitch anywhere in it;
-  - **an out-of-line array whose ELEMENT is not a struct** — a
-    variable-length table, a `*T`, a `string` or `bytes` element in a
-    `[..N]` field of a block-form table. Striding what has no fixed pitch
-    means nothing, which is the refusal in one line;
+- **The block form** (§2.7), each refusal naming the table and the field or
+  declaration at fault. **Nothing declares the form, so nothing is refused
+  FOR it** — a table that cannot have one simply has none (§19), and these
+  two are refusals of a DECLARATION that collides with what the form
+  generates:
   - **`| stride` in this version** — the pitch is `sizeof` by construction
-    (§2.7); declared headroom is a named follow-on (§15), and the attribute
+    (§19); declared headroom is a named follow-on (§15), and the attribute
     is refused rather than accepted-and-ignored, because an inert attribute
     is a lie about the declaration;
-  - **a field of a block-form table named `magic` or `layout_id`** — those
-    two are the projection's generated prologue (§19.1), as `<field>_present`
-    is an optional's generated companion;
-  - **`| block` under a backend that carries none** — which today is every
-    backend (status, above), refused with §19 cited and never emitted with
-    the block surface missing.
+  - **a field of a FIXED table named `magic` or `layout_id`** — those two are
+    the projection's generated prologue (§19.1), as `<field>_present` is an
+    optional's generated companion. Claimed on every fixed table, for the
+    reason the generated spellings below are: the form is not opted into, so
+    a name that was free yesterday must not become a collision tomorrow.
 
   **What is NOT refused, and it is worth stating because the block form's own
   need for a base invites the opposite guess**: a block-form table nested by
@@ -2116,10 +2070,10 @@ lockstep redeploy by a table edit. This independence is held by test.
   The set is claimed for EVERY closure member, not only pointer-bearing
   ones: a table gains or loses pointers as an edit, and a name that was
   free yesterday must not become a collision tomorrow. The nine block
-  spellings are claimed on the same terms, for the same reason: a table
-  gains `| block` as an edit.
+  spellings are claimed on the same terms and for a stronger reason: every
+  fixed table has a block form (§2.7), so every fixed table claims them.
 
-  **A BLOCK-FORM TABLE claims two more per out-of-line array, because its
+  **A FIXED TABLE claims two more per out-of-line array, because its
   row accessors are named after its fields.** `<Table>` followed by the
   PascalCase of the field's name is the accessor that hands back that
   field's rows, and the same name with `Span` appended is the contiguous
@@ -2230,13 +2184,13 @@ marshalling and no copy AT THE BOUNDARY. (What a consumer then does with a
 row is its own business: the one that exists copies rows into a pool so its
 jobs can take them, and that copy is the consumer's design, not the form's.)
 
-**The shape the gate is held to.** One fixed table marked `| block`
-(§2.7), fixed down to the leaves: bounded arrays of fixed-size records, no
-pointer anywhere in the closure. The block's storage is sized from the
-declared maxima and its layout is settled from the counts before any worker
-starts, so N workers fill disjoint row ranges with no lock, no atomic and no
-per-row synchronisation — and that is an OBLIGATION on the implementation,
-not a permission to the caller (§9, §19.1). The consumer maps the block,
+**The shape the gate is held to.** One fixed table (§2.7), fixed down to the
+leaves: bounded arrays of fixed-size records, no pointer anywhere in the
+closure. The block's storage is sized from the declared maxima and its layout
+is settled from the counts before any worker starts, so N workers fill
+disjoint row ranges with no lock, no atomic and no per-row synchronisation —
+and that is an OBLIGATION on the implementation, not a permission to the
+caller (§9, §19.1). The consumer maps the block,
 checks it once, and reads each array at the pitch the instance gives it. The
 layout contract — the projection's own offsets, every row's size, every
 field's offset, every pitch — is asserted by GENERATED code on both sides
@@ -2557,6 +2511,14 @@ Owner rulings, 2026-09-02, in the order given.
 - **The purpose, in one line**: "this is a 'nice' property to get some sort
   of more robust structure (ABI) between C++ and C# without hardcore
   versioning", "because both sides were previously manually updated."
+- **No per-table marker, 2026-09-02.** Asked "what is it about render data
+  that requires a specific per-table declaration?", the ruling was **"KISS"**.
+  Nothing does: the `| block` marker was a cost switch and not a semantic, so
+  it is gone. Every fixed table has a block form and the form is emitted on
+  the side (§19) — a consumer that includes it pays for it, one that does not
+  pays nothing — which is what the marker was buying and the only thing it
+  was buying. §2.7 declares nothing at all now, and §14's decision below
+  records what the marker cost.
 
 ## 14. Design notes: the models weighed
 
@@ -2803,20 +2765,24 @@ have added one are priced here.
 - **DEPTH ONE, BOUNDED ONLY — TAKEN, and it is what carries the rule a
   keyword would otherwise state.** With no keyword saying which arrays move
   out of line, the rule must be derivable from the declaration, and this is
-  the rule that is: the marked table's own `[..N]` arrays move, everything
-  else stays. **Deeper rules and per-field opt-ins are REJECTED** for the
-  reason a keyword is — they put the answer somewhere other than the one line
-  a reader is already looking at. The genuine cost is that a small array
+  the rule that is: the table's own `[..N]` arrays of structs move, and
+  everything else stays. **Deeper rules and per-field opt-ins are REJECTED**
+  for the reason a keyword is — they put the answer somewhere other than the
+  one line a reader is already looking at. The genuine cost is that a small array
   BESIDE the strided ones in one root cannot stay inline; the answer is to
   wrap it in a nested type, whose arrays are at depth two and therefore
-  inline (§2.7).
-- **The block form is selected by `| block` ALONE — TAKEN.** The alternative
-  is a per-field trigger, "any field carrying `| stride`, or the table
-  carrying `| block`", and its stride half is REJECTED on the evidence: the
-  case this form comes from has nine strided arrays and **zero** declared
-  strides — every pitch there is `sizeof`. A trigger the primary case never
-  fires is not a trigger. One table-level marker is explicit, answerable by
-  reading one line, and keeps §2.2's zero-cost gate stated verbatim.
+  inline (§19).
+- **NOTHING SELECTS THE FORM — TAKEN** (owner, §13.6: "KISS"). A per-table
+  marker was the earlier answer, and it was REJECTED once the question it
+  answered was named: the marker bought cost control, not meaning, and cost
+  is answered better by emitting the form on the side (§19), where a consumer
+  that does not include it pays nothing and no declaration has to predict who
+  will. A per-FIELD trigger, "any field carrying `| stride`", is rejected on
+  its own evidence: the case this form comes from has nine strided arrays and
+  **zero** declared strides — every pitch there is `sizeof` — and a trigger
+  the primary case never fires is not a trigger. What is left is the mode
+  (§2.2): fixed tables have the form, variable-length ones do not, and the
+  answer is derived rather than declared, exactly as the mode itself is.
 - **No `| stride` attribute at all in this version — TAKEN, on the same
   evidence plus the consumer's.** Beyond the zero declared strides, the one
   consumer that exists cannot read a strided array: it reads rows by casting
@@ -3384,11 +3350,12 @@ the other side's contract exactly as a row's is.
 
 Those are the only lines in this file that are not wire facts, and they are
 here for the same reason every other line is: they are what an edit can break
-and the compiler cannot remember. A table with no block form records none of
-them, so a unit with no block is projected exactly as it was — but the
-RENDERING VERSION on the file's first line moves, because the projection can
-now carry lines an older reader does not know, and §18.4's repair path is
-what a baseline written under the older version takes.
+and the compiler cannot remember. A table with no block form — a
+variable-length one (§2.7) — records none of them, so a unit of those is
+projected exactly as it was, but the RENDERING VERSION on the file's first
+line moves, because the projection can now carry lines an older reader does
+not know, and §18.4's repair path is what a baseline written under the older
+version takes.
 
 **The values are EVALUATED**, not the source text: a constant that moves
 and flows through an expression into a default shows up as the value it now
@@ -3413,7 +3380,7 @@ table ShipConfig
     field speed id=0x2e46 kind=10 default=500.0 was=velocity
     field name id=0x30df kind=12 size=32
 
-table RenderFrame | block
+table RenderFrame
     block sizeof=40 alignof=8
     field version id=0xe8e6 kind=9 offset=16 size=8
     field ships id=0x2d39 kind=14 elem=13 elem_type=RenderShip bound=..4096
@@ -3483,10 +3450,22 @@ can see which contract an edit broke:
   consumer reading its own prefix at offsets and pitches it took FROM THE
   INSTANCE is unaffected by all three.
 
-**`| block` added or removed takes no row here**, and that is deliberate:
-both sides are generated from one declaration, so adding or removing the form
-changes what compiles on both sides at once. It is loud already, and a
-baseline row would only repeat the compiler.
+**WHOSE layout this half judges is OPEN** (§13.6). Every fixed table has a
+block form now, so the literal reading is that every fixed table's layout
+lines are recorded and judged — which would refuse a field
+inserted in the middle of a table nobody points at, an edit its wire absorbs
+in silence. The narrower reading is that the layout half belongs only where a
+block crosses a boundary, and nothing in a declaration says where that is.
+Nothing is unguarded while this is open: a layout that drifts under a consumer
+is refused by the generated asserts and the layout id, loudly, at compile time
+(§19.3). The scope is the owner's to set.
+
+**A table GAINING or LOSING its block form takes no row here**, and that is
+deliberate: nothing declares the form, so the only edit that can move it is an
+edit that moves the MODE — a pointer added or removed somewhere in the closure
+(§2.2) — and the day a table's Block files stop being emitted, everything
+that included them stops compiling. It is loud already, and a baseline row
+would only repeat the compiler.
 
 ### 18.3 What a name is worth, and what a referent is worth
 
@@ -3602,8 +3581,22 @@ repairs it while keeping every history line.
 rows — for each of its bounded arrays, where the rows start, how many there
 are, and how far apart they sit — so another language reads those facts and
 points at the rows.** That is the block form, and it is the whole idea. It
-adds no declaration (§2.7): a table marked `| block` gets a THIRD projection
-of the same schema, beside its wire (§3) and its cook (§7).
+adds no declaration (§2.7): **every FIXED table has one**, a THIRD projection
+of the same schema beside its wire (§3) and its cook (§7).
+
+```
+table RenderFrame
+{
+    version uint64
+    cameras [..1]RenderCamera
+    ships   [..MaxShips]RenderShip
+    lasers  [..MaxLasers]RenderLaser
+}
+```
+
+Nothing there is new. Those are ordinary fields of an ordinary fixed table: a
+scalar and three bounded arrays of structs, which this document has always
+had. One declaration, three projections of it.
 
 | form | contract | who reads it | cost |
 |---|---|---|---|
@@ -3627,6 +3620,74 @@ and asserted into both generated sides, so nothing is decided, discovered or
 checked at frame time. That is what makes it the fastest thing tables have
 and why §12.1 ranks it as the hottest path.
 
+**IT IS EMITTED ON THE SIDE, and that is why no declaration selects it.** A
+table unit emits `<Base>Block.h` and `<Base>Block.cpp` beside its
+`<Base>Table.h` and `<Base>Table.cpp` (§13.5), and `<Base>Block.cs` for C#.
+The Block header carries the whole surface — the projection struct, the
+generated layout asserts (§19.3), the builder API (§19.1), and the
+`BlockOpen` / `BlockOpenCompatible` declarations (§19.2) — and the Block
+translation unit carries their definitions. **The Table headers carry nothing
+of it.** A consumer that uses the form includes the Block header and links the
+Block unit; a consumer that does not includes nothing and compiles nothing for
+it. This is §16's split taken one step further: the text form declares in the
+Table header and defines in the Table unit, because its cost is a body of code
+to compile; the block form's cost is in the header too — a projection struct
+and a wall of asserts per table — so its declarations move out with it.
+
+**The zero-cost gate, and it is a gate rather than a hope** (§2.2): **the
+Table headers are BYTE-IDENTICAL with or without the Block files existing**,
+and the Block files cost nothing unless they are included. The build fails if
+one symbol of the block machinery — a storage type, a `Begin`, an `Open`, a
+row accessor, a layout constant — appears in a Table header. The descriptor
+COLUMNS (§8) the block form reads are not machinery and ride in every unit as
+every other column does, because they describe the language.
+
+**A VARIABLE-LENGTH table has no block form, and it is refused by ABSENCE**:
+no Block declarations are emitted for it, so a consumer that reaches for one
+gets a missing name from its own compiler rather than a diagnostic from this
+one. The reason is one line — a pointer anywhere in the closure means no fixed
+pitch anywhere in it — and there is nothing for the schema compiler to refuse,
+because nothing in the declaration asked.
+
+**The rule, in full, because it is the one thing a reader has to know that the
+declaration does not spell:**
+
+- **DEPTH ONE, BOUNDED ONLY.** In the block form, every **bounded** array
+  field **of the table itself** — `[..N]T` — is laid out of line, in
+  declaration order, each at its own pitch, subject to the element rule below.
+  Everything else stays exactly where it is: a fixed `[N]T`, an enum-keyed
+  `[E]T`, and **every
+  array at any depth inside an element**. An element is one flat record or it
+  is not a record another language can point at, and one level is what makes
+  "which arrays move" answerable by reading one declaration.
+- **THE INSTANCE IS WHAT MOVES, not the schema.** The block form generates
+  the table's struct as a PROJECTION: each out-of-line array's inline storage
+  — `T[N]` and its count companion — is replaced, AT THAT FIELD'S POSITION,
+  by `(offset_of u64, count u32, stride u32)`, sixteen bytes with no interior
+  padding. Every other field keeps its by-value storage at its natural offset.
+  That projection is what sits at the front of the block, and nothing declares
+  it: it is what the table already knows about its own rows, written down
+  where the other side can read it.
+- **ONLY ARRAYS OF STRUCTS MOVE.** A bounded array takes the out-of-line form
+  only when its element is a fixed-class `table` or a declared `type` — the
+  same thing, semantically (the ladder). A bounded array of scalars, of
+  `string(N)` or of `bytes(N)` stays INLINE in the projection, exactly as a
+  fixed `[N]T` does: striding what another language cannot point at as a
+  record buys nothing, and the projection is a struct either way.
+- **THE PITCH IS `sizeof`.** A row's stride is the element's `sizeof`, rounded
+  up to its alignment — which for a standard-layout struct (§9) is `sizeof`
+  itself. It is derived, always, and no declaration adjusts it in this
+  version; declared headroom is a named follow-on (§15) with the reason it is
+  not here. The stride still RIDES in the triple, because it is the pitch the
+  consumer indexes with and it must come from the data, never from the
+  consumer's own constant (§19.2).
+- **A TABLE, NOT A NEW KIND OF TABLE.** A table in its block form keeps
+  everything an ordinary fixed table has: `Measure`, `Save` and `Load` over
+  the tolerant wire (§3), its cook (§7), its reflection descriptors (§8), its
+  place as a nested field or an array element in someone else's table. The
+  form adds a projection; it removes nothing. That is what makes "is the
+  render data a table?" answerable with one word.
+
 **Two halves, and neither is new machinery.** Building a block is §6.4's
 builder in its block form — reserve from the counts, write the facts, let the
 workers run. Reading one is §8's descriptors doing what they already do —
@@ -3638,7 +3699,7 @@ out when both are asked of one table.
 
 **One extent, 64-byte aligned at its base**, laid out in this order:
 
-- **The PROJECTION at offset 0** (§2.7). It opens with a generated PROLOGUE
+- **The PROJECTION at offset 0** (above). It opens with a generated PROLOGUE
   of two `uint64`s — `magic`, a constant identifying a schema block and the
   byte-order check with it, and `layout_id`, the digest §19.3 defines — and
   the table's own fields follow, each at its natural offset, with every
@@ -3818,7 +3879,7 @@ ReadOnlySpan<RenderShip> ships = block.ShipsSpan;   // contiguous: the pitch is 
   the idiom written at every call site is the one written wrong somewhere. A
   typed base pointer sits beside it for the producer, which addresses rows by
   index (§19.1).
-- **A contiguous view is available because the pitch IS `sizeof`** (§2.7), so
+- **A contiguous view is available because the pitch IS `sizeof`** (§19), so
   a consumer that casts a byte range to a row type — which is how the fast
   path is actually written — is always able to. That is a property of
   deriving the pitch; a version that let a declaration widen it would cost
@@ -3967,9 +4028,9 @@ it, and pretending otherwise is what the second entry point exists to avoid
 
 ### 19.5 Held by test
 
-- **A dogfood-shaped block-form table in the corpus** — a marked root of
-  several bounded arrays over fixed-size row types with a nested `type`
-  apiece — compiled, built and read by every backend that carries the form.
+- **A dogfood-shaped block-form table in the corpus** — a root of several
+  bounded arrays over fixed-size row types with a nested `type` apiece —
+  compiled, built and read by every backend that carries the form.
 - **A REAL multi-threaded fill.** N workers fill disjoint index ranges of
   every array; the resulting block is byte-identical to a serial fill of the
   same data over the rows each count covers. Run under the sanitizer leg,
@@ -4005,12 +4066,12 @@ it, and pretending otherwise is what the second entry point exists to avoid
   passes, a field appended at the end of a row passes, an array's element
   swapped refuses, an array moved between the inline and out-of-line classes
   refuses, a maximum raised passes, a maximum lowered warns.
-- **The zero-cost gate** (§2.2): a unit with no `| block` carries not one
-  symbol of the block machinery, and the build fails if one appears.
-- **The wire is untouched** (§3): a block-form table saves and loads over the
-  tolerant wire exactly as the same declaration does without the marker, and
-  its wire goldens are byte-identical with and without it. That is the test
-  that keeps the form a form.
+- **The zero-cost gate** (§19): the Table headers are byte-identical with the
+  Block files generated and with them absent, and the build fails if one
+  symbol of the block machinery appears in a Table header.
+- **The wire is untouched** (§3): a table's wire goldens are byte-identical
+  whether or not its block form is generated, and its `Save` and `Load` are
+  the ones any fixed table has. That is the test that keeps the form a form.
 - **The measured leg is §12.1's**, and it is the gate rather than a
   regression test: the per-frame C++ write and the per-frame C# read, against
   the hand-written scatter and the hand mirror, paired in one sitting under

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -584,7 +584,7 @@ pitch anywhere in it.
 emitted ON THE SIDE, in files of its own, and a consumer that does not include
 them pays for none of it — the same shape §16's text form already takes, one
 step further (§19). What a fixed table's declaration owes the form is two
-names it may not spell, `magic` and `layout_id` (§11), and nothing else.
+names it may not spell, `magic` and `build_version` (§11), and nothing else.
 
 The form itself — which arrays move out of line, what the projection is, what
 the pitch is, what it costs and what it refuses — is §19.
@@ -1996,8 +1996,8 @@ lockstep redeploy by a table edit. This independence is held by test.
     (§19); declared headroom is a named follow-on (§15), and the attribute
     is refused rather than accepted-and-ignored, because an inert attribute
     is a lie about the declaration;
-  - **a field of a FIXED table named `magic` or `layout_id`** — those two are
-    the projection's generated prologue (§19.1), as `<field>_present` is an
+  - **a field of a FIXED table named `magic` or `build_version`** — those two
+    are the projection's generated prologue (§19.1), as `<field>_present` is an
     optional's generated companion. Claimed on every fixed table, for the
     reason the generated spellings below are: the form is not opted into, so
     a name that was free yesterday must not become a collision tomorrow.
@@ -2020,11 +2020,7 @@ lockstep redeploy by a table edit. This independence is held by test.
   an array's ELEMENT kind changed; an array changed between the keyed and
   the positional spelling; an enum-keyed array's key enum swapped; a
   field's referent dropped, or swapped for one whose identities do not
-  ride; and, for a BLOCK-FORM table (§2.7), a field inserted before the end,
-  reordered, removed or retyped in that table or in any row type it names, an
-  out-of-line array's element swapped, an array moved between the out-of-line
-  and inline classes, or an out-of-line array removed or moved earlier.
-  Overridden only by moving the baseline with a recorded reason.
+  ride. Overridden only by moving the baseline with a recorded reason.
 - **A save-time data cycle reached from a builder** (§3.1): measure,
   save, cook and `Lock` all return failure with the cycle named. Nothing
   recurses away. A region loaded from a wire is not re-proved, and a save
@@ -2064,7 +2060,7 @@ lockstep redeploy by a table edit. This independence is held by test.
   Cook  CookMeasure  Open  OpenValidated  LayoutId  TableFields  TableInfo
   FromJson  ToJson  ToJsonMeasure
   Block  BlockStorage  BlockBegin  BlockBytes  BlockMaxBytes  BlockOpen
-  BlockOpenCompatible  BlockLayoutId  Counts
+  BlockOpenCompatible  BlockBuildVersion  Counts
   ```
 
   The set is claimed for EVERY closure member, not only pointer-bearing
@@ -2733,8 +2729,7 @@ have added one are priced here.
   lost.** A cook is produced FROM A BUILDER by a single-threaded `Lock`,
   which is precisely the serialization point §12.1's bar refuses. The two are
   not competitors and not the same accelerator: a cook accelerates a file
-  read once at load, a block is rebuilt every frame, and §7 says why they
-  must not share a layout id.
+  read once at load, and a block is rebuilt every frame.
 - **The tolerant table wire, per frame — REJECTED with a number implied.**
   It is a parse and a copy on every frame on both sides; the abandoned
   flatbuffers build is that rejection already paid for once (§7).
@@ -2790,12 +2785,12 @@ have added one are priced here.
   drops any array whose pitch differs. Shipping headroom costs that consumer
   its fast path in exchange for a property the owner has already called
   possibly obsolete. §15 holds it as a follow-on with the reason.
-- **An exact layout id, plus a NAMED compatible entry point — TAKEN, because
-  an append-tolerant digest is impossible.** A single number
-  cannot be verified against a PREFIX of the facts that produced it: a
-  consumer that knows fewer fields cannot recompute the producer's digest,
-  and any fold that ignored the difference would ignore a real break too. So
-  the id is exact, like a cooked file's (§7), and the tolerant path is a
+- **An exact id, plus a NAMED compatible entry point — TAKEN, because an
+  append-tolerant id is impossible.** A single number cannot be verified
+  against a PREFIX of the facts that produced it: a consumer that knows fewer
+  fields cannot recompute the producer's number, and any fold that ignored
+  the difference would ignore a real break too. So the block's id is exact —
+  the build version (§19.3) — and the tolerant path is a
   second entry point a caller asks for BY NAME — §7's `Open` /
   `OpenValidated` shape, for the same reason: no silent bypass, ever. What
   that path checks is a `<=` on the pitch and never an equality against the
@@ -3332,30 +3327,12 @@ and payloads.
 names** — a table, an `enum`, a `flags` or a `union` — because those four
 are judged by four different identity rules (§18.3).
 
-**A BLOCK-FORM table and the tables its out-of-line arrays name record LAYOUT
-FACTS BESIDE their wire facts** (§2.7, §19.3). A block-form table keeps every
-wire line it already had — it is an ordinary table (§2.7) — and gains, per
-field, the BYTE OFFSET and SIZE that field has IN THE PROJECTION, plus the
-projection's own `sizeof` and alignment; an out-of-line array's line adds its
-declared MAXIMUM and its evaluated STRIDE. Every table one of those arrays
-names records the same per-field offsets and sizes for its by-value layout,
-beside its `sizeof` and alignment.
-
-**The block-form table's OWN fields are recorded, not just its elements'**,
-and that is load-bearing rather than tidy: a scalar inserted before an
-out-of-line array moves every triple after it, and a consumer reading the
-projection by value then reads every offset, count and pitch at the wrong
-place. The table at the front of a block is a record too, and its layout is
-the other side's contract exactly as a row's is.
-
-Those are the only lines in this file that are not wire facts, and they are
-here for the same reason every other line is: they are what an edit can break
-and the compiler cannot remember. A table with no block form — a
-variable-length one (§2.7) — records none of them, so a unit of those is
-projected exactly as it was, but the RENDERING VERSION on the file's first
-line moves, because the projection can now carry lines an older reader does
-not know, and §18.4's repair path is what a baseline written under the older
-version takes.
+**Every line in it is a WIRE fact.** The block form's layout — the
+projection's offsets, each row's size, each pitch — is not recorded and not
+judged here (§19.3): **the baseline guards what the wire cannot report, and
+layout is a compile-time contract**, asserted in both generated sides and
+stamped with the build version, so a drift is a build error rather than
+something data quietly outlives.
 
 **The values are EVALUATED**, not the source text: a constant that moves
 and flows through an expression into a default shows up as the value it now
@@ -3372,24 +3349,13 @@ It carries no protocol id and no packet fact: the type wire, the wire-shape
 projection and the protocol id are untouched by all of it (§10).
 
 ```
-schema-tables-baseline 3
+schema-tables-baseline 2
 package shipdemo
 
 table ShipConfig
     field damage id=0x15a9 kind=10 default=21.0
     field speed id=0x2e46 kind=10 default=500.0 was=velocity
     field name id=0x30df kind=12 size=32
-
-table RenderFrame
-    block sizeof=40 alignof=8
-    field version id=0xe8e6 kind=9 offset=16 size=8
-    field ships id=0x2d39 kind=14 elem=13 elem_type=RenderShip bound=..4096
-        offset=24 size=16 out_of_line stride=32
-
-table RenderShip
-    row sizeof=32 alignof=8
-    field position id=0xdd45 kind=13 offset=0 size=24
-    field object_id id=0xdc71 kind=8 offset=24 size=4
 
 ## history
 ### 2026-09-02 — first baseline before 1.0 ships
@@ -3423,49 +3389,12 @@ committed file whenever one is there, and:
   grown; a bounded array made fixed or the reverse; a field moved between
   `T`, `?T` and `*T`, or between `bytes(N)` and `*bytes`.
 
-**A BLOCK-FORM table's LAYOUT facts are judged by a second standard beside
-the wire's** (§2.7). Its wire lines are judged exactly as above — it is an
-ordinary table and its wire absorbs what any table's does. Its layout lines
-are judged by what a POINTED-AT row can survive, which is a stricter and
-narrower question, and the two verdicts are reported separately so an author
-can see which contract an edit broke:
-
-- **REFUSES, naming `table.field` and the edit** — a field INSERTED before
-  the end, REORDERED, removed, or changed to a type of a different size or
-  alignment, in a block-form table ITSELF or in any table one of its
-  out-of-line arrays names. Each moves a byte offset the other side reads at,
-  and nothing in a block can report it. Also: an out-of-line array's ELEMENT
-  swapped for another declaration; an array moved between the out-of-line
-  class (`[..N]`) and an inline one (`[N]`, `[E]`) in a block-form table,
-  which moves it into or out of the block entirely; and an out-of-line array
-  removed or moved earlier among its siblings.
-- **WARNS** — an out-of-line array's declared maximum LOWERED (rows that used
-  to fit no longer do, and the producer's own bound is what says so), and a
-  block-form table that vanished under its baseline name (§18.3's rule,
-  unchanged).
-- **PASSES, in silence** — a field APPENDED at the end of a block-form table,
-  scalar or out-of-line array, past every offset the baseline records; a
-  field APPENDED at the end of a row; a declared maximum RAISED. These are
-  the three edits the form absorbs (§19.4), and each is silent because a
-  consumer reading its own prefix at offsets and pitches it took FROM THE
-  INSTANCE is unaffected by all three.
-
-**WHOSE layout this half judges is OPEN** (§13.6). Every fixed table has a
-block form now, so the literal reading is that every fixed table's layout
-lines are recorded and judged — which would refuse a field
-inserted in the middle of a table nobody points at, an edit its wire absorbs
-in silence. The narrower reading is that the layout half belongs only where a
-block crosses a boundary, and nothing in a declaration says where that is.
-Nothing is unguarded while this is open: a layout that drifts under a consumer
-is refused by the generated asserts and the layout id, loudly, at compile time
-(§19.3). The scope is the owner's to set.
-
-**A table GAINING or LOSING its block form takes no row here**, and that is
-deliberate: nothing declares the form, so the only edit that can move it is an
-edit that moves the MODE — a pointer added or removed somewhere in the closure
-(§2.2) — and the day a table's Block files stop being emitted, everything
-that included them stops compiling. It is loud already, and a baseline row
-would only repeat the compiler.
+**The BLOCK FORM takes no row here at all** (§18.1). A table's layout is a
+same-build contract that a compiler holds (§19.3), so an edit that moves an
+offset, a size or a pitch is a build error on both generated sides before it
+is anything else; a baseline row would only repeat the compiler, and a
+baseline cannot know which tables a project actually blocks. Every verdict
+above is the wire's.
 
 ### 18.3 What a name is worth, and what a referent is worth
 
@@ -3701,7 +3630,7 @@ out when both are asked of one table.
 
 - **The PROJECTION at offset 0** (above). It opens with a generated PROLOGUE
   of two `uint64`s — `magic`, a constant identifying a schema block and the
-  byte-order check with it, and `layout_id`, the digest §19.3 defines — and
+  byte-order check with it, and `build_version`, the id §19.3 names — and
   the table's own fields follow, each at its natural offset, with every
   out-of-line array's storage replaced in place by its sixteen-byte
   `(offset_of, count, stride)`. The prologue is generated, as an optional's
@@ -3865,8 +3794,9 @@ ReadOnlySpan<RenderShip> ships = block.ShipsSpan;   // contiguous: the pitch is 
 ```
 
 - **`BlockOpen` checks once and points, and this is the WHOLE check**: the
-  magic read bytewise, the byte order it establishes, the layout id against
-  this build's own, the used extent against the `bytes` the caller passed,
+  magic read bytewise, the byte order it establishes, the build version
+  against this build's own, the used extent against the `bytes` the caller
+  passed,
   the base's alignment, and each array's `offset_of` and extent inside the
   block. On a match the bytes are what a build with this layout wrote, so
   there is nothing to validate and nothing to fix up. On any failure it
@@ -3944,69 +3874,71 @@ the other's — both are checked against the compiler's own model, which is the
 only way a two-language contract can be held by a compiler that generates
 both halves.
 
-**The `layout_id` is a 64-bit digest** over the facts §18.2 refuses to move:
-the projection's own fields and their offsets and sizes, each out-of-line
-array's element and pitch, and every row field's offset, size and kind. It is
-the cooked form's layout id (§7) applied to a flatter shape, sized like a
-digest rather than a version counter — and it is a DIFFERENT id from that
-table's cook (§7), computed over different facts.
+**The prologue carries the BUILD VERSION, not a per-table digest** (#292).
+There are two ids in the design — the protocol id for the wire's shape, and
+the build version for artifacts a build points at — and the block uses the
+second: `Begin` stamps this build's version into the prologue and `BlockOpen`
+checks it against its own. The LAYOUT is held by the asserts above, at compile
+time, on both sides; the build version is what says the two halves came out of
+one build. A producer and a consumer generated together match by
+construction, and one pair from two different builds does not.
 
-**A declared MAXIMUM is deliberately NOT a digest fact**, and it is excluded
-rather than merely absent. A maximum sizes the storage and moves the
-`offset_of`s written into the instance; it moves no offset a consumer reads
-AT, because a consumer takes every `offset_of` from the instance (§19.2). So
-raising one is absorbed on the DEFAULT entry point (§19.4), and a port that
-folded the maximum into the digest would break that absorption with nothing
-to catch it. The rule for what belongs: a fact both sides must AGREE on is in
-the digest; a fact a consumer READS is not.
+**A declared MAXIMUM moves nothing a consumer reads AT.** It sizes the storage
+and moves the `offset_of`s written into the instance, and a consumer takes
+every `offset_of` from the instance (§19.2) rather than from a constant. So a
+build whose rows and fields did not move is read correctly by a consumer from
+an earlier build on the compatible path (§19.4), and a port that asserted a
+maximum on either side would break that with nothing to catch it. The rule for
+what belongs: a fact both sides must AGREE on is asserted; a fact a consumer
+READS is not.
 
-**What the digest sees, and what it does not.** It sees layout: a moved
+**What the contract sees, and what it does not.** It sees layout: a moved
 offset, a changed size, a different pitch. It does not see MEANING — a field
 whose units, frame of reference or interpretation changed while its offset
-and width did not moves no digest, because no layout fact moved. A semantic
-version is therefore an ordinary field an author declares and owns, and the
-digest neither replaces nor covers it.
+and width did not moves nothing here, because no layout fact moved. A semantic
+version is therefore an ordinary field an author declares and owns, and
+neither the asserts nor the build version replaces or covers it.
 
 ### 19.4 Evolution
 
-**Three edits are absorbed**, and §18.2 passes each in silence — but they are
-not absorbed by the same entry point, and which one matters:
+**Three edits are absorbed** — but not by the same entry point, and which one
+matters:
 
 1. **A field appended at the END of a block-form table** — a scalar, or a new
    out-of-line array. Every earlier offset is unchanged; a consumer built
    before the edit reads its own prefix of the projection at the same places,
    and the arrays it knows are at the `offset_of`s the producer actually
-   wrote. **The digest moves** (a new offset and size), so `BlockOpen`
-   REFUSES and this is absorbed only by `BlockOpenCompatible`.
+   wrote.
 2. **A field appended at the END of a row type.** The row grows and so does
    its derived pitch — and because a consumer indexes at the pitch it READ,
-   its shorter row type lands correctly on every row. **The digest moves**
-   (a changed row size and pitch), so again `BlockOpen` refuses and the
-   compatible path is what absorbs it.
+   its shorter row type lands correctly on every row.
 3. **A declared maximum raised.** The storage grows and the `offset_of`s
-   move; the consumer reads them. **The digest does NOT move** — a maximum is
-   excluded from it by design (§19.3) — so this one is absorbed by
-   `BlockOpen` ITSELF, on the default path, with no waiver.
+   move; the consumer reads them out of the instance.
 
-**So the default path absorbs exactly one of the three**, and that is not an
-oversight: edits 1 and 2 change what a row or a projection IS, and §14's "no
-silent bypass" says a consumer meets that by asking for the weaker check by
-name. Edit 3 changes only numbers the consumer was already reading out of the
-instance, and nothing about it needs a waiver.
+**All three are absorbed on the COMPATIBLE path and none on the default one**,
+and that follows from what the two entry points check. `BlockOpen` is the
+SAME-BUILD check: the build version an older consumer carries is not the one
+the producer stamped, whatever the edit was, so it refuses. Absorbing an edit
+is therefore always a caller asking for the weaker check by name, which is
+§14's "no silent bypass" holding: what makes these three absorbable is not
+that they escape an id, but that `BlockOpenCompatible`'s own checks — the
+extent, the alignment, each array's `offset_of` and extent, and this build's
+`sizeof( element ) <= the stride it read` — all pass for them.
 
-**Everything else is a break, and the baseline refuses it** (§18.2): a field
-inserted before the end, reordered, removed or retyped, in the table or in a
-row type; an array's element swapped; an array moved between the out-of-line
-and inline classes, or removed, or moved earlier. Each moves a byte the other
-side reads at, and a block has nothing that could report it — which is why
-the refusal is at compile time and loud.
+**Everything else is a break, and the GENERATED ASSERTS refuse it** (§19.3):
+a field inserted before the end, reordered, removed or retyped, in the table
+or in a row type; an array's element swapped; an array moved between the
+out-of-line and inline classes, or removed, or moved earlier. Each moves a
+byte the other side reads at, and a block has nothing that could report it —
+which is why the refusal is at compile time and loud, and why the baseline
+(§18) carries none of it.
 
 **And the runtime has ONE more entry point, taken by name.**
 `<Table>BlockOpenCompatible` checks **everything `BlockOpen` checks except
-the layout id** — the magic, the byte order, the extent, the alignment, and
-each array's `offset_of` and extent inside the block — and then, per array it
-knows, **this build's `sizeof( element ) <= the stride it read from the
-instance`**. Never an equality, and never against its own pitch constant: a
+the build version** — the magic, the byte order, the extent, the alignment,
+and each array's `offset_of` and extent inside the block — and then, per
+array it knows, **this build's `sizeof( element ) <= the stride it read from
+the instance`**. Never an equality, and never against its own pitch constant: a
 producer whose rows have grown writes a larger pitch, and it is precisely
 that case this entry point exists to absorb.
 
@@ -4020,7 +3952,7 @@ be the wrong trade in both directions.
 It is the tolerant path made available to a caller who deliberately runs a
 consumer older than its producer: a transitional deploy, a hot reload, a tool
 built against last week's schema. **There is no silent bypass** — a caller
-either gets the layout id's guarantee from `BlockOpen`, or asks for the
+either gets the build version's guarantee from `BlockOpen`, or asks for the
 weaker one by name, exactly as §7 splits `Open` from `OpenValidated`. A
 single number cannot be checked against a prefix of the facts that produced
 it, and pretending otherwise is what the second entry point exists to avoid
@@ -4061,11 +3993,11 @@ it, and pretending otherwise is what the second entry point exists to avoid
   wrong one and pass.
 - **The refusal battery**: one fixture per §11 block refusal, each with its
   negative control.
-- **The baseline battery**: one fixture per §18.2 block row — a field
-  inserted in the middle refuses, a field appended at the end of the table
-  passes, a field appended at the end of a row passes, an array's element
-  swapped refuses, an array moved between the inline and out-of-line classes
-  refuses, a maximum raised passes, a maximum lowered warns.
+- **The evolution battery** (§19.4), against the generated asserts and the
+  two entry points rather than against a baseline: a field inserted in the
+  middle fails the build, a field appended at the end of the table and one
+  appended at the end of a row each open under `BlockOpenCompatible` and not
+  under `BlockOpen`, and a maximum raised opens under both.
 - **The zero-cost gate** (§19): the Table headers are byte-identical with the
   Block files generated and with them absent, and the build fails if one
   symbol of the block machinery appears in a Table header.

--- a/SPEC.md
+++ b/SPEC.md
@@ -289,8 +289,8 @@ TypeDecl    = "type" ident ( Block
 TableDecl   = "table" ident ( Block
             | AttrSection NL Block ) NL .               // the TABLE wire, SPEC-TABLES.md —
                                                         // a type body, plus pointers and `was`.
-                                                        // The one qualifier a table takes is
-                                                        // `block` (SPEC-TABLES.md §2.7)
+                                                        // A table declaration takes no
+                                                        // qualifier of its own (§4.2)
 
 Block       = "{" { Item } "}" .
 Item        = Field | ConstField | Reserved | Align | If .
@@ -544,14 +544,7 @@ sequence    uint16
   compressed float); `fixed`/`ufixed`/`int128` take `min`/`max` (required —
   §4.3); enum declarations take `max`; type declarations take a tag and the
   `cpp_native`/`cpp_include` pair (below); a field of a **table** body takes
-  `was` (below); and a **table declaration** takes `block` (below).
-- **`block` — the block form, table declarations only** (SPEC-TABLES.md
-  §2.7). A valueless marker on a fixed table: `table RenderFrame | block`. It
-  declares nothing and changes no field. It says the table has a third
-  projection beside its wire and its cook — one in which the table's own
-  bounded arrays are laid out of line at a fixed pitch, so another language
-  points at their rows. Refused on a `type`, and on a table that reaches a
-  pointer.
+  `was` (below); and a **table declaration** takes none.
 - **`was = "old_name"` — the rename attribute, table bodies only**
   (SPEC-TABLES.md §5). A table field's wire id is the hash of its name, so a
   bare rename would orphan every byte ever written under the old one; `was`

--- a/USAGE.md
+++ b/USAGE.md
@@ -1100,8 +1100,8 @@ foreach ( ref readonly RenderShip ship in block.Ships )
     Draw( ship );
 ```
 
-`BlockOpen` verifies the magic, the byte order, the layout id and the extent,
-and then you index. A generic consumer does not even need the generated
+`BlockOpen` verifies the magic, the byte order, the build version and the
+extent, and then you index. A generic consumer does not even need the generated
 struct: the reflection descriptors carry the projection's layout, so a tool
 can walk any block's rows without a type per table.
 
@@ -1114,9 +1114,10 @@ can walk any block's rows without a type per table.
   wrote it, use the wire — which this same table still has.
 - **The edits it absorbs are appends.** A field appended at the end of the
   table, a field appended at the end of a row, or a maximum raised: all three
-  are absorbed, because the consumer reads offsets and pitches from the
-  instance rather than assuming them. Anything that moves an existing offset
-  is a break, and the tables baseline refuses it.
+  are absorbed on `BlockOpenCompatible`, because the consumer reads offsets
+  and pitches from the instance rather than assuming them. Anything that
+  moves an existing offset is a break, and the generated asserts refuse it at
+  compile time — the tables baseline carries no layout fact.
 - **The allocation is the maximum, once.** `BlockMaxBytes` sums every array's
   declared maximum; the block is allocated once at that size and never grown.
   The bytes you hand off are only the frame's.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1016,17 +1016,17 @@ Two sentences that go together: **a tolerant wire load COPIES the blob** — a
 gigabyte on the wire path is a gigabyte read — and **the cooked path is the
 zero-copy one**, where a pointer into a mapped file IS the asset.
 
-### The block form: `| block`, and rows another language points at
+### The block form: rows another language points at
 
-*Specified, not yet implemented — no backend emits this; a table marked
-`| block` is refused by name today (SPEC-TABLES.md §2.7, §19).*
+*Specified, not yet implemented — no backend emits the Block files yet
+(SPEC-TABLES.md §2.7, §19).*
 
 Some data is not a file and not a message. It is a block you rebuild every
 frame and hand to something in another language, which points at it and reads
-it in place. Mark the table:
+it in place. You declare nothing for it:
 
 ```
-table RenderFrame | block
+table RenderFrame
 {
     version uint64
     cameras [..1]RenderCamera
@@ -1037,16 +1037,32 @@ table RenderFrame | block
 
 **Nothing there is new.** Those are ordinary bounded arrays of ordinary fixed
 tables, and `RenderFrame` is an ordinary table — it still has `Measure`,
-`Save` and `Load` over the tolerant wire, and still cooks. The marker adds a
-third *form* of the same declaration: one in which the table's own bounded
-arrays sit out of line at a fixed pitch, and the instance at the front of the
-block carries, per array, where its rows start, how many there are, and how
-far apart they sit. The other side reads those three facts and points.
+`Save` and `Load` over the tolerant wire, and still cooks. **Every fixed table
+also gets a third *form* of the same declaration**: one in which the table's
+own bounded arrays sit out of line at a fixed pitch, and the instance at the
+front of the block carries, per array, where its rows start, how many there
+are, and how far apart they sit. The other side reads those three facts and
+points.
 
-Which arrays move out of line is the one rule to know: **the marked table's
-own `[..N]` arrays, and nothing else** — a fixed `[N]T`, an enum-keyed
-`[E]T`, and any array inside a row all stay where they are. Elements must be
-structs: a fixed table or a plain `type`. A row's pitch is its `sizeof`.
+You reach for it by INCLUDING it. The form is generated on the side, in
+`<Base>Block.h` / `<Base>Block.cpp` beside the unit's `<Base>Table.h`, and in
+`<Base>Block.cs` for C# — so a project that never blocks a table compiles
+none of it, and the table headers are the same bytes either way:
+
+```cpp
+#include "RenderTable.h"                      // the ordinary table surface
+#include "RenderBlock.h"                      // the block form, only if you use it
+```
+
+```
+c++ -c RenderBlock.cpp                        // and link it, once, if you did
+```
+
+Which arrays move out of line is the one rule to know: **the table's own
+`[..N]` arrays whose element is a struct, and nothing else** — a fixed `[N]T`,
+an enum-keyed `[E]T`, a bounded array of scalars, and any array inside a row
+all stay where they are. A row's pitch is its `sizeof`. A variable-length
+table has no block form at all: a pointer means no fixed pitch.
 
 **Building it goes wide, and that is required, not merely allowed.** Declare
 the counts, lay the block out once, then let N workers fill disjoint ranges:

--- a/USECASES.md
+++ b/USECASES.md
@@ -119,11 +119,12 @@ A C++ producer writes a block of per-frame render data and a C# consumer
 points at it and reads rows in place — large structures, both directions,
 sixty times a second or better.
 
-- **Form** — the **block form** (SPEC-TABLES.md §19): a fixed table marked
-  `| block` gets a third projection beside its wire and its cook, in which
-  the table's own bounded arrays are laid out of line at a fixed pitch and
-  the instance at the front of the block carries, per array, an `(offset_of,
-  count, stride)` triple.
+- **Form** — the **block form** (SPEC-TABLES.md §19): every fixed table has a
+  third projection beside its wire and its cook, in which the table's own
+  bounded arrays are laid out of line at a fixed pitch and the instance at
+  the front of the block carries, per array, an `(offset_of, count, stride)`
+  triple. Nothing declares it; it is emitted on the side, and a consumer that
+  does not include it pays nothing.
 - **Contract** — one exact layout, held as a **two-language layout contract**
   (§19.3). The compiler derives every offset and size, C++ asserts them with
   `static_assert` and C# with a blittable `Sequential` struct plus generated

--- a/USECASES.md
+++ b/USECASES.md
@@ -129,7 +129,7 @@ sixty times a second or better.
   (§19.3). The compiler derives every offset and size, C++ asserts them with
   `static_assert` and C# with a blittable `Sequential` struct plus generated
   padding fields and a generated size and offset check, so neither side can
-  drift silently. `BlockOpen` matches the layout digest;
+  drift silently. `BlockOpen` matches the build version;
   `BlockOpenCompatible` drops that one check by name and nothing else, for a
   consumer deliberately older than its producer. The block carries no field
   ids, no lengths, no elision and no read report — §4's counters do not


### PR DESCRIPTION
Owner ruling 2026-09-02 on #288, verbatim **"KISS"**, answering "what is it about render data that requires a specific per-table declaration?" — nothing does. The `| block` marker was a cost switch and not a semantic. Spec-only; no compiler change, because no backend ever implemented the marker.

**The rule now.** Every FIXED table has a block form. It is emitted ON THE SIDE — `<Base>Block.h` (the projection struct, the generated layout asserts, the builder API, the `BlockOpen` / `BlockOpenCompatible` declarations) and `<Base>Block.cpp` (their definitions), `<Base>Block.cs` for C# — which a consumer includes and links only when it uses the form. The Table headers carry nothing of it. The zero-cost gate reads: **the Table headers are byte-identical with or without the Block files existing, and the Block files cost nothing unless included.** A variable-length table has no block form, refused by absence, reason in one line: no fixed pitch.

**Where it landed**

- **§2.7 stays as a SHORT POINTER** rather than collapsing into §19. Reason: §2 is the declaration chapter and the form now declares nothing, so its rules belong in §19 — but 25 places in the tree cite §2.7, and two spec PRs (#297, #299) are in flight. A pointer keeps every citation landing on a true statement and keeps this diff local. §2.7 now says only: nothing selects the form, the mode decides who has one, the form is on the side, and §19 is the form.
- **§19** gains the declaration example, the on-the-side emission rule with its §16/§13.5 precedent, the variable-length absence line, the zero-cost gate in its new terms, and "the rule, in full" moved down from §2.7 (depth one bounded only, the projection, which elements move, pitch is `sizeof`, a table not a new kind of table).
- **§2.2** — the derivation paragraph, the zero-cost paragraph (held by SEPARATION now, not by a switch) and the large-maxima paragraph, all without the marker.
- **SPEC.md §4.2** loses the `block` attribute and the `TableDecl` grammar comment that named it. A table declaration takes no qualifier, so `table X | block` is now an unknown attribute, which §4.2 already makes a compile error.
- **§11** loses the four marker refusals and keeps two, both refusals of a DECLARATION that collides with what the form generates: `| stride`, and a field named `magic` or `build_version`. The nine block spellings and the two per-array accessor spellings are claimed for every fixed table now.
- **§13.6** records the ruling verbatim with the question it answered. **§14**'s "selected by `| block` ALONE — TAKEN" becomes "NOTHING SELECTS THE FORM — TAKEN", keeping the per-field `| stride` trigger rejection on its own evidence.
- **§12.1, §3, §6, §8** — the marker's remaining traces. §8's `block` descriptor flag is gone: every fixed table has the form, and the mode is already in the descriptors.
- **USAGE** — the example loses the marker and gains the include and the link line. **USECASES** entry 5 likewise.
- **Non-struct array elements.** Under the marker, an out-of-line array whose element was not a struct was a refusal. It cannot be one now — a fixed table may declare `[..N]uint32` and nobody asked for a block form. Such an array **stays INLINE in the projection**, exactly as a fixed `[N]T` does; the set that moves out of line is unchanged.

**Second commit — two decisions folded in after the first review**

1. **The BASELINE judges the wire only.** With nothing declaring the form, a baseline cannot know which tables a project blocks, and layout drift is loud at compile time through the generated asserts and the build version. §18.1 loses the layout-fact paragraphs and states the boundary in one line — *the baseline guards what the wire cannot report, and layout is a compile-time contract*; §18.2 loses the layout verdicts; the sample file returns to rendering version 2 with its wire lines only; §11's baseline refusal loses its block clause; §19.4 and §19.5 stop citing §18 as the guard, and §19.5's baseline battery becomes an evolution battery against the asserts and the two entry points.
2. **Two ids: the protocol id and the build version.** The per-table layout id is gone (#292 carries the definition), so the block prologue's field is `build_version`. §19.3 names it and stops defining a per-table digest; `BlockOpen` checks it, `BlockOpenCompatible` drops that one check; the claimed field names are `magic` and `build_version` and the claimed spelling is `BlockBuildVersion`. One consequence worth the line-read: §19.4's three edits are now **all** absorbed on the compatible path and none on the default one, because an older consumer's build version never matches whatever the edit was — what makes them absorbable is the compatible path's own checks (`sizeof( element ) <= the stride it read`, plus the bounds), not escaping an id. Only block-form lines are swept; the cook's layout id in §7/§14/§15 is left for #297.

`make check` green over the whole corpus. Closes #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
