### PR TITLE
Stale language counts outside the spec: ci.yml comments say six-language conformance; SPEC.md's per-language behaviour lists omit Dart, Java and Elixir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,9 @@ name: CI
 #
 # What the split moves is WHEN the inline-budget gates run, not whether —
 # nothing checks less. Measured basis (2026-08-25, runs 32826150095 /
-# 32827197339): the full six-language conformance (`make test`) costs 31-45s;
-# the inline-budget gates cost ~9 of the ~10:30 wall minutes (go 2:44,
+# 32827197339): the full conformance run (`make test`) cost 31-45s — six
+# languages when that was measured, nine today; the inline-budget gates
+# cost ~9 of the ~10:30 wall minutes (go 2:44,
 # cs 3:47, rust 1:16, cpp 0:36, c 0:32 on macOS; go 2:23 on ubuntu). So the
 # PR leg KEEPS the entire conformance corpus — every construct class, every
 # target, both OSes, the goldens, the fuzz seeds, the staleness check — and
@@ -401,8 +402,9 @@ jobs:
 
   # The compiler that generates C++ for a Windows-targeting game engine was
   # never itself run on Windows. `make test` needs the six sibling runtime
-  # clones and a POSIX toolchain, so vet + build is the cheap first step the
-  # issue prescribes; growing this into a real test leg is a follow-up.
+  # clones, the three self-contained targets' toolchains and a POSIX
+  # toolchain, so vet + build is the cheap first step the issue prescribes;
+  # growing this into a real test leg is a follow-up.
   windows:
     runs-on: windows-latest
     timeout-minutes: 15

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -2043,7 +2043,7 @@ lives a table has without being told; and a table's own **node type id**
 (§3.1), so a tool can map a node table's records — or a region's node
 directory — onto descriptors with no schema files on hand. The
 compile-time refusals those ids bring (§11) apply to EVERY unit, as the
-26 generated spellings do, because a unit gains and loses pointers as an
+24 generated spellings do, because a unit gains and loses pointers as an
 edit and a name that was free yesterday must not become a collision
 tomorrow. A self-referential pointer resolves to its own type's
 descriptor. Where pointers exist the descriptors are CONSTANT-INITIALISED
@@ -2651,7 +2651,7 @@ in build version (§20.5).
 
   - **The three per-declaration spellings the descriptors emit** —
     `<Name>TableFields`, `<Name>TableInfo` and `<Name>TableType` — claimed
-    for every declaration in every unit. All three are in the 26 above and
+    for every declaration in every unit. All three are in the 24 above and
     are claimed today only for closure members; the descriptor emission
     spells all three per declaration, so widening one of them would leave
     two open.

--- a/SPEC.md
+++ b/SPEC.md
@@ -462,7 +462,9 @@ FloatExpr   = float expression over float literals, int literals and const names
     constant per variant (`1 << bit`),
     because mask tests are how flag state is consumed, **plus the `Count`
     constant** — the declared variant count, spelled per target beside the
