### PR TITLE
the cook (2/3): the C++ Open — point at a cook, from the page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -612,6 +612,161 @@ tables-cook-scale-1gb: bin/schema
 	./build/cookgen --bytes 1073741824 --out build/cook/1gb.cook
 	./bin/schema cook-check --verbose build/cook/1gb.cook $(COOKGEN_UNIT)
 
+# ---- the COOK's C++ READ SIDE (SPEC-TABLES.md §7) --------------------------
+#
+# `schema cook` writes the file and the generated <Root>Open points at it, and
+# the two were written from the page independently — the tool in Go, the C++
+# side from §7 alone, neither reading the other. That is what makes the golden
+# mode a CROSS-IMPLEMENTATION gate rather than one implementation agreeing with
+# itself: every node the C++ side reaches through its own derefs must be a node
+# the cook's ATTRIBUTION part names, at that offset, with that type id, and the
+# two sets must be equal.
+#
+# THE FIXTURES come from test/cookgen, which streams a synthetic region in O(1)
+# memory (§7.5), so the 100 MB arm of the O(1) gate is regenerated rather than
+# committed. Five roots cover the shapes a region has: a pointer chain, a tree,
+# a keyed array of variable tables beside an optional, a cross-file graph
+# through a by-value variable table, and a bare chain node as its own root.
+COOK_ROOTS := Scene Depot Album TreeNode ListNode
+# The FIXED roots. A fixed table's cook is ONE REGION OF ONE NODE (§7) and the
+# same header match, and it is where the VALUE crossing lives: a fixed table has
+# no pointer, so it has no node table and no kind 17, so this backend's wire and
+# the tool's are the same bytes — the C++ side writes a known instance, the tool
+# cooks it, and the C++ side reads the values back out of the tool's layout.
+# Settings is POINTED AT; Stamp is pointed at by nothing and is declared in a
+# file with no variable table of its own, which is the shape a file-scoped
+# emission rule forgets.
+COOK_FIXED_ROOTS := Settings Stamp
+
+COOK_INCLUDES := -Ibuild/tables-generated/pointers -Itest/tables
+COOK_CXXFLAGS := -std=c++17 -Wall -Wextra -Werror -Wshadow -ffp-contract=off -pthread
+# The SANITIZED twin is a gate and not a nicety here: Open is handed a hostile
+# buffer by construction, the driver allocates each fixture at EXACTLY the
+# length it claims so a redzone sits on the next byte, and
+# -fno-sanitize-recover=all is what stops UBSan printing and continuing.
+COOK_SANITIZE := -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g
+
+build/schema_test_cook: build/tables-generated/.stamp test/tables/cook_main.cpp
+	@mkdir -p build
+	$(CXX) $(COOK_CXXFLAGS) $(COOK_INCLUDES) test/tables/cook_main.cpp -o $@
+
+build/schema_test_cook_asan: build/tables-generated/.stamp test/tables/cook_main.cpp
+	@mkdir -p build
+	$(CXX) $(COOK_CXXFLAGS) $(COOK_SANITIZE) $(COOK_INCLUDES) test/tables/cook_main.cpp -o $@
+
+# The fixtures the C++ gate opens. Small ones per root for the golden lock, the
+# battery and the fuzzer; a big-endian one for the byte-order leg; and the two
+# scale arms for the O(1) gate. `schema cook-check` runs over every small one
+# first, so a fixture the TOOL itself would refuse can never be what a green
+# C++ run is standing on.
+build/cook-open/.stamp: bin/schema $(SCHEMAS_TABLES_POINTERS)
+	@rm -rf build/cook-open && mkdir -p build/cook-open
+	go build -o build/cookgen ./test/cookgen
+	./build/cookgen --bytes 4096 --root Scene    --ref head --chain ListNode --next next --out build/cook-open/Scene.cook
+	./build/cookgen --bytes 3000 --root Depot    --ref head --chain ListNode --next next --out build/cook-open/Depot.cook
+	./build/cookgen --bytes 3000 --root Album    --ref head --chain ListNode --next next --out build/cook-open/Album.cook
+	./build/cookgen --bytes 3000 --root TreeNode --ref left --chain TreeNode --next left --out build/cook-open/TreeNode.cook
+	./build/cookgen --bytes 3000 --root ListNode --ref next --chain ListNode --next next --out build/cook-open/ListNode.cook
+	./build/cookgen --bytes 4096 --root Scene    --byte-order big --out build/cook-open/Scene-be.cook
+	./build/cookgen --bytes 1048576   --root Scene --out build/cook-open/1mb.cook
+	./build/cookgen --bytes 104857600 --root Scene --out build/cook-open/100mb.cook
+	@for r in $(COOK_ROOTS); do \
+		./bin/schema cook-check --root $$r build/cook-open/$$r.cook tables/pointers || exit 1; \
+	done
+	./bin/schema cook-check --root Scene build/cook-open/Scene-be.cook tables/pointers
+	@touch $@
+
+# The FIXED-root fixtures, which the C++ side WRITES: it saves a known instance
+# to the tolerant wire, the tool cooks that wire, and the value gate reads the
+# instance back out of the cook. The tool's own read report must be SILENT over
+# a wire this backend wrote — a crossing in the other direction, for free.
+build/cook-open-fixed/.stamp: bin/schema build/schema_test_cook build/cook-open/.stamp
+	@rm -rf build/cook-open-fixed && mkdir -p build/cook-open-fixed
+	@for r in $(COOK_FIXED_ROOTS); do \
+		./build/schema_test_cook write $$r build/cook-open-fixed/$$r.bin || exit 1; \
+		./bin/schema cook --root $$r --in build/cook-open-fixed/$$r.bin \
+			--out build/cook-open-fixed/$$r.cook --verbose tables/pointers || exit 1; \
+		./bin/schema cook-check --root $$r build/cook-open-fixed/$$r.cook tables/pointers || exit 1; \
+	done
+	@touch $@
+
+.PHONY: tables-cook-open
+tables-cook-open: build/schema_test_cook build/schema_test_cook_asan build/cook-open/.stamp build/cook-open-fixed/.stamp
+	@for r in $(COOK_ROOTS); do \
+		./build/schema_test_cook      golden $$r build/cook-open/$$r.cook || exit 1; \
+		./build/schema_test_cook_asan golden $$r build/cook-open/$$r.cook || exit 1; \
+	done
+	@for r in $(COOK_FIXED_ROOTS); do \
+		./build/schema_test_cook      golden      $$r build/cook-open-fixed/$$r.cook || exit 1; \
+		./build/schema_test_cook_asan golden      $$r build/cook-open-fixed/$$r.cook || exit 1; \
+		./build/schema_test_cook      fixedvalues $$r build/cook-open-fixed/$$r.cook || exit 1; \
+		./build/schema_test_cook_asan fixedvalues $$r build/cook-open-fixed/$$r.cook || exit 1; \
+		./build/schema_test_cook_asan forge       $$r build/cook-open-fixed/$$r.cook || exit 1; \
+	done
+	./build/schema_test_cook      usage Scene build/cook-open/Scene.cook
+	./build/schema_test_cook      forge Scene build/cook-open/Scene.cook
+	./build/schema_test_cook_asan forge Scene build/cook-open/Scene.cook
+	./build/schema_test_cook_asan forge Depot build/cook-open/Depot.cook
+	SEED=$(SEED) N=$(N) ./build/schema_test_cook_asan fuzz Scene build/cook-open/Scene.cook
+	SEED=$(SEED) N=$(N) ./build/schema_test_cook_asan fuzz TreeNode build/cook-open/TreeNode.cook
+	./build/schema_test_cook accept Scene build/cook-open/Scene.cook
+	./build/schema_test_cook refuse Scene build/cook-open/Scene-be.cook
+	./build/schema_test_cook time Scene build/cook-open/1mb.cook build/cook-open/100mb.cook
+
+# THE GIGABYTE ARM, by hand (§7.5): a 1.5 GB fixture is not something a CI
+# runner's disk should meet on every push, and the two arms above already span
+# two orders of magnitude.
+.PHONY: tables-cook-open-1gb
+tables-cook-open-1gb: build/schema_test_cook build/cook-open/.stamp
+	go build -o build/cookgen ./test/cookgen
+	./build/cookgen --bytes 1073741824 --root Scene --out build/cook-open/1gb.cook
+	./build/schema_test_cook time Scene build/cook-open/1mb.cook build/cook-open/1gb.cook
+
+# THE NEGATIVE CONTROLS, and a battery whose battery has never gone red is
+# watching nothing. Each removes ONE clause of TableCookOpen through a
+# `go build -overlay` on the emitter — so no tracked file is ever written to,
+# an interrupt cannot leave a sabotaged working tree, and a parallel `make -j`
+# cannot compile the sabotage into something else — regenerates the corpus from
+# the sabotaged emitter, and requires the C++ gate to go RED.
+#
+# The two clauses chosen are the two that decide whether Open can hand back
+# storage the caller never gave it: the part-length equation, which is what
+# refuses a truncated file, and the root-fits check, which is what refuses a
+# data part too short to hold the root.
+define cook_open_sabotage
+	@mkdir -p build
+	@rm -rf build/cook-open-$(1) && mkdir -p build/cook-open-$(1)
+	@sed 's|^.*$(2).*$$|    $(3) // NEGATIVE CONTROL|' \
+		internal/codegen/cpptable/cook.go > build/cook-open-$(1)/cook.gotext
+	@cmp -s build/cook-open-$(1)/cook.gotext internal/codegen/cpptable/cook.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the $(1) sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/cook.go":"%s/build/cook-open-$(1)/cook.gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/cook-open-$(1)/overlay.json
+	@go build -overlay=build/cook-open-$(1)/overlay.json -o build/cook-open-$(1)/schema ./cmd/schema
+	./build/cook-open-$(1)/schema generate --lang cpp --out build/cook-open-$(1)/gen tables/pointers
+	$(CXX) $(COOK_CXXFLAGS) $(COOK_SANITIZE) -Ibuild/cook-open-$(1)/gen -Itest/tables \
+		test/tables/cook_main.cpp -o build/cook-open-$(1)/test
+	@if ./build/cook-open-$(1)/test forge Scene build/cook-open/Scene.cook > build/cook-open-$(1)/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: the battery stayed green with the $(1) check removed"; exit 1; \
+	fi
+	@grep -q "FAILED" build/cook-open-$(1)/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the battery went red, but not on a forgery"; cat build/cook-open-$(1)/log; exit 1; }
+	@grep -m1 -A3 "FAILED" build/cook-open-$(1)/log
+	@echo "negative control: removing the $(1) check turns the cook forgery battery RED"
+endef
+
+# The sabotage keeps the local it defeats IN USE, because a generated C++ file
+# with an unused local does not compile under -Werror and a control that fails
+# to build is not a control that went red.
+.PHONY: tables-cook-open-lengths-negative-control
+tables-cook-open-lengths-negative-control: build/cook-open/.stamp
+	$(call cook_open_sabotage,lengths,attribution_length != length - data_offset - data_length,if ( attribution_length == UINT64_MAX ) { return NULL; })
+
+.PHONY: tables-cook-open-root-negative-control
+tables-cook-open-root-negative-control: build/cook-open/.stamp
+	$(call cook_open_sabotage,root,data_length < root_size,if ( root_size == UINT64_MAX ) { return NULL; })
+
+
 # THE COOK ROUND TRIP THROUGH THE CLI (SPEC-TABLES.md §7.5). The Go tests hold
 # the engine; this holds the three COMMANDS and their flags, over a pinned pack
 # tree, in both byte orders and with the attribution written both ways.
@@ -646,16 +801,34 @@ tables-cook-cli: bin/schema
 #
 # They are ordinary goldens from here on: `make update-goldens` re-pins them
 # when a TABLE emitter legitimately changes, and a move under an unchanged
