### PR TITLE
contraction: the cook sprint's scaffolding goes — notes now true, unclaimed names, superseded gates, duplicated examples, goldens by hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,22 @@ jobs:
       - name: inline gate — ${{ matrix.leg }} leg
         run: bench/tools/inline-gate.sh leg ${{ matrix.leg }}
 
+      # GATE 2's SMOKE (SPEC-TABLES.md §12.1). The gate itself is a paired
+      # measurement and its verdict belongs on a quiet box, so it is not on the
+      # PR path and its 5% band is not enforced here. What runs is the
+      # CORRECTNESS half at a small N — the generated block form and the
+      # hand-written mirror agreeing byte for byte across all nine sections,
+      # and the C# side reading the frame the C++ side wrote. Before this the
+      # gate ran nowhere at all, which is how a gate rots.
+      #
+      # ONE matrix combination, not six: this job's `make test` has already
+      # built the tree on every leg, and the smoke needs one extra C++ compile
+      # and one dotnet run. The go/ubuntu leg carries it because it is the one
+      # combination that always runs.
+      - name: gate 2 smoke — the block form still writes what the hand mirror does
+        if: matrix.os == 'ubuntu-latest' && matrix.leg == 'go'
+        run: make tables-block-gate2-smoke
+
   # Self-contained Go lint job; .golangci.yml carries the config.
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -939,23 +939,17 @@ tables-cook-cli: bin/schema
 # THE BLOCK ZERO-COST GATE (SPEC-TABLES.md §2.2, §19), in its two halves.
 #
 # The first asks "did any block symbol leak into a Table source?" — a grep.
-# The second is the property §19 actually states, and it is the stronger one:
-# **the Table sources are BYTE-IDENTICAL with or without the Block files
-# existing.** The pins under testdata/golden/tables/ were written by the
-# PRE-BLOCK compiler (schema at f55e711, before this branch's emitters), so
-# the comparison is against a build that could not emit a Block file at all
-# rather than against this branch's own output. That is what makes it a proof
-# rather than a restatement.
+# The second is the property §19 actually states: **the Table sources are
+# BYTE-IDENTICAL with or without the Block files existing**, held by comparing
+# 38 of them against frozen pins under testdata/golden/tables/.
 #
-# They are ordinary goldens from here on: `make update-goldens` re-pins them
-# when a TABLE emitter legitimately changes, and a move under an unchanged
-# emitter is stop-the-line, exactly as it is for every other golden. **The
-# fourteen Table HEADERS were re-pinned when the cook's read side landed** (§7),
-# so their text is no longer the pre-block compiler's — git carries that
-# provenance, and the .cpp pins still are. Replacing the frozen pins with a
-# mechanical comparison against a corpus generated from a block-less emitter,
-# the way the negative controls already do it, is the follow-on that would give
-# the byte-identity half back its independence.
+# They are ordinary goldens: `make update-goldens` re-pins them when a TABLE
+# emitter legitimately changes, and a move under an unchanged emitter is
+# stop-the-line, exactly as it is for every other golden. What a frozen pin
+# cannot do is survive a legitimate Table-emitter change without being
+# re-pinned; schema#331 carries the follow-on that would replace it with a
+# mechanical comparison against a block-less emitter, the way the negative
+# controls below already build sabotaged ones.
 .PHONY: tables-block-zero-cost
 tables-block-zero-cost: build/tables-generated/.stamp build/tables-generated-cs/.stamp
 	@for f in build/tables-generated/*/*Table.h build/tables-generated/*/*Table.cpp \
@@ -965,12 +959,11 @@ tables-block-zero-cost: build/tables-generated/.stamp build/tables-generated-cs/
 		fi; \
 	done
 	@echo "block zero-cost gate: no Table source carries one symbol of the block form"
