### PR TITLE
cpptable: value-initialising a multi-MB aggregate — cl compiles a fixed table in 0.4 s, not 20 (#320)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,13 @@ name: CI
 # A cross-compiler inline regression a PR cannot see still fails loudly on
 # main minutes after merge, and nightly re-certifies a quiet main.
 #
-# The `msvc` leg sits on the certification side for the same reason and by the
-# same measurement (#286, #317): the job cost 2:27, 2:28 and 2:26 across three
-# runs and 5:14 on a fourth, with byte-identical input — the longest job in the
-# PR gate at its slow end, and a flake at any end. Its job comment carries the
-# per-translation-unit numbers and where they come from.
+# The `msvc` leg RIDES EVERY PULL REQUEST, and that is a measurement too: the
+# job costs about a minute and a quarter, well inside the one-to-two minute
+# rule (#320). Its job comment carries the per-translation-unit numbers.
 #
 # For a full run on a branch before merging (e.g. a change near the hot
 # paths, or anything that moves the C++ emitters): gh workflow run ci.yml
-# --ref <branch>. That is also the only way to exercise the msvc leg from a
-# pull request, since it does not run on the pull_request event.
+# --ref <branch>.
 
 on:
   push:
@@ -430,30 +427,27 @@ jobs:
   # line of what the compiler EMITS with cl. The `windows` job above proves the
   # COMPILER runs on Windows; this one proves its OUTPUT builds there.
   #
-  # A CERTIFICATION INSTRUMENT, NOT AN ITERATION ONE — same condition and same
-  # reasoning as the inline-budget gates above, and it is a measurement rather
-  # than a preference. Whole job, four runs: 2:27, 2:28, 2:26 — and one at
-  # 5:14, on input BYTE-IDENTICAL to a 2:27. One run in four at 2.1x the
-  # median is a flake in the PR gate, which is worse than a slow job, and at
-  # 5:14 it was also the longest job in that gate. On push-to-main it costs
-  # nothing anybody waits for, and a Windows regression fails loudly minutes
-  # after merge.
+  # AN ITERATION GATE: it runs on every pull request, and the one-to-two
+  # minute rule is what says it may. Whole job, three runs on identical input:
+  # RUNS-PLACEHOLDER. The corpus step itself is RUNS-CORPUS-PLACEHOLDER of
+  # that; the rest is checkout, Go, and vcvars.
   #
-  # WHERE THE TIME GOES, per translation unit (runs 33640076155 / 33641197840,
-  # and the reason this job compiles one TU at a time): the `block` unit is
-  # 80.7 s of an 89.7 s corpus, spread almost evenly across its FOUR
-  # translation units — 23.0 / 19.1 / 19.2 / 19.2 s, and 22.0 / 19.4 / 19.4 /
-  # 19.3 s on the second run. It is not one pathological function, and the
-  # per-TU cost reproduces to within a second: the 5:14 outlier was the whole
-  # runner being slow, not this. Every one of those four includes
-  # RenderTable.h — PaddedTable.h and RenderBlock.h include it directly,
-  # PaddedBlock.h through PaddedTable.h — and that header defines
-  # blockdemo::RenderFrame, a 7 879 320-byte aggregate. cl charges ~20 s per
-  # translation unit for having that type in scope; clang compiles the same
-  # four in 0.18, 0.14, 0.13 and 0.15 s. Roughly 130x, uniform.
+  # WHERE THE TIME GOES, per translation unit (and the reason this job compiles
+  # one TU at a time): nothing dominates. The whole 44-TU corpus is about
+  # twenty seconds, the first cl invocation of the job carries several of them
+  # on its own — toolchain and STL headers cold — and no unit past it costs
+  # more than half a second.
   #
-  # So moving this leg back into the PR gate is a question about what cl does
-  # with a multi-megabyte aggregate, not about this file.
+  # It did not start here. Until #320 this job cost 2:26–5:14 and sat on the
+  # certification side, because four translation units cost ~20 s each: all
+  # four include RenderTable.h, which defines blockdemo::RenderFrame, a
+  # 7 879 320-byte aggregate, and cl expands a value-initialisation of an
+  # aggregate that large element by element in its FRONT END (c1xx 19.85 s, c2
+  # 0.03 s, zero functions generated). The emitter wrote three such
+  # value-inits per fixed table; it now prefills member by member and fills
+  # each array from its own first element, and those four units cost 0.4 s.
+  # The instrument below is what found that, and it is what any future
+  # argument about this job's cost will be settled with.
   #
   # THE PIN. The image is NAMED rather than `-latest`, the argument the
   # big-endian leg makes: which extensions cl accepts is exactly a
@@ -471,14 +465,12 @@ jobs:
   # THE TIMING IS PART OF THE OUTPUT. One cl invocation per translation unit,
   # each preceded by a clock line, so the log shows where the cost is and how
   # far it swings between runs. That is what turned #316's "the corpus does not
-  # compile" into two named emitter defects, and it is what any future argument
-  # about this job's cost will be settled with. It is also why /MP is absent:
-  # parallel TUs are faster and unmeasurable, and here the measurement is worth
-  # more than the minute.
+  # compile" into two named emitter defects and #320's ~20 s per TU into one
+  # named one. It is also why /MP is absent: parallel TUs are faster and
+  # unmeasurable, and here the measurement is worth more than the seconds.
   msvc:
-    if: github.event_name != 'pull_request'
     runs-on: windows-2025
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -586,42 +578,6 @@ jobs:
           cl 2>&1 | findstr /C:"Version"
           echo ---- the corpus, one cl per translation unit ----
           call build\msvc\compile.cmd || exit /b 1
-
-      # ---- TEMPORARY (#320): what a CONSUMER of the fixed table pays ----
-      - name: probe — build the consumer variants
-        shell: bash
-        run: |
-          set -e
-          rm -rf build/probe
-          mk() {
-            mkdir -p "build/probe/$1"
-            cp build/msvc/block/Render.h build/msvc/block/RenderTable.h "build/probe/$1/"
-            { printf '#include "RenderTable.h"\n'; printf '%s\n' "$2"; } > "build/probe/$1/Probe.cpp"
-          }
-          mk k_include   'int probe_include = 0;'
-          mk k_decl      'int probe_decl() { blockdemo::RenderFrame f; return (int) f.version; }'
-          mk k_valueinit 'int probe_valueinit() { blockdemo::RenderFrame f{}; return (int) f.version; }'
-          mk k_reset     'void probe_reset( void * p ) { blockdemo::RenderFrameReset( *(blockdemo::RenderFrame *) p ); }'
-          {
-            echo "@echo off"
-            echo "mkdir build\\probe-obj"
-            for d in build/probe/*/; do
-              n=$(basename "$d")
-              echo "echo [%TIME%] probe $n"
-              echo "cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Ibuild\\probe\\$n /Fobuild\\probe-obj\\$n.obj build\\probe\\$n\\Probe.cpp || exit /b 1"
-            done
-            echo "echo [%TIME%] probes done"
-          } > build/probe/probe.cmd
-
-      - name: probe — cl over the consumer variants, one at a time
-        shell: cmd
-        run: |
-          call build\msvc\vc.cmd || exit /b 1
-          call build\probe\probe.cmd || exit /b 1
-          echo ---- /Bt+ front end vs back end, the bare include ----
-          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /Ibuild\probe\k_include /Fobuild\probe-obj\bt0.obj build\probe\k_include\Probe.cpp
-          echo ---- /Bt+ front end vs back end, a declared RenderFrame ----
-          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /Ibuild\probe\k_decl /Fobuild\probe-obj\bt1.obj build\probe\k_decl\Probe.cpp
 
       # Its own step, and it ASSERTS the failure: a control that is merely run
       # proves nothing. The planted extension must make cl refuse, and if cl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,6 +587,82 @@ jobs:
           echo ---- the corpus, one cl per translation unit ----
           call build\msvc\compile.cmd || exit /b 1
 
+      # ---- TEMPORARY (#320): where cl's ~20 s per TU goes ----
+      - name: probe — build the header variants
+        shell: bash
+        run: |
+          set -e
+          SRC=build/msvc/block/RenderTable.h
+          rm -rf build/probe
+          mk() {
+            mkdir -p "build/probe/$1"
+            cp build/msvc/block/Render.h "build/probe/$1/Render.h"
+            printf '#include "RenderTable.h"\nint probe_%s = 0;\n' "$1" > "build/probe/$1/Probe.cpp"
+          }
+          cut_at() {
+            mk "$1"
+            awk -v m="$2" 'index($0,m){exit} {print}' "$SRC" > "build/probe/$1/RenderTable.h"
+            echo '} // namespace blockdemo' >> "build/probe/$1/RenderTable.h"
+          }
+          # coarse: keep the header up to each emitted section, in order
+          cut_at s1_structs      '// ---- codecs: measure/save/load per closure member ----'
+          cut_at s2_codecs       '// ---- relocatability, enforced:'
+          cut_at s3_asserts      '// ---- reflection descriptors'
+          cut_at s4_descriptors  '// ---- the text form'
+          mk v0_full;         cp "$SRC" build/probe/v0_full/RenderTable.h
+          # fine: one emitted construct switched off at a time, whole header
+          mk f1_noarrayinit;  sed -E 's/^(    [A-Za-z_][A-Za-z0-9_:]*[[:space:]]+[a-z_0-9]+\[[0-9]+\]) = \{\};/\1;/' "$SRC" > build/probe/f1_noarrayinit/RenderTable.h
+          mk f2_noprefill;    sed '/new ( &value ) .*{}; \/\/ prefill/d' "$SRC" > build/probe/f2_noprefill/RenderTable.h
+          mk f3_noresetfn;    sed -E 's/\+\[\]\( void \* p \) \{ new \( p \) [A-Za-z0-9_]+\{\}; \}/NULL/g' "$SRC" > build/probe/f3_noresetfn/RenderTable.h
+          mk f4_noasserts;    sed '/^static_assert( std::is_/d' "$SRC" > build/probe/f4_noasserts/RenderTable.h
+          mk f5_novalueinit;  sed -E 's/^(    [A-Za-z_][A-Za-z0-9_:]*[[:space:]]+[a-z_0-9]+\[[0-9]+\]) = \{\};/\1;/' "$SRC" \
+                              | sed '/new ( &value ) .*{}; \/\/ prefill/d' \
+                              | sed -E 's/\+\[\]\( void \* p \) \{ new \( p \) [A-Za-z0-9_]+\{\}; \}/NULL/g' > build/probe/f5_novalueinit/RenderTable.h
+          mk f6_smallarrays;  sed -E 's/\[(32000|20000|8192|4096|1024)\]/[1]/g' "$SRC" > build/probe/f6_smallarrays/RenderTable.h
+          for d in build/probe/*/; do
+            n=$(basename "$d")
+            echo "$n: $(wc -l < "$d/RenderTable.h") lines, $(grep -c '= {};' "$d/RenderTable.h" || true) '= {}' members"
+          done
+          {
+            echo "@echo off"
+            echo "mkdir build\\probe-obj"
+            for d in build/probe/*/; do
+              n=$(basename "$d")
+              echo "echo [%TIME%] probe $n"
+              echo "cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Ibuild\\probe\\$n /Fobuild\\probe-obj\\$n.obj build\\probe\\$n\\Probe.cpp || exit /b 1"
+            done
+            echo "echo [%TIME%] probes done"
+          } > build/probe/probe.cmd
+
+      - name: probe — cl over the variants, one at a time
+        shell: cmd
+        run: |
+          call build\msvc\vc.cmd || exit /b 1
+          call build\probe\probe.cmd || exit /b 1
+          dir build\probe-obj
+
+      - name: probe — /Bt+ /d2cgsummary and /d1reportTime on the full header
+        shell: cmd
+        run: |
+          call build\msvc\vc.cmd || exit /b 1
+          echo ---- /Bt+ /d2cgsummary, full header ----
+          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /d2cgsummary /Ibuild\probe\v0_full /Fobuild\probe-obj\bt.obj build\probe\v0_full\Probe.cpp
+          echo ---- /Bt+ , structs-only header ----
+          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /d2cgsummary /Ibuild\probe\s1_structs /Fobuild\probe-obj\bt1.obj build\probe\s1_structs\Probe.cpp
+          echo ---- /d1reportTime, full header (captured) ----
+          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /d1reportTime /Ibuild\probe\v0_full /Fobuild\probe-obj\rt.obj build\probe\v0_full\Probe.cpp > build\probe\reportTime.txt 2>&1
+          exit /b 0
+
+      - name: probe — the expensive entries from /d1reportTime
+        shell: bash
+        run: |
+          wc -l build/probe/reportTime.txt || true
+          head -40 build/probe/reportTime.txt || true
+          echo "---- lines carrying a time over 0.1 s ----"
+          grep -E '[0-9]+\.[0-9]+s' build/probe/reportTime.txt | sort -t: -k2 -rn | head -60 || true
+          echo "---- the section headings ----"
+          grep -nE '^[A-Za-z].*:$' build/probe/reportTime.txt | head -40 || true
+
       # Its own step, and it ASSERTS the failure: a control that is merely run
       # proves nothing. The planted extension must make cl refuse, and if cl
       # accepts it the step goes red saying exactly why that matters.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,8 +429,8 @@ jobs:
   #
   # AN ITERATION GATE: it runs on every pull request, and the one-to-two
   # minute rule is what says it may. Whole job, three runs on identical input:
-  # RUNS-PLACEHOLDER. The corpus step itself is RUNS-CORPUS-PLACEHOLDER of
-  # that; the rest is checkout, Go, and vcvars.
+  # 1:18, 1:08, 1:09. The corpus step itself is 19, 16 and 17 s of that; the
+  # rest is checkout, Go, the serialize clone and vcvars.
   #
   # WHERE THE TIME GOES, per translation unit (and the reason this job compiles
   # one TU at a time): nothing dominates. The whole 44-TU corpus is about
@@ -438,16 +438,13 @@ jobs:
   # on its own — toolchain and STL headers cold — and no unit past it costs
   # more than half a second.
   #
-  # It did not start here. Until #320 this job cost 2:26–5:14 and sat on the
-  # certification side, because four translation units cost ~20 s each: all
-  # four include RenderTable.h, which defines blockdemo::RenderFrame, a
-  # 7 879 320-byte aggregate, and cl expands a value-initialisation of an
-  # aggregate that large element by element in its FRONT END (c1xx 19.85 s, c2
-  # 0.03 s, zero functions generated). The emitter wrote three such
-  # value-inits per fixed table; it now prefills member by member and fills
-  # each array from its own first element, and those four units cost 0.4 s.
-  # The instrument below is what found that, and it is what any future
-  # argument about this job's cost will be settled with.
+  # WHAT IT GUARDS BEYOND COMPILING. cl's front end expands a
+  # value-initialisation of a large aggregate element by element, at O(bytes)
+  # — which is why the emitted header never writes `T{}` over a table and
+  # prefills member by member instead (#320). One such `T{}` over
+  # blockdemo::RenderFrame, a 7 879 320-byte aggregate, costs cl about six
+  # seconds in a translation unit clang compiles whole in 0.15 s, and this job
+  # is the only place in the tree where that is visible at all.
   #
   # THE PIN. The image is NAMED rather than `-latest`, the argument the
   # big-endian leg makes: which extensions cl accepts is exactly a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,42 +587,21 @@ jobs:
           echo ---- the corpus, one cl per translation unit ----
           call build\msvc\compile.cmd || exit /b 1
 
-      # ---- TEMPORARY (#320): where cl's ~20 s per TU goes ----
-      - name: probe — build the header variants
+      # ---- TEMPORARY (#320): what a CONSUMER of the fixed table pays ----
+      - name: probe — build the consumer variants
         shell: bash
         run: |
           set -e
-          SRC=build/msvc/block/RenderTable.h
           rm -rf build/probe
           mk() {
             mkdir -p "build/probe/$1"
-            cp build/msvc/block/Render.h "build/probe/$1/Render.h"
-            printf '#include "RenderTable.h"\nint probe_%s = 0;\n' "$1" > "build/probe/$1/Probe.cpp"
+            cp build/msvc/block/Render.h build/msvc/block/RenderTable.h "build/probe/$1/"
+            { printf '#include "RenderTable.h"\n'; printf '%s\n' "$2"; } > "build/probe/$1/Probe.cpp"
           }
-          cut_at() {
-            mk "$1"
-            awk -v m="$2" 'index($0,m){exit} {print}' "$SRC" > "build/probe/$1/RenderTable.h"
-            echo '} // namespace blockdemo' >> "build/probe/$1/RenderTable.h"
-          }
-          # coarse: keep the header up to each emitted section, in order
-          cut_at s1_structs      '// ---- codecs: measure/save/load per closure member ----'
-          cut_at s2_codecs       '// ---- relocatability, enforced:'
-          cut_at s3_asserts      '// ---- reflection descriptors'
-          cut_at s4_descriptors  '// ---- the text form'
-          mk v0_full;         cp "$SRC" build/probe/v0_full/RenderTable.h
-          # fine: one emitted construct switched off at a time, whole header
-          mk f1_noarrayinit;  sed -E 's/^(    [A-Za-z_][A-Za-z0-9_:]*[[:space:]]+[a-z_0-9]+\[[0-9]+\]) = \{\};/\1;/' "$SRC" > build/probe/f1_noarrayinit/RenderTable.h
-          mk f2_noprefill;    sed '/new ( &value ) .*{}; \/\/ prefill/d' "$SRC" > build/probe/f2_noprefill/RenderTable.h
-          mk f3_noresetfn;    sed -E 's/\+\[\]\( void \* p \) \{ new \( p \) [A-Za-z0-9_]+\{\}; \}/NULL/g' "$SRC" > build/probe/f3_noresetfn/RenderTable.h
-          mk f4_noasserts;    sed '/^static_assert( std::is_/d' "$SRC" > build/probe/f4_noasserts/RenderTable.h
-          mk f5_novalueinit;  sed -E 's/^(    [A-Za-z_][A-Za-z0-9_:]*[[:space:]]+[a-z_0-9]+\[[0-9]+\]) = \{\};/\1;/' "$SRC" \
-                              | sed '/new ( &value ) .*{}; \/\/ prefill/d' \
-                              | sed -E 's/\+\[\]\( void \* p \) \{ new \( p \) [A-Za-z0-9_]+\{\}; \}/NULL/g' > build/probe/f5_novalueinit/RenderTable.h
-          mk f6_smallarrays;  sed -E 's/\[(32000|20000|8192|4096|1024)\]/[1]/g' "$SRC" > build/probe/f6_smallarrays/RenderTable.h
-          for d in build/probe/*/; do
-            n=$(basename "$d")
-            echo "$n: $(wc -l < "$d/RenderTable.h") lines, $(grep -c '= {};' "$d/RenderTable.h" || true) '= {}' members"
-          done
+          mk k_include   'int probe_include = 0;'
+          mk k_decl      'int probe_decl() { blockdemo::RenderFrame f; return (int) f.version; }'
+          mk k_valueinit 'int probe_valueinit() { blockdemo::RenderFrame f{}; return (int) f.version; }'
+          mk k_reset     'void probe_reset( void * p ) { blockdemo::RenderFrameReset( *(blockdemo::RenderFrame *) p ); }'
           {
             echo "@echo off"
             echo "mkdir build\\probe-obj"
@@ -634,34 +613,15 @@ jobs:
             echo "echo [%TIME%] probes done"
           } > build/probe/probe.cmd
 
-      - name: probe — cl over the variants, one at a time
+      - name: probe — cl over the consumer variants, one at a time
         shell: cmd
         run: |
           call build\msvc\vc.cmd || exit /b 1
           call build\probe\probe.cmd || exit /b 1
-          dir build\probe-obj
-
-      - name: probe — /Bt+ /d2cgsummary and /d1reportTime on the full header
-        shell: cmd
-        run: |
-          call build\msvc\vc.cmd || exit /b 1
-          echo ---- /Bt+ /d2cgsummary, full header ----
-          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /d2cgsummary /Ibuild\probe\v0_full /Fobuild\probe-obj\bt.obj build\probe\v0_full\Probe.cpp
-          echo ---- /Bt+ , structs-only header ----
-          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /d2cgsummary /Ibuild\probe\s1_structs /Fobuild\probe-obj\bt1.obj build\probe\s1_structs\Probe.cpp
-          echo ---- /d1reportTime, full header (captured) ----
-          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /d1reportTime /Ibuild\probe\v0_full /Fobuild\probe-obj\rt.obj build\probe\v0_full\Probe.cpp > build\probe\reportTime.txt 2>&1
-          exit /b 0
-
-      - name: probe — the expensive entries from /d1reportTime
-        shell: bash
-        run: |
-          wc -l build/probe/reportTime.txt || true
-          head -40 build/probe/reportTime.txt || true
-          echo "---- lines carrying a time over 0.1 s ----"
-          grep -E '[0-9]+\.[0-9]+s' build/probe/reportTime.txt | sort -t: -k2 -rn | head -60 || true
-          echo "---- the section headings ----"
-          grep -nE '^[A-Za-z].*:$' build/probe/reportTime.txt | head -40 || true
+          echo ---- /Bt+ front end vs back end, the bare include ----
+          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /Ibuild\probe\k_include /Fobuild\probe-obj\bt0.obj build\probe\k_include\Probe.cpp
+          echo ---- /Bt+ front end vs back end, a declared RenderFrame ----
+          cl /nologo /c /W4 /std:c++17 /permissive- /EHsc /Bt+ /Ibuild\probe\k_decl /Fobuild\probe-obj\bt1.obj build\probe\k_decl\Probe.cpp
 
       # Its own step, and it ASSERTS the failure: a control that is merely run
       # proves nothing. The planted extension must make cl refuse, and if cl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,18 +65,16 @@ CI runs on Linux and macOS, and both must be green:
 
 Run both locally before opening a pull request.
 
-Two gates are **not** in the pull request leg, and both run on push to main,
-nightly, and on `gh workflow run ci.yml --ref <branch>`:
+A third rides every pull request on Windows: **`msvc`** — cl
+`/W4 /WX /std:c++17 /permissive-` over the generated C++ corpus, one
+translation unit at a time, on a pinned `windows-2025` image, with a negative
+control that must go red on a GNU extension. Visual C++ is a hard requirement
+here, so what the compiler emits is compiled with cl before a change lands.
 
-- the **inline-budget gates**, which fire on compiler-version changes by
-  design and cost most of the wall clock;
-- **`msvc`** — cl `/W4 /WX /std:c++17 /permissive-` over the generated C++
-  corpus, one translation unit at a time, on a pinned `windows-2025` image,
-  with a negative control that must go red on a GNU extension. It is out of
-  the pull request leg because cl costs 2:27–5:14 over this corpus — 90% of
-  that in the four translation units that see `RenderFrame`, a 7.9 MB
-  aggregate, at ~20 s each where clang takes 0.15 s — and two runs of
-  identical input swung 3.1x (#286).
+One gate is **not** in the pull request leg, and runs on push to main,
+nightly, and on `gh workflow run ci.yml --ref <branch>`: the
+**inline-budget gates**, which fire on compiler-version changes by design and
+cost most of the wall clock.
 
 So a change to the C++ emitters wants a dispatch run on its branch before
 merging, not just a green pull request.

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -2013,7 +2013,19 @@ returns that table's descriptor.
 its declared defaults, in place. A generic walker that FILLS a value has to
 be able to establish the defaults an absent field takes, and it holds no
 type to spell; this is the one thing the columns cannot express without a
-function. It does what the wire's read path does, with no temporary.
+function. It calls `<Name>Reset`, the same named prefill the wire's read
+path calls, and neither materialises a temporary.
+
+**`<Name>Reset` establishes the defaults ONE MEMBER AT A TIME**, and fills
+an array from its own first element rather than initialising the array as a
+whole. A table is a bounded record whose declared maximum can be
+megabytes, and the cost of establishing its defaults has to grow with the
+number of DECLARATIONS, not with the number of bytes — some compilers
+expand a whole-object initialisation of a large aggregate element by
+element, and charge tens of seconds for it per translation unit. For the
+same reason an array of a self-initialising element type carries no
+redundant `= {}`: the element type's own member initializers already say
+what an element starts as.
 
 **A field carries its TEXT KEY** beside its name — the `json = "..."`
 attribute's value, else the field's own name (§16.4) — so a walker over the
@@ -2098,7 +2110,7 @@ lives a table has without being told; and a table's own **node type id**
 (§3.1), so a tool can map a node table's records — or a region's node
 directory — onto descriptors with no schema files on hand. The
 compile-time refusals those ids bring (§11) apply to EVERY unit, as the
-24 generated spellings do, because a unit gains and loses pointers as an
+25 generated spellings do, because a unit gains and loses pointers as an
 edit and a name that was free yesterday must not become a collision
 tomorrow. A self-referential pointer resolves to its own type's
 descriptor. Where pointers exist the descriptors are CONSTANT-INITIALISED
@@ -2645,11 +2657,11 @@ in build version (§20.5).
   types share one symbol table (§13.1), which is what makes the generated
   surface unprefixed and collision-free — so every name a closure member
   claims is refused to everything else. A member `X` claims `X` followed by
-  each of these **24 suffixes**, and a declaration spelling one of them is
+  each of these **25 suffixes**, and a declaration spelling one of them is
   refused naming the collision:
 
   ```
-  Measure  MeasureBody  Save  SaveBody  Load  LoadBody
+  Measure  MeasureBody  Save  SaveBody  Load  LoadBody  Reset
   LoadMeasure  LoadMeasureBody  LoadBuilder  TableType  Builder
   At  Emplace  Pack  PackMeasure  OpenWalk
   Cook  CookMeasure  Open  TableFields  TableInfo
@@ -2663,7 +2675,7 @@ in build version (§20.5).
   here equal `tableGeneratedVerbs` exactly, because a claim the page states
   and the checker does not make is a name a user may take.
 
-  **Four of the twenty-four are claimed AHEAD of their emitter.** `Cook`,
+  **Four of the twenty-five are claimed AHEAD of their emitter.** `Cook`,
   `CookMeasure`, `Open` and `OpenWalk` are the cook's spellings and no backend
   emits one: the cook is wire v2's (§7) and is not built (schema#251). The
   claim is held while the emitter is absent, on this list's own rule — a name
@@ -2706,7 +2718,7 @@ in build version (§20.5).
 
   - **The three per-declaration spellings the descriptors emit** —
     `<Name>TableFields`, `<Name>TableInfo` and `<Name>TableType` — claimed
-    for every declaration in every unit. All three are in the 24 above and
+    for every declaration in every unit. All three are in the 25 above and
     are claimed today only for closure members; the descriptor emission
     spells all three per declaration, so widening one of them would leave
     two open.

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2702,7 +2702,7 @@ func (c *checker) addTableSymbols(add func(name, what string, pos ast.Pos), name
 // rule — freeing a name now is a collision the day it lands.
 var tableGeneratedVerbs = []string{
 	"Measure", "MeasureBody", "Save", "SaveBody", "Load", "LoadBody",
-	"LoadMeasure", "LoadMeasureBody", "LoadBuilder", "TableType", "Builder",
+	"Reset", "LoadMeasure", "LoadMeasureBody", "LoadBuilder", "TableType", "Builder",
 	"At", "Emplace", "Pack", "PackMeasure", "OpenWalk",
 	"Cook", "CookMeasure", "Open", "TableFields", "TableInfo",
 	"FromJson", "ToJson", "ToJsonMeasure",

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -118,6 +118,8 @@ func TestTableRefusals(t *testing.T) {
 			src: "package t\ntable Node { x int32 }\ntype NodeTableInfo { y int32 }\n"},
 		{name: "a declaration colliding with the descriptor field storage", want: "generated TABLE-wire functions",
 			src: "package t\ntable Node { x int32 }\ntype NodeTableFields { y int32 }\n"},
+		{name: "a declaration colliding with the prefill", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeReset { y int32 }\n"},
 
 		// a table named after a Builder member would emit a header that cannot
 		// compile — a member function hides the type name it shares

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -158,9 +158,9 @@ func (g *tableGen) emitTableStorageField(f *ir.Field) {
 		g.pf("    TableKeyed<%s, %s, %d> %s; // [%s]: one slot per variant, indexed by the value\n",
 			typ, f.KeyEnum, f.ArrayBound, f.Name, f.KeyEnum)
 	case f.Array == ir.ArrayFixed:
-		g.pf("    %s %s[%d] = {};\n", typ, f.Name, f.ArrayBound)
+		g.pf("    %s %s[%d]%s;\n", typ, f.Name, f.ArrayBound, tableArrayInit(selfInit))
 	case f.Array == ir.ArrayCounted:
-		g.pf("    %s %s[%d] = {}; // used count beside it; count in [0, %d]\n", typ, f.Name, f.ArrayBound, f.ArrayBound)
+		g.pf("    %s %s[%d]%s; // used count beside it; count in [0, %d]\n", typ, f.Name, f.ArrayBound, tableArrayInit(selfInit), f.ArrayBound)
 		g.pf("    int32_t %s_count = 0;\n", f.Name)
 	default:
 		init := ""
@@ -175,6 +175,130 @@ func (g *tableGen) emitTableStorageField(f *ir.Field) {
 		// not content, decides whether the field rides.
 		g.pf("    bool %s_present = false; // ?%s: absent until set\n", f.Name, tableFieldTypeName(f))
 	}
+}
+
+// tableArrayInit renders an array member's initializer. An element type that
+// initializes itself — a generated struct, a union, a native mapping — needs
+// none: default-initializing the array runs the element type's own member
+// initializers, and value-initializing it does the same, so ` = {}` states
+// what already holds. It is also the expensive half of #320 (below), which is
+// why the redundant form is not kept for symmetry. A scalar element type has
+// no initializers of its own and keeps the braces.
+func tableArrayInit(selfInit bool) string {
+	if selfInit {
+		return ""
+	}
+	return " = {}"
+}
+
+// ---- prefill: the declared defaults, one member at a time ----
+//
+// Every site that needs a closure member's declared defaults calls its
+// `<T>Reset` — the read path before it overlays, and the descriptor's reset
+// column. None of them writes `T{}` over the whole object.
+//
+// THE REASON IS A COMPILE-TIME ONE, MEASURED (#320). cl 19.51 expands a
+// value-initialisation of a large aggregate element by element in its front
+// end, at O(bytes) rather than O(declarations). Against blockdemo::RenderFrame
+// — 7,879,320 bytes over ~105,000 rows — each `T{}` cost ~6 s and ` = {}` on
+// the array members another ~5 s, so a translation unit with that table in
+// scope cost cl ~20 s against clang's 0.15 s, all of it in the front end
+// (c1xx 19.85 s, c2 0.03 s, zero functions generated). Giving one element the
+// defaults and copying it across the array is the same work at run time and
+// the cost of a single element at compile time.
+func (g *tableGen) emitTableResetDeclarations(members []*ir.Struct) {
+	g.pf("// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----\n\n")
+	for _, st := range members {
+		g.pf("inline void %sReset( %s & value );\n", st.Name, st.Name)
+	}
+	g.pf("\n")
+}
+
+func (g *tableGen) emitTableReset(st *ir.Struct) {
+	if !st.IsTable {
+		// a closure `type` is declared in <Base>.h and bounded by a packet: one
+		// value-init says exactly what its own initializers say, and costs the
+		// size of a packet field to compile
+		g.pf("inline void %sReset( %s & value ) { value = %s(); }\n\n", st.Name, st.Name, st.Name)
+		return
+	}
+	g.pf("inline void %sReset( %s & value )\n{\n", st.Name, st.Name)
+	if len(st.Fields) == 0 {
+		g.pf("    (void) value;\n")
+	}
+	for _, f := range st.Fields {
+		g.emitTableResetField(f)
+	}
+	g.pf("}\n\n")
+}
+
+func (g *tableGen) emitTableResetField(f *ir.Field) {
+	if f.Type.Pointer {
+		g.pf("    value.%s.value = 0; // *%s — null\n", f.Name, f.Type.Name)
+		return
+	}
+	typ, selfInit := g.cppFieldType(f.Type)
+	switch {
+	case f.Type.Kind == ir.TString, f.Type.Kind == ir.TBytes:
+		g.pf("    memset( value.%s, 0, sizeof( value.%s ) );\n", f.Name, f.Name)
+		g.pf("    value.%s_length = 0;\n", f.Name)
+	case f.KeyEnum != "":
+		g.emitTableResetArray("value."+f.Name+".slots", f.ArrayBound, typ, selfInit, f)
+	case f.Array == ir.ArrayFixed:
+		g.emitTableResetArray("value."+f.Name, f.ArrayBound, typ, selfInit, f)
+	case f.Array == ir.ArrayCounted:
+		g.emitTableResetArray("value."+f.Name, f.ArrayBound, typ, selfInit, f)
+		g.pf("    value.%s_count = 0;\n", f.Name)
+	case selfInit:
+		g.emitTableResetOne("value."+f.Name, typ, f)
+	default:
+		g.pf("    value.%s = %s;\n", f.Name, g.fieldDefaultExpr(f))
+	}
+	if f.Type.Optional {
+		g.pf("    value.%s_present = false;\n", f.Name)
+	}
+}
+
+// emitTableResetArray gives ONE element the declared defaults and copies it
+// across the rest. Compiling this costs one element whatever the bound is.
+func (g *tableGen) emitTableResetArray(expr string, bound int64, typ string, selfInit bool, f *ir.Field) {
+	if bound <= 0 {
+		return
+	}
+	if !selfInit {
+		// a scalar element's array carries ` = {}`, which gives every element a
+		// zero whatever the field's own default says (SPEC-TABLES.md): a memset
+		// is that, exactly
+		g.pf("    memset( %s, 0, sizeof( %s ) );\n", expr, expr)
+		return
+	}
+	g.emitTableResetOne(expr+"[0]", typ, f)
+	if bound > 1 {
+		g.pf("    for ( int32_t i = 1; i < %d; i++ ) { %s[i] = %s[0]; }\n", bound, expr, expr)
+	}
+}
+
+// emitTableResetOne gives one self-initializing member its declared defaults:
+// through the element type's own Reset where this header emits one — so a
+// table nested inside a table stays O(declarations) too — and otherwise, for a
+// union or a native mapping, through the value-init its own declaration means.
+func (g *tableGen) emitTableResetOne(expr, typ string, f *ir.Field) {
+	if name, ok := g.tableResetName(f.Type, typ); ok {
+		g.pf("    %sReset( %s );\n", name, expr)
+		return
+	}
+	g.pf("    %s = %s();\n", expr, typ)
+}
+
+// tableResetName names the member type's Reset when the storage spelling IS
+// the generated type. A native mapping stores a hand type whose Reset no
+// header emits, and a union is not a struct; both take the value-init their
+// own declaration means.
+func (g *tableGen) tableResetName(t ir.FieldType, typ string) (string, bool) {
+	if _, ok := t.Ref.(*ir.Struct); !ok || typ != t.Name {
+		return "", false
+	}
+	return t.Name, true
 }
 
 // ---- enum identity on the table wire (SPEC-TABLES.md §5) ----
@@ -773,10 +897,12 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 	} else {
 		g.pf("inline bool %sLoadBody( TableReader & r, %s & value )\n{\n", st.Name, st.Name)
 	}
-	// placement new, NOT `value = T{}`: assignment materializes a temporary,
-	// and generated types can be large — a stack bomb on worker threads.
-	// In-place value-init applies the same NSDMI defaults with no temporary.
-	g.pf("    new ( &value ) %s{}; // prefill declared defaults in place, then overlay\n", st.Name)
+	// `<T>Reset`, NOT `value = T{}` and not `new ( &value ) T{}`: assignment
+	// materializes a temporary, and generated types can be large — a stack
+	// bomb on worker threads — while a whole-object value-init costs cl
+	// O(bytes) to COMPILE (#320). Reset applies the same declared defaults in
+	// place, with neither cost.
+	g.pf("    %sReset( value ); // prefill declared defaults in place, then overlay\n", st.Name)
 	g.pf("    for ( ;; )\n    {\n")
 	g.pf("        if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }\n")
 	g.pf("        uint16_t field_id = r.get16();\n")
@@ -1107,11 +1233,12 @@ func unionArmLambda(un *ir.Union, result string, arm func(ir.UnionVariant) strin
 	return b.String()
 }
 
-// resetLambda renders a type descriptor's reset column: placement-new
-// value-init, the same in-place prefill the read path uses, behind a
-// captureless lambda so the descriptor stays constant-initialisable.
+// resetLambda renders a type descriptor's reset column: the same in-place
+// prefill the read path uses, behind a captureless lambda so the descriptor
+// stays constant-initialisable. The storage a walk hands it is a live object
+// of the type, so this assigns rather than starting a lifetime.
 func resetLambda(name string) string {
-	return fmt.Sprintf("+[]( void * p ) { new ( p ) %s{}; }", name)
+	return fmt.Sprintf("+[]( void * p ) { %sReset( *(%s *) p ); }", name, name)
 }
 
 // unionArmsLambda renders a union field's arms column: a captureless lambda

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -494,6 +494,10 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 			for _, e := range tableEnums(members) {
 				g.emitEnumIdentity(e)
 			}
+			g.emitTableResetDeclarations(members)
+			for _, st := range members {
+				g.emitTableReset(st)
+			}
 			g.emitCodecDeclarations(members)
 			for _, st := range members {
 				g.owner = st
@@ -547,10 +551,11 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 		fmt.Fprintf(&h, "// package %s — protocol id 0x%016x (packets only: tables version by field id, not by protocol id)\n", u.Package, u.ProtocolId)
 		h.WriteString("// The TABLE wire (evolution-tolerant, SPEC-TABLES.md): no serialize\n")
 		h.WriteString("// dependency — includable from any TU.\n\n")
-		h.WriteString("#pragma once\n\n#include <cstdint>\n#include <cstring>\n#include <cstddef> // offsetof, for the reflection descriptors\n#include <new> // in-place prefill (placement new): no giant stack temporaries\n#include <type_traits> // the enforced relocatability asserts\n")
+		h.WriteString("#pragma once\n\n#include <cstdint>\n#include <cstring> // the prefill's scalar-array fills\n#include <cstddef> // offsetof, for the reflection descriptors\n#include <type_traits> // the enforced relocatability asserts\n")
 		if anyVariable {
 			// VARIABLE-LENGTH tables only: a unit of pointer-free tables pays
-			// for neither header (SPEC-TABLES.md §2, the zero-cost gate)
+			// for none of these headers (SPEC-TABLES.md §2, the zero-cost gate)
+			h.WriteString("#include <new> // a node's lifetime starts in arena storage (placement new)\n")
 			h.WriteString("#include <cstdlib> // the arena's segments (the AUTHORING path may allocate)\n")
 			h.WriteString("#include <atomic> // one atomic per slab: the arena is lock-free by ownership\n")
 		}

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -318,7 +317,7 @@ struct PaddedRow {
 struct PaddedFrame {
     uint8_t marker = 0;
     uint64_t stamp = 0;
-    PaddedRow rows[64] = {}; // used count beside it; count in [0, 64]
+    PaddedRow rows[64]; // used count beside it; count in [0, 64]
     int32_t rows_count = 0;
     uint8_t blob[12] = {}; // bytes(12): fixed buffer, used length beside it
     int32_t blob_length = 0;
@@ -354,6 +353,36 @@ inline bool TableEnumValue( uint16_t id, Team & out )
     }
 }
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_TEAM
+
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void PaddedRowReset( PaddedRow & value );
+inline void PaddedFrameReset( PaddedFrame & value );
+
+inline void PaddedRowReset( PaddedRow & value )
+{
+    value.tag = 0;
+    value.value = 0.0;
+    value.flag = false;
+    value.id = 0;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+    memset( value.slots, 0, sizeof( value.slots ) );
+    memset( value.teams.slots, 0, sizeof( value.teams.slots ) );
+    value.counter = 0;
+    value.counter_present = false;
+}
+
+inline void PaddedFrameReset( PaddedFrame & value )
+{
+    value.marker = 0;
+    value.stamp = 0;
+    PaddedRowReset( value.rows[0] );
+    for ( int32_t i = 1; i < 64; i++ ) { value.rows[i] = value.rows[0]; }
+    value.rows_count = 0;
+    memset( value.blob, 0, sizeof( value.blob ) );
+    value.blob_length = 0;
+}
 
 // ---- codecs: measure/save/load per closure member ----
 
@@ -494,7 +523,7 @@ inline int64_t PaddedRowSave( const PaddedRow & value, uint8_t * buffer, int64_t
 
 inline bool PaddedRowLoadBody( TableReader & r, PaddedRow & value )
 {
-    new ( &value ) PaddedRow{}; // prefill declared defaults in place, then overlay
+    PaddedRowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -762,7 +791,7 @@ inline int64_t PaddedFrameSave( const PaddedFrame & value, uint8_t * buffer, int
 
 inline bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & value )
 {
-    new ( &value ) PaddedFrame{}; // prefill declared defaults in place, then overlay
+    PaddedFrameReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -922,7 +951,7 @@ inline const TableTypeInfo * PaddedRowTableType()
         { "teams", "teams", "uint8", 0x9ae1, 6, true, false, false, 5, (uint32_t) offsetof( PaddedRow, teams ), (uint32_t) sizeof( PaddedRow::teams.slots[0] ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, "Team", +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, "" },
         { "counter", "counter", "int32", 0x428f, 4, false, false, true, 0, (uint32_t) offsetof( PaddedRow, counter ), (uint32_t) sizeof( PaddedRow::counter ), 0xffffffffu, (uint32_t) offsetof( PaddedRow, counter_present ), NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "PaddedRow", (uint32_t) sizeof( PaddedRow ), 8, fields, +[]( void * p ) { new ( p ) PaddedRow{}; } };
+    static const TableTypeInfo info = { "PaddedRow", (uint32_t) sizeof( PaddedRow ), 8, fields, +[]( void * p ) { PaddedRowReset( *(PaddedRow *) p ); } };
     return &info;
 }
 
@@ -934,7 +963,7 @@ inline const TableTypeInfo * PaddedFrameTableType()
         { "rows", "rows", "PaddedRow", 0x99af, 13, true, true, false, 64, (uint32_t) offsetof( PaddedFrame, rows ), (uint32_t) sizeof( PaddedFrame::rows[0] ), (uint32_t) offsetof( PaddedFrame, rows_count ), 0xffffffffu, PaddedRowTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "blob", "blob", "bytes", 0xd316, 6, true, true, false, 12, (uint32_t) offsetof( PaddedFrame, blob ), (uint32_t) sizeof( PaddedFrame::blob[0] ), (uint32_t) offsetof( PaddedFrame, blob_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "PaddedFrame", (uint32_t) sizeof( PaddedFrame ), 4, fields, +[]( void * p ) { new ( p ) PaddedFrame{}; } };
+    static const TableTypeInfo info = { "PaddedFrame", (uint32_t) sizeof( PaddedFrame ), 4, fields, +[]( void * p ) { PaddedFrameReset( *(PaddedFrame *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -414,23 +413,23 @@ struct RenderExplosion {
 // member initializers (SPEC-TABLES.md)
 struct RenderFrame {
     uint64_t version = 0;
-    RenderCamera cameras[1] = {}; // used count beside it; count in [0, 1]
+    RenderCamera cameras[1]; // used count beside it; count in [0, 1]
     int32_t cameras_count = 0;
-    RenderShip ships[4096] = {}; // used count beside it; count in [0, 4096]
+    RenderShip ships[4096]; // used count beside it; count in [0, 4096]
     int32_t ships_count = 0;
-    RenderTurret turrets[1024] = {}; // used count beside it; count in [0, 1024]
+    RenderTurret turrets[1024]; // used count beside it; count in [0, 1024]
     int32_t turrets_count = 0;
-    RenderMissile missiles[4096] = {}; // used count beside it; count in [0, 4096]
+    RenderMissile missiles[4096]; // used count beside it; count in [0, 4096]
     int32_t missiles_count = 0;
-    RenderDynamicProp dynamic_props[4096] = {}; // used count beside it; count in [0, 4096]
+    RenderDynamicProp dynamic_props[4096]; // used count beside it; count in [0, 4096]
     int32_t dynamic_props_count = 0;
-    RenderStaticProp static_props[20000] = {}; // used count beside it; count in [0, 20000]
+    RenderStaticProp static_props[20000]; // used count beside it; count in [0, 20000]
     int32_t static_props_count = 0;
-    RenderCosmeticProp cosmetic_props[8192] = {}; // used count beside it; count in [0, 8192]
+    RenderCosmeticProp cosmetic_props[8192]; // used count beside it; count in [0, 8192]
     int32_t cosmetic_props_count = 0;
-    RenderLaser lasers[32000] = {}; // used count beside it; count in [0, 32000]
+    RenderLaser lasers[32000]; // used count beside it; count in [0, 32000]
     int32_t lasers_count = 0;
-    RenderExplosion explosions[32000] = {}; // used count beside it; count in [0, 32000]
+    RenderExplosion explosions[32000]; // used count beside it; count in [0, 32000]
     int32_t explosions_count = 0;
 };
 
@@ -604,6 +603,160 @@ inline bool TableEnumValue( uint16_t id, ExplosionType & out )
 }
 #endif // BLOCKDEMO_SCHEMA_TABLE_ENUM_EXPLOSIONTYPE
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void RenderCameraReset( RenderCamera & value );
+inline void RenderShipReset( RenderShip & value );
+inline void RenderTurretReset( RenderTurret & value );
+inline void RenderMissileReset( RenderMissile & value );
+inline void RenderDynamicPropReset( RenderDynamicProp & value );
+inline void RenderStaticPropReset( RenderStaticProp & value );
+inline void RenderCosmeticPropReset( RenderCosmeticProp & value );
+inline void RenderLaserReset( RenderLaser & value );
+inline void RenderExplosionReset( RenderExplosion & value );
+inline void RenderFrameReset( RenderFrame & value );
+inline void RenderVector3Reset( RenderVector3 & value );
+inline void RenderQuaternionReset( RenderQuaternion & value );
+
+inline void RenderCameraReset( RenderCamera & value )
+{
+    RenderVector3Reset( value.position );
+    RenderQuaternionReset( value.rotation );
+    value.camera_id = 0;
+    value.camera_type = 0;
+    value.target_object_id = 0;
+    value.fov = 0.0f;
+}
+
+inline void RenderShipReset( RenderShip & value )
+{
+    RenderVector3Reset( value.position );
+    RenderQuaternionReset( value.rotation );
+    value.flags = 0;
+    value.object_id = 0;
+    value.target_object_id = 0;
+    value.thrust = 0.0f;
+    value.object_sequence = 0;
+    value.ship_type = ShipType::None;
+    value.team = Team::None;
+    value.has_target_lock = false;
+    value.predicted_explode = false;
+}
+
+inline void RenderTurretReset( RenderTurret & value )
+{
+    RenderQuaternionReset( value.rotation );
+    value.flags = 0;
+    value.object_id = 0;
+    value.parent_object_id = 0;
+    value.turret_index = 0;
+    value.target_object_id = 0;
+    value.object_sequence = 0;
+    value.team = Team::None;
+    value.has_target_lock = false;
+}
+
+inline void RenderMissileReset( RenderMissile & value )
+{
+    RenderVector3Reset( value.position );
+    RenderQuaternionReset( value.rotation );
+    value.flags = 0;
+    value.object_id = 0;
+    value.object_sequence = 0;
+    value.missile_type = MissileType::None;
+    value.team = Team::None;
+}
+
+inline void RenderDynamicPropReset( RenderDynamicProp & value )
+{
+    RenderVector3Reset( value.position );
+    RenderQuaternionReset( value.rotation );
+    value.flags = 0;
+    value.object_id = 0;
+    value.object_sequence = 0;
+    value.prop_type = PropType::None;
+    value.team = Team::None;
+}
+
+inline void RenderStaticPropReset( RenderStaticProp & value )
+{
+    RenderVector3Reset( value.position );
+    RenderQuaternionReset( value.rotation );
+    value.scale = 0.0;
+    value.flags = 0;
+    value.static_prop_id = 0;
+    value.prop_type = PropType::None;
+    value.team = Team::None;
+}
+
+inline void RenderCosmeticPropReset( RenderCosmeticProp & value )
+{
+    RenderVector3Reset( value.position );
+    RenderQuaternionReset( value.rotation );
+    value.scale = 0.0;
+    value.flags = 0;
+    value.cosmetic_prop_id = 0;
+    value.prop_sequence = 0;
+    value.prop_type = PropType::None;
+    value.team = Team::None;
+}
+
+inline void RenderLaserReset( RenderLaser & value )
+{
+    RenderVector3Reset( value.start );
+    RenderVector3Reset( value.finish );
+    value.t = 0.0;
+    value.laser_id = 0;
+    value.laser_type = LaserType::None;
+    value.team = Team::None;
+}
+
+inline void RenderExplosionReset( RenderExplosion & value )
+{
+    RenderVector3Reset( value.position );
+    RenderQuaternionReset( value.rotation );
+    value.t = 0.0;
+    value.explosion_id = 0;
+    value.parent_object_id = 0;
+    value.explosion_type = ExplosionType::None;
+    value.team = Team::None;
+}
+
+inline void RenderFrameReset( RenderFrame & value )
+{
+    value.version = 0;
+    RenderCameraReset( value.cameras[0] );
+    value.cameras_count = 0;
+    RenderShipReset( value.ships[0] );
+    for ( int32_t i = 1; i < 4096; i++ ) { value.ships[i] = value.ships[0]; }
+    value.ships_count = 0;
+    RenderTurretReset( value.turrets[0] );
+    for ( int32_t i = 1; i < 1024; i++ ) { value.turrets[i] = value.turrets[0]; }
+    value.turrets_count = 0;
+    RenderMissileReset( value.missiles[0] );
+    for ( int32_t i = 1; i < 4096; i++ ) { value.missiles[i] = value.missiles[0]; }
+    value.missiles_count = 0;
+    RenderDynamicPropReset( value.dynamic_props[0] );
+    for ( int32_t i = 1; i < 4096; i++ ) { value.dynamic_props[i] = value.dynamic_props[0]; }
+    value.dynamic_props_count = 0;
+    RenderStaticPropReset( value.static_props[0] );
+    for ( int32_t i = 1; i < 20000; i++ ) { value.static_props[i] = value.static_props[0]; }
+    value.static_props_count = 0;
+    RenderCosmeticPropReset( value.cosmetic_props[0] );
+    for ( int32_t i = 1; i < 8192; i++ ) { value.cosmetic_props[i] = value.cosmetic_props[0]; }
+    value.cosmetic_props_count = 0;
+    RenderLaserReset( value.lasers[0] );
+    for ( int32_t i = 1; i < 32000; i++ ) { value.lasers[i] = value.lasers[0]; }
+    value.lasers_count = 0;
+    RenderExplosionReset( value.explosions[0] );
+    for ( int32_t i = 1; i < 32000; i++ ) { value.explosions[i] = value.explosions[0]; }
+    value.explosions_count = 0;
+}
+
+inline void RenderVector3Reset( RenderVector3 & value ) { value = RenderVector3(); }
+
+inline void RenderQuaternionReset( RenderQuaternion & value ) { value = RenderQuaternion(); }
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t RenderCameraMeasure( const RenderCamera & value );
@@ -718,7 +871,7 @@ inline int64_t RenderCameraSave( const RenderCamera & value, uint8_t * buffer, i
 
 inline bool RenderCameraLoadBody( TableReader & r, RenderCamera & value )
 {
-    new ( &value ) RenderCamera{}; // prefill declared defaults in place, then overlay
+    RenderCameraReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -951,7 +1104,7 @@ inline int64_t RenderShipSave( const RenderShip & value, uint8_t * buffer, int64
 
 inline bool RenderShipLoadBody( TableReader & r, RenderShip & value )
 {
-    new ( &value ) RenderShip{}; // prefill declared defaults in place, then overlay
+    RenderShipReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1231,7 +1384,7 @@ inline int64_t RenderTurretSave( const RenderTurret & value, uint8_t * buffer, i
 
 inline bool RenderTurretLoadBody( TableReader & r, RenderTurret & value )
 {
-    new ( &value ) RenderTurret{}; // prefill declared defaults in place, then overlay
+    RenderTurretReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1480,7 +1633,7 @@ inline int64_t RenderMissileSave( const RenderMissile & value, uint8_t * buffer,
 
 inline bool RenderMissileLoadBody( TableReader & r, RenderMissile & value )
 {
-    new ( &value ) RenderMissile{}; // prefill declared defaults in place, then overlay
+    RenderMissileReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1715,7 +1868,7 @@ inline int64_t RenderDynamicPropSave( const RenderDynamicProp & value, uint8_t *
 
 inline bool RenderDynamicPropLoadBody( TableReader & r, RenderDynamicProp & value )
 {
-    new ( &value ) RenderDynamicProp{}; // prefill declared defaults in place, then overlay
+    RenderDynamicPropReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1950,7 +2103,7 @@ inline int64_t RenderStaticPropSave( const RenderStaticProp & value, uint8_t * b
 
 inline bool RenderStaticPropLoadBody( TableReader & r, RenderStaticProp & value )
 {
-    new ( &value ) RenderStaticProp{}; // prefill declared defaults in place, then overlay
+    RenderStaticPropReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -2190,7 +2343,7 @@ inline int64_t RenderCosmeticPropSave( const RenderCosmeticProp & value, uint8_t
 
 inline bool RenderCosmeticPropLoadBody( TableReader & r, RenderCosmeticProp & value )
 {
-    new ( &value ) RenderCosmeticProp{}; // prefill declared defaults in place, then overlay
+    RenderCosmeticPropReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -2431,7 +2584,7 @@ inline int64_t RenderLaserSave( const RenderLaser & value, uint8_t * buffer, int
 
 inline bool RenderLaserLoadBody( TableReader & r, RenderLaser & value )
 {
-    new ( &value ) RenderLaser{}; // prefill declared defaults in place, then overlay
+    RenderLaserReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -2652,7 +2805,7 @@ inline int64_t RenderExplosionSave( const RenderExplosion & value, uint8_t * buf
 
 inline bool RenderExplosionLoadBody( TableReader & r, RenderExplosion & value )
 {
-    new ( &value ) RenderExplosion{}; // prefill declared defaults in place, then overlay
+    RenderExplosionReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -3061,7 +3214,7 @@ inline int64_t RenderFrameSave( const RenderFrame & value, uint8_t * buffer, int
 
 inline bool RenderFrameLoadBody( TableReader & r, RenderFrame & value )
 {
-    new ( &value ) RenderFrame{}; // prefill declared defaults in place, then overlay
+    RenderFrameReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -3518,7 +3671,7 @@ inline int64_t RenderVector3Save( const RenderVector3 & value, uint8_t * buffer,
 
 inline bool RenderVector3LoadBody( TableReader & r, RenderVector3 & value )
 {
-    new ( &value ) RenderVector3{}; // prefill declared defaults in place, then overlay
+    RenderVector3Reset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -3626,7 +3779,7 @@ inline int64_t RenderQuaternionSave( const RenderQuaternion & value, uint8_t * b
 
 inline bool RenderQuaternionLoadBody( TableReader & r, RenderQuaternion & value )
 {
-    new ( &value ) RenderQuaternion{}; // prefill declared defaults in place, then overlay
+    RenderQuaternionReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -3757,7 +3910,7 @@ inline const TableTypeInfo * RenderCameraTableType()
         { "target_object_id", "target_object_id", "uint32", 0x38dc, 8, false, false, false, 0, (uint32_t) offsetof( RenderCamera, target_object_id ), (uint32_t) sizeof( RenderCamera::target_object_id ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "fov", "fov", "float32", 0x392f, 10, false, false, false, 0, (uint32_t) offsetof( RenderCamera, fov ), (uint32_t) sizeof( RenderCamera::fov ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderCamera", (uint32_t) sizeof( RenderCamera ), 6, fields, +[]( void * p ) { new ( p ) RenderCamera{}; } };
+    static const TableTypeInfo info = { "RenderCamera", (uint32_t) sizeof( RenderCamera ), 6, fields, +[]( void * p ) { RenderCameraReset( *(RenderCamera *) p ); } };
     return &info;
 }
 
@@ -3776,7 +3929,7 @@ inline const TableTypeInfo * RenderShipTableType()
         { "has_target_lock", "has_target_lock", "bool", 0xf223, 1, false, false, false, 0, (uint32_t) offsetof( RenderShip, has_target_lock ), (uint32_t) sizeof( RenderShip::has_target_lock ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "predicted_explode", "predicted_explode", "bool", 0x88bd, 1, false, false, false, 0, (uint32_t) offsetof( RenderShip, predicted_explode ), (uint32_t) sizeof( RenderShip::predicted_explode ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderShip", (uint32_t) sizeof( RenderShip ), 11, fields, +[]( void * p ) { new ( p ) RenderShip{}; } };
+    static const TableTypeInfo info = { "RenderShip", (uint32_t) sizeof( RenderShip ), 11, fields, +[]( void * p ) { RenderShipReset( *(RenderShip *) p ); } };
     return &info;
 }
 
@@ -3793,7 +3946,7 @@ inline const TableTypeInfo * RenderTurretTableType()
         { "team", "team", "Team", 0xdff1, 7, false, false, false, 0, (uint32_t) offsetof( RenderTurret, team ), (uint32_t) sizeof( RenderTurret::team ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 4, +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
         { "has_target_lock", "has_target_lock", "bool", 0xf223, 1, false, false, false, 0, (uint32_t) offsetof( RenderTurret, has_target_lock ), (uint32_t) sizeof( RenderTurret::has_target_lock ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderTurret", (uint32_t) sizeof( RenderTurret ), 9, fields, +[]( void * p ) { new ( p ) RenderTurret{}; } };
+    static const TableTypeInfo info = { "RenderTurret", (uint32_t) sizeof( RenderTurret ), 9, fields, +[]( void * p ) { RenderTurretReset( *(RenderTurret *) p ); } };
     return &info;
 }
 
@@ -3808,7 +3961,7 @@ inline const TableTypeInfo * RenderMissileTableType()
         { "missile_type", "missile_type", "MissileType", 0x423a, 7, false, false, false, 0, (uint32_t) offsetof( RenderMissile, missile_type ), (uint32_t) sizeof( RenderMissile::missile_type ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 2, +[]( uint64_t v ) { return EnumName( MissileType( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( MissileType( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
         { "team", "team", "Team", 0xdff1, 7, false, false, false, 0, (uint32_t) offsetof( RenderMissile, team ), (uint32_t) sizeof( RenderMissile::team ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 4, +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderMissile", (uint32_t) sizeof( RenderMissile ), 7, fields, +[]( void * p ) { new ( p ) RenderMissile{}; } };
+    static const TableTypeInfo info = { "RenderMissile", (uint32_t) sizeof( RenderMissile ), 7, fields, +[]( void * p ) { RenderMissileReset( *(RenderMissile *) p ); } };
     return &info;
 }
 
@@ -3823,7 +3976,7 @@ inline const TableTypeInfo * RenderDynamicPropTableType()
         { "prop_type", "prop_type", "PropType", 0xe338, 7, false, false, false, 0, (uint32_t) offsetof( RenderDynamicProp, prop_type ), (uint32_t) sizeof( RenderDynamicProp::prop_type ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 3, +[]( uint64_t v ) { return EnumName( PropType( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( PropType( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
         { "team", "team", "Team", 0xdff1, 7, false, false, false, 0, (uint32_t) offsetof( RenderDynamicProp, team ), (uint32_t) sizeof( RenderDynamicProp::team ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 4, +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderDynamicProp", (uint32_t) sizeof( RenderDynamicProp ), 7, fields, +[]( void * p ) { new ( p ) RenderDynamicProp{}; } };
+    static const TableTypeInfo info = { "RenderDynamicProp", (uint32_t) sizeof( RenderDynamicProp ), 7, fields, +[]( void * p ) { RenderDynamicPropReset( *(RenderDynamicProp *) p ); } };
     return &info;
 }
 
@@ -3838,7 +3991,7 @@ inline const TableTypeInfo * RenderStaticPropTableType()
         { "prop_type", "prop_type", "PropType", 0xe338, 7, false, false, false, 0, (uint32_t) offsetof( RenderStaticProp, prop_type ), (uint32_t) sizeof( RenderStaticProp::prop_type ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 3, +[]( uint64_t v ) { return EnumName( PropType( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( PropType( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
         { "team", "team", "Team", 0xdff1, 7, false, false, false, 0, (uint32_t) offsetof( RenderStaticProp, team ), (uint32_t) sizeof( RenderStaticProp::team ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 4, +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderStaticProp", (uint32_t) sizeof( RenderStaticProp ), 7, fields, +[]( void * p ) { new ( p ) RenderStaticProp{}; } };
+    static const TableTypeInfo info = { "RenderStaticProp", (uint32_t) sizeof( RenderStaticProp ), 7, fields, +[]( void * p ) { RenderStaticPropReset( *(RenderStaticProp *) p ); } };
     return &info;
 }
 
@@ -3854,7 +4007,7 @@ inline const TableTypeInfo * RenderCosmeticPropTableType()
         { "prop_type", "prop_type", "PropType", 0xe338, 7, false, false, false, 0, (uint32_t) offsetof( RenderCosmeticProp, prop_type ), (uint32_t) sizeof( RenderCosmeticProp::prop_type ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 3, +[]( uint64_t v ) { return EnumName( PropType( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( PropType( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
         { "team", "team", "Team", 0xdff1, 7, false, false, false, 0, (uint32_t) offsetof( RenderCosmeticProp, team ), (uint32_t) sizeof( RenderCosmeticProp::team ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 4, +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderCosmeticProp", (uint32_t) sizeof( RenderCosmeticProp ), 8, fields, +[]( void * p ) { new ( p ) RenderCosmeticProp{}; } };
+    static const TableTypeInfo info = { "RenderCosmeticProp", (uint32_t) sizeof( RenderCosmeticProp ), 8, fields, +[]( void * p ) { RenderCosmeticPropReset( *(RenderCosmeticProp *) p ); } };
     return &info;
 }
 
@@ -3868,7 +4021,7 @@ inline const TableTypeInfo * RenderLaserTableType()
         { "laser_type", "laser_type", "LaserType", 0xc46a, 7, false, false, false, 0, (uint32_t) offsetof( RenderLaser, laser_type ), (uint32_t) sizeof( RenderLaser::laser_type ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 2, +[]( uint64_t v ) { return EnumName( LaserType( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( LaserType( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
         { "team", "team", "Team", 0xdff1, 7, false, false, false, 0, (uint32_t) offsetof( RenderLaser, team ), (uint32_t) sizeof( RenderLaser::team ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 4, +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderLaser", (uint32_t) sizeof( RenderLaser ), 6, fields, +[]( void * p ) { new ( p ) RenderLaser{}; } };
+    static const TableTypeInfo info = { "RenderLaser", (uint32_t) sizeof( RenderLaser ), 6, fields, +[]( void * p ) { RenderLaserReset( *(RenderLaser *) p ); } };
     return &info;
 }
 
@@ -3883,7 +4036,7 @@ inline const TableTypeInfo * RenderExplosionTableType()
         { "explosion_type", "explosion_type", "ExplosionType", 0x98fa, 7, false, false, false, 0, (uint32_t) offsetof( RenderExplosion, explosion_type ), (uint32_t) sizeof( RenderExplosion::explosion_type ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 2, +[]( uint64_t v ) { return EnumName( ExplosionType( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( ExplosionType( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
         { "team", "team", "Team", 0xdff1, 7, false, false, false, 0, (uint32_t) offsetof( RenderExplosion, team ), (uint32_t) sizeof( RenderExplosion::team ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 4, +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderExplosion", (uint32_t) sizeof( RenderExplosion ), 7, fields, +[]( void * p ) { new ( p ) RenderExplosion{}; } };
+    static const TableTypeInfo info = { "RenderExplosion", (uint32_t) sizeof( RenderExplosion ), 7, fields, +[]( void * p ) { RenderExplosionReset( *(RenderExplosion *) p ); } };
     return &info;
 }
 
@@ -3901,7 +4054,7 @@ inline const TableTypeInfo * RenderFrameTableType()
         { "lasers", "lasers", "RenderLaser", 0x411a, 13, true, true, false, 32000, (uint32_t) offsetof( RenderFrame, lasers ), (uint32_t) sizeof( RenderFrame::lasers[0] ), (uint32_t) offsetof( RenderFrame, lasers_count ), 0xffffffffu, RenderLaserTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "explosions", "explosions", "RenderExplosion", 0x6bfb, 13, true, true, false, 32000, (uint32_t) offsetof( RenderFrame, explosions ), (uint32_t) sizeof( RenderFrame::explosions[0] ), (uint32_t) offsetof( RenderFrame, explosions_count ), 0xffffffffu, RenderExplosionTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderFrame", (uint32_t) sizeof( RenderFrame ), 10, fields, +[]( void * p ) { new ( p ) RenderFrame{}; } };
+    static const TableTypeInfo info = { "RenderFrame", (uint32_t) sizeof( RenderFrame ), 10, fields, +[]( void * p ) { RenderFrameReset( *(RenderFrame *) p ); } };
     return &info;
 }
 
@@ -3912,7 +4065,7 @@ inline const TableTypeInfo * RenderVector3TableType()
         { "y", "y", "float64", 0xb2f8, 11, false, false, false, 0, (uint32_t) offsetof( RenderVector3, y ), (uint32_t) sizeof( RenderVector3::y ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "z", "z", "float64", 0xaca1, 11, false, false, false, 0, (uint32_t) offsetof( RenderVector3, z ), (uint32_t) sizeof( RenderVector3::z ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderVector3", (uint32_t) sizeof( RenderVector3 ), 3, fields, +[]( void * p ) { new ( p ) RenderVector3{}; } };
+    static const TableTypeInfo info = { "RenderVector3", (uint32_t) sizeof( RenderVector3 ), 3, fields, +[]( void * p ) { RenderVector3Reset( *(RenderVector3 *) p ); } };
     return &info;
 }
 
@@ -3924,7 +4077,7 @@ inline const TableTypeInfo * RenderQuaternionTableType()
         { "z", "z", "float64", 0xaca1, 11, false, false, false, 0, (uint32_t) offsetof( RenderQuaternion, z ), (uint32_t) sizeof( RenderQuaternion::z ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "w", "w", "float64", 0xcd3a, 11, false, false, false, 0, (uint32_t) offsetof( RenderQuaternion, w ), (uint32_t) sizeof( RenderQuaternion::w ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RenderQuaternion", (uint32_t) sizeof( RenderQuaternion ), 4, fields, +[]( void * p ) { new ( p ) RenderQuaternion{}; } };
+    static const TableTypeInfo info = { "RenderQuaternion", (uint32_t) sizeof( RenderQuaternion ), 4, fields, +[]( void * p ) { RenderQuaternionReset( *(RenderQuaternion *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/blockhome/ConstantsTable.h
+++ b/testdata/golden/tables/blockhome/ConstantsTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 
 #include "Constants.h"

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 
 #include "Data.h"
@@ -212,6 +211,21 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 namespace blockhome {
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void ArmorPlateReset( ArmorPlate & value );
+inline void ArmorConfigReset( ArmorConfig & value );
+inline void FiringGroupReset( FiringGroup & value );
+inline void GunnerSettingsReset( GunnerSettings & value );
+
+inline void ArmorPlateReset( ArmorPlate & value ) { value = ArmorPlate(); }
+
+inline void ArmorConfigReset( ArmorConfig & value ) { value = ArmorConfig(); }
+
+inline void FiringGroupReset( FiringGroup & value ) { value = FiringGroup(); }
+
+inline void GunnerSettingsReset( GunnerSettings & value ) { value = GunnerSettings(); }
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t ArmorPlateMeasure( const ArmorPlate & value );
@@ -266,7 +280,7 @@ inline int64_t ArmorPlateSave( const ArmorPlate & value, uint8_t * buffer, int64
 
 inline bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & value )
 {
-    new ( &value ) ArmorPlate{}; // prefill declared defaults in place, then overlay
+    ArmorPlateReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -394,7 +408,7 @@ inline int64_t ArmorConfigSave( const ArmorConfig & value, uint8_t * buffer, int
 
 inline bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & value )
 {
-    new ( &value ) ArmorConfig{}; // prefill declared defaults in place, then overlay
+    ArmorConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -515,7 +529,7 @@ inline int64_t FiringGroupSave( const FiringGroup & value, uint8_t * buffer, int
 
 inline bool FiringGroupLoadBody( TableReader & r, FiringGroup & value )
 {
-    new ( &value ) FiringGroup{}; // prefill declared defaults in place, then overlay
+    FiringGroupReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -654,7 +668,7 @@ inline int64_t GunnerSettingsSave( const GunnerSettings & value, uint8_t * buffe
 
 inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value )
 {
-    new ( &value ) GunnerSettings{}; // prefill declared defaults in place, then overlay
+    GunnerSettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -819,7 +833,7 @@ inline const TableTypeInfo * ArmorPlateTableType()
         { "material", "material", "uint32", 0x0284, 8, false, false, false, 0, (uint32_t) offsetof( ArmorPlate, material ), (uint32_t) sizeof( ArmorPlate::material ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "layer", "layer", "uint8", 0x4750, 6, false, false, false, 0, (uint32_t) offsetof( ArmorPlate, layer ), (uint32_t) sizeof( ArmorPlate::layer ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "ArmorPlate", (uint32_t) sizeof( ArmorPlate ), 3, fields, +[]( void * p ) { new ( p ) ArmorPlate{}; } };
+    static const TableTypeInfo info = { "ArmorPlate", (uint32_t) sizeof( ArmorPlate ), 3, fields, +[]( void * p ) { ArmorPlateReset( *(ArmorPlate *) p ); } };
     return &info;
 }
 
@@ -831,7 +845,7 @@ inline const TableTypeInfo * ArmorConfigTableType()
         { "rating", "rating", "float32", 0xe2d9, 10, false, false, false, 0, (uint32_t) offsetof( ArmorConfig, rating ), (uint32_t) sizeof( ArmorConfig::rating ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "tier", "tier", "uint8", 0xe958, 6, false, false, false, 0, (uint32_t) offsetof( ArmorConfig, tier ), (uint32_t) sizeof( ArmorConfig::tier ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "ArmorConfig", (uint32_t) sizeof( ArmorConfig ), 4, fields, +[]( void * p ) { new ( p ) ArmorConfig{}; } };
+    static const TableTypeInfo info = { "ArmorConfig", (uint32_t) sizeof( ArmorConfig ), 4, fields, +[]( void * p ) { ArmorConfigReset( *(ArmorConfig *) p ); } };
     return &info;
 }
 
@@ -841,7 +855,7 @@ inline const TableTypeInfo * FiringGroupTableType()
         { "barrel", "barrel", "uint32", 0x87ed, 8, false, false, false, 0, (uint32_t) offsetof( FiringGroup, barrel ), (uint32_t) sizeof( FiringGroup::barrel ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "cooldown", "cooldown", "float32", 0x2230, 10, false, false, false, 0, (uint32_t) offsetof( FiringGroup, cooldown ), (uint32_t) sizeof( FiringGroup::cooldown ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "FiringGroup", (uint32_t) sizeof( FiringGroup ), 2, fields, +[]( void * p ) { new ( p ) FiringGroup{}; } };
+    static const TableTypeInfo info = { "FiringGroup", (uint32_t) sizeof( FiringGroup ), 2, fields, +[]( void * p ) { FiringGroupReset( *(FiringGroup *) p ); } };
     return &info;
 }
 
@@ -853,7 +867,7 @@ inline const TableTypeInfo * GunnerSettingsTableType()
         { "reload_seconds", "reload_seconds", "float32", 0xd08f, 10, false, false, false, 0, (uint32_t) offsetof( GunnerSettings, reload_seconds ), (uint32_t) sizeof( GunnerSettings::reload_seconds ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "gunner_id", "gunner_id", "uint32", 0xe0d2, 8, false, false, false, 0, (uint32_t) offsetof( GunnerSettings, gunner_id ), (uint32_t) sizeof( GunnerSettings::gunner_id ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "GunnerSettings", (uint32_t) sizeof( GunnerSettings ), 4, fields, +[]( void * p ) { new ( p ) GunnerSettings{}; } };
+    static const TableTypeInfo info = { "GunnerSettings", (uint32_t) sizeof( GunnerSettings ), 4, fields, +[]( void * p ) { GunnerSettingsReset( *(GunnerSettings *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 
 #include "Frame.h"
@@ -226,9 +225,30 @@ struct PartRow {
 // member initializers (SPEC-TABLES.md)
 struct PartFrame {
     uint64_t version = 0;
-    PartRow parts[32] = {}; // used count beside it; count in [0, 32]
+    PartRow parts[32]; // used count beside it; count in [0, 32]
     int32_t parts_count = 0;
 };
+
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void PartRowReset( PartRow & value );
+inline void PartFrameReset( PartFrame & value );
+
+inline void PartRowReset( PartRow & value )
+{
+    ArmorConfigReset( value.armor );
+    GunnerSettingsReset( value.gunner );
+    value.part_id = 0;
+    value.slot = 0;
+}
+
+inline void PartFrameReset( PartFrame & value )
+{
+    value.version = 0;
+    PartRowReset( value.parts[0] );
+    for ( int32_t i = 1; i < 32; i++ ) { value.parts[i] = value.parts[0]; }
+    value.parts_count = 0;
+}
 
 // ---- codecs: measure/save/load per closure member ----
 
@@ -302,7 +322,7 @@ inline int64_t PartRowSave( const PartRow & value, uint8_t * buffer, int64_t cap
 
 inline bool PartRowLoadBody( TableReader & r, PartRow & value )
 {
-    new ( &value ) PartRow{}; // prefill declared defaults in place, then overlay
+    PartRowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -445,7 +465,7 @@ inline int64_t PartFrameSave( const PartFrame & value, uint8_t * buffer, int64_t
 
 inline bool PartFrameLoadBody( TableReader & r, PartFrame & value )
 {
-    new ( &value ) PartFrame{}; // prefill declared defaults in place, then overlay
+    PartFrameReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -551,7 +571,7 @@ inline const TableTypeInfo * PartRowTableType()
         { "part_id", "part_id", "uint32", 0x6deb, 8, false, false, false, 0, (uint32_t) offsetof( PartRow, part_id ), (uint32_t) sizeof( PartRow::part_id ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "slot", "slot", "uint8", 0x37e4, 6, false, false, false, 0, (uint32_t) offsetof( PartRow, slot ), (uint32_t) sizeof( PartRow::slot ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "PartRow", (uint32_t) sizeof( PartRow ), 4, fields, +[]( void * p ) { new ( p ) PartRow{}; } };
+    static const TableTypeInfo info = { "PartRow", (uint32_t) sizeof( PartRow ), 4, fields, +[]( void * p ) { PartRowReset( *(PartRow *) p ); } };
     return &info;
 }
 
@@ -561,7 +581,7 @@ inline const TableTypeInfo * PartFrameTableType()
         { "version", "version", "uint64", 0xe8e6, 9, false, false, false, 0, (uint32_t) offsetof( PartFrame, version ), (uint32_t) sizeof( PartFrame::version ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "parts", "parts", "PartRow", 0xfc18, 13, true, true, false, 32, (uint32_t) offsetof( PartFrame, parts ), (uint32_t) sizeof( PartFrame::parts[0] ), (uint32_t) offsetof( PartFrame, parts_count ), 0xffffffffu, PartRowTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "PartFrame", (uint32_t) sizeof( PartFrame ), 2, fields, +[]( void * p ) { new ( p ) PartFrame{}; } };
+    static const TableTypeInfo info = { "PartFrame", (uint32_t) sizeof( PartFrame ), 2, fields, +[]( void * p ) { PartFrameReset( *(PartFrame *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -321,6 +320,21 @@ struct Patrol {
     int32_t note_length = 0;
 };
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void PatrolReset( Patrol & value );
+
+inline void PatrolReset( Patrol & value )
+{
+    value.active = false;
+    value.speed = 1.0f;
+    value.has_target = false;
+    value.target_id = 0;
+    value.wander = 0.5f;
+    memset( value.note, 0, sizeof( value.note ) );
+    value.note_length = 0;
+}
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t PatrolMeasure( const Patrol & value );
@@ -417,7 +431,7 @@ inline int64_t PatrolSave( const Patrol & value, uint8_t * buffer, int64_t capac
 
 inline bool PatrolLoadBody( TableReader & r, Patrol & value )
 {
-    new ( &value ) Patrol{}; // prefill declared defaults in place, then overlay
+    PatrolReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -549,7 +563,7 @@ inline const TableTypeInfo * PatrolTableType()
         { "wander", "wander", "float32", 0x832f, 10, false, false, false, 0, (uint32_t) offsetof( Patrol, wander ), (uint32_t) sizeof( Patrol::wander ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "active && !has_target" },
         { "note", "note", "string", 0x9da7, 12, false, true, false, 8, (uint32_t) offsetof( Patrol, note ), (uint32_t) sizeof( Patrol::note ), (uint32_t) offsetof( Patrol, note_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "!active" },
     };
-    static const TableTypeInfo info = { "Patrol", (uint32_t) sizeof( Patrol ), 6, fields, +[]( void * p ) { new ( p ) Patrol{}; } };
+    static const TableTypeInfo info = { "Patrol", (uint32_t) sizeof( Patrol ), 6, fields, +[]( void * p ) { PatrolReset( *(Patrol *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -424,6 +423,55 @@ inline bool TableEnumValue( uint16_t id, Hull & out )
 }
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_HULL
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void TeamConfigReset( TeamConfig & value );
+inline void GunnerConfigReset( GunnerConfig & value );
+inline void TurretConfigReset( TurretConfig & value );
+inline void HullConfigReset( HullConfig & value );
+inline void KeyedConfigReset( KeyedConfig & value );
+inline void ScoreBoardReset( ScoreBoard & value );
+
+inline void TeamConfigReset( TeamConfig & value )
+{
+    value.spawn_count = 4;
+    memset( value.banner, 0, sizeof( value.banner ) );
+    value.banner_length = 0;
+}
+
+inline void GunnerConfigReset( GunnerConfig & value )
+{
+    value.reaction = 0.2f;
+    value.tracking = false;
+}
+
+inline void TurretConfigReset( TurretConfig & value )
+{
+    value.damage = 10.0f;
+    value.cooldown = 0.5f;
+    GunnerConfigReset( value.gunner );
+    value.gunner_present = false;
+}
+
+inline void HullConfigReset( HullConfig & value )
+{
+    value.health = 100.0f;
+    value.mass = 1.0f;
+    TurretConfigReset( value.turrets.slots[0] );
+    for ( int32_t i = 1; i < 4; i++ ) { value.turrets.slots[i] = value.turrets.slots[0]; }
+}
+
+inline void KeyedConfigReset( KeyedConfig & value )
+{
+    TeamConfigReset( value.teams.slots[0] );
+    for ( int32_t i = 1; i < 4; i++ ) { value.teams.slots[i] = value.teams.slots[0]; }
+    HullConfigReset( value.hulls.slots[0] );
+    for ( int32_t i = 1; i < 4; i++ ) { value.hulls.slots[i] = value.hulls.slots[0]; }
+    ScoreBoardReset( value.scores );
+}
+
+inline void ScoreBoardReset( ScoreBoard & value ) { value = ScoreBoard(); }
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t TeamConfigMeasure( const TeamConfig & value );
@@ -481,7 +529,7 @@ inline int64_t TeamConfigSave( const TeamConfig & value, uint8_t * buffer, int64
 
 inline bool TeamConfigLoadBody( TableReader & r, TeamConfig & value )
 {
-    new ( &value ) TeamConfig{}; // prefill declared defaults in place, then overlay
+    TeamConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -575,7 +623,7 @@ inline int64_t GunnerConfigSave( const GunnerConfig & value, uint8_t * buffer, i
 
 inline bool GunnerConfigLoadBody( TableReader & r, GunnerConfig & value )
 {
-    new ( &value ) GunnerConfig{}; // prefill declared defaults in place, then overlay
+    GunnerConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -673,7 +721,7 @@ inline int64_t TurretConfigSave( const TurretConfig & value, uint8_t * buffer, i
 
 inline bool TurretConfigLoadBody( TableReader & r, TurretConfig & value )
 {
-    new ( &value ) TurretConfig{}; // prefill declared defaults in place, then overlay
+    TurretConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -826,7 +874,7 @@ inline int64_t HullConfigSave( const HullConfig & value, uint8_t * buffer, int64
 
 inline bool HullConfigLoadBody( TableReader & r, HullConfig & value )
 {
-    new ( &value ) HullConfig{}; // prefill declared defaults in place, then overlay
+    HullConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1065,7 +1113,7 @@ inline int64_t KeyedConfigSave( const KeyedConfig & value, uint8_t * buffer, int
 
 inline bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & value )
 {
-    new ( &value ) KeyedConfig{}; // prefill declared defaults in place, then overlay
+    KeyedConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1279,7 +1327,7 @@ inline int64_t ScoreBoardSave( const ScoreBoard & value, uint8_t * buffer, int64
 
 inline bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & value )
 {
-    new ( &value ) ScoreBoard{}; // prefill declared defaults in place, then overlay
+    ScoreBoardReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1396,7 +1444,7 @@ inline const TableTypeInfo * TeamConfigTableType()
         { "spawn_count", "spawn_count", "int32", 0x3668, 4, false, false, false, 0, (uint32_t) offsetof( TeamConfig, spawn_count ), (uint32_t) sizeof( TeamConfig::spawn_count ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 64.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "banner", "banner", "string", 0x80e4, 12, false, true, false, 16, (uint32_t) offsetof( TeamConfig, banner ), (uint32_t) sizeof( TeamConfig::banner ), (uint32_t) offsetof( TeamConfig, banner_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "TeamConfig", (uint32_t) sizeof( TeamConfig ), 2, fields, +[]( void * p ) { new ( p ) TeamConfig{}; } };
+    static const TableTypeInfo info = { "TeamConfig", (uint32_t) sizeof( TeamConfig ), 2, fields, +[]( void * p ) { TeamConfigReset( *(TeamConfig *) p ); } };
     return &info;
 }
 
@@ -1406,7 +1454,7 @@ inline const TableTypeInfo * GunnerConfigTableType()
         { "reaction", "reaction", "float32", 0x900f, 10, false, false, false, 0, (uint32_t) offsetof( GunnerConfig, reaction ), (uint32_t) sizeof( GunnerConfig::reaction ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "tracking", "tracking", "bool", 0x53d5, 1, false, false, false, 0, (uint32_t) offsetof( GunnerConfig, tracking ), (uint32_t) sizeof( GunnerConfig::tracking ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "GunnerConfig", (uint32_t) sizeof( GunnerConfig ), 2, fields, +[]( void * p ) { new ( p ) GunnerConfig{}; } };
+    static const TableTypeInfo info = { "GunnerConfig", (uint32_t) sizeof( GunnerConfig ), 2, fields, +[]( void * p ) { GunnerConfigReset( *(GunnerConfig *) p ); } };
     return &info;
 }
 
@@ -1417,7 +1465,7 @@ inline const TableTypeInfo * TurretConfigTableType()
         { "cooldown", "cooldown", "float32", 0x2230, 10, false, false, false, 0, (uint32_t) offsetof( TurretConfig, cooldown ), (uint32_t) sizeof( TurretConfig::cooldown ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "gunner", "gunner", "GunnerConfig", 0x2bc9, 13, false, false, true, 0, (uint32_t) offsetof( TurretConfig, gunner ), (uint32_t) sizeof( TurretConfig::gunner ), 0xffffffffu, (uint32_t) offsetof( TurretConfig, gunner_present ), GunnerConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "TurretConfig", (uint32_t) sizeof( TurretConfig ), 3, fields, +[]( void * p ) { new ( p ) TurretConfig{}; } };
+    static const TableTypeInfo info = { "TurretConfig", (uint32_t) sizeof( TurretConfig ), 3, fields, +[]( void * p ) { TurretConfigReset( *(TurretConfig *) p ); } };
     return &info;
 }
 
@@ -1428,7 +1476,7 @@ inline const TableTypeInfo * HullConfigTableType()
         { "mass", "mass", "float32", 0xe7a6, 10, false, false, false, 0, (uint32_t) offsetof( HullConfig, mass ), (uint32_t) sizeof( HullConfig::mass ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "turrets", "turrets", "TurretConfig", 0x48ad, 13, true, false, false, 4, (uint32_t) offsetof( HullConfig, turrets ), (uint32_t) sizeof( HullConfig::turrets.slots[0] ), 0xffffffffu, 0xffffffffu, TurretConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, "Weapon", +[]( uint64_t v ) { return EnumName( Weapon( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Weapon( v ), id ); return id; }, NULL, "" },
     };
-    static const TableTypeInfo info = { "HullConfig", (uint32_t) sizeof( HullConfig ), 3, fields, +[]( void * p ) { new ( p ) HullConfig{}; } };
+    static const TableTypeInfo info = { "HullConfig", (uint32_t) sizeof( HullConfig ), 3, fields, +[]( void * p ) { HullConfigReset( *(HullConfig *) p ); } };
     return &info;
 }
 
@@ -1439,7 +1487,7 @@ inline const TableTypeInfo * KeyedConfigTableType()
         { "hulls", "hulls", "HullConfig", 0xeff5, 13, true, false, false, 4, (uint32_t) offsetof( KeyedConfig, hulls ), (uint32_t) sizeof( KeyedConfig::hulls.slots[0] ), 0xffffffffu, 0xffffffffu, HullConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, "Hull", +[]( uint64_t v ) { return EnumName( Hull( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Hull( v ), id ); return id; }, NULL, "" },
         { "scores", "scores", "ScoreBoard", 0xdcf3, 13, false, false, false, 0, (uint32_t) offsetof( KeyedConfig, scores ), (uint32_t) sizeof( KeyedConfig::scores ), 0xffffffffu, 0xffffffffu, ScoreBoardTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "KeyedConfig", (uint32_t) sizeof( KeyedConfig ), 3, fields, +[]( void * p ) { new ( p ) KeyedConfig{}; } };
+    static const TableTypeInfo info = { "KeyedConfig", (uint32_t) sizeof( KeyedConfig ), 3, fields, +[]( void * p ) { KeyedConfigReset( *(KeyedConfig *) p ); } };
     return &info;
 }
 
@@ -1448,7 +1496,7 @@ inline const TableTypeInfo * ScoreBoardTableType()
     static const TableFieldInfo fields[] = {
         { "per_team", "per_team", "int32", 0x443f, 4, true, false, false, 4, (uint32_t) offsetof( ScoreBoard, per_team ), (uint32_t) sizeof( ScoreBoard::per_team[0] ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 100000.0, -1, NULL, NULL, "Team", +[]( uint64_t v ) { return EnumName( Team( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Team( v ), id ); return id; }, NULL, "" },
     };
-    static const TableTypeInfo info = { "ScoreBoard", (uint32_t) sizeof( ScoreBoard ), 1, fields, +[]( void * p ) { new ( p ) ScoreBoard{}; } };
+    static const TableTypeInfo info = { "ScoreBoard", (uint32_t) sizeof( ScoreBoard ), 1, fields, +[]( void * p ) { ScoreBoardReset( *(ScoreBoard *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/examples/NestedTable.h
+++ b/testdata/golden/tables/examples/NestedTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -305,6 +304,16 @@ struct ArchiveConfig {
     int32_t count = 1;
 };
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void ArchiveConfigReset( ArchiveConfig & value );
+
+inline void ArchiveConfigReset( ArchiveConfig & value )
+{
+    RootConfigReset( value.root );
+    value.count = 1;
+}
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t ArchiveConfigMeasure( const ArchiveConfig & value );
@@ -353,7 +362,7 @@ inline int64_t ArchiveConfigSave( const ArchiveConfig & value, uint8_t * buffer,
 
 inline bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfig & value )
 {
-    new ( &value ) ArchiveConfig{}; // prefill declared defaults in place, then overlay
+    ArchiveConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -432,7 +441,7 @@ inline const TableTypeInfo * ArchiveConfigTableType()
         { "root", "root", "RootConfig", 0x2eb8, 13, false, false, false, 0, (uint32_t) offsetof( ArchiveConfig, root ), (uint32_t) sizeof( ArchiveConfig::root ), 0xffffffffu, 0xffffffffu, RootConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "count", "count", "int32", 0xe445, 4, false, false, false, 0, (uint32_t) offsetof( ArchiveConfig, count ), (uint32_t) sizeof( ArchiveConfig::count ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 100.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "ArchiveConfig", (uint32_t) sizeof( ArchiveConfig ), 2, fields, +[]( void * p ) { new ( p ) ArchiveConfig{}; } };
+    static const TableTypeInfo info = { "ArchiveConfig", (uint32_t) sizeof( ArchiveConfig ), 2, fields, +[]( void * p ) { ArchiveConfigReset( *(ArchiveConfig *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -336,7 +335,7 @@ struct PackConfig {
     GlobalSettings global;
     TableKeyed<ShipEntry, ShipType, 4> ships; // [ShipType]: one slot per variant, indexed by the value
     TableKeyed<int32_t, Difficulty, 4> thresholds; // [Difficulty]: one slot per variant, indexed by the value
-    ShipEntry reserves[3] = {}; // used count beside it; count in [0, 3]
+    ShipEntry reserves[3]; // used count beside it; count in [0, 3]
     int32_t reserves_count = 0;
 };
 
@@ -398,6 +397,54 @@ inline bool TableEnumValue( uint16_t id, ShipType & out )
 }
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_SHIPTYPE
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void GunnerSettingsReset( GunnerSettings & value );
+inline void ShipEntryReset( ShipEntry & value );
+inline void GlobalSettingsReset( GlobalSettings & value );
+inline void PackConfigReset( PackConfig & value );
+
+inline void GunnerSettingsReset( GunnerSettings & value )
+{
+    value.reaction = 0.2f;
+    value.tracking = false;
+    memset( value.callsign, 0, sizeof( value.callsign ) );
+    value.callsign_length = 0;
+}
+
+inline void ShipEntryReset( ShipEntry & value )
+{
+    memset( value.display_name, 0, sizeof( value.display_name ) );
+    value.display_name_length = 0;
+    value.health = 100.0f;
+    value.mass = 1.0f;
+    memset( value.hardpoints, 0, sizeof( value.hardpoints ) );
+    value.hardpoints_count = 0;
+    GunnerSettingsReset( value.gunner );
+    value.gunner_present = false;
+}
+
+inline void GlobalSettingsReset( GlobalSettings & value )
+{
+    value.tick_rate = 60;
+    value.difficulty = Difficulty::Normal;
+    memset( value.build_note, 0, sizeof( value.build_note ) );
+    value.build_note_length = 0;
+    memset( value.spawn_delays, 0, sizeof( value.spawn_delays ) );
+}
+
+inline void PackConfigReset( PackConfig & value )
+{
+    value.version = 1;
+    GlobalSettingsReset( value.global );
+    ShipEntryReset( value.ships.slots[0] );
+    for ( int32_t i = 1; i < 4; i++ ) { value.ships.slots[i] = value.ships.slots[0]; }
+    memset( value.thresholds.slots, 0, sizeof( value.thresholds.slots ) );
+    ShipEntryReset( value.reserves[0] );
+    for ( int32_t i = 1; i < 3; i++ ) { value.reserves[i] = value.reserves[0]; }
+    value.reserves_count = 0;
+}
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t GunnerSettingsMeasure( const GunnerSettings & value );
@@ -455,7 +502,7 @@ inline int64_t GunnerSettingsSave( const GunnerSettings & value, uint8_t * buffe
 
 inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value )
 {
-    new ( &value ) GunnerSettings{}; // prefill declared defaults in place, then overlay
+    GunnerSettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -598,7 +645,7 @@ inline int64_t ShipEntrySave( const ShipEntry & value, uint8_t * buffer, int64_t
 
 inline bool ShipEntryLoadBody( TableReader & r, ShipEntry & value )
 {
-    new ( &value ) ShipEntry{}; // prefill declared defaults in place, then overlay
+    ShipEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -798,7 +845,7 @@ inline int64_t GlobalSettingsSave( const GlobalSettings & value, uint8_t * buffe
 
 inline bool GlobalSettingsLoadBody( TableReader & r, GlobalSettings & value )
 {
-    new ( &value ) GlobalSettings{}; // prefill declared defaults in place, then overlay
+    GlobalSettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1074,7 +1121,7 @@ inline int64_t PackConfigSave( const PackConfig & value, uint8_t * buffer, int64
 
 inline bool PackConfigLoadBody( TableReader & r, PackConfig & value )
 {
-    new ( &value ) PackConfig{}; // prefill declared defaults in place, then overlay
+    PackConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1311,7 +1358,7 @@ inline const TableTypeInfo * GunnerSettingsTableType()
         { "tracking", "tracking", "bool", 0x53d5, 1, false, false, false, 0, (uint32_t) offsetof( GunnerSettings, tracking ), (uint32_t) sizeof( GunnerSettings::tracking ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "callsign", "callsign", "string", 0x74dc, 12, false, true, false, 24, (uint32_t) offsetof( GunnerSettings, callsign ), (uint32_t) sizeof( GunnerSettings::callsign ), (uint32_t) offsetof( GunnerSettings, callsign_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "GunnerSettings", (uint32_t) sizeof( GunnerSettings ), 3, fields, +[]( void * p ) { new ( p ) GunnerSettings{}; } };
+    static const TableTypeInfo info = { "GunnerSettings", (uint32_t) sizeof( GunnerSettings ), 3, fields, +[]( void * p ) { GunnerSettingsReset( *(GunnerSettings *) p ); } };
     return &info;
 }
 
@@ -1324,7 +1371,7 @@ inline const TableTypeInfo * ShipEntryTableType()
         { "hardpoints", "hardpoints", "int32", 0xc4b2, 4, true, true, false, 4, (uint32_t) offsetof( ShipEntry, hardpoints ), (uint32_t) sizeof( ShipEntry::hardpoints[0] ), (uint32_t) offsetof( ShipEntry, hardpoints_count ), 0xffffffffu, NULL, true, 0.0, 8.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "gunner", "gunner", "GunnerSettings", 0x2bc9, 13, false, false, true, 0, (uint32_t) offsetof( ShipEntry, gunner ), (uint32_t) sizeof( ShipEntry::gunner ), 0xffffffffu, (uint32_t) offsetof( ShipEntry, gunner_present ), GunnerSettingsTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "ShipEntry", (uint32_t) sizeof( ShipEntry ), 5, fields, +[]( void * p ) { new ( p ) ShipEntry{}; } };
+    static const TableTypeInfo info = { "ShipEntry", (uint32_t) sizeof( ShipEntry ), 5, fields, +[]( void * p ) { ShipEntryReset( *(ShipEntry *) p ); } };
     return &info;
 }
 
@@ -1336,7 +1383,7 @@ inline const TableTypeInfo * GlobalSettingsTableType()
         { "build_note", "build_note", "string", 0xb2d4, 12, false, true, false, 48, (uint32_t) offsetof( GlobalSettings, build_note ), (uint32_t) sizeof( GlobalSettings::build_note ), (uint32_t) offsetof( GlobalSettings, build_note_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "spawn_delays", "spawn_delays", "float32", 0x7c01, 10, true, false, false, 3, (uint32_t) offsetof( GlobalSettings, spawn_delays ), (uint32_t) sizeof( GlobalSettings::spawn_delays[0] ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "GlobalSettings", (uint32_t) sizeof( GlobalSettings ), 4, fields, +[]( void * p ) { new ( p ) GlobalSettings{}; } };
+    static const TableTypeInfo info = { "GlobalSettings", (uint32_t) sizeof( GlobalSettings ), 4, fields, +[]( void * p ) { GlobalSettingsReset( *(GlobalSettings *) p ); } };
     return &info;
 }
 
@@ -1349,7 +1396,7 @@ inline const TableTypeInfo * PackConfigTableType()
         { "thresholds", "thresholds", "int32", 0xb2eb, 4, true, false, false, 4, (uint32_t) offsetof( PackConfig, thresholds ), (uint32_t) sizeof( PackConfig::thresholds.slots[0] ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 1000.0, -1, NULL, NULL, "Difficulty", +[]( uint64_t v ) { return EnumName( Difficulty( v ) ); }, +[]( uint64_t v ) -> uint16_t { uint16_t id = 0; TableEnumId( Difficulty( v ), id ); return id; }, NULL, "" },
         { "reserves", "reserves", "ShipEntry", 0x049d, 13, true, true, false, 3, (uint32_t) offsetof( PackConfig, reserves ), (uint32_t) sizeof( PackConfig::reserves[0] ), (uint32_t) offsetof( PackConfig, reserves_count ), 0xffffffffu, ShipEntryTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "PackConfig", (uint32_t) sizeof( PackConfig ), 5, fields, +[]( void * p ) { new ( p ) PackConfig{}; } };
+    static const TableTypeInfo info = { "PackConfig", (uint32_t) sizeof( PackConfig ), 5, fields, +[]( void * p ) { PackConfigReset( *(PackConfig *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -317,8 +316,8 @@ struct LoadoutConfig {
     Grade podium[3] = {};
     Perks perks = 0;
     WeaponConfig primary;
-    WeaponConfig backups[2] = {};
-    Attachment attachments[8] = {}; // used count beside it; count in [0, 8]
+    WeaponConfig backups[2];
+    Attachment attachments[8]; // used count beside it; count in [0, 8]
     int32_t attachments_count = 0;
 };
 
@@ -350,9 +349,9 @@ struct ProfileConfig {
 struct RootConfig {
     char version_note[16 + 1] = {}; // string(16): max length, used length beside it
     int32_t version_note_length = 0;
-    WeaponConfig weapons[8] = {}; // used count beside it; count in [0, 8]
+    WeaponConfig weapons[8]; // used count beside it; count in [0, 8]
     int32_t weapons_count = 0;
-    ProfileConfig profiles[4] = {}; // used count beside it; count in [0, 4]
+    ProfileConfig profiles[4]; // used count beside it; count in [0, 4]
     int32_t profiles_count = 0;
 };
 
@@ -384,6 +383,78 @@ inline bool TableEnumValue( uint16_t id, Grade & out )
     }
 }
 #endif // TABLEDEMO_SCHEMA_TABLE_ENUM_GRADE
+
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void WeaponConfigReset( WeaponConfig & value );
+inline void LoadoutConfigReset( LoadoutConfig & value );
+inline void ProfileConfigReset( ProfileConfig & value );
+inline void RootConfigReset( RootConfig & value );
+inline void AttachmentReset( Attachment & value );
+inline void BuffReset( Buff & value );
+inline void DebuffReset( Debuff & value );
+
+inline void WeaponConfigReset( WeaponConfig & value )
+{
+    value.damage = 21.0f;
+    value.speed = 500.0f;
+    value.penetration = 1;
+    value.channel = 0;
+    value.homing = false;
+    value.effect = Effect();
+}
+
+inline void LoadoutConfigReset( LoadoutConfig & value )
+{
+    value.grade = Grade::Silver;
+    memset( value.grades, 0, sizeof( value.grades ) );
+    value.grades_count = 0;
+    memset( value.podium, 0, sizeof( value.podium ) );
+    value.perks = 0;
+    WeaponConfigReset( value.primary );
+    WeaponConfigReset( value.backups[0] );
+    for ( int32_t i = 1; i < 2; i++ ) { value.backups[i] = value.backups[0]; }
+    AttachmentReset( value.attachments[0] );
+    for ( int32_t i = 1; i < 8; i++ ) { value.attachments[i] = value.attachments[0]; }
+    value.attachments_count = 0;
+}
+
+inline void ProfileConfigReset( ProfileConfig & value )
+{
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+    memset( value.icon, 0, sizeof( value.icon ) );
+    value.icon_length = 0;
+    value.experience = 0;
+    value.tilt = 0;
+    value.heading = 0;
+    value.timestamp = 0;
+    value.badge = 0;
+    value.port = 0;
+    value.epoch = 0;
+    value.precision = 0.0;
+    memset( value.ratings, 0, sizeof( value.ratings ) );
+    value.has_loadout = false;
+    LoadoutConfigReset( value.loadout );
+}
+
+inline void RootConfigReset( RootConfig & value )
+{
+    memset( value.version_note, 0, sizeof( value.version_note ) );
+    value.version_note_length = 0;
+    WeaponConfigReset( value.weapons[0] );
+    for ( int32_t i = 1; i < 8; i++ ) { value.weapons[i] = value.weapons[0]; }
+    value.weapons_count = 0;
+    ProfileConfigReset( value.profiles[0] );
+    for ( int32_t i = 1; i < 4; i++ ) { value.profiles[i] = value.profiles[0]; }
+    value.profiles_count = 0;
+}
+
+inline void AttachmentReset( Attachment & value ) { value = Attachment(); }
+
+inline void BuffReset( Buff & value ) { value = Buff(); }
+
+inline void DebuffReset( Debuff & value ) { value = Debuff(); }
 
 // ---- codecs: measure/save/load per closure member ----
 
@@ -499,7 +570,7 @@ inline int64_t WeaponConfigSave( const WeaponConfig & value, uint8_t * buffer, i
 
 inline bool WeaponConfigLoadBody( TableReader & r, WeaponConfig & value )
 {
-    new ( &value ) WeaponConfig{}; // prefill declared defaults in place, then overlay
+    WeaponConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -794,7 +865,7 @@ inline int64_t LoadoutConfigSave( const LoadoutConfig & value, uint8_t * buffer,
 
 inline bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfig & value )
 {
-    new ( &value ) LoadoutConfig{}; // prefill declared defaults in place, then overlay
+    LoadoutConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1173,7 +1244,7 @@ inline int64_t ProfileConfigSave( const ProfileConfig & value, uint8_t * buffer,
 
 inline bool ProfileConfigLoadBody( TableReader & r, ProfileConfig & value )
 {
-    new ( &value ) ProfileConfig{}; // prefill declared defaults in place, then overlay
+    ProfileConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1506,7 +1577,7 @@ inline int64_t RootConfigSave( const RootConfig & value, uint8_t * buffer, int64
 
 inline bool RootConfigLoadBody( TableReader & r, RootConfig & value )
 {
-    new ( &value ) RootConfig{}; // prefill declared defaults in place, then overlay
+    RootConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1669,7 +1740,7 @@ inline int64_t AttachmentSave( const Attachment & value, uint8_t * buffer, int64
 
 inline bool AttachmentLoadBody( TableReader & r, Attachment & value )
 {
-    new ( &value ) Attachment{}; // prefill declared defaults in place, then overlay
+    AttachmentReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1750,7 +1821,7 @@ inline int64_t BuffSave( const Buff & value, uint8_t * buffer, int64_t capacity 
 
 inline bool BuffLoadBody( TableReader & r, Buff & value )
 {
-    new ( &value ) Buff{}; // prefill declared defaults in place, then overlay
+    BuffReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1816,7 +1887,7 @@ inline int64_t DebuffSave( const Debuff & value, uint8_t * buffer, int64_t capac
 
 inline bool DebuffLoadBody( TableReader & r, Debuff & value )
 {
-    new ( &value ) Debuff{}; // prefill declared defaults in place, then overlay
+    DebuffReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1899,7 +1970,7 @@ inline const TableTypeInfo * WeaponConfigTableType()
         { "homing", "homing", "bool", 0xab40, 1, false, false, false, 0, (uint32_t) offsetof( WeaponConfig, homing ), (uint32_t) sizeof( WeaponConfig::homing ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "effect", "effect", "Effect", 0xe33a, 15, false, false, false, 0, (uint32_t) offsetof( WeaponConfig, effect ), (uint32_t) sizeof( WeaponConfig::effect ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 2, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "buff"; case 2: return "debuff"; default: return "???"; } }, +[]( uint64_t v ) -> uint16_t { switch ( v ) { case 0: return 0; case 1: return 0xeae6; case 2: return 0xb0d3; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableUnionArmInfo arms[] = { { 0, NULL }, { (uint32_t) offsetof( Effect, buff ), BuffTableType() }, { (uint32_t) offsetof( Effect, debuff ), DebuffTableType() }, }; static const TableUnionInfo info = { (uint32_t) offsetof( Effect, type ), (uint32_t) sizeof( Effect::type ), arms }; return &info; }, "" },
     };
-    static const TableTypeInfo info = { "WeaponConfig", (uint32_t) sizeof( WeaponConfig ), 6, fields, +[]( void * p ) { new ( p ) WeaponConfig{}; } };
+    static const TableTypeInfo info = { "WeaponConfig", (uint32_t) sizeof( WeaponConfig ), 6, fields, +[]( void * p ) { WeaponConfigReset( *(WeaponConfig *) p ); } };
     return &info;
 }
 
@@ -1914,7 +1985,7 @@ inline const TableTypeInfo * LoadoutConfigTableType()
         { "backups", "backups", "WeaponConfig", 0x1647, 13, true, false, false, 2, (uint32_t) offsetof( LoadoutConfig, backups ), (uint32_t) sizeof( LoadoutConfig::backups[0] ), 0xffffffffu, 0xffffffffu, WeaponConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "attachments", "attachments", "Attachment", 0x44d5, 13, true, true, false, 8, (uint32_t) offsetof( LoadoutConfig, attachments ), (uint32_t) sizeof( LoadoutConfig::attachments[0] ), (uint32_t) offsetof( LoadoutConfig, attachments_count ), 0xffffffffu, AttachmentTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "LoadoutConfig", (uint32_t) sizeof( LoadoutConfig ), 7, fields, +[]( void * p ) { new ( p ) LoadoutConfig{}; } };
+    static const TableTypeInfo info = { "LoadoutConfig", (uint32_t) sizeof( LoadoutConfig ), 7, fields, +[]( void * p ) { LoadoutConfigReset( *(LoadoutConfig *) p ); } };
     return &info;
 }
 
@@ -1935,7 +2006,7 @@ inline const TableTypeInfo * ProfileConfigTableType()
         { "has_loadout", "has_loadout", "bool", 0xb4db, 1, false, false, false, 0, (uint32_t) offsetof( ProfileConfig, has_loadout ), (uint32_t) sizeof( ProfileConfig::has_loadout ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "loadout", "loadout", "LoadoutConfig", 0x9f78, 13, false, false, false, 0, (uint32_t) offsetof( ProfileConfig, loadout ), (uint32_t) sizeof( ProfileConfig::loadout ), 0xffffffffu, 0xffffffffu, LoadoutConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "has_loadout" },
     };
-    static const TableTypeInfo info = { "ProfileConfig", (uint32_t) sizeof( ProfileConfig ), 13, fields, +[]( void * p ) { new ( p ) ProfileConfig{}; } };
+    static const TableTypeInfo info = { "ProfileConfig", (uint32_t) sizeof( ProfileConfig ), 13, fields, +[]( void * p ) { ProfileConfigReset( *(ProfileConfig *) p ); } };
     return &info;
 }
 
@@ -1946,7 +2017,7 @@ inline const TableTypeInfo * RootConfigTableType()
         { "weapons", "weapons", "WeaponConfig", 0x91cd, 13, true, true, false, 8, (uint32_t) offsetof( RootConfig, weapons ), (uint32_t) sizeof( RootConfig::weapons[0] ), (uint32_t) offsetof( RootConfig, weapons_count ), 0xffffffffu, WeaponConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "profiles", "profiles", "ProfileConfig", 0x73fd, 13, true, true, false, 4, (uint32_t) offsetof( RootConfig, profiles ), (uint32_t) sizeof( RootConfig::profiles[0] ), (uint32_t) offsetof( RootConfig, profiles_count ), 0xffffffffu, ProfileConfigTableType(), false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "RootConfig", (uint32_t) sizeof( RootConfig ), 3, fields, +[]( void * p ) { new ( p ) RootConfig{}; } };
+    static const TableTypeInfo info = { "RootConfig", (uint32_t) sizeof( RootConfig ), 3, fields, +[]( void * p ) { RootConfigReset( *(RootConfig *) p ); } };
     return &info;
 }
 
@@ -1956,7 +2027,7 @@ inline const TableTypeInfo * AttachmentTableType()
         { "slot", "slot", "int32", 0x37e4, 4, false, false, false, 0, (uint32_t) offsetof( Attachment, slot ), (uint32_t) sizeof( Attachment::slot ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 7.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "power", "power", "float32", 0xd609, 10, false, false, false, 0, (uint32_t) offsetof( Attachment, power ), (uint32_t) sizeof( Attachment::power ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "Attachment", (uint32_t) sizeof( Attachment ), 2, fields, +[]( void * p ) { new ( p ) Attachment{}; } };
+    static const TableTypeInfo info = { "Attachment", (uint32_t) sizeof( Attachment ), 2, fields, +[]( void * p ) { AttachmentReset( *(Attachment *) p ); } };
     return &info;
 }
 
@@ -1965,7 +2036,7 @@ inline const TableTypeInfo * BuffTableType()
     static const TableFieldInfo fields[] = {
         { "multiplier", "multiplier", "float32", 0x32e0, 10, false, false, false, 0, (uint32_t) offsetof( Buff, multiplier ), (uint32_t) sizeof( Buff::multiplier ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "Buff", (uint32_t) sizeof( Buff ), 1, fields, +[]( void * p ) { new ( p ) Buff{}; } };
+    static const TableTypeInfo info = { "Buff", (uint32_t) sizeof( Buff ), 1, fields, +[]( void * p ) { BuffReset( *(Buff *) p ); } };
     return &info;
 }
 
@@ -1974,7 +2045,7 @@ inline const TableTypeInfo * DebuffTableType()
     static const TableFieldInfo fields[] = {
         { "amount", "amount", "int32", 0x39cc, 4, false, false, false, 0, (uint32_t) offsetof( Debuff, amount ), (uint32_t) sizeof( Debuff::amount ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 100.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "Debuff", (uint32_t) sizeof( Debuff ), 1, fields, +[]( void * p ) { new ( p ) Debuff{}; } };
+    static const TableTypeInfo info = { "Debuff", (uint32_t) sizeof( Debuff ), 1, fields, +[]( void * p ) { DebuffReset( *(Debuff *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
 #include <cassert> // the keyed accessor's None refusal
 #include <iterator> // the keyed iterator's traits typedefs
@@ -308,6 +307,20 @@ struct WideBlob {
     int32_t samples_count = 0;
 };
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void WideBlobReset( WideBlob & value );
+
+inline void WideBlobReset( WideBlob & value )
+{
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+    memset( value.payload, 0, sizeof( value.payload ) );
+    value.payload_length = 0;
+    memset( value.samples, 0, sizeof( value.samples ) );
+    value.samples_count = 0;
+}
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t WideBlobMeasure( const WideBlob & value );
@@ -371,7 +384,7 @@ inline int64_t WideBlobSave( const WideBlob & value, uint8_t * buffer, int64_t c
 
 inline bool WideBlobLoadBody( TableReader & r, WideBlob & value )
 {
-    new ( &value ) WideBlob{}; // prefill declared defaults in place, then overlay
+    WideBlobReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -511,7 +524,7 @@ inline const TableTypeInfo * WideBlobTableType()
         { "payload", "payload", "bytes", 0x44aa, 6, true, true, false, 70000, (uint32_t) offsetof( WideBlob, payload ), (uint32_t) sizeof( WideBlob::payload[0] ), (uint32_t) offsetof( WideBlob, payload_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
         { "samples", "samples", "uint16", 0xaf9a, 7, true, true, false, 70000, (uint32_t) offsetof( WideBlob, samples ), (uint32_t) sizeof( WideBlob::samples[0] ), (uint32_t) offsetof( WideBlob, samples_count ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     };
-    static const TableTypeInfo info = { "WideBlob", (uint32_t) sizeof( WideBlob ), 3, fields, +[]( void * p ) { new ( p ) WideBlob{}; } };
+    static const TableTypeInfo info = { "WideBlob", (uint32_t) sizeof( WideBlob ), 3, fields, +[]( void * p ) { WideBlobReset( *(WideBlob *) p ); } };
     return &info;
 }
 

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
+#include <new> // a node's lifetime starts in arena storage (placement new)
 #include <cstdlib> // the arena's segments (the AUTHORING path may allocate)
 #include <atomic> // one atomic per slab: the arena is lock-free by ownership
 #include <cassert> // the keyed accessor's None refusal
@@ -574,7 +574,7 @@ struct Scene {
     TableRef settings; // *Settings — null until assigned
     TableRef alias; // *ListNode — null until assigned
     Layer ground;
-    Layer layers[4] = {}; // used count beside it; count in [0, 4]
+    Layer layers[4]; // used count beside it; count in [0, 4]
     int32_t layers_count = 0;
     Meta meta;
 };
@@ -628,6 +628,91 @@ inline bool TableEnumValue( uint16_t id, Tier & out )
     }
 }
 #endif // GRAPHDEMO_SCHEMA_TABLE_ENUM_TIER
+
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void MetaReset( Meta & value );
+inline void SettingsReset( Settings & value );
+inline void ListNodeReset( ListNode & value );
+inline void TreeNodeReset( TreeNode & value );
+inline void LayerReset( Layer & value );
+inline void SceneReset( Scene & value );
+inline void DepotReset( Depot & value );
+inline void AlbumReset( Album & value );
+
+inline void MetaReset( Meta & value )
+{
+    value.build = 1;
+    memset( value.tag, 0, sizeof( value.tag ) );
+    value.tag_length = 0;
+}
+
+inline void SettingsReset( Settings & value )
+{
+    value.quality = 2;
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+}
+
+inline void ListNodeReset( ListNode & value )
+{
+    value.value = 0;
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+    value.next.value = 0; // *ListNode — null
+}
+
+inline void TreeNodeReset( TreeNode & value )
+{
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+    value.left.value = 0; // *TreeNode — null
+    value.right.value = 0; // *TreeNode — null
+}
+
+inline void LayerReset( Layer & value )
+{
+    value.depth = 0;
+    value.head.value = 0; // *ListNode — null
+}
+
+inline void SceneReset( Scene & value )
+{
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+    value.version = 1;
+    value.head.value = 0; // *ListNode — null
+    value.tree.value = 0; // *TreeNode — null
+    value.settings.value = 0; // *Settings — null
+    value.alias.value = 0; // *ListNode — null
+    LayerReset( value.ground );
+    LayerReset( value.layers[0] );
+    for ( int32_t i = 1; i < 4; i++ ) { value.layers[i] = value.layers[0]; }
+    value.layers_count = 0;
+    MetaReset( value.meta );
+}
+
+inline void DepotReset( Depot & value )
+{
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+    LayerReset( value.banks.slots[0] );
+    for ( int32_t i = 1; i < 3; i++ ) { value.banks.slots[i] = value.banks.slots[0]; }
+    MetaReset( value.spare );
+    value.spare_present = false;
+    value.head.value = 0; // *ListNode — null
+}
+
+inline void AlbumReset( Album & value )
+{
+    memset( value.name, 0, sizeof( value.name ) );
+    value.name_length = 0;
+    value.tint = ::ColourMath();
+    StampReset( value.stamp );
+    MarkerReset( value.marker );
+    value.pin.value = 0; // *Marker — null
+    value.head.value = 0; // *ListNode — null
+}
 
 // ---- pointer targets: allocation and resolution (SPEC-TABLES.md §2) ----
 //
@@ -845,7 +930,7 @@ inline int64_t MetaSave( const Meta & value, uint8_t * buffer, int64_t capacity 
 
 inline bool MetaLoadBody( TableReader & r, Meta & value )
 {
-    new ( &value ) Meta{}; // prefill declared defaults in place, then overlay
+    MetaReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -942,7 +1027,7 @@ inline int64_t SettingsSave( const Settings & value, uint8_t * buffer, int64_t c
 
 inline bool SettingsLoadBody( TableReader & r, Settings & value )
 {
-    new ( &value ) Settings{}; // prefill declared defaults in place, then overlay
+    SettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1059,7 +1144,7 @@ inline bool ListNodeSaveBody( const Ctx & ctx, TableWriter & w, const ListNode &
 template <typename Sink>
 inline bool ListNodeLoadBody( TableReader & r, Sink & sink, ListNode & value, int32_t depth )
 {
-    new ( &value ) ListNode{}; // prefill declared defaults in place, then overlay
+    ListNodeReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1216,7 +1301,7 @@ inline bool TreeNodeSaveBody( const Ctx & ctx, TableWriter & w, const TreeNode &
 template <typename Sink>
 inline bool TreeNodeLoadBody( TableReader & r, Sink & sink, TreeNode & value, int32_t depth )
 {
-    new ( &value ) TreeNode{}; // prefill declared defaults in place, then overlay
+    TreeNodeReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1368,7 +1453,7 @@ inline bool LayerSaveBody( const Ctx & ctx, TableWriter & w, const Layer & value
 template <typename Sink>
 inline bool LayerLoadBody( TableReader & r, Sink & sink, Layer & value, int32_t depth )
 {
-    new ( &value ) Layer{}; // prefill declared defaults in place, then overlay
+    LayerReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1615,7 +1700,7 @@ inline bool SceneSaveBody( const Ctx & ctx, TableWriter & w, const Scene & value
 template <typename Sink>
 inline bool SceneLoadBody( TableReader & r, Sink & sink, Scene & value, int32_t depth )
 {
-    new ( &value ) Scene{}; // prefill declared defaults in place, then overlay
+    SceneReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1993,7 +2078,7 @@ inline bool DepotSaveBody( const Ctx & ctx, TableWriter & w, const Depot & value
 template <typename Sink>
 inline bool DepotLoadBody( TableReader & r, Sink & sink, Depot & value, int32_t depth )
 {
-    new ( &value ) Depot{}; // prefill declared defaults in place, then overlay
+    DepotReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -2253,7 +2338,7 @@ inline bool AlbumSaveBody( const Ctx & ctx, TableWriter & w, const Album & value
 template <typename Sink>
 inline bool AlbumLoadBody( TableReader & r, Sink & sink, Album & value, int32_t depth )
 {
-    new ( &value ) Album{}; // prefill declared defaults in place, then overlay
+    AlbumReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -4270,14 +4355,14 @@ inline const TableFieldInfo MetaTableFields[] = {
     { "build", "build", "int32", 0x3138, 4, false, false, false, false, 0, (uint32_t) offsetof( Meta, build ), (uint32_t) sizeof( Meta::build ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 1000.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "tag", "tag", "string", 0xbc64, 12, false, false, true, false, 8, (uint32_t) offsetof( Meta, tag ), (uint32_t) sizeof( Meta::tag ), (uint32_t) offsetof( Meta, tag_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo MetaTableInfo = { "Meta", (uint32_t) sizeof( Meta ), 2, MetaTableFields, +[]( void * p ) { new ( p ) Meta{}; }, false };
+inline const TableTypeInfo MetaTableInfo = { "Meta", (uint32_t) sizeof( Meta ), 2, MetaTableFields, +[]( void * p ) { MetaReset( *(Meta *) p ); }, false };
 inline const TableTypeInfo * MetaTableType() { return &MetaTableInfo; }
 
 inline const TableFieldInfo SettingsTableFields[] = {
     { "quality", "quality", "int32", 0xcaf3, 4, false, false, false, false, 0, (uint32_t) offsetof( Settings, quality ), (uint32_t) sizeof( Settings::quality ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 4.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "label", "label", "string", 0xe16a, 12, false, false, true, false, 16, (uint32_t) offsetof( Settings, label ), (uint32_t) sizeof( Settings::label ), (uint32_t) offsetof( Settings, label_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo SettingsTableInfo = { "Settings", (uint32_t) sizeof( Settings ), 2, SettingsTableFields, +[]( void * p ) { new ( p ) Settings{}; }, false };
+inline const TableTypeInfo SettingsTableInfo = { "Settings", (uint32_t) sizeof( Settings ), 2, SettingsTableFields, +[]( void * p ) { SettingsReset( *(Settings *) p ); }, false };
 inline const TableTypeInfo * SettingsTableType() { return &SettingsTableInfo; }
 
 inline const TableFieldInfo ListNodeTableFields[] = {
@@ -4285,7 +4370,7 @@ inline const TableFieldInfo ListNodeTableFields[] = {
     { "name", "name", "string", 0x30df, 12, false, false, true, false, 12, (uint32_t) offsetof( ListNode, name ), (uint32_t) sizeof( ListNode::name ), (uint32_t) offsetof( ListNode, name_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "next", "next", "ListNode", 0xd15e, 13, false, true, false, false, 0, (uint32_t) offsetof( ListNode, next ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &ListNodeTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo ListNodeTableInfo = { "ListNode", (uint32_t) sizeof( ListNode ), 3, ListNodeTableFields, +[]( void * p ) { new ( p ) ListNode{}; }, true };
+inline const TableTypeInfo ListNodeTableInfo = { "ListNode", (uint32_t) sizeof( ListNode ), 3, ListNodeTableFields, +[]( void * p ) { ListNodeReset( *(ListNode *) p ); }, true };
 inline const TableTypeInfo * ListNodeTableType() { return &ListNodeTableInfo; }
 
 inline const TableFieldInfo TreeNodeTableFields[] = {
@@ -4293,14 +4378,14 @@ inline const TableFieldInfo TreeNodeTableFields[] = {
     { "left", "left", "TreeNode", 0xfe3a, 13, false, true, false, false, 0, (uint32_t) offsetof( TreeNode, left ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &TreeNodeTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "right", "right", "TreeNode", 0x5506, 13, false, true, false, false, 0, (uint32_t) offsetof( TreeNode, right ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &TreeNodeTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo TreeNodeTableInfo = { "TreeNode", (uint32_t) sizeof( TreeNode ), 3, TreeNodeTableFields, +[]( void * p ) { new ( p ) TreeNode{}; }, true };
+inline const TableTypeInfo TreeNodeTableInfo = { "TreeNode", (uint32_t) sizeof( TreeNode ), 3, TreeNodeTableFields, +[]( void * p ) { TreeNodeReset( *(TreeNode *) p ); }, true };
 inline const TableTypeInfo * TreeNodeTableType() { return &TreeNodeTableInfo; }
 
 inline const TableFieldInfo LayerTableFields[] = {
     { "depth", "depth", "int32", 0x609f, 4, false, false, false, false, 0, (uint32_t) offsetof( Layer, depth ), (uint32_t) sizeof( Layer::depth ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 64.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "head", "head", "ListNode", 0x79aa, 13, false, true, false, false, 0, (uint32_t) offsetof( Layer, head ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &ListNodeTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo LayerTableInfo = { "Layer", (uint32_t) sizeof( Layer ), 2, LayerTableFields, +[]( void * p ) { new ( p ) Layer{}; }, true };
+inline const TableTypeInfo LayerTableInfo = { "Layer", (uint32_t) sizeof( Layer ), 2, LayerTableFields, +[]( void * p ) { LayerReset( *(Layer *) p ); }, true };
 inline const TableTypeInfo * LayerTableType() { return &LayerTableInfo; }
 
 inline const TableFieldInfo SceneTableFields[] = {
@@ -4314,7 +4399,7 @@ inline const TableFieldInfo SceneTableFields[] = {
     { "layers", "layers", "Layer", 0x1ee8, 13, true, false, true, false, 4, (uint32_t) offsetof( Scene, layers ), (uint32_t) sizeof( Scene::layers[0] ), (uint32_t) offsetof( Scene, layers_count ), 0xffffffffu, &LayerTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "meta", "meta", "Meta", 0xcea6, 13, false, false, false, false, 0, (uint32_t) offsetof( Scene, meta ), (uint32_t) sizeof( Scene::meta ), 0xffffffffu, 0xffffffffu, &MetaTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo SceneTableInfo = { "Scene", (uint32_t) sizeof( Scene ), 9, SceneTableFields, +[]( void * p ) { new ( p ) Scene{}; }, true };
+inline const TableTypeInfo SceneTableInfo = { "Scene", (uint32_t) sizeof( Scene ), 9, SceneTableFields, +[]( void * p ) { SceneReset( *(Scene *) p ); }, true };
 inline const TableTypeInfo * SceneTableType() { return &SceneTableInfo; }
 
 inline const TableFieldInfo DepotTableFields[] = {
@@ -4323,7 +4408,7 @@ inline const TableFieldInfo DepotTableFields[] = {
     { "spare", "spare", "Meta", 0x3a4f, 13, false, false, false, true, 0, (uint32_t) offsetof( Depot, spare ), (uint32_t) sizeof( Depot::spare ), 0xffffffffu, (uint32_t) offsetof( Depot, spare_present ), &MetaTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "head", "head", "ListNode", 0x79aa, 13, false, true, false, false, 0, (uint32_t) offsetof( Depot, head ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &ListNodeTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo DepotTableInfo = { "Depot", (uint32_t) sizeof( Depot ), 4, DepotTableFields, +[]( void * p ) { new ( p ) Depot{}; }, true };
+inline const TableTypeInfo DepotTableInfo = { "Depot", (uint32_t) sizeof( Depot ), 4, DepotTableFields, +[]( void * p ) { DepotReset( *(Depot *) p ); }, true };
 inline const TableTypeInfo * DepotTableType() { return &DepotTableInfo; }
 
 inline const TableFieldInfo AlbumTableFields[] = {
@@ -4334,7 +4419,7 @@ inline const TableFieldInfo AlbumTableFields[] = {
     { "pin", "pin", "Marker", 0x69d5, 13, false, true, false, false, 0, (uint32_t) offsetof( Album, pin ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &MarkerTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "head", "head", "ListNode", 0x79aa, 13, false, true, false, false, 0, (uint32_t) offsetof( Album, head ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &ListNodeTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo AlbumTableInfo = { "Album", (uint32_t) sizeof( Album ), 6, AlbumTableFields, +[]( void * p ) { new ( p ) Album{}; }, true };
+inline const TableTypeInfo AlbumTableInfo = { "Album", (uint32_t) sizeof( Album ), 6, AlbumTableFields, +[]( void * p ) { AlbumReset( *(Album *) p ); }, true };
 inline const TableTypeInfo * AlbumTableType() { return &AlbumTableInfo; }
 
 // ---- the text form (SPEC-TABLES.md §16) ----

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
+#include <new> // a node's lifetime starts in arena storage (placement new)
 #include <cstdlib> // the arena's segments (the AUTHORING path may allocate)
 #include <atomic> // one atomic per slab: the arena is lock-free by ownership
 #include <cassert> // the keyed accessor's None refusal
@@ -533,6 +533,23 @@ struct Marker {
     TableRef note; // *Tally — null until assigned
 };
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void TallyReset( Tally & value );
+inline void MarkerReset( Marker & value );
+
+inline void TallyReset( Tally & value )
+{
+    value.hits = 0;
+}
+
+inline void MarkerReset( Marker & value )
+{
+    memset( value.label, 0, sizeof( value.label ) );
+    value.label_length = 0;
+    value.note.value = 0; // *Tally — null
+}
+
 // ---- pointer targets: allocation and resolution (SPEC-TABLES.md §2) ----
 //
 // A reference resolves differently in the two forms, and the CONTEXT says
@@ -666,7 +683,7 @@ inline int64_t TallySave( const Tally & value, uint8_t * buffer, int64_t capacit
 
 inline bool TallyLoadBody( TableReader & r, Tally & value )
 {
-    new ( &value ) Tally{}; // prefill declared defaults in place, then overlay
+    TallyReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -758,7 +775,7 @@ inline bool MarkerSaveBody( const Ctx & ctx, TableWriter & w, const Marker & val
 template <typename Sink>
 inline bool MarkerLoadBody( TableReader & r, Sink & sink, Marker & value, int32_t depth )
 {
-    new ( &value ) Marker{}; // prefill declared defaults in place, then overlay
+    MarkerReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -1142,14 +1159,14 @@ extern const TableTypeInfo MarkerTableInfo;
 inline const TableFieldInfo TallyTableFields[] = {
     { "hits", "hits", "int32", 0xb723, 4, false, false, false, false, 0, (uint32_t) offsetof( Tally, hits ), (uint32_t) sizeof( Tally::hits ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 10000.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo TallyTableInfo = { "Tally", (uint32_t) sizeof( Tally ), 1, TallyTableFields, +[]( void * p ) { new ( p ) Tally{}; }, false };
+inline const TableTypeInfo TallyTableInfo = { "Tally", (uint32_t) sizeof( Tally ), 1, TallyTableFields, +[]( void * p ) { TallyReset( *(Tally *) p ); }, false };
 inline const TableTypeInfo * TallyTableType() { return &TallyTableInfo; }
 
 inline const TableFieldInfo MarkerTableFields[] = {
     { "label", "label", "string", 0xe16a, 12, false, false, true, false, 8, (uint32_t) offsetof( Marker, label ), (uint32_t) sizeof( Marker::label ), (uint32_t) offsetof( Marker, label_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "note", "note", "Tally", 0x9da7, 13, false, true, false, false, 0, (uint32_t) offsetof( Marker, note ), (uint32_t) sizeof( TableRef ), 0xffffffffu, 0xffffffffu, &TallyTableInfo, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo MarkerTableInfo = { "Marker", (uint32_t) sizeof( Marker ), 2, MarkerTableFields, +[]( void * p ) { new ( p ) Marker{}; }, true };
+inline const TableTypeInfo MarkerTableInfo = { "Marker", (uint32_t) sizeof( Marker ), 2, MarkerTableFields, +[]( void * p ) { MarkerReset( *(Marker *) p ); }, true };
 inline const TableTypeInfo * MarkerTableType() { return &MarkerTableInfo; }
 
 // ---- the text form (SPEC-TABLES.md §16) ----

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <cstdint>
-#include <cstring>
+#include <cstring> // the prefill's scalar-array fills
 #include <cstddef> // offsetof, for the reflection descriptors
-#include <new> // in-place prefill (placement new): no giant stack temporaries
 #include <type_traits> // the enforced relocatability asserts
+#include <new> // a node's lifetime starts in arena storage (placement new)
 #include <cstdlib> // the arena's segments (the AUTHORING path may allocate)
 #include <atomic> // one atomic per slab: the arena is lock-free by ownership
 #include <cassert> // the keyed accessor's None refusal
@@ -527,6 +527,20 @@ struct Stamp {
     int32_t seq = 0;
 };
 
+// ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
+
+inline void StampReset( Stamp & value );
+inline void ColourReset( Colour & value );
+
+inline void StampReset( Stamp & value )
+{
+    memset( value.tag, 0, sizeof( value.tag ) );
+    value.tag_length = 0;
+    value.seq = 0;
+}
+
+inline void ColourReset( Colour & value ) { value = Colour(); }
+
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t StampMeasure( const Stamp & value );
@@ -572,7 +586,7 @@ inline int64_t StampSave( const Stamp & value, uint8_t * buffer, int64_t capacit
 
 inline bool StampLoadBody( TableReader & r, Stamp & value )
 {
-    new ( &value ) Stamp{}; // prefill declared defaults in place, then overlay
+    StampReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -672,7 +686,7 @@ inline int64_t ColourSave( const Colour & value, uint8_t * buffer, int64_t capac
 
 inline bool ColourLoadBody( TableReader & r, Colour & value )
 {
-    new ( &value ) Colour{}; // prefill declared defaults in place, then overlay
+    ColourReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
     {
         if ( !r.has( 2 ) ) { r.report->malformed = true; return false; }
@@ -770,7 +784,7 @@ inline const TableFieldInfo StampTableFields[] = {
     { "tag", "tag", "string", 0xbc64, 12, false, false, true, false, 8, (uint32_t) offsetof( Stamp, tag ), (uint32_t) sizeof( Stamp::tag ), (uint32_t) offsetof( Stamp, tag_length ), 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "seq", "seq", "int32", 0xc29b, 4, false, false, false, false, 0, (uint32_t) offsetof( Stamp, seq ), (uint32_t) sizeof( Stamp::seq ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 1000.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo StampTableInfo = { "Stamp", (uint32_t) sizeof( Stamp ), 2, StampTableFields, +[]( void * p ) { new ( p ) Stamp{}; }, false };
+inline const TableTypeInfo StampTableInfo = { "Stamp", (uint32_t) sizeof( Stamp ), 2, StampTableFields, +[]( void * p ) { StampReset( *(Stamp *) p ); }, false };
 inline const TableTypeInfo * StampTableType() { return &StampTableInfo; }
 
 inline const TableFieldInfo ColourTableFields[] = {
@@ -778,7 +792,7 @@ inline const TableFieldInfo ColourTableFields[] = {
     { "g", "g", "uint8", 0xc40a, 6, false, false, false, false, 0, (uint32_t) offsetof( Colour, g ), (uint32_t) sizeof( Colour::g ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
     { "b", "b", "uint8", 0xcae9, 6, false, false, false, false, 0, (uint32_t) offsetof( Colour, b ), (uint32_t) sizeof( Colour::b ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, -1, NULL, NULL, NULL, NULL, NULL, NULL, "" },
 };
-inline const TableTypeInfo ColourTableInfo = { "Colour", (uint32_t) sizeof( Colour ), 3, ColourTableFields, +[]( void * p ) { new ( p ) Colour{}; }, false };
+inline const TableTypeInfo ColourTableInfo = { "Colour", (uint32_t) sizeof( Colour ), 3, ColourTableFields, +[]( void * p ) { ColourReset( *(Colour *) p ); }, false };
 inline const TableTypeInfo * ColourTableType() { return &ColourTableInfo; }
 
 // ---- the text form (SPEC-TABLES.md §16) ----


### PR DESCRIPTION
Closes #320.

## The term

cl expands a **value-initialisation of a large aggregate element by element, in the front end**. The emitted header wrote three such sites per fixed table, and against `blockdemo::RenderFrame` — 7,879,320 bytes, ~105,000 rows across nine arrays — each one cost seconds:

| | |
|---|---|
| `RenderShip ships[4096] = {};` — the storage declaration's member initializers | 4.75 s |
| `new ( &value ) RenderFrame{};` — the read path's prefill in `RenderFrameLoadBody` | 5.68 s |
| `+[]( void * p ) { new ( p ) RenderFrame{}; }` — the descriptor's reset column | 8.08 s |
| all three at once | **19.46 s of a 19.76 s translation unit** |

`/Bt+` says where: **front end 19.85 s, back end 0.03 s, `Total Function Count: 0`.** cl never reaches code generation. `/d1reportTime` charges the whole cost to the one include. The `static_assert`s were the negative control on that bisect and came in at 0.05 s; rewriting every array bound to `[1]` and changing nothing else gave 0.32 s, so the cost tracks element count and nothing else.

Full bisect — eleven variants of the same header, one cl each — on #320. It is `O(bytes)` where it should be `O(declarations)`, which is why clang does the same header in 0.15 s.

## The fix

Every table now carries `<Name>Reset`, which establishes the declared defaults **one member at a time** and fills each array from its own first element:

```cpp
inline void RenderFrameReset( RenderFrame & value )
{
    value.version = 0;
    RenderCameraReset( value.cameras[0] );
    value.cameras_count = 0;
    RenderShipReset( value.ships[0] );
    for ( int32_t i = 1; i < 4096; i++ ) { value.ships[i] = value.ships[0]; }
    ...
}
```

The read path calls it, the descriptor's reset column calls it, and an array of a self-initialising element type drops its now-redundant `= {}` — the element type's own member initializers already say what an element starts as, for both default- and value-initialisation. A scalar array keeps `= {}` and Reset memsets it, which is exactly what `= {}` meant. It recurses through nested tables, so a table inside a table stays `O(declarations)` too.

Same defaults, same work at run time; the compile cost is now one element per array instead of the whole array.

`<Name>Reset` is a generated per-declaration spelling, so the checker claims it — **25 suffixes, not 24** — with a diagnostics case, and SPEC-TABLES §8.1 states what it does and why the shape matters. `<new>` is now emitted only for units with pointered tables, which are the only ones that still start a lifetime in arena storage.

## Before and after, on the leg

Per translation unit, the four that include `RenderTable.h`:

| TU | before | after |
|---|---|---|
| `block/PaddedBlock.cpp` | 22.55 s | 3.43 s |
| `block/PaddedTable.cpp` | 20.44 s | 0.43 s |
| `block/RenderBlock.cpp` | 20.20 s | 0.39 s |
| `block/RenderTable.cpp` | 20.10 s | 0.38 s |
| the corpus step, 44 TUs | 95 s | 17 s |

`PaddedBlock.cpp` is the job's FIRST cl invocation and carries the toolchain and STL headers cold; every unit after it is under half a second. `/Bt+` on a bare TU that only includes the header: **c1xx 19.85 s → 0.30 s, c2 0.03 s → 0.006 s.**

**The cost did not move onto consumers.** Measured on the same leg, same header:

| a consumer TU that writes | cl |
|---|---|
| nothing (bare include) | 0.33 s |
| `RenderFrame f;` | 0.38 s |
| `RenderFrame f{};` | 0.33 s |
| `RenderFrameReset( *(RenderFrame *) p );` | 0.33 s |

## The gate decision

Whole `msvc` job, three dispatch runs on identical input:

| run | job | corpus step |
|---|---|---|
| [33690700177](https://github.com/mas-bandwidth/schema/actions/runs/33690700177) | **1:18** | 19 s |
| [33691260671](https://github.com/mas-bandwidth/schema/actions/runs/33691260671) | **1:08** | 16 s |
| [33691856140](https://github.com/mas-bandwidth/schema/actions/runs/33691856140) | **1:09** | 17 s |

And on this pull request itself, where the leg now runs: **1:09**, against `test (ubuntu-latest)` at 3:52 — it is not close to being the longest job in the gate.

All three inside the one-to-two minute rule, against 2:26–5:14 before. So the leg moves into the pull request gate: the `if:` is gone, and the job comment and CONTRIBUTING say the present state. Visual C++ is a hard requirement in this estate, and what the compiler emits is now compiled with cl before a change lands rather than minutes after.

The per-TU clock lines stay, and `/MP` stays absent: they are what turned #316's "the corpus does not compile" into two named emitter defects and #320's ~20 s per TU into one.

## Gates

Green locally: tables zero-cost, block zero-cost (38 Table sources byte-identical to the pre-block pins, re-pinned for this emitter change), the generic-walk gate, the JSON negative control, `schema_test_tables`, `tables-block` (C++, ASan, TSan, C#), the block forgery fuzzer (314,084 mutants over three units, both backends and C#), `tables-pack`, `tables-hostile-values`, `go test ./...`, `make check`. Big-endian needs the s390x cross toolchain and ran on CI. **No wire golden moved and the block build version is unchanged** — this is a compile-time change to how defaults are established, not to what they are.

The generated header goldens moved and are re-pinned; the diff is the new prefill section plus the two call sites plus the dropped `= {}`.

## Remaining, named

The arena path still writes `new ( p ) T{}` to start a node's lifetime in raw arena storage (`pointers/GraphTable.h`). Those are pointered node tables and none in the corpus is large, but it is the same construct one form down; it is not a straight swap, because that site starts a lifetime rather than resetting a live object. Worth its own pass if a large variable-length table ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