-# emitter is stop-the-line, exactly as it is for every other golden.
+# emitter is stop-the-line, exactly as it is for every other golden. **The
+# fourteen Table HEADERS were re-pinned when the cook's read side landed** (§7),
+# so their text is no longer the pre-block compiler's — git carries that
+# provenance, and the .cpp pins still are. Replacing the frozen pins with a
+# mechanical comparison against a corpus generated from a block-less emitter,
+# the way the negative controls already do it, is the follow-on that would give
+# the byte-identity half back its independence.
 .PHONY: tables-block-zero-cost
 tables-block-zero-cost: build/tables-generated/.stamp build/tables-generated-cs/.stamp
 	@for f in build/tables-generated/*/*Table.h build/tables-generated/*/*Table.cpp \
 	          build/tables-generated-cs/*/*Table.cs; do \
-		if grep -nE "TableBlock|[A-Za-z0-9_]Block|BuildVersion" $$f; then \
+		if grep -nE "TableBlock|[A-Za-z0-9_]Block" $$f; then \
 			echo "BLOCK ZERO-COST GATE FAILED: the block form leaked into $$f"; exit 1; \
 		fi; \
 	done
 	@echo "block zero-cost gate: no Table source carries one symbol of the block form"
+# BuildVersion LEFT this grep when the cook's read side landed. It is not a
+# block symbol and never was: a build version answers "which build?" and not
+# "which form?", both accelerators carry it (SPEC-TABLES.md §20.6), and every
+# Table header now carries it because every table cooks (§7). What still holds
+# the block form to zero cost is the line above — no Table source carries one
+# BLOCK symbol — and the byte comparison below.
+	@for f in build/tables-generated-cs/*/*Table.cs; do \
+		if grep -n "BuildVersion" $$f; then \
+			echo "BLOCK ZERO-COST GATE FAILED: the C# Table sources carry BuildVersion, which is the BLOCK file's there: $$f"; exit 1; \
+		fi; \
+	done
+	@echo "block zero-cost gate: the C# Table sources still carry no build version — it is their Block file's"
 	@n=0; d=0; \
 	for f in testdata/golden/tables/examples/*Table.* testdata/golden/tables/pointers/*Table.* \
 	         testdata/golden/tables/block/*Table.* testdata/golden/tables/blockhome/*Table.* ; do \
@@ -681,7 +854,7 @@ tables-block-zero-cost: build/tables-generated/.stamp build/tables-generated-cs/
 	done; \
 	if [ "$$d" != "0" ]; then exit 1; fi; \
 	if [ "$$n" -lt 38 ]; then echo "ZERO-COST GATE FAILED: compared $$n Table files, expected at least 38 — the glob, not the property, is what broke"; exit 1; fi; \
-	echo "block zero-cost gate: $$n Table sources byte-identical to the pins the PRE-BLOCK compiler wrote"
+	echo "block zero-cost gate: $$n Table sources byte-identical to their pins (the .cpp half still the PRE-BLOCK compiler's text)"
 
 # THE BUILD VERSION IS ONE NUMBER (SPEC-TABLES.md §20.7): the constant each
 # backend emits, and the number `schema build-version` prints, are the same
@@ -1034,6 +1207,15 @@ build/schema_test_tables_be: build/tables-generated/.stamp test/tables/main.cpp
 	@mkdir -p build
 	$(BE_CXX) $(TABLES_CXXFLAGS) -static $(TABLES_INCLUDES) test/tables/main.cpp $(TABLES_JSON_SOURCES) -o $@
 
+# The COOK's read side, for a BIG-ENDIAN target. A cook is produced in the byte
+# order of the build it is cooked for (SPEC-TABLES.md §7), so this is where that
+# stops being a sentence: the big-endian build opens the big-endian cook
+# NATIVELY — magic, header words, deltas and all, with no fix-up pass anywhere —
+# and refuses the little-endian one, and this host does the mirror image.
+build/schema_test_cook_be: build/tables-generated/.stamp test/tables/cook_main.cpp
+	@mkdir -p build
+	$(BE_CXX) $(COOK_CXXFLAGS) -static $(COOK_INCLUDES) test/tables/cook_main.cpp -o $@
+
 # The cross-endian BLOCK driver, built BOTH ways: a block is produced in the
 # byte order of the build that wrote it, and every other block test in this
 # tree runs producer and consumer in one process. This is the one part of
@@ -1047,7 +1229,7 @@ build/schema_test_block_endian_be: build/tables-generated/.stamp test/tables/blo
 	$(BE_CXX) $(BLOCK_CXXFLAGS) -static $(BLOCK_INCLUDES) test/tables/block_endian_main.cpp $(BLOCK_SOURCES) -o $@
 
 .PHONY: tables-big-endian
-tables-big-endian: build/schema_test_tables_be build/schema_test_block_endian build/schema_test_block_endian_be
+tables-big-endian: build/schema_test_tables_be build/schema_test_block_endian build/schema_test_block_endian_be build/schema_test_cook build/schema_test_cook_be build/cook-open/.stamp
 	$(BE_RUN) ./build/schema_test_tables_be
 	@echo "big-endian leg: the wire crosses the byte order"
 	./build/schema_test_block_endian write build/block-host.bin
@@ -1057,6 +1239,12 @@ tables-big-endian: build/schema_test_tables_be build/schema_test_block_endian bu
 	./build/schema_test_block_endian accept build/block-host.bin
 	./build/schema_test_block_endian refuse build/block-target.bin
 	@echo "big-endian leg: a block does not cross the byte order either — the magic refuses it and the prologue's word names the order that wrote it"
+	$(BE_RUN) ./build/schema_test_cook_be accept Scene build/cook-open/Scene-be.cook
+	$(BE_RUN) ./build/schema_test_cook_be golden Scene build/cook-open/Scene-be.cook
+	$(BE_RUN) ./build/schema_test_cook_be refuse Scene build/cook-open/Scene.cook
+	./build/schema_test_cook accept Scene build/cook-open/Scene.cook
+	./build/schema_test_cook refuse Scene build/cook-open/Scene-be.cook
+	@echo "big-endian leg: a cook opens NATIVELY in the order it was cooked for, whole graph and all, and a cook of the other order is refused by the magic"
 	$(MAKE) tables-cook-endian
 
 # THE COOK IS THE HOST'S BUSINESS IN NEITHER DIRECTION (SPEC-TABLES.md §7).
@@ -1441,6 +1629,9 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) tables-cook-cli
 	$(MAKE) tables-cook-scale
 	$(MAKE) tables-cook-fuzz-negative-control
+	$(MAKE) tables-cook-open
+	$(MAKE) tables-cook-open-lengths-negative-control
+	$(MAKE) tables-cook-open-root-negative-control
 	$(MAKE) tables-block-zero-cost
 	$(MAKE) tables-block-build-version
 	$(MAKE) tables-block-fill-refuser

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1776,6 +1776,14 @@ nowhere either.
 is a consequence of that one sentence, and none of it is a second format
 of record.
 
+**IT IS NOT A WIRE PROTOCOL. It is a LOAD-TRUSTED-DATA-FROM-TOOLS protocol**,
+in the owner's words — *"It's not a 'wire' protocol, it's a load trusted data
+from tools protocol."* That is the name and the whole frame: a wire is what
+crosses a boundary between builds, and this crosses none. Tooling writes a cook
+for one build and that build loads it off its own disk, so nothing here
+negotiates, tolerates or defends; the tolerant table wire (§3) is what carries
+data across versions, and it stays the format of record.
+
 **What it is for**: reducing the load time of assets, and nothing else —
 don't parse, just point at an mmap'd data structure loaded as it stands,
 and have it work.
@@ -1789,16 +1797,18 @@ int64_t data, attribution;
 SceneCookMeasure( builder, &data, &attribution );
 SceneCook( builder, buffer, data, attribution );   // write it
 
-const Scene * scene = SceneOpen( bytes, size );    // point at it, or NULL
+const Scene * scene = SceneOpen( bytes, length ); // point at it, or NULL
 ```
 
-**Backend status: the TOOL is built and the EMITTERS are not (schema#251).**
-`schema cook`, `schema cook-check` and `schema uncook` produce, validate and
-read back the form below, in both byte orders, over the same IR the emitters
-consume — and `wire → cook → wire` is byte-identical over the corpus, which is
-what proves the accelerator loses no fact. No generated runtime carries `Cook`,
-`CookMeasure` or `Open` yet: a game still rides the tolerant wire, and the four
-spellings stay claimed ahead of their emitter (§11).
+**Backend status: the TOOL and the C++ READ SIDE are built; the C++ WRITE side
+is not (schema#251).** `schema cook`, `schema cook-check` and `schema uncook`
+produce, validate and read back the form below, in both byte orders, over the
+same IR the emitters consume — and `wire → cook → wire` is byte-identical over
+the corpus, which is what proves the accelerator loses no fact. The C++ table
+backend emits `<Root>Open` for EVERY TABLE (below) — a root is any table — so a
+game points at a cook the tooling produced. What no generated runtime carries
+yet is `Cook` and `CookMeasure`: a build that wants to WRITE a cook runs the
+tool, and those two spellings stay claimed ahead of their emitter (§11).
 
 **THE SCALE THE COOK IS BUILT FOR, stated as the requirement it is** —
 *"Assume we have say, 100mbs or many gigabytes of data in Assets.bin at some
@@ -1911,12 +1921,62 @@ the wire, and keeps the flexibility that comes with it.
   (`schema cook-check`, below), so a build that ships no
   tooling need not carry it at all: the header records its length as zero and
   the file is just data.
+- **A COOK IS TRUSTED INPUT, LOADED FROM DISK, and that is the sentence every
+  clause below descends from.** A cook is an artifact the owner's own pipeline
+  produced for the owner's own build and put on the owner's own disk beside it;
+  the game loads it. **`Open`'s checks are IDENTITY checks — is this file for
+  THIS build — and not a trust boundary**: the magic, the byte order, the build
+  version, the lengths and the alignment answer "did we write this?", and
+  nothing answers "is this hostile?" because that is not the question a load is
+  asking. **There is NO PER-NODE VALIDATION AT LOAD, ever**, and that is not a
+  cost saved but the design: a per-node pass over a catalogue-scale file is the
+  parse the whole form exists to delete.
+
+  **A file that did not come from your own pipeline is a TOOL's problem, not a
+  loader's**: `schema cook-check` (below), run by a person, once, offline. And
+  **if integrity is wanted, it is a SIGNATURE** — over the whole file, verified
+  once before `Open`, with sodium — never per-node checks smuggled into the
+  loader. It costs the lazy paging, and §15 carries both that and the shape
+  that keeps it; not built.
+
+  **The forgery battery and the fuzzer (§7.5) are hardening gates on the
+  REFUSAL PATH and they do not shape this runtime.** What they hold is that a
+  file `Open` refuses is refused cleanly — no crash, no read past the `length`
+  the caller passed, no undefined behaviour inside the check — because the
+  check runs on whatever bytes a disk hands back, including a corrupt or
+  truncated one. They do not ask `Open` to validate a graph, and the three
+  forgeries that OPEN by design (a reference leaving the region, a negative
+  delta past the base, a directory entry outside it) are exactly that
+  distinction written down.
+
 - **`Open` checks the header and points, and this is the WHOLE check**,
   because nothing else is checked at all: **the magic, the byte order it
-  establishes, the build version, every RESERVED word zero, the two part
-  lengths against the `size` the caller passed — a truncated file refuses —
-  and the alignment of the base.** That is the enumeration, and it is stated
-  once: §11 and §20.6 cite it rather than repeat it. On a match the bytes ARE
+  establishes, the build version, every RESERVED word zero, the region
+  ALIGNMENT the header names, the two part lengths against the `length` the
+  caller passed — a truncated file refuses — the ROOT's own storage inside the
+  data part, and the alignment of the base.** That is the enumeration, and it is
+  stated once: §11 and §20.6 cite it rather than repeat it.
+
+  **Two of those clauses are there because the header's own words are DATA**,
+  and a reader that took them on trust would do arithmetic with a forgery:
+
+  - **The `alignment` word is the one field the check computes WITH** rather
+    than only compares against — the data part begins at `align_up( 64,
+    alignment )` and the base's alignment is measured against it — so a word
+    that is not an alignment rounds nothing and aligns nothing. It must be a
+    POWER OF TWO, at least EIGHT (§7.1's floor) and at most SIXTY-FOUR — the
+    same sixty-four a block's base takes (§19.1), and past which the derived
+    data offset would no longer be the 64 every unit this language can declare
+    produces — and a multiple of the ROOT's own `alignof`, since the root sits
+    at the region's base. A zero there is a division by
+    zero inside the check, which is the defect the check exists to prevent.
+  - **The DATA PART MUST HOLD THE ROOT.** The two part lengths frame the FILE;
+    they do not say the region is at least `sizeof( root )`. Without that
+    clause a forged short data part describes a root partly outside the file,
+    and a match-and-point reader would hand back storage the caller never gave
+    it — the one way this design could read past the length it was passed.
+
+  On a match the bytes ARE
   what this build wrote, in this build's layout and this build's byte order,
   so there is nothing to validate and nothing to fix up: `Open` returns the
   root. That is the runtime path and there is no other. On any failure it
@@ -1927,6 +1987,63 @@ the wire, and keeps the flexibility that comes with it.
   build either wrote a file or it did not, and the build version is what says
   which. A cook is an accelerator for a build's own assets, and a runtime
   that wanted to reason about a foreign one has already left the fast path.
+
+- **THE C++ SURFACE, because a consumer written from this page needs the
+  spelling and not a description of one.** One free function per root, name
+  first (§6.1), taking the caller's bytes and returning the root or `NULL`:
+
+  ```cpp
+  const Scene * SceneOpen( const void * bytes, uint64_t length );
+  ```
+
+  **The length is UNSIGNED, and that is a decision the check makes rather than
+  a style.** Every number `Open` compares comes out of the file, so all of its
+  arithmetic is unsigned and each term is bounded before it is added; a signed
+  length would put one signed value into that arithmetic and one negative case
+  into every comparison. A caller holding an `int64_t` from a `stat` casts once,
+  at the call site, where the sign is still its own business.
+
+  **A ROOT IS ANY TABLE, and every table gets one.** Nothing on this page
+  narrows which table a cook may be rooted at, and two things say it is any of
+  them: `schema cook --root` names a TABLE and refuses anything else — a `type`
+  is not a node and has no type id (§3.1) — and §11 claims the spelling on every
+  closure member. So the emission is per table, in every unit that declares one,
+  and a FIXED root is not a second case: its cook is one region of one node
+  (below), which is this same header match and then the one record.
+
+  **The price is bytes of header and it is measured, not assumed.** The shared
+  read runtime plus one `Open` per table plus §20.3's layout asserts grew the
+  corpus's fourteen Table headers by 207 KB in total — a mean of 14.8 KB, about
+  a fifth of each — and the paired instrument §13.5 uses (one empty translation
+  unit including one generated Table header, arms interleaved in one sitting,
+  medians of 15) puts the compile-time cost at **+0.2 ms, +0.2%, inside a 4–6%
+  spread**. It is comment and constant-folded arithmetic, and it does not reach
+  the clock.
+
+  **None of it is POINTER MACHINERY**, which is what keeps §2.2's question
+  answerable with the form emitted everywhere: a value-only table still gets no
+  arena, no builder, no reference slot and no lifecycle surface. What it gets is
+  a header match, and a header match is what a cook is.
+
+  **A REFERENCE IS DEREFERENCED THROUGH `<T>At`**, which is emitted for every
+  pointer target and is the same call in a locked region and an opened cook,
+  because they are the same encoding (§6.3):
+
+  ```cpp
+  const Node * next = NodeAt( node->next );   // one add; NULL when the delta is zero
+  ```
+
+  The slot is eight bytes, signed, self-relative from the slot's own address, so
+  a deref needs no base pointer and no bounds test, and NULL is a delta of zero.
+  **Nothing about that call is the cook's**: it is what a region reference is,
+  and a cook is a region written verbatim.
+
+  **THE GENERATED STRUCT IS THE COOKED RECORD**, and the backend asserts it
+  rather than assuming it: every record a unit's files declare carries
+  `static_assert`s on its `sizeof`, its `alignof` and every field's `offsetof`
+  against the numbers the compiler folded into the build version, so a compiler
+  that lays a record out differently fails to BUILD, naming the record and the
+  field (§20.3).
 - **Validating an untrusted cook is a TOOL, not a runtime surface**:
   `schema cook-check`, over the same reflection descriptors
   (§8) the runtime already carries, checking the DATA against the ATTRIBUTION.
@@ -1977,7 +2094,8 @@ the wire, and keeps the flexibility that comes with it.
   struct's bytes behind the header: memcpy it, or point at it where it
   lies. There is no node table and no graph, and the build version is the
   whole of what `Open` checks — which is the whole of what `Open` checks
-  for any cook.
+  for any cook. **The generated `Open` reads one**, on exactly the terms above:
+  a root is any table, and this is a root.
   **It is ONE REGION OF ONE NODE and not a second shape**, and the
   attribution part names that node like any other: sixteen bytes, the root
   at offset zero. One shape is what lets `schema cook-check` bound a fixed
@@ -2232,7 +2350,7 @@ with `scene.name = "hi"`, `scene.head = A`, `A.next = B`, `A.value = 1`,
 00c0  e0 ad 84 20 6e 53 af c8   node 4: type id, Palette
 ```
 
-**The BIG-ENDIAN cook of the same structure is the same 168 bytes with every
+**The BIG-ENDIAN cook of the same structure is the same 200 bytes with every
 scalar reversed in place** — the header's words, the region's lengths, counts,
 deltas and values, and the directory's pairs — and nothing else moves: no
 offset, no size, no node order, and the same directory read in its own order.
@@ -2320,12 +2438,112 @@ every clause above by construction.
   `cook-check` through a build overlay, and the battery must go red. A checker
   whose battery has never gone red is watching nothing.
 - **THE SCALE FIXTURES**: a synthetic region generator writes a 1 MB, a 100 MB
-  and a 1 GB cook, streaming, so the open-cost gate the emitter owes — open
-  time FLAT across the three — has inputs a person regenerates rather than a
-  gigabyte in the tree. CI runs the first two under the two-minute rule; the
-  gigabyte is run by hand. **The gate itself belongs to the RUNTIME and not to
-  this tool**: `Open` is what has to be O(1), and a tool that walks a directory
-  is measuring its own scan.
+  and a 1 GB cook, streaming, so the open-cost gate — open time FLAT across the
+  three — has inputs a person regenerates rather than a gigabyte in the tree.
+  CI runs the first two under the two-minute rule; the gigabyte is run by hand.
+  **The gate itself belongs to the RUNTIME and not to this tool**: `Open` is
+  what has to be O(1), and a tool that walks a directory is measuring its own
+  scan. It is held over the C++ `Open`, below.
+
+- **THE CROSS-IMPLEMENTATION LOCK, and it is what makes two implementations of
+  one page worth having.** The tool writes a cook in Go and the C++ `Open`
+  points at it, and neither was written from the other. The lock is the
+  ATTRIBUTION part: every node the C++ side reaches by following its OWN
+  derefs, through its own record layouts, must be a node the directory names,
+  at that offset, with that type id — and the two SETS must be equal, so an
+  edge the reader stops following is as loud as one it invents. A record laid
+  out one byte differently on either side lands a deref off a directory entry
+  and the gate says which node and which type. It runs over SEVEN roots, which
+  is the shapes a region has: a pointer chain, a tree, a keyed array of
+  variable tables beside an optional, a cross-file graph through a by-value
+  variable table, a chain node as its own root, and TWO FIXED ROOTS — one region
+  of one node — of which one is pointed at and one is declared in a file with no
+  variable table of its own.
+
+  Beside it, and from the same walk: **every byte no field covers is ZERO**
+  (§7.2), checked over the slack the directory frames; and every COUNT
+  COMPANION inside its declared bound, which is pass two's own reading (§7.4)
+  done by the other implementation.
+
+- **THE VALUE CROSSING, and the FIXED class is where it lives today.** A fixed
+  table has no pointer, so it has no node table and no kind `17`, so this
+  backend's wire and the tool's are the SAME BYTES for one. The gate rides that:
+  the C++ side writes a known instance to the wire, `schema cook` cooks it —
+  reading that wire with its own model of the record's layout — and the C++
+  side opens the cook and reads the fields back. Value for value, including a
+  string's used length and the zero tail past it (§7.2). The tool's own read
+  report over a wire this backend wrote is SILENT, which is the same crossing in
+  the other direction and comes free.
+
+  **For the VARIABLE class it does not cross yet**, and the reason is §3.1's
+  backend status rather than anything about the cook: the tool writes the flat
+  node table and no backend does, so a tool-written wire's pointer fields reach
+  a generated reader as a kind it cannot skip and the decode stops. It lands
+  with that emitter work. What stands in for it meanwhile is that a value is its
+  bytes at its offset, and the directory lock pins the offsets while §20.3's
+  asserts pin the layout they come from.
+
+- **THE C++ `Open`'s OWN GATES**, on §19.5's shape and with §7's oracle rather
+  than §19's:
+
+  - **THE DIRECTED BATTERY**: one forgery per fact the enumeration names — each
+    byte of the magic, the magic byte-reversed (a cook of the other order), the
+    BLOCK form's magic, every byte-order word the magic contradicts, three
+    build versions, both reserved words, thirteen alignment words that are not
+    alignments, both part lengths long and short and saturated, a data part too
+    short to hold the root with the file's total kept exact, six truncations
+    and an extension, and every unaligned base — each refused, under ASan and
+    UBSan with `-fno-sanitize-recover=all`, over a buffer allocated at EXACTLY
+    the length claimed so a redzone sits on the next byte.
+  - **AND ONE PER FACT THE ENUMERATION DOES NOT NAME**, each of which must
+    OPEN: a reference slot with an enormous forward delta, a negative delta
+    past the base, a directory entry naming an offset outside the region.
+    **Those are `cook-check`'s refusals and not the runtime's** (§7.4), and a
+    battery that expected `Open` to catch them would be holding this code to a
+    design this page does not have. A cook is trusted input loaded from disk
+    (§7): the battery asserting that these OPEN is that ruling written as a
+    test, so a walk cannot be put back without the gate saying so.
+
+  **WHAT THE BATTERY AND THE FUZZER ARE FOR, stated because it is easy to read
+  them as a threat model and they are not one.** They harden the REFUSAL PATH.
+  `Open` runs on whatever bytes a disk hands back — including a corrupt one, a
+  truncated one, a file from a build that moved — and what these hold is that
+  refusing is CLEAN: no crash, no read past the `length` the caller passed, no
+  undefined behaviour inside the check. They do not shape the runtime, and they
+  ask `Open` to validate nothing.
+  - **THE FUZZER**, seeded, with the oracle §7 actually promises. A mutation
+    inside the HEADER must be refused, or open onto a data part that is still
+    this build's own bytes — and then the whole graph must agree with the
+    directory, exactly as the lock above requires. A mutation inside the DATA
+    PART must not change `Open`'s answer AT ALL, which is the O(1) promise
+    written as a property a fuzzer can falsify rather than as a timing. On
+    every path, opened or refused, nothing outside the length the caller passed
+    is read; and an opened cook's ROOT STORAGE is read whole, so the sanitizer
+    proves it lies inside that length rather than the oracle computing that it
+    does.
+  - **ITS TWO NEGATIVE CONTROLS**, each removing ONE clause of the check
+    through a build overlay on the emitter and requiring the battery to go RED:
+    the part-length equation, which is what refuses a truncated file, and the
+    root-fits clause, which is what refuses a data part too short to hold the
+    root. A battery that has never gone red is watching nothing.
+  - **THE O(1) GATE**: the 1 MB and the 100 MB fixture, opened the same number
+    of times, paired in one sitting, reported as medians — the bar is that the
+    two are the same time. A walk of any shape over the larger one would be
+    orders of magnitude out, so the band cannot pass one by accident. The
+    gigabyte arm is run by hand.
+  - **THE BYTE-ORDER LEG**: on the big-endian target, a cook written
+    `--byte-order big` opens NATIVELY — header, deltas and the whole graph
+    walk, with no fix-up pass anywhere — and a little-endian cook is refused by
+    the MAGIC; on this host, the mirror image.
+  - **THE ZERO-COST HALF**: a value-only unit emits no `Open`, no build-version
+    constant and no cook runtime, and its Table sources stay byte-identical to
+    the pins (§2.2).
+  - **THE DOCUMENTED SURFACE COMPILES**: USAGE's cook example is a translation
+    unit in the gate and it runs against a real cook, so the day the surface
+    moves the documentation goes red with the code rather than a release later.
+  - **AND `cl /W4 /WX` COMPILES IT**: the msvc leg generates the pointered unit
+    and compiles its header, so the cook runtime meets the estate's hard
+    requirement on every pull request (SPEC.md's Visual C++ rule).
 
 ## 8. Reflection: the view
 
@@ -3002,13 +3220,13 @@ in build version (§20.5).
   types share one symbol table (§13.1), which is what makes the generated
   surface unprefixed and collision-free — so every name a closure member
   claims is refused to everything else. A member `X` claims `X` followed by
-  each of these **25 suffixes**, and a declaration spelling one of them is
+  each of these **24 suffixes**, and a declaration spelling one of them is
   refused naming the collision:
 
   ```
   Measure  MeasureBody  Save  SaveBody  Load  LoadBody  Reset
   LoadMeasure  LoadMeasureBody  LoadBuilder  TableType  Builder
-  At  Emplace  Pack  PackMeasure  OpenWalk
+  At  Emplace  Pack  PackMeasure
   Cook  CookMeasure  Open  TableFields  TableInfo
   FromJson  ToJson  ToJsonMeasure
   ```
@@ -3020,13 +3238,21 @@ in build version (§20.5).
   here equal `tableGeneratedVerbs` exactly, because a claim the page states
   and the checker does not make is a name a user may take.
 
-  **Four of the twenty-five are claimed AHEAD of their emitter.** `Cook`,
-  `CookMeasure`, `Open` and `OpenWalk` are the cook's spellings and no backend
-  emits one: the cook is wire v2's (§7) and is not built (schema#251). The
-  claim is held while the emitter is absent, on this list's own rule — a name
-  freed now is a collision the day it lands. `<X>Root` is NOT claimed and needs
-  no claim: the builder's accessor is the member `GetRoot`, renamed for the
-  reason below, so no emitter ever spells it.
+  **`Open` IS EMITTED; two of the twenty-four are still claimed AHEAD of their
+  emitter, and `OpenWalk` was RETIRED.** The C++ table backend emits `<X>Open`
+  for every TABLE (§7) — a root is any table — so that spelling is a definition
+  now and not only a claim, and it is claimed for every closure member all the
+  same, on this list's own rule. `Cook` and `CookMeasure` are the WRITE side
+  and no backend emits one: a build that writes a cook runs the tool (§7).
+  **`OpenWalk` LEFT THIS LIST**, and it is the one entry ever removed: it named
+  wire v1's validating walk, and §7's `Open` is a header match with no walk in
+  it, so the name went with the design rather than being held for an emitter
+  nothing will write. A claim nothing needs takes a name away from every schema
+  for free, and freeing one is cheap before release and never again — the count
+  above moved with it, and a test asserts `<X>OpenWalk` is legal, because an
+  unclaimed name is invisible unless something asks for it. `<X>Root` is NOT
+  claimed and needs no claim: the builder's accessor is the member `GetRoot`,
+  renamed for the reason below, so no emitter ever spells it.
 
   **The BLOCK FORM claims nine more, and the checker claims them.** They are
   law on the same terms and for a stronger reason — every fixed table has a
@@ -3074,7 +3300,10 @@ in build version (§20.5).
     `TableKeyed` (an enum-keyed array's storage, and a keyed array occurs in
     a `type` body: this document's own `ScoreBoard` declares one),
     `TableRef`, `TableReport`, `TableWriter`, `TableReader`, `TableEnumId`,
-    `TableEnumValue` and the rest of that list. §8.2 has a table-free unit's
+    `TableEnumValue`, the COOKED form's read runtime (`TableCookOpen`,
+    `TableCookMagic`, `TableCookByteOrder`, `TableCookMaxAlign`,
+    `table_cook_read64` — §7), `BuildVersion` (§20, which both accelerators
+    carry) and the rest of that list. §8.2 has a table-free unit's
     view file DEFINING those primitives, so a unit that declares no table
     can no longer be allowed to declare their names.
 
@@ -3416,9 +3645,21 @@ are these rulings, in the owner's words:
   beside them (§7).
 - **The scale, and when its gate binds**: "We can keep the gigabyte scale
   stuff for v2, but think about it as we work now." The 1 GB open-time gate
-  belongs to the wire v2 emitter (§7, schema#251); the design constraint it
-  comes from — nothing per node at open — is what §7's `Open` is specified as,
-  a match and a point.
+  belongs to the COOK's emitter (§7, schema#251) and is held over it: the
+  design constraint it comes from — nothing per node at open — is what §7's
+  `Open` is, a match and a point, and open time is flat from a megabyte to a
+  gigabyte.
+- **What it is NOT**, and it is the name: "It's not a 'wire' protocol, it's a
+  load trusted data from tools protocol." A wire crosses a boundary between
+  builds; a cook crosses none.
+- **A cook is TRUSTED INPUT**, 2026-09-03: "OK to be clear, cooked data is
+  generally trusted and will be loaded from disk." That is what makes `Open`'s
+  checks IDENTITY checks rather than a trust boundary, and it is why there is no
+  per-node validation at load at any scale (§7).
+- **And if trust is in question, the answer is a SIGNATURE and not a walk**:
+  "If we have concerns, then we should sign it." / "We just have to load the
+  data." Integrity is one verification over the whole file before `Open`, never
+  per-node checks in the loader; banked as a named follow-on (§15).
 - **Which files earn one**: "imagine a huge data file that specifies all
   the meshes used in the game for example, or all the texture files" —
   "that would be a cook"; against "Config.bin and Assets.bin are small
@@ -4005,6 +4246,22 @@ pre-empted here.
   a catalogue is re-cooked when any table in its unit moves (§7).
   Everything about it is a decision — who declares the set, what proves two
   versions interchangeable — and none of that is decided here.
+- **A SIGNED COOK.** A cook is trusted input loaded from disk (§7), so nothing
+  in the load path asks whether it is hostile. Where integrity IS wanted, it is
+  a SIGNATURE over the whole file, verified ONCE before `Open`, and never
+  per-node checks in the loader — which is the parse the form exists to delete.
+  Owner: *"If we have concerns, then we should sign it."* / *"We just have to
+  load the data."* The library is **sodium**, and the reason is the scale this
+  form is built for: *"sodium is faster and we could be loading large data"* —
+  verification is one hash pass over the whole file.
+
+  **The cost is stated because it is the one thing a signature takes away.** A
+  pass over the whole file at load forfeits the lazy paging §7 counts as a
+  property of touching nothing at open: a mapped cook whose pages are read only
+  as they are used becomes a cook read whole, once, before the first field. If
+  that matters, the shape that keeps both is a SIGNED TABLE OF PER-CHUNK
+  HASHES — the signature covers the table, and a page verifies as it faults in.
+  Not built.
 - **Per-language backends beyond C++ and C#** (the refusal in §11 names this).
   C# came first, because the dogfood's game engine reads the same config and
   asset bytes the C++ tools write (§12), and the FIXED class is what that
@@ -5407,32 +5664,39 @@ constant. A build whose compiler lays a record out differently is meant to
 fail to BUILD, loudly, naming the type and the field; those asserts are owed
 and not yet emitted, which §20.3 states in full.
 
-**Backend status: the id and its projection are LIVE; the cook is not.**
+**Backend status: the id, its projection and both READ sides are LIVE.**
 `schema build-version` prints the id and `schema build-version --facts` prints
 the projection of §20.2, both pinned as goldens over the corpus. The C++ and
 C# BLOCK backends emit the constant and stamp it into every block's prologue
-(§19.1), and `BlockOpen` compares it. What remains owed, largest first:
+(§19.1), and `BlockOpen` compares it; `schema cook` stamps it into the cooked
+header, `schema cook-check` reads it back, and the C++ `<Root>Open` compares
+it (§7). What remains owed, largest first:
 
-1. **The constant rides in the BLOCK sources only.** §20.7 asks for one
-   beside `ProtocolId` in every backend; today the two block backends emit it
-   into `<Base>Block.h` / `<Base>Block.cs`, and the seven backends that carry
-   no table emit none. The cooked side has no constant at all.
-2. **The layout asserts cover the BLOCK CLOSURE, not every cookable record.**
-   C++ `static_assert`s each block projection's and each row type's `sizeof`,
-   `alignof` and every field `offsetof`, and C# asserts the same facts under
-   the managed model in a once-run check — but only for the records the block
-   form reaches. §20.3 commits the model to every record in the unit's table
-   closure, and a record no block reaches is asserted by neither side.
+1. **The constant rides in the BLOCK and COOK sources only.** §20.7 asks for
+   one beside `ProtocolId` in every backend; today the two block backends emit
+   it into `<Base>Block.h` / `<Base>Block.cs`, the C++ table backend emits it
+   into the `<Base>Table.h` of a unit that has a variable-length table — where
+   the cook's reader is — and the seven backends that carry no table emit none.
+   A VALUE-ONLY unit's Table sources carry no constant, which is the zero-cost
+   gate (§2.2) rather than an omission: nothing in one reads a cook.
+2. **The layout asserts cover the BLOCK CLOSURE and the COOK closure of a
+   POINTERED unit, not every cookable record.** C++ `static_assert`s each block
+   projection's and each row type's `sizeof`, `alignof` and every field
+   `offsetof`, and does the same for every record declared by a file of a unit
+   that has a variable-length table; C# asserts the block facts under the
+   managed model in a once-run check. What neither side asserts is a record in
+   a unit with NO pointer anywhere — which is exactly the unit whose header the
+   zero-cost gate holds byte-identical, so closing it and §20.3's commitment
+   are one question, and it is OPEN.
 3. **The C# check is a THROW at first use, not a build error.** §20.3 asks
    for a build error on the side that disagrees; C# has no `static_assert`,
    so the generated check runs once at type initialization and throws naming
    the type, the field, the offset it found and the offset the C++ side
    asserts. Loud and early, but not at compile time.
-4. **The COOK carries it in the TOOL and not in a runtime.** `schema cook`
-   stamps the id into the cooked header and `schema cook-check` reads it back,
-   both held to `schema build-version` by test (§7, §20.8). What is still owed
-   is the generated `Open` that checks it — no backend emits one (§7,
-   schema#251).
+4. **The COOK's WRITE side is the TOOL's alone.** `schema cook` produces a
+   cooked file and no generated runtime does: `Cook` and `CookMeasure` stay
+   claimed ahead of their emitter (§7, §11, schema#251). The read side is
+   emitted and gated.
 
 ### 20.1 What it digests
 
@@ -5728,16 +5992,21 @@ Pack = 1, Size = N)`) with generated padding and a once-run layout check
 that disagrees**, naming the type, the field, the expected offset and the one
 its compiler produced.
 
-**Those asserts are in the tree for the BLOCK CLOSURE and nowhere else.** C++
-`static_assert`s each block projection's and each row type's `sizeof`,
-`alignof` and every field `offsetof`; C# emits blittable storage with
-generated padding and asserts the same facts under the managed model in a
-once-run check that THROWS rather than failing the build, because C# has no
-`static_assert`. What neither side asserts is a record no block form reaches —
-so for those, and for the cooked path generally, this section's guarantee is
-still a specification and not a property of any build: **two builds whose ABIs
-differ there would share a build version and cook different bytes, with
-nothing to say so.** The model is not self-evidently right either — on 32-bit System V
+**Those asserts are in the tree for the BLOCK CLOSURE and for the COOK closure
+of a POINTERED unit.** C++ `static_assert`s each block projection's and each
+row type's `sizeof`, `alignof` and every field `offsetof`, and asserts the same
+three facts for every record declared by a file of a unit that has a
+variable-length table — the records a cook's region is laid out from, asserted
+in the file that DECLARES them, which is the same rule §7 gives a member's
+walk. C# emits blittable storage with generated padding and asserts the block
+facts under the managed model in a once-run check that THROWS rather than
+failing the build, because C# has no `static_assert`. What neither side asserts
+is a record in a unit with NO pointer in it — so for those this section's
+guarantee is still a specification and not a property of any build: **two
+builds whose ABIs differ there would share a build version and cook different
+bytes, with nothing to say so.** Closing it means emitting the asserts into a
+value-only unit's Table header, which moves bytes the zero-cost gate holds
+identical (§2.2), so it is one question with that gate and it is OPEN. The model is not self-evidently right either — on 32-bit System V
 `alignof(uint64_t)` is 4, not 8 — which is precisely why it is asserted rather
 than assumed, and why "it never reaches a cook" is a claim the asserts make
 true rather than one the model makes true on its own.
@@ -5853,7 +6122,7 @@ be — a finer key buys a smaller re-cook and pays for it with a second id, and
 this design has two ids in total.
 
 **The cooked header carries the build version, and `Open` is a match** — the
-six-item check §7 states, in one place, with the build version among them. On
+check §7 states, in one place, with the build version among them. On
 a match the bytes ARE what a build at this version wrote, so there is nothing
 to validate and nothing to fix up (§7). A hit in the store under the right
 tuple therefore cannot be refused by `Open`, save on a corrupt or truncated

--- a/USAGE.md
+++ b/USAGE.md
@@ -1176,28 +1176,62 @@ this side allocates: the bytes are yours, from wherever you got them.
 
 ### The cooked form: point at a file instead of parsing it
 
-*The TOOL is built and the generated runtime is not (SPEC-TABLES.md §7,
-schema#251). `schema cook`, `schema cook-check` and `schema uncook` produce,
-validate and read back cooked files today, in either byte order. The `Open` in
-the C++ below is the design you will get; a game still rides the tolerant
-wire.*
+*The TOOL and the C++ READ side are built; the C++ WRITE side is not
+(SPEC-TABLES.md §7, schema#251). `schema cook`, `schema cook-check` and
+`schema uncook` produce, validate and read back cooked files today, in either
+byte order, and the C++ backend emits `<Root>Open` for every table.
+`SceneCook` and `SceneCookMeasure` are the design you will get; today your
+tools write the cook with `schema cook` and your game opens it.*
 
-The wire is generic — it allocates, walks and parses, and any build reads any
-data. When you want a big file to start instantly, cook it: the locked region
-written verbatim behind a small header, laid out exactly as the runtime reads
-it.
+**A cook is not a wire protocol — it is a load-trusted-data-from-tools
+protocol.** A wire crosses a boundary between builds; a cook crosses none. Your
+tools write one for one build, and that build loads it off its own disk. So
+`Open`'s checks are IDENTITY checks — is this file for this build — and not a
+trust boundary, and there is no per-node validation at load, ever: a pass over a
+catalogue-scale file is the parse the whole form exists to delete. A file that
+did not come from your own pipeline is `schema cook-check`'s problem, run by a
+person, once. If you want integrity, sign the file and verify the signature
+before you open it; do not ask the loader to walk anything.
+
+The tolerant wire is generic — it allocates, walks and parses, and any build
+reads any data. When you want a big file to start instantly, cook it: the
+locked region written verbatim behind a small header, laid out exactly as the
+runtime reads it.
+
+```sh
+# your build writes the cook, beside the build that will read it
+schema cook --root Scene --in config/ --out Scene.cook .
+```
 
 ```cpp
-int64_t size = SceneCookMeasure( builder );
-SceneCook( builder, buffer, size );                  // write Scene.bin
+#include "GraphTable.h"
 
-// later, in the game — mmap it or read it, then just point:
-const Scene * scene = SceneOpen( bytes, size );
+// in the game — mmap the file or read it, then just point. Nothing is parsed,
+// nothing is allocated, and nothing is walked: this is a header match and a
+// cast, so a one-megabyte cook and a one-gigabyte cook open in the same time
+// and a mapped file's pages are touched only as you use them.
+const Scene * scene = graphdemo::SceneOpen( bytes, length );
 if ( scene == NULL )
 {
-    // wrong build, corrupt, or foreign byte order: fall back to the wire
+    // wrong build, corrupt, truncated, or a foreign byte order:
+    // fall back to a wire load, which is the path that carries every version
+    return load_from_wire();
+}
+
+// read it as it lies. A reference is one add through <T>At — the slot holds a
+// signed self-relative delta — and a null reference is a null pointer.
+printf( "%s v%d\n", scene->name, scene->version );
+for ( const ListNode * n = graphdemo::ListNodeAt( scene->head ); n != NULL;
+      n = graphdemo::ListNodeAt( n->next ) )
+{
+    printf( "  %s = %d\n", n->name, n->value );
 }
 ```
+
+`SceneOpen` takes `const void *` and a `uint64_t` length and returns
+`const Scene *` or `NULL`. The length is unsigned because every number the
+check compares comes out of the file, so all of its arithmetic is unsigned; a
+caller holding an `int64_t` from a `stat` casts once, at the call site.
 
 A cooked file is an ACCELERATOR, not an archive: it is build-locked by a
 build version that covers the schema's layout, its meaning facts and your
@@ -1205,9 +1239,11 @@ target's byte order, so it refuses the moment any of it moves and you
 regenerate it. The tolerant wire stays the format of record.
 
 `Open` checks the header and points — the magic, the byte order it
-establishes, the build version, every reserved word zero, the two part lengths
-against the size you passed, the base's alignment — and that is the whole of
-it. On a match the bytes ARE what this build wrote, so there is nothing to
+establishes, the build version, every reserved word zero, the region alignment
+the header names, the two part lengths against the length you passed, the
+root's own storage inside the data part, the base's alignment — and that is the
+whole of it. On a match the bytes ARE what this build wrote, so there is
+nothing to
 validate and nothing to fix up, and open time does not grow with the file. It
 is the only runtime entry point there is: a cook is your build's own
 accelerator, and a file that is not your build's returns NULL and you load the
@@ -1225,7 +1261,12 @@ one struct behind the header, so you memcpy it or point at it where it lies —
 no node table and no graph, and the build version is the whole of what `Open`
 checks. Its attribution part still names that one node, so `cook-check` can
 bound its string lengths and array counts, which are as forgeable in one
-struct as in a graph.
+struct as in a graph. **A root is any table**, so a fixed table has an `Open`
+like every other, and it is the same call:
+
+```cpp
+const Settings * settings = graphdemo::SettingsOpen( bytes, length );
+```
 
 **The three commands, today.** They run over the same declarations the
 compiler already read, and the input may be a wire file or the directory tree

--- a/bench/SHAPE-GATE.allow
+++ b/bench/SHAPE-GATE.allow
@@ -130,3 +130,13 @@ timing internal/baseline/file.go 1 the history entry's calendar date — a day w
 
 timing test/tables/block_gate2_main.cpp 6 gate 2's C++ half (§12.1): the per-frame write, generated against the hand-written scatter
 timing test/cs-block/src/Gate2.cs 2 gate 2's C# half (§12.1): the per-frame read, generated against the hand mirror
+
+# THE COOK's OPEN-COST GATE (SPEC-TABLES.md §7, §7.5) measures the ABSENCE of
+# work, which is why it needs a clock and why it is not a bench. `Open` is
+# O(1) in the file's size — a header match and nothing per node — and the gate
+# is that a 1 MB cook and a 100 MB cook open in the SAME time. It names no
+# shape and reads no field: the two arms are the same generated `SceneOpen`
+# over two synthetic regions, paired in one sitting and reported as medians,
+# and what a red arm would mean is that somebody put a walk back.
+
+timing test/tables/cook_main.cpp 2 the cook's open-cost gate (§7, §7.5): open time flat across 1 MB and 100 MB, paired medians — a constant-time header match, no shape named

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2696,14 +2696,18 @@ func (c *checker) addTableSymbols(add func(name, what string, pos ast.Pos), name
 // block form, every fixed table has one, and a table gains and loses the form
 // as its closure gains and loses a pointer — so a name that was free yesterday
 // must not become a collision tomorrow (§11).
-// Cook, CookMeasure, Open and OpenWalk are the COOK's spellings and no
-// backend emits them: the cook is wire v2's (SPEC-TABLES.md §7, schema#251)
-// and is not built. The claim is held while the emitter is absent, on the same
-// rule — freeing a name now is a collision the day it lands.
+// Open is the COOK's read side and the C++ table backend emits it, for every
+// TABLE, because every table cooks and any table may be a cook's root
+// (SPEC-TABLES.md §7). Cook and CookMeasure are the WRITE side and no backend
+// emits one — a build that writes a cook runs `schema cook` — and the claim is
+// held while that emitter is absent, on the same rule: freeing a name now is a
+// collision the day it lands. OpenWalk is NOT claimed: it named wire v1's
+// validating walk, and §7's Open is a header match with no walk in it, so the
+// name went with the design.
 var tableGeneratedVerbs = []string{
 	"Measure", "MeasureBody", "Save", "SaveBody", "Load", "LoadBody",
 	"Reset", "LoadMeasure", "LoadMeasureBody", "LoadBuilder", "TableType", "Builder",
-	"At", "Emplace", "Pack", "PackMeasure", "OpenWalk",
+	"At", "Emplace", "Pack", "PackMeasure",
 	"Cook", "CookMeasure", "Open", "TableFields", "TableInfo",
 	"FromJson", "ToJson", "ToJsonMeasure",
 	"Block", "BlockStorage", "BlockBegin", "BlockBytes", "BlockMaxBytes", "BlockOpen", "Counts",

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -112,8 +112,10 @@ func TestTableRefusals(t *testing.T) {
 			src: "package t\ntable Node { x int32 }\ntype NodeLoadMeasureBody { y int32 }\n"},
 		{name: "a declaration colliding with the builder load path", want: "generated TABLE-wire functions",
 			src: "package t\ntable Node { x int32 }\ntype NodeLoadBuilder { y int32 }\n"},
-		{name: "a declaration colliding with the Open bounds walk", want: "generated TABLE-wire functions",
-			src: "package t\ntable Node { x int32 }\ntype NodeOpenWalk { y int32 }\n"},
+		{name: "a declaration colliding with the cook's read side", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeOpen { y int32 }\n"},
+		{name: "a declaration colliding with the cook's write side", want: "generated TABLE-wire functions",
+			src: "package t\ntable Node { x int32 }\ntype NodeCookMeasure { y int32 }\n"},
 		{name: "a declaration colliding with the descriptor storage", want: "generated TABLE-wire functions",
 			src: "package t\ntable Node { x int32 }\ntype NodeTableInfo { y int32 }\n"},
 		{name: "a declaration colliding with the descriptor field storage", want: "generated TABLE-wire functions",
@@ -515,6 +517,19 @@ func TestCanonicalRootTableNameIsLegal(t *testing.T) {
 	}
 	if !ir.VariableTables(u)["Root"] {
 		t.Error("table Root did not derive VARIABLE-LENGTH")
+	}
+}
+
+// TestRetiredOpenWalkIsFree: `<X>OpenWalk` named wire v1's validating walk, and
+// §7's Open is a header match with NO WALK IN IT — so the name went with the
+// design and the claim went with the name (SPEC-TABLES.md §7, §11). A claim
+// nothing needs takes a name away from every schema for free, and this is the
+// one direction the claim list cannot police itself in: an unclaimed name is
+// invisible unless something asks for it.
+func TestRetiredOpenWalkIsFree(t *testing.T) {
+	u := buildUnit(t, "package t\ntable Node { x int32 }\ntype NodeOpenWalk { y int32 }\n")
+	if u.Structs["NodeOpenWalk"] == nil {
+		t.Fatal("type NodeOpenWalk did not survive checking: the retired claim is still being made")
 	}
 }
 

--- a/internal/codegen/cpptable/block.go
+++ b/internal/codegen/cpptable/block.go
@@ -35,24 +35,16 @@ import (
 // blockRuntime is the shared block runtime: emitted into every <Base>Block.h
 // behind a per-package guard, so one definition survives per translation unit
 // whatever the include order and a lone Block.h works standalone.
-func blockRuntime(pkg string, buildVersion uint64) string {
+//
+// The unit's BUILD VERSION is NOT here: both accelerators carry it (§20.6) and
+// a Block header includes the Table header beside it, so it has a guard of its
+// own and one text — buildVersionConstant, emitted by both.
+func blockRuntime(pkg string) string {
 	guard := strings.ToUpper(pkg) + "_SCHEMA_BLOCK_PRIMITIVES"
 	return `#ifndef ` + guard + `
 #define ` + guard + `
 
 namespace ` + pkg + ` {
-
-// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
-// this build produces depend on — the type wire's protocol id, every table's
-// layout keyed by wire id, every table's meaning (defaults, ranges, enum and
-// union vocabularies, keyed the same way), and the build's byte order. It is
-// the number a block carries and the number BlockOpen compares.
-//
-// There are TWO ids in the design and they are not interchangeable: the
-// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
-// what everything cooked or blocked is keyed by. A table edit moves this and
-// never the protocol id; a type edit moves both.
-inline constexpr uint64_t BuildVersion = ` + fmt.Sprintf("0x%016xull", buildVersion) + `;
 
 // ---- the block form's runtime (SPEC-TABLES.md §19) ----
 
@@ -316,7 +308,9 @@ func blockHeader(u *ir.Unit, f *ir.File, g *tableGen, formed int) []byte {
 	}
 	h.WriteString("\n")
 	if formed > 0 {
-		h.WriteString(blockRuntime(u.Package, ir.BuildVersion(u)))
+		h.WriteString(buildVersionConstant(u.Package, ir.BuildVersion(u)))
+		h.WriteString("\n")
+		h.WriteString(blockRuntime(u.Package))
 	}
 	fmt.Fprintf(&h, "\nnamespace %s {\n\n", u.Package)
 	h.WriteString(g.body.String())

--- a/internal/codegen/cpptable/cook.go
+++ b/internal/codegen/cpptable/cook.go
@@ -1,0 +1,343 @@
+// The COOKED FORM's read side in C++ (SPEC-TABLES.md §7): <Name>Open, which
+// matches a header and POINTS.
+//
+// Cooking is fundamentally an optimization, and this file is the half that
+// makes it one. A cook is the structure a build at one BUILD VERSION (§20)
+// laid out, in that build's byte order, behind a 64-byte header that
+// build-locks it. Opening it is a header match and a cast: no walk, no
+// per-node work, no fix-up pass, nothing touched but the header — which is
+// what makes open O(1) IN THE FILE'S SIZE and what lets a mapped file's pages
+// be touched only as they are used.
+//
+// THE SCALE THAT ASKS FOR IT is stated on the page as the requirement it is —
+// *"Assume we have say, 100mbs or many gigabytes of data in Assets.bin at some
+// point."* / *"We would want this to be fast :)"*. A walk of any shape
+// forfeits it, so there is none here.
+//
+// WHAT VALIDATES AN UNTRUSTED FILE IS A TOOL, not this code: `schema
+// cook-check` reads the DATA against the ATTRIBUTION over the same descriptors
+// (§7.4). The runtime keeps ONE entry point, and it either matched this
+// build's header or it returns NULL and the caller falls back to a wire load —
+// the path that carries every version.
+//
+// Nothing here is emitted for a unit of value-only tables: a cook's reader is
+// the variable-length surface's, so a pointer-free unit's <Base>Table.h is
+// byte-identical with or without this file, which is what the zero-cost gate
+// (§2.2) asks.
+package cpptable
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// buildVersionConstant is the unit's BUILD VERSION behind its OWN per-package
+// guard.
+//
+// It has a guard of its own because two generated headers define it — the cook
+// runtime below, in <Base>Table.h, and the block runtime, in <Base>Block.h —
+// and a Block header includes the Table header beside it. One guard around one
+// text is what makes "both forms carry the same id" (§20.6) a fact of the
+// build rather than a redefinition in any translation unit that uses both.
+func buildVersionConstant(pkg string, buildVersion uint64) string {
+	guard := strings.ToUpper(pkg) + "_SCHEMA_BUILD_VERSION"
+	return `#ifndef ` + guard + `
+#define ` + guard + `
+
+namespace ` + pkg + ` {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = ` + fmt.Sprintf("0x%016xull", buildVersion) + `;
+
+} // namespace ` + pkg + `
+
+#endif // ` + guard + `
+`
+}
+
+// tableCookRuntime is the cooked form's shared read runtime, guarded per
+// package like the rest of the table runtime so one definition survives any
+// include order and a lone Table.h works standalone.
+func tableCookRuntime(pkg string) string {
+	guard := strings.ToUpper(pkg) + "_SCHEMA_TABLE_COOK"
+	return `#ifndef ` + guard + `
+#define ` + guard + `
+
+namespace ` + pkg + ` {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace ` + pkg + `
+
+#endif // ` + guard + `
+`
+}
+
+// emitCookSurface emits one table's <Name>Open — the RUNTIME's only entry point
+// into a cooked file (SPEC-TABLES.md §7).
+//
+// EVERY TABLE GETS ONE. A cook's root is a table, any table: the tool's
+// `--root` names one and refuses a `type`, which is not a node and has no type
+// id, and §11 claims the spelling on every closure member for the same reason
+// the mutable-life suffixes are claimed there — a table gains and loses
+// pointers as an edit, and a name free yesterday must not become a collision
+// tomorrow. A fixed root's cook is one region of one node (§7), which is this
+// same header match and then the one record.
+func (g *tableGen) emitCookSurface(members []*ir.Struct) {
+	first := true
+	for _, st := range members {
+		if !st.IsTable {
+			continue // a `type` is not a node and cannot be a cook's root
+		}
+		if first {
+			g.pf("// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----\n\n")
+			first = false
+		}
+		g.emitCookOpen(st)
+	}
+}
+
+func (g *tableGen) emitCookOpen(st *ir.Struct) {
+	n := st.Name
+	g.pf("// %sOpen: match the header and POINT. On a match the bytes ARE what this\n", n)
+	g.pf("// build wrote, in this build's layout and this build's byte order, so there\n")
+	g.pf("// is nothing to validate and nothing to fix up and the root comes back as it\n")
+	g.pf("// lies. On ANY refusal it returns NULL and the caller falls back to a wire\n")
+	g.pf("// load, which is the path that carries every version.\n")
+	g.pf("//\n")
+	g.pf("// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one\n")
+	g.pf("// megabyte cook and a one gigabyte cook open in the same time, and a mapped\n")
+	g.pf("// file's pages are touched only as they are used. That is a property of\n")
+	g.pf("// touching nothing at open rather than a separate mechanism.\n")
+	g.pf("//\n")
+	if g.isVar(st.Name) {
+		// the deref sentence belongs to a table that HAS a reference slot; a
+		// value-only table has none, and its header should not describe one
+		g.pf("// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH %sAt: the slot holds\n", n)
+		g.pf("// the signed self-relative byte delta of §6.3, so a deref is one add and\n")
+		g.pf("// needs no base pointer, a whole region relocates by plain memcpy, and a\n")
+		g.pf("// delta of zero is null.\n")
+	} else {
+		g.pf("// %s IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second\n", n)
+		g.pf("// shape (§7): one struct behind the header, at the region's base, which is\n")
+		g.pf("// what this returns. There is no graph below it and nothing to resolve.\n")
+	}
+	g.pf("//\n")
+	g.pf("// There is ONE entry point and no tolerant twin: a build either wrote this\n")
+	g.pf("// file or it did not, and the build version is what says which. Validating a\n")
+	g.pf("// file whose provenance a person doubts is schema cook-check, offline,\n")
+	g.pf("// over the ATTRIBUTION part beside the data — a person's decision, never a\n")
+	g.pf("// parameter on a load.\n")
+	g.pf("inline const %s * %sOpen( const void * bytes, uint64_t length )\n{\n", n, n)
+	g.pf("    return (const %s *) TableCookOpen( bytes, length, (uint64_t) sizeof( %s ), (uint64_t) alignof( %s ) );\n}\n\n", n, n, n)
+}
+
+// emitCookLayoutAsserts is this backend's half of the LAYOUT CONTRACT
+// (SPEC-TABLES.md §20.3) for the COOK closure: the compiler computes each
+// record's layout from the declaration and folds it into the build version,
+// and this backend emits code asserting that ITS OWN compiler agrees. A
+// disagreement is a BUILD ERROR naming the record, the field and both offsets
+// — which is what lets the id be settled from the schema alone, before any
+// game binary exists, and what turns ABI drift from a silent refusal at open
+// into a failure at build.
+//
+// THE GENERATED STRUCT IS THE COOKED RECORD. A cooked node is this record at
+// these offsets: the region's bytes and the build version's record lines come
+// from one computation, and these asserts are what make that a property of the
+// build rather than a claim on a page.
+//
+// EVERY COOKABLE RECORD, which §20.3 commits the model to and which is every
+// record in a unit's table closure — not only the ones a block form reaches,
+// and not only the ones a pointered unit declares. They are emitted by the file
+// that DECLARES each record, which is the same rule §7 gives a member's walk:
+// per referencing file would assert one record many times, and only where
+// pointers are declared would leave a value-only file's records unasserted.
+func (g *tableGen) emitCookLayoutAsserts(members []*ir.Struct) {
+	var laid []*ir.Struct
+	for _, st := range members {
+		if ir.RecordLayout(g.unit, st) != nil {
+			laid = append(laid, st)
+		}
+	}
+	if len(laid) == 0 {
+		return
+	}
+	g.pf("// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----\n")
+	g.pf("//\n")
+	g.pf("// The compiler derived every number below from the declaration and folded it\n")
+	g.pf("// into the BUILD VERSION; these asserts are this compiler saying whether it\n")
+	g.pf("// agrees. The model is not self-evidently right — on 32-bit System V\n")
+	g.pf("// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted\n")
+	g.pf("// rather than assumed.\n")
+	for _, st := range laid {
+		ml := ir.RecordLayout(g.unit, st)
+		g.pf("static_assert( sizeof( %s ) == %d, \"%s's sizeof moved: the build version was taken over %d, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)\" );\n",
+			st.Name, ml.Size, st.Name, ml.Size)
+		g.pf("static_assert( alignof( %s ) == %d, \"%s's alignof moved: the build version was taken over %d (SPEC-TABLES.md §20.3)\" );\n",
+			st.Name, ml.Align, st.Name, ml.Align)
+		for _, fl := range ml.Fields {
+			g.pf("static_assert( offsetof( %s, %s ) == %d, \"%s's field %s moved: the build version was taken over offset %d (SPEC-TABLES.md §20.3)\" );\n",
+				st.Name, fl.Field.Name, fl.Offset, st.Name, fl.Field.Name, fl.Offset)
+		}
+	}
+	g.pf("\n")
+}

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -507,12 +507,14 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 				g.emitTableRead(st)
 			}
 			g.emitVariableSurface(members)
+			g.emitCookSurface(members)
 			g.emitRelocatabilityPreamble()
 			for _, st := range members {
 				g.pf("static_assert( std::is_trivially_copyable<%s>::value, \"%s must stay relocatable\" );\n", st.Name, st.Name)
 				g.pf("static_assert( std::is_standard_layout<%s>::value, \"%s must stay standard-layout for offsetof\" );\n", st.Name, st.Name)
 			}
 			g.pf("\n")
+			g.emitCookLayoutAsserts(members)
 			g.pf("// ---- reflection descriptors (tables only, SPEC-TABLES.md) ----\n\n")
 			for _, st := range members {
 				g.pf("inline const TableTypeInfo * %sTableType();\n", st.Name)
@@ -588,6 +590,16 @@ func Generate(u *ir.Unit) (map[string][]byte, error) {
 			h.WriteString("\n")
 			h.WriteString(tableArenaRuntime(u.Package))
 		}
+		// the COOKED FORM's read side (SPEC-TABLES.md §7) and the BUILD VERSION
+		// it matches against, in EVERY unit that declares a table: every table
+		// cooks and any table may be a cook's root, so there is no unit with
+		// tables and no cook reader. It is not pointer machinery — no arena, no
+		// builder, no reference slot — which is what keeps §2.2's question
+		// answerable with the form still emitted.
+		h.WriteString("\n")
+		h.WriteString(buildVersionConstant(u.Package, ir.BuildVersion(u)))
+		h.WriteString("\n")
+		h.WriteString(tableCookRuntime(u.Package))
 		fmt.Fprintf(&h, "\nnamespace %s {\n\n", u.Package)
 		h.WriteString(g.body.String())
 		fmt.Fprintf(&h, "} // namespace %s\n", u.Package)

--- a/internal/tablenames/tablenames.go
+++ b/internal/tablenames/tablenames.go
@@ -135,6 +135,19 @@ var registry = []Name{
 	{Name: "table_block_read64", By: Cpp, What: "the prologue read BYTEWISE"},
 	{Name: "table_block_align", By: Cpp, What: "round an offset up to an alignment"},
 
+	// the COOKED FORM's read runtime (SPEC-TABLES.md §7), emitted into
+	// <Base>Table.h of a unit that declares a variable-length table — a cook's
+	// root is one — and into no value-only unit's header at all. Claimed
+	// whenever a unit declares a table, on the same terms as the
+	// variable-length names above: a table gains and loses its cook reader as
+	// its closure gains and loses a pointer, and a name free today must not
+	// become a collision tomorrow.
+	{Name: "TableCookOpen", By: Cpp, What: "the cooked header's WHOLE check, shared by every <Name>Open"},
+	{Name: "TableCookMagic", By: Cpp, What: "the cooked header's magic, and the byte-order check with it"},
+	{Name: "TableCookByteOrder", By: Cpp, What: "this build's byte order, as a cooked header records it"},
+	{Name: "TableCookMaxAlign", By: Cpp, What: "the greatest region alignment a cooked header may name"},
+	{Name: "table_cook_read64", By: Cpp, What: "the cooked header read BYTEWISE"},
+
 	// the unit's BUILD VERSION (SPEC-TABLES.md §20): the one digest a block
 	// carries and BlockOpen compares. It is not a Table* spelling, and it is
 	// claimed here because it is a unit-level name the generated block sources

--- a/test/tables/cook_main.cpp
+++ b/test/tables/cook_main.cpp
@@ -1,0 +1,1268 @@
+/*
+    THE COOKED FORM's C++ READ SIDE, under test (SPEC-TABLES.md §7).
+
+    `schema cook` writes the file and the generated <Root>Open points at it, and
+    the two were written from the page independently: the tool in Go, this side
+    in C++, neither reading the other. That is what makes the first mode below a
+    CROSS-IMPLEMENTATION gate rather than one implementation agreeing with
+    itself. What it does NOT cross is field VALUES through the tolerant wire:
+    the tool writes §3.1's FLAT NODE TABLE and this backend still writes the
+    earlier nested form, so a tool-written wire's pointer fields reach this
+    reader as an unskippable kind and the decode stops (§3.1's backend status,
+    schema#251). The lock below needs no wire — it is the DIRECTORY, which is
+    the tool's own independent statement of where every node is and what it is.
+
+      write  <root> <wire>        a known instance of a FIXED root, to the wire,
+                                  for `schema cook` to cook
+      fixedvalues <root> <cook>   that instance read back OUT of the cook, value
+                                  for value: the VALUE crossing, which the fixed
+                                  class can have because its wire has no pointers
+      usage  <root> <cook>        USAGE.md's cook example, compiled and run, so
+                                  the documented surface goes red with the code
+      golden <root> <cook>        every node the C++ side reaches through its own
+                                  derefs is a node the cook's ATTRIBUTION part
+                                  names, at that offset, with that type id — and
+                                  the two sets are equal
+      forge  <root> <cook>        the directed battery: one edit per fact §7 says
+                                  Open checks, each refused; and one edit per
+                                  fact §7 says Open does NOT check, each opened
+      fuzz   <root> <cook>        the seeded fuzzer, oracle below (SEED=, N=)
+      time   <root> <a> <b>       open time flat across two cooks of very
+                                  different sizes: the O(1) bar (§7)
+      accept <root> <cook>        the byte-order leg: a cook of THIS build's
+      refuse <root> <cook>        order opens, one of the other order refuses
+
+    A COOK IS TRUSTED INPUT, LOADED FROM DISK (§7), so nothing here is a threat
+    model. The battery and the fuzzer HARDEN THE REFUSAL PATH: `Open` runs on
+    whatever bytes a disk hands back — corrupt, truncated, or from a build that
+    moved — and what these hold is that refusing is CLEAN. They ask `Open` to
+    validate nothing, and the forgeries that OPEN by design are that ruling
+    written as a test.
+
+    THE FUZZER'S ORACLE is shaped by what §7 actually promises, which is not
+    what a block's is (§19.2). `Open` checks the HEADER and points, and that is
+    the whole check: it reads no byte of the data part and follows no reference,
+    because validating a file whose provenance a person doubts is `schema
+    cook-check`, offline (§7.4). So:
+
+      - a mutation inside the HEADER must be REFUSED, or open onto a data part
+        that is still this build's own bytes — and then the whole graph walk
+        must agree with the directory exactly, as in `golden`;
+      - a mutation inside the DATA part must not change Open's answer AT ALL,
+        which is the O(1) promise stated as a property a fuzzer can falsify;
+      - on every path, opened or refused, nothing outside [ bytes, bytes +
+        length ) is read, which the sanitized twin is what proves — the buffer
+        is allocated at EXACTLY the length claimed, so a redzone sits on the
+        next byte;
+      - and an opened cook's ROOT STORAGE is inside the length the caller
+        passed, which the oracle reads to prove rather than computes.
+
+    Prints OK and exits 0 — no test framework, the exit code is the verdict.
+*/
+
+#include "GraphTable.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+#include <cstdarg>
+#include <ctime>
+
+// ---------------------------------------------------------------------------
+// the verdict
+// ---------------------------------------------------------------------------
+
+static char site[512];
+static volatile uint64_t sink = 0; // the oracle's reads, kept from being folded away
+
+static void describe( const char * format, ... )
+{
+    va_list args;
+    va_start( args, format );
+    vsnprintf( site, sizeof( site ), format, args );
+    va_end( args );
+}
+
+static void fail( const char * format, ... )
+{
+    fprintf( stderr, "\nFAILED: " );
+    va_list args;
+    va_start( args, format );
+    vfprintf( stderr, format, args );
+    va_end( args );
+    fprintf( stderr, "\n  site  %s\n\n", site[0] != 0 ? site : "(none)" );
+    fflush( stderr );
+    exit( 1 );
+}
+
+// A defect a SANITIZER saw: its report goes to stderr and the process dies
+// inside Open or inside the oracle's read, so nothing above ever runs. The
+// death callback is what carries the site out with it.
+#if defined( __has_feature )
+    #if __has_feature( address_sanitizer )
+        #define COOK_SANITIZED 1
+    #endif
+#endif
+#if defined( __SANITIZE_ADDRESS__ )
+    #define COOK_SANITIZED 1
+#endif
+
+#if defined( COOK_SANITIZED )
+extern "C" void __sanitizer_set_death_callback( void ( *callback )() );
+static void on_sanitizer_death()
+{
+    fprintf( stderr, "\n  a sanitizer stopped the run — its report is above\n  site  %s\n\n",
+             site[0] != 0 ? site : "(none)" );
+    fflush( stderr );
+}
+#endif
+
+static void install_death_callback()
+{
+#if defined( COOK_SANITIZED )
+    __sanitizer_set_death_callback( on_sanitizer_death );
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// the cooked file's shape, as §7.1 states it — read HERE and never by the
+// runtime
+// ---------------------------------------------------------------------------
+//
+// The header words this test reads for itself, and the ATTRIBUTION part it
+// reads as its ORACLE. Nothing that READS the structure touches the
+// attribution (§7): it is written beside the data for `schema cook-check` and,
+// here, for a gate that wants an independent statement of where every node is.
+
+static const uint64_t CookHeaderBytes = 64;
+static const uint64_t CookMagic = 0x4b4f4f434d484353ull; // "SCHMCOOK"
+
+enum HeaderWord
+{
+    WordMagic = 0,
+    WordBuildVersion = 8,
+    WordByteOrder = 16,
+    WordDataLength = 24,
+    WordAttributionLength = 32,
+    WordAlignment = 40,
+    WordReserved0 = 48,
+    WordReserved1 = 56
+};
+
+static uint64_t read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+static void write64( uint8_t * p, uint64_t v ) { memcpy( p, &v, sizeof( v ) ); }
+
+// A cooked file's own alignment rule, re-derived here rather than asked of the
+// code under test: the data part begins at align_up( 64, alignment ).
+static uint64_t data_offset_of( uint64_t alignment )
+{
+    return ( CookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+}
+
+// The node type id (SPEC-TABLES.md §3.1, §7.3): fnv1a64 over the TABLE'S NAME.
+// Written out here because the oracle must derive it from the declaration's own
+// name rather than read it back out of the file it is checking.
+static uint64_t fnv1a64( const char * s )
+{
+    uint64_t h = 0xcbf29ce484222325ull;
+    for ( ; *s != 0; s++ )
+    {
+        h ^= (uint64_t) (unsigned char) *s;
+        h *= 0x100000001b3ull;
+    }
+    return h;
+}
+
+// ---------------------------------------------------------------------------
+// the file, in a buffer of EXACTLY its bytes
+// ---------------------------------------------------------------------------
+
+struct File
+{
+    uint8_t * allocation;
+    uint8_t * base;  // allocation + lead: what Open is handed
+    uint64_t length; // what the caller claims
+
+    void destroy()
+    {
+        free( allocation );
+        allocation = NULL;
+        base = NULL;
+        length = 0;
+    }
+};
+
+static uint8_t * whole_file( const char * path, uint64_t * out_length )
+{
+    FILE * f = fopen( path, "rb" );
+    if ( f == NULL )
+        fail( "cannot open %s", path );
+    fseek( f, 0, SEEK_END );
+    const long size = ftell( f );
+    fseek( f, 0, SEEK_SET );
+    if ( size <= 0 )
+        fail( "%s is empty", path );
+    uint8_t * data = (uint8_t *) malloc( (size_t) size );
+    if ( data == NULL || fread( data, 1, (size_t) size, f ) != (size_t) size )
+        fail( "cannot read %s", path );
+    fclose( f );
+    *out_length = (uint64_t) size;
+    return data;
+}
+
+// A copy of `source`, `claim` bytes long, at a base `lead` bytes past a
+// 64-byte-aligned allocation. The allocation is EXACTLY what the caller
+// claims, so a read one byte past it lands on the sanitizer's redzone rather
+// than on a page that happens to be mapped.
+static File place( const uint8_t * source, uint64_t source_length, uint64_t claim, int lead )
+{
+    File file;
+    file.allocation = NULL;
+    file.base = NULL;
+    file.length = claim;
+    size_t want = (size_t) ( claim + (uint64_t) lead );
+    if ( want == 0 )
+        want = 1; // a zero-length request may legally return NULL
+    void * p = NULL;
+    if ( posix_memalign( &p, 64, want ) != 0 || p == NULL )
+        fail( "out of memory for a %llu-byte cook", (unsigned long long) claim );
+    file.allocation = (uint8_t *) p;
+    file.base = file.allocation + lead;
+    const uint64_t copy = claim < source_length ? claim : source_length;
+    memcpy( file.base, source, (size_t) copy );
+    if ( copy < claim )
+        memset( file.base + copy, 0, (size_t) ( claim - copy ) );
+    return file;
+}
+
+// ---------------------------------------------------------------------------
+// the roots under test
+// ---------------------------------------------------------------------------
+//
+// One entry per root a fixture is cooked at. `open` is the generated entry
+// point, `type` its descriptor — the two things the whole test is written
+// against, and neither of them knows what wrote the file.
+
+typedef const void * ( *OpenFn )( const void * bytes, uint64_t length );
+typedef const graphdemo::TableTypeInfo * ( *TypeFn )();
+
+struct Root
+{
+    const char * name;
+    OpenFn open;
+    TypeFn type;
+    uint64_t size;
+};
+
+static const void * open_scene( const void * b, uint64_t n ) { return graphdemo::SceneOpen( b, n ); }
+static const void * open_depot( const void * b, uint64_t n ) { return graphdemo::DepotOpen( b, n ); }
+static const void * open_album( const void * b, uint64_t n ) { return graphdemo::AlbumOpen( b, n ); }
+static const void * open_tree( const void * b, uint64_t n ) { return graphdemo::TreeNodeOpen( b, n ); }
+static const void * open_list( const void * b, uint64_t n ) { return graphdemo::ListNodeOpen( b, n ); }
+static const void * open_marker( const void * b, uint64_t n ) { return graphdemo::MarkerOpen( b, n ); }
+// the FIXED class: a cook of one is ONE REGION OF ONE NODE (§7), and it is the
+// same header match. Settings is a fixed table something POINTS at; Stamp is a
+// fixed table nothing points at, declared in a file with no variable table of
+// its own — the shape a file-scoped emission rule forgets.
+static const void * open_settings( const void * b, uint64_t n ) { return graphdemo::SettingsOpen( b, n ); }
+static const void * open_stamp( const void * b, uint64_t n ) { return graphdemo::StampOpen( b, n ); }
+
+static const Root roots[] = {
+    { "Scene", open_scene, graphdemo::SceneTableType, sizeof( graphdemo::Scene ) },
+    { "Depot", open_depot, graphdemo::DepotTableType, sizeof( graphdemo::Depot ) },
+    { "Album", open_album, graphdemo::AlbumTableType, sizeof( graphdemo::Album ) },
+    { "TreeNode", open_tree, graphdemo::TreeNodeTableType, sizeof( graphdemo::TreeNode ) },
+    { "ListNode", open_list, graphdemo::ListNodeTableType, sizeof( graphdemo::ListNode ) },
+    { "Marker", open_marker, graphdemo::MarkerTableType, sizeof( graphdemo::Marker ) },
+    { "Settings", open_settings, graphdemo::SettingsTableType, sizeof( graphdemo::Settings ) },
+    { "Stamp", open_stamp, graphdemo::StampTableType, sizeof( graphdemo::Stamp ) },
+};
+
+static const Root * root_named( const char * name )
+{
+    for ( size_t i = 0; i < sizeof( roots ) / sizeof( roots[0] ); i++ )
+    {
+        if ( strcmp( roots[i].name, name ) == 0 )
+            return &roots[i];
+    }
+    fail( "no root named %s is under test", name );
+    return NULL;
+}
+
+// Every table of the unit, so a directory entry's type id can be turned back
+// into the descriptor that says how big that node is. A hand list rather than a
+// generated registry, because what it must not do is come from the same place
+// the file's own type ids come from.
+static const TypeFn unit_tables[] = {
+    graphdemo::SceneTableType, graphdemo::DepotTableType, graphdemo::AlbumTableType,
+    graphdemo::LayerTableType, graphdemo::ListNodeTableType, graphdemo::TreeNodeTableType,
+    graphdemo::SettingsTableType, graphdemo::MetaTableType, graphdemo::MarkerTableType,
+    graphdemo::TallyTableType, graphdemo::StampTableType,
+};
+
+static const graphdemo::TableTypeInfo * table_with_id( uint64_t id )
+{
+    for ( size_t i = 0; i < sizeof( unit_tables ) / sizeof( unit_tables[0] ); i++ )
+    {
+        const graphdemo::TableTypeInfo * t = unit_tables[i]();
+        if ( fnv1a64( t->name ) == id )
+            return t;
+    }
+    return NULL;
+}
+
+// ---------------------------------------------------------------------------
+// THE WALK: every node the C++ side reaches, through its own derefs
+// ---------------------------------------------------------------------------
+//
+// Generic over §8's descriptors, which is the whole point of them: a pointer
+// slot is eight bytes at `offset` holding the SIGNED SELF-RELATIVE delta of
+// §6.3, so a deref is one add and needs no base pointer, and a delta of zero is
+// null. A by-value nesting — a table inside a table, an element of a bounded or
+// enum-keyed array — is not a node; it is storage inside one, and the walk
+// descends through it to reach the pointer slots inside.
+
+struct Reached
+{
+    uint64_t offset;
+    const graphdemo::TableTypeInfo * type;
+};
+
+static const int MaxReached = 1 << 20;
+static Reached * reached = NULL;
+static int num_reached = 0;
+
+static int find_reached( uint64_t offset )
+{
+    for ( int i = 0; i < num_reached; i++ )
+    {
+        if ( reached[i].offset == offset )
+            return i;
+    }
+    return -1;
+}
+
+// The number of storage slots a field has, which is what a cook writes: a
+// COUNTED array writes all N slots (§7.2), a keyed array writes E.Max + 1, and
+// a fixed array writes N. Walking all of them is what the check does too — a
+// slot past the live count holds the value-initialized element, whose pointer
+// slots are zero.
+static int64_t field_slots( const graphdemo::TableFieldInfo & f )
+{
+    if ( !f.is_array )
+        return 1;
+    return f.array_bound;
+}
+
+static void walk_storage( const uint8_t * storage, const graphdemo::TableTypeInfo * type,
+                          const uint8_t * region, uint64_t data_length, int depth );
+
+static void walk_node( uint64_t offset, const graphdemo::TableTypeInfo * type,
+                       const uint8_t * region, uint64_t data_length, int depth )
+{
+    if ( depth > 4096 )
+        fail( "the walk nested past any depth a region can hold — a cycle the deref did not close" );
+    const int at = find_reached( offset );
+    if ( at >= 0 )
+    {
+        if ( reached[at].type != type )
+            fail( "two references name the node at offset %llu as two different tables: %s and %s",
+                  (unsigned long long) offset, reached[at].type->name, type->name );
+        return; // one node, one visit: sharing and a back-reference are the same fact (§6.3)
+    }
+    if ( num_reached >= MaxReached )
+        fail( "the region holds more nodes than this test can record" );
+    if ( offset > data_length || (uint64_t) type->size > data_length - offset )
+        fail( "the node at offset %llu (%s, sizeof %u) does not fit inside the region's %llu bytes",
+              (unsigned long long) offset, type->name, type->size, (unsigned long long) data_length );
+    reached[num_reached].offset = offset;
+    reached[num_reached].type = type;
+    num_reached++;
+    walk_storage( region + offset, type, region, data_length, depth );
+}
+
+static void walk_storage( const uint8_t * storage, const graphdemo::TableTypeInfo * type,
+                          const uint8_t * region, uint64_t data_length, int depth )
+{
+    for ( int i = 0; i < type->num_fields; i++ )
+    {
+        const graphdemo::TableFieldInfo & f = type->fields[i];
+
+        // every COUNT COMPANION, against its declared bound, and a negative one
+        // refuses too — an extent is never negative, and a walker handed one
+        // indexes backwards out of the region (§7.4's pass two).
+        if ( f.counted && f.count_offset != 0xffffffffu )
+        {
+            int32_t used = 0;
+            memcpy( &used, storage + f.count_offset, sizeof( used ) );
+            if ( used < 0 || used > f.array_bound )
+                fail( "%s.%s carries a count companion of %d, outside [ 0, %d ]",
+                      type->name, f.name, used, f.array_bound );
+        }
+
+        if ( f.is_pointer )
+        {
+            int64_t delta = 0;
+            memcpy( &delta, storage + f.offset, sizeof( delta ) );
+            if ( delta == 0 )
+                continue; // NULL IN A REGION IS A DELTA OF ZERO (§6.3)
+            const uint8_t * slot = storage + f.offset;
+            const uint8_t * target = slot + delta;
+            if ( target < region || target >= region + data_length )
+                fail( "%s.%s resolves outside the region — a delta of %lld from a slot at %lld",
+                      type->name, f.name, (long long) delta, (long long) ( slot - region ) );
+            if ( f.table == NULL )
+                fail( "%s.%s is a pointer whose descriptor names no table", type->name, f.name );
+            walk_node( (uint64_t) ( target - region ), f.table, region, data_length, depth + 1 );
+            continue;
+        }
+
+        if ( f.table == NULL )
+            continue; // a scalar, a string, a `bytes`: no edge and nothing to descend
+
+        // a nested record — by value, or every slot of an array of them
+        const int64_t slots = field_slots( f );
+        for ( int64_t s = 0; s < slots; s++ )
+            walk_storage( storage + f.offset + s * (int64_t) f.elem_size, f.table, region, data_length, depth );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the directory — the ORACLE (SPEC-TABLES.md §7.1)
+// ---------------------------------------------------------------------------
+//
+// One entry per numbered node, in index order, each `offset (u64), type id
+// (u64)`, position 0 being the root at offset 0. A node's extent runs to the
+// next entry's offset and the last node's to `data_length`.
+
+struct Directory
+{
+    const uint8_t * entries;
+    uint64_t count;
+};
+
+static Directory directory_of( const uint8_t * file, uint64_t length )
+{
+    const uint64_t alignment = read64( file + WordAlignment );
+    const uint64_t data_length = read64( file + WordDataLength );
+    const uint64_t attribution = read64( file + WordAttributionLength );
+    const uint64_t offset = data_offset_of( alignment );
+    if ( attribution == 0 )
+        fail( "the fixture carries no attribution part, so there is nothing to check the walk against" );
+    if ( attribution % 16 != 0 || offset + data_length + attribution != length )
+        fail( "the fixture's own header does not frame it: %llu + %llu + %llu != %llu",
+              (unsigned long long) offset, (unsigned long long) data_length,
+              (unsigned long long) attribution, (unsigned long long) length );
+    Directory dir;
+    dir.entries = file + offset + data_length;
+    dir.count = attribution / 16;
+    return dir;
+}
+
+static uint64_t entry_offset( const Directory & dir, uint64_t i ) { return read64( dir.entries + i * 16 ); }
+static uint64_t entry_type( const Directory & dir, uint64_t i ) { return read64( dir.entries + i * 16 + 8 ); }
+
+// ---------------------------------------------------------------------------
+// mode: golden — the cross-implementation lock
+// ---------------------------------------------------------------------------
+
+static void run_walk( const Root * root, const uint8_t * region, uint64_t data_length )
+{
+    num_reached = 0;
+    walk_node( 0, root->type(), region, data_length, 0 );
+}
+
+static void mode_golden( const Root * root, const char * path )
+{
+    uint64_t length = 0;
+    uint8_t * source = whole_file( path, &length );
+    describe( "golden %s over %s", root->name, path );
+
+    File file = place( source, length, length, 0 );
+    const void * opened = root->open( file.base, file.length );
+    if ( opened == NULL )
+        fail( "the cook %s did not open — the tool wrote it and this build cannot point at it", path );
+
+    const uint64_t alignment = read64( file.base + WordAlignment );
+    const uint64_t data_length = read64( file.base + WordDataLength );
+    const uint8_t * region = file.base + data_offset_of( alignment );
+    if ( (const uint8_t *) opened != region )
+        fail( "Open returned a root that is not at the data part's base" );
+    if ( read64( file.base + WordBuildVersion ) != graphdemo::BuildVersion )
+        fail( "the cook's build version is not this build's, yet it opened" );
+    if ( read64( file.base + WordMagic ) != CookMagic )
+        fail( "the cook's magic is not the constant §7.1 states, yet it opened" );
+
+    const Directory dir = directory_of( file.base, length );
+    run_walk( root, region, data_length );
+
+    // (1) every node the walk reached is a node the directory names, at that
+    // offset, with the type id the declaration requires. This is the whole
+    // crossing: if this build laid one record out one byte differently from the
+    // build the tool computed the cook for, a deref lands off a directory entry
+    // and it is this line that says so.
+    for ( int i = 0; i < num_reached; i++ )
+    {
+        bool found = false;
+        for ( uint64_t e = 0; e < dir.count && !found; e++ )
+        {
+            if ( entry_offset( dir, e ) != reached[i].offset )
+                continue;
+            found = true;
+            const uint64_t want = fnv1a64( reached[i].type->name );
+            if ( entry_type( dir, e ) != want )
+                fail( "the walk reached offset %llu as %s, and the directory names it 0x%016llx",
+                      (unsigned long long) reached[i].offset, reached[i].type->name,
+                      (unsigned long long) entry_type( dir, e ) );
+        }
+        if ( !found )
+            fail( "the walk reached offset %llu (%s) and the directory names no node there",
+                  (unsigned long long) reached[i].offset, reached[i].type->name );
+    }
+
+    // (2) and every node the directory names was reached. A cook is produced
+    // from a wire whose node table is the pre-order from the root, so nothing
+    // in it is unreachable — an entry the walk never met means the C++ side
+    // stopped following an edge the writer wrote.
+    for ( uint64_t e = 0; e < dir.count; e++ )
+    {
+        if ( find_reached( entry_offset( dir, e ) ) < 0 )
+            fail( "the directory names a node at offset %llu (type id 0x%016llx) that the walk never reached",
+                  (unsigned long long) entry_offset( dir, e ), (unsigned long long) entry_type( dir, e ) );
+    }
+    if ( (uint64_t) num_reached != dir.count )
+        fail( "the walk reached %d nodes and the directory names %llu", num_reached, (unsigned long long) dir.count );
+
+    // (3) the directory's own shape, as §7.1 states it, checked against the
+    // descriptors: the root first at offset zero, offsets ascending, each node
+    // aligned for its own type, and each node's storage fitting before the next
+    // entry — the facts a node's EXTENT is read off, and the ones that make
+    // (1) mean what it says.
+    if ( dir.count == 0 || entry_offset( dir, 0 ) != 0 || entry_type( dir, 0 ) != fnv1a64( root->type()->name ) )
+        fail( "the directory's first entry is not the root at offset zero" );
+    for ( uint64_t e = 0; e < dir.count; e++ )
+    {
+        const graphdemo::TableTypeInfo * type = table_with_id( entry_type( dir, e ) );
+        if ( type == NULL )
+            fail( "the directory names a type id 0x%016llx no table in this unit has",
+                  (unsigned long long) entry_type( dir, e ) );
+        const uint64_t start = entry_offset( dir, e );
+        const uint64_t end = e + 1 < dir.count ? entry_offset( dir, e + 1 ) : data_length;
+        if ( e + 1 < dir.count && end <= start )
+            fail( "the directory does not ascend at entry %llu", (unsigned long long) e );
+        if ( end - start < type->size )
+            fail( "node %llu (%s) has %llu bytes before the next entry and needs %u",
+                  (unsigned long long) e, type->name, (unsigned long long) ( end - start ), type->size );
+    }
+
+    // (4) EVERY BYTE NO FIELD COVERS IS ZERO (§7.2). It is not tidiness: a
+    // cooked artifact is CONTENT-ADDRESSED by (asset hash, build version), so
+    // two cooks of one wire have to be one artifact and one uninitialized pad
+    // byte would make them two. What this side can check independently is the
+    // slack the DIRECTORY frames — the alignment padding between one node's
+    // storage and the next node's start, and the bytes between the last node
+    // and the rounded data_length.
+    for ( uint64_t e = 0; e < dir.count; e++ )
+    {
+        const graphdemo::TableTypeInfo * type = table_with_id( entry_type( dir, e ) );
+        const uint64_t used = entry_offset( dir, e ) + type->size;
+        const uint64_t next = e + 1 < dir.count ? entry_offset( dir, e + 1 ) : data_length;
+        for ( uint64_t at = used; at < next; at++ )
+        {
+            if ( region[at] != 0 )
+                fail( "the byte at region offset %llu covers no field and is 0x%02x, not zero (SPEC-TABLES.md §7.2)",
+                      (unsigned long long) at, (unsigned) region[at] );
+        }
+    }
+
+    printf( "cook golden lock: %s over %s — %d nodes, every one at the offset and type the tool's directory names, "
+            "every byte no field covers zero\n",
+            root->name, path, num_reached );
+    file.destroy();
+    free( source );
+}
+
+// ---------------------------------------------------------------------------
+// modes: write / fixedvalues — the FIXED class, and the VALUE crossing
+// ---------------------------------------------------------------------------
+//
+// A FIXED table has no pointer, so it has no node table and no kind 17: this
+// backend's wire and the tool's are the SAME BYTES for one, and that is what
+// opens the crossing the variable class cannot have yet (§3.1's backend
+// status). So:
+//
+//     this side writes a known instance to the wire  ->  `schema cook` cooks it
+//     ->  this side OPENS the cook and reads the fields back
+//
+// and the values it reads must be the values it wrote. Nothing about that goes
+// through this side twice: the bytes in between were laid out by the tool, from
+// its own reading of the wire, using its own model of the record's layout.
+
+static const int32_t SettingsQuality = 3;
+static const char * const SettingsLabel = "cooked-fixed";
+static const int32_t StampSeq = 907;
+static const char * const StampTag = "stamped";
+
+static void mode_write( const Root * root, const char * path )
+{
+    uint8_t buffer[4096];
+    int64_t size = 0;
+    if ( strcmp( root->name, "Settings" ) == 0 )
+    {
+        graphdemo::Settings settings;
+        settings.quality = SettingsQuality;
+        snprintf( settings.label, sizeof( settings.label ), "%s", SettingsLabel );
+        settings.label_length = (int32_t) strlen( SettingsLabel );
+        size = graphdemo::SettingsMeasure( settings );
+        if ( size <= 0 || size > (int64_t) sizeof( buffer ) || !graphdemo::SettingsSave( settings, buffer, size ) )
+            fail( "could not write a Settings wire" );
+    }
+    else if ( strcmp( root->name, "Stamp" ) == 0 )
+    {
+        graphdemo::Stamp stamp;
+        stamp.seq = StampSeq;
+        snprintf( stamp.tag, sizeof( stamp.tag ), "%s", StampTag );
+        stamp.tag_length = (int32_t) strlen( StampTag );
+        size = graphdemo::StampMeasure( stamp );
+        if ( size <= 0 || size > (int64_t) sizeof( buffer ) || !graphdemo::StampSave( stamp, buffer, size ) )
+            fail( "could not write a Stamp wire" );
+    }
+    else
+    {
+        fail( "the write mode covers the FIXED roots only, and was asked for %s", root->name );
+    }
+    FILE * f = fopen( path, "wb" );
+    if ( f == NULL || fwrite( buffer, 1, (size_t) size, f ) != (size_t) size )
+        fail( "cannot write %s", path );
+    fclose( f );
+    printf( "cook fixed fixture: wrote a %s wire of %lld bytes for the tool to cook\n",
+            root->name, (long long) size );
+}
+
+static void mode_fixedvalues( const Root * root, const char * path )
+{
+    uint64_t length = 0;
+    uint8_t * source = whole_file( path, &length );
+    File file = place( source, length, length, 0 );
+    describe( "fixedvalues %s over %s", root->name, path );
+
+    if ( strcmp( root->name, "Settings" ) == 0 )
+    {
+        const graphdemo::Settings * s = graphdemo::SettingsOpen( file.base, file.length );
+        if ( s == NULL )
+            fail( "the cook of a FIXED root did not open" );
+        if ( s->quality != SettingsQuality )
+            fail( "Settings.quality read back as %d, and %d was written", s->quality, SettingsQuality );
+        if ( s->label_length != (int32_t) strlen( SettingsLabel ) || strcmp( s->label, SettingsLabel ) != 0 )
+            fail( "Settings.label read back as \"%s\" (%d), and \"%s\" was written",
+                  s->label, s->label_length, SettingsLabel );
+        // EVERY BYTE NO FIELD COVERS IS ZERO (§7.2): a string's unused tail is
+        // one of the places the page names, and it is content-addressing that
+        // needs it rather than tidiness
+        for ( size_t i = strlen( SettingsLabel ) + 1; i < sizeof( s->label ); i++ )
+        {
+            if ( s->label[i] != 0 )
+                fail( "Settings.label's unused tail is not zero at %zu", i );
+        }
+    }
+    else if ( strcmp( root->name, "Stamp" ) == 0 )
+    {
+        const graphdemo::Stamp * s = graphdemo::StampOpen( file.base, file.length );
+        if ( s == NULL )
+            fail( "the cook of a FIXED root did not open" );
+        if ( s->seq != StampSeq )
+            fail( "Stamp.seq read back as %d, and %d was written", s->seq, StampSeq );
+        if ( s->tag_length != (int32_t) strlen( StampTag ) || strcmp( s->tag, StampTag ) != 0 )
+            fail( "Stamp.tag read back as \"%s\" (%d), and \"%s\" was written",
+                  s->tag, s->tag_length, StampTag );
+    }
+    else
+    {
+        fail( "the fixedvalues mode covers the FIXED roots only, and was asked for %s", root->name );
+    }
+
+    printf( "cook value lock: %s's fields survive wire -> `schema cook` -> Open, value for value, "
+            "with the tool laying out the record in between\n", root->name );
+    file.destroy();
+    free( source );
+}
+
+// ---------------------------------------------------------------------------
+// mode: usage — USAGE.md's cook example, compiled and run
+// ---------------------------------------------------------------------------
+//
+// The example a reader is handed has to be one that builds: this is that text,
+// as a translation unit, so the day the surface moves the documentation goes
+// red with the code rather than a release later.
+
+static int usage_example( const uint8_t * bytes, uint64_t length )
+{
+    // in the game — mmap the file or read it, then just point. Nothing is
+    // parsed, nothing is allocated, and nothing is walked.
+    const graphdemo::Scene * scene = graphdemo::SceneOpen( bytes, length );
+    if ( scene == NULL )
+    {
+        // wrong build, corrupt, truncated, or a foreign byte order: fall back
+        // to a wire load, which is the path that carries every version
+        return 1;
+    }
+
+    // read it as it lies. A reference is one add through <T>At — the slot holds
+    // a signed self-relative delta — and a null reference is a null pointer.
+    printf( "%s v%d\n", scene->name, scene->version );
+    int nodes = 0;
+    for ( const graphdemo::ListNode * n = graphdemo::ListNodeAt( scene->head ); n != NULL;
+          n = graphdemo::ListNodeAt( n->next ) )
+    {
+        nodes++;
+        sink += (uint64_t) n->value;
+    }
+    return nodes;
+}
+
+static void mode_usage( const Root * root, const char * path )
+{
+    if ( strcmp( root->name, "Scene" ) != 0 )
+        fail( "USAGE's example is written against Scene, and was asked for %s", root->name );
+    uint64_t length = 0;
+    uint8_t * source = whole_file( path, &length );
+    File file = place( source, length, length, 0 );
+    describe( "usage over %s", path );
+    const int nodes = usage_example( file.base, file.length );
+    if ( nodes <= 0 )
+        fail( "USAGE's example did not open the cook, or found no chain in it" );
+    printf( "cook usage example: USAGE.md's C++ compiles and runs — %d chain nodes off Scene.head\n", nodes );
+    file.destroy();
+    free( source );
+}
+
+// ---------------------------------------------------------------------------
+// mode: forge — the directed battery
+// ---------------------------------------------------------------------------
+//
+// One edit per fact §7 says Open checks, each of which must REFUSE; and one
+// edit per fact §7 says Open does NOT check, each of which must OPEN. The
+// second half is the one worth stating: a forged reference and a forged count
+// are `schema cook-check`'s refusals, not the runtime's, and a battery that
+// expected Open to catch them would be testing a design the page does not have.
+
+static int forged = 0;
+static int refused = 0;
+
+static void expect_refusal( const Root * root, const uint8_t * source, uint64_t length,
+                            uint64_t claim, int lead, uint64_t at, int width, uint64_t value,
+                            const char * what )
+{
+    File file = place( source, length, claim, lead );
+    if ( at != UINT64_MAX && at + (uint64_t) width <= claim )
+    {
+        if ( width == 8 )
+            write64( file.base + at, value );
+        else
+            memcpy( file.base + at, &value, (size_t) width );
+    }
+    describe( "%s", what );
+    forged++;
+    if ( root->open( file.base, file.length ) != NULL )
+        fail( "a forgery OPENED that §7 says Open refuses: %s", what );
+    refused++;
+    file.destroy();
+}
+
+static void expect_open( const Root * root, const uint8_t * source, uint64_t length,
+                         uint64_t at, int width, uint64_t value, const char * what )
+{
+    File file = place( source, length, length, 0 );
+    if ( at != UINT64_MAX )
+        memcpy( file.base + at, &value, (size_t) width );
+    describe( "%s", what );
+    forged++;
+    const void * opened = root->open( file.base, file.length );
+    if ( opened == NULL )
+        fail( "Open REFUSED an edit §7 says it does not check: %s", what );
+    // and it must have read nothing but the header to decide: the answer is
+    // the same as the unmutated file's, which is what O(1) means as a property
+    sink += *(const uint8_t *) opened;
+    file.destroy();
+}
+
+static void mode_forge( const Root * root, const char * path )
+{
+    uint64_t length = 0;
+    uint8_t * source = whole_file( path, &length );
+    const uint64_t alignment = read64( source + WordAlignment );
+    const uint64_t data_length = read64( source + WordDataLength );
+    const uint64_t attribution = read64( source + WordAttributionLength );
+    const uint64_t offset = data_offset_of( alignment );
+
+    // it opens unforged, so a green run is not a reader that refuses everything
+    {
+        File file = place( source, length, length, 0 );
+        describe( "the valid cook, unforged" );
+        if ( root->open( file.base, file.length ) == NULL )
+            fail( "the valid cook did not open" );
+        file.destroy();
+    }
+
+    // THE MAGIC, bytewise: every byte of it, one at a time, and the whole word
+    // byte-reversed — which is a cook of the OTHER byte order and refuses here
+    // rather than reaching a fix-up pass.
+    for ( int b = 0; b < 8; b++ )
+    {
+        uint8_t bytes8[8];
+        memcpy( bytes8, source, 8 );
+        bytes8[b] = (uint8_t) ( bytes8[b] ^ 0xff );
+        uint64_t forgedMagic = 0;
+        memcpy( &forgedMagic, bytes8, 8 );
+        expect_refusal( root, source, length, length, 0, WordMagic, 8, forgedMagic, "one byte of the magic" );
+    }
+    {
+        uint64_t swapped = 0;
+        const uint8_t * m = source;
+        uint8_t r[8];
+        for ( int i = 0; i < 8; i++ )
+            r[i] = m[7 - i];
+        memcpy( &swapped, r, 8 );
+        expect_refusal( root, source, length, length, 0, WordMagic, 8, swapped,
+                        "the magic byte-reversed: a cook of the other byte order" );
+    }
+    expect_refusal( root, source, length, length, 0, WordMagic, 8, 0x4b4c42414d484353ull,
+                    "the BLOCK form's magic: a block where a cook was written" );
+
+    // THE BYTE ORDER word, which the magic has already agreed with: a file
+    // whose magic matched and whose order word did not is corrupt, and there is
+    // no reading that recovers it.
+    for ( uint64_t v = 0; v < 4; v++ )
+    {
+        if ( v == read64( source + WordByteOrder ) )
+            continue;
+        expect_refusal( root, source, length, length, 0, WordByteOrder, 8, v, "the byte-order word" );
+    }
+
+    // THE BUILD VERSION: the sole guard between a runtime and a foreign region
+    expect_refusal( root, source, length, length, 0, WordBuildVersion, 8, 0, "a zero build version" );
+    expect_refusal( root, source, length, length, 0, WordBuildVersion, 8,
+                    graphdemo::BuildVersion ^ 1ull, "a build version one bit away from this build's" );
+    expect_refusal( root, source, length, length, 0, WordBuildVersion, 8, UINT64_MAX, "a saturated build version" );
+
+    // THE RESERVED WORDS: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it
+    expect_refusal( root, source, length, length, 0, WordReserved0, 8, 1, "the first reserved word non-zero" );
+    expect_refusal( root, source, length, length, 0, WordReserved1, 8, 1, "the second reserved word non-zero" );
+    expect_refusal( root, source, length, length, 0, WordReserved0, 8, UINT64_MAX, "the first reserved word saturated" );
+
+    // THE ALIGNMENT WORD, which the rest of the check does arithmetic with
+    static const uint64_t bad_alignments[] = { 0, 1, 2, 3, 4, 5, 6, 7, 12, 24, 128, 1ull << 63, UINT64_MAX };
+    for ( size_t i = 0; i < sizeof( bad_alignments ) / sizeof( bad_alignments[0] ); i++ )
+        expect_refusal( root, source, length, length, 0, WordAlignment, 8, bad_alignments[i],
+                        "an alignment word that is not a region's alignment" );
+
+    // THE TWO PART LENGTHS, against the length the caller passed
+    expect_refusal( root, source, length, length, 0, WordDataLength, 8, data_length + 1, "a data length one byte long" );
+    expect_refusal( root, source, length, length, 0, WordDataLength, 8, data_length - 1, "a data length one byte short" );
+    expect_refusal( root, source, length, length, 0, WordDataLength, 8, UINT64_MAX, "a saturated data length" );
+    expect_refusal( root, source, length, length, 0, WordDataLength, 8, root->size - 1,
+                    "a data part too short to hold the root, and one byte off the total too" );
+
+    // A DATA PART TOO SHORT TO HOLD THE ROOT, with the file's TOTAL kept exact
+    // so nothing but the root-fits check can refuse it. The root sits at the
+    // region's base, so a shorter data part describes a root partly outside the
+    // file, and a match-and-point reader that let this through would hand back
+    // storage the caller never gave it. It takes two words to state, which is
+    // why it is written out here rather than driven from the table above.
+    {
+        File file = place( source, length, length, 0 );
+        write64( file.base + WordDataLength, 8 );
+        write64( file.base + WordAttributionLength, length - offset - 8 );
+        describe( "a data part of eight bytes, with the attribution length made up so the total still matches" );
+        forged++;
+        if ( root->open( file.base, file.length ) != NULL )
+            fail( "a data part too short to hold the root OPENED, and its root's storage is outside the file" );
+        refused++;
+        file.destroy();
+    }
+    expect_refusal( root, source, length, length, 0, WordDataLength, 8, 0, "an empty data part" );
+    expect_refusal( root, source, length, length, 0, WordAttributionLength, 8, attribution + 1,
+                    "an attribution length one byte long" );
+    expect_refusal( root, source, length, length, 0, WordAttributionLength, 8, attribution - 1,
+                    "an attribution length one byte short" );
+    expect_refusal( root, source, length, length, 0, WordAttributionLength, 8, UINT64_MAX,
+                    "a saturated attribution length" );
+
+    // TRUNCATION AND EXTENSION are one refusal: the whole file is data_offset +
+    // data_length + attribution_length, and a size that is not exactly that
+    // refuses
+    static const uint64_t claims[] = { 0, 1, 8, 63, 64, 65 };
+    for ( size_t i = 0; i < sizeof( claims ) / sizeof( claims[0] ); i++ )
+        expect_refusal( root, source, length, claims[i], 0, UINT64_MAX, 0, 0, "a truncated file" );
+    expect_refusal( root, source, length, length - 1, 0, UINT64_MAX, 0, 0, "one byte short" );
+    expect_refusal( root, source, length, length + 1, 0, UINT64_MAX, 0, 0, "one trailing byte" );
+    expect_refusal( root, source, length, offset, 0, UINT64_MAX, 0, 0, "the header alone" );
+    expect_refusal( root, source, length, offset + data_length, 0, UINT64_MAX, 0, 0,
+                    "the data part with the attribution cut off, and the header still claiming it" );
+
+    // AN UNALIGNED BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned;
+    // one that is not is a caller's buffer this form cannot be read out of.
+    for ( int lead = 1; lead < 64; lead++ )
+    {
+        if ( ( (uint64_t) lead % alignment ) == 0 )
+            continue;
+        expect_refusal( root, source, length, length, lead, UINT64_MAX, 0, 0, "an unaligned base" );
+    }
+
+    // A NULL POINTER and a zero length, which are the caller's own two errors
+    describe( "a NULL buffer" );
+    forged++;
+    if ( root->open( NULL, length ) != NULL )
+        fail( "Open accepted a NULL buffer" );
+    refused++;
+
+    // AND THE OTHER HALF: what §7 says Open does NOT check. Each of these OPENS,
+    // because Open reads the header and points and that is the whole check —
+    // and each is a refusal `schema cook-check` owns instead (§7.4). A battery
+    // that expected Open to catch them would be holding this code to a design
+    // the page does not have, and the cost of that design is the O(1) bar.
+    if ( data_length >= offset + 8 )
+    {
+        // a reference slot pointing outside the region, and one pointing back
+        // past the base: both are deltas Open never reads
+        expect_open( root, source, length, offset + root->size - 8, 8, UINT64_MAX / 2,
+                     "a reference slot with an enormous forward delta — cook-check's refusal, not Open's" );
+        expect_open( root, source, length, offset + root->size - 8, 8, (uint64_t) -( (int64_t) offset + 4096 ),
+                     "a negative delta past the base — cook-check's refusal, not Open's" );
+    }
+    expect_open( root, source, length, offset + data_length, 8, UINT64_MAX,
+                 "a directory entry naming an offset outside the region — the attribution is not read at open" );
+
+    printf( "cook forgery battery: %s over %s — %d forgeries, %d refused, and the ones §7 hands to cook-check opened\n",
+            root->name, path, forged, refused );
+    free( source );
+}
+
+// ---------------------------------------------------------------------------
+// mode: fuzz — the seeded forgery fuzzer
+// ---------------------------------------------------------------------------
+
+struct Rng
+{
+    uint64_t state;
+    uint64_t next()
+    {
+        state += 0x9e3779b97f4a7c15ull;
+        uint64_t z = state;
+        z = ( z ^ ( z >> 30 ) ) * 0xbf58476d1ce4e5b9ull;
+        z = ( z ^ ( z >> 27 ) ) * 0x94d049bb133111ebull;
+        return z ^ ( z >> 31 );
+    }
+    uint64_t below( uint64_t n ) { return n == 0 ? 0 : next() % n; }
+};
+
+static uint64_t mix( uint64_t a, uint64_t b )
+{
+    uint64_t z = a + 0x9e3779b97f4a7c15ull * ( b + 1 );
+    z = ( z ^ ( z >> 30 ) ) * 0xbf58476d1ce4e5b9ull;
+    z = ( z ^ ( z >> 27 ) ) * 0x94d049bb133111ebull;
+    return z ^ ( z >> 31 );
+}
+
+static uint8_t * walk_scratch = NULL;
+
+static void mode_fuzz( const Root * root, const char * path, uint64_t seed, int64_t mutants )
+{
+    uint64_t length = 0;
+    uint8_t * source = whole_file( path, &length );
+    const uint64_t alignment = read64( source + WordAlignment );
+    const uint64_t data_length = read64( source + WordDataLength );
+    const uint64_t offset = data_offset_of( alignment );
+
+    int64_t opened = 0;
+    int64_t header_mutants = 0;
+    int64_t data_mutants = 0;
+
+    for ( int64_t k = 0; k < mutants; k++ )
+    {
+        Rng rng;
+        rng.state = mix( seed, (uint64_t) k );
+
+        // one of three axes, so every pass gets coverage rather than the
+        // largest one swallowing the budget
+        const uint64_t axis = rng.below( 3 );
+        uint64_t claim = length;
+        int lead = 0;
+        if ( axis == 2 )
+        {
+            claim = rng.below( length + 65 );
+            if ( rng.below( 4 ) == 0 )
+                lead = 1 + (int) rng.below( 63 );
+        }
+
+        File file = place( source, length, claim, lead );
+
+        bool header_touched = ( axis != 2 ) || claim != length || lead != 0;
+        if ( axis == 0 )
+        {
+            // the HEADER: a boundary value into one of its words, or a byte flip
+            const uint64_t word = rng.below( 8 ) * 8;
+            static const uint64_t values[] = { 0, 1, 2, 3, 7, 8, 15, 16, 63, 64, 65,
+                                               0x7fffffffull, 0x80000000ull, 0xffffffffull,
+                                               1ull << 62, 1ull << 63, UINT64_MAX - 1, UINT64_MAX };
+            if ( word + 8 <= claim )
+            {
+                if ( rng.below( 2 ) == 0 )
+                    write64( file.base + word, values[ rng.below( sizeof( values ) / sizeof( values[0] ) ) ] );
+                else
+                    file.base[ word + rng.below( 8 ) ] ^= (uint8_t) ( 1u << rng.below( 8 ) );
+            }
+            header_mutants++;
+        }
+        else if ( axis == 1 && claim > offset )
+        {
+            // the DATA part: Open's answer must not move, because Open reads no
+            // byte of it. This is the O(1) promise as a property, not a timing.
+            const uint64_t at = offset + rng.below( claim - offset );
+            file.base[at] ^= (uint8_t) ( 1u << rng.below( 8 ) );
+            header_touched = false;
+            data_mutants++;
+        }
+
+        describe( "fuzz %s seed=%llu k=%lld axis=%llu claim=%llu lead=%d",
+                  root->name, (unsigned long long) seed, (long long) k,
+                  (unsigned long long) axis, (unsigned long long) claim, lead );
+
+        const void * result = root->open( file.base, file.length );
+
+        if ( !header_touched )
+        {
+            // untouched header, untouched framing: the answer is the answer the
+            // unmutated file gets, whatever the data part now holds
+            if ( result == NULL )
+                fail( "a mutation INSIDE THE DATA PART changed Open's answer — Open read a byte it must not" );
+        }
+
+        if ( result != NULL )
+        {
+            opened++;
+            // and what it handed back is inside what the caller passed: the
+            // root's whole storage, actually READ, so the sanitized twin proves
+            // it to the byte rather than to the page
+            const uint8_t * base = (const uint8_t *) result;
+            if ( base < file.base || base + root->size > file.base + file.length )
+                fail( "an opened cook's root storage leaves the length the caller passed" );
+            memcpy( walk_scratch, base, (size_t) root->size );
+            sink += walk_scratch[0] + walk_scratch[root->size - 1];
+
+            if ( axis == 0 && claim == length && lead == 0 )
+            {
+                // a HEADER mutation that opened: the data part is still this
+                // build's own bytes, so the whole graph must still agree with
+                // the directory, exactly as in the golden mode
+                const uint64_t opened_alignment = read64( file.base + WordAlignment );
+                const uint64_t opened_data = read64( file.base + WordDataLength );
+                if ( opened_alignment == alignment && opened_data == data_length )
+                    run_walk( root, file.base + offset, data_length );
+            }
+        }
+
+        file.destroy();
+    }
+
+    printf( "cook forgery fuzzer: %s over %s — %lld mutants (%lld header, %lld data), %lld opened, "
+            "none read past the length the caller passed (SPEC-TABLES.md §7, §7.5)\n",
+            root->name, path, (long long) mutants, (long long) header_mutants,
+            (long long) data_mutants, (long long) opened );
+    free( source );
+}
+
+// ---------------------------------------------------------------------------
+// mode: time — the O(1) bar
+// ---------------------------------------------------------------------------
+//
+// `Open` is O(1) IN THE FILE'S SIZE: the header match and nothing per node. The
+// instrument is two cooks whose sizes differ by two orders of magnitude, opened
+// the same number of times, PAIRED in one sitting and reported as medians —
+// the estate's usual shape, because a mean over a scheduler is not a number.
+
+static int compare_double( const void * a, const void * b )
+{
+    const double x = *(const double *) a;
+    const double y = *(const double *) b;
+    return x < y ? -1 : ( x > y ? 1 : 0 );
+}
+
+static double median_open_ns( const Root * root, const File & file, int64_t iterations )
+{
+    static const int runs = 9;
+    double samples[runs];
+    for ( int r = 0; r < runs; r++ )
+    {
+        struct timespec start, end;
+        clock_gettime( CLOCK_MONOTONIC, &start );
+        for ( int64_t i = 0; i < iterations; i++ )
+        {
+            const void * p = root->open( file.base, file.length );
+            sink += (uint64_t) ( p != NULL );
+        }
+        clock_gettime( CLOCK_MONOTONIC, &end );
+        const double ns = ( (double) ( end.tv_sec - start.tv_sec ) * 1e9 + (double) ( end.tv_nsec - start.tv_nsec ) )
+                          / (double) iterations;
+        samples[r] = ns;
+    }
+    qsort( samples, runs, sizeof( samples[0] ), compare_double );
+    return samples[runs / 2];
+}
+
+static void mode_time( const Root * root, const char * small_path, const char * large_path )
+{
+    uint64_t small_length = 0, large_length = 0;
+    uint8_t * small_source = whole_file( small_path, &small_length );
+    uint8_t * large_source = whole_file( large_path, &large_length );
+    File small_file = place( small_source, small_length, small_length, 0 );
+    File large_file = place( large_source, large_length, large_length, 0 );
+    describe( "time %s over %s and %s", root->name, small_path, large_path );
+
+    if ( root->open( small_file.base, small_file.length ) == NULL ||
+         root->open( large_file.base, large_file.length ) == NULL )
+        fail( "one of the two fixtures did not open" );
+
+    const int64_t iterations = 200000;
+    // warm both, then interleave: two arms measured in one sitting, alternating,
+    // so a machine that drifts drifts under both
+    median_open_ns( root, small_file, iterations / 10 );
+    median_open_ns( root, large_file, iterations / 10 );
+    const double small_ns = median_open_ns( root, small_file, iterations );
+    const double large_ns = median_open_ns( root, large_file, iterations );
+
+    const double ratio = large_ns / small_ns;
+    printf( "cook open is O(1) in the file's size: %s at %llu bytes opens in %.1f ns, at %llu bytes in %.1f ns "
+            "(medians of 9 x %lld, paired, one sitting) — ratio %.3f\n",
+            root->name, (unsigned long long) small_length, small_ns,
+            (unsigned long long) large_length, large_ns, (long long) iterations, ratio );
+
+    // The bar is FLAT, and flat is stated as a band rather than as equality: a
+    // header match is tens of nanoseconds, where the scheduler and the cache
+    // are the whole variance. A walk of any shape over a hundred-megabyte
+    // region would be five orders of magnitude out, so this band cannot pass
+    // one by accident.
+    if ( ratio > 2.0 || ratio < 0.5 )
+        fail( "open time is not flat across the two sizes: ratio %.3f", ratio );
+
+    small_file.destroy();
+    large_file.destroy();
+    free( small_source );
+    free( large_source );
+}
+
+// ---------------------------------------------------------------------------
+// modes: accept / refuse — the byte-order leg
+// ---------------------------------------------------------------------------
+
+static void mode_order( const Root * root, const char * path, bool expect_accept )
+{
+    uint64_t length = 0;
+    uint8_t * source = whole_file( path, &length );
+    File file = place( source, length, length, 0 );
+    describe( "%s %s over %s", expect_accept ? "accept" : "refuse", root->name, path );
+    const void * opened = root->open( file.base, file.length );
+    if ( expect_accept )
+    {
+        if ( opened == NULL )
+            fail( "a cook produced for THIS build's byte order did not open" );
+        // and the order word says which order wrote it, so a tool dumping the
+        // file reads the fact rather than deducing it from a constant
+        const uint64_t order = read64( file.base + WordByteOrder );
+        if ( order != 1 && order != 2 )
+            fail( "the byte-order word is %llu", (unsigned long long) order );
+        printf( "cook byte-order leg: a cook written in this build's order (%s) opens natively\n",
+                order == 1 ? "little" : "big" );
+    }
+    else
+    {
+        if ( opened != NULL )
+            fail( "a cook of the OTHER byte order opened — the magic is what refuses it" );
+        printf( "cook byte-order leg: a cook of the other byte order is refused by the MAGIC, read bytewise\n" );
+    }
+    file.destroy();
+    free( source );
+}
+
+// ---------------------------------------------------------------------------
+
+int main( int argc, char ** argv )
+{
+    install_death_callback();
+    reached = (Reached *) malloc( sizeof( Reached ) * MaxReached );
+    walk_scratch = (uint8_t *) malloc( 4096 );
+    if ( reached == NULL || walk_scratch == NULL )
+    {
+        printf( "FAILED: out of memory\n" );
+        return 1;
+    }
+
+    if ( argc < 4 )
+    {
+        printf( "usage: %s golden|write|fixedvalues|usage|forge|fuzz|time|accept|refuse <root> <file> [file]\n", argv[0] );
+        return 1;
+    }
+    const char * mode = argv[1];
+    const Root * root = root_named( argv[2] );
+
+    if ( strcmp( mode, "golden" ) == 0 )
+    {
+        mode_golden( root, argv[3] );
+    }
+    else if ( strcmp( mode, "write" ) == 0 )
+    {
+        mode_write( root, argv[3] );
+    }
+    else if ( strcmp( mode, "fixedvalues" ) == 0 )
+    {
+        mode_fixedvalues( root, argv[3] );
+    }
+    else if ( strcmp( mode, "usage" ) == 0 )
+    {
+        mode_usage( root, argv[3] );
+    }
+    else if ( strcmp( mode, "forge" ) == 0 )
+    {
+        mode_forge( root, argv[3] );
+    }
+    else if ( strcmp( mode, "fuzz" ) == 0 )
+    {
+        uint64_t seed = 0xc00c1e5eedull;
+        int64_t mutants = 20000;
+        if ( const char * e = getenv( "SEED" ) )
+            if ( *e != 0 ) seed = strtoull( e, NULL, 0 );
+        if ( const char * e = getenv( "N" ) )
+            if ( *e != 0 ) mutants = strtoll( e, NULL, 0 );
+        mode_fuzz( root, argv[3], seed, mutants );
+    }
+    else if ( strcmp( mode, "time" ) == 0 )
+    {
+        if ( argc < 5 ) { printf( "FAILED: time wants two cooks\n" ); return 1; }
+        mode_time( root, argv[3], argv[4] );
+    }
+    else if ( strcmp( mode, "accept" ) == 0 )
+    {
+        mode_order( root, argv[3], true );
+    }
+    else if ( strcmp( mode, "refuse" ) == 0 )
+    {
+        mode_order( root, argv[3], false );
+    }
+    else
+    {
+        printf( "FAILED: unknown mode %s\n", mode );
+        return 1;
+    }
+
+    printf( "OK\n" );
+    return 0;
+}

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -295,6 +295,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // BLOCKDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef BLOCKDEMO_SCHEMA_BUILD_VERSION
+#define BLOCKDEMO_SCHEMA_BUILD_VERSION
+
+namespace blockdemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0xb34bc386659d9873ull;
+
+} // namespace blockdemo
+
+#endif // BLOCKDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef BLOCKDEMO_SCHEMA_TABLE_COOK
+#define BLOCKDEMO_SCHEMA_TABLE_COOK
+
+namespace blockdemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace blockdemo
+
+#endif // BLOCKDEMO_SCHEMA_TABLE_COOK
+
 namespace blockdemo {
 
 // table PaddedRow — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -923,6 +1103,58 @@ inline bool PaddedFrameLoad( PaddedFrame & value, const uint8_t * buffer, int64_
     return PaddedFrameLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// PaddedRowOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// PaddedRow IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const PaddedRow * PaddedRowOpen( const void * bytes, uint64_t length )
+{
+    return (const PaddedRow *) TableCookOpen( bytes, length, (uint64_t) sizeof( PaddedRow ), (uint64_t) alignof( PaddedRow ) );
+}
+
+// PaddedFrameOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// PaddedFrame IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const PaddedFrame * PaddedFrameOpen( const void * bytes, uint64_t length )
+{
+    return (const PaddedFrame *) TableCookOpen( bytes, length, (uint64_t) sizeof( PaddedFrame ), (uint64_t) alignof( PaddedFrame ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -933,6 +1165,30 @@ static_assert( std::is_trivially_copyable<PaddedRow>::value, "PaddedRow must sta
 static_assert( std::is_standard_layout<PaddedRow>::value, "PaddedRow must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<PaddedFrame>::value, "PaddedFrame must stay relocatable" );
 static_assert( std::is_standard_layout<PaddedFrame>::value, "PaddedFrame must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( PaddedRow ) == 72, "PaddedRow's sizeof moved: the build version was taken over 72, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( PaddedRow ) == 8, "PaddedRow's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, tag ) == 0, "PaddedRow's field tag moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, value ) == 8, "PaddedRow's field value moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, flag ) == 16, "PaddedRow's field flag moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, id ) == 20, "PaddedRow's field id moved: the build version was taken over offset 20 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, label ) == 24, "PaddedRow's field label moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, slots ) == 44, "PaddedRow's field slots moved: the build version was taken over offset 44 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, teams ) == 52, "PaddedRow's field teams moved: the build version was taken over offset 52 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedRow, counter ) == 60, "PaddedRow's field counter moved: the build version was taken over offset 60 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( PaddedFrame ) == 4648, "PaddedFrame's sizeof moved: the build version was taken over 4648, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( PaddedFrame ) == 8, "PaddedFrame's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedFrame, marker ) == 0, "PaddedFrame's field marker moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedFrame, stamp ) == 8, "PaddedFrame's field stamp moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedFrame, rows ) == 16, "PaddedFrame's field rows moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PaddedFrame, blob ) == 4628, "PaddedFrame's field blob moved: the build version was taken over offset 4628 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -294,6 +294,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // BLOCKDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef BLOCKDEMO_SCHEMA_BUILD_VERSION
+#define BLOCKDEMO_SCHEMA_BUILD_VERSION
+
+namespace blockdemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0xb34bc386659d9873ull;
+
+} // namespace blockdemo
+
+#endif // BLOCKDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef BLOCKDEMO_SCHEMA_TABLE_COOK
+#define BLOCKDEMO_SCHEMA_TABLE_COOK
+
+namespace blockdemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace blockdemo
+
+#endif // BLOCKDEMO_SCHEMA_TABLE_COOK
+
 namespace blockdemo {
 
 // table RenderCamera — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -3854,6 +4034,258 @@ inline bool RenderQuaternionLoad( RenderQuaternion & value, const uint8_t * buff
     return RenderQuaternionLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// RenderCameraOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderCamera IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderCamera * RenderCameraOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderCamera *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderCamera ), (uint64_t) alignof( RenderCamera ) );
+}
+
+// RenderShipOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderShip IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderShip * RenderShipOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderShip *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderShip ), (uint64_t) alignof( RenderShip ) );
+}
+
+// RenderTurretOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderTurret IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderTurret * RenderTurretOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderTurret *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderTurret ), (uint64_t) alignof( RenderTurret ) );
+}
+
+// RenderMissileOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderMissile IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderMissile * RenderMissileOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderMissile *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderMissile ), (uint64_t) alignof( RenderMissile ) );
+}
+
+// RenderDynamicPropOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderDynamicProp IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderDynamicProp * RenderDynamicPropOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderDynamicProp *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderDynamicProp ), (uint64_t) alignof( RenderDynamicProp ) );
+}
+
+// RenderStaticPropOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderStaticProp IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderStaticProp * RenderStaticPropOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderStaticProp *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderStaticProp ), (uint64_t) alignof( RenderStaticProp ) );
+}
+
+// RenderCosmeticPropOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderCosmeticProp IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderCosmeticProp * RenderCosmeticPropOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderCosmeticProp *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderCosmeticProp ), (uint64_t) alignof( RenderCosmeticProp ) );
+}
+
+// RenderLaserOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderLaser IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderLaser * RenderLaserOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderLaser *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderLaser ), (uint64_t) alignof( RenderLaser ) );
+}
+
+// RenderExplosionOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderExplosion IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderExplosion * RenderExplosionOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderExplosion *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderExplosion ), (uint64_t) alignof( RenderExplosion ) );
+}
+
+// RenderFrameOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RenderFrame IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RenderFrame * RenderFrameOpen( const void * bytes, uint64_t length )
+{
+    return (const RenderFrame *) TableCookOpen( bytes, length, (uint64_t) sizeof( RenderFrame ), (uint64_t) alignof( RenderFrame ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -3884,6 +4316,123 @@ static_assert( std::is_trivially_copyable<RenderVector3>::value, "RenderVector3 
 static_assert( std::is_standard_layout<RenderVector3>::value, "RenderVector3 must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<RenderQuaternion>::value, "RenderQuaternion must stay relocatable" );
 static_assert( std::is_standard_layout<RenderQuaternion>::value, "RenderQuaternion must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( RenderCamera ) == 72, "RenderCamera's sizeof moved: the build version was taken over 72, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderCamera ) == 8, "RenderCamera's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCamera, position ) == 0, "RenderCamera's field position moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCamera, rotation ) == 24, "RenderCamera's field rotation moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCamera, camera_id ) == 56, "RenderCamera's field camera_id moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCamera, camera_type ) == 60, "RenderCamera's field camera_type moved: the build version was taken over offset 60 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCamera, target_object_id ) == 64, "RenderCamera's field target_object_id moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCamera, fov ) == 68, "RenderCamera's field fov moved: the build version was taken over offset 68 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderShip ) == 88, "RenderShip's sizeof moved: the build version was taken over 88, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderShip ) == 8, "RenderShip's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, position ) == 0, "RenderShip's field position moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, rotation ) == 24, "RenderShip's field rotation moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, flags ) == 56, "RenderShip's field flags moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, object_id ) == 64, "RenderShip's field object_id moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, target_object_id ) == 68, "RenderShip's field target_object_id moved: the build version was taken over offset 68 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, thrust ) == 72, "RenderShip's field thrust moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, object_sequence ) == 76, "RenderShip's field object_sequence moved: the build version was taken over offset 76 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, ship_type ) == 77, "RenderShip's field ship_type moved: the build version was taken over offset 77 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, team ) == 78, "RenderShip's field team moved: the build version was taken over offset 78 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, has_target_lock ) == 79, "RenderShip's field has_target_lock moved: the build version was taken over offset 79 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderShip, predicted_explode ) == 80, "RenderShip's field predicted_explode moved: the build version was taken over offset 80 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderTurret ) == 64, "RenderTurret's sizeof moved: the build version was taken over 64, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderTurret ) == 8, "RenderTurret's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, rotation ) == 0, "RenderTurret's field rotation moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, flags ) == 32, "RenderTurret's field flags moved: the build version was taken over offset 32 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, object_id ) == 40, "RenderTurret's field object_id moved: the build version was taken over offset 40 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, parent_object_id ) == 44, "RenderTurret's field parent_object_id moved: the build version was taken over offset 44 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, turret_index ) == 48, "RenderTurret's field turret_index moved: the build version was taken over offset 48 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, target_object_id ) == 52, "RenderTurret's field target_object_id moved: the build version was taken over offset 52 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, object_sequence ) == 56, "RenderTurret's field object_sequence moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, team ) == 57, "RenderTurret's field team moved: the build version was taken over offset 57 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderTurret, has_target_lock ) == 58, "RenderTurret's field has_target_lock moved: the build version was taken over offset 58 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderMissile ) == 72, "RenderMissile's sizeof moved: the build version was taken over 72, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderMissile ) == 8, "RenderMissile's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderMissile, position ) == 0, "RenderMissile's field position moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderMissile, rotation ) == 24, "RenderMissile's field rotation moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderMissile, flags ) == 56, "RenderMissile's field flags moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderMissile, object_id ) == 64, "RenderMissile's field object_id moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderMissile, object_sequence ) == 68, "RenderMissile's field object_sequence moved: the build version was taken over offset 68 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderMissile, missile_type ) == 69, "RenderMissile's field missile_type moved: the build version was taken over offset 69 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderMissile, team ) == 70, "RenderMissile's field team moved: the build version was taken over offset 70 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderDynamicProp ) == 72, "RenderDynamicProp's sizeof moved: the build version was taken over 72, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderDynamicProp ) == 8, "RenderDynamicProp's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderDynamicProp, position ) == 0, "RenderDynamicProp's field position moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderDynamicProp, rotation ) == 24, "RenderDynamicProp's field rotation moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderDynamicProp, flags ) == 56, "RenderDynamicProp's field flags moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderDynamicProp, object_id ) == 64, "RenderDynamicProp's field object_id moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderDynamicProp, object_sequence ) == 68, "RenderDynamicProp's field object_sequence moved: the build version was taken over offset 68 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderDynamicProp, prop_type ) == 69, "RenderDynamicProp's field prop_type moved: the build version was taken over offset 69 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderDynamicProp, team ) == 70, "RenderDynamicProp's field team moved: the build version was taken over offset 70 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderStaticProp ) == 80, "RenderStaticProp's sizeof moved: the build version was taken over 80, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderStaticProp ) == 8, "RenderStaticProp's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderStaticProp, position ) == 0, "RenderStaticProp's field position moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderStaticProp, rotation ) == 24, "RenderStaticProp's field rotation moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderStaticProp, scale ) == 56, "RenderStaticProp's field scale moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderStaticProp, flags ) == 64, "RenderStaticProp's field flags moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderStaticProp, static_prop_id ) == 72, "RenderStaticProp's field static_prop_id moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderStaticProp, prop_type ) == 76, "RenderStaticProp's field prop_type moved: the build version was taken over offset 76 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderStaticProp, team ) == 77, "RenderStaticProp's field team moved: the build version was taken over offset 77 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderCosmeticProp ) == 80, "RenderCosmeticProp's sizeof moved: the build version was taken over 80, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderCosmeticProp ) == 8, "RenderCosmeticProp's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, position ) == 0, "RenderCosmeticProp's field position moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, rotation ) == 24, "RenderCosmeticProp's field rotation moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, scale ) == 56, "RenderCosmeticProp's field scale moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, flags ) == 64, "RenderCosmeticProp's field flags moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, cosmetic_prop_id ) == 72, "RenderCosmeticProp's field cosmetic_prop_id moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, prop_sequence ) == 76, "RenderCosmeticProp's field prop_sequence moved: the build version was taken over offset 76 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, prop_type ) == 77, "RenderCosmeticProp's field prop_type moved: the build version was taken over offset 77 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderCosmeticProp, team ) == 78, "RenderCosmeticProp's field team moved: the build version was taken over offset 78 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderLaser ) == 64, "RenderLaser's sizeof moved: the build version was taken over 64, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderLaser ) == 8, "RenderLaser's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderLaser, start ) == 0, "RenderLaser's field start moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderLaser, finish ) == 24, "RenderLaser's field finish moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderLaser, t ) == 48, "RenderLaser's field t moved: the build version was taken over offset 48 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderLaser, laser_id ) == 56, "RenderLaser's field laser_id moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderLaser, laser_type ) == 60, "RenderLaser's field laser_type moved: the build version was taken over offset 60 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderLaser, team ) == 61, "RenderLaser's field team moved: the build version was taken over offset 61 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderExplosion ) == 80, "RenderExplosion's sizeof moved: the build version was taken over 80, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderExplosion ) == 8, "RenderExplosion's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderExplosion, position ) == 0, "RenderExplosion's field position moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderExplosion, rotation ) == 24, "RenderExplosion's field rotation moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderExplosion, t ) == 56, "RenderExplosion's field t moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderExplosion, explosion_id ) == 64, "RenderExplosion's field explosion_id moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderExplosion, parent_object_id ) == 68, "RenderExplosion's field parent_object_id moved: the build version was taken over offset 68 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderExplosion, explosion_type ) == 72, "RenderExplosion's field explosion_type moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderExplosion, team ) == 73, "RenderExplosion's field team moved: the build version was taken over offset 73 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderFrame ) == 7879320, "RenderFrame's sizeof moved: the build version was taken over 7879320, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderFrame ) == 8, "RenderFrame's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, version ) == 0, "RenderFrame's field version moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, cameras ) == 8, "RenderFrame's field cameras moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, ships ) == 88, "RenderFrame's field ships moved: the build version was taken over offset 88 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, turrets ) == 360544, "RenderFrame's field turrets moved: the build version was taken over offset 360544 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, missiles ) == 426088, "RenderFrame's field missiles moved: the build version was taken over offset 426088 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, dynamic_props ) == 721008, "RenderFrame's field dynamic_props moved: the build version was taken over offset 721008 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, static_props ) == 1015928, "RenderFrame's field static_props moved: the build version was taken over offset 1015928 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, cosmetic_props ) == 2615936, "RenderFrame's field cosmetic_props moved: the build version was taken over offset 2615936 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, lasers ) == 3271304, "RenderFrame's field lasers moved: the build version was taken over offset 3271304 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderFrame, explosions ) == 5319312, "RenderFrame's field explosions moved: the build version was taken over offset 5319312 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderVector3 ) == 24, "RenderVector3's sizeof moved: the build version was taken over 24, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderVector3 ) == 8, "RenderVector3's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderVector3, x ) == 0, "RenderVector3's field x moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderVector3, y ) == 8, "RenderVector3's field y moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderVector3, z ) == 16, "RenderVector3's field z moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RenderQuaternion ) == 32, "RenderQuaternion's sizeof moved: the build version was taken over 32, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RenderQuaternion ) == 8, "RenderQuaternion's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderQuaternion, x ) == 0, "RenderQuaternion's field x moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderQuaternion, y ) == 8, "RenderQuaternion's field y moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderQuaternion, z ) == 16, "RenderQuaternion's field z moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RenderQuaternion, w ) == 24, "RenderQuaternion's field w moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/blockhome/ConstantsTable.h
