### PR TITLE
check/parser/README: stale section citations and the C++-only line (#248 audit C3–C5, A9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ would have hand-written, not an interpreter walking a schema at runtime.
 - **A second wire for things that version: tables.** The bitpacked
   `type` wire above is the key feature of the library; `table` is its
   companion for data that must cross builds — flexible data structures
-  with in-wire versioning (C++ today): unknown fields skip, absent fields default, renames survive
+  with in-wire versioning (C++ and C# today): unknown fields skip, absent fields default, renames survive
   via `was = "old_name"`, and every table ships with reflection
   descriptors for tools that walk fields by name. Use tables as files,
   blobs, or messages — a config a tool saves, an archive a build bakes, or

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1346,17 +1346,17 @@ func (c *checker) resolveAttrs(f *ast.Field, out *ir.Field) {
 			}
 			out.WasName = lit.Value
 		case "json":
-			// the text form's key (SPEC-TABLES.md §16.3): the one attribute
+			// the text form's key (SPEC-TABLES.md §16.4): the one attribute
 			// the JSON walk adds, so a declaration can meet an existing text.
 			// Table fields only — enforced below, where the owner's kind is
 			// known — and it moves no wire byte.
 			lit, ok := a.Value.(*ast.StringLit)
 			if !ok {
-				c.errf(a.Pos, `json takes the field's text key as a quoted string, e.g. json = "type" (SPEC-TABLES.md §16.3)`)
+				c.errf(a.Pos, `json takes the field's text key as a quoted string, e.g. json = "type" (SPEC-TABLES.md §16.4)`)
 				continue
 			}
 			if lit.Value == "" {
-				c.errf(a.Pos, "json = \"\" names nothing — json records the key this field reads and writes in the text form (SPEC-TABLES.md §16.3)")
+				c.errf(a.Pos, "json = \"\" names nothing — json records the key this field reads and writes in the text form (SPEC-TABLES.md §16.4)")
 				continue
 			}
 			out.JsonKey = lit.Value
@@ -1365,7 +1365,7 @@ func (c *checker) resolveAttrs(f *ast.Field, out *ir.Field) {
 			// fixed-point rule, half away from zero, everywhere (SPEC §4.3)
 			c.errf(a.Pos, "round is not part of the language — rounding is the one fixed-point rule: half away from zero, everywhere (SPEC §4.3)")
 		default:
-			c.errf(a.Pos, "unknown attribute %q — the vocabulary is typed and closed per compiler version (SPEC §4.6)", a.Key)
+			c.errf(a.Pos, "unknown attribute %q — the vocabulary is typed and closed per compiler version (SPEC §4.2)", a.Key)
 		}
 	}
 
@@ -1747,7 +1747,7 @@ func (c *checker) checkTables() {
 			c.errf(pos, "table %s: the name collides with a member of the generated %sBuilder — a member function hides the type name it shares, and the header would not compile; rename the table (SPEC-TABLES.md §6.2)",
 				name, name)
 		}
-		// the TEXT form's keys (SPEC-TABLES.md §16.3): two fields of one
+		// the TEXT form's keys (SPEC-TABLES.md §16.4): two fields of one
 		// closure member whose keys collide are indistinguishable in a JSON
 		// object, exactly as colliding ids are on the wire — refused once,
 		// naming both, whether the collision comes from a `json` attribute
@@ -1756,7 +1756,7 @@ func (c *checker) checkTables() {
 		for _, f := range st.Fields {
 			key := ir.TableFieldJsonKey(f)
 			if prev, dup := seenKey[key]; dup {
-				c.errf(pos, "%s %s: fields %s and %s collide on the JSON key %q — rename one, or give one a different json key (SPEC-TABLES.md §16.3)",
+				c.errf(pos, "%s %s: fields %s and %s collide on the JSON key %q — rename one, or give one a different json key (SPEC-TABLES.md §16.4)",
 					what, name, describeTableJsonField(prev), describeTableJsonField(f), key)
 				continue
 			}
@@ -1815,7 +1815,7 @@ func (c *checker) checkTables() {
 }
 
 // checkJsonKeysInClosure refuses `json = "key"` on a field no table closure
-// reaches (SPEC-TABLES.md §16.3). The text form is the table closure's — a
+// reaches (SPEC-TABLES.md §16.4). The text form is the table closure's — a
 // `type` a table nests has one and may carry the attribute; a type nothing in
 // a closure reaches has no text form for a key to name.
 func (c *checker) checkJsonKeysInClosure() {
@@ -1830,7 +1830,7 @@ func (c *checker) checkJsonKeysInClosure() {
 		}
 		for _, f := range st.Fields {
 			if f.JsonKey != "" {
-				c.errf(pos, "type %s: field %s carries json = %q, but no table reaches %s — the text form is the table closure's, and a type outside one has none (SPEC-TABLES.md §16.3)",
+				c.errf(pos, "type %s: field %s carries json = %q, but no table reaches %s — the text form is the table closure's, and a type outside one has none (SPEC-TABLES.md §16.4)",
 					name, f.Name, f.JsonKey, name)
 			}
 		}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -257,7 +257,7 @@ func (p *parser) parseDecl() {
 			p.expectTerminator("union declaration")
 			p.file.Decls = append(p.file.Decls, d)
 		default:
-			p.errf(t.Pos, "unexpected %q at file scope (declarations begin with package, const, enum, flags, type or union)", t.Text)
+			p.errf(t.Pos, "unexpected %q at file scope (declarations begin with package, const, enum, flags, type, table or union)", t.Text)
 			p.skipDecl()
 		}
 

--- a/test/tables/JsonKeys.schema
+++ b/test/tables/JsonKeys.schema
@@ -1,4 +1,4 @@
-// JsonKeys.schema — the `json = "key"` attribute (SPEC-TABLES.md §16.3): a
+// JsonKeys.schema — the `json = "key"` attribute (SPEC-TABLES.md §16.4): a
 // declaration meeting a text that already exists. The keys differ from the
 // schema names, and no wire byte moves — a field's wire id is still the hash
 // of its own name, so this file's wire is exactly what it would be with the


### PR DESCRIPTION
Four fixes to text a user actually reads, from the cold audit on #248 (items C3, C4, C5, A9). No behaviour change, no wire byte moves, no spec file touched — the three spec PRs in flight are untouched.

- **`internal/check/check.go`** — the unknown-attribute refusal said *"the vocabulary is typed and closed per compiler version (SPEC §4.6)"*; now cites **§4.2**. Verified on `main`: SPEC.md §4.6 (SPEC.md:802) is "Shape checks"; the sentence the message quotes verbatim is SPEC.md:540, inside §4.2 "Grammar" (SPEC.md:258). This is the diagnostic `| block` and `| stride` produce today — both reach it through the `default:` arm, neither is refused by name. Same file: seven `json`-key citations said **SPEC-TABLES.md §16.3**, now **§16.4**. Verified on `main`: §16.3 (SPEC-TABLES.md:3085) is "What the writer refuses" (enum/flags names, union tags, non-finite floats); §16.4 (SPEC-TABLES.md:3112) is "The key: `json`", and it is also where the collision refusal lives — *"Two fields of one table whose keys collide are refused at compile time, naming both"*.
- **`internal/parser/parser.go`** — the file-scope refusal said *"declarations begin with package, const, enum, flags, type or union"*; now *"…type, table or union"*. Verified: `table` parses (the `scanner.KwTable` arm in the same switch) and `TableDecl` is in the §4.2 grammar's `Declaration` production, in this order.
- **`test/tables/JsonKeys.schema`** — the header comment cited §16.3 for the `json = "key"` attribute; now §16.4, same verification as above.
- **`README.md`** — tables' in-wire versioning said *"(C++ today)"*; now *"(C++ and C# today)"*. Verified against the compiler's own refusal, `compiler/builtin.go:35`: *"tables are C++ and C# only today"*, and both `internal/codegen/cpptable` and `internal/codegen/cstable` exist. Grepped the rest of README — this was the only C++-only claim for tables. One line, no added prose.

**Owner ruling 2026-09-02: stride cut.** `| stride` is no longer named anywhere and takes the unknown-attribute path exactly as `| block` does. This is already the tree's state — `grep -rn stride` over `internal/`, `compiler/`, `test/`, `testdata/`, `examples/` and `tables/` returns nothing, so there is no stride-specific message or golden to remove.

**Gates.** `make check`, `make fmt`, `make id`, `make shape-gate` and `go test ./...` all clean; `make test` (the nine-language gate) clean. No golden moved — the one diagnostics assertion in range (`internal/check/diagnostics_test.go:91`) matches on the substring `unknown attribute`, not the citation.

**Not done, reported instead.** The same wrong §16.3-for-the-key citation survives at `ir/ir.go:196`, `ir/table.go:39`, `internal/tabletext/value.go:414`, `test/tables/main.cpp:1048` and `:3737`, and — most visibly — `internal/codegen/cpptable/cpptable.go:266`, which *emits* it into every generated table header. That last one moves checked-in goldens, so it is a follow-on rather than a rider here. `internal/check/check.go:655` cites §4.6 for the enum attribute vocabulary, which is §4.2 by the same reading.