-# BuildVersion LEFT this grep when the cook's read side landed. It is not a
-# block symbol and never was: a build version answers "which build?" and not
-# "which form?", both accelerators carry it (SPEC-TABLES.md §20.6), and every
-# Table header now carries it because every table cooks (§7). What still holds
-# the block form to zero cost is the line above — no Table source carries one
-# BLOCK symbol — and the byte comparison below.
+# BuildVersion is NOT in that grep: it is not a block symbol — a build version
+# answers "which build?" and not "which form?", both accelerators carry it
+# (SPEC-TABLES.md §20.6), and every C++ Table header carries it because every
+# table cooks (§7). What holds the block form to zero cost is the line above —
+# no Table source carries one BLOCK symbol — and the byte comparison below.
 	@for f in build/tables-generated-cs/*/*Table.cs; do \
 		if grep -n "BuildVersion" $$f; then \
 			echo "BLOCK ZERO-COST GATE FAILED: the C# Table sources carry BuildVersion, which is the BLOCK file's there: $$f"; exit 1; \
@@ -1002,7 +995,7 @@ tables-block-zero-cost: build/tables-generated/.stamp build/tables-generated-cs/
 	done; \
 	if [ "$$d" != "0" ]; then exit 1; fi; \
 	if [ "$$n" -lt 38 ]; then echo "ZERO-COST GATE FAILED: compared $$n Table files, expected at least 38 — the glob, not the property, is what broke"; exit 1; fi; \
-	echo "block zero-cost gate: $$n Table sources byte-identical to their pins (the .cpp half still the PRE-BLOCK compiler's text)"
+	echo "block zero-cost gate: $$n Table sources byte-identical to their pins"
 
 # THE BUILD VERSION IS ONE NUMBER (SPEC-TABLES.md §20.7): the constant each
 # backend emits, and the number `schema build-version` prints, are the same

--- a/Makefile
+++ b/Makefile
@@ -1239,6 +1239,19 @@ build/schema_test_block_gate2: build/tables-generated/.stamp test/tables/block_g
 tables-block-gate2: build/schema_test_block_gate2 build/tables-generated-cs/.stamp
 	./build/schema_test_block_gate2
 	cd test/cs-block && dotnet run -c Release -- --gate2
+
+# THE SMOKE, which is what CI runs (certification legs only, never a PR).
+# The gate above is a MEASUREMENT and its verdict belongs on a quiet box; a
+# gate nothing runs anywhere is a gate that rots, which is the other failure.
+# So the correctness half — the two arms agreeing byte for byte across all
+# nine sections, and the frame the C# half reads — runs on every push to main
+# and nightly, at a small N, with the 5% band NOT enforced and both halves
+# saying so. A drift in what the generated form WRITES goes red here; a slow
+# runner does not.
+.PHONY: tables-block-gate2-smoke
+tables-block-gate2-smoke: build/schema_test_block_gate2 build/tables-generated-cs/.stamp
+	./build/schema_test_block_gate2 --smoke
+	cd test/cs-block && dotnet run -c Release -- --gate2-smoke
 # The NEGATIVE CONTROL for a KEYED object's duplicate counting
 # (SPEC-TABLES.md §16.2). Last-wins inside a keyed object was already true, so
 # the missing count was invisible to every round-trip test — the value was

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ list and what the gates prove.
 | **[CONTRIBUTING.md](CONTRIBUTING.md)** | How to build it, the gates a change has to pass, and what a golden change means. |
 | **[SECURITY.md](SECURITY.md)** | The threat model, and how to report a vulnerability privately. |
 
+Where a guide and a spec cover the same ground: the spec keeps the spelling a
+consumer needs to write from the page alone, even when USAGE also shows it.
+
 ## License
 
 **The compiler is AGPL-3.0 — and will stay that way. The code it generates is

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1978,15 +1978,8 @@ the wire, and keeps the flexibility that comes with it.
   loader. It costs the lazy paging, and §15 carries both that and the shape
   that keeps it; not built.
 
-  **The forgery battery and the fuzzer (§7.5) are hardening gates on the
-  REFUSAL PATH and they do not shape this runtime.** What they hold is that a
-  file `Open` refuses is refused cleanly — no crash, no read past the `length`
-  the caller passed, no undefined behaviour inside the check — because the
-  check runs on whatever bytes a disk hands back, including a corrupt or
-  truncated one. They do not ask `Open` to validate a graph, and the three
-  forgeries that OPEN by design (a reference leaving the region, a negative
-  delta past the base, a directory entry outside it) are exactly that
-  distinction written down.
+  The forgery battery and the fuzzer harden the REFUSAL PATH and shape nothing
+  here; §7.5 states what they hold and what they do not.
 
 - **`Open` checks the header and points, and this is the WHOLE check**,
   because nothing else is checked at all: **the magic, the byte order it

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -5519,10 +5519,6 @@ would be the quiet one. The declared maximum is a contract the producer keeps
 and `Begin` checks; it is not a policy `Begin` applies. A gather buffer sized
 larger than the bound is the ordinary case and clamping it is one line, and the
 page says so here rather than leaving a caller to find it at sixty hertz.
-Clamping a count to its maximum before `Begin` is the PRODUCER's job, and the
-page says so rather than leaving a caller to discover it: `Begin` is a
-contract check, not a policy. The `Counts` value is filled before `Begin` and
-`Begin` is single-threaded, so nothing about counting is concurrent.
 
 **Then the fill, and the fill is the requirement:**
 

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -875,8 +875,7 @@ read as an index. The kind byte already rides, so the distinct number
 costs zero bytes and one row in the fixed-width skip rule, and it makes
 that edit an ordinary kind mismatch (§4). §3's rule that an unknown kind
 is not skippable is what makes spending a kind expensive AFTER readers
-exist; the set is closed before any of them ship, and §14 records the
-trade.
+exist; the set is closed before any of them ship.
 
 **What a pointer edge is, and what it is not.** Only a `*T` naming a
 declared TABLE takes a node index, and it is the only pointer spelling the
@@ -977,7 +976,7 @@ then carries WHOLE RECORDS, and the fields concatenate in order:
   node table is the large part and the part most likely to be damaged,
   and a reader that dies a gigabyte into it still holds the root's real
   values. It buys nothing for a reader that gives up EARLIER, which is
-  the ordinary case for a build that does not have kind `17` (§14): that
+  the ordinary case for a build that does not have kind `17`: that
   one stops at the first pointer field and never reaches these at all.
   Field order is not part of the contract (§3), so a reader finds them by
   id.
@@ -3326,7 +3325,7 @@ held by construction:
   N workers then own disjoint index ranges and write with no per-row
   synchronisation and no lock. A generated fill path that allocates, locks or
   takes an atomic does not conform, and §19.1 states that as a refuser rather
-  than as an aspiration. The builder's four models (§14) all exist because a
+  than as an aspiration. The builder's rejected models (§14) all exist because a
   general structure cannot know its bound; a block-form table declares one,
   which is why item 3 there — reserve the max and never resize — is exactly
   what the block form does.
@@ -4156,338 +4155,176 @@ produced.
 - **And the whole design's id count**: "yes on protocol id and build version"
   — two ids, and §20 states them as the two.
 
-## 14. Design notes: the models weighed
+## 14. Design notes: the shapes rejected
 
-Recorded because the rejected options are the useful part.
+One paragraph a rejected shape: what it was, and the reason it lost. The
+designs of record are stated where they belong and are not restated here.
 
-**The builder's storage.** Four models were weighed against the owner's
-criterion — lockless if possible, and minimize copying:
+**The builder's storage**, against the owner's criterion — lockless if
+possible, and minimize copying (§6.2):
 
-1. **One buffer under a lock, grown by `realloc` — REJECTED.** The hazard
-   is specific and worth naming: a `realloc` moves the buffer under a
-   worker that is mid-write. Offsets fix identity but they do not fix the
-   raw references already resolved from them, and the resulting
-   corruption is invisible until much later. This design does not admit
-   that bug class.
-2. **Sharded builders merged at Lock — considered.** Each worker owns a
-   private growable array; references are (worker, slot) handles;
-   `Lock` merges the shards and resolves every handle. Contention-free,
-   but it pays a full memcpy of every node at merge and a handle-to-offset
-   resolution pass on top of it.
-3. **Reserve-max with an atomic bump — considered.** One buffer sized to
-   a declared bound; allocation is one atomic add and nothing ever
-   resizes. It is the allocate-max law dissolving the lock, and it is the
-   right answer for a caller who genuinely knows the bound; it is kept as
-   the documented alternative rather than the default, because a general
+1. **One buffer under a lock, grown by `realloc` — REJECTED.** A `realloc`
+   moves the buffer under a worker that is mid-write. Offsets fix identity but
+   not the raw references already resolved from them, and the corruption is
+   invisible until much later.
+2. **Sharded builders merged at `Lock` — REJECTED.** Each worker owns a
+   private growable array and references are (worker, slot) handles.
+   Contention-free, but it pays a full memcpy of every node at merge and a
+   handle-to-offset resolution pass on top of it.
+3. **Reserve-max with an atomic bump — NOT THE DEFAULT.** One buffer sized to
+   a declared bound, allocation one atomic add, nothing ever resizes. It is
+   the right answer for a caller who genuinely knows the bound, and it is kept
+   as the documented alternative rather than the default because a general
    builder cannot require one.
-4. **A segmented slab arena — THE DESIGN OF RECORD.** One logical arena
-   made of equal-size segments; a worker takes a slab with a single
-   atomic and then allocates privately inside it. One synchronization per
-   thousands of nodes, nodes born at final offsets, no handles and no
-   resolution pass, growth by appending a segment, and nothing ever
-   moves.
 
-`Lock` remains a full copy, because it is the compaction: it produces the
-single contiguous exact-packed region that §6.2 and §7 both need, and it
-is the ONLY copy in the lifecycle besides `Save` (which is inherent — it
-writes a wire). A non-compacted arena is relocatable only per segment;
-that is the reason `Lock` compacts rather than merely freezing.
+**The node table's shape** (§3.1):
 
-**Reference encoding.** The arena's offset is segment-indexed, so a deref
-there is a small table load plus an add. The region's is self-relative,
-so a deref there is one add with no base pointer — and it makes the
-region relocatable by pure `memcpy`. Two encodings, converted where a
-copy already happens.
+4. **A visited-index guard on load — REJECTED.** It is what an untyped node
+   table forces: type the nodes by traversing, and bound the traversal with a
+   set. That is state proportional to the graph on the READING path, which
+   §6.5 forbids. The type id removes the walk instead of bounding it.
+5. **An index-monotonic reference rule — REJECTED.** Requiring every reference
+   to name a larger index would bound a traversal with no state at all, but it
+   holds only under a TOPOLOGICAL numbering and pre-order is not one:
+   `Scene { a *X, b *Y }` with `X.p` and `Y.p` naming one `P` numbers
+   `X = 2, P = 3, Y = 4`, and `Y`'s reference names 3 from 4. Topological
+   order also cannot be assigned in one descent — a node's position is known
+   only once its whole subtree is.
+6. **A hybrid: inline the singly-referenced pointee, table only the shared
+   ones — REJECTED.** It reintroduces the exact problem the flat table
+   removes: a 200-node chain is singly referenced at every link, so it would
+   still nest 200 deep.
+7. **A NEW KIND for the node table — REJECTED.** Skipping is defined only over
+   §3's closed set, so a reader that does not have the kind cannot skip past
+   it, and the node table must stay skippable by a reader that never heard of
+   it. **Kind `14`, an array of tables — also rejected**: an array element's
+   framing has room for a length and nothing else, so the type id would have
+   to ride inside each body as a reserved FIELD, and every node body would
+   carry a field no schema declared.
+8. **A `u64` LENGTH on the reserved field, to lift the aggregate ceiling —
+   REJECTED, because it breaks the very reader it exists for.** A skipper
+   reads kind `12` as `L (u32)` then `L` bytes; given a `u64` it takes the low
+   half, skips that far, and lands four bytes short of the payload's end,
+   where it reads two payload bytes as the next field id. The whole point of
+   riding under an existing kind is that an old reader frames the body and
+   counts `unknown`.
+9. **A reader-side acyclicity check — PRICED, NOT TAKEN.** Pre-order numbering
+   gives every node a contiguous index interval, so with a `max index in
+   subtree` on each record a cycle is an `O(1)` test per reference. It costs
+   bytes a node plus a pass to prove the intervals are genuinely nested, for a
+   property the writer already guarantees (§3.1). It is the shape the check
+   would take if untrusted-input hardening ever demands one.
+10. **Node-directory INDICES in place of self-relative deltas** — making the
+    region and the wire one encoding — **REJECTED on the hot path.** A deref
+    would become a directory load plus a base pointer where today it is one
+    add (§6.3).
 
-**The node table's shape** (§3.1). The whole design turns on one
-decision — a TYPE ID on every record — and the rest follows from it:
+**The cooked check** (§7.4):
 
-1. **A type id per record — KEPT.** It is what makes a load a SCAN rather
-   than a traversal: the reader learns a node's type from the record, not
-   from the pointer field that names it, so it never follows a reference
-   to know what it is looking at. It also keeps §6.5's promise literally
-   true — `LoadMeasure` reads framing and no field value, and a type id
-   is framing — and it lets a tool decode a node table with descriptors
-   alone (§8).
-2. **A visited-index guard on load — REJECTED.** It is what an untyped
-   node table would force: type the nodes by traversing, and bound the
-   traversal with a set. That is state proportional to the graph on the
-   READING path, which §6.5 forbids. A type id removes the walk instead
-   of bounding it.
-3. **An index-monotonic rule — REJECTED.** Requiring every reference to
-   name a larger index would bound a traversal with no state at all, but
-   it holds only under a TOPOLOGICAL numbering, and pre-order numbering
-   is not topological: `Scene { a *X, b *Y }` with `X.p` and `Y.p` naming
-   one `P` numbers `X = 2, P = 3, Y = 4`, and `Y`'s reference names 3
-   from 4. Topological order also cannot be assigned in one descent — a
-   node's position is known only once its whole subtree is — and it would
-   give the node table a different order from the one the region is
-   packed in, for no property either form needs.
-4. **A hybrid — inline the singly-referenced pointee, table only the
-   shared ones — REJECTED.** It would have kept a pointer field and a
-   by-value nesting under one framing for the common case. It also
-   reintroduces the exact problem the flat table removes: a 200-node
-   chain is singly referenced at every link, so it would still nest 200
-   deep.
-5. **A NEW KIND for the node table — REJECTED.** Skipping is defined only
-   over §3's closed set, so a reader that does not have a new kind cannot
-   skip past it. That objection has a scope worth stating exactly,
-   because the pointer index below spends a kind on the same page: it
-   bites for a kind added AFTER readers exist, and the node table's kind
-   would have to be skippable by a reader that has never heard of it,
-   which is the whole reason it rides under an existing one. **Kind `14`,
-   an array of tables — also rejected**: an array element's framing has
-   room for a length and nothing else, so the type id would have to ride
-   inside each body as a reserved FIELD, and every node body would carry
-   a field no schema declared. Kind `12` is §3's opaque byte payload,
-   which is exactly what the node table is to a reader that cannot name
-   it.
-6. **A DISTINCT KIND for the pointer index — TAKEN, kind `17`.** The
-   opposite case, and the difference is who has to skip it. A node index
-   is four bytes and so is a `uint32`; under a shared kind an edit
-   between them reports nothing in either direction, and the direction
-   that matters — an index read back as a number — is silent always,
-   not merely often. A kind costs zero bytes, since the kind byte
-   already rides, and one row in the fixed-width skip rule. The set is
-   closed before any reader ships, so nothing has to skip a kind it does
-   not have; a kind spent now is simply part of the set every reader will
-   ever have, and spending one later would not be available. That last
-   clause is the reason this is decided here rather than deferred as an
-   optimization: the window closes at ship. It puts §4.1's silent class
-   back at two, beside `[E]T`'s kind `16`, which closed the previous one
-   the same way.
+11. **A stateless traversal from the root — REJECTED.** Bounds and forwardness
+    are not enough: a forged region can be a legal-looking DAG, forward and in
+    range and aligned, and a walk with no memory re-visits shared subtrees
+    exponentially (26 nodes, 312 ms; ~60 nodes, never).
+12. **A traversal with a monotonic high-water mark — REJECTED, and it FAILS
+    rather than merely costing.** The mark advances over region BYTES, not
+    over entered NODES, so a forward reference may jump past a node the walk
+    never enters; that node is then below the mark with its slots unchecked,
+    and a later reference to it passes an "already visited" test that was
+    never true of it. A 48-byte forgery is enough. Any repair keeps the
+    traversal and adds state to make "below the mark" and "already entered"
+    the same statement.
 
-   **The cost that is not zero, stated**: §3's rule cuts both ways, so a
-   reader built before this kind existed meets kind `17` as framing
-   damage and stops that body rather than skipping the field and reading
-   on. That is the price of the number, it is why item 5 refuses one for
-   the node table — which must stay skippable by a reader that never
-   heard of it — and it is bounded by the same fact that makes the kind
-   affordable: no such reader ships. A pointered save was already not
-   readable by a build of the tree encoding, since the node table carries
-   what the bodies used to.
-7. **A `u64` LENGTH on the reserved field, to lift the aggregate ceiling
-   — REJECTED, because it breaks the very reader it exists for.** A
-   skipper reads kind `12` as `L (u32)` then `L` bytes; given a `u64` it
-   takes the low half, skips that far, and lands four bytes short of the
-   payload's end, where it reads two payload bytes as the next field id.
-   The whole point of riding under an existing kind is that an old reader
-   frames the body and counts `unknown`, and a wider length forfeits it.
-   **The repeating field was taken instead**: same `u32`, same skip rule,
-   one narrow exception to last-occurrence-wins for one reserved id, and
-   no ceiling at all. **Its chunks close at RECORD boundaries**, and that
-   is the load-bearing half. A straddling record has no contiguous view,
-   so a reader would need a segmented cursor for every multi-byte read
-   AND a copy to hand a body to the generated decoder — an allocation on
-   the reading path, which §6.5 forbids, propagating into code that has
-   nothing to do with chunking. Record alignment costs under one record
-   of slack per field, keeps the chunking deterministic, and makes the
-   naive reader the correct reader. The one thing it cannot frame is a
-   record larger than a field, which the `u32` record length already
-   refuses (§11).
-8. **A reader-side acyclicity check — PRICED, NOT TAKEN.** Pre-order
-   numbering gives every node a contiguous index interval `[i, extent]`,
-   so with a `max index in subtree` on each record, a reference to a
-   LOWER index is an ancestor edge — a cycle — exactly when the
-   referrer's index is inside the target's interval: an `O(1)` test per
-   reference. It costs bytes a node plus a pass to prove the intervals
-   are genuinely nested, for a property the writer already guarantees
-   (§3.1) and no schema-generated walk depends on. It is the shape the
-   check would take if untrusted-input hardening ever demands one.
+**The block form: the shapes it is not** (§19). The form adds no declaration
+(§2.7), which is a strong claim, so the alternatives that would have added one
+are priced here.
 
-**Region references stay OFFSETS, not indices.** The node directory
-(§6.3) could have replaced the self-relative delta in every slot, making
-the region and the wire one encoding. It was rejected on the hot path: a
-deref would become a directory load plus a base pointer where today it is
-one add. The directory is kept for what only it can do — resolving wire
-indices on load, and checking a file whose provenance is in doubt — and
-the runtime's read path never touches it, which is what makes it
-separable at cook time (§7).
+13. **A `section` CONSTRUCT** — a field spelling whose storage is an
+    `(offset, count, stride)` triple, in a table with no wire because a triple
+    has no wire kind — **REJECTED, and the argument for it is circular.** The
+    triple is an artifact of ONE PROJECTION of a declaration; a wire form has
+    no triple to ride, only a bounded array of fixed tables, which already
+    rides as kind `14` with element kind `13` and the live count. With the
+    wire objection gone the construct has nothing left to justify it.
+14. **A bounded array BY VALUE, with the layout left to compile-time constants
+    — REJECTED, and it is the near miss.** Two things defeat the plain form:
+    the struct is the size of its maxima (§2.2) and cannot be read by value
+    across a boundary, and the layout facts stay constants a consumer ASSUMES
+    rather than reads, so every drift garbles silently and nothing on the
+    boundary can say so.
+15. **A pointer and a region (§2.1, §6.3) — REJECTED.** That is the
+    variable-length class. The producer would pay a single-threaded compaction
+    per frame and the consumer would need the region surface, which C# does
+    not have and would not want at sixty hertz.
+16. **The cooked form (§7), per frame — REJECTED, and for the same reason
+    flatbuffers lost.** A cook is produced FROM A BUILDER by a single-threaded
+    `Lock`, which is precisely the serialization point §12.1's bar refuses.
+17. **The tolerant table wire, per frame — REJECTED with a number implied.**
+    It is a parse and a copy on every frame on both sides; the abandoned
+    flatbuffers build is that rejection already paid for once (§7).
+18. **SELF-RELATIVE offsets inside a block — REJECTED**, which is a stated
+    exception to §6.3. A blittable consumer reads the projection BY VALUE, a
+    struct copy out of the mapped bytes, which a self-relative delta does not
+    survive: the copy's address is not the original's. A block's consumer is
+    handed the base, so block-relative costs it nothing and keeps relocation
+    by `memcpy` intact.
+19. **Compile-time block offsets from the maxima — REJECTED.** They would let
+    workers run before the counts exist, which nothing in the case wants — the
+    counts come from the same gather that produces the work — and every block
+    would be near its maximum extent, which a boundary handoff that copies
+    pays for on every frame.
+20. **Deeper out-of-line rules, and per-field opt-ins — REJECTED** for the
+    reason a keyword is: they put the answer somewhere other than the one line
+    a reader is already looking at. The genuine cost is that a small array
+    beside the strided ones in one root cannot stay inline; the answer is to
+    wrap it in a nested type, whose arrays are at depth two and therefore
+    inline (§19).
+21. **A per-table MARKER selecting the form — REJECTED** once the question it
+    answered was named (owner, §13.6: "KISS"): the marker bought cost control,
+    not meaning, and cost is answered better by emitting the form on the side
+    (§19), where a consumer that does not include it pays nothing and no
+    declaration has to predict who will.
+22. **A per-FIELD trigger, "any field carrying `| stride`" — REJECTED on its
+    own evidence.** The case this form comes from has nine strided arrays and
+    **zero** declared strides — every pitch there is `sizeof` — and a trigger
+    the primary case never fires is not a trigger.
+23. **A `| stride` attribute at all — CUT, not deferred** (§13.6). The one
+    consumer that exists cannot read a strided array: it reads rows by casting
+    the byte range to a row type, which requires pitch `== sizeof`, and it
+    drops any array whose pitch differs. That consumer's fast path is the hard
+    requirement the form exists to serve, so headroom trades it away for a
+    property both generated sides already give. Nothing is held for it: no
+    follow-on, no refusal by name, no reserved word.
+24. **A tolerant second entry point, or a tolerant block id — REJECTED,
+    because a block is same-build.** Both sides are generated from one
+    declaration by one compiler run, so a consumer older than its producer is
+    half a shipped build rather than a case to absorb. The id could not have
+    been made tolerant in any case: a single number cannot be verified against
+    a PREFIX of the facts that produced it, and any fold that ignored the
+    difference would ignore a real break too.
 
-**Why the cooked check is a SCAN and not a walk.** Three models were
-weighed:
+**The view's shape** (§8), against the owner's picture of it — an editor that
+inspects everything in the schema built:
 
-1. **A stateless traversal from the root — REJECTED.** Bounds and
-   forwardness are not enough: a forged region can be a legal-looking
-   DAG, forward and in range and aligned, and a walk with no memory
-   re-visits shared subtrees exponentially (26 nodes, 312 ms; ~60 nodes,
-   never).
-2. **A traversal with a monotonic high-water mark — REJECTED, and it is
-   worth saying why it FAILS rather than merely costing.** The mark
-   advances over region BYTES, not over entered NODES, so a forward
-   reference may jump past a node the walk never enters. That node is
-   then below the mark with its slots unchecked, and a later reference to
-   it passes an "already visited" test that was never true of it. A
-   48-byte forgery is enough: the root names the third node, the third
-   names the second, and the second's slot — never checked — points far
-   outside the region. Any repair keeps the traversal and adds state to
-   make "below the mark" and "already entered" the same statement.
-3. **A linear scan over the node directory — THE DESIGN OF RECORD.** The
-   directory already names every node start and its type. Spending that
-   the way §3.1 spends the wire's type id — removing the walk instead of
-   bounding it — makes each node checked exactly once, follows no
-   reference at all, and needs no order invariant, so the pack order and
-   the check are independent. It also checks the nodes NOTHING points at,
-   which no traversal from the root can, and that is precisely where the
-   marked traversal's hole was. `O(R + P log N)`, no allocation, and less
-   machinery than the walk it replaces.
-
-**The block form: the shapes it is not, and why.** The form adds no
-declaration (§2.7), which is a strong claim, so the alternatives that would
-have added one are priced here.
-
-- **A `section` CONSTRUCT — a field spelling whose storage is an
-  `(offset, count, stride)` triple, in a table with no wire because a triple
-  has no wire kind — REJECTED, and the argument for it is circular.** The
-  triple is an artifact of ONE PROJECTION of a declaration. A wire form has
-  no triple to ride: it has a bounded array of fixed tables, which already
-  rides as kind `14` with element kind `13` and the live count. Nothing is
-  spent, §3 is untouched, and the table keeps `Measure`, `Save`, `Load` and
-  its cook. With the wire objection gone the construct has nothing left to
-  justify it — the storage is a bounded array, the layout is a second
-  projection of the same declaration, and "is the render data a table?" is
-  answered with one word.
-- **A bounded array BY VALUE, with the layout left to compile-time constants
-  — REJECTED, and it is the near miss.** The storage is already a strided
-  array at pitch `sizeof`, at a fixed offset, fillable by N workers with no
-  synchronisation, so the storage half needs nothing added. Two things defeat
-  the plain form. **The struct is the size of its maxima** (§2.2) and cannot
-  be read by value across a boundary. And **the layout facts stay constants a
-  consumer ASSUMES** rather than reads, so every drift garbles silently and
-  nothing on the boundary can say so. The PROJECTION answers both without a
-  construct: it replaces each out-of-line array's inline storage with sixteen
-  bytes at the same field position, so the instance is small and copyable and
-  the three facts a consumer needs become data. What the form adds over the
-  plain array is not storage — it is a second layout of one declaration.
-- **A pointer and a region (§2.1, §6.3) — REJECTED.** That is the
-  variable-length class: an arena, a `Lock` that compacts, a node directory,
-  self-relative derefs. The producer would pay a single-threaded compaction
-  per frame and the consumer would need the region surface, which C# does not
-  have and would not want at sixty hertz. The block form needs no arena
-  because the table declares its bounds.
-- **The cooked form (§7) — REJECTED, and for the same reason flatbuffers
-  lost.** A cook is produced FROM A BUILDER by a single-threaded `Lock`,
-  which is precisely the serialization point §12.1's bar refuses. The two are
-  not competitors and not the same accelerator: a cook accelerates a file
-  read once at load, and a block is rebuilt every frame.
-- **The tolerant table wire, per frame — REJECTED with a number implied.**
-  It is a parse and a copy on every frame on both sides; the abandoned
-  flatbuffers build is that rejection already paid for once (§7).
-
-**And four decisions inside the form.**
-
-- **Block-relative offsets, not self-relative — TAKEN, and it is a stated
-  exception to §6.3.** A region reference is self-relative because nothing
-  hands a walker a base pointer down inside a region. A block's consumer is
-  handed the base — it is the thing it mapped — and, decisively, a blittable
-  consumer reads the projection BY VALUE (a struct copy out of the mapped
-  bytes), which a self-relative delta does not survive: the copy's address is
-  not the original's. Block-relative keeps relocation by `memcpy` intact,
-  since every offset is relative to a base that moves with the block.
-- **Storage sized from the declared maxima; layout settled ONCE per block
-  from the counts — TAKEN.** The storage half is the allocate-max law (the
-  builder's item 3 above, which a general builder could not require and a
-  bounded table can): one extent, never grown, never pooled. The layout half
-  is a single pass over the table's out-of-line ARRAYS — a handful, not
-  thousands of rows — run before any worker starts, which is all the property
-  needs. **Compile-time offsets from the maxima are the alternative, and they
-  are REJECTED**: they would let workers run before the counts exist, which
-  nothing in the case wants — the counts come from the same gather that
-  produces the work — and every block would be near its maximum extent, which
-  a boundary handoff that copies pays for on every frame. The projection
-  carries the offsets either way, so a consumer reads them rather than
-  assuming them.
-- **DEPTH ONE, BOUNDED ONLY — TAKEN, and it is what carries the rule a
-  keyword would otherwise state.** With no keyword saying which arrays move
-  out of line, the rule must be derivable from the declaration, and this is
-  the rule that is: the table's own `[..N]` arrays of structs move, and
-  everything else stays. **Deeper rules and per-field opt-ins are REJECTED**
-  for the reason a keyword is — they put the answer somewhere other than the
-  one line a reader is already looking at. The genuine cost is that a small array
-  BESIDE the strided ones in one root cannot stay inline; the answer is to
-  wrap it in a nested type, whose arrays are at depth two and therefore
-  inline (§19).
-- **NOTHING SELECTS THE FORM — TAKEN** (owner, §13.6: "KISS"). A per-table
-  marker was the earlier answer, and it was REJECTED once the question it
-  answered was named: the marker bought cost control, not meaning, and cost
-  is answered better by emitting the form on the side (§19), where a consumer
-  that does not include it pays nothing and no declaration has to predict who
-  will. A per-FIELD trigger, "any field carrying `| stride`", is rejected on
-  its own evidence: the case this form comes from has nine strided arrays and
-  **zero** declared strides — every pitch there is `sizeof` — and a trigger
-  the primary case never fires is not a trigger. What is left is the mode
-  (§2.2): fixed tables have the form, variable-length ones do not, and the
-  answer is derived rather than declared, exactly as the mode itself is.
-- **No `| stride` attribute at all — TAKEN, on the same evidence plus the
-  consumer's, and taken as a CUT rather than a deferral** (§13.6). Beyond the
-  zero declared strides, the one consumer that exists cannot read a strided
-  array: it reads rows by casting the byte range to a row type, which
-  requires pitch `== sizeof`, and it drops any array whose pitch differs.
-  That consumer's fast path is the hard requirement the form exists to serve,
-  so headroom trades it away for a property both generated sides already
-  give. Nothing is held for it: no follow-on, no refusal by name, no reserved
-  word.
-- **ONE exact id and ONE entry point — TAKEN, because a block is
-  same-build.** A tolerant second entry point was weighed and dropped: both
-  sides of a block are generated from one declaration by one compiler run, so
-  a consumer older than its producer is half a shipped build rather than a
-  case to absorb, and a refusal is the honest answer to it. The id could not
-  have been made tolerant in any case — a single number cannot be verified
-  against a PREFIX of the facts that produced it: a consumer that knows fewer
-  fields cannot recompute the producer's number, and any fold that ignored
-  the difference would ignore a real break too. So the block's id is exact —
-  the build version (§19.3), like a cooked file's (§7) — and there is nothing
-  beside it. What a cook and a block both keep is one surface each and no
-  silent bypass anywhere.
-
-**The view's shape** (§8). Four models were weighed against the owner's
-picture of it — an editor that inspects everything in the schema built:
-
-1. **A SECOND descriptor vocabulary for types — REJECTED.** A `type` is not
-   a table, so a type-shaped `TypeFieldInfo` beside `TableFieldInfo` looked
-   tidy. It is two vocabularies, therefore two walkers, therefore every
-   printer, differ and property grid written twice — and the JSON walker
-   (§16) and the block form's reflective read (§19.2) are already written
-   against the first one. One surface, filled by the same rules, is what
-   makes a type walkable by code that was never told about views.
-2. **A MARKER on the declaration plus a generate flag to select what is
-   viewed — REJECTED, and this is the subtraction the design turns on.** It
-   was the shape this section was first written in: `| view` on a type, a
-   three-valued `--views`, a closure rule for what a marker reaches, a
-   refusal for each declaration kind the marker does not fit, a reserved
-   word taken out of the type-tag namespace to make the marker parse, and a
-   gate proving the flag moved nothing. All of it existed to answer one
-   question — what does this build pay for — that placement answers by
-   itself (§8.4): the file is on the side, a consumer that does not compile
-   it pays nothing, and a consumer that does wants everything anyway. Every
-   one of those constructs went with the question.
-3. **A view file per SCHEMA FILE — REJECTED.** It mirrors §6.1's
-   one-file-per-schema-file layout and leaves the registry homeless: the
-   registry is the set of everything the UNIT declares, so it would either
-   live in one arbitrarily chosen file's output or force each file's view to
-   reach into the others and back — the cross-file cycle §11 refuses. A
-   unit-level fact gets a unit-level file.
-4. **One unit-level file carrying everything, always — THE DESIGN OF
-   RECORD.** One `UnitView()` over constant data, every declaration's view
-   beside it, `<Name>TableType()` unchanged for anything a table already
-   reached, and a file an editor links and a game never compiles.
-
-**Completeness is what an editor needs, and a subset is what a marker
-sells.** A tool that inspects a build cannot be served by the declarations
-someone remembered to mark — the one it needs is the one nobody marked. So
-the registry is complete by construction, and the price of completeness is
-paid where it is cheap: in a translation unit a build either compiles or
-does not.
-
-**No decision here knowingly costs TIME.** The `u64` type id and the
-repeating node-table field cost BYTES and nothing else — the record scan
-is linear either way, and a wider id compares no slower than a narrow
-one. The directory scan replaced a traversal with a scan of the same
-asymptotic class and a smaller constant, and it moved off the runtime
-path entirely (§7): a matching build version points, and checks nothing.
-Where a cost is real it is stated with its number (§6.3) rather than
-deferred, and the optimization work that follows real profiles is not
-pre-empted here.
+25. **A SECOND descriptor vocabulary for types — REJECTED.** A `type` is not a
+    table, so a type-shaped `TypeFieldInfo` beside `TableFieldInfo` looked
+    tidy. It is two vocabularies, therefore two walkers, therefore every
+    printer, differ and property grid written twice — and the JSON walker
+    (§16) and the block form's reflective read (§19.2) are already written
+    against the first one.
+26. **A MARKER on the declaration plus a `--views` flag to select what is
+    viewed — REJECTED, and this is the subtraction the design turns on.** It
+    was the shape this section was first written in: `| view` on a type, a
+    three-valued flag, a closure rule for what a marker reaches, a refusal for
+    each declaration kind the marker does not fit, a reserved word taken out
+    of the type-tag namespace to make the marker parse, and a gate proving the
+    flag moved nothing. All of it existed to answer one question — what does
+    this build pay for — that placement answers by itself (§8.4). Every one of
+    those constructs went with the question.
+27. **A view file per SCHEMA FILE — REJECTED.** It mirrors §6.1's
+    one-file-per-schema-file layout and leaves the registry homeless: the
+    registry is the set of everything the UNIT declares, so it would either
+    live in one arbitrarily chosen file's output or force each file's view to
+    reach into the others and back — the cross-file cycle §11 refuses.
 
 ## 15. Named follow-ons
 

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1832,12 +1832,10 @@ that can be memory mapped, endian-fixed and loaded quickly by a build at
 the exact version it was cooked to. That is cooking.
 
 ```cpp
-int64_t data, attribution;
-SceneCookMeasure( builder, &data, &attribution );
-SceneCook( builder, buffer, data, attribution );   // write it
-
 const Scene * scene = SceneOpen( bytes, length ); // point at it, or NULL
 ```
+
+`schema cook` writes the file; the runtime only ever points at one.
 
 **Backend status: the TOOL and BOTH READ SIDES are built; no WRITE side is
 (schema#251).** `schema cook`, `schema cook-check` and `schema uncook` produce,

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -4537,9 +4537,11 @@ pre-empted here.
   A port mirrors this document and invents no contract of
   its own; where a language forces a shape — a pseudo-union for a language
   with no native union — the ladder above already says what is licensed.
-- **The C# VARIABLE class** — the arena, the region, the cooked form and the
-  pointer surface, on top of the fixed class C# carries today (§11). And the
-  C# text form (§16), whose walk C++ carries alone.
+- **The C# VARIABLE class on the WIRE** — the arena, the region, the builder
+  and the node-table codec, on top of the fixed class C# carries today (§11).
+  The cooked form is NOT in it: a cook is pointed at, not parsed, so
+  `<Base>Cook.cs` and `<Root>Cook.Open` are emitted for a pointered unit
+  already (§7, §11). And the C# text form (§16), whose walk C++ carries alone.
 - **The variable class in a ported backend** — the arena, the region, the
   cooked form and the pointer surface — after that port's fixed class.
 - **The TEXT FORM for the variable class** (§16.1) — a second walker that

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -2136,8 +2136,8 @@ the wire, and keeps the flexibility that comes with it.
     handed back by static accessors on `<Root>Cook` named after the field — so
     reading one copies nothing and allocates nothing, and neither accelerator
     adds a member to the other's structs. **A table claims one member per field
-    on its `Cook` type**, exactly as it claims one per out-of-line array on its
-    `Block` type (§11), and a language whose accessors are members claims nothing
+    on its `Cook` type**, on the same rule that claims its `Block` type's row
+    accessors (§11), and a language whose accessors are members claims nothing
     at file scope for them.
 
   **WHERE IT IS EMITTED is §19.2's rule, for §19.2's reason**: C# has no include

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -2256,13 +2256,10 @@ the wire, and keeps the flexibility that comes with it.
 - **Alignment.** The header pads the data part to the region's alignment,
   so a base the allocator or `mmap` gave you is already aligned; `mmap`
   gives page alignment for free.
-- **Endianness is part of the COOK, not of `Open`.** A cook is produced
-  in the byte order of the build it is cooked for — the cook knows its
-  target — so a matching build version already means a matching byte order
-  and `Open` never fixes anything up. Cooking for a foreign target is
-  where a byte swap would live if one is ever wanted (§15); a cooked file
-  whose recorded order is not this build's is simply not this build's
-  file, and refuses.
+- **Endianness is part of the COOK, not of `Open`** (above): a matching
+  build version already means a matching byte order, so `Open` never fixes
+  anything up. Cooking for a foreign target is where a byte swap would live
+  if one is ever wanted (§15).
 
 Prior art gets one sentence, and it is the contrast: systems that made
 pointed-at access their ONLY wire coupled access to evolution and paid

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -3555,8 +3555,8 @@ in build version (§20.5).
 
   - **The three per-declaration spellings the descriptors emit** —
     `<Name>TableFields`, `<Name>TableInfo` and `<Name>TableType` — claimed
-    for every declaration in every unit. All three are in the 25 above and
-    are claimed today only for closure members; the descriptor emission
+    for every declaration in every unit. All three are in the suffix list
+    above and are claimed today only for closure members; the descriptor emission
     spells all three per declaration, so widening one of them would leave
     two open.
   - **The unit-level TABLE-RUNTIME names**, claimed in every unit rather

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1910,10 +1910,8 @@ enough that the cost of loading it does not matter is the wire, and stays
 the wire, and keeps the flexibility that comes with it.
 
 - **The header build-locks it**: a magic (which is also the byte-order
-  check), the unit's BUILD VERSION (§20), and the lengths of the two parts
-  below. The reserved words are reserved: a non-zero one means a writer used
-  a form this build does not understand, and `Open` refuses rather than
-  ignoring it.
+  check), the unit's BUILD VERSION (§20), the lengths of the two parts
+  below, and two reserved words (§7.1).
 
   A cooked file never crosses builds, so most of the header's shape is
   the implementation's business. **Three widths are not**, because each

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -4457,9 +4457,9 @@ inspects everything in the schema built:
   compare. It is the same harness pointed at two more directories, and it
   belongs with the emitters rather than with this page, because a snapshot
   taken before the code that could move it is a snapshot of nothing.
-- **The view in a ported backend** — C++ and C# take it together (§0); every
-  other backend emits no view file until it emits the same registry against
-  the same pin (§8.7). Nothing is refused meanwhile, because nothing in a schema
+- **The view in a ported backend** — C++ and C# take it together (§8); every
+  other backend emits no view file until it emits the same registry against the
+  same pin (§8.7). Nothing is refused meanwhile, because nothing in a schema
   asks for one (§8.4): a backend without the emitter is a backend whose
   users have no registry, and the status paragraph says so.
 - **DOC STRINGS in the view.** Doc comments are deferred with their design

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -4457,9 +4457,9 @@ inspects everything in the schema built:
   compare. It is the same harness pointed at two more directories, and it
   belongs with the emitters rather than with this page, because a snapshot
   taken before the code that could move it is a snapshot of nothing.
-- **The view in a ported backend** — C++ and C# carry it; every other
-  backend emits no view file until it emits the same registry against the
-  same pin (§8.7). Nothing is refused meanwhile, because nothing in a schema
+- **The view in a ported backend** — C++ and C# take it together (§0); every
+  other backend emits no view file until it emits the same registry against
+  the same pin (§8.7). Nothing is refused meanwhile, because nothing in a schema
   asks for one (§8.4): a backend without the emitter is a backend whose
   users have no registry, and the status paragraph says so.
 - **DOC STRINGS in the view.** Doc comments are deferred with their design

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -1610,7 +1610,7 @@ to resolve.
 
 **Backend status: OWED, not emitted.** No guarded block carries an identity
 today and no generated file asserts one, so the silent case above is live in
-all four of the C++ table emitter's guarded blocks. Tracked as schema#301,
+every one of the C++ table emitter's guarded blocks. Tracked as schema#301,
 with the negative control it must carry: perturb one header's copy of a block
 and show the translation unit red, naming that header — the same control that
 measured the silence, run in the other direction.

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -3588,19 +3588,6 @@ in build version (§20.5).
   It is a file-name collision rather than a declaration collision, so it is
   refused naming the FILE, and it is stated here because the view is what
   introduces a generated name that is not derived from a schema file's own.
-
-  **A FIXED TABLE claims two more per out-of-line array, because its
-  row accessors are named after its fields — and this claim is owed with the
-  block form too, on the same terms as the seven above** (schema#287): the
-  checker makes it today for neither. `<Table>` followed by the
-  PascalCase of the field's name is the accessor that hands back that
-  field's rows, and the same name with `Span` appended is the contiguous
-  view (§19.2) — so `RenderFrame` with a `ships` array claims
-  `RenderFrameShips` AND `RenderFrameShipsSpan`, and a declaration spelling
-  either is refused naming both. A language whose accessors are members
-  spells the same two names on the block type instead, and claims nothing at
-  file scope for them. This part of the set moves with the declaration,
-  which is why it is stated as a rule rather than as a list.
 - **A table named after a member of its generated builder** — a member
   function hides the type name it shares, so the header would not
   compile. The two accessors a real schema would plausibly hit were

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -5932,9 +5932,9 @@ Tooling cooks before any game binary exists, so Y has to be knowable from the
 schema alone. The compiler owns every fact in it, including the layout: it
 computes each record's layout from its own C ABI model — the model §19.3
 states and both backends MUST assert against (§20.3) — and emits the id as one
-constant. A build whose compiler lays a record out differently is meant to
-fail to BUILD, loudly, naming the type and the field; those asserts are owed
-and not yet emitted, which §20.3 states in full.
+constant. A build whose compiler lays a record out differently fails to BUILD,
+loudly, naming the type and the field; §20.3 states the asserts in full and
+names the one closure they do not yet reach.
 
 **Backend status: the id, its projection and both READ sides are LIVE.**
 `schema build-version` prints the id and `schema build-version --facts` prints

--- a/SPEC-TABLES.md
+++ b/SPEC-TABLES.md
@@ -5756,8 +5756,7 @@ schema alone. The compiler owns every fact in it, including the layout: it
 computes each record's layout from its own C ABI model — the model §19.3
 states and both backends MUST assert against (§20.3) — and emits the id as one
 constant. A build whose compiler lays a record out differently fails to BUILD,
-loudly, naming the type and the field; §20.3 states the asserts in full and
-names the one closure they do not yet reach.
+loudly, naming the type and the field; §20.3 states the asserts in full.
 
 **Backend status: the id, its projection and both READ sides are LIVE.**
 `schema build-version` prints the id and `schema build-version --facts` prints
@@ -5767,41 +5766,29 @@ C# BLOCK backends emit the constant and stamp it into every block's prologue
 header, `schema cook-check` reads it back, and the C++ `<Root>Open` and the C#
 `<Root>Cook.Open` each compare it (§7). What remains owed, largest first:
 
-1. **The constant rides in the BLOCK and COOK sources only.** §20.7 asks for
+1. **The constant rides in the TABLE-bearing sources only.** §20.7 asks for
    one beside `ProtocolId` in every backend; today the two block backends emit
    it into `<Base>Block.h` / `<Base>Block.cs`, the C++ table backend emits it
-   into the `<Base>Table.h` of a unit that has a variable-length table — where
-   the cook's reader is — the C# cook emits it into `<Base>Cook.cs` when the
-   unit has no block form to carry it already, and the seven backends that carry
-   no table emit none. A VALUE-ONLY unit's Table sources carry no constant, which
-   is the zero-cost gate (§2.2) rather than an omission: nothing in one reads a
-   cook. **In C# exactly one accelerator defines it** — `Schema` is one partial
-   class across a unit's files, so a second definition is a compile error rather
-   than C++'s harmless re-inclusion behind a guard.
-2. **The layout asserts cover the BLOCK CLOSURE and the COOK CLOSURE on BOTH
-   backends, but not a record in a unit with no accelerator reader in it.**
-   C++ `static_assert`s each block
-   projection's and each row type's `sizeof`, `alignof` and every field
-   `offsetof`, and does the same for every record declared by a file of a unit
-   that has a variable-length table. C# asserts the block facts under the
-   managed model in one once-run check and, in `TableCookLayout`, every record of
-   the unit's COOK closure — each `<Name>Row`'s size and each field's offset — in
-   another. What neither side asserts is a record in a unit with NO pointer
-   anywhere, which is exactly the unit whose sources the zero-cost gate holds
-   byte-identical, so closing it and §20.3's commitment are one question, and it
-   is OPEN.
-3. **The C# check is a THROW at first use, not a build error.** §20.3 asks
+   into every `<Base>Table.h` — where the cook's reader is — the C# cook emits
+   it into `<Base>Cook.cs` when the unit has no block form to carry it already,
+   and the seven backends that carry no table emit none. The C# Table sources
+   carry none, which is the zero-cost gate (§2.2) rather than an omission: the
+   C# cook reader is in the accelerator's own file. **In C# exactly one
+   accelerator defines it** — `Schema` is one partial class across a unit's
+   files, so a second definition is a compile error rather than C++'s harmless
+   re-inclusion behind a guard.
+2. **The C# check is a THROW at first use, not a build error.** §20.3 asks
    for a build error on the side that disagrees; C# has no `static_assert`,
    so the generated check runs once at type initialization and throws naming
    the type, the field, the offset it found and the offset the compiler's model
    gives. Loud and early, but not at compile time. The gate runs both `Verify()`
    halves as their own start-up mode rather than waiting for a first open, which
    is the most a runtime with no compile-time assert can do.
-4. **The COOK's WRITE side is the TOOL's alone.** `schema cook` produces a
+3. **The COOK's WRITE side is the TOOL's alone.** `schema cook` produces a
    cooked file and no generated runtime does: `CookMeasure` and the write half
    of `Cook` stay claimed ahead of their emitter (§7, §11, schema#251). BOTH
    read sides are emitted and gated.
-5. **A UNION-BEARING closure has no C# cook reader**, for the reason it has no
+4. **A UNION-BEARING closure has no C# cook reader**, for the reason it has no
    block form: §19.3 pins a blittable C# record to `Sequential`, which cannot
    overlay arms. The generated file names the table and the reason, the table's
    cook and its wire are untouched, and C++ reads one. A named follow-on (§15).
@@ -6100,21 +6087,18 @@ Pack = 1, Size = N)`) with generated padding and a once-run layout check
 that disagrees**, naming the type, the field, the expected offset and the one
 its compiler produced.
 
-**Those asserts are in the tree for the BLOCK CLOSURE and for the COOK closure
-of a POINTERED unit.** C++ `static_assert`s each block projection's and each
+**Those asserts are in the tree, for EVERY COOKABLE RECORD of every unit that
+declares a table.** C++ `static_assert`s each block projection's and each
 row type's `sizeof`, `alignof` and every field `offsetof`, and asserts the same
-three facts for every record declared by a file of a unit that has a
-variable-length table — the records a cook's region is laid out from, asserted
-in the file that DECLARES them, which is the same rule §7 gives a member's
-walk. C# emits blittable storage with generated padding and asserts the block
-facts under the managed model in a once-run check that THROWS rather than
-failing the build, because C# has no `static_assert`. What neither side asserts
-is a record in a unit with NO pointer in it — so for those this section's
-guarantee is still a specification and not a property of any build: **two
-builds whose ABIs differ there would share a build version and cook different
-bytes, with nothing to say so.** Closing it means emitting the asserts into a
-value-only unit's Table header, which moves bytes the zero-cost gate holds
-identical (§2.2), so it is one question with that gate and it is OPEN. The model is not self-evidently right either — on 32-bit System V
+three facts for every record a file declares — the records a cook's region is
+laid out from, asserted in the file that DECLARES them, which is the same rule
+§7 gives a member's walk. C# emits blittable storage with generated padding and
+asserts the block facts under the managed model in a once-run check that THROWS
+rather than failing the build, because C# has no `static_assert`, and asserts
+every record of the unit's cook closure in `TableCookLayout`. A VALUE-ONLY unit
+is not an exception: its Table header carries the asserts like any other, and
+the bytes they added are pinned by the zero-cost gate rather than excluded from
+it (§2.2). The model is not self-evidently right either — on 32-bit System V
 `alignof(uint64_t)` is 4, not 8 — which is precisely why it is asserted rather
 than assumed, and why "it never reaches a cook" is a claim the asserts make
 true rather than one the model makes true on its own.

--- a/USAGE.md
+++ b/USAGE.md
@@ -588,7 +588,8 @@ that has no native union, and a variable-length table allocates by nature —
 in C++ the caller owns it.
 
 A table lives on its own wire — evolution-tolerant TLV, carried by C++ and by
-C# (the fixed class; C#'s pointer surface and text form are follow-ons). Field
+C# (the fixed class; C#'s pointer surface ON THE WIRE and its text form are
+follow-ons — its cook and block accelerators read a pointered unit today). Field
 identity is a hash of the field NAME, so any reader takes any data, both
 directions: unknown fields are skipped, absent fields take their declared
 defaults, a field whose type changed is skipped rather than misdecoded,

--- a/USAGE.md
+++ b/USAGE.md
@@ -1350,12 +1350,12 @@ puts the two back together when you want to check one.
 
 ### The build version: what a cooked asset is stored under
 
-*Live for the BLOCK form: `schema build-version [--facts]` prints the id and
-the projection it digests, both pinned as goldens, and the C++ and C# block
-backends emit `BuildVersion` and stamp it into every block's prologue. `schema
-cook` stamps the same id into every cooked header and `cook-check` reads it
-back — what is still owed, the constant beside `ProtocolId` in every backend
-and the generated `Open` that checks it, is SPEC-TABLES.md §20's status list.*
+*`schema build-version [--facts]` prints the id and the projection it digests,
+both pinned as goldens; the C++ and C# block backends emit `BuildVersion` and
+stamp it into every block's prologue; `schema cook` stamps the same id into
+every cooked header, and `cook-check`, the C++ `<Root>Open` and the C#
+`<Root>Cook.Open` each read it back and compare. What is still owed is
+SPEC-TABLES.md §20's status list.*
 
 A cook is only ever produced for one build, so something has to name which
 build. That is the **build version**: one digest over everything a cook's
@@ -1388,11 +1388,10 @@ side — but WHEN it tells you differs by language, and only C++ tells you at
 build time. C++ `static_assert`s every `sizeof`, `alignof` and `offsetof`,
 so a compiler that lays a record out differently fails the BUILD, naming the
 type and the field. C# has no `static_assert`: the generated
-`TableBlockLayout.Verify()` runs once at first use and THROWS, naming the
-type, the field, the offset it found and the offset the C++ side asserts —
-loud and early, but at run time. Both cover the records the block form
-reaches, not yet every record in the unit's table closure. SPEC-TABLES.md
-§20's status list carries both gaps as items 2 and 3.
+`TableBlockLayout.Verify()` and `TableCookLayout.Verify()` run once at first
+use and THROW, naming the type, the field, the offset it found and the offset
+the C++ side asserts — loud and early, but at run time. What neither side
+reaches is SPEC-TABLES.md §20's status list.
 
 Two things it does not do:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1390,8 +1390,9 @@ so a compiler that lays a record out differently fails the BUILD, naming the
 type and the field. C# has no `static_assert`: the generated
 `TableBlockLayout.Verify()` and `TableCookLayout.Verify()` run once at first
 use and THROW, naming the type, the field, the offset it found and the offset
-the C++ side asserts — loud and early, but at run time. What neither side
-reaches is SPEC-TABLES.md §20's status list.
+the C++ side asserts — loud and early, but at run time. Both cover every
+cookable record of a unit that declares a table; what is still owed is
+SPEC-TABLES.md §20's status list.
 
 Two things it does not do:
 

--- a/USECASES.md
+++ b/USECASES.md
@@ -102,7 +102,7 @@ layout; the game memory-maps it and points at it with minimal fix-up.
   64-bit digest over every fact a cook's bytes depend on — the type wire's
   protocol id, every record's layout keyed by wire id, kind and referent, the
   facts that decide what a load PUTS in a slot, and the target's byte order —
-  so schema drift refuses at `Open` and ABI drift is meant to fail the build
+  so schema drift refuses at `Open` and ABI drift fails the build
   (§20.3). `Open` checks the magic, the byte order, the build version, every
   reserved word zero, the two part lengths and the base alignment — that is
   the whole check, and it is the runtime's only entry point — returning NULL
@@ -114,12 +114,17 @@ layout; the game memory-maps it and points at it with minimal fix-up.
   config-format example holding gate 1 (§12), the C# backend reads the same
   bytes the C++ tools write, and the dogfood carries a real game's two files
   on this wire end to end — 803 values byte-identical, every injected bit
-  flip refused rather than read as data. **The cook half is not built**: no
-  backend emits `Cook`, `CookMeasure` or `Open`, there is no cooked header,
-  `schema cook-check` does not exist, and addressing an artifact by
-  **(asset hash, build version)** is designed only. It lands with the variable
-  class's flat node encoding (§3.1), tracked by **#251**; the build version
-  itself is **#292** and is live for the block form.
+  flip refused rather than read as data. **The cook's READ half is proven
+  too**: `schema cook`, `schema cook-check` and `schema uncook` produce,
+  validate and read back the form in both byte orders, `wire → cook → wire` is
+  byte-identical over the corpus, and the C++ `<Root>Open` and the C#
+  `<Root>Cook.Open` both point at what the tool wrote — locked against the
+  tool's own attribution directory over seven roots, and against each other
+  byte for byte. What no generated runtime carries is the WRITE half, `Cook`
+  and `CookMeasure`: a build that writes a cook runs the tool (§7, §11).
+  Addressing an artifact by **(asset hash, build version)** is half live — the
+  build version is stamped in every cooked header and compared at `Open`; no
+  header field carries the asset hash (§7).
 
 ## 5. Render data written and read across two languages at runtime
 

--- a/USECASES.md
+++ b/USECASES.md
@@ -245,8 +245,9 @@ reference.
   cycle refusal and the stale-leak and zero-cost gates beside it. §3.1's
   flat node encoding is the landed spec; the emitter still writes the
   nested form, and moving it over is tracked by **#251**. The variable
-  class exists in C++ only — C# refuses a pointered unit by name (§11) —
-  and the variable class's text form is a named follow-on (§15).
+  class's WIRE exists in C++ only — C# refuses that surface by name and
+  emits the pointered unit's cook and block accelerators regardless (§11)
+  — and the variable class's text form is a named follow-on (§15).
 
 ## 10. Config delivered from a backend into a running server
 

--- a/USECASES.md
+++ b/USECASES.md
@@ -147,13 +147,13 @@ sixty times a second or better.
   version refuses and both sides regenerate. The block carries no field ids,
   no lengths, no elision and no read report — §4's counters do not exist here,
   because none of the events they count can occur.
-- **Proof** — designed, not yet built, and the layout asserts above are the
-  largest missing piece: the tree carries no `sizeof`/`offsetof`
-  `static_assert` and the C# fixed class is not blittable yet (§20.3). §12.1
-  states the gate: both sides generated, the multi-threaded fill held by a
-  refuser, and the speed of the hand-written scatter it replaces.
-  **#288** tracks the gate; **#287** tracks the C# blittable struct form the
-  consumer needs.
+- **Proof** — both sides are generated and the layout contract is asserted:
+  C++ `static_assert`s every `sizeof`, `alignof` and `offsetof` of each block
+  projection and row, and the C# rows are blittable
+  `StructLayout(Sequential, Pack = 1, Size = N)` with a generated padding and a
+  once-run `TableBlockLayout.Verify()` (§20.3). §12.1 states the rest of the
+  gate: the multi-threaded fill held by a refuser, and the speed of the
+  hand-written scatter it replaces.
 
 ## 6. JSON parsed and packed into tables
 
@@ -285,5 +285,5 @@ layout.
 
 The claim is held to this page's own standard: where an entry says
 **designed, not yet proven**, that capability is not being claimed. Today
-those are the message set (#258), the cook key (#292), the block form (#288,
-#287), and the flat node encoding's emitter (#251).
+those are the message set (#258), the cook key (#292), and the flat node
+encoding's emitter (#251).

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -476,7 +476,7 @@ func TestTableRuntimeNamesAreClaimed(t *testing.T) {
 	// Every Table*-prefixed identifier, whatever surrounds it. The word
 	// boundary is what keeps the name-first spellings out: RootConfigTableType
 	// has no boundary before its Table, and is claimed by suffix instead
-	// (SPEC-TABLES.md §11's 23). Line comments are stripped first — prose is
+	// (SPEC-TABLES.md §11). Line comments are stripped first — prose is
 	// not an identifier, and scanning it would make the gate a spelling
 	// police for the runtime's own documentation.
 	ident := regexp.MustCompile(`\bTable[A-Za-z0-9_]*\b`)

--- a/internal/codegen/cpptable/cook.go
+++ b/internal/codegen/cpptable/cook.go
@@ -20,10 +20,11 @@
 // build's header or it returns NULL and the caller falls back to a wire load —
 // the path that carries every version.
 //
-// Nothing here is emitted for a unit of value-only tables: a cook's reader is
-// the variable-length surface's, so a pointer-free unit's <Base>Table.h is
-// byte-identical with or without this file, which is what the zero-cost gate
-// (§2.2) asks.
+// EVERY unit that declares a table gets this, value-only ones included: a
+// cook's root is any table, so a value-only unit's <Base>Table.h carries the
+// build version, the shared read runtime, one <Name>Open per table and §20.3's
+// layout asserts, and the zero-cost gate (§2.2) pins those bytes rather than
+// excluding them.
 package cpptable
 
 import (

--- a/internal/codegen/cstable/codecs.go
+++ b/internal/codegen/cstable/codecs.go
@@ -379,8 +379,8 @@ func guardWalk(st *ir.Struct, csharp bool) map[string]string {
 // allocation.
 //
 // The name is VERB-FIRST and overloaded on the value's type, deliberately:
-// SPEC-TABLES.md §11 freezes the 23 name-first suffixes a closure member
-// claims, and a port must not quietly mint a 24th. TableReset joins
+// SPEC-TABLES.md §11 freezes the name-first suffixes a closure member
+// claims, and a port must not quietly mint another. TableReset joins
 // TableEnumId/TableEnumValue in the verb-first family instead, which claims
 // nothing from a declaration's name.
 func (g *tableGen) emitTableReset(st *ir.Struct) {

--- a/internal/tablenames/tablenames.go
+++ b/internal/tablenames/tablenames.go
@@ -88,9 +88,10 @@ var registry = []Name{
 	{Name: "table_double_to_bits", By: Cpp, What: "double -> u64 bits"},
 
 	// C#'s twins, plus the reader's in-place prefill. These are VERB-FIRST on
-	// purpose: §11 freezes the 26 name-first suffixes a closure member claims,
-	// and a port does not mint a 27th — so the reset joins the runtime family
-	// here instead, where it is claimed at unit level.
+	// purpose: §11 freezes the name-first suffixes a closure member claims
+	// (internal/check's tableGeneratedVerbs), and a port does not mint another —
+	// so the reset joins the runtime family here instead, where it is claimed at
+	// unit level.
 	// BOTH backends define TableReset, for the same reason and in two shapes:
 	// C# has no `<Name>Reset` and this IS its reset, while C++ has one per
 	// member and adds a verb-first overload set on top so the ARENA's generic

--- a/test/cs-block/src/Gate2.cs
+++ b/test/cs-block/src/Gate2.cs
@@ -176,7 +176,12 @@ static class Gate2
     }
 
     // Returns true when the gate passes. The caller owns the exit code.
-    internal static unsafe bool Run(string goldenPath)
+    // smoke runs the CORRECTNESS half whole and does not enforce the timing
+    // band: the band is a paired same-sitting measurement and a shared CI
+    // runner has no quiet window, so a nightly leg enforcing it would report
+    // the runner's mood. What a nightly leg CAN prove is that this gate still
+    // builds and still reads the C++ half's frame through the generated form.
+    internal static unsafe bool Run(string goldenPath, bool smoke = false)
     {
         if (!File.Exists(goldenPath))
         {
@@ -214,9 +219,9 @@ static class Gate2
                 return false;
             }
 
-            const int Warmup = 2000;
-            const int Samples = 15;
-            const int Reads = 200;
+            int Warmup = smoke ? 50 : 2000;
+            int Samples = smoke ? 3 : 15;
+            int Reads = smoke ? 10 : 200;
 
             double sink = 0.0;
             for (int i = 0; i < Warmup; i++)
@@ -253,6 +258,11 @@ static class Gate2
 
             // THE BAR: the same speed, or not significantly slower.
             const double Band = 1.05;
+            if (smoke)
+            {
+                Console.WriteLine("GATE 2 (C# read) SMOKE: correctness held, the band NOT enforced — a shared runner has no quiet window");
+                return true;
+            }
             if (ratio > Band)
             {
                 Console.WriteLine("GATE 2 FAILED: the generated form is " + ((ratio - 1.0) * 100.0).ToString("F1") +

--- a/test/cs-block/src/Program.cs
+++ b/test/cs-block/src/Program.cs
@@ -262,13 +262,14 @@ static class Program
         string[] argv = Environment.GetCommandLineArgs();
         foreach (string arg in argv)
         {
-            if (arg == "--gate2")
+            if (arg == "--gate2" || arg == "--gate2-smoke")
             {
                 // the REPRESENTATIVE frame §19.1 works, written by the C++
                 // gate-2 harness into build/ — a half-megabyte golden in the
                 // tree would buy the gate nothing the pinned small one does
                 // not already prove about the bytes
-                if (!Gate2.Run(Path.Combine("..", "..", "build", "block_gate2.bin")))
+                if (!Gate2.Run(Path.Combine("..", "..", "build", "block_gate2.bin"),
+                               arg == "--gate2-smoke"))
                 {
                     failed = true;
                 }

--- a/test/tables/block_gate2_main.cpp
+++ b/test/tables/block_gate2_main.cpp
@@ -340,8 +340,18 @@ static double median( std::vector<double> & samples )
 
 int main( int argc, char ** argv )
 {
-    (void) argc;
-    (void) argv;
+    // --smoke runs the CORRECTNESS half whole and does not enforce the timing
+    // band. The band is a paired same-sitting measurement and a shared CI
+    // runner has no quiet window, so a nightly leg that enforced it would be
+    // reporting the runner's mood; what a nightly leg CAN prove is that this
+    // gate still builds, still agrees byte for byte with the hand-written
+    // mirror across every section, and still writes the frame the C# half
+    // reads. The numbers print either way, unjudged in smoke.
+    bool smoke = false;
+    for ( int i = 1; i < argc; i++ )
+    {
+        if ( strcmp( argv[i], "--smoke" ) == 0 ) { smoke = true; }
+    }
 
     RenderFrameBlockStorage generated_storage;
     RenderFrameBlockStorage hand_storage;
@@ -414,9 +424,9 @@ int main( int argc, char ** argv )
     }
 
     // Arms INTERLEAVED in one sitting, medians paired.
-    const int warmup = 50;
-    const int samples = 15;
-    const int frames = 20; // per sample, so one measurement is many frames
+    const int warmup = smoke ? 2 : 50;
+    const int samples = smoke ? 3 : 15;
+    const int frames = smoke ? 2 : 20; // per sample, so one measurement is many frames
 
     volatile uint64_t sink = 0;
     for ( int i = 0; i < warmup; i++ )
@@ -457,6 +467,13 @@ int main( int argc, char ** argv )
     // so anything inside it is noise and anything outside it is a defect to
     // explain or close, never a trade to license.
     const double band = 1.05;
+    if ( smoke )
+    {
+        printf( "GATE 2 (C++ write) SMOKE: correctness held, the band NOT enforced — a shared runner has no quiet window\n" );
+        generated_storage.Destroy();
+        hand_storage.Destroy();
+        return 0;
+    }
     if ( ratio > band )
     {
         printf( "GATE 2 FAILED: the generated form is %.1f%% slower than the hand-written scatter, past the %.0f%% band\n",


### PR DESCRIPTION
**Do not merge.** The five open questions this pass raised have been ruled on and
applied (see "Rulings applied" below); the PR is held for the owner.

Rebased onto `ad1b6d3` (#327). One conflict, in `internal/tablenames` where #327
gave `TableReset` the `Cpp` backend on the same lines this pass dropped a stale
suffix count from — resolved keeping both. #327 touches no other file this PR
touches, and no golden needed regenerating: `internal/goldens` is green and
`generated/` is clean after a full `make test`, because nothing here moves an
emitted byte. §11's count is unchanged by it, as expected — `TableReset` is a
unit-level registry name, not a claimed name-first suffix.

Contraction queue item 1 (issue #248), plus item 5 and the parts of items 2 and 4
that turned out to have anything in them. Owner: *"We really want to land this and
remove all scaffolding."*

**22 commits, one change each, the reason in the message. Net −146 lines
(355 insertions, 501 deletions); SPEC-TABLES.md 6504 → 6296.**

Nothing here changes a byte any emitter produces: the Go edits are comments, and
`internal/goldens` is green. The five coordinator rulings at the bottom are the
only additions — a CI leg for a gate that was running nowhere, and one sentence
of written-down rule.

---

## Lines deleted, by category

### 1. Honesty notes that became true (7 commits)

Each verified against the tree before deleting; the evidence is in the commit
message.

| the note | where | what refutes it |
|---|---|---|
| "the cook half is not built: no backend emits `Cook`, `CookMeasure` or `Open`, there is no cooked header, `schema cook-check` does not exist" | USECASES 4 | every clause false but the `Cook`/`CookMeasure` half — the CLI's own usage text, `cpptable/cook.go`, `cstable/cook.go` |
| "those asserts are owed and not yet emitted" | §20 lead | contradicted by §20.3 and §20's own status item in the same section |
| "**what neither side asserts is a record in a unit with NO pointer** … the guarantee is still a specification and not a property of any build … it is **OPEN**" | §20.3 **and** §20 status item 2 | **the biggest one — see below** |
| "the generated `Open` that checks it is still owed" / "both cover the records the block form reaches, not yet every record in the closure" | USAGE | both read sides emitted and compared; `TableCookLayout.Verify()` covers the C# cook closure |
| "the cooked form" listed as a thing the C# variable class still owes | §15 | `cstable/cook.go:78` emits `<Base>Cook.cs` for a pointered unit; §11 already states why |
| "the tree carries no `sizeof`/`offsetof` `static_assert` and the C# fixed class is not blittable yet" | USECASES 5 | `cpptable/block.go:475-512`, `cstable/block.go:183,198`; **#287 and #288 are both CLOSED** |
| "C++ and C# carry it" (the view) | §15 | `grep -rn UnitView internal/codegen/ ir/ compiler/` finds nothing — §0 states it correctly |

**The one worth reading twice.** §20.3 and §20's status list both said a value-only
unit's records are asserted by neither backend, called the §20.3 guarantee "still a
specification and not a property of any build", and marked the question **OPEN**. It
is closed, and has been since #323:

- `tables/examples` declares no pointer field at all, and its committed golden
  `testdata/golden/tables/examples/NestedTable.h:664-674` carries the §20.3
  `sizeof`/`alignof`/`offsetof` asserts for every record;
- `cpptable.go`'s `emitCookLayoutAsserts` call is **unconditional** — unlike the arena
  and builder emission beside it, it is not gated on the unit being pointered;
- the same unit's C# output carries `TableCookLayout.Verify()` with a `Size` and a
  per-field `Offset` check for every cook-closure record.

#323 closed it by emitting the asserts everywhere and re-pinning; the page kept the
question. §20.3 now states the reach it has and says the zero-cost gate **pins** those
bytes rather than being in tension with them. Two smaller claims in the same family
went with it: §20 item 1 said a value-only unit's Table sources carry no build version
(the C++ header carries one at `NestedTable.h:338` — it is the **C#** Table sources
that carry none), and `cpptable/cook.go`'s package doc said nothing in it reaches a
value-only unit, which its own sibling comment in `cpptable.go` contradicts.

### 2. Claimed names, reconciled (2 commits)

Printed both sides. `internal/check`'s `tableGeneratedVerbs` is **24 name-first
suffixes + 9 block spellings**, and `internal/tablenames`' unit-level registry is
already held honest in both directions by `TestTableRuntimeNamesAreClaimed`.

**Every name the checker claims is either emitted or deliberately claimed ahead of an
emitter, and there are exactly two of the latter: `Cook`'s write half and
`CookMeasure`.** `Open` is emitted (C++ for every table, C# as `<X>Cook.Open`);
`OpenWalk` is genuinely retired and free. Of #321's "four claimed spellings stay
claimed", two are now definitions and one is gone. §11 already says all of this
correctly.

What was wrong was the **count**, restated in five places, four of them stale:

| site | said | actual |
|---|---|---|
| §11's list | 24 | ✅ |
| §11, 84 lines later | "the 25 above" | left behind when #323 retired `OpenWalk` |
| `internal/tablenames/tablenames.go` | 26 | — |
| `internal/codegen/cstable/codecs.go` | 23 | — |
| `compiler/tables_test.go` | "§11's 23" | — |

Nothing gates any of them. The rule each comment carries — *do not mint a new
name-first suffix, join the verb-first family* — survives without the number, so the
number goes and the list stays the one home. A **sixth** instance turned up in §7,
which said a table claims "one per out-of-line array on its `Block` type" where §11
says two and the checker adds both.

Also removed: §11 stated the out-of-line row-accessor claim **twice**, and the second
copy said *"the checker makes it today for neither"*. It does — proved with a Go
scratch on a FIXED table, which is the half that copy claimed was unmade:

```
declaration RenderFrameShips collides with RenderFrame's generated block row
accessors (SPEC-TABLES.md §11, §19.2) — both generate the symbol RenderFrameShips
```

### 3. Superseded gates — measured, and the answer is "none deleted"

I checked each of the three the brief named and **deleted nothing**, because none of
them was what it looked like. Reporting the negative results rather than manufacturing
a removal:

- **Duplicate negative controls across the block and cook batteries** — there are 18
  negative controls and **all 18 sabotage a distinct clause**. The four cook-open ones
  look like two pairs, but each pair proves a *different emitter's* battery goes red;
  dropping either half leaves one emitter's battery unproven.
- **Two fuzzers with one oracle that could share a harness** — the cook fuzzers are
  C++, C# and Go, one per implementation, and the block fuzzer is a different format
  with a different oracle. Nothing to share.
- **Three "dump" mechanisms** — there are two (C++ and C#), and each already shares one
  function with its `golden` mode (`mode_golden( …, bool as_dump )` /
  `ModeGolden( root, path, true )`). The third hit is `block_fuzz --dump`, an unrelated
  corpus-output directory. The dump lock subsumes no older equality gate: the directory
  lock proves the readers agree on *where* every node is, the dump lock that they agree
  on the *bytes inside one*.
- **`tables-*` target sprawl** — not collapsed; ruled to stay (ruling 2 below).
- **What the pass DID find** was the opposite problem: one gate running nowhere at
  all. See ruling 1.

### 4. Pages: restated neighbours and §14 (6 commits)

Five sentences in §7 and §19.1 that said a thing the page had already said, some
verbatim: the reserved-word refusal (§7 lead vs §7.1's byte-for-byte table), the
battery-and-fuzzer disclaimer (§7 body vs §7.5, near-verbatim including its
three-item list), the endian derivation (§7's frame vs the `Open` bullet 380 lines
later), §11's per-array count, and §19.1's clamping rule — which restated the two
sentences immediately above it, in the same paragraph. In each case the copy at the
site that OWNS the fact survives and the other cites it.

**SPEC-TABLES ↔ USAGE duplication: I deliberately left it.** There is a lot of it —
the `RenderFrame` declaration is verbatim in both, so are the `BlockOpen` call, the
`SceneOpen` call, the `ReadOnlySpan` paragraph and the fixed-root cook. But #323 and
#325 put those spellings on the page *on purpose*: their page defects 1, 2 and 7 were
exactly "a consumer written from the page alone could not spell it". Deleting SPEC's
copy would re-create the defect the sprint just fixed. And in almost every pair SPEC's
copy carries a **rule** USAGE's does not (`Begin` does not clamp; overlap is not
refused; the C# length is signed and converts once; a fixed root's cook is one region
of one node). Listed below as an owner decision rather than acted on.

**§14: 333 lines → 171** (queue item 5). The section's own purpose line says the
rejected options are the useful part. It had grown to carry, beside the rejections:
four **designs of record** (the slab arena, the linear directory scan, the kind-`17`
decision, the one unit-level view file), five positive rules already stated in the
sections that own them (`Lock` is the compaction §6.2, the two reference encodings
§6.3, the type id per record §3.1, the repeating field's record-aligned chunking
§3.1, block-relative offsets §19), and two closing paragraphs of pure narration.

**Every rejected shape survives with its reason intact — 27 of them, one paragraph
each**, including six that were buried as sub-clauses of TAKEN bullets and are now
stated in their own right: self-relative offsets in a block, compile-time block
offsets, deeper out-of-line rules, the per-table marker, the per-field `| stride`
trigger, and the tolerant second entry point. Before deleting each design of record I
grepped for its statement in the section that owns it; the three §14 citations the cut
orphaned are repaired.

### 5. Goldens (queue item 2 lite) — measured, nothing to do

- **"Pin block/cook binaries by hash rather than committing the bytes."** There are
  **no committed block or cook binaries**. The fixtures are generated — `test/cookgen`
  streams a synthetic region in O(1) memory, the Makefile writes the rest into
  gitignored `build/`. Nothing to convert.
- **Repo size**: 18,979,984 bytes tracked, of which `.bin` files are **245,734 —
  1.3%**. They are the *wire* goldens, which is the cross-language wire-identity
  standing gate: C++ writes the pins and nine other languages byte-compare them.
  Replacing them with hashes would trade the diagnostic (a byte-compare says WHAT
  differs) for a bit (a hash says only THAT it differs), across nine languages, to save
  1.3%. **Recommend against.**
- **Corpus units pinning the same emitter path**: none found. All five table corpora
  are load-bearing across many gates (`examples` 34 Makefile references, `pointers` 14,
  `block` 43, `blockhome` 14, `pack` 21), and `blockhome` in particular exists for a
  defect class found in the dogfood and is guarded by its own negative control. No
  deletion is provable here, so none was made.

---

## Rulings applied, in this PR

The five open questions this pass turned up went to the coordinator and came back
ruled. Each is its own commit.

1. **`tables-block-gate2` was invoked by NOTHING** — not `make test`, not CI. It is
   out of `make test` deliberately and the Makefile says why (it is a MEASUREMENT,
   and a correctness suite whose verdict depends on the machine's mood is not one),
   but that left §12.1's gate running nowhere at all, which is how a gate rots.
   **Ruled: wire it into the certification legs the way `msvc` first ran.**

   Done by splitting the two halves it was carrying. The **band** stays a by-hand
   measurement on a quiet box — `make tables-block-gate2` behaves exactly as before,
   verified at 0.889 (C++ write) and 0.977 (C# read). The **correctness** half now
   runs on every push to main and nightly as `tables-block-gate2-smoke`: the
   generated block form and the hand-written mirror agreeing byte for byte across all
   nine sections, and the C# side reading the frame the C++ side wrote — at a small N,
   with the 5% band NOT enforced and both halves printing that they did not enforce
   it. **A drift in what the generated form writes goes red; a slow runner does not.**

   It rides the `inline-gate` job, which is already the certification leg
   (`if: github.event_name != 'pull_request'`) and has already built the tree, on ONE
   matrix combination rather than six — one C++ compile and one `dotnet run`, and the
   two-minute PR path is untouched.

2. **The `tables-*` targets stay.** Iteration instrument, per the owner's
   fast-iteration law. No change.

3. **The guide/spec overlap rule is written down**, one sentence under README's
   documentation table: *the spec keeps the spelling a consumer needs to write from
   the page alone, even when USAGE also shows it.* Without it, the next contraction
   pass deletes the same sentences #323 and #325 just added — this one nearly did.

4. **`tables-block-zero-cost`'s comment is present-state.** The provenance narration
   goes (it said git carries the provenance and then narrated it anyway), and
   **schema#331** is filed for the follow-on it carried: replace the frozen pins with
   a mechanical comparison against a block-less emitter, the way the negative controls
   already build sabotaged ones. Same trim on the `BuildVersion` note, which explained
   why the symbol *left* the grep rather than why it is not in it, and on the echo line
   that ended "(the .cpp half still the PRE-BLOCK compiler's text)". Gate re-run: 38
   Table sources byte-identical, both grep halves green.

5. **§7's opening block** no longer shows `SceneCookMeasure` and `SceneCook` beside
   `SceneOpen`. Nothing emits the first two, and the section said so eight lines
   later — under the blindness rule that is a page handing a consumer two calls that
   do not link. Holding the spelling is §11's job and §11 does it. One sentence
   replaces them: *`schema cook` writes the file; the runtime only ever points at
   one.*

## Left in place, and why

- **SPEC-TABLES ↔ USAGE example duplication.** Real and substantial — the
  `RenderFrame` declaration is verbatim in both, so are the `BlockOpen` and
  `SceneOpen` calls, the `ReadOnlySpan` paragraph and the fixed-root cook. Kept under
  ruling 3, and in almost every pair SPEC's copy carries a **rule** USAGE's does not
  (`Begin` does not clamp; overlap is not refused; the C# length is signed and
  converts once; a fixed root's cook is one region of one node).
- **§20.8's "now owed"** — flagged to me as stale; I verified it and it is **correct
  as written**. The layout-model negative control sabotages the shared model in
  `ir/blocklayout.go` but only asserts on the block form's C++ and C# output, so the
  obligation genuinely does extend past blocks and rows.
- **§8.7's source-goldens follow-on** — also flagged, also **correct as written**.
  `internal/goldens`' `TestGoldenSource*` runs over `examples` and `examples128` only;
  the table corpora's `*Table.*` pins are the Makefile's separate zero-cost mechanism,
  and the `Block`/`Cook` sources are pinned nowhere.

## Honesty notes verified STILL TRUE — kept, as the brief asks

The cook WRITER (`Cook`/`CookMeasure`, no emitter anywhere); the flat node table on
the wire (`TableKindPointer` is used only in `ir/buildversion.go`, never in a codec —
`kTableMaxDepth = 128` is still in the goldens); the node directory in a generated
region; guarded-block identity (#301); the view file; the variable class's text form;
table arms in unions; C# big-endian native open (unprovable until a big-endian .NET
exists); the signed cook; and the union-bearing closure's missing C# cook reader.

---

## Gates

- **`make test` — full run, every leg, green ON THE REBASED BRANCH**, with
  `generated/` clean afterwards (no staleness, no re-pin) (the local bench needed the pinned
  JDK/Dart/Elixir from `dist/`; nothing in the tree changed to get it)
- `make check` — green
- `go build ./...`, `go vet ./...`, `go test ./...` — green
- **All 21 negative controls run and still RED**, each on its own bar
- `make tables-block-gate2` (by hand, unchanged) and `make tables-block-gate2-smoke`
  (new) — both green
- **4,548 §-citations across the tree, all resolving.** Verified with a Go scratch
  that resolves each `§N.M` against the headings of SPEC.md, SPEC-TABLES.md and the
  citing file. It caught the one citation this pass broke — `§0`, which is not a
  heading, since the view's status paragraph sits in an unnumbered preamble — fixed in
  `fd2ba99`. Same unresolved set before and after otherwise.
- `internal/goldens` green — **no emitted byte moved.**
- **The new CI leg is proven, not just written.** `inline-gate` is skipped on pull
  requests by design, so the gate-2 smoke step cannot go green on this PR's own
  checks. Dispatched a certification run on the branch the way the workflow's
  header documents (`gh workflow run ci.yml --ref contract-cook`): the step ran and
  passed in `inline-gate (ubuntu-latest, go)`, both halves reporting correctness
  held. Worth noting the C++ ratio there came out at 1.037 — inside the band, but
  wandering, which is exactly why the band is not enforced on a shared runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