+++ b/testdata/golden/tables/blockhome/ConstantsTable.h
@@ -209,6 +209,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef BLOCKHOME_SCHEMA_BUILD_VERSION
+#define BLOCKHOME_SCHEMA_BUILD_VERSION
+
+namespace blockhome {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x3de2d055d5640b6aull;
+
+} // namespace blockhome
+
+#endif // BLOCKHOME_SCHEMA_BUILD_VERSION
+
+#ifndef BLOCKHOME_SCHEMA_TABLE_COOK
+#define BLOCKHOME_SCHEMA_TABLE_COOK
+
+namespace blockhome {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace blockhome
+
+#endif // BLOCKHOME_SCHEMA_TABLE_COOK
+
 namespace blockhome {
 
 // no tables declared or referenced in this file — codecs are emitted

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -209,6 +209,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef BLOCKHOME_SCHEMA_BUILD_VERSION
+#define BLOCKHOME_SCHEMA_BUILD_VERSION
+
+namespace blockhome {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x3de2d055d5640b6aull;
+
+} // namespace blockhome
+
+#endif // BLOCKHOME_SCHEMA_BUILD_VERSION
+
+#ifndef BLOCKHOME_SCHEMA_TABLE_COOK
+#define BLOCKHOME_SCHEMA_TABLE_COOK
+
+namespace blockhome {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace blockhome
+
+#endif // BLOCKHOME_SCHEMA_TABLE_COOK
+
 namespace blockhome {
 
 // ---- prefill: the declared defaults, in place (SPEC-TABLES.md) ----
@@ -818,6 +998,35 @@ static_assert( std::is_trivially_copyable<FiringGroup>::value, "FiringGroup must
 static_assert( std::is_standard_layout<FiringGroup>::value, "FiringGroup must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<GunnerSettings>::value, "GunnerSettings must stay relocatable" );
 static_assert( std::is_standard_layout<GunnerSettings>::value, "GunnerSettings must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( ArmorPlate ) == 16, "ArmorPlate's sizeof moved: the build version was taken over 16, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( ArmorPlate ) == 8, "ArmorPlate's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArmorPlate, thickness ) == 0, "ArmorPlate's field thickness moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArmorPlate, material ) == 8, "ArmorPlate's field material moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArmorPlate, layer ) == 12, "ArmorPlate's field layer moved: the build version was taken over offset 12 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( ArmorConfig ) == 40, "ArmorConfig's sizeof moved: the build version was taken over 40, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( ArmorConfig ) == 8, "ArmorConfig's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArmorConfig, front ) == 0, "ArmorConfig's field front moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArmorConfig, rear ) == 16, "ArmorConfig's field rear moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArmorConfig, rating ) == 32, "ArmorConfig's field rating moved: the build version was taken over offset 32 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArmorConfig, tier ) == 36, "ArmorConfig's field tier moved: the build version was taken over offset 36 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( FiringGroup ) == 8, "FiringGroup's sizeof moved: the build version was taken over 8, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( FiringGroup ) == 4, "FiringGroup's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( FiringGroup, barrel ) == 0, "FiringGroup's field barrel moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( FiringGroup, cooldown ) == 4, "FiringGroup's field cooldown moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( GunnerSettings ) == 304, "GunnerSettings's sizeof moved: the build version was taken over 304, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( GunnerSettings ) == 4, "GunnerSettings's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerSettings, firing_groups ) == 0, "GunnerSettings's field firing_groups moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerSettings, missile_groups ) == 260, "GunnerSettings's field missile_groups moved: the build version was taken over offset 260 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerSettings, reload_seconds ) == 296, "GunnerSettings's field reload_seconds moved: the build version was taken over offset 296 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerSettings, gunner_id ) == 300, "GunnerSettings's field gunner_id moved: the build version was taken over offset 300 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -210,6 +210,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef BLOCKHOME_SCHEMA_BUILD_VERSION
+#define BLOCKHOME_SCHEMA_BUILD_VERSION
+
+namespace blockhome {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x3de2d055d5640b6aull;
+
+} // namespace blockhome
+
+#endif // BLOCKHOME_SCHEMA_BUILD_VERSION
+
+#ifndef BLOCKHOME_SCHEMA_TABLE_COOK
+#define BLOCKHOME_SCHEMA_TABLE_COOK
+
+namespace blockhome {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace blockhome
+
+#endif // BLOCKHOME_SCHEMA_TABLE_COOK
+
 namespace blockhome {
 
 // table PartRow — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -547,6 +727,58 @@ inline bool PartFrameLoad( PartFrame & value, const uint8_t * buffer, int64_t by
     return PartFrameLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// PartRowOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// PartRow IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const PartRow * PartRowOpen( const void * bytes, uint64_t length )
+{
+    return (const PartRow *) TableCookOpen( bytes, length, (uint64_t) sizeof( PartRow ), (uint64_t) alignof( PartRow ) );
+}
+
+// PartFrameOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// PartFrame IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const PartFrame * PartFrameOpen( const void * bytes, uint64_t length )
+{
+    return (const PartFrame *) TableCookOpen( bytes, length, (uint64_t) sizeof( PartFrame ), (uint64_t) alignof( PartFrame ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -557,6 +789,24 @@ static_assert( std::is_trivially_copyable<PartRow>::value, "PartRow must stay re
 static_assert( std::is_standard_layout<PartRow>::value, "PartRow must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<PartFrame>::value, "PartFrame must stay relocatable" );
 static_assert( std::is_standard_layout<PartFrame>::value, "PartFrame must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( PartRow ) == 352, "PartRow's sizeof moved: the build version was taken over 352, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( PartRow ) == 8, "PartRow's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PartRow, armor ) == 0, "PartRow's field armor moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PartRow, gunner ) == 40, "PartRow's field gunner moved: the build version was taken over offset 40 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PartRow, part_id ) == 344, "PartRow's field part_id moved: the build version was taken over offset 344 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PartRow, slot ) == 348, "PartRow's field slot moved: the build version was taken over offset 348 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( PartFrame ) == 11280, "PartFrame's sizeof moved: the build version was taken over 11280, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( PartFrame ) == 8, "PartFrame's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PartFrame, version ) == 0, "PartFrame's field version moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PartFrame, parts ) == 8, "PartFrame's field parts moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -294,6 +294,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef TABLEDEMO_SCHEMA_BUILD_VERSION
+#define TABLEDEMO_SCHEMA_BUILD_VERSION
+
+namespace tabledemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x324fda67cd7d76efull;
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef TABLEDEMO_SCHEMA_TABLE_COOK
+#define TABLEDEMO_SCHEMA_TABLE_COOK
+
+namespace tabledemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_TABLE_COOK
+
 namespace tabledemo {
 
 // table Patrol — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -540,6 +720,33 @@ inline bool PatrolLoad( Patrol & value, const uint8_t * buffer, int64_t bytes, T
     return PatrolLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// PatrolOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// Patrol IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Patrol * PatrolOpen( const void * bytes, uint64_t length )
+{
+    return (const Patrol *) TableCookOpen( bytes, length, (uint64_t) sizeof( Patrol ), (uint64_t) alignof( Patrol ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -548,6 +755,22 @@ inline bool PatrolLoad( Patrol & value, const uint8_t * buffer, int64_t bytes, T
 // non-trivial member crept into generated storage.
 static_assert( std::is_trivially_copyable<Patrol>::value, "Patrol must stay relocatable" );
 static_assert( std::is_standard_layout<Patrol>::value, "Patrol must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( Patrol ) == 36, "Patrol's sizeof moved: the build version was taken over 36, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Patrol ) == 4, "Patrol's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Patrol, active ) == 0, "Patrol's field active moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Patrol, speed ) == 4, "Patrol's field speed moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Patrol, has_target ) == 8, "Patrol's field has_target moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Patrol, target_id ) == 12, "Patrol's field target_id moved: the build version was taken over offset 12 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Patrol, wander ) == 16, "Patrol's field wander moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Patrol, note ) == 20, "Patrol's field note moved: the build version was taken over offset 20 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -294,6 +294,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef TABLEDEMO_SCHEMA_BUILD_VERSION
+#define TABLEDEMO_SCHEMA_BUILD_VERSION
+
+namespace tabledemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x324fda67cd7d76efull;
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef TABLEDEMO_SCHEMA_TABLE_COOK
+#define TABLEDEMO_SCHEMA_TABLE_COOK
+
+namespace tabledemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_TABLE_COOK
+
 namespace tabledemo {
 
 // table TeamConfig — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -1410,6 +1590,133 @@ inline bool ScoreBoardLoad( ScoreBoard & value, const uint8_t * buffer, int64_t 
     return ScoreBoardLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// TeamConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// TeamConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const TeamConfig * TeamConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const TeamConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( TeamConfig ), (uint64_t) alignof( TeamConfig ) );
+}
+
+// GunnerConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// GunnerConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const GunnerConfig * GunnerConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const GunnerConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( GunnerConfig ), (uint64_t) alignof( GunnerConfig ) );
+}
+
+// TurretConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// TurretConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const TurretConfig * TurretConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const TurretConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( TurretConfig ), (uint64_t) alignof( TurretConfig ) );
+}
+
+// HullConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// HullConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const HullConfig * HullConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const HullConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( HullConfig ), (uint64_t) alignof( HullConfig ) );
+}
+
+// KeyedConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// KeyedConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const KeyedConfig * KeyedConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const KeyedConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( KeyedConfig ), (uint64_t) alignof( KeyedConfig ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -1428,6 +1735,40 @@ static_assert( std::is_trivially_copyable<KeyedConfig>::value, "KeyedConfig must
 static_assert( std::is_standard_layout<KeyedConfig>::value, "KeyedConfig must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<ScoreBoard>::value, "ScoreBoard must stay relocatable" );
 static_assert( std::is_standard_layout<ScoreBoard>::value, "ScoreBoard must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( TeamConfig ) == 28, "TeamConfig's sizeof moved: the build version was taken over 28, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( TeamConfig ) == 4, "TeamConfig's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TeamConfig, spawn_count ) == 0, "TeamConfig's field spawn_count moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TeamConfig, banner ) == 4, "TeamConfig's field banner moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( GunnerConfig ) == 8, "GunnerConfig's sizeof moved: the build version was taken over 8, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( GunnerConfig ) == 4, "GunnerConfig's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerConfig, reaction ) == 0, "GunnerConfig's field reaction moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerConfig, tracking ) == 4, "GunnerConfig's field tracking moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( TurretConfig ) == 20, "TurretConfig's sizeof moved: the build version was taken over 20, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( TurretConfig ) == 4, "TurretConfig's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TurretConfig, damage ) == 0, "TurretConfig's field damage moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TurretConfig, cooldown ) == 4, "TurretConfig's field cooldown moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TurretConfig, gunner ) == 8, "TurretConfig's field gunner moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( HullConfig ) == 88, "HullConfig's sizeof moved: the build version was taken over 88, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( HullConfig ) == 4, "HullConfig's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( HullConfig, health ) == 0, "HullConfig's field health moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( HullConfig, mass ) == 4, "HullConfig's field mass moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( HullConfig, turrets ) == 8, "HullConfig's field turrets moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( KeyedConfig ) == 480, "KeyedConfig's sizeof moved: the build version was taken over 480, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( KeyedConfig ) == 4, "KeyedConfig's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( KeyedConfig, teams ) == 0, "KeyedConfig's field teams moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( KeyedConfig, hulls ) == 112, "KeyedConfig's field hulls moved: the build version was taken over offset 112 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( KeyedConfig, scores ) == 464, "KeyedConfig's field scores moved: the build version was taken over offset 464 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( ScoreBoard ) == 16, "ScoreBoard's sizeof moved: the build version was taken over 16, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( ScoreBoard ) == 4, "ScoreBoard's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ScoreBoard, per_team ) == 0, "ScoreBoard's field per_team moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/examples/NestedTable.h
+++ b/testdata/golden/tables/examples/NestedTable.h
@@ -295,6 +295,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef TABLEDEMO_SCHEMA_BUILD_VERSION
+#define TABLEDEMO_SCHEMA_BUILD_VERSION
+
+namespace tabledemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x324fda67cd7d76efull;
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef TABLEDEMO_SCHEMA_TABLE_COOK
+#define TABLEDEMO_SCHEMA_TABLE_COOK
+
+namespace tabledemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_TABLE_COOK
+
 namespace tabledemo {
 
 // table ArchiveConfig — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -422,6 +602,33 @@ inline bool ArchiveConfigLoad( ArchiveConfig & value, const uint8_t * buffer, in
     return ArchiveConfigLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// ArchiveConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// ArchiveConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const ArchiveConfig * ArchiveConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const ArchiveConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( ArchiveConfig ), (uint64_t) alignof( ArchiveConfig ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -430,6 +637,18 @@ inline bool ArchiveConfigLoad( ArchiveConfig & value, const uint8_t * buffer, in
 // non-trivial member crept into generated storage.
 static_assert( std::is_trivially_copyable<ArchiveConfig>::value, "ArchiveConfig must stay relocatable" );
 static_assert( std::is_standard_layout<ArchiveConfig>::value, "ArchiveConfig must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( ArchiveConfig ) == 1488, "ArchiveConfig's sizeof moved: the build version was taken over 1488, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( ArchiveConfig ) == 8, "ArchiveConfig's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArchiveConfig, root ) == 0, "ArchiveConfig's field root moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ArchiveConfig, count ) == 1480, "ArchiveConfig's field count moved: the build version was taken over offset 1480 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -294,6 +294,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef TABLEDEMO_SCHEMA_BUILD_VERSION
+#define TABLEDEMO_SCHEMA_BUILD_VERSION
+
+namespace tabledemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x324fda67cd7d76efull;
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef TABLEDEMO_SCHEMA_TABLE_COOK
+#define TABLEDEMO_SCHEMA_TABLE_COOK
+
+namespace tabledemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_TABLE_COOK
+
 namespace tabledemo {
 
 // table GunnerSettings — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -1329,6 +1509,108 @@ inline bool PackConfigLoad( PackConfig & value, const uint8_t * buffer, int64_t 
     return PackConfigLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// GunnerSettingsOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// GunnerSettings IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const GunnerSettings * GunnerSettingsOpen( const void * bytes, uint64_t length )
+{
+    return (const GunnerSettings *) TableCookOpen( bytes, length, (uint64_t) sizeof( GunnerSettings ), (uint64_t) alignof( GunnerSettings ) );
+}
+
+// ShipEntryOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// ShipEntry IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const ShipEntry * ShipEntryOpen( const void * bytes, uint64_t length )
+{
+    return (const ShipEntry *) TableCookOpen( bytes, length, (uint64_t) sizeof( ShipEntry ), (uint64_t) alignof( ShipEntry ) );
+}
+
+// GlobalSettingsOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// GlobalSettings IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const GlobalSettings * GlobalSettingsOpen( const void * bytes, uint64_t length )
+{
+    return (const GlobalSettings *) TableCookOpen( bytes, length, (uint64_t) sizeof( GlobalSettings ), (uint64_t) alignof( GlobalSettings ) );
+}
+
+// PackConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// PackConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const PackConfig * PackConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const PackConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( PackConfig ), (uint64_t) alignof( PackConfig ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -1343,6 +1625,39 @@ static_assert( std::is_trivially_copyable<GlobalSettings>::value, "GlobalSetting
 static_assert( std::is_standard_layout<GlobalSettings>::value, "GlobalSettings must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<PackConfig>::value, "PackConfig must stay relocatable" );
 static_assert( std::is_standard_layout<PackConfig>::value, "PackConfig must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( GunnerSettings ) == 36, "GunnerSettings's sizeof moved: the build version was taken over 36, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( GunnerSettings ) == 4, "GunnerSettings's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerSettings, reaction ) == 0, "GunnerSettings's field reaction moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerSettings, tracking ) == 4, "GunnerSettings's field tracking moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GunnerSettings, callsign ) == 5, "GunnerSettings's field callsign moved: the build version was taken over offset 5 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( ShipEntry ) == 108, "ShipEntry's sizeof moved: the build version was taken over 108, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( ShipEntry ) == 4, "ShipEntry's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ShipEntry, display_name ) == 0, "ShipEntry's field display_name moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ShipEntry, health ) == 40, "ShipEntry's field health moved: the build version was taken over offset 40 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ShipEntry, mass ) == 44, "ShipEntry's field mass moved: the build version was taken over offset 44 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ShipEntry, hardpoints ) == 48, "ShipEntry's field hardpoints moved: the build version was taken over offset 48 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ShipEntry, gunner ) == 68, "ShipEntry's field gunner moved: the build version was taken over offset 68 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( GlobalSettings ) == 72, "GlobalSettings's sizeof moved: the build version was taken over 72, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( GlobalSettings ) == 4, "GlobalSettings's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GlobalSettings, tick_rate ) == 0, "GlobalSettings's field tick_rate moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GlobalSettings, difficulty ) == 4, "GlobalSettings's field difficulty moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GlobalSettings, build_note ) == 5, "GlobalSettings's field build_note moved: the build version was taken over offset 5 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( GlobalSettings, spawn_delays ) == 60, "GlobalSettings's field spawn_delays moved: the build version was taken over offset 60 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( PackConfig ) == 852, "PackConfig's sizeof moved: the build version was taken over 852, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( PackConfig ) == 4, "PackConfig's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PackConfig, version ) == 0, "PackConfig's field version moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PackConfig, global ) == 4, "PackConfig's field global moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PackConfig, ships ) == 76, "PackConfig's field ships moved: the build version was taken over offset 76 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PackConfig, thresholds ) == 508, "PackConfig's field thresholds moved: the build version was taken over offset 508 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( PackConfig, reserves ) == 524, "PackConfig's field reserves moved: the build version was taken over offset 524 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -294,6 +294,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef TABLEDEMO_SCHEMA_BUILD_VERSION
+#define TABLEDEMO_SCHEMA_BUILD_VERSION
+
+namespace tabledemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x324fda67cd7d76efull;
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef TABLEDEMO_SCHEMA_TABLE_COOK
+#define TABLEDEMO_SCHEMA_TABLE_COOK
+
+namespace tabledemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_TABLE_COOK
+
 namespace tabledemo {
 
 // table WeaponConfig — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -1929,6 +2109,108 @@ inline bool DebuffLoad( Debuff & value, const uint8_t * buffer, int64_t bytes, T
     return DebuffLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// WeaponConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// WeaponConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const WeaponConfig * WeaponConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const WeaponConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( WeaponConfig ), (uint64_t) alignof( WeaponConfig ) );
+}
+
+// LoadoutConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// LoadoutConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const LoadoutConfig * LoadoutConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const LoadoutConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( LoadoutConfig ), (uint64_t) alignof( LoadoutConfig ) );
+}
+
+// ProfileConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// ProfileConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const ProfileConfig * ProfileConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const ProfileConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( ProfileConfig ), (uint64_t) alignof( ProfileConfig ) );
+}
+
+// RootConfigOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// RootConfig IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const RootConfig * RootConfigOpen( const void * bytes, uint64_t length )
+{
+    return (const RootConfig *) TableCookOpen( bytes, length, (uint64_t) sizeof( RootConfig ), (uint64_t) alignof( RootConfig ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -1949,6 +2231,61 @@ static_assert( std::is_trivially_copyable<Buff>::value, "Buff must stay relocata
 static_assert( std::is_standard_layout<Buff>::value, "Buff must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<Debuff>::value, "Debuff must stay relocatable" );
 static_assert( std::is_standard_layout<Debuff>::value, "Debuff must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( WeaponConfig ) == 28, "WeaponConfig's sizeof moved: the build version was taken over 28, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( WeaponConfig ) == 4, "WeaponConfig's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WeaponConfig, damage ) == 0, "WeaponConfig's field damage moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WeaponConfig, speed ) == 4, "WeaponConfig's field speed moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WeaponConfig, penetration ) == 8, "WeaponConfig's field penetration moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WeaponConfig, channel ) == 12, "WeaponConfig's field channel moved: the build version was taken over offset 12 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WeaponConfig, homing ) == 16, "WeaponConfig's field homing moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WeaponConfig, effect ) == 20, "WeaponConfig's field effect moved: the build version was taken over offset 20 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( LoadoutConfig ) == 176, "LoadoutConfig's sizeof moved: the build version was taken over 176, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( LoadoutConfig ) == 8, "LoadoutConfig's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( LoadoutConfig, grade ) == 0, "LoadoutConfig's field grade moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( LoadoutConfig, grades ) == 1, "LoadoutConfig's field grades moved: the build version was taken over offset 1 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( LoadoutConfig, podium ) == 12, "LoadoutConfig's field podium moved: the build version was taken over offset 12 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( LoadoutConfig, perks ) == 16, "LoadoutConfig's field perks moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( LoadoutConfig, primary ) == 24, "LoadoutConfig's field primary moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( LoadoutConfig, backups ) == 52, "LoadoutConfig's field backups moved: the build version was taken over offset 52 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( LoadoutConfig, attachments ) == 108, "LoadoutConfig's field attachments moved: the build version was taken over offset 108 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( ProfileConfig ) == 304, "ProfileConfig's sizeof moved: the build version was taken over 304, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( ProfileConfig ) == 8, "ProfileConfig's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, name ) == 0, "ProfileConfig's field name moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, icon ) == 40, "ProfileConfig's field icon moved: the build version was taken over offset 40 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, experience ) == 60, "ProfileConfig's field experience moved: the build version was taken over offset 60 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, tilt ) == 64, "ProfileConfig's field tilt moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, heading ) == 66, "ProfileConfig's field heading moved: the build version was taken over offset 66 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, timestamp ) == 72, "ProfileConfig's field timestamp moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, badge ) == 80, "ProfileConfig's field badge moved: the build version was taken over offset 80 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, port ) == 82, "ProfileConfig's field port moved: the build version was taken over offset 82 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, epoch ) == 88, "ProfileConfig's field epoch moved: the build version was taken over offset 88 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, precision ) == 96, "ProfileConfig's field precision moved: the build version was taken over offset 96 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, ratings ) == 104, "ProfileConfig's field ratings moved: the build version was taken over offset 104 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, has_loadout ) == 120, "ProfileConfig's field has_loadout moved: the build version was taken over offset 120 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ProfileConfig, loadout ) == 128, "ProfileConfig's field loadout moved: the build version was taken over offset 128 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( RootConfig ) == 1480, "RootConfig's sizeof moved: the build version was taken over 1480, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( RootConfig ) == 8, "RootConfig's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RootConfig, version_note ) == 0, "RootConfig's field version_note moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RootConfig, weapons ) == 24, "RootConfig's field weapons moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( RootConfig, profiles ) == 256, "RootConfig's field profiles moved: the build version was taken over offset 256 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Attachment ) == 8, "Attachment's sizeof moved: the build version was taken over 8, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Attachment ) == 4, "Attachment's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Attachment, slot ) == 0, "Attachment's field slot moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Attachment, power ) == 4, "Attachment's field power moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Buff ) == 4, "Buff's sizeof moved: the build version was taken over 4, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Buff ) == 4, "Buff's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Buff, multiplier ) == 0, "Buff's field multiplier moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Debuff ) == 4, "Debuff's sizeof moved: the build version was taken over 4, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Debuff ) == 4, "Debuff's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Debuff, amount ) == 0, "Debuff's field amount moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -294,6 +294,186 @@ inline uint64_t table_double_to_bits( double d ) { uint64_t b; memcpy( &b, &d, 8
 
 #endif // TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+#ifndef TABLEDEMO_SCHEMA_BUILD_VERSION
+#define TABLEDEMO_SCHEMA_BUILD_VERSION
+
+namespace tabledemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x324fda67cd7d76efull;
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef TABLEDEMO_SCHEMA_TABLE_COOK
+#define TABLEDEMO_SCHEMA_TABLE_COOK
+
+namespace tabledemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace tabledemo
+
+#endif // TABLEDEMO_SCHEMA_TABLE_COOK
+
 namespace tabledemo {
 
 // table WideBlob — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -504,6 +684,33 @@ inline bool WideBlobLoad( WideBlob & value, const uint8_t * buffer, int64_t byte
     return WideBlobLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// WideBlobOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// WideBlob IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const WideBlob * WideBlobOpen( const void * bytes, uint64_t length )
+{
+    return (const WideBlob *) TableCookOpen( bytes, length, (uint64_t) sizeof( WideBlob ), (uint64_t) alignof( WideBlob ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -512,6 +719,19 @@ inline bool WideBlobLoad( WideBlob & value, const uint8_t * buffer, int64_t byte
 // non-trivial member crept into generated storage.
 static_assert( std::is_trivially_copyable<WideBlob>::value, "WideBlob must stay relocatable" );
 static_assert( std::is_standard_layout<WideBlob>::value, "WideBlob must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( WideBlob ) == 280016, "WideBlob's sizeof moved: the build version was taken over 280016, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( WideBlob ) == 4, "WideBlob's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WideBlob, label ) == 0, "WideBlob's field label moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WideBlob, payload ) == 70008, "WideBlob's field payload moved: the build version was taken over offset 70008 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( WideBlob, samples ) == 140012, "WideBlob's field samples moved: the build version was taken over offset 140012 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -529,6 +529,186 @@ struct TableRegionSink
 
 #endif // GRAPHDEMO_SCHEMA_TABLE_ARENA
 
+#ifndef GRAPHDEMO_SCHEMA_BUILD_VERSION
+#define GRAPHDEMO_SCHEMA_BUILD_VERSION
+
+namespace graphdemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x7970dae87b5cf43aull;
+
+} // namespace graphdemo
+
+#endif // GRAPHDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef GRAPHDEMO_SCHEMA_TABLE_COOK
+#define GRAPHDEMO_SCHEMA_TABLE_COOK
+
+namespace graphdemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace graphdemo
+
+#endif // GRAPHDEMO_SCHEMA_TABLE_COOK
+
 namespace graphdemo {
 
 // table Meta — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -4308,6 +4488,214 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire, int6
     return AlbumLoadBody( r, builder.main, *root, 1 );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// MetaOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// Meta IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Meta * MetaOpen( const void * bytes, uint64_t length )
+{
+    return (const Meta *) TableCookOpen( bytes, length, (uint64_t) sizeof( Meta ), (uint64_t) alignof( Meta ) );
+}
+
+// SettingsOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// Settings IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Settings * SettingsOpen( const void * bytes, uint64_t length )
+{
+    return (const Settings *) TableCookOpen( bytes, length, (uint64_t) sizeof( Settings ), (uint64_t) alignof( Settings ) );
+}
+
+// ListNodeOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH ListNodeAt: the slot holds
+// the signed self-relative byte delta of §6.3, so a deref is one add and
+// needs no base pointer, a whole region relocates by plain memcpy, and a
+// delta of zero is null.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const ListNode * ListNodeOpen( const void * bytes, uint64_t length )
+{
+    return (const ListNode *) TableCookOpen( bytes, length, (uint64_t) sizeof( ListNode ), (uint64_t) alignof( ListNode ) );
+}
+
+// TreeNodeOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH TreeNodeAt: the slot holds
+// the signed self-relative byte delta of §6.3, so a deref is one add and
+// needs no base pointer, a whole region relocates by plain memcpy, and a
+// delta of zero is null.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const TreeNode * TreeNodeOpen( const void * bytes, uint64_t length )
+{
+    return (const TreeNode *) TableCookOpen( bytes, length, (uint64_t) sizeof( TreeNode ), (uint64_t) alignof( TreeNode ) );
+}
+
+// LayerOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH LayerAt: the slot holds
+// the signed self-relative byte delta of §6.3, so a deref is one add and
+// needs no base pointer, a whole region relocates by plain memcpy, and a
+// delta of zero is null.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Layer * LayerOpen( const void * bytes, uint64_t length )
+{
+    return (const Layer *) TableCookOpen( bytes, length, (uint64_t) sizeof( Layer ), (uint64_t) alignof( Layer ) );
+}
+
+// SceneOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH SceneAt: the slot holds
+// the signed self-relative byte delta of §6.3, so a deref is one add and
+// needs no base pointer, a whole region relocates by plain memcpy, and a
+// delta of zero is null.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Scene * SceneOpen( const void * bytes, uint64_t length )
+{
+    return (const Scene *) TableCookOpen( bytes, length, (uint64_t) sizeof( Scene ), (uint64_t) alignof( Scene ) );
+}
+
+// DepotOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH DepotAt: the slot holds
+// the signed self-relative byte delta of §6.3, so a deref is one add and
+// needs no base pointer, a whole region relocates by plain memcpy, and a
+// delta of zero is null.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Depot * DepotOpen( const void * bytes, uint64_t length )
+{
+    return (const Depot *) TableCookOpen( bytes, length, (uint64_t) sizeof( Depot ), (uint64_t) alignof( Depot ) );
+}
+
+// AlbumOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH AlbumAt: the slot holds
+// the signed self-relative byte delta of §6.3, so a deref is one add and
+// needs no base pointer, a whole region relocates by plain memcpy, and a
+// delta of zero is null.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Album * AlbumOpen( const void * bytes, uint64_t length )
+{
+    return (const Album *) TableCookOpen( bytes, length, (uint64_t) sizeof( Album ), (uint64_t) alignof( Album ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -4334,6 +4722,61 @@ static_assert( std::is_trivially_copyable<Depot>::value, "Depot must stay reloca
 static_assert( std::is_standard_layout<Depot>::value, "Depot must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<Album>::value, "Album must stay relocatable" );
 static_assert( std::is_standard_layout<Album>::value, "Album must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( Meta ) == 20, "Meta's sizeof moved: the build version was taken over 20, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Meta ) == 4, "Meta's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Meta, build ) == 0, "Meta's field build moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Meta, tag ) == 4, "Meta's field tag moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Settings ) == 28, "Settings's sizeof moved: the build version was taken over 28, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Settings ) == 4, "Settings's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Settings, quality ) == 0, "Settings's field quality moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Settings, label ) == 4, "Settings's field label moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( ListNode ) == 32, "ListNode's sizeof moved: the build version was taken over 32, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( ListNode ) == 8, "ListNode's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ListNode, value ) == 0, "ListNode's field value moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ListNode, name ) == 4, "ListNode's field name moved: the build version was taken over offset 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( ListNode, next ) == 24, "ListNode's field next moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( TreeNode ) == 40, "TreeNode's sizeof moved: the build version was taken over 40, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( TreeNode ) == 8, "TreeNode's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TreeNode, label ) == 0, "TreeNode's field label moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TreeNode, left ) == 24, "TreeNode's field left moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( TreeNode, right ) == 32, "TreeNode's field right moved: the build version was taken over offset 32 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Layer ) == 16, "Layer's sizeof moved: the build version was taken over 16, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Layer ) == 8, "Layer's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Layer, depth ) == 0, "Layer's field depth moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Layer, head ) == 8, "Layer's field head moved: the build version was taken over offset 8 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Scene ) == 176, "Scene's sizeof moved: the build version was taken over 176, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Scene ) == 8, "Scene's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, name ) == 0, "Scene's field name moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, version ) == 32, "Scene's field version moved: the build version was taken over offset 32 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, head ) == 40, "Scene's field head moved: the build version was taken over offset 40 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, tree ) == 48, "Scene's field tree moved: the build version was taken over offset 48 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, settings ) == 56, "Scene's field settings moved: the build version was taken over offset 56 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, alias ) == 64, "Scene's field alias moved: the build version was taken over offset 64 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, ground ) == 72, "Scene's field ground moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, layers ) == 88, "Scene's field layers moved: the build version was taken over offset 88 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Scene, meta ) == 156, "Scene's field meta moved: the build version was taken over offset 156 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Depot ) == 104, "Depot's sizeof moved: the build version was taken over 104, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Depot ) == 8, "Depot's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Depot, name ) == 0, "Depot's field name moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Depot, banks ) == 24, "Depot's field banks moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Depot, spare ) == 72, "Depot's field spare moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Depot, head ) == 96, "Depot's field head moved: the build version was taken over offset 96 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Album ) == 88, "Album's sizeof moved: the build version was taken over 88, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Album ) == 8, "Album's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Album, name ) == 0, "Album's field name moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Album, tint ) == 24, "Album's field tint moved: the build version was taken over offset 24 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Album, stamp ) == 28, "Album's field stamp moved: the build version was taken over offset 28 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Album, marker ) == 48, "Album's field marker moved: the build version was taken over offset 48 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Album, pin ) == 72, "Album's field pin moved: the build version was taken over offset 72 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Album, head ) == 80, "Album's field head moved: the build version was taken over offset 80 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -526,6 +526,186 @@ struct TableRegionSink
 
 #endif // GRAPHDEMO_SCHEMA_TABLE_ARENA
 
+#ifndef GRAPHDEMO_SCHEMA_BUILD_VERSION
+#define GRAPHDEMO_SCHEMA_BUILD_VERSION
+
+namespace graphdemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x7970dae87b5cf43aull;
+
+} // namespace graphdemo
+
+#endif // GRAPHDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef GRAPHDEMO_SCHEMA_TABLE_COOK
+#define GRAPHDEMO_SCHEMA_TABLE_COOK
+
+namespace graphdemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace graphdemo
+
+#endif // GRAPHDEMO_SCHEMA_TABLE_COOK
+
 namespace graphdemo {
 
 // table Tally — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -1137,6 +1317,59 @@ inline bool MarkerLoadBuilder( MarkerBuilder & builder, const uint8_t * wire, in
     return MarkerLoadBody( r, builder.main, *root, 1 );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// TallyOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// Tally IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Tally * TallyOpen( const void * bytes, uint64_t length )
+{
+    return (const Tally *) TableCookOpen( bytes, length, (uint64_t) sizeof( Tally ), (uint64_t) alignof( Tally ) );
+}
+
+// MarkerOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// A REFERENCE INSIDE THE REGION IS DEREFERENCED THROUGH MarkerAt: the slot holds
+// the signed self-relative byte delta of §6.3, so a deref is one add and
+// needs no base pointer, a whole region relocates by plain memcpy, and a
+// delta of zero is null.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Marker * MarkerOpen( const void * bytes, uint64_t length )
+{
+    return (const Marker *) TableCookOpen( bytes, length, (uint64_t) sizeof( Marker ), (uint64_t) alignof( Marker ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -1151,6 +1384,21 @@ static_assert( std::is_trivially_copyable<Tally>::value, "Tally must stay reloca
 static_assert( std::is_standard_layout<Tally>::value, "Tally must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<Marker>::value, "Marker must stay relocatable" );
 static_assert( std::is_standard_layout<Marker>::value, "Marker must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( Tally ) == 4, "Tally's sizeof moved: the build version was taken over 4, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Tally ) == 4, "Tally's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Tally, hits ) == 0, "Tally's field hits moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Marker ) == 24, "Marker's sizeof moved: the build version was taken over 24, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Marker ) == 8, "Marker's alignof moved: the build version was taken over 8 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Marker, label ) == 0, "Marker's field label moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Marker, note ) == 16, "Marker's field note moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -526,6 +526,186 @@ struct TableRegionSink
 
 #endif // GRAPHDEMO_SCHEMA_TABLE_ARENA
 
+#ifndef GRAPHDEMO_SCHEMA_BUILD_VERSION
+#define GRAPHDEMO_SCHEMA_BUILD_VERSION
+
+namespace graphdemo {
+
+// THE BUILD VERSION (SPEC-TABLES.md §20): one digest over every fact the bytes
+// this build produces depend on — the type wire's protocol id, every record's
+// layout as the compiler's own C ABI model computes it, and the facts that
+// decide what a load PUTS in those slots. It is the number a cook's header
+// carries and the number Open compares, and the number a block's prologue
+// carries and BlockOpen compares: a build version answers "which build?" and
+// not "which form?", and what separates the two forms is their MAGIC.
+//
+// There are TWO ids in the design and they are not interchangeable: the
+// PROTOCOL ID is the type wire's and nothing else, and the BUILD VERSION is
+// what everything cooked or blocked is keyed by. A table edit moves this and
+// never the protocol id; a type edit moves both.
+inline constexpr uint64_t BuildVersion = 0x7970dae87b5cf43aull;
+
+} // namespace graphdemo
+
+#endif // GRAPHDEMO_SCHEMA_BUILD_VERSION
+
+#ifndef GRAPHDEMO_SCHEMA_TABLE_COOK
+#define GRAPHDEMO_SCHEMA_TABLE_COOK
+
+namespace graphdemo {
+
+// ---- the cooked form (SPEC-TABLES.md §7) ----
+//
+// A cooked file is a HEADER, a DATA part and an ATTRIBUTION part, in that
+// order. Every word of the header is a u64 written in the byte order the cook
+// was produced in, and the header is 64 bytes:
+//
+//     0  magic               0x4b4f4f434d484353, read BYTEWISE before anything else
+//     8  build_version       the unit's id (SPEC-TABLES.md §20)
+//    16  byte_order          1 little, 2 big — the order that WROTE the file
+//    24  data_length         the region's bytes, rounded up to alignment
+//    32  attribution_length  the directory's bytes, or 0
+//    40  alignment           the region's alignment, never below eight
+//    48  reserved            zero
+//    56  reserved            zero
+//
+// The DATA part is Lock's region written verbatim (§7.2) — the root at its
+// base — and it is what a runtime points at. The ATTRIBUTION part is the node
+// directory (§6.3), and NOTHING THAT READS THE STRUCTURE TOUCHES IT: it is
+// written beside the data for schema cook-check, so a build that ships no
+// tooling need not carry it at all.
+static const int64_t kTableCookHeaderBytes = 64;
+
+// THE MAGIC'S VALUE, and a consumer written from the page needs the constant
+// rather than a description of one. It is "SCHMCOOK" read as ASCII in the byte
+// order a little-endian store produces — the same shape the block form's
+// SCHMABLK takes, so a hex dump of a little-endian cook is legible and the two
+// accelerators sit in one vocabulary.
+//
+// IT IS STORED IN THE PRODUCER'S ORDER, which is what makes it the byte-order
+// check as well as the form check: a consumer reads back this build's
+// constant, or that constant byte-reversed — which identifies a cook of the
+// OTHER order — or something that is not a cook. All three answers but the
+// first refuse, and a cook and a BLOCK are separated here too, because a
+// form's identity belongs in its magic rather than in a second digest.
+inline constexpr uint64_t TableCookMagic = 0x4b4f4f434d484353ull;
+
+// THIS BUILD's byte order, as the header's own word carries it. The magic is
+// what REFUSES a foreign order; this word is what RECORDS which order wrote
+// the file, so a refusal names the order rather than inferring it and a tool
+// dumping a cook reads the fact. A file whose magic matched and whose order
+// word did not is corrupt, and there is no reading that recovers it.
+//
+// The BUILD VERSION cannot do either job: §20.1 digests byteorder as a
+// GENERATION input, little for every target schema generates for today, so
+// two builds of one schema for two orders emit the same id.
+#if defined( __BYTE_ORDER__ ) && defined( __ORDER_BIG_ENDIAN__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+inline constexpr uint64_t TableCookByteOrder = 2; // big
+#else
+inline constexpr uint64_t TableCookByteOrder = 1; // little
+#endif
+
+// The greatest region alignment a cooked file may name. The DATA part begins
+// at align_up( 64, alignment ), which is 64 for every unit this language can
+// declare — the largest alignment it has is sixteen — so a word past this cap
+// describes a file no build of this schema wrote (SPEC-TABLES.md §7.1).
+inline constexpr uint64_t TableCookMaxAlign = 64;
+
+// The header read, BYTEWISE. memcpy is the portable spelling of "these eight
+// bytes, in this machine's order"; every compiler this repo builds under folds
+// it to one load, and it is the only read in the whole of Open that is not a
+// comparison.
+inline uint64_t table_cook_read64( const uint8_t * p )
+{
+    uint64_t v;
+    memcpy( &v, p, sizeof( v ) );
+    return v;
+}
+
+// TableCookOpen: THE WHOLE CHECK, in one place, because §7 states the
+// enumeration once and every generated <Name>Open is that one enumeration plus
+// its own root's two layout facts.
+//
+// THE CHECK, in order: the magic read bytewise, the byte order it establishes,
+// the build version against this build's own, both RESERVED words zero, the
+// region alignment the header names, the two part lengths against the length
+// the caller passed — a truncated file and a file with trailing bytes are the
+// same refusal — the root's own storage inside the data part, and the
+// alignment of the base.
+//
+// AND THAT IS ALL OF IT. On a match the bytes ARE what this build wrote, in
+// this build's layout and this build's byte order, so there is nothing to
+// validate and nothing to fix up: the caller gets the root. Nothing per node
+// happens here, which is what makes open O(1) in the file's size; a walk of
+// any shape would forfeit that, and validating an untrusted file is schema
+// cook-check's job and a person's decision (§7.4).
+//
+// EVERY NUMBER BELOW COMES OUT OF THE FILE, so the arithmetic is unsigned and
+// each term is BOUNDED BEFORE IT IS ADDED: a forged length near 2^64 must
+// refuse, and an addition that wrapped would be the defect the comparison
+// after it was supposed to catch. Nothing past length is read on any path,
+// including every refusing one.
+inline const uint8_t * TableCookOpen( const void * bytes, uint64_t length, uint64_t root_size, uint64_t root_align )
+{
+    if ( bytes == NULL ) { return NULL; }
+    if ( length < (uint64_t) kTableCookHeaderBytes ) { return NULL; }
+    const uint8_t * raw = (const uint8_t *) bytes;
+    // the MAGIC, bytewise and first: it is what establishes the byte order
+    // every other header word is read in, so nothing else may be read before
+    // it. A byte-reversed constant is a cook of the other order and refuses
+    // here, which is why the order never reaches a fix-up pass.
+    if ( table_cook_read64( raw ) != TableCookMagic ) { return NULL; }
+    if ( table_cook_read64( raw + 16 ) != TableCookByteOrder ) { return NULL; }
+    if ( table_cook_read64( raw + 8 ) != BuildVersion ) { return NULL; }
+    // the RESERVED words: a non-zero one means a writer used a form this build
+    // does not understand, and Open refuses rather than ignoring it.
+    if ( table_cook_read64( raw + 48 ) != 0 ) { return NULL; }
+    if ( table_cook_read64( raw + 56 ) != 0 ) { return NULL; }
+    const uint64_t data_length = table_cook_read64( raw + 24 );
+    const uint64_t attribution_length = table_cook_read64( raw + 32 );
+    const uint64_t alignment = table_cook_read64( raw + 40 );
+    // THE ALIGNMENT WORD IS DATA, and it is the one header field the rest of
+    // the check does arithmetic WITH rather than only comparison against. A
+    // region's alignment is a power of two, never below eight (the floor that
+    // puts the attribution part on an eight-byte boundary without a second
+    // padding rule) and never past the cap above; a word that is none of those
+    // rounds nothing and aligns nothing, so it is refused before it is used.
+    if ( alignment < 8 || alignment > TableCookMaxAlign ) { return NULL; }
+    if ( ( alignment & ( alignment - 1 ) ) != 0 ) { return NULL; }
+    // and it must be an alignment THE ROOT CAN SIT AT, since the root is at
+    // the region's base: both are powers of two, so "at least the root's"
+    // is one division.
+    if ( ( alignment % root_align ) != 0 ) { return NULL; }
+    // The DATA part begins at align_up( 64, alignment ). It is DERIVED and not
+    // a header field, because a fact a reader computes is a fact two writers
+    // cannot disagree about.
+    const uint64_t data_offset = ( (uint64_t) kTableCookHeaderBytes + alignment - 1 ) & ~( alignment - 1 );
+    if ( length < data_offset ) { return NULL; }
+    // the two part lengths against the length the caller passed. The whole
+    // file is data_offset + data_length + attribution_length, and a length
+    // that is not EXACTLY that refuses — truncation and trailing bytes are one
+    // refusal, and both terms are subtracted rather than added so no sum can
+    // carry.
+    if ( data_length > length - data_offset ) { return NULL; }
+    if ( attribution_length != length - data_offset - data_length ) { return NULL; }
+    // the ROOT sits at the region's base, so the region has to hold it: a
+    // shorter data part describes a root partly outside the file, which is the
+    // one way a match-and-point reader could hand back storage it never
+    // received.
+    if ( data_length < root_size ) { return NULL; }
+    const uint8_t * base = raw + data_offset;
+    // the alignment of the BASE. The header pads the data part to the region's
+    // alignment, so a base an allocator or mmap gave you is already aligned —
+    // mmap gives page alignment for free — and a base that is not is a caller's
+    // buffer this form cannot be read out of.
+    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+}
+
+} // namespace graphdemo
+
+#endif // GRAPHDEMO_SCHEMA_TABLE_COOK
+
 namespace graphdemo {
 
 // table Stamp — TABLE-wire storage: relocatable, bounded, defaults in the
@@ -761,6 +941,33 @@ inline bool ColourLoad( Colour & value, const uint8_t * buffer, int64_t bytes, T
     return ColourLoadBody( r, value );
 }
 
+// ---- the cooked form: point at a cook (SPEC-TABLES.md §7) ----
+
+// StampOpen: match the header and POINT. On a match the bytes ARE what this
+// build wrote, in this build's layout and this build's byte order, so there
+// is nothing to validate and nothing to fix up and the root comes back as it
+// lies. On ANY refusal it returns NULL and the caller falls back to a wire
+// load, which is the path that carries every version.
+//
+// It is O(1) IN THE FILE'S SIZE — the header and nothing per node — so a one
+// megabyte cook and a one gigabyte cook open in the same time, and a mapped
+// file's pages are touched only as they are used. That is a property of
+// touching nothing at open rather than a separate mechanism.
+//
+// Stamp IS FIXED-SIZE, so its cook is ONE REGION OF ONE NODE and not a second
+// shape (§7): one struct behind the header, at the region's base, which is
+// what this returns. There is no graph below it and nothing to resolve.
+//
+// There is ONE entry point and no tolerant twin: a build either wrote this
+// file or it did not, and the build version is what says which. Validating a
+// file whose provenance a person doubts is schema cook-check, offline,
+// over the ATTRIBUTION part beside the data — a person's decision, never a
+// parameter on a load.
+inline const Stamp * StampOpen( const void * bytes, uint64_t length )
+{
+    return (const Stamp *) TableCookOpen( bytes, length, (uint64_t) sizeof( Stamp ), (uint64_t) alignof( Stamp ) );
+}
+
 // ---- relocatability, enforced: the wire is a pure length-prefixed
 // stream AND the decoded storage is pointer-free — every closure type
 // must stay trivially copyable and standard-layout, so instances can be
@@ -775,6 +982,23 @@ static_assert( std::is_trivially_copyable<Stamp>::value, "Stamp must stay reloca
 static_assert( std::is_standard_layout<Stamp>::value, "Stamp must stay standard-layout for offsetof" );
 static_assert( std::is_trivially_copyable<Colour>::value, "Colour must stay relocatable" );
 static_assert( std::is_standard_layout<Colour>::value, "Colour must stay standard-layout for offsetof" );
+
+// ---- the cook's layout contract (SPEC-TABLES.md §20.3) ----
+//
+// The compiler derived every number below from the declaration and folded it
+// into the BUILD VERSION; these asserts are this compiler saying whether it
+// agrees. The model is not self-evidently right — on 32-bit System V
+// alignof(uint64_t) is 4, not 8 — which is precisely why it is asserted
+// rather than assumed.
+static_assert( sizeof( Stamp ) == 20, "Stamp's sizeof moved: the build version was taken over 20, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Stamp ) == 4, "Stamp's alignof moved: the build version was taken over 4 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Stamp, tag ) == 0, "Stamp's field tag moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Stamp, seq ) == 16, "Stamp's field seq moved: the build version was taken over offset 16 (SPEC-TABLES.md §20.3)" );
+static_assert( sizeof( Colour ) == 3, "Colour's sizeof moved: the build version was taken over 3, so a cook of it would not be this build's file (SPEC-TABLES.md §20.3)" );
+static_assert( alignof( Colour ) == 1, "Colour's alignof moved: the build version was taken over 1 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Colour, r ) == 0, "Colour's field r moved: the build version was taken over offset 0 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Colour, g ) == 1, "Colour's field g moved: the build version was taken over offset 1 (SPEC-TABLES.md §20.3)" );
+static_assert( offsetof( Colour, b ) == 2, "Colour's field b moved: the build version was taken over offset 2 (SPEC-TABLES.md §20.3)" );
 
 // ---- reflection descriptors (tables only, SPEC-TABLES.md) ----
 


### PR DESCRIPTION
The second of the cook sprint's three (#251). `schema cook` landed in #321; this is the
C++ side that points at what it wrote, **written from SPEC-TABLES §7 alone** —
`internal/tablecook` and `cmd/schema/cook*.go` were not read, and the tool was used only
as a black box to produce fixtures and to cross-check bytes against the page.

## What it emits

For **every table** — a root is any table, which is what §7 already implies and what the
tool confirms (`schema cook --root` names a table and refuses a `type`, which is not a
node and has no type id):

```cpp
const Scene * SceneOpen( const void * bytes, uint64_t length );
```

Match the magic bytewise, the byte order it establishes, the build version, both reserved
words, the region alignment, the two part lengths against `length`, the root's own storage
inside the data part, the base's alignment — **then POINT**. No walk, no per-node work,
nothing read past `length`, NULL on any refusal. A reference derefs through the eight-byte
signed self-relative slot already emitted (`<T>At`), unchanged. A FIXED root is not a
second case: its cook is one region of one node, so it is the same header match and then
the one record.

Beside it: `BuildVersion` in its own include guard (both accelerators carry it, and
Block.h includes Table.h), and §20.3's layout `static_assert`s widened from the block
closure to **every cookable record**, emitted by the file that declares each one.

## The owner's ruling, folded in

> "OK to be clear, cooked data is generally trusted and will be loaded from disk."
> "It's not a 'wire' protocol, it's a load trusted data from tools protocol."
> "If we have concerns, then we should sign it." / "We just have to load the data."
> "sodium is faster and we could be loading large data"

§7 opens with the name — a wire crosses a boundary between builds, a cook crosses none —
and gains a paragraph stating that `Open`'s checks are **identity** checks, not a trust
boundary; that there is **no per-node validation at load, ever**; that a file from outside
your own pipeline is `schema cook-check`'s problem, offline; and that integrity, where
wanted, is a signature. §13.4 carries the verbatims. §15 banks the signed cook with its
cost stated: sodium, one hash pass over the whole file, which **forfeits the lazy paging**
§7 counts as a property of touching nothing at open — and, if that matters, a signed table
of per-chunk hashes so a page verifies as it faults in. Not built.

That ruling also settles the three by-design opens below for good, and the battery
asserting they open is now that ruling written as a test.

## Page defects hit, and what I wrote

The blindness rule makes every gap a defect. Five, each fixed on the page here:

1. **§7 gave no C++ signature for `Open`.** The only C++ in §7 was `SceneOpen( bytes,
   size )` with untyped names, and §11 claimed the spelling with no shape at all — a
   consumer written from the page alone could not spell it. **Written:** the signature
   above, with the reason the length is UNSIGNED (every number the check compares comes
   out of the file, so all of the arithmetic is unsigned; a signed length would put one
   signed value into it and one negative case into every comparison).
2. **The enumeration said nothing about a forged `alignment` word.** It is the one header
   field the check does ARITHMETIC with — `align_up( 64, alignment )` and the base's
   alignment both come from it — and a zero there is a modulo by zero inside the check.
   **Written:** power of two, at least eight (§7.1's floor), at most sixty-four (the same
   64 a block's base takes), and a multiple of the root's own `alignof`.
3. **The enumeration did not require the DATA PART TO HOLD THE ROOT.** The part lengths
   frame the FILE; they do not say the region is at least `sizeof( root )`. Without it a
   forged short data part describes a root partly outside the file — the one way a
   match-and-point reader could hand back storage the caller never gave it. It has its own
   negative control.
4. **§7.3 called the big-endian worked example "the same 168 bytes"** where the same
   subsection computes `64 + 72 + 64 = 200` and the dump ends at `0x00c8`. **Written:** 200.
5. **§20.6 cited "the six-item check §7 states"** — a count kept in a second place, which
   is the drift §11's own list warns about, and which this PR would have moved.

Also: §11 **retires `OpenWalk`'s claim** (24 suffixes now, not 25) — it named wire v1's
validating walk, and §7's `Open` is a header match with no walk in it, so the name went
with the design; a test asserts `<X>OpenWalk` is legal now, because an unclaimed name is
invisible unless something asks for it. And §7's, §20's and USAGE's status paragraphs move
to present state.

## Gate numbers

`make tables-cook-open` plus the two controls, all in `make test`.

- **Cross-implementation lock — SEVEN roots.** Every node the C++ walk reaches through its
  own derefs is a node the tool's attribution directory names, at that offset, with that
  type id; the two sets are equal; every byte no field covers is zero; every count
  companion inside its bound.
  | root | shape | nodes |
  |---|---|---|
  | Scene | chain | 123 |
  | Depot | keyed array of variable tables + optional | 91 |
  | Album | cross-file, by-value variable table + pointer to one | 92 |
  | TreeNode | tree | 75 |
  | ListNode | chain node as its own root | 93 |
  | Settings | **fixed**, pointed at | 1 |
  | Stamp | **fixed**, pointed at by nothing, in a file with no variable table | 1 |
  Green on the first run — neither side was adjusted to the other.
- **The VALUE crossing, which the fixed class makes possible.** A fixed table has no
  pointer, so no node table and no kind 17, so this backend's wire and the tool's are the
  same bytes. The C++ side writes a known instance to the wire, `schema cook` cooks it
  using its own model of the record's layout, and the C++ side opens the cook and reads
  the fields back — value for value, including a string's used length and the zero tail
  past it. The tool's read report over a C++-written wire is *"silent — the data matched
  the schema exactly"*, which is the same crossing the other way, free.
  For the **variable** class it still does not cross, and the reason is §3.1's backend
  status: the tool writes the flat node table and no backend does, so a tool-written
  wire's pointer fields reach a generated reader as a kind it cannot skip and the decode
  stops (measured — `SceneLoad` returns malformed).
- **O(1) open**, paired, medians of 9 × 200,000, one sitting:
  | fixture | file | median open |
  |---|---|---|
  | 1 MB region | 1,572,832 B | **15.0 ns** |
  | 100 MB region | 157,286,368 B | **15.0 ns** |
  | 1 GB region (by hand, not CI) | 1,610,612,704 B | **15.3 ns** |
  Ratio 1.003 across the first pair, 1.015 across 1 MB → 1 GB. CI (ubuntu) reproduces at
  30.0/30.0, ratio 0.997. The gigabyte arm is `make tables-cook-open-1gb`, deliberately
  not in CI (a 1.6 GB fixture).
- **Forgeries** — 111 directed edits per variable root (108 refused), 109 per fixed root
  (108 refused), under ASan + UBSan with `-fno-sanitize-recover=all`, over a buffer
  allocated at EXACTLY the length claimed so a redzone sits on the next byte: each byte of
  the magic, the magic byte-reversed, the BLOCK form's magic, every byte-order word the
  magic contradicts, three build versions, both reserved words, thirteen non-alignment
  alignment words, both part lengths long/short/saturated, a data part too short to hold
  the root with the total kept exact, six truncations, an extension, every unaligned base.
- **Three OPEN by design**: a reference with an enormous forward delta, a negative delta
  past the base, a directory entry outside the region. `cook-check`'s refusals, not the
  runtime's — and now the owner's ruling in test form.
- **Fuzzer** — 100,000 mutants × 2 roots, seeded, under ASan/UBSan. N measured against the
  60 s budget: 200,000 run in ~1.4 s, so the shared `N ?= 100000` was left alone. Oracle:
  a HEADER mutation refuses or opens onto bytes whose whole graph still matches the
  directory; a DATA-PART mutation must not change `Open`'s answer AT ALL, which is the
  O(1) promise as a property a fuzzer can falsify rather than as a timing; nothing outside
  the claimed length is read on any path; an opened cook's root storage is READ whole, so
  the sanitizer proves it lies inside that length.
- **Two negative controls**, each removing one clause through a `go build -overlay` on the
  emitter and requiring the battery to go RED: the part-length equation (*"a forgery
  OPENED that §7 says Open refuses: a data length one byte long"*) and the root-fits clause
  (*"a data part too short to hold the root OPENED, and its root's storage is outside the
  file"*). The sabotage keeps the local it defeats in use, because a generated C++ file
  with an unused local does not compile under `-Werror` and a control that fails to build
  is not a control that went red. The first draft of control 2 stayed green — its forgery
  was also caught by the length equation — which is exactly what a control is for; the
  battery gained an isolated two-word forgery.
- **Big-endian — green in CI** (this bench has no `qemu-s390x`). On the s390x target: *"a
  cook written in this build's order (big) opens natively"*, then the full golden lock over
  it — 123 nodes — and the little-endian cook *"refused by the MAGIC, read bytewise"*; the
  host does the mirror image. A big-endian cook's header, deltas and whole graph read
  natively with no fix-up pass anywhere.
- **msvc — green in CI**: the leg generates `tables/pointers` and compiles its header with
  `cl /W4 /WX /std:c++17 /permissive-`.
- **USAGE's example compiles and runs** — it is a translation unit in the gate, so the
  documented surface goes red with the code.

## The price of emitting it everywhere, measured

Fourteen Table headers grew by **207 KB total, mean 14.8 KB (~+21%)** — the shared read
runtime, one `Open` per table, and §20.3's asserts.

The compile-time cost, on §13.5's instrument (one empty TU including one generated Table
header, arms interleaved in one sitting, medians of 15, a corpus generated by the
pre-cook compiler as the before arm):

| arm | min | median |
|---|---|---|
| before | 0.0993 s | 0.1001 s |
| after | 0.0991 s | 0.1003 s |

**+0.2 ms, +0.2%, inside a 4–6% spread.** It is comment and constant-folded arithmetic and
it does not reach the clock. Stated on the page in §7.

**Zero-cost still holds where it means something**: `tables-zero-cost` is green — a
value-only table pays for no arena, no builder, no reference slot, no lifecycle surface.
What it now carries is a header match, and a header match is what a cook is.

## One thing that got weaker, named

`tables-block-zero-cost`'s byte-identity half compared 38 Table sources against pins the
PRE-BLOCK compiler wrote. Fourteen of them — the headers — were re-pinned here, so that
half is no longer a pre-block proof for the headers; the `.cpp` pins still are, and git
carries the provenance. `BuildVersion` also left its block-leak grep, because it is not a
block symbol and every Table header now carries it (§20.6). The grep half — no Table source
carries one BLOCK symbol — is untouched.

**The follow-on that would give it back**, noted in the Makefile: replace the frozen pins
with a mechanical comparison against a corpus generated from a block-less emitter, the way
the two negative controls already build sabotaged emitters. That is a standing gate that
survives any legitimate Table-emitter change, which a frozen pin cannot.

## Still open

- **§20.3's commitment is now stated AND met for every cookable record** — the asserts ride
  in every unit that declares a table. What is still specification-only is a backend other
  than C++ asserting the same facts outside the block closure.
- **The variable class's value crossing** waits on §3.1's flat node table in the emitters.

Draft → ready. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
