### PR TITLE
CI: an msvc leg on the certification side — cl /W4 /WX over the generated corpus (#286)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,16 @@ name: CI
 # A cross-compiler inline regression a PR cannot see still fails loudly on
 # main minutes after merge, and nightly re-certifies a quiet main.
 #
+# The `msvc` leg sits on the certification side for the same reason and by the
+# same measurement (#286, #317): the job cost 2:27, 2:28 and 2:26 across three
+# runs and 5:14 on a fourth, with byte-identical input — the longest job in the
+# PR gate at its slow end, and a flake at any end. Its job comment carries the
+# per-translation-unit numbers and where they come from.
+#
 # For a full run on a branch before merging (e.g. a change near the hot
-# paths): gh workflow run ci.yml --ref <branch>.
+# paths, or anything that moves the C++ emitters): gh workflow run ci.yml
+# --ref <branch>. That is also the only way to exercise the msvc leg from a
+# pull request, since it does not run on the pull_request event.
 
 on:
   push:
@@ -400,11 +408,10 @@ jobs:
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
-  # The compiler that generates C++ for a Windows-targeting game engine was
-  # never itself run on Windows. `make test` needs the six sibling runtime
-  # clones, the three self-contained targets' toolchains and a POSIX
-  # toolchain, so vet + build is the cheap first step the issue prescribes;
-  # growing this into a real test leg is a follow-up.
+  # The compiler that generates C++ for a Windows-targeting game engine, run on
+  # Windows: vet + build, cheap enough to ride every pull request. What it
+  # EMITS is compiled with cl by the `msvc` job below, which runs on the
+  # certification side.
   windows:
     runs-on: windows-latest
     timeout-minutes: 15
@@ -416,6 +423,183 @@ jobs:
           cache: false
       - run: go vet ./...
       - run: go build ./...
+
+  # MSVC over the generated corpus (issue #286). The estate's standing rule is
+  # that Visual C++ is a hard requirement — emulate extensions, never require
+  # them — and until this job existed nothing in this file compiled a single
+  # line of what the compiler EMITS with cl. The `windows` job above proves the
+  # COMPILER runs on Windows; this one proves its OUTPUT builds there.
+  #
+  # A CERTIFICATION INSTRUMENT, NOT AN ITERATION ONE — same condition and same
+  # reasoning as the inline-budget gates above, and it is a measurement rather
+  # than a preference. Whole job, four runs: 2:27, 2:28, 2:26 — and one at
+  # 5:14, on input BYTE-IDENTICAL to a 2:27. One run in four at 2.1x the
+  # median is a flake in the PR gate, which is worse than a slow job, and at
+  # 5:14 it was also the longest job in that gate. On push-to-main it costs
+  # nothing anybody waits for, and a Windows regression fails loudly minutes
+  # after merge.
+  #
+  # WHERE THE TIME GOES, per translation unit (runs 33640076155 / 33641197840,
+  # and the reason this job compiles one TU at a time): the `block` unit is
+  # 80.7 s of an 89.7 s corpus, spread almost evenly across its FOUR
+  # translation units — 23.0 / 19.1 / 19.2 / 19.2 s, and 22.0 / 19.4 / 19.4 /
+  # 19.3 s on the second run. It is not one pathological function, and the
+  # per-TU cost reproduces to within a second: the 5:14 outlier was the whole
+  # runner being slow, not this. Every one of those four includes
+  # RenderTable.h — PaddedTable.h and RenderBlock.h include it directly,
+  # PaddedBlock.h through PaddedTable.h — and that header defines
+  # blockdemo::RenderFrame, a 7 879 320-byte aggregate. cl charges ~20 s per
+  # translation unit for having that type in scope; clang compiles the same
+  # four in 0.18, 0.14, 0.13 and 0.15 s. Roughly 130x, uniform.
+  #
+  # So moving this leg back into the PR gate is a question about what cl does
+  # with a multi-megabyte aggregate, not about this file.
+  #
+  # THE PIN. The image is NAMED rather than `-latest`, the argument the
+  # big-endian leg makes: which extensions cl accepts is exactly a
+  # toolchain-version fact, so the image it comes from has to be a decision
+  # rather than whatever `-latest` moved to overnight. windows-2025 carries
+  # Visual Studio 2026 (cl 19.51.x); the compile step prints what the pin
+  # actually resolved to on the day.
+  #
+  # THE CORPUS is the tables corpus plus every packet header emitted beside it,
+  # not `make test` — `make test` needs the six sibling runtime clones, the
+  # three self-contained targets' toolchains and a POSIX toolchain. This job
+  # needs one sibling (serialize, header-only, and only the packet headers
+  # include it) and cl.
+  #
+  # THE TIMING IS PART OF THE OUTPUT. One cl invocation per translation unit,
+  # each preceded by a clock line, so the log shows where the cost is and how
+  # far it swings between runs. That is what turned #316's "the corpus does not
+  # compile" into two named emitter defects, and it is what any future argument
+  # about this job's cost will be settled with. It is also why /MP is absent:
+  # parallel TUs are faster and unmeasurable, and here the measurement is worth
+  # more than the minute.
+  msvc:
+    if: github.event_name != 'pull_request'
+    runs-on: windows-2025
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
+          cache: false
+
+      # The one sibling this leg needs, at the same pin every other job uses.
+      # Header-only, and only the PACKET headers (<Base>.h / <Base>Wire.h)
+      # reach for it — a table header includes nothing of it.
+      - name: Check out the serialize runtime (pinned release)
+        shell: bash
+        run: git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git ../serialize
+
+      # Generation and script emission happen in bash because they are readable
+      # there; the cl steps stay short. The corpus list mirrors the Makefile's
+      # tables_generate macro and cannot reuse it — the runner image carries no
+      # make, and installing one to share ten lines would cost more than the
+      # ten lines.
+      - name: Generate the corpus and the cl scripts
+        shell: bash
+        run: |
+          set -e
+          go build -o bin/schema.exe ./cmd/schema
+          rm -rf build/msvc build/msvc-negative build/msvc-obj
+          mkdir -p build/msvc
+          while read -r out src; do
+            ./bin/schema.exe generate --lang cpp --out "build/msvc/$out" "$src"
+          done <<'UNITS'
+          examples tables/examples
+          pointers tables/pointers
+          block tables/block
+          blockhome tables/blockhome
+          v1 test/tables/V1.schema
+          v2 test/tables/V2.schema
+          p1 test/tables/P1.schema
+          p2 test/tables/P2.schema
+          p3 test/tables/P3.schema
+          jsonkeys test/tables/JsonKeys.schema
+          UNITS
+
+          # Every unit gets an _AllHeaders.cpp, because compiling only the
+          # emitted .cpp files would leave two classes of header unbuilt: the
+          # packet headers have no .cpp of their own, and a unit whose tables
+          # are ALL variable-length emits no .cpp at all (test/tables/P2.schema
+          # is that unit). A header that HAS a .cpp is left out of it — it is
+          # already a translation unit, and on the block unit compiling it
+          # twice costs more than the whole rest of the corpus.
+          for d in build/msvc/*/; do
+            u=$(basename "$d")
+            : > "$d/_AllHeaders.cpp"
+            for h in "$d"*.h; do
+              b=$(basename "$h" .h)
+              [ -f "$d$b.cpp" ] && continue
+              echo "#include \"$b.h\"" >> "$d/_AllHeaders.cpp"
+            done
+            echo "int schema_msvc_all_$u = 0;" >> "$d/_AllHeaders.cpp"
+          done
+
+          # vcvars, once, for both cl steps to call: a step's environment does
+          # not survive into the next one.
+          {
+            echo "@echo off"
+            echo "for /f \"usebackq tokens=*\" %%i in (\`\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe\" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath\`) do set \"VSPATH=%%i\""
+            echo "call \"%VSPATH%\\VC\\Auxiliary\\Build\\vcvars64.bat\""
+          } > build/msvc/vc.cmd
+
+          # One cl per translation unit, each with a clock line in front of it.
+          # /Itest\tables for the same reason the Makefile's tables legs carry
+          # -Itest/tables: a `cpp_native` type names its own header through
+          # `cpp_include`, and tables/pointers' Colour names one that lives
+          # with the tests.
+          {
+            echo "@echo off"
+            for d in build/msvc/*/; do
+              u=$(basename "$d")
+              echo "mkdir build\\msvc-obj\\$u"
+              for f in "$d"*.cpp; do
+                n=$(basename "$f")
+                echo "echo [%TIME%] $u/$n"
+                echo "cl /nologo /c /W4 /WX /std:c++17 /permissive- /EHsc /Ibuild\\msvc\\$u /Itest\\tables /I..\\serialize /Fobuild\\msvc-obj\\$u\\ build\\msvc\\$u\\$n || exit /b 1"
+              done
+            done
+            echo "echo [%TIME%] corpus done"
+          } > build/msvc/compile.cmd
+
+          # THE NEGATIVE CONTROL. A GNU statement expression — gcc and clang
+          # take it under -Wall -Wextra -Werror without a word, cl cannot parse
+          # it — planted in one generated header of a copied tree. The green
+          # above proves nothing unless this goes red.
+          cp -r build/msvc/examples build/msvc-negative
+          rm -f build/msvc-negative/_AllHeaders.cpp
+          printf '\nnamespace tabledemo { inline int schema_msvc_negative_control() { return ({ 1; }); } }\n' >> build/msvc-negative/GuardedTable.h
+          {
+            echo "@echo off"
+            echo "mkdir build\\msvc-obj\\negative"
+            echo "cl /nologo /c /W4 /WX /std:c++17 /permissive- /EHsc /Ibuild\\msvc-negative /Fobuild\\msvc-obj\\negative\\ build\\msvc-negative\\GuardedTable.cpp"
+          } > build/msvc/negative.cmd
+
+      - name: cl /W4 /WX over the generated corpus, one translation unit at a time
+        shell: cmd
+        run: |
+          call build\msvc\vc.cmd || exit /b 1
+          echo ---- what the windows-2025 pin resolved to ----
+          cl 2>&1 | findstr /C:"Version"
+          echo ---- the corpus, one cl per translation unit ----
+          call build\msvc\compile.cmd || exit /b 1
+
+      # Its own step, and it ASSERTS the failure: a control that is merely run
+      # proves nothing. The planted extension must make cl refuse, and if cl
+      # accepts it the step goes red saying exactly why that matters.
+      - name: negative control — cl must REFUSE a GNU extension in a generated header
+        shell: cmd
+        run: |
+          call build\msvc\vc.cmd || exit /b 1
+          call build\msvc\negative.cmd && (echo ::error::NEGATIVE CONTROL FAILED: cl accepted a GNU statement expression in a generated header, so this leg cannot catch the class it exists for & exit /b 1)
+          echo negative control red as required: cl refused the planted extension
+          rem the control's FAILURE is this step's success, and echo does not
+          rem clear ERRORLEVEL — without this the step inherits the exit code of
+          rem the compile that was SUPPOSED to fail
+          exit /b 0
 
   # The one-benchmark rule, made mechanical. The estate has exactly one
   # sanctioned benchmark — this repo's data-driven bench — and shape knowledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,22 @@ CI runs on Linux and macOS, and both must be green:
 
 Run both locally before opening a pull request.
 
