### PR TITLE
The block form in C#: no generated namespace, and arrays inside a record stay inline (dogfood)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,6 +629,44 @@ tables-block-home-negative-control: bin/schema
 		{ echo "NEGATIVE CONTROL FAILED: it went red, but not on an undefined name"; tail -20 build/blockhome-sabotage.log; exit 1; }
 	@echo "block home negative control: emitting the runtime into the protocol id's home leaves the unit uncompilable"
 
+# DEFECT B's NEGATIVE CONTROL (SPEC-TABLES.md §2.7's DEPTH ONE, BOUNDED ONLY).
+# The dogfood found the C# blittable emitter projecting a bounded array INSIDE
+# a nested record out of line — a sixteen-byte triple where C++ put the whole
+# array, and every field after it somewhere else. Nothing said so until
+# Verify() threw on the first Open, in the game.
+#
+# This puts the defect back — through `go build -overlay`, so no tracked file
+# is written — and requires the gate to go red. The gate has TWO halves and
+# either firing is it working: COMPILING every corpus unit's generated C# is
+# half (a projected array is not the struct the rest of the unit indexes), and
+# running each unit's Verify() is the other (a projected array moves the sizes
+# and offsets). The control reports which one fired.
+.PHONY: tables-block-inline-array-negative-control
+tables-block-inline-array-negative-control: bin/schema
+	@mkdir -p build
+	@sed -e 's|if projection \&\& ir.BlockOutOfLine(f) {|if ir.BlockOutOfLine(f) { // SABOTAGED: project at every depth|' \
+	     -e 's|if !(projection \&\& ir.BlockOutOfLine(f)) \&\&|if !ir.BlockOutOfLine(f) \&\&|' \
+		internal/codegen/cstable/block.go > build/csblock-depth.gotext
+	@cmp -s build/csblock-depth.gotext internal/codegen/cstable/block.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cstable/block.go":"%s/build/csblock-depth.gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/csblock-depth-overlay.json
+	@go build -overlay=build/csblock-depth-overlay.json -o build/schema-depth-sabotaged ./cmd/schema
+	@rm -rf build/blockhome-depth && mkdir -p build/blockhome-depth
+	@./build/schema-depth-sabotaged generate --lang cs --out build/blockhome-depth tables/blockhome
+	@if ( cd test/cs-block && dotnet run -p:BlockHomeGeneratedDir=../../build/blockhome-depth ) \
+		> build/blockhome-depth.log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: a bounded array projected inside a nested record passed the layout gate"; \
+		cat build/blockhome-depth.log; exit 1; \
+	fi
+	@if grep -q "schema block layout" build/blockhome-depth.log; then \
+		echo "block inline-array negative control: the LAYOUT CHECK went red — a projected array inside a nested record moves the offsets"; \
+	elif grep -qE "CS1061|CS0246|CS0117" build/blockhome-depth.log; then \
+		echo "block inline-array negative control: the COMPILE went red — a projected array is not the struct the rest of the generated unit indexes"; \
+	else \
+		echo "NEGATIVE CONTROL FAILED: it went red, but not on either half of the gate"; tail -20 build/blockhome-depth.log; exit 1; \
+	fi
+
 # GATE 2 (SPEC-TABLES.md §12.1): the MEASURED gate, two numbers, and it is not
 # part of `make test` on purpose — a correctness suite whose verdict depends on
 # the machine's mood is not a correctness suite, and the estate's bench rules
@@ -1152,6 +1190,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) tables-block-layout-model-negative-control
 	$(MAKE) tables-block-race-negative-control
 	$(MAKE) tables-block-home-negative-control
+	$(MAKE) tables-block-inline-array-negative-control
 	$(MAKE) tables-pack
 	$(MAKE) tables-pack-negative
 	$(MAKE) tables-hostile-values

--- a/Makefile
+++ b/Makefile
@@ -645,7 +645,7 @@ tables-block-home-negative-control: bin/schema
 tables-block-inline-array-negative-control: bin/schema
 	@mkdir -p build
 	@sed -e 's|if projection \&\& ir.BlockOutOfLine(f) {|if ir.BlockOutOfLine(f) { // SABOTAGED: project at every depth|' \
-	     -e 's|if !(projection \&\& ir.BlockOutOfLine(f)) \&\&|if !ir.BlockOutOfLine(f) \&\&|' \
+	     -e 's|inline := !projection \|\| !ir.BlockOutOfLine(f)|inline := !ir.BlockOutOfLine(f)|' \
 		internal/codegen/cstable/block.go > build/csblock-depth.gotext
 	@cmp -s build/csblock-depth.gotext internal/codegen/cstable/block.go && \
 		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; } || true

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -2650,14 +2650,20 @@ in build version (§20.5).
   nothing and is tracked for removal as schema#310, page and checker moving
   together.
 
-  **The BLOCK FORM claims seven more, and the checker claims them.** They are
+  **The BLOCK FORM claims nine more, and the checker claims them.** They are
   law on the same terms and for a stronger reason — every fixed table has a
   block form (§2.7), so every fixed table claims them:
 
   ```
   Block  BlockStorage  BlockBegin  BlockBytes  BlockMaxBytes  BlockOpen
-  Counts
+  Counts  Row  BlockProjection
   ```
+
+  **`Row` and `BlockProjection` are the C# BLITTABLE records' names** (§19.2),
+  and they are claimed for the reason the rest of this list exists rather than
+  planted in a namespace of their own: a generated namespace named by a common
+  noun collides with declarations in OTHER units of the same assembly, which a
+  compiler that sees one unit cannot refuse.
 
   **A table also claims TWO PER OUT-OF-LINE ARRAY**, because its row
   accessors are named after its fields: `<Table>` followed by the PascalCase
@@ -4440,7 +4446,10 @@ declaration does not spell:**
   declaration order, each at its own pitch, subject to the element rule below.
   Everything else stays exactly where it is: a fixed `[N]T`, an enum-keyed
   `[E]T`, and **every
-  array at any depth inside an element**. An element is one flat record or it
+  array at any depth inside an element** — which is a rule about the EMITTERS
+  as much as about the form: a backend that projects a bounded array inside a
+  nested record writes sixteen bytes where the other side wrote the whole
+  array, and lands every field after it somewhere else. An element is one flat record or it
   is not a record another language can point at, and one level is what makes
   "which arrays move" answerable by reading one declaration.
 - **THE INSTANCE IS WHAT MOVES, not the schema.** The block form generates
@@ -4694,20 +4703,32 @@ picks by what it is doing: reflection to walk anything, the struct to read
 one thing fast.
 
 ```csharp
-using Row = Demo.Block;   // the BLITTABLE records; the unit's own namespace
-                          // holds a sealed CLASS of each of these names, which
-                          // is the table wire's storage and not a block's row
-
 if ( !RenderFrameBlock.Open( out RenderFrameBlock block, pointer, bytes ) )
     return;               // and the caller falls back, or reports
 
 ulong version = block.Projection.Version;     // the table's own declared fields
 
-foreach ( ref readonly Row.RenderShip ship in block.Ships )
+foreach ( ref readonly RenderShipRow ship in block.Ships )
     Draw( ship );
 
-ReadOnlySpan<Row.RenderShip> ships = block.ShipsSpan;   // contiguous: the pitch is sizeof
+ReadOnlySpan<RenderShipRow> ships = block.ShipsSpan;   // contiguous: the pitch is sizeof
 ```
+
+**THE BLITTABLE RECORDS TAKE A CLAIMED SUFFIX, NEVER A NAMESPACE OF THEIR
+OWN.** A row is `<Name>Row` and a projection is `<Table>BlockProjection`, in
+the unit's own namespace, both claimed in §11 like every other generated
+spelling — so a declaration that would collide is refused at the source, which
+is the doctrine the whole generated surface already follows.
+
+**A generated NAMESPACE named by a common noun is a collision class no refusal
+can close, and that is the reason.** A nested `<Pkg>.Block` reads well until a
+unit declares a `Block` — and `Block` is a common noun a game will have. Worse,
+the collision is not even the DECLARING unit's to see: C# compiles many units
+into one assembly, so a `Block` in ANOTHER unit of the same package namespace
+collides with the namespace this unit planted, and a compiler that checks one
+unit at a time cannot refuse what it cannot see. A claimed suffix has neither
+problem: it collides only inside the unit that declares it, which is exactly
+where §11's claim reaches.
 
 **WHERE THE C# SURFACE IS EMITTED, because C# has no include guard and the
 answer is not "beside the declaration".** A unit's shared block runtime — the
@@ -4729,11 +4750,10 @@ page alone needs all three.** `Open` is a static on the block type, taking the
 destination first (§6.1) and then an `IntPtr` and a `long` — a block is memory
 another language wrote, so the C# side takes a pointer and a length and the
 generated source is `unsafe`. The ROWS are `[StructLayout(Sequential, Pack = 1,
-Size = N)]` STRUCTS in the unit's `.Block` namespace, never the sealed classes
-of the same names in the unit's own namespace: those are the table wire's
-storage, and binding one here is the mistake this paragraph exists to stop. A
-field's C# member is the PascalCase of its schema name, as everywhere else in
-that backend.
+Size = N)]` STRUCTS named `<Name>Row`, never the sealed CLASS of the bare name
+beside them: that is the table wire's storage, and binding one here is the
+mistake the suffix exists to stop. A field's C# member is the PascalCase of its
+schema name, as everywhere else in that backend.
 
 - **`BlockOpen` checks once and points, and this is the WHOLE check**: the
   magic read bytewise, the byte order it establishes, the build version

--- a/USAGE.md
+++ b/USAGE.md
@@ -1116,17 +1116,17 @@ yours to own.
 **Reading it is one check and then pointers:**
 
 ```csharp
-using Row = MyPackage.Block;                  // the blittable records live here
-
 if ( !RenderFrameBlock.Open( out RenderFrameBlock block, pointer, bytes ) )
     return;
 
-foreach ( ref readonly Row.RenderShip ship in block.Ships )
+// the blittable records are <Name>Row in the unit's own namespace — a claimed
+// suffix, so nothing you declare can take it
+foreach ( ref readonly RenderShipRow ship in block.Ships )
     Draw( ship );
 
 // and the fast path a per-frame job takes: one contiguous reinterpret, at
 // pitch == sizeof, with nothing per row
