### PR TITLE
ci: an emulated big-endian leg runs the tables battery (#303)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,63 @@ jobs:
       - name: fuzz seeds
         run: go test ./internal/fuzz/
 
+  # DOGFOOD BIG-ENDIAN (issue #303). SPEC-TABLES.md §3 says the wire is
+  # little-endian and byte-oriented throughout; §7 says a cook is produced in
+  # the byte order of the build it is cooked for, and that Open refuses any
+  # other. Every host this repo has built on is little-endian, so both rules
+  # were assertions on a page: a generated codec that reached for HOST order
+  # anywhere would have passed every other leg in this file, and the goldens
+  # would have said nothing.
+  #
+  # This leg builds the tables battery for s390x — big-endian, and the target
+  # both qemu-user and the Ubuntu gcc cross packages support best — and runs it
+  # under emulation, plus a cross-endian cook pair the host and the target hand
+  # to each other. Its negative control puts one byte-order-neutral store back
+  # to a host-order copy and proves the leg goes red on the target while
+  # staying green here, which is the whole argument for having it.
+  #
+  # It runs on PRs: it is an iteration gate, not a certification one — it
+  # answers a question about the code in the diff, not about the compiler that
+  # built it — and it fits the budget.
+  #
+  # THE PINS. The runner image is named rather than `-latest`, because package
+  # versions are only meaningful against one archive; the cross compiler and
+  # the emulator are then installed by EXACT version, so this leg proves the
+  # same thing next month as today. Bumping either is a deliberate one-line
+  # edit, the same act as the golangci-lint pin below, and the versions come
+  # from the policy the failing install prints. The step after the install
+  # records the resolved closure both pins pull in.
+  big-endian:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: the pinned cross toolchain and emulator
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            g++-13-s390x-linux-gnu=13.3.0-6ubuntu2~24.04.1cross1 \
+            qemu-user=1:8.2.2+ds-0ubuntu1.18
+
+      - name: what the pins resolved to
+        run: |
+          s390x-linux-gnu-g++-13 --version | head -1
+          qemu-s390x --version | head -1
+          dpkg-query -W -f='${Package} ${Version}\n' | grep -E 's390x|^qemu-user'
+
+      # The battery on the target, then the control that proves it can fail.
+      # BE_CXX names the pinned compiler: the exact-version package installs
+      # the SUFFIXED driver, and the Makefile's unsuffixed default is for a
+      # workstation that installed the metapackage.
+      - name: the big-endian leg, and its negative control
+        run: make tables-big-endian-negative BE_CXX=s390x-linux-gnu-g++-13
+
   # The per-port inline-budget gate (issue #25; BENCH-STANDARD.md §4.3),
   # fanned out one leg per job so the legs run concurrently instead of
   # serially (they were ~9 minutes end to end in one job; the longest single

--- a/Makefile
+++ b/Makefile
@@ -199,16 +199,28 @@ build/schema_test_guard: build/guard-generated/.stamp test/guard/main.cpp
 # The tables corpus (SPEC-TABLES.md): the tabledemo unit plus the
 # two-generation evolution pair (tblv1/tblv2), generated at build time into
 # build/ — test-only, never part of the committed generated/ tree.
+#
+# The generate step and the include path are parameterised by generator binary
+# and output root, because the big-endian negative control below regenerates
+# the WHOLE corpus from a sabotaged emitter: a second copy of these lists would
+# be a second corpus, and the gate would stop covering what the leg covers.
+define tables_generate
+	$(1) generate --lang cpp --out $(2)/examples tables/examples
+	$(1) generate --lang cpp --out $(2)/pointers tables/pointers
+	$(1) generate --lang cpp --out $(2)/v1 test/tables/V1.schema
+	$(1) generate --lang cpp --out $(2)/v2 test/tables/V2.schema
+	$(1) generate --lang cpp --out $(2)/p1 test/tables/P1.schema
+	$(1) generate --lang cpp --out $(2)/p2 test/tables/P2.schema
+	$(1) generate --lang cpp --out $(2)/p3 test/tables/P3.schema
+	$(1) generate --lang cpp --out $(2)/jsonkeys test/tables/JsonKeys.schema
+endef
+
+tables_includes = -I$(1)/examples -I$(1)/pointers -Itest/tables \
+	-I$(1)/v1 -I$(1)/v2 -I$(1)/p1 -I$(1)/p2 -I$(1)/p3 -I$(1)/jsonkeys
+
 build/tables-generated/.stamp: bin/schema $(SCHEMAS_TABLES) $(SCHEMAS_TABLES_POINTERS) test/tables/V1.schema test/tables/V2.schema test/tables/P1.schema test/tables/P2.schema test/tables/P3.schema test/tables/JsonKeys.schema
 	@mkdir -p build/tables-generated
-	./bin/schema generate --lang cpp --out build/tables-generated/examples tables/examples
-	./bin/schema generate --lang cpp --out build/tables-generated/pointers tables/pointers
-	./bin/schema generate --lang cpp --out build/tables-generated/v1 test/tables/V1.schema
-	./bin/schema generate --lang cpp --out build/tables-generated/v2 test/tables/V2.schema
-	./bin/schema generate --lang cpp --out build/tables-generated/p1 test/tables/P1.schema
-	./bin/schema generate --lang cpp --out build/tables-generated/p2 test/tables/P2.schema
-	./bin/schema generate --lang cpp --out build/tables-generated/p3 test/tables/P3.schema
-	./bin/schema generate --lang cpp --out build/tables-generated/jsonkeys test/tables/JsonKeys.schema
+	$(call tables_generate,./bin/schema,build/tables-generated)
 	@touch $@
 
 # The ZERO-COST GATE (SPEC-TABLES.md): a table with no pointer in its by-value
@@ -333,10 +345,7 @@ tables-json-keyed-dup-negative-control: bin/schema test/tables/json_keyed_dup_ne
 #
 # TABLES_INCLUDES is shared with the sanitized twin below, so the two builds
 # can never drift into covering different code.
-TABLES_INCLUDES := -Ibuild/tables-generated/examples -Ibuild/tables-generated/pointers -Itest/tables \
-	-Ibuild/tables-generated/v1 -Ibuild/tables-generated/v2 \
-	-Ibuild/tables-generated/p1 -Ibuild/tables-generated/p2 -Ibuild/tables-generated/p3 \
-	-Ibuild/tables-generated/jsonkeys
+TABLES_INCLUDES := $(call tables_includes,build/tables-generated)
 TABLES_CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -pthread
 
 # The text form's runtime is a generated TRANSLATION UNIT now, not header
@@ -368,6 +377,90 @@ build/schema_test_tables_asan: build/tables-generated/.stamp test/tables/main.cp
 	@mkdir -p build
 	$(CXX) $(TABLES_CXXFLAGS) -fsanitize=address,undefined -fno-sanitize-recover=all \
 		-fno-omit-frame-pointer -g $(TABLES_INCLUDES) test/tables/main.cpp $(TABLES_JSON_SOURCES) -o $@
+
+# ---- the BIG-ENDIAN leg (SPEC-TABLES.md §3 and §7) -------------------------
+#
+# The wire is little-endian and byte-oriented (§3), and a cook is produced in
+# the byte order of the build it is cooked for (§7). Both were rules on a page:
+# every host this repo builds on is little-endian, so nothing ever read a
+# golden the other way round. This leg builds the tables battery for a
+# BIG-ENDIAN target and runs it under an emulator, which turns the two rules
+# into gates — the goldens a little-endian host wrote are loaded, re-written
+# and byte-compared by a big-endian reader, and a cook that crosses the byte
+# order is proven to refuse rather than to garble.
+#
+# The toolchain is not a system binary and is not assumed: CI installs an
+# exact pinned version (.github/workflows/ci.yml) and these two variables name
+# what it installed, so the leg runs anywhere the same pair is on PATH.
+BE_CXX ?= s390x-linux-gnu-g++
+BE_RUN ?= qemu-s390x
+
+# Same flags and includes as the plain leg, shared through the same variables
+# for the same reason the sanitized twin shares them (#278): a twin that
+# covers different code is not a twin. -static so the runner needs no sysroot
+# and the emulator invocation is just the binary.
+build/schema_test_tables_be: build/tables-generated/.stamp test/tables/main.cpp
+	@mkdir -p build
+	$(BE_CXX) $(TABLES_CXXFLAGS) -static $(TABLES_INCLUDES) test/tables/main.cpp $(TABLES_JSON_SOURCES) -o $@
+
+# The cross-endian COOK driver, built BOTH ways: the rule it holds — a cook
+# does not cross a byte order — needs two builds and a file between them, which
+# is the one part of §7 no single-process test can reach.
+build/schema_test_cook_endian: build/tables-generated/.stamp test/tables/cook_endian_main.cpp
+	@mkdir -p build
+	$(CXX) $(TABLES_CXXFLAGS) $(TABLES_INCLUDES) test/tables/cook_endian_main.cpp -o $@
+
+build/schema_test_cook_endian_be: build/tables-generated/.stamp test/tables/cook_endian_main.cpp
+	@mkdir -p build
+	$(BE_CXX) $(TABLES_CXXFLAGS) -static $(TABLES_INCLUDES) test/tables/cook_endian_main.cpp -o $@
+
+.PHONY: tables-big-endian
+tables-big-endian: build/schema_test_tables_be build/schema_test_cook_endian build/schema_test_cook_endian_be
+	$(BE_RUN) ./build/schema_test_tables_be
+	./build/schema_test_cook_endian write build/cook-host.bin
+	$(BE_RUN) ./build/schema_test_cook_endian_be write build/cook-target.bin
+	$(BE_RUN) ./build/schema_test_cook_endian_be accept build/cook-target.bin
+	$(BE_RUN) ./build/schema_test_cook_endian_be refuse build/cook-host.bin
+	./build/schema_test_cook_endian accept build/cook-host.bin
+	./build/schema_test_cook_endian refuse build/cook-target.bin
+	@echo "big-endian leg: the wire crosses the byte order, the cook refuses to"
+
+# Its NEGATIVE CONTROL. Put ONE of the wire's byte-order-neutral stores back to
+# a host-order copy — put16, which writes every field id, every enum value and
+# every union arm id — and the leg must go RED on the big-endian target. The
+# same sabotage stays GREEN on this little-endian host, and that pair is the
+# whole argument for the leg: this is precisely the defect class no
+# little-endian CI can see.
+#
+# The sabotaged emitter reaches the compiler through `go build -overlay`, so no
+# tracked file is ever written to: an interrupt cannot leave a sabotaged
+# working tree, and a parallel `make -j` cannot compile the sabotage into
+# something else.
+.PHONY: tables-big-endian-negative
+tables-big-endian-negative: tables-big-endian
+	@mkdir -p build
+	@sed 's|void put16( uint16_t v ) { uint8_t b\[2\] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }|void put16( uint16_t v ) { raw( \&v, 2 ); } // SABOTAGED: host order|' \
+		internal/codegen/cpptable/cpptable.go > build/cpptable-host-order.gotext
+	@cmp -s build/cpptable-host-order.gotext internal/codegen/cpptable/cpptable.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/cpptable.go":"%s/build/cpptable-host-order.gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/cpptable-overlay.json
+	@go build -overlay=build/cpptable-overlay.json -o build/schema-host-order ./cmd/schema
+	@rm -rf build/tables-host-order && mkdir -p build/tables-host-order
+	$(call tables_generate,./build/schema-host-order,build/tables-host-order)
+	$(CXX) $(TABLES_CXXFLAGS) $(call tables_includes,build/tables-host-order) \
+		test/tables/main.cpp $$(ls build/tables-host-order/*/*Table.cpp) -o build/schema_test_tables_host_order
+	$(BE_CXX) $(TABLES_CXXFLAGS) -static $(call tables_includes,build/tables-host-order) \
+		test/tables/main.cpp $$(ls build/tables-host-order/*/*Table.cpp) -o build/schema_test_tables_host_order_be
+	@./build/schema_test_tables_host_order > /dev/null || \
+		{ echo "NEGATIVE CONTROL FAILED: a host-order put16 is visible on a little-endian host — this host is not little-endian, or the sabotage is not the one described"; exit 1; }
+	@echo "negative control: a host-order put16 leaves the LITTLE-ENDIAN leg green"
+	@if $(BE_RUN) ./build/schema_test_tables_host_order_be > build/host-order-be.log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: a host-order put16 left the BIG-ENDIAN leg green"; exit 1; \
+	fi
+	@grep -q "table wire golden" build/host-order-be.log || \
+		{ echo "NEGATIVE CONTROL FAILED: the big-endian leg went red, but not on a wire golden"; cat build/host-order-be.log; exit 1; }
+	@echo "negative control: the same put16 turns the BIG-ENDIAN leg red, on the wire goldens"
 
 # The PACK GOLDEN (SPEC-TABLES.md §17.4, issue #257). `schema pack` carries an
 # IR-driven engine in Go — the compiler cannot run the code it emits — so the

--- a/test/tables/cook_endian_main.cpp
+++ b/test/tables/cook_endian_main.cpp
@@ -1,0 +1,226 @@
+// The CROSS-ENDIAN COOK driver (SPEC-TABLES.md §7).
+//
+// "Endianness is part of the COOK, not of `Open`." A cook is produced in the
+// byte order of the build it is cooked for, and the magic is the byte-order
+// check: a file whose recorded order is not this build's is simply not this
+// build's file, and refuses. Every other test in this tree runs both halves in
+// ONE process, so the rule that a cook does not cross a byte order is the one
+// part of §7 no single-process test can reach — it needs two builds and a file
+// between them.
+//
+// This driver is one of those builds. The Makefile's tables-big-endian leg
+// runs it four ways: the host writes a cook the big-endian target must refuse,
+// the target writes one the host must refuse, and each opens its own.
+//
+//   cook-endian write  <path>   cook a scene and write it
+//   cook-endian accept <path>   Open must succeed and the scene must read back
+//   cook-endian refuse <path>   Open must return NULL, and by BYTE ORDER
+//
+// The refusal case proves three things and not just the first: that Open
+// returned NULL rather than pointing at garbage, that the file's magic is this
+// build's magic byte-reversed (so byte order is what refused it, not some
+// other mismatch), and that the reader still works afterwards — a clean
+// refusal leaves the caller able to fall back, which is the whole point of
+// returning NULL.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "GraphTable.h"
+
+static int failures = 0;
+
+#define CHECK( cond )                                                    \
+    do {                                                                 \
+        if ( !( cond ) ) {                                               \
+            printf( "FAIL %s:%d %s\n", __FILE__, __LINE__, #cond );      \
+            failures++;                                                  \
+        }                                                                \
+    } while ( 0 )
+
+static void set_string( char * dest, int32_t & length, const char * s )
+{
+    length = (int32_t) strlen( s );
+    memcpy( dest, s, length + 1 );
+}
+
+// A scene with the shapes a cooked region is made of: a pointer chain, an
+// aliased node, a variable table nested by value, and a bounded array of them.
+static void build_scene( graphdemo::SceneBuilder & builder )
+{
+    graphdemo::Scene * root = builder.GetRoot();
+    set_string( root->name, root->name_length, "cooked" );
+    root->version = 7;
+    root->meta.build = 42;
+    set_string( root->meta.tag, root->meta.tag_length, "m" );
+
+    graphdemo::TableSlot<graphdemo::Settings> settings = builder.Alloc<graphdemo::Settings>();
+    settings->quality = 4;
+    set_string( settings->label, settings->label_length, "high" );
+    root->settings = settings;
+
+    graphdemo::TableSlot<graphdemo::ListNode> n0 = builder.Alloc<graphdemo::ListNode>();
+    graphdemo::TableSlot<graphdemo::ListNode> n1 = builder.Alloc<graphdemo::ListNode>();
+    n0->value = 10; set_string( n0->name, n0->name_length, "a" );
+    n1->value = 20; set_string( n1->name, n1->name_length, "b" );
+    n0->next = n1;
+    root->head = n0;
+    root->alias = n1; // two references, one node
+
+    root->ground.depth = 3;
+    root->layers_count = 2;
+    root->layers[0].depth = 1;
+    root->layers[1].depth = 2;
+    root->layers[1].head = n1;
+}
+
+static void check_scene( const graphdemo::Scene * scene )
+{
+    CHECK( scene != NULL );
+    if ( scene == NULL ) return;
+    CHECK( strcmp( scene->name, "cooked" ) == 0 );
+    CHECK( scene->version == 7 );
+    CHECK( scene->meta.build == 42 );
+    const graphdemo::ListNode * a = graphdemo::ListNodeAt( scene->head );
+    CHECK( a != NULL && a->value == 10 && strcmp( a->name, "a" ) == 0 );
+    const graphdemo::ListNode * b = graphdemo::ListNodeAt( a->next );
+    CHECK( b != NULL && b->value == 20 );
+    CHECK( graphdemo::ListNodeAt( b->next ) == NULL );
+    // a node named twice packs as two nodes — the packed form is a tree, as
+    // the wire is (SPEC-TABLES.md §3) — so the alias is a distinct node with
+    // the same value, and that is what a reader must find on either byte order
+    const graphdemo::ListNode * aliased = graphdemo::ListNodeAt( scene->alias );
+    CHECK( aliased != NULL && aliased != b && aliased->value == 20 );
+    const graphdemo::Settings * settings = graphdemo::SettingsAt( scene->settings );
+    CHECK( settings != NULL && settings->quality == 4 );
+    CHECK( scene->layers_count == 2 && scene->layers[0].depth == 1 );
+    const graphdemo::ListNode * layered = graphdemo::ListNodeAt( scene->layers[1].head );
+    CHECK( layered != NULL && layered != b && layered->value == 20 );
+}
+
+// cook_scene returns a malloc'd cooked file, or NULL. malloc's alignment is
+// already past the region's (kTableAlign is 8), which is the same reason Open
+// can point at an mmap'd base.
+static uint8_t * cook_scene( int64_t * bytes )
+{
+    static graphdemo::SceneBuilder builder;
+    build_scene( builder );
+    if ( !builder.Lock() ) { printf( "FAIL Lock refused\n" ); failures++; return NULL; }
+    int64_t need = graphdemo::SceneCookMeasure( builder );
+    uint8_t * cooked = (uint8_t *) malloc( (size_t) need );
+    if ( cooked == NULL ) { printf( "FAIL out of memory\n" ); failures++; return NULL; }
+    if ( graphdemo::SceneCook( builder, cooked, need ) != need )
+    {
+        printf( "FAIL Cook wrote the wrong length\n" );
+        failures++;
+        free( cooked );
+        return NULL;
+    }
+    *bytes = need;
+    return cooked;
+}
+
+static uint8_t * read_file( const char * path, int64_t * bytes )
+{
+    FILE * f = fopen( path, "rb" );
+    if ( f == NULL ) { printf( "FAIL cannot read %s\n", path ); failures++; return NULL; }
+    fseek( f, 0, SEEK_END );
+    long size = ftell( f );
+    fseek( f, 0, SEEK_SET );
+    uint8_t * buffer = (uint8_t *) malloc( (size_t) size );
+    size_t got = fread( buffer, 1, (size_t) size, f );
+    fclose( f );
+    if ( (long) got != size ) { printf( "FAIL short read of %s\n", path ); failures++; free( buffer ); return NULL; }
+    *bytes = (int64_t) size;
+    return buffer;
+}
+
+// this build's own magic bytes, in the order it writes them — the four bytes
+// every comparison below is against
+static void local_magic( uint8_t out[4] )
+{
+    uint32_t magic = graphdemo::kTableCookedMagic;
+    memcpy( out, &magic, 4 );
+}
+
+static int do_write( const char * path )
+{
+    int64_t bytes = 0;
+    uint8_t * cooked = cook_scene( &bytes );
+    if ( cooked == NULL ) return 1;
+    FILE * f = fopen( path, "wb" );
+    if ( f == NULL ) { printf( "FAIL cannot write %s\n", path ); free( cooked ); return 1; }
+    fwrite( cooked, 1, (size_t) bytes, f );
+    fclose( f );
+    uint8_t magic[4];
+    local_magic( magic );
+    printf( "cook-endian write: %lld bytes, magic %02x %02x %02x %02x\n",
+            (long long) bytes, magic[0], magic[1], magic[2], magic[3] );
+    free( cooked );
+    return 0;
+}
+
+static int do_accept( const char * path )
+{
+    int64_t bytes = 0;
+    uint8_t * file = read_file( path, &bytes );
+    if ( file == NULL ) return 1;
+    const graphdemo::Scene * scene = graphdemo::SceneOpen( file, bytes );
+    CHECK( scene != NULL );
+    CHECK( (const uint8_t *) scene == file + graphdemo::kTableCookedHeaderBytes ); // pointed at, not copied
+    check_scene( scene );
+    free( file );
+    if ( failures > 0 ) { printf( "cook-endian accept: %d failure(s)\n", failures ); return 1; }
+    printf( "cook-endian accept: %s opened, in this build's byte order\n", path );
+    return 0;
+}
+
+static int do_refuse( const char * path )
+{
+    int64_t bytes = 0;
+    uint8_t * file = read_file( path, &bytes );
+    if ( file == NULL ) return 1;
+
+    // the file is a cook, and its magic is this build's magic REVERSED: the
+    // two builds agree about the constant and disagree about byte order, so
+    // byte order is the only thing that can refuse it
+    uint8_t mine[4];
+    local_magic( mine );
+    CHECK( bytes >= graphdemo::kTableCookedHeaderBytes );
+    for ( int i = 0; i < 4; i++ ) { CHECK( file[i] == mine[3 - i] ); }
+
+    // and it refuses: NULL, not a pointer into bytes this build cannot read
+    CHECK( graphdemo::SceneOpen( file, bytes ) == NULL );
+    free( file );
+
+    // the refusal is CLEAN — a caller that fell back would find the reader
+    // exactly as it was, so a cook this build wrote still opens
+    int64_t own_bytes = 0;
+    uint8_t * own = cook_scene( &own_bytes );
+    if ( own != NULL )
+    {
+        const graphdemo::Scene * scene = graphdemo::SceneOpen( own, own_bytes );
+        CHECK( scene != NULL );
+        check_scene( scene );
+        free( own );
+    }
+
+    if ( failures > 0 ) { printf( "cook-endian refuse: %d failure(s)\n", failures ); return 1; }
+    printf( "cook-endian refuse: %s refused by byte order, cleanly\n", path );
+    return 0;
+}
+
+int main( int argc, char ** argv )
+{
+    if ( argc != 3 )
+    {
+        printf( "usage: cook-endian <write|accept|refuse> <path>\n" );
+        return 2;
+    }
+    if ( strcmp( argv[1], "write" ) == 0 )  return do_write( argv[2] );
+    if ( strcmp( argv[1], "accept" ) == 0 ) return do_accept( argv[2] );
+    if ( strcmp( argv[1], "refuse" ) == 0 ) return do_refuse( argv[2] );
+    printf( "unknown mode %s\n", argv[1] );
+    return 2;
+}

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <new>
 #include <thread>
 #include <vector>
 
@@ -2833,6 +2834,94 @@ static void pin_table_golden( const char * name, const uint8_t * data, int64_t b
     }
 }
 
+// ---- and the goldens READ BACK (SPEC-TABLES.md §3) --------------------------
+//
+// pin_table_golden proves the WRITER: the bytes this build produces are the
+// bytes on disk. This proves the READER against those same files — every
+// golden is loaded from disk into a fresh instance and re-saved, and the bytes
+// must come back identical.
+//
+// On a little-endian host that is a round trip through a file. On the
+// BIG-ENDIAN leg (Makefile: tables-big-endian) it is the claim itself: the
+// files were written by a little-endian build, so a codec that reached for
+// host byte order anywhere would read them wrong and write them back
+// differently. §3's "little-endian, byte-oriented throughout" is a property of
+// the WIRE, not of the machine, and this is where that costs something.
+
+static uint8_t golden_pinned[1u << 20];
+static uint8_t golden_again[1u << 20];
+
+static int64_t read_table_golden( const char * name )
+{
+    char path[256];
+    snprintf( path, sizeof( path ), "testdata/wire/tables/%s.bin", name );
+    FILE * f = fopen( path, "rb" );
+    if ( f == NULL )
+    {
+        printf( "FAIL missing table wire golden %s (run: make update-goldens)\n", path );
+        failures++;
+        return -1;
+    }
+    size_t n = fread( golden_pinned, 1, sizeof( golden_pinned ), f );
+    fclose( f );
+    return (int64_t) n;
+}
+
+template <typename T, typename Report>
+static void reload_table_golden( const char * name,
+                                 bool ( *load )( T &, const uint8_t *, int64_t, Report * ),
+                                 int64_t ( *save )( const T &, uint8_t *, int64_t ) )
+{
+    const int64_t pinned = read_table_golden( name );
+    if ( pinned < 0 ) return;
+
+    static T value;
+    new ( &value ) T(); // the read path's own reset: value-init, in place
+    Report report;
+    if ( !load( value, golden_pinned, pinned, &report ) || report.malformed )
+    {
+        printf( "FAIL table wire golden %s does not load\n", name );
+        failures++;
+        return;
+    }
+    // its own writer's bytes: nothing in them is unknown, nothing mismatches
+    CHECK( report.unknown == 0 && report.kind_mismatch == 0 );
+
+    const int64_t wrote = save( value, golden_again, sizeof( golden_again ) );
+    if ( wrote != pinned || memcmp( golden_again, golden_pinned, (size_t) pinned ) != 0 )
+    {
+        printf( "FAIL table wire golden %s re-saves differently: %lld bytes out, %lld pinned\n",
+                name, (long long) wrote, (long long) pinned );
+        failures++;
+    }
+}
+
+// Every file in testdata/wire/tables, read by the type that wrote it. The
+// three pointer-form goldens are read by their by-value and optional twins,
+// which is exactly right: the three spellings are ONE FRAMING (§3), and the
+// twins' Save is the one that answers in bytes.
+static void test_golden_reload()
+{
+    reload_table_golden( "root_full", tabledemo::RootConfigLoad, tabledemo::RootConfigSave );
+    reload_table_golden( "root_default", tabledemo::RootConfigLoad, tabledemo::RootConfigSave );
+    reload_table_golden( "profile_elide", tabledemo::ProfileConfigLoad, tabledemo::ProfileConfigSave );
+    reload_table_golden( "loadout_full", tabledemo::LoadoutConfigLoad, tabledemo::LoadoutConfigSave );
+    reload_table_golden( "wide_blob", tabledemo::WideBlobLoad, tabledemo::WideBlobSave );
+    reload_table_golden( "archive", tabledemo::ArchiveConfigLoad, tabledemo::ArchiveConfigSave );
+    reload_table_golden( "keyed_config", tabledemo::KeyedConfigLoad, tabledemo::KeyedConfigSave );
+    reload_table_golden( "keyed_default", tabledemo::KeyedConfigLoad, tabledemo::KeyedConfigSave );
+    reload_table_golden( "v1_cfg", tblv1::CfgLoad, tblv1::CfgSave );
+    reload_table_golden( "v1_seams", tblv1::CfgLoad, tblv1::CfgSave );
+    reload_table_golden( "v2_cfg", tblv2::CfgLoad, tblv2::CfgSave );
+    reload_table_golden( "v2_seams", tblv2::CfgLoad, tblv2::CfgSave );
+    reload_table_golden( "chain_value", tblp1::ChainLoad, tblp1::ChainSave );
+    reload_table_golden( "chain_value_empty", tblp1::ChainLoad, tblp1::ChainSave );
+    reload_table_golden( "chain_pointer", tblp1::ChainLoad, tblp1::ChainSave );
+    reload_table_golden( "chain_optional", tblp3::ChainLoad, tblp3::ChainSave );
+    reload_table_golden( "chain_optional_empty", tblp3::ChainLoad, tblp3::ChainSave );
+    reload_table_golden( "chain_pointer_empty", tblp3::ChainLoad, tblp3::ChainSave );
+}
+
 // The pinned instances, built here and mirrored VALUE FOR VALUE by every port
 // (test/cs-tables/src/Program.cs is the C# twin). Keep the two in step: a
 // divergence in the instance is a divergence in the gate.
@@ -4860,9 +4949,10 @@ static void test_golden_seams()
         tblp2::Chain * root = builder.GetRoot();
         root->link = builder.Alloc<tblp2::Link>(); // non-null and all-default: it RIDES
         CHECK( builder.Lock() );
-        int64_t w_ptr = tblp2::ChainSave( builder, other, sizeof( other ) );
-        CHECK( w_ptr == w_opt && memcmp( other, other, (size_t) w_ptr ) == 0 );
-        pin_table_golden( "chain_pointer_empty", other, w_ptr );
+        static uint8_t pointered[4096];
+        int64_t w_ptr = tblp2::ChainSave( builder, pointered, sizeof( pointered ) );
+        CHECK( w_ptr == w_opt && memcmp( pointered, other, (size_t) w_ptr ) == 0 );
+        pin_table_golden( "chain_pointer_empty", pointered, w_ptr );
     }
 }
 