+Two gates are **not** in the pull request leg, and both run on push to main,
+nightly, and on `gh workflow run ci.yml --ref <branch>`:
+
+- the **inline-budget gates**, which fire on compiler-version changes by
+  design and cost most of the wall clock;
+- **`msvc`** — cl `/W4 /WX /std:c++17 /permissive-` over the generated C++
+  corpus, one translation unit at a time, on a pinned `windows-2025` image,
+  with a negative control that must go red on a GNU extension. It is out of
+  the pull request leg because cl costs 2:27–5:14 over this corpus — 90% of
+  that in the four translation units that see `RenderFrame`, a 7.9 MB
+  aggregate, at ~20 s each where clang takes 0.15 s — and two runs of
+  identical input swung 3.1x (#286).
+
+So a change to the C++ emitters wants a dispatch run on its branch before
+merging, not just a green pull request.
+
 ## Changing generated output
 
 Any change to a backend's emitted code will move the goldens, and that is


### PR DESCRIPTION
Follows #317, which fixed the two emitter defects that made this leg impossible. The corpus now compiles clean under cl; this wires the gate that keeps it that way.

## Where it runs, and why there

`if: github.event_name != 'pull_request'` — **push to main, the nightly schedule, and `workflow_dispatch`**. Same condition and the same reasoning as the inline-budget gates above it, and it is a measurement, not a preference.

Whole job, four runs: **2:27, 2:28, 2:26** — and **one at 5:14**, on input byte-identical to a 2:27. One run in four at 2.1x the median is a flake in the PR gate, which is worse than a slow job. At 5:14 it was also the longest job in that gate (test-ubuntu 3:23, big-endian 1:36). On push-to-main it costs nothing anybody waits for, and a Windows regression fails loudly minutes after merge — the bargain #133's gate split already struck for the inline gates.

## A correction to #317's numbers

#317's body said `block/RenderTable.cpp` was ~92% of the cost. **That was inferred from `/MP`'s scheduling order and it is wrong.** Compiling one TU at a time says so ([run 33640076155](https://github.com/mas-bandwidth/schema/actions/runs/33640076155)):

| translation unit | cl (two runs) | clang, this bench |
|---|---|---|
| `block/PaddedBlock.cpp` | 23.0 s / 22.0 s | 0.18 s |
| `block/PaddedTable.cpp` | 19.1 s / 19.4 s | 0.14 s |
| `block/RenderBlock.cpp` | 19.2 s / 19.4 s | 0.13 s |
| `block/RenderTable.cpp` | 19.2 s / 19.3 s | 0.15 s |
| `block/_AllHeaders.cpp` | 0.2 s | — |
| the other nine units, 39 TUs | 9.1 s total | — |
| **corpus** | **89.7 s** | |

The block unit is 80.7 s of 89.7 s, spread almost evenly across **four** translation units — not one pathological function, and reproducible to within a second across two runs, which also says the 5:14 outlier was the whole runner rather than anything in the tree. Every one of them includes `RenderTable.h` (`PaddedTable.h` and `RenderBlock.h` include it directly, `PaddedBlock.h` through `PaddedTable.h`), and that header defines `blockdemo::RenderFrame`, a **7 879 320-byte aggregate**. cl charges ~20 s per translation unit for having that type in scope. clang charges ~0.15 s. Roughly **130x, uniform**.

The mechanism was right; the shape of the number was not, and the instrument that corrected it is the one this job now carries.

## What the job is

- **Named `msvc`**, separate from `windows`. `windows` keeps riding every PR with vet + build (the compiler runs on Windows); `msvc` proves what it **emits** builds there.
- **Pinned image, stated**: `windows-2025`, Visual Studio 2026, cl 19.51.36256 — the argument the big-endian leg makes, since which extensions cl accepts is a toolchain-version fact. The compile step prints what the pin resolved to on the day.
- **Flags**: `/W4 /WX /std:c++17 /permissive- /EHsc`.
- **Corpus**: the ten tables units plus every packet header emitted beside them. Each unit gets an `_AllHeaders.cpp` covering the headers no `.cpp` covers — the packet headers, and `P2.schema`, whose tables are all variable-length so it emits no `.cpp` at all. A header that *has* a `.cpp` is left out of it; on the block unit, compiling it twice cost more than the whole rest of the corpus.
- **One `cl` per translation unit, each with a clock line. No `/MP`.** Parallel TUs are faster and unmeasurable. Dropping `/MP` cost 89.7 s against 81 s and bought the correction above; any future argument about this job's cost gets settled from its log.
- **Negative control in its own step, asserted.** A GNU statement expression planted in one generated header of a copied tree — every POSIX leg in this file takes it silently under `-Wall -Wextra -Werror`. cl must refuse it; if cl accepts, the step goes red saying why that matters. The control's *failure* is the step's success, so the step ends on an explicit `exit /b 0` — `cmd` would otherwise hand the job the exit code of the compile that was supposed to fail (that exact bug ate one measurement run).

## Documentation

`CONTRIBUTING.md`'s "The gates a change has to pass" gains the present-state line: which two gates are not in the PR leg, where they do run, and the measured reason for `msvc` — plus the consequence for a contributor, which is the point of writing it down. **A change to the C++ emitters wants `gh workflow run ci.yml --ref <branch>` before merging, because a green pull request has not compiled anything with cl.** The `ci.yml` header comment records the same split.

## CI on this PR

- **The `pull_request` run does not exercise this leg** — that is the design. `msvc` shows as **skipped**. Everything else green, proving the workflow still parses and nothing else moved.
- **The leg itself ran by `workflow_dispatch` on this branch, twice, both green:** [run 33640076155](https://github.com/mas-bandwidth/schema/actions/runs/33640076155) (`msvc` 2:28) and [run 33641197840](https://github.com/mas-bandwidth/schema/actions/runs/33641197840) (`msvc` 2:26, on the current head). Whole corpus clean under `/W4 /WX`, negative control red as required in both (`cl refused the planted extension`), per-TU timings in the logs. The tables above are from those runs.

Closes #286.