-ReadOnlySpan<Row.RenderShip> ships = block.ShipsSpan;
+ReadOnlySpan<RenderShipRow> ships = block.ShipsSpan;
 ```
 
 `Open` verifies the magic, the byte order, the build version, the base's

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2703,6 +2703,12 @@ var tableGeneratedVerbs = []string{
 	"Cook", "CookMeasure", "Open", "LayoutId", "TableFields", "TableInfo",
 	"FromJson", "ToJson", "ToJsonMeasure",
 	"Block", "BlockStorage", "BlockBegin", "BlockBytes", "BlockMaxBytes", "BlockOpen", "Counts",
+	// the C# BLITTABLE records take claimed suffixes in the package namespace
+	// rather than a nested namespace of their own: a generated namespace named
+	// by a common noun is a collision class no refusal can close, because it
+	// collides with declarations in OTHER units of the same assembly and this
+	// compiler sees one unit (SPEC-TABLES.md §19.2).
+	"Row", "BlockProjection",
 }
 
 // tableBuilderMembers are the member names of a generated <Name>Builder. A

--- a/internal/codegen/cpptable/block.go
+++ b/internal/codegen/cpptable/block.go
@@ -746,7 +746,11 @@ func (g *tableGen) emitBlockRecordDescriptor(owner, record string, ml *ir.Member
 			}
 		}
 		element := "NULL"
-		if f.Type.Kind == ir.TNamed && f.Array == ir.ArrayNone && !f.Type.Pointer {
+		// A field that NAMES a record carries that record's layout, whether it
+		// holds one or an array of them: an INLINE array of records is part of
+		// a row, and a walker descending one reaches its element through this
+		// same column. Only the pointer class has no layout to name.
+		if f.Type.Kind == ir.TNamed && !f.Type.Pointer {
 			if ref, ok := f.Type.Ref.(*ir.Struct); ok {
 				element = fmt.Sprintf("+[]() { return &%s; }", blockInfoSymbol(owner, ref.Name))
 			}

--- a/internal/codegen/cstable/block.go
+++ b/internal/codegen/cstable/block.go
@@ -469,7 +469,8 @@ func (g *blockGen) blockFieldAddress(f *ir.Field, projection bool) string {
 	if f.Type.Kind == ir.TString || f.Type.Kind == ir.TBytes {
 		return "probe." + name // a fixed-size buffer IS a pointer in unsafe context
 	}
-	if !(projection && ir.BlockOutOfLine(f)) && (f.KeyEnum != "" || f.Array != ir.ArrayNone) {
+	inline := !projection || !ir.BlockOutOfLine(f)
+	if inline && (f.KeyEnum != "" || f.Array != ir.ArrayNone) {
 		if csFixedBufferPrimitive(g.blittableType(f.Type)) {
 			return "probe." + name
 		}

--- a/internal/codegen/cstable/block.go
+++ b/internal/codegen/cstable/block.go
@@ -41,9 +41,6 @@ func generateBlockFiles(u *ir.Unit, blocks *ir.BlockUnit) (map[string][]byte, er
 	if blocks == nil {
 		return out, nil
 	}
-	if err := refuseBlockNamespaceCollision(u); err != nil {
-		return nil, err
-	}
 	// THE BLOCK HOME is the first file, by basename, that declares a table
 	// WITH a block form — never the protocol id's home, which may declare no
 	// table at all (a unit whose constants live in their own file is the
@@ -81,22 +78,6 @@ func blockHome(u *ir.Unit, blocks *ir.BlockUnit) string {
 	return ""
 }
 
-// refuseBlockNamespaceCollision is the one refusal this backend's block half
-// adds, and it is C#'s alone: the blittable structs live in the nested
-// namespace <Pkg>.Block, so a declaration named `Block` would put a TYPE and a
-// NAMESPACE at the same name and the generated C# would not compile. Refused
-// by name rather than emitted broken (SPEC-TABLES.md §11's rule, applied to a
-// spelling this port introduces).
-func refuseBlockNamespaceCollision(u *ir.Unit) error {
-	for _, name := range []string{"Block"} {
-		if u.Tables[name] != nil || u.Structs[name] != nil || u.Enums[name] != nil || u.Flags[name] != nil || u.Unions[name] != nil {
-			return fmt.Errorf("declaration %s collides with the C# block form's namespace: the blittable block structs are emitted into %s.Block, so a type of that name would be both a type and a namespace and the generated C# would not compile — rename the declaration (SPEC-TABLES.md §19.2, §11)",
-				name, capitalize(u.Package))
-		}
-	}
-	return nil
-}
-
 type blockGen struct {
 	unit    *ir.Unit
 	file    *ir.File
@@ -104,7 +85,7 @@ type blockGen struct {
 	home    bool
 	runtime strings.Builder // the shared runtime, home file only
 	handles strings.Builder // namespace <Pkg>: the block handles
-	structs strings.Builder // namespace <Pkg>.Block: the blittable records
+	structs strings.Builder // the blittable records, in the package namespace
 }
 
 func (g *blockGen) rf(format string, args ...any) { fmt.Fprintf(&g.runtime, format, args...) }
@@ -166,27 +147,27 @@ func (g *blockGen) assemble() []byte {
 	h.WriteString("using System.Runtime.InteropServices;\n\n")
 	fmt.Fprintf(&h, "namespace %s\n{\n\n", capitalize(g.unit.Package))
 	h.WriteString(indent4(g.runtime.String()))
+	if g.structs.Len() > 0 {
+		var b strings.Builder
+		b.WriteString("// The BLITTABLE records: one per record the block form touches, laid out to\n")
+		b.WriteString("// the C ABI with GENERATED PADDING FIELDS wherever the layout has interior\n")
+		b.WriteString("// padding and a Size that pins the trailing padding — both are needed\n")
+		b.WriteString("// (SPEC-TABLES.md §19.3). Explicit padding is chosen over LayoutKind.Explicit\n")
+		b.WriteString("// because Sequential is the form every blittable path handles best, and over\n")
+		b.WriteString("// relying on a padding-free field order because that is discipline, and\n")
+		b.WriteString("// discipline is what this form exists to delete.\n")
+		b.WriteString("//\n")
+		b.WriteString("// They take a CLAIMED SUFFIX in the unit's own namespace — <Name>Row for a\n")
+		b.WriteString("// row and <Table>BlockProjection for a projection — because the namespace\n")
+		b.WriteString("// already holds a sealed CLASS of each declaration's name, which is the\n")
+		b.WriteString("// table wire's storage, and one declaration cannot be two types.\n")
+		h.WriteString(indent4(b.String()))
+		h.WriteString(indent4(g.structs.String()))
+	}
 	if g.handles.Len() > 0 {
 		h.WriteString(indent4(g.handles.String()))
 	}
 	h.WriteString("\n}\n")
-	if g.structs.Len() > 0 {
-		h.WriteString("\n")
-		h.WriteString("// The BLITTABLE records: one per record the block form touches, laid out to\n")
-		h.WriteString("// the C ABI with GENERATED PADDING FIELDS wherever the layout has interior\n")
-		h.WriteString("// padding and a Size that pins the trailing padding — both are needed\n")
-		h.WriteString("// (SPEC-TABLES.md §19.3). Explicit padding is chosen over LayoutKind.Explicit\n")
-		h.WriteString("// because Sequential is the form every blittable path handles best, and over\n")
-		h.WriteString("// relying on a padding-free field order because that is discipline, and\n")
-		h.WriteString("// discipline is what this form exists to delete.\n")
-		h.WriteString("//\n")
-		h.WriteString("// They sit in their own namespace because the unit's own namespace already\n")
-		h.WriteString("// holds a sealed CLASS of each of these names — the table wire's storage —\n")
-		h.WriteString("// and one declaration cannot be two types.\n")
-		fmt.Fprintf(&h, "namespace %s.Block\n{\n\n", capitalize(g.unit.Package))
-		h.WriteString(indent4(g.structs.String()))
-		h.WriteString("\n}\n")
-	}
 	return []byte(h.String())
 }
 
@@ -197,10 +178,11 @@ func (g *blockGen) emitBlittable(name string) {
 	if ml == nil {
 		return
 	}
-	g.sf("// %s — a block row, or a record one nests by value.\n", name)
+	g.sf("// %s — a block row, or a record one nests by value. `Row` is a CLAIMED\n", name)
+	g.sf("// suffix (SPEC-TABLES.md §11), so no declaration in the unit can take it.\n")
 	g.sf("[StructLayout(LayoutKind.Sequential, Pack = 1, Size = %d)]\n", ml.Size)
-	g.sf("public unsafe struct %s\n{\n", name)
-	g.emitBlittableFields(ml, 0)
+	g.sf("public unsafe struct %sRow\n{\n", name)
+	g.emitBlittableFields(ml, 0, false)
 	g.sf("}\n\n")
 }
 
@@ -211,56 +193,104 @@ func (g *blockGen) emitProjection(bl *ir.BlockLayout) {
 	g.sf("// out-of-line array, the triple that says where its rows are. It is a record\n")
 	g.sf("// like any other and follows the same C ABI rule (SPEC-TABLES.md §19.3).\n")
 	g.sf("//\n")
-	g.sf("// It is a SEPARATE record from the row of the same name: a table can be both\n")
-	g.sf("// a block root and another block's row, and the two differ by the prologue.\n")
+	g.sf("// It is a SEPARATE record from <Table>Row: a table can be both a block root\n")
+	g.sf("// and another block's row, and the two differ by the prologue.\n")
 	g.sf("[StructLayout(LayoutKind.Sequential, Pack = 1, Size = %d)]\n", bl.Projection.Size)
-	g.sf("public unsafe struct %sProjection\n{\n", name)
+	g.sf("public unsafe struct %sBlockProjection\n{\n", name)
 	g.sf("    public ulong Magic;        // generated: identifies a schema block\n")
 	g.sf("    public ulong BuildVersion; // generated: the unit's build version (SPEC-TABLES.md §20)\n")
 	g.sf("    public ulong ByteOrder;    // generated: 1 little, 2 big\n")
-	g.emitBlittableFields(&bl.Projection, ir.BlockPrologueBytes)
+	g.emitBlittableFields(&bl.Projection, ir.BlockPrologueBytes, true)
 	g.sf("}\n\n")
 }
 
 // emitBlittableFields walks one record's computed layout and emits its fields
 // with generated padding between them.
-func (g *blockGen) emitBlittableFields(ml *ir.MemberLayout, at int64) {
-	pad := func(to int64) {
-		for at < to {
-			g.sf("    private byte _pad%d;\n", at)
-			at++
-		}
-	}
+//
+// `projection` is the whole of what decides whether a bounded array becomes a
+// TRIPLE or stays INLINE, and it is load-bearing (SPEC-TABLES.md §2.7): DEPTH
+// ONE, BOUNDED ONLY — only the block-form TABLE'S OWN bounded arrays of
+// structs are laid out of line, and every array at any depth inside a row or
+// inside a record a row nests is inline storage exactly where it always was.
+// Emitting a triple for one of those puts sixteen bytes where the C++ side put
+// the whole array, and every field after it lands somewhere else.
+func (g *blockGen) emitBlittableFields(ml *ir.MemberLayout, at int64, projection bool) {
+	w := &blockWriter{g: g, at: at}
 	for _, fl := range ml.Fields {
-		pad(fl.Offset)
-		g.emitBlittableField(fl.Field)
-		at = fl.Offset + fl.Size
+		// Pad to each PIECE of the field, not only to the field: a field's own
+		// storage can carry interior padding — a `string(N)` buffer followed by
+		// its int32 length is the ordinary case — and padding only between
+		// fields slides every field after it.
+		w.pieces = ir.BlockFieldPieceOffsets(g.unit, fl.Field, fl.Offset, projection)
+		w.piece = 0
+		g.emitBlittableField(fl.Field, projection, w)
 	}
-	pad(ml.Size) // the trailing padding is pinned by Size too, and stating it costs nothing
+	w.pad(ml.Size) // the trailing padding is pinned by Size too, and stating it costs nothing
 }
 
-func (g *blockGen) emitBlittableField(f *ir.Field) {
+// blockWriter lays a record out piece by piece, padding to the offset the
+// compiler's model gives each one and advancing past the bytes it takes. It
+// exists because a field is not always one piece (§19.3).
+type blockWriter struct {
+	g      *blockGen
+	at     int64
+	pieces []ir.BlockFieldPiece
+	piece  int
+}
+
+func (w *blockWriter) pad(to int64) {
+	for w.at < to {
+		w.g.sf("    private byte _pad%d;\n", w.at)
+		w.at++
+	}
+}
+
+// next pads to the next piece's offset and accounts for the bytes it takes;
+// the caller emits the piece's own spelling between the two.
+func (w *blockWriter) next() {
+	if w.piece >= len(w.pieces) {
+		return
+	}
+	p := w.pieces[w.piece]
+	w.pad(p.Offset)
+	w.at = p.Offset + p.Size
+	w.piece++
+}
+
+// emitBlittableField emits one field's pieces, padding to each piece's own
+// offset — the model's answer for where every piece starts (§19.3).
+func (g *blockGen) emitBlittableField(f *ir.Field, projection bool, w *blockWriter) {
 	name := ir.GoExportName(f.Name)
-	if ir.BlockOutOfLine(f) {
+	next := w.next
+	if projection && ir.BlockOutOfLine(f) {
+		next()
 		g.sf("    public TableBlockTriple %s; // [..%d]%s, laid out of line\n", name, f.ArrayBound, f.Type.Name)
 		return
 	}
 	switch {
 	case f.Type.Kind == ir.TString:
+		next()
 		g.sf("    public fixed byte %s[%d]; // string(%d): max length, used length beside it\n", name, f.Type.Size+1, f.Type.Size)
+		next()
 		g.sf("    public int %sLength;\n", name)
 	case f.Type.Kind == ir.TBytes:
+		next()
 		g.sf("    public fixed byte %s[%d]; // bytes(%d): fixed buffer, used length beside it\n", name, f.Type.Size, f.Type.Size)
+		next()
 		g.sf("    public int %sLength;\n", name)
 	case f.KeyEnum != "", f.Array == ir.ArrayFixed, f.Array == ir.ArrayCounted:
+		next()
 		g.emitBlittableArray(f, name)
 		if f.Array == ir.ArrayCounted {
+			next()
 			g.sf("    public int %sCount;\n", name)
 		}
 	default:
+		next()
 		g.sf("    public %s %s;\n", g.blittableType(f.Type), name)
 	}
 	if f.Type.Optional {
+		next()
 		g.sf("    public bool %sPresent; // ?%s: one byte, in the managed model as in C++\n", name, f.Type.Name)
 	}
 }
@@ -339,7 +369,7 @@ func (g *blockGen) blittableType(t ir.FieldType) string {
 		case *ir.Flags:
 			return "ulong"
 		case *ir.Struct:
-			return t.Name
+			return t.Name + "Row"
 		}
 	}
 	return "byte"
@@ -363,7 +393,11 @@ func (g *blockGen) emitLayoutCheck() {
 	g.rf("// Neither side's layout is inferred from the other's: both are checked\n")
 	g.rf("// against their own runtime's model, which is the only way a two-language\n")
 	g.rf("// contract can be held by a compiler that generates both halves.\n")
-	g.rf("internal static unsafe class TableBlockLayout\n{\n")
+	// PUBLIC, not internal: a consumer's own test leg calls Verify() to hold
+	// §19.3's contract at start-up rather than waiting for the first Open to
+	// throw in a game, and a check nobody outside the assembly can call is a
+	// check nobody calls.
+	g.rf("public static unsafe class TableBlockLayout\n{\n")
 	g.rf("    private static bool checked_;\n\n")
 	g.rf("    internal static void Verify()\n    {\n")
 	g.rf("        if (checked_) { return; }\n")
@@ -378,9 +412,9 @@ func (g *blockGen) emitLayoutCheck() {
 		// it on one side only — which is §19.5's named negative control —
 		// could not turn anything red here.
 		for _, a := range bl.Arrays {
-			g.rf("        Size(\"%sBlock.%sStride\", (int) %sBlock.%sStride, Unsafe.SizeOf<%s.Block.%s>());\n",
+			g.rf("        Size(\"%sBlock.%sStride\", (int) %sBlock.%sStride, Unsafe.SizeOf<%sRow>());\n",
 				bl.Table.Name, ir.GoExportName(a.Field.Name), bl.Table.Name, ir.GoExportName(a.Field.Name),
-				capitalize(g.unit.Package), a.ElemName)
+				a.ElemName)
 		}
 	}
 	g.rf("    }\n\n")
@@ -403,9 +437,9 @@ func (g *blockGen) emitRecordCheck(name string, ml *ir.MemberLayout, projection 
 	if ml == nil {
 		return
 	}
-	spelled := capitalize(g.unit.Package) + ".Block." + name
+	spelled := name + "Row"
 	if projection {
-		spelled += "Projection"
+		spelled = name + "BlockProjection"
 	}
 	g.rf("        {\n")
 	g.rf("            %s probe = default;\n", spelled)
@@ -418,7 +452,7 @@ func (g *blockGen) emitRecordCheck(name string, ml *ir.MemberLayout, projection 
 	}
 	for _, fl := range ml.Fields {
 		g.rf("            Offset(\"%s.%s\", (byte*) %s - at, %d);\n", spelled, ir.GoExportName(fl.Field.Name),
-			g.blockFieldAddress(fl.Field), fl.Offset)
+			g.blockFieldAddress(fl.Field, projection), fl.Offset)
 	}
 	g.rf("        }\n")
 }
@@ -426,12 +460,16 @@ func (g *blockGen) emitRecordCheck(name string, ml *ir.MemberLayout, projection 
 // blockFieldAddress spells the address of one field of the stack probe. A
 // fixed-size buffer has no address of its own — its FIRST element does, and
 // that is the same byte.
-func (g *blockGen) blockFieldAddress(f *ir.Field) string {
+// blockFieldAddress spells the address of one field of the stack probe. It
+// takes `projection` for the same reason emitBlittableFields does: a bounded
+// array of structs is a TRIPLE in a projection and INLINE everywhere else, and
+// the two have different addresses to take (SPEC-TABLES.md §2.7).
+func (g *blockGen) blockFieldAddress(f *ir.Field, projection bool) string {
 	name := ir.GoExportName(f.Name)
 	if f.Type.Kind == ir.TString || f.Type.Kind == ir.TBytes {
 		return "probe." + name // a fixed-size buffer IS a pointer in unsafe context
 	}
-	if !ir.BlockOutOfLine(f) && (f.KeyEnum != "" || f.Array != ir.ArrayNone) {
+	if !(projection && ir.BlockOutOfLine(f)) && (f.KeyEnum != "" || f.Array != ir.ArrayNone) {
 		if csFixedBufferPrimitive(g.blittableType(f.Type)) {
 			return "probe." + name
 		}
@@ -459,10 +497,16 @@ func (g *blockGen) emitBlockHandle(bl *ir.BlockLayout) {
 	g.hf("        // the layout contract, run once before any static member of this type\n")
 	g.hf("        TableBlockLayout.Verify();\n")
 	g.hf("    }\n\n")
+	g.hf("    // The storage a PRODUCER of this block allocates, sized from the declared\n")
+	g.hf("    // maxima (SPEC-TABLES.md §19.1). A C# consumer does not allocate a block —\n")
+	g.hf("    // the bytes are handed to it — but it caps by this: a playback buffer, a\n")
+	g.hf("    // recording, a scratch copy all size from the generated constant rather\n")
+	g.hf("    // than from a number a person wrote down beside it.\n")
+	g.hf("    public const long BlockMaxBytes = %d;\n\n", bl.MaxBytes)
 	g.hf("    public byte* Base { get { return basePointer; } }\n")
 	g.hf("    public long Bytes { get { return bytes; } }\n\n")
 	g.hf("    // the table's own declared fields, read where they lie\n")
-	g.hf("    public ref readonly Block.%sProjection Projection { get { return ref *(Block.%sProjection*) basePointer; } }\n\n", name, name)
+	g.hf("    public ref readonly %sBlockProjection Projection { get { return ref *(%sBlockProjection*) basePointer; } }\n\n", name, name)
 	for _, a := range bl.Arrays {
 		field := ir.GoExportName(a.Field.Name)
 		g.hf("    // %s: the constants this build asserts against. A consumer INDEXES with\n", a.Field.Name)
@@ -472,18 +516,18 @@ func (g *blockGen) emitBlockHandle(bl *ir.BlockLayout) {
 		g.hf("    public const long %sProjectionOffset = %d;\n\n", field, a.TripleOffset)
 		g.hf("    // ITERATED, not indexed by hand: the accessor yields a reference to each\n")
 		g.hf("    // row where it lies, at the pitch the INSTANCE gives, for count rows.\n")
-		g.hf("    public TableBlockRows<Block.%s> %s\n    {\n", a.ElemName, field)
+		g.hf("    public TableBlockRows<%sRow> %s\n    {\n", a.ElemName, field)
 		g.hf("        get\n        {\n")
-		g.hf("            Block.%sProjection* p = (Block.%sProjection*) basePointer;\n", name, name)
-		g.hf("            return new TableBlockRows<Block.%s>(basePointer + p->%s.OffsetOf, (int) p->%s.Count, (int) p->%s.Stride);\n",
+		g.hf("            %sBlockProjection* p = (%sBlockProjection*) basePointer;\n", name, name)
+		g.hf("            return new TableBlockRows<%sRow>(basePointer + p->%s.OffsetOf, (int) p->%s.Count, (int) p->%s.Stride);\n",
 			a.ElemName, field, field, field)
 		g.hf("        }\n    }\n\n")
 		g.hf("    // and the CONTIGUOUS view, available because the pitch IS sizeof (§2.7),\n")
 		g.hf("    // which is how the per-frame fast path is actually written.\n")
-		g.hf("    public ReadOnlySpan<Block.%s> %sSpan\n    {\n", a.ElemName, field)
+		g.hf("    public ReadOnlySpan<%sRow> %sSpan\n    {\n", a.ElemName, field)
 		g.hf("        get\n        {\n")
-		g.hf("            Block.%sProjection* p = (Block.%sProjection*) basePointer;\n", name, name)
-		g.hf("            return new ReadOnlySpan<Block.%s>(basePointer + p->%s.OffsetOf, (int) p->%s.Count);\n",
+		g.hf("            %sBlockProjection* p = (%sBlockProjection*) basePointer;\n", name, name)
+		g.hf("            return new ReadOnlySpan<%sRow>(basePointer + p->%s.OffsetOf, (int) p->%s.Count);\n",
 			a.ElemName, field, field)
 		g.hf("        }\n    }\n\n")
 	}
@@ -519,7 +563,7 @@ func (g *blockGen) emitBlockOpen(bl *ir.BlockLayout) {
 	g.hf("        if (Schema.TableBlockRead64(at) != Schema.TableBlockMagic) { return false; }\n")
 	g.hf("        if (Schema.TableBlockRead64(at + 8) != Schema.BuildVersion) { return false; }\n")
 	g.hf("        if (Schema.TableBlockRead64(at + 16) != Schema.TableBlockByteOrder) { return false; }\n")
-	g.hf("        Block.%sProjection* projection = (Block.%sProjection*) at;\n", name, name)
+	g.hf("        %sBlockProjection* projection = (%sBlockProjection*) at;\n", name, name)
 	g.hf("        long used = %d;\n", bl.Projection.Size)
 	for _, a := range bl.Arrays {
 		field := ir.GoExportName(a.Field.Name)
@@ -531,7 +575,7 @@ func (g *blockGen) emitBlockOpen(bl *ir.BlockLayout) {
 		g.hf("            long offsetOf = (long) projection->%s.OffsetOf;\n", field)
 		g.hf("            long count = projection->%s.Count;\n", field)
 		g.hf("            long stride = projection->%s.Stride;\n", field)
-		g.hf("            if (stride != Unsafe.SizeOf<Block.%s>()) { return false; }\n", a.ElemName)
+		g.hf("            if (stride != Unsafe.SizeOf<%sRow>()) { return false; }\n", a.ElemName)
 		g.hf("            // past the DECLARED MAXIMUM: Begin refuses this on the producer\n")
 		g.hf("            // side and Open refuses it here, because a consumer that sizes\n")
 		g.hf("            // anything by the maximum would overflow on a count the maximum\n")
@@ -596,7 +640,11 @@ func (g *blockGen) emitBlockRecordDescriptor(owner, record string, ml *ir.Member
 			}
 		}
 		element := "null"
-		if f.Type.Kind == ir.TNamed && f.Array == ir.ArrayNone && !f.Type.Pointer {
+		// A field that NAMES a record carries that record's layout, whether it
+		// holds one or an array of them: an INLINE array of records is part of
+		// a row, and a walker descending one reaches its element through this
+		// same column. Only the pointer class has no layout to name.
+		if f.Type.Kind == ir.TNamed && !f.Type.Pointer {
 			if ref, ok := f.Type.Ref.(*ir.Struct); ok {
 				element = fmt.Sprintf("delegate { return %s; }", blockInfoSymbol(owner, ref.Name))
 			}

--- a/ir/blocklayout.go
+++ b/ir/blocklayout.go
@@ -428,14 +428,48 @@ func layoutProjection(u *Unit, st *Struct) MemberLayout {
 	return ml
 }
 
+// BlockFieldPieceOffsets is the absolute offset of each contiguous PIECE of
+// one field's storage, given where the field starts.
+//
+// A field is not always one piece: a `string(N)` is a buffer AND an int32 used
+// length, a counted array is its elements AND an int32 count, an optional adds
+// a presence bool. The C ABI aligns each piece on its own, so a field can carry
+// INTERIOR padding — `char[49]` followed by an `int32_t` puts two bytes between
+// them — and a port that lays a record out field by field, padding only BETWEEN
+// fields, silently slides everything after it.
+//
+// The C# blittable emitter walks this rather than deriving it, because the two
+// derivations disagreeing is exactly the defect it exists to prevent (§19.3).
+func BlockFieldPieceOffsets(u *Unit, f *Field, fieldOffset int64, projection bool) []BlockFieldPiece {
+	pieces := fieldPieces(u, f, projection)
+	out := make([]BlockFieldPiece, 0, len(pieces))
+	at := fieldOffset
+	for _, p := range pieces {
+		at = alignUp(at, p.align)
+		out = append(out, BlockFieldPiece{Offset: at, Size: p.size})
+		at += p.size
+	}
+	return out
+}
+
+// BlockFieldPiece is one contiguous member of a field's generated storage:
+// where it starts inside the record, and how many bytes it takes.
+type BlockFieldPiece struct {
+	Offset int64
+	Size   int64
+}
+
 // fieldPieces spells one field's storage as the contiguous pieces the
 // generated record declares, in order. `projection` selects the block form's
 // projection spelling, in which an out-of-line array is its triple.
 func fieldPieces(u *Unit, f *Field, projection bool) []storagePiece {
 	if projection && BlockOutOfLine(f) {
-		// (offset_of u64, count u32, stride u32) — sixteen bytes, no interior
-		// padding, at the field's own position
-		return []storagePiece{{size: 8, align: 8}, {size: 4, align: 4}, {size: 4, align: 4}}
+		// (offset_of u64, count u32, stride u32) — ONE sixteen-byte piece with
+		// no interior padding, at the field's own position. It is one piece and
+		// not three because both backends spell it as one member of a triple
+		// TYPE, and a port that walked three would account for eight bytes
+		// where sixteen were written.
+		return []storagePiece{{size: 16, align: 8}}
 	}
 	var pieces []storagePiece
 	switch {

--- a/tables/blockhome/Data.schema
+++ b/tables/blockhome/Data.schema
@@ -22,3 +22,36 @@ type ArmorConfig
     rating float32
     tier   uint8
 }
+
+// `Block` is a COMMON NOUN, and a game unit will have one — the dogfood's is a
+// wire message. It is declared here on purpose: the C# backend used to plant a
+// nested `<Pkg>.Block` namespace for its blittable records, so this
+// declaration made the generated unit refuse to compile, and a declaration in
+// ANOTHER unit of the same assembly did the same with nothing this compiler
+// could see. The records take claimed suffixes in the package namespace now
+// (§19.2), and this type is what keeps that true.
+type Block
+{
+    width  uint32
+    height uint32
+}
+
+// The dogfood's shape, and defect B's fixture: a `type` holding TWO bounded
+// arrays, nested by value inside a block row. §2.7 is DEPTH ONE, BOUNDED ONLY
+// — these two arrays stay INLINE wherever this type sits, because only the
+// block-form TABLE'S OWN bounded arrays are laid out of line. A C# emitter
+// that projected them would put a sixteen-byte triple where C++ put the whole
+// array and land every field after it somewhere else.
+type FiringGroup
+{
+    barrel   uint32
+    cooldown float32
+}
+
+type GunnerSettings
+{
+    firing_groups  [..MaxParts]FiringGroup
+    missile_groups [..MaxPlates]FiringGroup
+    reload_seconds float32
+    gunner_id      uint32
+}

--- a/tables/blockhome/Frame.schema
+++ b/tables/blockhome/Frame.schema
@@ -6,7 +6,10 @@ package blockhome
 
 table PartRow
 {
-    armor   ArmorConfig
+    armor ArmorConfig
+    // a `type` holding two bounded arrays, nested by value in a ROW: both stay
+    // INLINE, at every depth (SPEC-TABLES.md §2.7, depth one bounded only)
+    gunner  GunnerSettings
     part_id uint32
     slot    uint8
 }

--- a/test/cs-block/schemablock.csproj
+++ b/test/cs-block/schemablock.csproj
@@ -42,6 +42,12 @@
          that does not compile at all, and this project is where that is
          caught. -->
     <Compile Include="$(BlockHomeGeneratedDir)/*.cs" />
+    <!-- EVERY corpus unit the C# backend emits a block form for, so §19.3's
+         layout contract is a GENERATION-TIME gate and not only a throw the
+         first time somebody opens a block. Compiling is half of it — a
+         projected array where an inline one belongs does not compile the same
+         — and src/LayoutGate.cs runs each unit's Verify() for the other half. -->
+    <Compile Include="../../build/tables-generated-cs/examples/*.cs" Exclude="../../build/tables-generated-cs/examples/*Table.cs" />
     <Compile Include="../../../serialize.cs/src/Serialize.cs" />
     <Compile Include="../../../serialize.cs/src/Int128Pair.cs" />
   </ItemGroup>

--- a/test/cs-block/src/BlockHome.cs
+++ b/test/cs-block/src/BlockHome.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Runtime.CompilerServices;
 using Blockhome;
-using HomeRow = Blockhome.Block;
 
 static class BlockHomeGate
 {
@@ -48,15 +47,50 @@ static class BlockHomeGate
 
         // the BLITTABLE RECORD from the type-only file, and the layout the
         // block form asserts for it
-        if (Unsafe.SizeOf<HomeRow.ArmorConfig>() == 0 || Unsafe.SizeOf<HomeRow.ArmorPlate>() == 0)
+        if (Unsafe.SizeOf<ArmorConfigRow>() == 0 || Unsafe.SizeOf<ArmorPlateRow>() == 0)
         {
             Console.WriteLine("FAILED: the block home's records from the type-only file");
             ok = false;
         }
         long stride = PartFrameBlock.PartsStride;
-        if (Unsafe.SizeOf<HomeRow.PartRow>() != stride)
+        if (Unsafe.SizeOf<PartRowRow>() != stride)
         {
             Console.WriteLine("FAILED: the row's size is not the pitch the block declares");
+            ok = false;
+        }
+
+        // `Block` is a COMMON NOUN and the unit declares one: the table wire's
+        // sealed class of that name, in the same namespace the block form's
+        // records live in. A nested <Pkg>.Block namespace made this a CS0101,
+        // and a `Block` in another unit of the same assembly made it one with
+        // nothing the compiler could see. Naming both here is the gate.
+        Block wireBlock = new Block();
+        wireBlock.Width = 3;
+        if (wireBlock.Width != 3)
+        {
+            Console.WriteLine("FAILED: the unit's own `Block` declaration");
+            ok = false;
+        }
+
+        // <Table>BlockMaxBytes: a consumer caps a playback buffer, a recording
+        // or a scratch copy from the GENERATED constant, not from a number
+        // somebody wrote down beside it (SPEC-TABLES.md §19.1).
+        long cap = PartFrameBlock.BlockMaxBytes;
+        if (cap <= Unsafe.SizeOf<PartFrameBlockProjection>())
+        {
+            Console.WriteLine("FAILED: BlockMaxBytes does not cover the projection and its rows");
+            ok = false;
+        }
+
+        // the dogfood's shape: a `type` holding TWO bounded arrays, nested by
+        // value in a row. Both stay INLINE at every depth (§2.7), so the row is
+        // as wide as C++ says and the arrays are addressable in place.
+        long gunner = Unsafe.SizeOf<GunnerSettingsRow>();
+        long group = Unsafe.SizeOf<FiringGroupRow>();
+        if (gunner < group * (32 + 4))
+        {
+            Console.WriteLine("FAILED: a bounded array inside a nested record was not laid out inline — it is " +
+                gunner + " bytes and its two arrays alone are " + (group * (32 + 4)));
             ok = false;
         }
 

--- a/test/cs-block/src/Gate2.cs
+++ b/test/cs-block/src/Gate2.cs
@@ -29,7 +29,6 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Blockdemo;
-using Row = Blockdemo.Block;
 
 static class Gate2
 {
@@ -148,20 +147,20 @@ static class Gate2
     {
         double sum = 0.0;
 
-        ReadOnlySpan<Row.RenderShip> ships = block.ShipsSpan;
+        ReadOnlySpan<RenderShipRow> ships = block.ShipsSpan;
         for (int i = 0; i < ships.Length; i++)
         {
             sum += ships[i].Position.X + ships[i].Rotation.W + ships[i].ObjectId + ships[i].Thrust
                  + (byte) ships[i].Team + (ships[i].HasTargetLock ? 1 : 0);
         }
 
-        ReadOnlySpan<Row.RenderTurret> turrets = block.TurretsSpan;
+        ReadOnlySpan<RenderTurretRow> turrets = block.TurretsSpan;
         for (int i = 0; i < turrets.Length; i++)
         {
             sum += turrets[i].Rotation.W + turrets[i].ObjectId + turrets[i].TurretIndex + (byte) turrets[i].Team;
         }
 
-        ReadOnlySpan<Row.RenderStaticProp> props = block.StaticPropsSpan;
+        ReadOnlySpan<RenderStaticPropRow> props = block.StaticPropsSpan;
         for (int i = 0; i < props.Length; i++)
         {
             sum += props[i].Position.X + props[i].Scale + props[i].StaticPropId + (byte) props[i].Team;

--- a/test/cs-block/src/LayoutGate.cs
+++ b/test/cs-block/src/LayoutGate.cs
@@ -1,0 +1,50 @@
+// §19.3's LAYOUT CONTRACT as a GENERATION-TIME gate (SPEC-TABLES.md §19.3,
+// §19.5).
+//
+// The C# half of the contract is a check that runs once and throws — C# has no
+// `static_assert`, so a disagreement between the compiler's layout model and
+// this runtime's cannot be a build error the way it is in C++. Left at that,
+// the first thing to discover a bad layout is a consumer opening a block, at
+// run time, in a game.
+//
+// This closes the distance. The project compiles the generated C# of EVERY
+// corpus unit the backend emits a block form for — which is already half the
+// gate, because a projected array where an inline one belongs does not produce
+// the same struct — and this runs each unit's own `Verify()`, so every record
+// of every unit has its size and every field's offset checked against the
+// compiler's model before any test does anything else.
+//
+// The dogfood is why: a C# emitter that projected a bounded array INSIDE a
+// nested record put a sixteen-byte triple where C++ put the whole array, and
+// nothing said so until `Verify()` threw on the first `Open` — in the game.
+
+using System;
+
+static class LayoutGate
+{
+    internal static bool Run()
+    {
+        bool ok = true;
+        // one call per unit: each carries its own TableBlockLayout, and the
+        // check is idempotent, so calling it here costs one branch after the
+        // first and gives every unit a verdict at start-up.
+        ok &= Verify("blockdemo", () => Blockdemo.TableBlockLayout.Verify());
+        ok &= Verify("blockhome", () => Blockhome.TableBlockLayout.Verify());
+        ok &= Verify("tabledemo", () => Tabledemo.TableBlockLayout.Verify());
+        return ok;
+    }
+
+    static bool Verify(string unit, Action verify)
+    {
+        try
+        {
+            verify();
+            return true;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("FAILED: " + unit + "'s block layout disagrees with the compiler's model: " + e.Message);
+            return false;
+        }
+    }
+}

--- a/test/cs-block/src/Program.cs
+++ b/test/cs-block/src/Program.cs
@@ -21,7 +21,6 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Blockdemo;
-using Row = Blockdemo.Block;
 
 static class Program
 {
@@ -82,14 +81,14 @@ static class Program
         w = 1.0 - 0.5 * (i % 3);
     }
 
-    static void CheckVec3(in Row.RenderVector3 got, int salt, int i, string what)
+    static void CheckVec3(in RenderVector3Row got, int salt, int i, string what)
     {
         double x, y, z;
         Vec3(salt, i, out x, out y, out z);
         Check(got.X == x && got.Y == y && got.Z == z, what);
     }
 
-    static void CheckQuat(in Row.RenderQuaternion got, int salt, int i, string what)
+    static void CheckQuat(in RenderQuaternionRow got, int salt, int i, string what)
     {
         double x, y, z, w;
         Quat(salt, i, out x, out y, out z, out w);
@@ -143,16 +142,16 @@ static class Program
 
             // ---- the projection's own fields, and the facts about its rows ----
 
-            ref readonly Row.RenderFrameProjection projection = ref block.Projection;
+            ref readonly RenderFrameBlockProjection projection = ref block.Projection;
             Check(projection.Magic == Schema.TableBlockMagic, "the prologue's magic");
             Check(projection.BuildVersion == Schema.BuildVersion, "the prologue's build version is this build's own");
             Check(projection.ByteOrder == Schema.TableBlockByteOrder, "the prologue's byte order is this build's own");
             Check(projection.Version == 1, "the table's own declared field, read where it lies");
 
             Check(projection.Ships.Count == Ships, "the ships triple's count");
-            Check(projection.Ships.Stride == Unsafe.SizeOf<Row.RenderShip>(),
+            Check(projection.Ships.Stride == Unsafe.SizeOf<RenderShipRow>(),
                 "the ships triple's stride is this build's own sizeof — the pitch IS sizeof (§2.7)");
-            Check(projection.Ships.OffsetOf >= (ulong) Unsafe.SizeOf<Row.RenderFrameProjection>(),
+            Check(projection.Ships.OffsetOf >= (ulong) Unsafe.SizeOf<RenderFrameBlockProjection>(),
                 "the ships array starts past the projection");
             Check(projection.Cameras.Count == Cameras && projection.Turrets.Count == Turrets &&
                   projection.Missiles.Count == Missiles && projection.DynamicProps.Count == DynamicProps &&
@@ -242,6 +241,7 @@ static class Program
 
         CheckPadded();
         Check(BlockHomeGate.Run(), "the block home unit's C# surface is emitted and reachable");
+        Check(LayoutGate.Run(), "every corpus unit's block layout agrees with the compiler's model (SPEC-TABLES.md §19.3)");
 
         // GATE 2's C# half (SPEC-TABLES.md §12.1), run only when asked: it is a
         // MEASUREMENT, and a measurement in a correctness leg would make the
@@ -297,21 +297,21 @@ static class Program
             {
                 return;
             }
-            Check(Unsafe.SizeOf<Row.PaddedRow>() == 72, "a padded row is 72 bytes in the managed model, as it is in C++");
+            Check(Unsafe.SizeOf<PaddedRowRow>() == 72, "a padded row is 72 bytes in the managed model, as it is in C++");
 
-            ref readonly Row.PaddedFrameProjection projection = ref block.Projection;
+            ref readonly PaddedFrameBlockProjection projection = ref block.Projection;
             Check(projection.Marker == 7, "the projection's scalar before the hole");
             Check(projection.Stamp == 0x0123456789abcdefUL, "the projection's scalar after it");
             Check(projection.BlobLength == 12, "the projection's inline bytes length");
 
             int i = 0;
-            foreach (ref readonly Row.PaddedRow row in block.Rows)
+            foreach (ref readonly PaddedRowRow row in block.Rows)
             {
                 Check(row.Tag == (byte) (10 + i), "padded row tag, before seven bytes of hole");
                 Check(row.Value == 0.5 * i + 100.0, "padded row value, after them");
                 Check(row.Flag == ((i % 2) == 0), "padded row flag");
                 Check(row.Id == (uint) (i * 1000 + 3), "padded row id, after three more");
-                fixed (Row.PaddedRow* p = &row)
+                fixed (PaddedRowRow* p = &row)
                 {
                     string label = Marshal.PtrToStringAnsi(new IntPtr(p->Label), row.LabelLength);
                     Check(label == "row-" + i, "padded row label — an inline string buffer");
@@ -347,7 +347,7 @@ static class Program
     {
         {
             int i = 0;
-            foreach (ref readonly Row.RenderCamera camera in block.Cameras)
+            foreach (ref readonly RenderCameraRow camera in block.Cameras)
             {
                 CheckVec3(in camera.Position, 1, i, "camera position");
                 CheckQuat(in camera.Rotation, 1, i, "camera rotation");
@@ -361,7 +361,7 @@ static class Program
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderShip ship in block.Ships)
+            foreach (ref readonly RenderShipRow ship in block.Ships)
             {
                 CheckVec3(in ship.Position, 2, i, "ship position");
                 CheckQuat(in ship.Rotation, 2, i, "ship rotation");
@@ -381,17 +381,17 @@ static class Program
                 i++;
             }
             Check(i == Ships, "the ships accessor yields count rows");
-            Check(Unsafe.SizeOf<Row.RenderShip>() == 88, "a ship row is 88 bytes in the managed model, as it is in C++");
+            Check(Unsafe.SizeOf<RenderShipRow>() == 88, "a ship row is 88 bytes in the managed model, as it is in C++");
         }
         {
-            ReadOnlySpan<Row.RenderShip> ships = block.ShipsSpan;
+            ReadOnlySpan<RenderShipRow> ships = block.ShipsSpan;
             Check(ships.Length == Ships, "the contiguous view carries the same count");
             Check(ships.Length == 0 || ships[Ships - 1].ObjectId == (uint) ((Ships - 1) * 3 + 11),
                 "and the contiguous view lands the same values as the iterator");
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderTurret turret in block.Turrets)
+            foreach (ref readonly RenderTurretRow turret in block.Turrets)
             {
                 CheckQuat(in turret.Rotation, 3, i, "turret rotation");
                 Check(turret.Flags == (ulong) (i * 17), "turret flags");
@@ -408,7 +408,7 @@ static class Program
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderMissile missile in block.Missiles)
+            foreach (ref readonly RenderMissileRow missile in block.Missiles)
             {
                 CheckVec3(in missile.Position, 4, i, "missile position");
                 CheckQuat(in missile.Rotation, 4, i, "missile rotation");
@@ -423,7 +423,7 @@ static class Program
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderDynamicProp prop in block.DynamicProps)
+            foreach (ref readonly RenderDynamicPropRow prop in block.DynamicProps)
             {
                 CheckVec3(in prop.Position, 5, i, "dynamic prop position");
                 Check(prop.Flags == (ulong) (i * 29), "dynamic prop flags");
@@ -437,7 +437,7 @@ static class Program
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderStaticProp prop in block.StaticProps)
+            foreach (ref readonly RenderStaticPropRow prop in block.StaticProps)
             {
                 CheckVec3(in prop.Position, 6, i, "static prop position");
                 Check(prop.Scale == 0.5 + 0.25 * (i % 7), "static prop scale");
@@ -451,7 +451,7 @@ static class Program
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderCosmeticProp prop in block.CosmeticProps)
+            foreach (ref readonly RenderCosmeticPropRow prop in block.CosmeticProps)
             {
                 CheckVec3(in prop.Position, 7, i, "cosmetic prop position");
                 Check(prop.Scale == 0.25 + 0.125 * (i % 5), "cosmetic prop scale");
@@ -466,7 +466,7 @@ static class Program
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderLaser laser in block.Lasers)
+            foreach (ref readonly RenderLaserRow laser in block.Lasers)
             {
                 CheckVec3(in laser.Start, 8, i, "laser start");
                 CheckVec3(in laser.Finish, 9, i, "laser finish");
@@ -480,7 +480,7 @@ static class Program
         }
         {
             int i = 0;
-            foreach (ref readonly Row.RenderExplosion explosion in block.Explosions)
+            foreach (ref readonly RenderExplosionRow explosion in block.Explosions)
             {
                 CheckVec3(in explosion.Position, 10, i, "explosion position");
                 Check(explosion.T == 0.0625 * (i % 16), "explosion t");
@@ -508,7 +508,7 @@ static class Program
         TableBlockInfo info = RenderFrameBlock.Type;
         Check(info.Name == "RenderFrame", "the block descriptor names its table");
         Check(info.BuildVersion == Schema.BuildVersion, "the block descriptor carries the unit's build version");
-        Check(info.Size == Unsafe.SizeOf<Row.RenderFrameProjection>(), "the block descriptor's size is the projection's own");
+        Check(info.Size == Unsafe.SizeOf<RenderFrameBlockProjection>(), "the block descriptor's size is the projection's own");
 
         byte* at = block.Base;
         int outOfLine = 0;
@@ -549,7 +549,7 @@ static class Program
             }
             Check(hasLock.Size == 1, "a bool row field is ONE byte in the descriptors too (§19.3)");
 
-            ReadOnlySpan<Row.RenderShip> ships = block.ShipsSpan;
+            ReadOnlySpan<RenderShipRow> ships = block.ShipsSpan;
             int mismatches = 0;
             for (uint r = 0; r < count; r++)
             {

--- a/testdata/golden/build-version/tables-blockhome.txt
+++ b/testdata/golden/build-version/tables-blockhome.txt
@@ -1,6 +1,6 @@
-0x831c4abc9b71036d
+0x3de2d055d5640b6a
 schema-build-version 1
-protocol b08615b7d62a9648
+protocol a6612e5b3f07080a
 byteorder little
 block prologue=magic:8,build_version:8,byte_order:8
 record ArmorConfig sizeof=40 alignof=8
@@ -12,13 +12,22 @@ record ArmorPlate sizeof=16 alignof=8
     field c81a kind=11 offset=0 size=8
     field 0284 kind=8 offset=8 size=4
     field 4750 kind=6 offset=12 size=1
-record PartFrame sizeof=1552 alignof=8
+record FiringGroup sizeof=8 alignof=4
+    field 87ed kind=8 offset=0 size=4
+    field 2230 kind=10 offset=4 size=4
+record GunnerSettings sizeof=304 alignof=4
+    field c79d kind=13 offset=0 size=260 type=FiringGroup elem=8 array=bounded bound=32
+    field 6a31 kind=13 offset=260 size=36 type=FiringGroup elem=8 array=bounded bound=4
+    field d08f kind=10 offset=296 size=4
+    field e0d2 kind=8 offset=300 size=4
+record PartFrame sizeof=11280 alignof=8
     field e8e6 kind=9 offset=0 size=8
-    field fc18 kind=13 offset=8 size=1540 type=PartRow elem=48 array=bounded bound=32
+    field fc18 kind=13 offset=8 size=11268 type=PartRow elem=352 array=bounded bound=32
 block PartFrame sizeof=48 alignof=8
     slot e8e6 offset=24 size=8
-    slot fc18 offset=32 size=16 out_of_line stride=48
-record PartRow sizeof=48 alignof=8
+    slot fc18 offset=32 size=16 out_of_line stride=352
+record PartRow sizeof=352 alignof=8
     field 7c9d kind=13 offset=0 size=40 type=ArmorConfig
-    field 6deb kind=8 offset=40 size=4
-    field 37e4 kind=6 offset=44 size=1
+    field 2bc9 kind=13 offset=40 size=304 type=GunnerSettings
+    field 6deb kind=8 offset=344 size=4
+    field 37e4 kind=6 offset=348 size=1

--- a/testdata/golden/tables/blockhome-cs/DataTable.cs
+++ b/testdata/golden/tables/blockhome-cs/DataTable.cs
@@ -294,6 +294,342 @@ namespace Blockhome
             return ArmorConfigLoadBody(ref r, value);
         }
 
+        // TableReset(FiringGroup) restores FiringGroup's declared defaults in place, reusing every
+        // buffer the value already owns. The reader calls it before overlaying.
+        public static void TableReset(FiringGroup value)
+        {
+            value.Barrel = 0;
+            value.Cooldown = 0.0f;
+        }
+
+        public static long FiringGroupMeasure(FiringGroup value)
+        {
+            long bytes = 2; // terminator
+            if (value.Barrel != 0) { bytes += 3 + 4; } // barrel
+            if (value.Cooldown != 0.0f) { bytes += 3 + 4; } // cooldown
+            return bytes;
+        }
+
+        public static bool FiringGroupSaveBody(ref TableWriter w, FiringGroup value)
+        {
+            if (value.Barrel != 0)
+            {
+                w.Put16(0x87ed); w.Put8(8); // barrel
+                w.Put32(unchecked((uint)(value.Barrel)));
+            }
+            if (value.Cooldown != 0.0f)
+            {
+                w.Put16(0x2230); w.Put8(10); // cooldown
+                w.Put32(TableFloatToBits(value.Cooldown));
+            }
+            w.Put16(0); // terminator
+            return !w.Overflow;
+        }
+
+        public static long FiringGroupSave(FiringGroup value, Span<byte> buffer)
+        {
+            TableWriter w = new TableWriter(buffer);
+            if (!FiringGroupSaveBody(ref w, value)) { return -1; }
+            return w.Offset; // == FiringGroupMeasure(value)
+        }
+
+        public static bool FiringGroupLoadBody(ref TableReader r, FiringGroup value)
+        {
+            TableReset(value); // restore declared defaults in place, then overlay
+            for (;;)
+            {
+                if (!r.Has(2)) { r.Report.Malformed = true; return false; }
+                ushort fieldId = r.Get16();
+                if (fieldId == 0) { return true; }
+                if (!r.Has(1)) { r.Report.Malformed = true; return false; }
+                byte kind = r.Get8();
+                switch (fieldId)
+                {
+                    case 0x87ed: // barrel
+                    {
+                        if (kind != 8)
+                        {
+                            r.Report.KindMismatch++;
+                            if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                            break;
+                        }
+                        if (!r.Has(4)) { r.Report.Malformed = true; return false; }
+                        {
+                            uint decodedV = unchecked((uint)r.Get32());
+                            value.Barrel = decodedV;
+                        }
+                        break;
+                    }
+                    case 0x2230: // cooldown
+                    {
+                        if (kind != 10)
+                        {
+                            r.Report.KindMismatch++;
+                            if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                            break;
+                        }
+                        if (!r.Has(4)) { r.Report.Malformed = true; return false; }
+                        value.Cooldown = TableBitsToFloat(r.Get32());
+                        break;
+                    }
+                    default:
+                    {
+                        r.Report.Unknown++;
+                        if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                        break;
+                    }
+                }
+            }
+        }
+
+        public static bool FiringGroupLoad(FiringGroup value, ReadOnlySpan<byte> bytes, TableReport report)
+        {
+            TableReader r = new TableReader(bytes, report != null ? report : new TableReport());
+            return FiringGroupLoadBody(ref r, value);
+        }
+
+        // TableReset(GunnerSettings) restores GunnerSettings's declared defaults in place, reusing every
+        // buffer the value already owns. The reader calls it before overlaying.
+        public static void TableReset(GunnerSettings value)
+        {
+            for (int i = 0; i < value.FiringGroups.Length; i++)
+            {
+                TableReset(value.FiringGroups[i]);
+            }
+            value.FiringGroupsCount = 0;
+            for (int i = 0; i < value.MissileGroups.Length; i++)
+            {
+                TableReset(value.MissileGroups[i]);
+            }
+            value.MissileGroupsCount = 0;
+            value.ReloadSeconds = 0.0f;
+            value.GunnerId = 0;
+        }
+
+        public static long GunnerSettingsMeasure(GunnerSettings value)
+        {
+            long bytes = 2; // terminator
+            if (value.FiringGroupsCount < 0 || value.FiringGroupsCount > 32) { return -1; } // storage invariant
+            if (value.FiringGroupsCount > 0)
+            {
+                bytes += 3 + 4 + 5; // firing_groups
+                for (int i = 0; i < value.FiringGroupsCount; i++)
+                {
+                    long elem = FiringGroupMeasure(value.FiringGroups[i]);
+                    if (elem < 0) { return -1; }
+                    bytes += 4 + elem;
+                }
+            }
+            if (value.MissileGroupsCount < 0 || value.MissileGroupsCount > 4) { return -1; } // storage invariant
+            if (value.MissileGroupsCount > 0)
+            {
+                bytes += 3 + 4 + 5; // missile_groups
+                for (int i = 0; i < value.MissileGroupsCount; i++)
+                {
+                    long elem = FiringGroupMeasure(value.MissileGroups[i]);
+                    if (elem < 0) { return -1; }
+                    bytes += 4 + elem;
+                }
+            }
+            if (value.ReloadSeconds != 0.0f) { bytes += 3 + 4; } // reload_seconds
+            if (value.GunnerId != 0) { bytes += 3 + 4; } // gunner_id
+            return bytes;
+        }
+
+        public static bool GunnerSettingsSaveBody(ref TableWriter w, GunnerSettings value)
+        {
+            if (value.FiringGroupsCount < 0 || value.FiringGroupsCount > 32) { return false; } // storage invariant
+            if (value.FiringGroupsCount > 0)
+            {
+                w.Put16(0xc79d); w.Put8(14); // firing_groups
+                int lenAt = w.Offset; w.Put32(0);
+                w.Put8(13); w.Put32((uint)value.FiringGroupsCount);
+                for (int i = 0; i < value.FiringGroupsCount; i++)
+                {
+                    {
+                        int elemLenAt = w.Offset; w.Put32(0);
+                        if (!FiringGroupSaveBody(ref w, value.FiringGroups[i])) { return false; }
+                        w.Patch32(elemLenAt, (uint)(w.Offset - elemLenAt - 4));
+                    }
+                }
+                w.Patch32(lenAt, (uint)(w.Offset - lenAt - 4));
+            }
+            if (value.MissileGroupsCount < 0 || value.MissileGroupsCount > 4) { return false; } // storage invariant
+            if (value.MissileGroupsCount > 0)
+            {
+                w.Put16(0x6a31); w.Put8(14); // missile_groups
+                int lenAt = w.Offset; w.Put32(0);
+                w.Put8(13); w.Put32((uint)value.MissileGroupsCount);
+                for (int i = 0; i < value.MissileGroupsCount; i++)
+                {
+                    {
+                        int elemLenAt = w.Offset; w.Put32(0);
+                        if (!FiringGroupSaveBody(ref w, value.MissileGroups[i])) { return false; }
+                        w.Patch32(elemLenAt, (uint)(w.Offset - elemLenAt - 4));
+                    }
+                }
+                w.Patch32(lenAt, (uint)(w.Offset - lenAt - 4));
+            }
+            if (value.ReloadSeconds != 0.0f)
+            {
+                w.Put16(0xd08f); w.Put8(10); // reload_seconds
+                w.Put32(TableFloatToBits(value.ReloadSeconds));
+            }
+            if (value.GunnerId != 0)
+            {
+                w.Put16(0xe0d2); w.Put8(8); // gunner_id
+                w.Put32(unchecked((uint)(value.GunnerId)));
+            }
+            w.Put16(0); // terminator
+            return !w.Overflow;
+        }
+
+        public static long GunnerSettingsSave(GunnerSettings value, Span<byte> buffer)
+        {
+            TableWriter w = new TableWriter(buffer);
+            if (!GunnerSettingsSaveBody(ref w, value)) { return -1; }
+            return w.Offset; // == GunnerSettingsMeasure(value)
+        }
+
+        public static bool GunnerSettingsLoadBody(ref TableReader r, GunnerSettings value)
+        {
+            TableReset(value); // restore declared defaults in place, then overlay
+            for (;;)
+            {
+                if (!r.Has(2)) { r.Report.Malformed = true; return false; }
+                ushort fieldId = r.Get16();
+                if (fieldId == 0) { return true; }
+                if (!r.Has(1)) { r.Report.Malformed = true; return false; }
+                byte kind = r.Get8();
+                switch (fieldId)
+                {
+                    case 0xc79d: // firing_groups
+                    {
+                        if (kind != 14)
+                        {
+                            r.Report.KindMismatch++;
+                            if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                            break;
+                        }
+                        if (!r.Has(4)) { r.Report.Malformed = true; return false; }
+                        uint bodyLen = r.Get32();
+                        if (!r.Has(bodyLen)) { r.Report.Malformed = true; return false; }
+                        int bodyEnd = r.Offset + (int)bodyLen;
+                        if (bodyLen >= 5)
+                        {
+                            byte elemKind = r.Get8();
+                            uint count = r.Get32();
+                            if (elemKind != 13) { r.Report.KindMismatch++; r.Offset = bodyEnd; break; }
+                            uint keep = count;
+                            if (keep > 32) { keep = 32; r.Report.Clamped++; }
+                            // elements are BOUNDED by the field body: a count the length
+                            // cannot cover keeps the decoded prefix, flags malformed, and
+                            // the parent continues at the next field — following fields'
+                            // bytes are never fabricated into elements
+                            TableReader sub = new TableReader(r.Buffer.Slice(r.Offset, bodyEnd - r.Offset), r.Report);
+                            uint decoded = 0;
+                            for (uint i = 0; i < keep; i++)
+                            {
+                                if (!sub.Has(4)) { r.Report.Malformed = true; break; }
+                                uint elemLen = sub.Get32();
+                                if (!sub.Has(elemLen)) { r.Report.Malformed = true; break; }
+                                {
+                                    TableReader elem = new TableReader(sub.Buffer.Slice(sub.Offset, (int)elemLen), r.Report);
+                                    FiringGroupLoadBody(ref elem, value.FiringGroups[i]);
+                                }
+                                sub.Offset += (int)elemLen;
+                                decoded = i + 1;
+                            }
+                            value.FiringGroupsCount = (int)decoded;
+                        }
+                        r.Offset = bodyEnd; // excess elements and slack skip via the length
+                        break;
+                    }
+                    case 0x6a31: // missile_groups
+                    {
+                        if (kind != 14)
+                        {
+                            r.Report.KindMismatch++;
+                            if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                            break;
+                        }
+                        if (!r.Has(4)) { r.Report.Malformed = true; return false; }
+                        uint bodyLen = r.Get32();
+                        if (!r.Has(bodyLen)) { r.Report.Malformed = true; return false; }
+                        int bodyEnd = r.Offset + (int)bodyLen;
+                        if (bodyLen >= 5)
+                        {
+                            byte elemKind = r.Get8();
+                            uint count = r.Get32();
+                            if (elemKind != 13) { r.Report.KindMismatch++; r.Offset = bodyEnd; break; }
+                            uint keep = count;
+                            if (keep > 4) { keep = 4; r.Report.Clamped++; }
+                            // elements are BOUNDED by the field body: a count the length
+                            // cannot cover keeps the decoded prefix, flags malformed, and
+                            // the parent continues at the next field — following fields'
+                            // bytes are never fabricated into elements
+                            TableReader sub = new TableReader(r.Buffer.Slice(r.Offset, bodyEnd - r.Offset), r.Report);
+                            uint decoded = 0;
+                            for (uint i = 0; i < keep; i++)
+                            {
+                                if (!sub.Has(4)) { r.Report.Malformed = true; break; }
+                                uint elemLen = sub.Get32();
+                                if (!sub.Has(elemLen)) { r.Report.Malformed = true; break; }
+                                {
+                                    TableReader elem = new TableReader(sub.Buffer.Slice(sub.Offset, (int)elemLen), r.Report);
+                                    FiringGroupLoadBody(ref elem, value.MissileGroups[i]);
+                                }
+                                sub.Offset += (int)elemLen;
+                                decoded = i + 1;
+                            }
+                            value.MissileGroupsCount = (int)decoded;
+                        }
+                        r.Offset = bodyEnd; // excess elements and slack skip via the length
+                        break;
+                    }
+                    case 0xd08f: // reload_seconds
+                    {
+                        if (kind != 10)
+                        {
+                            r.Report.KindMismatch++;
+                            if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                            break;
+                        }
+                        if (!r.Has(4)) { r.Report.Malformed = true; return false; }
+                        value.ReloadSeconds = TableBitsToFloat(r.Get32());
+                        break;
+                    }
+                    case 0xe0d2: // gunner_id
+                    {
+                        if (kind != 8)
+                        {
+                            r.Report.KindMismatch++;
+                            if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                            break;
+                        }
+                        if (!r.Has(4)) { r.Report.Malformed = true; return false; }
+                        {
+                            uint decodedV = unchecked((uint)r.Get32());
+                            value.GunnerId = decodedV;
+                        }
+                        break;
+                    }
+                    default:
+                    {
+                        r.Report.Unknown++;
+                        if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                        break;
+                    }
+                }
+            }
+        }
+
+        public static bool GunnerSettingsLoad(GunnerSettings value, ReadOnlySpan<byte> bytes, TableReport report)
+        {
+            TableReader r = new TableReader(bytes, report != null ? report : new TableReport());
+            return GunnerSettingsLoadBody(ref r, value);
+        }
+
         // ---- reflection descriptors (tables only, SPEC-TABLES.md §8) ----
 
         private static TableTypeInfo ArmorPlateTableInfo;
@@ -330,6 +666,42 @@ namespace Blockhome
                 new TableFieldInfo { Name = "tier", TypeName = "uint8", Id = 0xe958, Kind = 6, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = null },
             };
             ArmorConfigTableInfo = info;
+            return info;
+        }
+
+        private static TableTypeInfo FiringGroupTableInfo;
+        public static TableTypeInfo FiringGroupTableType()
+        {
+            TableTypeInfo info = FiringGroupTableInfo;
+            if (info != null) { return info; }
+            info = new TableTypeInfo();
+            info.Name = "FiringGroup";
+            info.NumFields = 2;
+            info.Fields = new TableFieldInfo[]
+            {
+                new TableFieldInfo { Name = "barrel", TypeName = "uint32", Id = 0x87ed, Kind = 8, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = null },
+                new TableFieldInfo { Name = "cooldown", TypeName = "float32", Id = 0x2230, Kind = 10, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = null },
+            };
+            FiringGroupTableInfo = info;
+            return info;
+        }
+
+        private static TableTypeInfo GunnerSettingsTableInfo;
+        public static TableTypeInfo GunnerSettingsTableType()
+        {
+            TableTypeInfo info = GunnerSettingsTableInfo;
+            if (info != null) { return info; }
+            info = new TableTypeInfo();
+            info.Name = "GunnerSettings";
+            info.NumFields = 4;
+            info.Fields = new TableFieldInfo[]
+            {
+                new TableFieldInfo { Name = "firing_groups", TypeName = "FiringGroup", Id = 0xc79d, Kind = 13, IsArray = true, Counted = true, Optional = false, ArrayBound = 32, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = delegate { return FiringGroupTableType(); } },
+                new TableFieldInfo { Name = "missile_groups", TypeName = "FiringGroup", Id = 0x6a31, Kind = 13, IsArray = true, Counted = true, Optional = false, ArrayBound = 4, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = delegate { return FiringGroupTableType(); } },
+                new TableFieldInfo { Name = "reload_seconds", TypeName = "float32", Id = 0xd08f, Kind = 10, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = null },
+                new TableFieldInfo { Name = "gunner_id", TypeName = "uint32", Id = 0xe0d2, Kind = 8, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = null },
+            };
+            GunnerSettingsTableInfo = info;
             return info;
         }
     }

--- a/testdata/golden/tables/blockhome-cs/FrameTable.cs
+++ b/testdata/golden/tables/blockhome-cs/FrameTable.cs
@@ -16,6 +16,7 @@ namespace Blockhome
     public sealed class PartRow
     {
         public ArmorConfig Armor = new ArmorConfig();
+        public GunnerSettings Gunner = new GunnerSettings();
         public uint PartId;
         public byte Slot;
     }
@@ -47,6 +48,7 @@ namespace Blockhome
         public static void TableReset(PartRow value)
         {
             TableReset(value.Armor);
+            TableReset(value.Gunner);
             value.PartId = 0;
             value.Slot = 0;
         }
@@ -58,6 +60,11 @@ namespace Blockhome
                 long body = ArmorConfigMeasure(value.Armor);
                 if (body < 0) { return -1; }
                 if (body > 2) { bytes += 3 + 4 + body; } // armor: all-default nested elides
+            }
+            {
+                long body = GunnerSettingsMeasure(value.Gunner);
+                if (body < 0) { return -1; }
+                if (body > 2) { bytes += 3 + 4 + body; } // gunner: all-default nested elides
             }
             if (value.PartId != 0) { bytes += 3 + 4; } // part_id
             if (value.Slot != 0) { bytes += 3 + 1; } // slot
@@ -74,6 +81,16 @@ namespace Blockhome
                     w.Put16(0x7c9d); w.Put8(13); // armor
                     w.Put32((uint)body);
                     if (!ArmorConfigSaveBody(ref w, value.Armor)) { return false; }
+                }
+            }
+            {
+                long body = GunnerSettingsMeasure(value.Gunner);
+                if (body < 0) { return false; } // storage invariant, refused as measure refuses it
+                if (body > 2) // all-default nested elides
+                {
+                    w.Put16(0x2bc9); w.Put8(13); // gunner
+                    w.Put32((uint)body);
+                    if (!GunnerSettingsSaveBody(ref w, value.Gunner)) { return false; }
                 }
             }
             if (value.PartId != 0)
@@ -123,6 +140,24 @@ namespace Blockhome
                         {
                             TableReader sub = new TableReader(r.Buffer.Slice(r.Offset, (int)bodyLen), r.Report);
                             ArmorConfigLoadBody(ref sub, value.Armor);
+                        }
+                        r.Offset += (int)bodyLen;
+                        break;
+                    }
+                    case 0x2bc9: // gunner
+                    {
+                        if (kind != 13)
+                        {
+                            r.Report.KindMismatch++;
+                            if (!r.Skip(kind)) { r.Report.Malformed = true; return false; }
+                            break;
+                        }
+                        if (!r.Has(4)) { r.Report.Malformed = true; return false; }
+                        uint bodyLen = r.Get32();
+                        if (!r.Has(bodyLen)) { r.Report.Malformed = true; return false; }
+                        {
+                            TableReader sub = new TableReader(r.Buffer.Slice(r.Offset, (int)bodyLen), r.Report);
+                            GunnerSettingsLoadBody(ref sub, value.Gunner);
                         }
                         r.Offset += (int)bodyLen;
                         break;
@@ -331,10 +366,11 @@ namespace Blockhome
             if (info != null) { return info; }
             info = new TableTypeInfo();
             info.Name = "PartRow";
-            info.NumFields = 3;
+            info.NumFields = 4;
             info.Fields = new TableFieldInfo[]
             {
                 new TableFieldInfo { Name = "armor", TypeName = "ArmorConfig", Id = 0x7c9d, Kind = 13, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = delegate { return ArmorConfigTableType(); } },
+                new TableFieldInfo { Name = "gunner", TypeName = "GunnerSettings", Id = 0x2bc9, Kind = 13, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = delegate { return GunnerSettingsTableType(); } },
                 new TableFieldInfo { Name = "part_id", TypeName = "uint32", Id = 0x6deb, Kind = 8, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = null },
                 new TableFieldInfo { Name = "slot", TypeName = "uint8", Id = 0x37e4, Kind = 6, IsArray = false, Counted = false, Optional = false, ArrayBound = 0, HasRange = false, RangeMin = 0.0, RangeMax = 0.0, EnumMax = -1, EnumName = null, VariantId = null, KeyTypeName = null, KeyName = null, KeyId = null, Guard = "", TableRef = null },
             };

--- a/testdata/golden/tables/blockhome/ConstantsTable.h
+++ b/testdata/golden/tables/blockhome/ConstantsTable.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: NONE — this generated output is yours, under terms of
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
-// package blockhome — protocol id 0xb08615b7d62a9648 (packets only: tables version by field id, not by protocol id)
+// package blockhome — protocol id 0xa6612e5b3f07080a (packets only: tables version by field id, not by protocol id)
 // The TABLE wire (evolution-tolerant, SPEC-TABLES.md): no serialize
 // dependency — includable from any TU.
 

--- a/testdata/golden/tables/blockhome/DataTable.cpp
+++ b/testdata/golden/tables/blockhome/DataTable.cpp
@@ -1647,4 +1647,34 @@ int64_t ArmorConfigToJson( const ArmorConfig & value, char * buffer, int64_t cap
     return TableJsonWrite( &value, ArmorConfigTableType(), buffer, capacity );
 }
 
+bool FiringGroupFromJson( FiringGroup & value, const char * text, int64_t bytes, TableReport * report )
+{
+    return TableJsonRead( &value, FiringGroupTableType(), text, bytes, report );
+}
+
+int64_t FiringGroupToJsonMeasure( const FiringGroup & value )
+{
+    return TableJsonWrite( &value, FiringGroupTableType(), NULL, 0 );
+}
+
+int64_t FiringGroupToJson( const FiringGroup & value, char * buffer, int64_t capacity )
+{
+    return TableJsonWrite( &value, FiringGroupTableType(), buffer, capacity );
+}
+
+bool GunnerSettingsFromJson( GunnerSettings & value, const char * text, int64_t bytes, TableReport * report )
+{
+    return TableJsonRead( &value, GunnerSettingsTableType(), text, bytes, report );
+}
+
+int64_t GunnerSettingsToJsonMeasure( const GunnerSettings & value )
+{
+    return TableJsonWrite( &value, GunnerSettingsTableType(), NULL, 0 );
+}
+
+int64_t GunnerSettingsToJson( const GunnerSettings & value, char * buffer, int64_t capacity )
+{
+    return TableJsonWrite( &value, GunnerSettingsTableType(), buffer, capacity );
+}
+
 } // namespace blockhome

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: NONE — this generated output is yours, under terms of
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
-// package blockhome — protocol id 0xb08615b7d62a9648 (packets only: tables version by field id, not by protocol id)
+// package blockhome — protocol id 0xa6612e5b3f07080a (packets only: tables version by field id, not by protocol id)
 // The TABLE wire (evolution-tolerant, SPEC-TABLES.md): no serialize
 // dependency — includable from any TU.
 
@@ -216,6 +216,12 @@ inline bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & value );
 inline int64_t ArmorConfigMeasure( const ArmorConfig & value );
 inline bool ArmorConfigSaveBody( TableWriter & w, const ArmorConfig & value );
 inline bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & value );
+inline int64_t FiringGroupMeasure( const FiringGroup & value );
+inline bool FiringGroupSaveBody( TableWriter & w, const FiringGroup & value );
+inline bool FiringGroupLoadBody( TableReader & r, FiringGroup & value );
+inline int64_t GunnerSettingsMeasure( const GunnerSettings & value );
+inline bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value );
+inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value );
 
 inline int64_t ArmorPlateMeasure( const ArmorPlate & value )
 {
@@ -472,6 +478,314 @@ inline bool ArmorConfigLoad( ArmorConfig & value, const uint8_t * buffer, int64_
     return ArmorConfigLoadBody( r, value );
 }
 
+inline int64_t FiringGroupMeasure( const FiringGroup & value )
+{
+    int64_t bytes = 2; // terminator
+    if ( value.barrel != 0 ) { bytes += 3 + 4; } // barrel
+    if ( value.cooldown != 0.0f ) { bytes += 3 + 4; } // cooldown
+    return bytes;
+}
+
+inline bool FiringGroupSaveBody( TableWriter & w, const FiringGroup & value )
+{
+    if ( value.barrel != 0 )
+    {
+        w.put16( 0x87ed ); w.put8( 8 ); // barrel
+        w.put32( uint32_t( value.barrel ) );
+    }
+    if ( value.cooldown != 0.0f )
+    {
+        w.put16( 0x2230 ); w.put8( 10 ); // cooldown
+        w.put32( table_float_to_bits( value.cooldown ) );
+    }
+    w.put16( 0 ); // terminator
+    return !w.overflow;
+}
+
+inline int64_t FiringGroupSave( const FiringGroup & value, uint8_t * buffer, int64_t capacity )
+{
+    TableWriter w( buffer, capacity );
+    if ( !FiringGroupSaveBody( w, value ) ) { return -1; }
+    return w.offset; // == FiringGroupMeasure( value )
+}
+
+inline bool FiringGroupLoadBody( TableReader & r, FiringGroup & value )
+{
+    new ( &value ) FiringGroup{}; // prefill declared defaults in place, then overlay
+    for ( ;; )
+    {
+        if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
+        uint16_t field_id = r.get16();
+        if ( field_id == 0 ) return true;
+        if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
+        uint8_t kind = r.get8();
+        switch ( field_id )
+        {
+            case 0x87ed: // barrel
+            {
+                if ( kind != 8 )
+                {
+                    r.report->kind_mismatch++;
+                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                    break;
+                }
+                if ( !r.has( 4 ) ) { r.report->malformed = true; return false; }
+                uint32_t decoded_v = uint32_t( r.get32( ) );
+                value.barrel = decoded_v;
+                break;
+            }
+            case 0x2230: // cooldown
+            {
+                if ( kind != 10 )
+                {
+                    r.report->kind_mismatch++;
+                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                    break;
+                }
+                if ( !r.has( 4 ) ) { r.report->malformed = true; return false; }
+                value.cooldown = table_bits_to_float( r.get32() );
+                break;
+            }
+            default:
+            {
+                r.report->unknown++;
+                if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                break;
+            }
+        }
+    }
+}
+
+inline bool FiringGroupLoad( FiringGroup & value, const uint8_t * buffer, int64_t bytes, TableReport * report )
+{
+    TableReport ignored;
+    TableReader r( buffer, bytes, report != NULL ? report : &ignored );
+    return FiringGroupLoadBody( r, value );
+}
+
+inline int64_t GunnerSettingsMeasure( const GunnerSettings & value )
+{
+    int64_t bytes = 2; // terminator
+    if ( value.firing_groups_count < 0 || value.firing_groups_count > 32 ) { return -1; } // storage invariant
+    if ( value.firing_groups_count > 0 )
+    {
+        bytes += 3 + 4 + 5; // firing_groups
+        for ( int32_t i = 0; i < value.firing_groups_count; i++ )
+        {
+            int64_t elem_firing_groups = FiringGroupMeasure( value.firing_groups[i] );
+            if ( elem_firing_groups < 0 ) { return -1; }
+            bytes += 4 + elem_firing_groups;
+        }
+    }
+    if ( value.missile_groups_count < 0 || value.missile_groups_count > 4 ) { return -1; } // storage invariant
+    if ( value.missile_groups_count > 0 )
+    {
+        bytes += 3 + 4 + 5; // missile_groups
+        for ( int32_t i = 0; i < value.missile_groups_count; i++ )
+        {
+            int64_t elem_missile_groups = FiringGroupMeasure( value.missile_groups[i] );
+            if ( elem_missile_groups < 0 ) { return -1; }
+            bytes += 4 + elem_missile_groups;
+        }
+    }
+    if ( value.reload_seconds != 0.0f ) { bytes += 3 + 4; } // reload_seconds
+    if ( value.gunner_id != 0 ) { bytes += 3 + 4; } // gunner_id
+    return bytes;
+}
+
+inline bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value )
+{
+    if ( value.firing_groups_count < 0 || value.firing_groups_count > 32 ) { return false; } // storage invariant
+    if ( value.firing_groups_count > 0 )
+    {
+        w.put16( 0xc79d ); w.put8( 14 ); // firing_groups
+        int64_t len_at_firing_groups = w.offset; w.put32( 0 );
+        w.put8( 13 ); w.put32( uint32_t( value.firing_groups_count ) );
+        for ( int32_t i = 0; i < value.firing_groups_count; i++ )
+        {
+            {
+                int64_t elem_len_at = w.offset; w.put32( 0 );
+                if ( !FiringGroupSaveBody( w, value.firing_groups[i] ) ) return false;
+                w.patch32( elem_len_at, uint32_t( w.offset - elem_len_at - 4 ) );
+            }
+        }
+        w.patch32( len_at_firing_groups, uint32_t( w.offset - len_at_firing_groups - 4 ) );
+    }
+    if ( value.missile_groups_count < 0 || value.missile_groups_count > 4 ) { return false; } // storage invariant
+    if ( value.missile_groups_count > 0 )
+    {
+        w.put16( 0x6a31 ); w.put8( 14 ); // missile_groups
+        int64_t len_at_missile_groups = w.offset; w.put32( 0 );
+        w.put8( 13 ); w.put32( uint32_t( value.missile_groups_count ) );
+        for ( int32_t i = 0; i < value.missile_groups_count; i++ )
+        {
+            {
+                int64_t elem_len_at = w.offset; w.put32( 0 );
+                if ( !FiringGroupSaveBody( w, value.missile_groups[i] ) ) return false;
+                w.patch32( elem_len_at, uint32_t( w.offset - elem_len_at - 4 ) );
+            }
+        }
+        w.patch32( len_at_missile_groups, uint32_t( w.offset - len_at_missile_groups - 4 ) );
+    }
+    if ( value.reload_seconds != 0.0f )
+    {
+        w.put16( 0xd08f ); w.put8( 10 ); // reload_seconds
+        w.put32( table_float_to_bits( value.reload_seconds ) );
+    }
+    if ( value.gunner_id != 0 )
+    {
+        w.put16( 0xe0d2 ); w.put8( 8 ); // gunner_id
+        w.put32( uint32_t( value.gunner_id ) );
+    }
+    w.put16( 0 ); // terminator
+    return !w.overflow;
+}
+
+inline int64_t GunnerSettingsSave( const GunnerSettings & value, uint8_t * buffer, int64_t capacity )
+{
+    TableWriter w( buffer, capacity );
+    if ( !GunnerSettingsSaveBody( w, value ) ) { return -1; }
+    return w.offset; // == GunnerSettingsMeasure( value )
+}
+
+inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value )
+{
+    new ( &value ) GunnerSettings{}; // prefill declared defaults in place, then overlay
+    for ( ;; )
+    {
+        if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
+        uint16_t field_id = r.get16();
+        if ( field_id == 0 ) return true;
+        if ( !r.has( 1 ) ) { r.report->malformed = true; return false; }
+        uint8_t kind = r.get8();
+        switch ( field_id )
+        {
+            case 0xc79d: // firing_groups
+            {
+                if ( kind != 14 )
+                {
+                    r.report->kind_mismatch++;
+                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                    break;
+                }
+                if ( !r.has( 4 ) ) { r.report->malformed = true; return false; }
+                uint32_t body_len = r.get32();
+                if ( !r.has( body_len ) ) { r.report->malformed = true; return false; }
+                int64_t body_end = r.offset + body_len;
+                if ( body_len >= 5 )
+                {
+                    uint8_t elem_kind = r.get8();
+                    uint32_t count = r.get32();
+                    if ( elem_kind != 13 ) { r.report->kind_mismatch++; r.offset = body_end; break; }
+                    uint32_t keep = count;
+                    if ( keep > 32 ) { keep = 32; r.report->clamped++; }
+                    // elements are BOUNDED by the field body: a count the length
+                    // cannot cover keeps the decoded prefix, flags malformed, and
+                    // the parent continues at the next field — following fields'
+                    // bytes are never fabricated into elements
+                    TableReader sub( r.buffer + r.offset, body_end - r.offset, r.report );
+                    uint32_t decoded = 0;
+                    for ( uint32_t i = 0; i < keep; i++ )
+                    {
+                        if ( !sub.has( 4 ) ) { r.report->malformed = true; break; }
+                        uint32_t elem_len = sub.get32();
+                        if ( !sub.has( elem_len ) ) { r.report->malformed = true; break; }
+                        {
+                            TableReader elem( sub.buffer + sub.offset, elem_len, r.report );
+                            FiringGroupLoadBody( elem, value.firing_groups[i] );
+                        }
+                        sub.offset += elem_len;
+                        decoded = i + 1;
+                    }
+                    value.firing_groups_count = (int32_t) decoded;
+                }
+                r.offset = body_end; // excess elements and slack skip via the length
+                break;
+            }
+            case 0x6a31: // missile_groups
+            {
+                if ( kind != 14 )
+                {
+                    r.report->kind_mismatch++;
+                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                    break;
+                }
+                if ( !r.has( 4 ) ) { r.report->malformed = true; return false; }
+                uint32_t body_len = r.get32();
+                if ( !r.has( body_len ) ) { r.report->malformed = true; return false; }
+                int64_t body_end = r.offset + body_len;
+                if ( body_len >= 5 )
+                {
+                    uint8_t elem_kind = r.get8();
+                    uint32_t count = r.get32();
+                    if ( elem_kind != 13 ) { r.report->kind_mismatch++; r.offset = body_end; break; }
+                    uint32_t keep = count;
+                    if ( keep > 4 ) { keep = 4; r.report->clamped++; }
+                    // elements are BOUNDED by the field body: a count the length
+                    // cannot cover keeps the decoded prefix, flags malformed, and
+                    // the parent continues at the next field — following fields'
+                    // bytes are never fabricated into elements
+                    TableReader sub( r.buffer + r.offset, body_end - r.offset, r.report );
+                    uint32_t decoded = 0;
+                    for ( uint32_t i = 0; i < keep; i++ )
+                    {
+                        if ( !sub.has( 4 ) ) { r.report->malformed = true; break; }
+                        uint32_t elem_len = sub.get32();
+                        if ( !sub.has( elem_len ) ) { r.report->malformed = true; break; }
+                        {
+                            TableReader elem( sub.buffer + sub.offset, elem_len, r.report );
+                            FiringGroupLoadBody( elem, value.missile_groups[i] );
+                        }
+                        sub.offset += elem_len;
+                        decoded = i + 1;
+                    }
+                    value.missile_groups_count = (int32_t) decoded;
+                }
+                r.offset = body_end; // excess elements and slack skip via the length
+                break;
+            }
+            case 0xd08f: // reload_seconds
+            {
+                if ( kind != 10 )
+                {
+                    r.report->kind_mismatch++;
+                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                    break;
+                }
+                if ( !r.has( 4 ) ) { r.report->malformed = true; return false; }
+                value.reload_seconds = table_bits_to_float( r.get32() );
+                break;
+            }
+            case 0xe0d2: // gunner_id
+            {
+                if ( kind != 8 )
+                {
+                    r.report->kind_mismatch++;
+                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                    break;
+                }
+                if ( !r.has( 4 ) ) { r.report->malformed = true; return false; }
+                uint32_t decoded_v = uint32_t( r.get32( ) );
+                value.gunner_id = decoded_v;
+                break;
+            }
+            default:
+            {
+                r.report->unknown++;
+                if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                break;
+            }
+        }
+    }
+}
+
+inline bool GunnerSettingsLoad( GunnerSettings & value, const uint8_t * buffer, int64_t bytes, TableReport * report )
+{
+    TableReport ignored;
+    TableReader r( buffer, bytes, report != NULL ? report : &ignored );
+    return GunnerSettingsLoadBody( r, value );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -482,11 +796,17 @@ static_assert( std::is_trivially_copyable<ArmorPlate>::value, "ArmorPlate must s
 static_assert( std::is_standard_layout<ArmorPlate>::value, "ArmorPlate must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<ArmorConfig>::value, "ArmorConfig must stay relocatable" );
 static_assert( std::is_standard_layout<ArmorConfig>::value, "ArmorConfig must stay standard-layout for offsetof" );
+static_assert( std::is_trivially_copyable<FiringGroup>::value, "FiringGroup must stay relocatable" );
+static_assert( std::is_standard_layout<FiringGroup>::value, "FiringGroup must stay standard-layout for offsetof" );
+static_assert( std::is_trivially_copyable<GunnerSettings>::value, "GunnerSettings must stay relocatable" );
+static_assert( std::is_standard_layout<GunnerSettings>::value, "GunnerSettings must stay standard-layout for offsetof" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 
 inline const TableTypeInfo * ArmorPlateTableType();
 inline const TableTypeInfo * ArmorConfigTableType();
+inline const TableTypeInfo * FiringGroupTableType();
+inline const TableTypeInfo * GunnerSettingsTableType();
 
 inline const TableTypeInfo * ArmorPlateTableType()
 {
@@ -511,6 +831,28 @@ inline const TableTypeInfo * ArmorConfigTableType()
     return &info;
 }
 
+inline const TableTypeInfo * FiringGroupTableType()
+{
+    static const TableFieldInfo fields[] = {
+        { "barrel", "barrel", "uint32", 0x87ed, 8, false, false, false, 0, (uint32_t) offsetof( FiringGroup, barrel ), (uint32_t) sizeof( FiringGroup{}.barrel ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
+        { "cooldown", "cooldown", "float32", 0x2230, 10, false, false, false, 0, (uint32_t) offsetof( FiringGroup, cooldown ), (uint32_t) sizeof( FiringGroup{}.cooldown ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
+    };
+    static const TableTypeInfo info = { "FiringGroup", (uint32_t) sizeof( FiringGroup ), 2, fields, +[]( void * p ) { new ( p ) FiringGroup{}; } };
+    return &info;
+}
+
+inline const TableTypeInfo * GunnerSettingsTableType()
+{
+    static const TableFieldInfo fields[] = {
+        { "firing_groups", "firing_groups", "FiringGroup", 0xc79d, 13, true, true, false, 32, (uint32_t) offsetof( GunnerSettings, firing_groups ), (uint32_t) sizeof( GunnerSettings{}.firing_groups[0] ), (uint32_t) offsetof( GunnerSettings, firing_groups_count ), 0xffffffffu, FiringGroupTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
+        { "missile_groups", "missile_groups", "FiringGroup", 0x6a31, 13, true, true, false, 4, (uint32_t) offsetof( GunnerSettings, missile_groups ), (uint32_t) sizeof( GunnerSettings{}.missile_groups[0] ), (uint32_t) offsetof( GunnerSettings, missile_groups_count ), 0xffffffffu, FiringGroupTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
+        { "reload_seconds", "reload_seconds", "float32", 0xd08f, 10, false, false, false, 0, (uint32_t) offsetof( GunnerSettings, reload_seconds ), (uint32_t) sizeof( GunnerSettings{}.reload_seconds ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
+        { "gunner_id", "gunner_id", "uint32", 0xe0d2, 8, false, false, false, 0, (uint32_t) offsetof( GunnerSettings, gunner_id ), (uint32_t) sizeof( GunnerSettings{}.gunner_id ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
+    };
+    static const TableTypeInfo info = { "GunnerSettings", (uint32_t) sizeof( GunnerSettings ), 4, fields, +[]( void * p ) { new ( p ) GunnerSettings{}; } };
+    return &info;
+}
+
 // ---- the text form (SPEC-TABLES.md §16) ----
 
 // ArmorPlate in and out of a JSON text — one instance, one text, the generic
@@ -526,5 +868,19 @@ int64_t ArmorPlateToJson( const ArmorPlate & value, char * buffer, int64_t capac
 bool ArmorConfigFromJson( ArmorConfig & value, const char * text, int64_t bytes, TableReport * report );
 int64_t ArmorConfigToJsonMeasure( const ArmorConfig & value );
 int64_t ArmorConfigToJson( const ArmorConfig & value, char * buffer, int64_t capacity );
+
+// FiringGroup in and out of a JSON text — one instance, one text, the generic
+// walk over this type's descriptors (SPEC-TABLES.md §16). Defined in
+// DataTable.cpp; link it to use them.
+bool FiringGroupFromJson( FiringGroup & value, const char * text, int64_t bytes, TableReport * report );
+int64_t FiringGroupToJsonMeasure( const FiringGroup & value );
+int64_t FiringGroupToJson( const FiringGroup & value, char * buffer, int64_t capacity );
+
+// GunnerSettings in and out of a JSON text — one instance, one text, the generic
+// walk over this type's descriptors (SPEC-TABLES.md §16). Defined in
+// DataTable.cpp; link it to use them.
+bool GunnerSettingsFromJson( GunnerSettings & value, const char * text, int64_t bytes, TableReport * report );
+int64_t GunnerSettingsToJsonMeasure( const GunnerSettings & value );
+int64_t GunnerSettingsToJson( const GunnerSettings & value, char * buffer, int64_t capacity );
 
 } // namespace blockhome

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: NONE — this generated output is yours, under terms of
 // your choice. See the LICENSE exception in the schema compiler; the compiler is
 // AGPL-3.0, its output is not.
-// package blockhome — protocol id 0xb08615b7d62a9648 (packets only: tables version by field id, not by protocol id)
+// package blockhome — protocol id 0xa6612e5b3f07080a (packets only: tables version by field id, not by protocol id)
 // The TABLE wire (evolution-tolerant, SPEC-TABLES.md): no serialize
 // dependency — includable from any TU.
 
@@ -213,6 +213,7 @@ namespace blockhome {
 // member initializers (SPEC-TABLES.md)
 struct PartRow {
     ArmorConfig armor;
+    GunnerSettings gunner;
     uint32_t part_id = 0;
     uint8_t slot = 0;
 };
@@ -242,6 +243,11 @@ inline int64_t PartRowMeasure( const PartRow & value )
         if ( body_armor < 0 ) { return -1; }
         if ( body_armor > 2 ) { bytes += 3 + 4 + body_armor; } // armor: all-default nested elides
     }
+    {
+        int64_t body_gunner = GunnerSettingsMeasure( value.gunner );
+        if ( body_gunner < 0 ) { return -1; }
+        if ( body_gunner > 2 ) { bytes += 3 + 4 + body_gunner; } // gunner: all-default nested elides
+    }
     if ( value.part_id != 0 ) { bytes += 3 + 4; } // part_id
     if ( value.slot != 0 ) { bytes += 3 + 1; } // slot
     return bytes;
@@ -257,6 +263,16 @@ inline bool PartRowSaveBody( TableWriter & w, const PartRow & value )
             w.put16( 0x7c9d ); w.put8( 13 ); // armor
             w.put32( uint32_t( body_armor ) );
             if ( !ArmorConfigSaveBody( w, value.armor ) ) return false;
+        }
+    }
+    {
+        int64_t body_gunner = GunnerSettingsMeasure( value.gunner );
+        if ( body_gunner < 0 ) return false; // storage invariant, refused as measure refuses it
+        if ( body_gunner > 2 ) // all-default nested elides
+        {
+            w.put16( 0x2bc9 ); w.put8( 13 ); // gunner
+            w.put32( uint32_t( body_gunner ) );
+            if ( !GunnerSettingsSaveBody( w, value.gunner ) ) return false;
         }
     }
     if ( value.part_id != 0 )
@@ -306,6 +322,24 @@ inline bool PartRowLoadBody( TableReader & r, PartRow & value )
                 {
                     TableReader sub( r.buffer + r.offset, body_len, r.report );
                     ArmorConfigLoadBody( sub, value.armor );
+                }
+                r.offset += body_len;
+                break;
+            }
+            case 0x2bc9: // gunner
+            {
+                if ( kind != 13 )
+                {
+                    r.report->kind_mismatch++;
+                    if ( !r.skip( kind ) ) { r.report->malformed = true; return false; }
+                    break;
+                }
+                if ( !r.has( 4 ) ) { r.report->malformed = true; return false; }
+                uint32_t body_len = r.get32();
+                if ( !r.has( body_len ) ) { r.report->malformed = true; return false; }
+                {
+                    TableReader sub( r.buffer + r.offset, body_len, r.report );
+                    GunnerSettingsLoadBody( sub, value.gunner );
                 }
                 r.offset += body_len;
                 break;
@@ -509,10 +543,11 @@ inline const TableTypeInfo * PartRowTableType()
 {
     static const TableFieldInfo fields[] = {
         { "armor", "armor", "ArmorConfig", 0x7c9d, 13, false, false, false, 0, (uint32_t) offsetof( PartRow, armor ), (uint32_t) sizeof( PartRow{}.armor ), 0xffffffffu, 0xffffffffu, ArmorConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
+        { "gunner", "gunner", "GunnerSettings", 0x2bc9, 13, false, false, false, 0, (uint32_t) offsetof( PartRow, gunner ), (uint32_t) sizeof( PartRow{}.gunner ), 0xffffffffu, 0xffffffffu, GunnerSettingsTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "part_id", "part_id", "uint32", 0x6deb, 8, false, false, false, 0, (uint32_t) offsetof( PartRow, part_id ), (uint32_t) sizeof( PartRow{}.part_id ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "slot", "slot", "uint8", 0x37e4, 6, false, false, false, 0, (uint32_t) offsetof( PartRow, slot ), (uint32_t) sizeof( PartRow{}.slot ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "PartRow", (uint32_t) sizeof( PartRow ), 3, fields, +[]( void * p ) { new ( p ) PartRow{}; } };
+    static const TableTypeInfo info = { "PartRow", (uint32_t) sizeof( PartRow ), 4, fields, +[]( void * p ) { new ( p ) PartRow{}; } };
     return &info;
 }
 


### PR DESCRIPTION
Two defects the dogfood found on its first WHOLE-ASSEMBLY C# compile of the block form, and the three the fix for the second uncovered. Against `main` (89065cd).

## A. The C# backend planted a namespace named by a common noun

The blittable records lived in a nested `<Pkg>.Block`. `Block` is a common noun a game will have — the dogfood has a wire `message Block` in **another unit compiled into the same assembly**, so the generated namespace collided with a declaration this compiler never sees:

```
CS0101: the namespace 'Space' already contains a definition for 'Block'
```

`refuseBlockNamespaceCollision` could only ever have caught the same-unit half, which is the smaller one. A compiler that checks one unit at a time cannot refuse what another unit declares.

**The records take CLAIMED SUFFIXES in the unit's own namespace now** — `<Name>Row` for a row, `<Table>BlockProjection` for a projection — both added to §11's list, so a colliding declaration is refused at the source like every other generated spelling. The refusal row goes with the namespace. Reproduced in the corpus: `tables/blockhome` declares a `type Block` beside its block-form table and compiles clean.

Verified the claim reaches: with `type Part` present, `type PartRow` is now refused —

```
declaration PartRow collides with Part's generated TABLE-wire functions —
both generate the symbol PartRow; rename at the source
```

**Claimed count: 26 + 9 = 35** (the block set gains `Row` and `BlockProjection`), reconciled mechanically against `tableGeneratedVerbs` — page and code agree in both directions.

## B. An array inside a nested record was projected out of line

§19 says only the block-form table's **own** bounded arrays move; C++ did that, C# projected at every depth. A `type` holding two bounded arrays — the dogfood's gunner settings — got a sixteen-byte triple where C++ had the whole array, and every field after it moved:

```
GunnerSettings.MissileFiringGroups sits at 44 in this runtime and 576 in the schema the C++ side asserts
```

`projection` is now what decides, in the field emitter and in the layout check's address helper both. Corpus: a `type` holding two `[..N]T` arrays, nested by value in a row.

## What fixing B uncovered — both found by the new gate, on its first run

- **A field's own storage can carry INTERIOR padding.** A `string(48)` buffer followed by its `int32` length puts two bytes between them, and the emitter padded only *between* fields — so `GlobalSettings.spawn_delays` sat at 58 where the model says 60, and everything after it slid. It walks `ir.BlockFieldPieceOffsets` piece by piece now. This shipped in #309 and nothing in the tree could see it, because the corpus units that were compiled had no string whose buffer needed interior padding.
- **A descriptor for a record reached only through an inline array** was emitted and never referenced, which `-Werror` refuses. A field that NAMES a record carries that record's layout whether it holds one or an array of them — which is also how a walker descends into an inline array's element.

I also caught a regression I introduced mid-fix: the projection's triple is ONE 16-byte piece, not three, and walking it as three accounted for 8 bytes where 16 were written. Same gate, same run.

## §19.3's layout contract is a GENERATION-TIME gate now

Not only a throw on the first `Open` in a game. `test/cs-block` compiles the generated C# of **every** corpus unit the backend emits a block form for, and runs each unit's `Verify()` at start-up. Compiling is half the gate — a projected array is not the struct the rest of the unit indexes — and `Verify()` is the other. `TableBlockLayout` is `public` so a consumer's own leg can call it; a check nobody outside the assembly can call is a check nobody calls.

That gate is what found both defects above.

**Negative control** (`make tables-block-inline-array-negative-control`): put the projection back at every depth via `go build -overlay`, and the gate reds. It reports which half fired —

```
block inline-array negative control: the LAYOUT CHECK went red — a projected array inside a nested record moves the offsets
```

## Also from the dogfood

The C# backend emits **`<Table>BlockMaxBytes`**, which C++ had and it did not, so a consumer's playback cap comes from the generated constant rather than a number written down beside it.

## Verification

`make check`, `go test ./...`, `make shape-gate` green. Every block gate green: `tables-block` (leg + ASan + TSan twins + the C# consumer), `tables-block-zero-cost` (38 Table sources byte-identical to the pins the pre-block compiler wrote — re-pinned from f55e711 over the new corpus), `tables-block-build-version`, `tables-block-fill-refuser` and its control, and the padding, pitch, layout-model, race, block-home and inline-array controls. The surrounding tables battery green: `schema_test_tables`, `test/cs-tables`, `tables-zero-cost`, `tables-cs-standalone`, `tables-pack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