-    enum extents (`CapsCount` in C++/C#/Go/JS, `CAPS_COUNT` in C and Rust).
+    enum extents — the spelling is each target's own, and all nine emit it:
+    `CapsCount` in C++, C#, Go and JS; `CAPS_COUNT` in C and Rust;
+    `capsCount` in Dart and Java; `caps_count/0` in Elixir.
     **`flags` is a
     contextual keyword, not reserved** — it introduces a declaration at file
     scope only, so a *field* named `flags` stays fully legal; declarations at
@@ -913,9 +915,10 @@ exists for exactly one reason — it sizes the length prefix's bits.
 unchanged and identical to `bytes(N)`; what the `string` spelling adds is a
 CONTRACT: the payload is well-formed UTF-8 — the writer's obligation, never
 the reader's check. Writing malformed UTF-8 is a writer contract violation,
-surfaced by debug-only asserts where the language supports them (C and C++
-assert through a generated validator, Rust through `debug_assert!`; Go and C#
-assert nothing). There is no mandatory read-path validation and no
+surfaced by debug-only asserts where the language supports them. The list is
+exhaustive: C, C++ and Rust assert — C and C++ through a generated validator,
+Rust through `debug_assert!` — and the other six (C#, Dart, Elixir, Go, Java,
+JavaScript) assert nothing. There is no mandatory read-path validation and no
 release-path cost anywhere, and the conformance vectors carry only valid
 UTF-8. An application with genuinely arbitrary payloads uses `bytes(N)`,
 which remains exactly that.
@@ -939,13 +942,15 @@ a buffer of N + 1.
 
 **Generated-code consequence, stated so no backend discovers it late:** the
 runtimes' `serialize_string` is the **wire oracle** for `string(N)`, not
-necessarily the emitted call. The §6.1 storage rules make the runtime string
-methods unusable in two targets — C# stores a byte buffer but
-`SerializeString` takes `ref string`; Rust stores a byte buffer but
-`serialize_string` takes `&mut String` and rejects non-UTF-8 bytes, which are
-legal here — so the C# and Rust backends compose the wire from primitives:
-length over [0, N], then align, then raw bytes. C++ and Go may use their
-runtime string call for the framing. **The interior-null check is
+necessarily the emitted call. **All nine backends compose the framing from
+primitives** — length over [0, N], then align, then raw bytes — and none
+emits a runtime string call. C# and Rust have no alternative: the §6.1
+storage rules make the runtime string method unusable there — C# stores a
+byte buffer but `SerializeString` takes `ref string`; Rust stores a byte
+buffer but `serialize_string` takes `&mut String` and rejects non-UTF-8
+bytes, which are legal here. Dart, Java and Elixir have no runtime to call.
+C++, C, Go and JavaScript may use their runtime string call for the framing
+and do not. **The interior-null check is
 generated-code validation in every target** — no runtime primitive performs
 it (classic C++ read appends `'\0'` and would silently truncate).
 
@@ -1044,9 +1049,9 @@ union ColliderShape
   the `<Union>Type type;` tag over an anonymous union of the arms (member
   names = variant names), constructed as None, trivially copyable
   (asserted); a variant named `type` is refused at check time — the tag
-  field's own name. C mirrors it with its named `as` union. Go, C# and JS
-  lay the tag beside one pre-allocated arm per variant — nothing
-  heap-allocates per value. Rust holds the value as a real
+  field's own name. C mirrors it with its named `as` union. Go, C#, JS, Dart,
+  Java and Elixir lay the tag beside one pre-allocated arm per variant —
+  nothing heap-allocates per value. Rust holds the value as a real
   `enum <Union> { None, Box(BoxCollider), ... }`, `None` the default — and
   STILL emits the `<Union>Type` tag newtype beside it: the tag surface
   (constants, `Max`) is uniform across targets whatever the value
@@ -1198,10 +1203,14 @@ defined behaviors: the spec owes a conforming writer exact bytes and owes a
 misbehaving writer nothing. The read side is untouched by this doctrine —
 readers face untrusted data and keep every mandated check above.
 
-Within that doctrine, misuse surfaces by each runtime's own convention: C and
-C++ debug-assert (unchecked in release); Go and Rust panic and C# throws on
-misuse in all build modes. The generated write code's job is to make misuse
-impossible by construction — bounds come from the schema. Costlier contracts
+Within that doctrine, misuse surfaces by each target's own convention, and the
+list is exhaustive at all nine: C, C++, Dart and Java debug-assert (unchecked
+in release — C and C++ through `serialize_assert`, Dart and Java through the
+language's own `assert`, live under `--enable-asserts` and `-ea`); Go and Rust
+panic, C# throws and Elixir raises `ArgumentError`, on misuse in all build
+modes; generated JavaScript carries no write-side check of its own, so misuse
+reaches the runtime's stream methods. The generated write code's job is to
+make misuse impossible by construction — bounds come from the schema. Costlier contracts
 assert in DEBUG ONLY everywhere (§4.7's UTF-8 well-formedness contract is the
 type case: an O(n) check no release path should carry). Ranges are trusted
 inputs everywhere: generated code never feeds attacker-influenced values as
@@ -1268,13 +1277,14 @@ Per `type`, per target:
 2. **`Write(buffer, object) -> bytesWritten`** — straight-line write code in
    wire order.
 3. **`Read(buffer, object) -> ok/error`** — straight-line read code with full
-   validation, in each runtime's native error idiom (`bool` in C and C++,
-   `bool` + latched `Error` in C#, `error` in Go, `Result` in Rust, `bool` +
-   the stream's latched `error` in JS — generated validation refusals return
-   `false` latching nothing, so callers tell the two channels apart exactly
-   as in C#). The consumed size (§5) surfaces per target idiom — a success
-   value that carries bits consumed where the idiom allows, an out-parameter
-   where it does not.
+   validation, in each target's native error idiom — the list is exhaustive
+   at all nine: `int` 1/0 in C, `bool` in C++, Dart and Java, `bool` +
+   latched `Error` in C#, `error` in Go, `Result` in Rust, `{:ok, value}` or
+   `:error` in Elixir, and `bool` + the stream's latched `error` in JS
+   (generated validation refusals return `false` latching nothing, so callers
+   tell the two channels apart exactly as in C#). The consumed size (§5)
+   surfaces per target idiom — a success value that carries bits consumed
+   where the idiom allows, an out-parameter where it does not.
 4. **`MaxBits` / `MaxBytes`** — constants: the longest path through the
    schema, with worst-case (7-bit) padding assumed at each alignment point.
    Size write buffers from `MaxBytes`; conservative is correct for a buffer
@@ -1431,11 +1441,23 @@ closing.
 
 ### 6.3 Per-target notes
 
+All nine targets are covered, in the two groups §1 draws. The six that read
+and write through a serialize-family runtime:
+
 | | C | C++ | C# | Go | JavaScript | Rust |
 |---|---|---|---|---|---|---|
 | emits against | `serialize_write_stream_t`/`serialize_read_stream_t` free functions | `WriteStream`/`ReadStream` methods (or `serialize_*`-equivalent calls) | sealed `WriteStream`/`ReadStream` (`ref` params, `bool` returns + sticky `Error`) | `WriteStream`/`ReadStream` concrete types (no interface dispatch) | methods on the stream parameter — generated JS never imports the runtime | `WriteStream`/`ReadStream` via the `Stream` trait, monomorphized |
 | error idiom | `int` 1/0 early-out; the stream latches the error | `return false` early-out | `bool` early-out; counts checked before loops; latched `Error` for callers | sticky stream errors; counts checked before loops; `return stream.Err()` | `bool` early-out; validation failures return false without latching, stream failures latch on `stream.error` | `?` propagation of `serialize::Error` |
 | buffer contract | write buffers multiple of 8; read allocations extend ≥8 bytes past packet data (required) | write buffers multiple of 8 (asserted); read allocations extend ≥8 bytes past packet data (required) | write buffers multiple of 8 (throws); reader takes (buffer, bytes), no slack required | write buffers multiple of 8; ≥7 bytes read slack for the fast path | caller-owned DataViews; the flat tier requires ≥8 bytes read slack past the payload | write buffers multiple of 8; ≥8 bytes read slack for the fast path |
+
+The three self-contained targets — no runtime library, so there is no stream
+object to emit against; the bit reader and writer live in the generated code:
+
+| | Dart | Java | Elixir |
+|---|---|---|---|
+| emits against | free functions over a caller-owned `ByteData` view | `static` methods on the file's class over a caller-owned `byte[]` | module functions over a binary; read and write thread the output, scratch and bit position as rebound accumulators — no stream struct |
+| error idiom | `bool` early-out | `boolean` early-out | `{:ok, value}` or `:error`; the body throws `:invalid` to a catch at the surface |
+| buffer contract | write buffers hold `<name>MaxBytes` (a multiple of 8); read buffers need NO slack past the payload | write buffers hold `<name>MaxBytes` (a multiple of 8); read buffers need NO slack past the payload | the writer returns the binary; read buffers need NO slack past the payload |
 
 ## 7. The compiler
 
@@ -1443,7 +1465,7 @@ Go, zero third-party dependencies, one static binary: `schema`.
 
 ```
 schema check      [--verbose] [dir|files...]   // parse + typecheck; exit code for CI
-schema generate   [--lang c|cpp|cs|go|js|rust]
+schema generate   [--lang c|cpp|cs|dart|elixir|go|java|js|rust]
                   [--out <dir>] [--verbose] [dir|files...]
 schema id | dir|files... // print the protocol id
 schema projection | dir|files... // print the wire shape projection (§3.1)
@@ -1467,7 +1489,8 @@ meaning — and it verifies its own idempotence on every run.
 ### 7.1 Pipeline
 
 ```
-*.schema → scanner → parser → AST → resolver/checker → IR → {c, cpp, csharp, golang, js, rust} backends
+*.schema → scanner → parser → AST → resolver/checker → IR →
+         {c, cpp, csharp, dart, elixir, golang, java, js, rust} backends
 ```
 
 - **Scanner/parser: hand-written, recursive descent**, in the style of the Go
@@ -1495,7 +1518,7 @@ meaning — and it verifies its own idempotence on every run.
   the golden-wire gate (§7.2) holds still across compiler versions.
 - **Backends: dumb printers.** Hand-written emitters (a small indent-aware
   writer helper), not `text/template` — codegen wants precision. Each backend
-  is a single file a reviewer can hold.
+  is a small package a reviewer can hold (two to seven files).
 
 ### 7.2 Testing
 
@@ -1617,8 +1640,11 @@ internal/ast/
 internal/check/        resolver, constant folding, shape checks, dominance rule,
                        the protocol id
 internal/format/       schemafmt
-internal/codegen/      c/  cpp/  csharp/  golang/  js/  rust/ — registered on
-                       the driver through the public generator interface
+internal/codegen/      c/  cpp/  csharp/  dart/  elixir/  golang/  java/  js/
+                       rust/ — registered on the driver through the public
+                       generator interface; cpptable/ and cstable/ are the
+                       table emitters two of those backends carry
+                       (SPEC-TABLES.md)
 internal/fuzz/         compiler fuzzing (gate 6)
 internal/publicapi/    the acceptance gate: an external module, public API only
 examples/              the corpus — always compiles under this spec as written
@@ -1639,7 +1665,7 @@ Rows keep their numbers permanently — code and corpus cite them as `§9 qN`.
 Every row to date is settled, deferred with its design banked, or discarded.
 
 1. ~~Strings as byte strings~~ — settled: §4.7. One shape for
-   `string`/`bytes`; C# and Rust compose the wire from primitives; the
+   `string`/`bytes`; every backend composes the wire from primitives; the
    interior-null check is generated-code validation in every target.
 2. ~~Storage-type overrides~~ — settled by the integer family: storage is
    declared by the type name (`thrust int8 | min = 0, max = 100`); no

--- a/USAGE.md
+++ b/USAGE.md
@@ -1258,8 +1258,15 @@ cooked from.
 It is settled by the **compiler**, not by your C++ compiler, which is what
 lets tooling cook before any game binary exists. The layout half comes from
 the compiler's own C ABI model, and the generated code asserts it on every
-side: if your compiler lays a record out differently, the build fails and
-names the field.
+side — but WHEN it tells you differs by language, and only C++ tells you at
+build time. C++ `static_assert`s every `sizeof`, `alignof` and `offsetof`,
+so a compiler that lays a record out differently fails the BUILD, naming the
+type and the field. C# has no `static_assert`: the generated
+`TableBlockLayout.Verify()` runs once at first use and THROWS, naming the
+type, the field, the offset it found and the offset the C++ side asserts —
+loud and early, but at run time. Both cover the records the block form
+reaches, not yet every record in the unit's table closure. SPEC-TABLES.md
+§20's status list carries both gaps as items 2 and 3.
 
 Two things it does not do:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -122,18 +122,20 @@ add variants later without moving the field width.
 
 The `Max` member is the enum's **extent** — the same number `E.Max` names in
 schema expressions: the highest wire-legal value, and (headroom aside) the
-count of real variants under the sentinel-zero convention. Every target
-spells it its own way — `ShipType::Max` (C++), `ShipType.Max` (C#),
+count of real variants under the sentinel-zero convention. All nine targets
+spell it their own way — `ShipType::Max` (C++), `ShipType.Max` (C#),
 `ShipTypeMax` (Go), `ShipType::MAX` (Rust), `ShipType.Max` (JS),
-`SHIP_TYPE_MAX` (C) — and a union's generated `<Union>Type` tag enum
+`SHIP_TYPE_MAX` (C), `ShipType.max` (Dart and Java), `ShipType.max/0`
+(Elixir) — and a union's generated `<Union>Type` tag enum
 carries it too, so ranges and asserts reference the enum directly instead of
 a hand-declared count constant. `Max` is consequently reserved as a variant
 name, like `None`.
 
-Every target also generates a **debug/log name function** — `EnumName(value)`
-in C++ (overloaded per enum), `EnumNameShipType` in C#/Go/JS,
-`enum_name_ship_type` in Rust/C — returning the variant's declared spelling
-for any wire value, out-of-set values included (`"???"`).
+Every target also generates a **debug/log name function**, and the spelling is
+each target's own: `EnumName(value)` in C++ (overloaded per enum),
+`EnumNameShipType` in C#/Go/JS, `enumNameShipType` in Dart/Java, and
+`enum_name_ship_type` in C/Rust/Elixir — returning the variant's declared
+spelling for any wire value, out-of-set values included (`"???"`).
 
 ### flags
 
@@ -159,9 +161,10 @@ independent bits, not a range with a top; the compiler refuses `.Max` on a
 flags type and names `.Count` instead.
 
 Flags get the same **debug/log name surface** as enums, in two forms: a
-per-bit name — `FlagNameCapabilities(bit)` (`flag_name_capabilities` in
-Rust/C), out-of-range bits naming as `"???"` — and a set renderer,
-`FlagNamesCapabilities(value)`, which formats the set bits the way a log line
+per-bit name — `FlagNameCapabilities(bit)` in C++/C#/Go/JS
+(`flagNameCapabilities` in Dart/Java, `flag_name_capabilities` in
+C/Rust/Elixir), out-of-range bits naming as `"???"` — and a set renderer,
+`FlagNamesCapabilities(value)` under the same per-target spelling, which formats the set bits the way a log line
 wants them: `"Cloak|Warp"`, `"0"` for the empty set, and any bits past the
 declared variants rendered honestly as hex. In C and C++ the renderer writes
 into a caller-provided buffer (`CapabilitiesNamesMax` /
@@ -230,8 +233,9 @@ That replaces the bool-guard idiom — `has_box bool` / `if has_box { box
 BoxCollider }` repeated per shape — which spends a bit per absent arm and
 lets illegal states (two shapes at once) exist for every consumer to police.
 A read **rejects a tag above the count**, and a write validates the tag
-before it rides. C++ generates the tagged union above; Go, C# and JS lay
-the tag beside one pre-allocated arm per variant; Rust gets a real
+before it rides. The representation is per target, all nine covered: C++ and
+C generate the tagged union above; Go, C#, JS, Dart, Java and Elixir lay the
+tag beside one pre-allocated arm per variant; Rust gets a real
 `enum ColliderShape { None, Box(BoxCollider), ... }`.
 
 Payloads are declared types — wrap a scalar or enum in a type. Unions ride

--- a/compiler/builtin.go
+++ b/compiler/builtin.go
@@ -37,7 +37,7 @@ func refuseTables(u *ir.Unit, target string) error {
 }
 
 // builtins is the set [New] registers. The per-language emitters stay
-// internal — they are implementations, not API, and freezing eight emitter
+// internal — they are implementations, not API, and freezing nine emitter
 // packages under semver would buy nothing — but they reach the driver through
 // [Generator] and nothing else, which is what makes that interface a door
 // rather than a decoration: if a built-in target can be expressed as a

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -8,7 +8,7 @@
 // or the diagnostics; [Compiler.Generate] is pure — a unit in, the emitted
 // file bytes out, nothing written; writing is the caller's, so an embedder can
 // put the output in a build directory, a zip, or memory. Registration
-// ([Compiler.Register]) is the only door into Generate, and the eight built-in
+// ([Compiler.Register]) is the only door into Generate, and the nine built-in
 // backends come through it like anyone else's would.
 //
 // The whole surface is under semver from the release that first carries it.
@@ -30,7 +30,7 @@ import (
 
 // A Compiler is one driver instance: the generator registry plus the load
 // policy the CLI and an embedder differ on. Use [New] — it returns a Compiler
-// with the eight built-in generators registered.
+// with the nine built-in generators registered.
 //
 // Register and the two policy fields configure a Compiler; do that before use
 // and from one goroutine. Once configured it is read-only, and Load and
@@ -69,9 +69,9 @@ type Compiler struct {
 }
 
 // New returns a driver with the built-in generators registered — c, cpp, cs
-// (csharp), go, js (javascript) and rust — and the load policy of a library:
-// no writes to the input tree. Set [Compiler.FormatInPlace] for the CLI's
-// behavior.
+// (csharp), dart, elixir, go, java, js (javascript) and rust — and the load
+// policy of a library: no writes to the input tree. Set
+// [Compiler.FormatInPlace] for the CLI's behavior.
 func New() *Compiler {
 	c := &Compiler{}
 	for _, g := range builtins() {

--- a/compiler/generate.go
+++ b/compiler/generate.go
@@ -16,7 +16,7 @@ import (
 type Options map[string]string
 
 // A Generator emits one target language's source for a checked unit. The
-// eight built-in backends reach the driver through this interface and through no
+// nine built-in backends reach the driver through this interface and through no
 // other path, so a generator written outside this module is a first-class one:
 // register it on a [Compiler] and `--lang <name>` selects it.
 type Generator interface {


### PR DESCRIPTION
Closes #300.

Every count and every per-target list on the pages now equals the tree, and each list that is complete says so — the issue's "state the behaviour for all nine or say the list is exhaustive".

**One line per change, with the derivation.**

*ci.yml*
- `:8` — "the full six-language conformance (`make test`)" -> "the full conformance run (`make test`) cost 31-45s — six languages when that was measured, nine today". The 31-45s figure is a dated measurement (2026-08-25, runs 32826150095 / 32827197339) and is left as measured rather than restated as a nine-language number nobody has taken; the count beside it is now present-state. Derivation: `compiler/builtin.go` `builtins()` returns 9 generators; `make test` runs `test/{c,go,rust,cs,js,dart,java,elixir}` plus the C++ legs.
- `:403` (the `windows` job) — "`make test` needs the six sibling runtime clones and a POSIX toolchain" -> "...the six sibling runtime clones, the three self-contained targets' toolchains and a POSIX toolchain". The six was correct and stays; what was missing is that three more toolchains are needed. Derivation: the `test` job clones exactly 6 siblings (serialize, .c, .go, .rs, .cs, .js) and installs 3 more toolchains (setup-dart, setup-java, setup-beam) for the self-contained targets.
- `:40` "The six runtimes the generated code targets" — checked, correct, unchanged (6 `*_TAG` pins, 6 clones).

*SPEC.md*
- §4.2 flags `Count` — was `CapsCount` in C++/C#/Go/JS, `CAPS_COUNT` in C and Rust (6 of 9). Now all nine, adding `capsCount` in Dart and Java and `caps_count/0` in Elixir. Derivation: `grep -rni 'shipflags.*count' generated/ | grep -v ludicrous` over `examples/Enums.schema`'s `flags ShipFlags` — `ShipFlagsCount` (cpp, cs, go, js), `SHIP_FLAGS_COUNT` (c, rust), `shipFlagsCount` (dart, java), `ship_flags_count` (elixir).
- §4.7 UTF-8 write assert — was "C and C++ ... Rust ...; Go and C# assert nothing" (5 of 9). Now exhaustive: C, C++ and Rust assert; C#, Dart, Elixir, Go, Java and JavaScript assert nothing. Derivation: `grep -rli utf8 generated/<lang>` returns 3 files for c, cpp and rust and 0 for the other six.
- §4.7 string framing — was "the C# and Rust backends compose the wire from primitives ... C++ and Go may use their runtime string call". All nine compose from primitives today: `grep -rn 'serialize_string|SerializeString|serializeString|WriteString|ReadString' generated/` returns nothing. The permission C++/C/Go/JS hold is kept and stated as unexercised rather than withdrawn — withdrawing it would be a ruling, not a count fix.
- §9 q1 — the same claim's echo, "C# and Rust compose the wire from primitives" -> "every backend composes the wire from primitives".
- §4.8 union representation — was "Go, C# and JS lay the tag beside one pre-allocated arm" (missing Dart, Java, Elixir). Derivation: `generated/{dart,java,elixir}/Wire.ex|dart|java` `ProbeShape` carries `type` beside one pre-allocated field per arm, exactly the Go/C#/JS shape; C and C++ are the tagged union, Rust the real `enum`.
- §5 write-misuse convention — was "C and C++ debug-assert; Go and Rust panic and C# throws" (5 of 9). Now exhaustive at nine. Derivation over `generated/`: `serialize_assert` in c and cpp, `assert(` in dart (523), `assert <x>` in java (146+), `raise ArgumentError` in elixir (353, and `internal/codegen/elixir/elixir.go:21` names it "the port's misuse convention", always on), zero `throw`/`assert` in generated js — so JS carries no write-side check of its own.
- §6.1 read error idiom — was "`bool` in C and C++, ... `bool` + latched `error` in JS" (5 of 9, and C wrong). Now nine, and C is `int` not `bool`. Derivation: the emitted signatures — `int read_probe_header(...)` (c), `bool ReadProbeHeader` (cpp), `bool readProbeHeader` (dart), `boolean readProbeHeader` (java), `{:ok, value} | :error` (elixir, `internal/codegen/elixir/elixir.go:43`), the rest unchanged.
- §6.3 per-target notes — the table had six columns. The six runtime-backed targets keep their table unchanged; a second table states the three self-contained ones (emits against / error idiom / buffer contract). Derivation: the package docs of `internal/codegen/{dart,java,elixir}` state each contract, and the generated signatures agree.
- §7 `schema generate --lang` — was `c|cpp|cs|go|js|rust`. Now the CLI's own list, `c|cpp|cs|dart|elixir|go|java|js|rust` (`cmd/schema/main.go:164`).
- §7.1 pipeline — the backend set was `{c, cpp, csharp, golang, js, rust}`; now the nine of `compiler/builtin.go`.
- §7.1 "Each backend is a single file a reviewer can hold" — no backend is one file. Now "a small package a reviewer can hold (two to seven files)". Derivation: non-test `.go` files per `internal/codegen/*` — elixir 2, dart/golang/java/js/cstable 3, csharp/rust 4, cpp/cpptable 6, c 7.
- §8 tree listing — `internal/codegen/ c/ cpp/ csharp/ golang/ js/ rust/` now lists all nine plus `cpptable/` and `cstable/`.

*SPEC-TABLES.md*
- §2.2 and §11 both said "the 26 generated spellings"; the list is 24. #315 contracted the v1 cook surface out of §11's own block (`Root` and `LayoutId` gone) and updated that block's count, leaving two prose references behind. Derivation: `internal/check`'s `tableGeneratedVerbs` holds **33** elements — the 24 §11 lists, then the block form's nine, spellings identical and in order. Counted by parsing the composite literal's AST, not by eye.

*USAGE.md*
- enum `Max` spellings — 6 listed, now nine (`ShipType.max` in Dart and Java, `ShipType.max/0` in Elixir). Derivation: `generated/{dart,java}/Enums` `static const int max` / `public static final byte max` inside the per-enum class, `def max, do: 5` in the Elixir module.
- `EnumName` — "Every target also generates" then listed 6. Now nine: `enumNameShipType` (Dart, Java), `enum_name_ship_type` (C, Rust, Elixir).
- `FlagName`/`FlagNames` — same, now nine, same spelling groups (verified `FlagNameShipFlags` in cpp/cs/go/js, `flagNameShipFlags` in dart/java, `flag_name_ship_flags` in c/rust/elixir).
- union representation paragraph — the §4.8 correction's twin.
- the build-version paragraph's layout-assert sentence — "if your compiler lays a record out differently, the build fails and names the field" — is true of C++ and of no other target. C++ `static_assert`s `sizeof`/`alignof`/`offsetof`; C# has no `static_assert`, so the generated `TableBlockLayout.Verify()` (`internal/codegen/cstable/block.go:400`) throws at first use instead. Now per-language, and it cites SPEC-TABLES §20's status items 2 and 3 — which also carry the half neither side does yet: both cover the records the BLOCK FORM reaches, not every record in the unit's table closure.

*compiler/ godoc* (the only non-page files, comments only, no behaviour)
- `compiler.go:11`, `compiler.go:33`, `generate.go:19`, `builtin.go:40` said "eight built-in"; `builtins()` returns nine.
- `New`'s doc named `c, cpp, cs (csharp), go, js (javascript) and rust`; now all nine.

**Checked and found CORRECT — no change, recorded so the next audit skips them.**
- SPEC.md §1 "Six of the nine targets read and write through a serialize-family runtime" — 6 runtime-backed, 3 self-contained.
- SPEC.md §7.2 "The conformance program is seven gates" — seven numbered rows follow.
- SPEC-TABLES.md §11's "24 suffixes" list and its "The BLOCK FORM claims nine more" — both correct against `tableGeneratedVerbs` after #315, spellings identical and in order. Only the two prose references above were stale.
- SPEC-TABLES.md §20.7 "the seven backends that carry no table" — 9 backends, 2 block backends, 7.
- ci.yml `:59`, `:296` ("nine languages"), README.md `:8`/`:96`/`:150`, USAGE.md `:79`-`:80`/`:506` and USAGE.md's "Writes are the caller's responsibility" section — already at nine.

**No count on any of the four pages is asserted by a test**, so none is cited here as such: the suffix list is the only one the page claims is machine-held (§11: "the count and the spellings here equal `tableGeneratedVerbs` exactly") and nothing in the tree enforces it. Extending the source-golden gate to that claim would be a real gate rather than a count fix, so it is left alone.

**Open, not decided here** — two items this audit surfaced and did not resolve, because resolving either is a ruling rather than a derivation:
1. SPEC.md §5 and USAGE.md's "Writes are the caller's responsibility" disagree about Go, C, C#, Rust and JavaScript. SPEC says "Go and Rust panic and C# throws"; USAGE says Go "returns `ErrValueOutOfRange`" and "C, C#, Rust and JavaScript likewise return failure rather than invent an assert". Both predate this PR; neither claim was touched. One of them is wrong and only the owner should say which.
2. SPEC.md §2's deferred doc-comment design pins the emitted spelling in four targets (`///` Rust, `/// <summary>` C#, `//` Go, `//` C++) and names none of the other five. Doc comments are not implemented, so the tree cannot derive the missing five and inventing them would be inventing a design.