@@ -4993,6 +5083,7 @@ int main()
 {
     test_golden_wire();
     test_golden_seams();
+    test_golden_reload();
     test_round_trip();
     test_exact_capacity();
     test_storage_invariants();


### PR DESCRIPTION
SPEC-TABLES.md §3 says the wire is little-endian and byte-oriented throughout. §7 says a cook is produced in the byte order of the build it is cooked for, and that `Open` refuses any other. Every host this repo has ever built on is little-endian, so both were assertions with nothing behind them: a generated codec that reached for HOST byte order would have passed every leg in `ci.yml`, and the goldens would have said nothing.

This adds a CI leg that builds the tables battery for a big-endian target and runs it under emulation.

## The target and the pins

**s390x**, cross-compiled on the runner and run under `qemu-user`. It is the big-endian target both qemu-user and the Ubuntu gcc cross packages support best; ppc64 was the fallback and was not needed.

Nothing is a system binary and nothing floats:

| pin | value |
|---|---|
| runner image | `ubuntu-24.04` (named, not `-latest` — a package version is only meaningful against one archive) |
| cross compiler | `g++-13-s390x-linux-gnu=13.3.0-6ubuntu2~24.04.1cross1` → `s390x-linux-gnu-g++-13 (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0` |
| emulator | `qemu-user=1:8.2.2+ds-0ubuntu1.18` → `qemu-s390x version 8.2.2` |

A bump is a deliberate one-line edit, the same act as the golangci-lint pin. The step after the install prints the whole resolved closure, so the log carries what the two pins pulled in.

The target build uses the **same flags and the same includes** as the plain leg, shared through the same Makefile variables the sanitized twin shares (#278's rule: a twin that covers different code is not a twin), plus `-static` so the run is just the binary.

## The timings

Whole job **87s**, inside the two-minute law. No subset was cut — the leg runs the entire battery.

| step | time |
|---|---|
| pinned apt install | 15s |
| `go build bin/schema` + generate | 12s |
| cross-compile the battery | 5.5s |
| **the battery under qemu-s390x** | **35s** (0.5s native on the same runner) |
| the cross-endian cook pair, both directions | 0.05s |
| the negative control (regenerate, two compiles, two runs) | 13s |

## What the leg found

**The wire path is byte-order neutral, and it already was.** The emitted `TableWriter`/`TableReader` build and consume every multi-byte scalar with shifts and masks, never a host-order `memcpy`:

```cpp
void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
```

`put64`/`get64` compose the 32-bit pair; `f32`/`f64` go to their bit patterns through a same-width integer and then through `put32`/`put64`, which is byte-order-independent as a value; and `raw()` is reached only by byte buffers — strings, `bytes(N)`, `*bytes` — which have no byte order to get wrong. So there is **no emitter defect to fix here**, and nothing in this PR touches an emitter.

What was missing was the proof. Two gaps, both closed:

- **The goldens were only ever written, never read back.** `pin_table_golden` compares the bytes this build produces against the pinned file — a writer proof. `test_golden_reload` now loads all 18 files in `testdata/wire/tables/` from disk into a fresh instance and re-saves, and the bytes must come back identical. On a little-endian host that is a round trip through a file; on the target it is the claim itself, because those files were written by a little-endian build. The three pointer-form goldens are read by their by-value and optional twins, which is exactly right — the three spellings are one framing (§3).
- **The empty-end byte-identity check compared a buffer with itself.** `memcmp( other, other, w_ptr )` is vacuously 0, so the claim that a present-and-all-default `?T` and a non-null `*T` write identical bytes could not have failed. It compares the two buffers now. The pinned bytes are unchanged — the two goldens were in fact identical.

## The cook refuses across the byte order, cleanly

§7's rule needs two builds and a file between them, which is the one part of it no single-process test can reach. `test/tables/cook_endian_main.cpp` is that second build, run four ways by the leg. From the CI log:

```
cook-endian write: 312 bytes, magic 53 43 4b 31        <- the host
cook-endian write: 312 bytes, magic 31 4b 43 53        <- the target, the same constant reversed
cook-endian accept: build/cook-target.bin opened, in this build's byte order
cook-endian refuse: build/cook-host.bin refused by byte order, cleanly
cook-endian accept: build/cook-host.bin opened, in this build's byte order
cook-endian refuse: build/cook-target.bin refused by byte order, cleanly
```

The refusal case proves three things, not just the first: `Open` returned **NULL** rather than pointing at bytes it cannot read; the file's magic is this build's magic **byte-reversed**, so byte order is what refused it and not some other mismatch (the layout id is the same on both — same field shapes, same `sizeof`, same `offsetof`); and the reader **still works afterwards** — a cook this build wrote opens and reads back immediately after the refusal, which is what makes the caller's fall-back to a wire load real. No crash on either side.

And the target opens its own: the whole region, pointer, keyed, evolution, reflection and text battery — including `test_cooked_form`'s cook → open → cook — passes natively on s390x. `tables test passed`.

## The negative control

Put `put16` back to a host-order copy — the one store that writes every field id, every enum value and every union arm id — through a `go build -overlay` so no tracked file is ever written to, regenerate the whole corpus from the sabotaged emitter, and build it both ways:

```
negative control: a host-order put16 leaves the LITTLE-ENDIAN leg green
negative control: the same put16 turns the BIG-ENDIAN leg red, on the wire goldens
```

That pair is the argument for the leg existing. The same defect is invisible to every other job in this file.

## What is deliberately not here

- **The cross-endian fix-up** — producing a cook for a target whose byte order is not the cooking machine's — stays where §15 already names it. Nothing in this PR forced a shared helper, because the wire path needed no repair. Remaining work is filed on #303.
- **§19's block form** has no backend yet, so its prologue byte-order field is spec-only and the leg cannot exercise it. When the block form lands, this leg is where its magic gets tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
