### PR TITLE
README: the use cases first, an example per use case, the ladder, the languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,37 @@
 # schema
 
+**The schema language for games: your constants, enums and data types compiled to C, C++, C#, Dart, Elixir, Go, Java, JavaScript and Rust.**
+
 [![CI](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml/badge.svg)](https://github.com/mas-bandwidth/schema/actions/workflows/ci.yml)
 [![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 
 If this work helps you, please support it: **[Become a supporter](https://www.patreon.com/MasBandwidth/membership)**
+
+## What schema is
+
+A game is written in several languages at once. The engine is C++, the
+client is C#, the tools and the backend are Go, the website is something
+else. They all pass the same data around, and every one of them needs code
+to read and write it.
+
+schema is a small language for declaring that data, and a compiler that
+generates the reading and writing code for nine languages: C, C++, C#, Dart,
+Elixir, Go, Java, JavaScript and Rust. You declare a type once. Every
+language gets code that agrees with every other language on every bit,
+allocates nothing, and validates what it reads.
+
+It is meant to serve all your needs for data types across the languages of a
+game. The packet between a client and a server, where every bit counts and
+both sides ship together. The message between a tool and a backend that ship
+months apart. The save game that has to load in a build its writer never saw.
+The asset file the game maps and points at. The render data C++ writes and
+C# reads sixty times a second. One system does all of it, so you never end
+up with schema for the packets and something else for everything else.
+
+Each section below is one of those jobs: what you get, the declaration you
+write, and the call you make.
+
+## Serialized types with a protocol id
 
 Write your data types once and generate code to read and write them in nine languages.
 
@@ -37,7 +65,7 @@ type ShipState
     ship_flags ShipFlags
     position   Vec3
     rotation   Quaternion
-    health     int32 | min = 0, max = MaxHealth
+    health     int32      | min = 0, max = MaxHealth
     at_rest    bool
     if !at_rest
     {
@@ -50,9 +78,298 @@ type ShipState
 This declaration compiles to C, C++, C#, Go, Java, Rust, JavaScript, Dart and Elixir code that 
 reads and writes your data types and agrees on every bit. Now your native plugin, your Unity client, your Go backend, your browser client, and your tooling all speak the same language.
 
+- **Bit-packed, not byte-packed** — `| min = 0, max = 1000` costs 10 bits, not
+  4 bytes. Bounds are part of the type, and the wire cost follows from them.
+- **Branches that cost nothing** — `if !at_rest { … }` omits whole field groups
+  from the wire, back-referencing a bool already sent.
+- **Compressed floats** — `| min, max, resolution` sends a step index, not a
+  float. A 0–1 throttle at 0.01 costs 7 bits.
+- **Fixed point is a type in the language** — `fixed(48, 16)` and its unsigned
+  sibling `ufixed(48, 16)` are declared like any other field, and the compiler
+  owns both the storage and the wire for them.
+- **128-bit integers**, ranged like any other, in every target language.
+- **Zero allocation, no runtime reflection** — straight-line code reading and
+  writing your own buffers.
+- **Reads validate, always — in every language.** Out-of-range values are
+  refused, not clamped or trusted.
+- **Relocatable by construction** — generated types are trivially copyable
+  and standard-layout, so raw-struct blobs and parallel scatter/gather are
+  safe by design; see [The wire](docs/USAGE.md#the-wire).
+
+Nothing on the wire carries a version: the unit's protocol id is the
+handshake, and two sides at different ids do not exchange a byte.
+
+```cpp
+if ( peer_id != example::ProtocolId )
+    return false;                                   // different build: do not talk
+example::ShipState state;
+serialize::ReadStream stream( buffer, bytes );
+if ( !example::ReadShipState( stream, state ) )
+    return false;                                   // out of range: refused, not clamped
+```
+
+Depth: [USAGE.md — The protocol id](docs/USAGE.md#the-protocol-id); SPEC.md §3.
+
+## Messages between tools, backends and websites
+
+Tools, the backend and the website each ship on their own schedule. A file
+written by last month's tool has to load in this month's backend. That is
+the job people reach for Protocol Buffers to do, and schema does it with a
+`table`.
+
+A table rides a second wire. Each field carries an id, a kind and a length,
+so a reader that does not know a field skips it, a field that is missing
+takes its declared default, a field that was renamed is found under its old
+name, and a value out of range is clamped. Every one of those events is
+counted in a read report. Nothing is fatal in either direction.
+
+```
+package tools
+
+enum Platform { Windows, Mac, Linux }
+
+table BuildRequest
+{
+    branch   string(64)
+    platform Platform
+    revision uint64
+    shard    int32 = 0  | min = 0, max = 63
+    verbose  bool
+}
+```
+
+```csharp
+long size = Schema.BuildRequestMeasure(request);       // exact, writes nothing
+byte[] buffer = new byte[size];
+Schema.BuildRequestSave(request, buffer);
+
+TableReport report = new TableReport();
+if (!Schema.BuildRequestLoad(request, bytes, report))
+    return false;                                      // framing damage only
+// report.Unknown, .KindMismatch and .Clamped name every difference from the
+// writer's generation; the value is usable either way
+```
+
+Read more: [tables](docs/USAGE.md#tables-data-that-outlives-builds) in USAGE, and SPEC-TABLES.md §4.
+
+## Save games
+
+A save file is a table too, so it gets the same tolerance. It also gets a
+guard the wire cannot give: a committed baseline file that refuses, at
+compile time, the two edits that change what old data means without changing
+a byte of it. Changing a field's default is one. Reordering a `flags` variant
+is the other. When you mean the change, you record it with a reason, and the
+reason stays in the file.
+
+```
+package savegame
+
+table Hero
+{
+    name  string(32)
+    level int32 = 1       | min = 1, max = 99
+    speed float32 = 500.0 | was = "velocity"
+}
+
+table SaveGame
+{
+    party [..8]Hero
+}
+```
+
+```cpp
+// schema tables-baseline --update --reason "first baseline before 1.0 ships" .
+TableReport report;
+if ( !SaveGameLoad( save, bytes, length, &report ) )
+    return false;      // only structural damage stops a load
+// an older build's file: unknown fields skipped, absent fields at their
+// declared defaults, `velocity` found again under its new name
+```
+
+Read more: [the tables baseline](docs/USAGE.md#the-tables-baseline-catching-the-edits-the-wire-cannot-report) in USAGE, and SPEC-TABLES.md §18.
+
+## Assets cooked for a build
+
+Tools build the assets. The game should not parse them at load. It should
+map the file and point at it.
+
+`schema cook` writes a table's data in the exact memory layout of one build,
+in that build's byte order. Opening it is a header check and a cast: magic,
+byte order, build version, lengths, alignment. Nothing is walked, so a
+gigabyte opens as fast as a kilobyte. A cook only opens in the build it was
+cooked for. Any other build gets NULL and loads the wire instead, which every
+build can read.
+
+The cook is a preview in this release.
+
+```
+package assets
+
+table Mesh
+{
+    name      string(64)
+    vertices  uint32
+    triangles uint32
+}
+
+table MeshCatalogue
+{
+    meshes [..4096]Mesh
+}
+```
+
+```sh
+schema pack --root MeshCatalogue --out Assets.bin assets/ .
+schema cook --root MeshCatalogue --in Assets.bin --out Assets.cook .
+schema build-version .                          # 0x6d7787f793cf0d6a — the store key
+```
+
+```cpp
+const MeshCatalogue * catalogue = MeshCatalogueOpen( mapped, length );
+if ( catalogue == NULL )
+    return NULL;      // not this build's cook: fall back to a wire load
+return catalogue;     // nothing parsed, nothing allocated, nothing walked
+```
+
+Read more: [the cooked form](docs/USAGE.md#the-cooked-form-point-at-a-file-instead-of-parsing-it) in USAGE, and SPEC-TABLES.md §7 and §20.
+
+## Render data from C++ to C#
+
+Every frame, C++ writes a large block of render data and C# reads it. This is
+the seam between a native plugin and Unity, and neither side can afford a
+copy or a parse.
+
+Every fixed table has a block form. Its arrays are laid out at a fixed pitch
+with the offsets at the front. C++ fills it from as many threads as it likes,
+with no lock and no allocation. C# opens it and reads the rows as spans over
+the same memory. Both sides are generated from the one declaration, and the
+row sizes and field offsets are asserted at compile time in both languages.
+A field that moves is a build error, not a garbled frame.
+
+```
+package renderdemo
+
+table RenderShip
+{
+    position_x float64
+    position_y float64
+    position_z float64
+    object_id  uint32
+}
+
+table RenderFrame
+{
+    ships [..4096]RenderShip
+}
+```
+
+```csharp
+if (!RenderFrameBlock.Open(out RenderFrameBlock block, pointer, bytes))
+    return;                                              // wrong build, or misaligned
+
+ReadOnlySpan<RenderShipRow> ships = block.ShipsSpan;     // one contiguous reinterpret
+foreach (ref readonly RenderShipRow ship in block.Ships)
+    Draw(ship);
+```
+
+Read more: [the block form](docs/USAGE.md#the-block-form-rows-another-language-points-at) in USAGE, and SPEC-TABLES.md §19.
+
+## JSON packed into binary tables
+
+Data gets authored or exported as JSON. It needs to become a compact binary
+that several languages can read.
+
+`schema pack` takes a directory of JSON files shaped like the table and
+writes the table's wire bytes, nothing else around them. `schema unpack`
+writes the JSON back out. Both fail the build when the read report is not
+silent, so drift between the JSON and the schema does not slip through.
+
+```
+package configdemo
+
+table WeaponConfig
+{
+    damage float32 = 21.0
+    homing bool
+}
+
+table GameConfig
+{
+    level_name string(64)
+    weapons    [..16]WeaponConfig
+}
+```
+
+```sh
+schema pack   --root GameConfig --out Config.bin configs/ .
+schema unpack --root GameConfig --in  Config.bin --one-file configs/ .
+```
+
+```cpp
+TableReport report;
+GameConfigLoad( config, bytes, length, &report );            // the packed bytes
+GameConfigFromJson( config, text, text_bytes, &report );     // or one text, in place
+```
+
+Read more: [packing a directory into a table](docs/USAGE.md#packing-a-directory-into-a-table) in USAGE, and SPEC-TABLES.md §16 and §17.
+
+## Editors and debug views
+
+An editor wants to show any table as a property tree. A debug view wants to
+inspect what the game is holding this frame.
+
+Every table comes with reflection descriptors beside its code: each field's
+name, type, offset, range, and the names of every enum and union variant. A
+tool walks a table it has never seen. A debug view walks the live instance in
+memory. There is no RTTI and no schema file at run time.
+
+```
+package editor
+
+enum Grade { Bronze, Silver, Gold }
+
+table ShipConfig
+{
+    health float32 = 100.0
+    armor  int32 = 1       | min = 0, max = 10
+    grade  Grade = Silver
+}
+```
+
+```cpp
+const TableTypeInfo * type = ShipConfigTableType();
+for ( int32_t i = 0; i < type->num_fields; i++ )
+{
+    const TableFieldInfo & f = type->fields[i];
+    printf( "%s %s @%u", f.name, f.type_name, f.offset );
+    if ( f.has_range ) printf( " [%g, %g]", f.range_min, f.range_max );
+    if ( f.enum_name ) printf( " %s", f.enum_name( 1 ) );
+    printf( "\n" );
+}
+```
+
+Read more: [walking fields at runtime](docs/USAGE.md#walking-fields-at-runtime) in USAGE, and SPEC-TABLES.md §8.
+
+## Which one to use
+
+| you want | declare | you get |
+|---|---|---|
+| the smallest packet, both ends ship together | `type` | bitpacked wire, protocol id |
+| data that survives schema changes | `table` | tolerant wire, read report |
+| structures with pointers, trees, graphs | `table` with `*T` fields | the same wire, built in bulk through your allocator |
+| rows shared between C++ and C# every frame | any fixed `table` | the block form, pointed at |
+| a file the game maps and points at | `table`, then `schema cook` | the cook, one build |
+
+A `type` and a fixed `table` are the same struct. The difference is the wire
+around it. The type wire is bitpacked and tied to a build. The table wire
+spends bytes on ids and lengths so any build can read any data. The block
+form and the cook are accelerators beside the table wire, not replacements
+for it.
+
 ## Performance
 
-Cost to serialize a representative game packet, relative to generated C++ at 100% — lower is faster:
+Cost to serialize a representative game packet, relative to generated C++ at
+100%. Lower is faster.
 
 | Language | % |
 |---|---:|
@@ -66,141 +383,78 @@ Cost to serialize a representative game packet, relative to generated C++ at 100
 | JavaScript | 264% |
 | Elixir | 1283% |
 
-Measured by [the benchmark](bench/): the real generated code in every language, over the same
-wire corpus — a 438-byte packet exercising every construct, with integers carrying 92% of the
-bytes. Raw sweeps are committed under [bench/results](bench/results/); reproduce
-with `./bench/run.sh` and render any sweep's table with `./bench/run.sh --render <csv>`.
+Measured by [the benchmark](bench/): the real generated code in every
+language, over one 438-byte packet exercising every construct. Raw sweeps are
+committed under [bench/results](bench/results/); reproduce with
+`./bench/run.sh`.
 
-Tables — the evolvable format, tolerant across versions — ride a different wire and have their
-own board: the same shape, declared as a fixed table, written and read on that wire in every
-language that carries tables ([bench/tables](bench/tables/), `make bench-tables`).
+Tables ride their own wire and have their own board: the same shape declared
+as a fixed table, written and read in every language that carries tables
+([bench/tables](bench/tables/), `make bench-tables`).
 
-## Why it exists
+## Languages
 
-Multiplayer games serialize the same data in several languages at once — an
-engine client here, a dedicated server there, tools and services around them.
-Every way of solving that costs something:
+| language | runtime | type wire | tables | block form | cook reader | JSON text form |
+|---|---|---|---|---|---|---|
+| C | [serialize.c](https://github.com/mas-bandwidth/serialize.c) | yes | — | — | — | — |
+| C++ | [serialize](https://github.com/mas-bandwidth/serialize) | yes | fixed and variable | yes | yes | yes |
+| C# | [serialize.cs](https://github.com/mas-bandwidth/serialize.cs) | yes | fixed | yes | yes | — |
+| Dart | none, self-contained | yes | — | — | — | — |
+| Elixir | none, self-contained | yes | — | — | — | — |
+| Go | [serialize.go](https://github.com/mas-bandwidth/serialize.go) | yes | — | — | — | — |
+| Java | none, self-contained | yes | — | — | — | — |
+| JavaScript | [serialize.js](https://github.com/mas-bandwidth/serialize.js) | yes | — | — | — | — |
+| Rust | [serialize.rs](https://github.com/mas-bandwidth/serialize.rs) | yes | — | — | — | — |
 
-- **Hand-written serializers drift.** Someone changes a field on one side,
-  other side isn't updated, and an afternoon disappears finding the desync.
-- **A unified read/write function only works for some languages.**
-  Templating one function over a read stream and a write stream is a good C++
-  answer, but it doesn't work in other languages that games use like Golang or C#.
-- **General-purpose formats** fix the drift by paying for it on the wire.
-  On one representative gameplay packet schema encodes in just **28 bytes against
-  Cap'n Proto's 52, Protobuf's 56 and FlatBuffers' 72**.
+The type wire is bit-identical across all nine languages, held by shared
+golden bytes in CI. A language without a tables column refuses a unit that
+declares a table, by name.
 
-Generating the code takes the fourth path. One declaration produces the reader
-*and* the writer, in every language, so they cannot disagree — and because the
-format is decided at compile time, what comes out is the straight-line code you
-would have hand-written, not an interpreter walking a schema at runtime.
-
-## Features
-
-- **One declaration, nine languages** — C, C++, C#, Dart, Elixir, Go, Java,
-  Rust and JavaScript, bit-identical on the wire, reader and writer generated together
-  so they cannot drift.
-- **Bit-packed, not byte-packed** — `| min = 0, max = 1000` costs 10 bits, not
-  4 bytes. Bounds are part of the type, and the wire cost follows from them.
-- **Branches that cost nothing** — `if !at_rest { … }` omits whole field groups
-  from the wire, back-referencing a bool already sent.
-- **Compressed floats** — `| min, max, resolution` sends a step index, not a
-  float. A 0–1 throttle at 0.01 costs 7 bits.
-- **Fixed point is a type in the language** — `fixed(48, 16)` and its unsigned
-  sibling `ufixed(48, 16)` are declared like any other field, and the compiler
-  owns both the storage and the wire for them.
-- **128-bit integers**, ranged like any other, in every target language.
-- **A second wire for things that version: tables.** The bitpacked
-  `type` wire above is the key feature of the library; `table` is its
-  companion for data that must cross builds — flexible data structures
-  with in-wire versioning (C++ and C# today): unknown fields skip, absent fields default, renames survive
-  via `was = "old_name"`, and every table ships with reflection
-  descriptors for tools that walk fields by name. Use tables as files,
-  blobs, or messages — a config a tool saves, an archive a build bakes, or
-  a versioned message between peers that don't deploy in lockstep:
-  schema's take on the protobufs/flatbuffers class, beside the bitpacked
-  wire rather than replacing it. The two version independently — a table
-  never moves the protocol id.
-- **Pointers, where they belong.** Types stay value semantics; TABLES may
-  point at tables (`next *Node`), so linked lists, trees and optional
-  subtables are expressible. The compiler DERIVES the consequence and you
-  never declare it: a table with no pointer in its by-value closure is a
-  plain struct that pays nothing for any of this, and a table with one is
-  built through a lock-free arena, locked once into a single packed region,
-  and read through a root pointer. That region also cooks: write it verbatim
-  behind a build-locked header and a later run points at its root — no copy,
-  no parse — while the tolerant wire stays the format of record.
-- **Zero allocation, no runtime reflection** — straight-line code reading and
-  writing your own buffers.
-- **Reads validate, always — in every language.** Out-of-range values are
-  refused, not clamped or trusted.
-- **Relocatable by construction** — generated types are trivially copyable
-  and standard-layout, so raw-struct blobs and parallel scatter/gather are
-  safe by design; see [The wire](docs/USAGE.md#the-wire).
-- **The compiler is a library too** — load, check and generate from Go,
-  and register generators of your own; the nine built-in backends come through
-  the same interface yours does. See
-  [Embedding the compiler](docs/USAGE.md#embedding-the-compiler).
-- **Canonical source format** — every command formats in place.
-- **Generated code is yours**, under whatever licence you ship. See
-  [License](#license).
-
-## How do I use it?
+## Install and build
 
 ```
 make            # builds the compiler at bin/schema — needs only Go
 
-schema check    <dir of .schema files>
-schema generate --lang c|cpp|cs|dart|elixir|go|java|js|rust --out <outdir> <dir>
+bin/schema check    <dir of .schema files>
+bin/schema generate --lang c|cpp|cs|dart|elixir|go|java|js|rust --out <outdir> <dir>
 ```
 
-**[USAGE.md](docs/USAGE.md)** is the guide — every language feature, with real
-examples and the code each one generates, and how to drive the compiler from
-Go instead of the command line.
-
-Building the tests needs the serialize runtimes checked out beside this
-repo (generated Dart, Java and Elixir are self-contained and need only their
-pinned toolchains), then
-`make test` — [CONTRIBUTING.md](docs/CONTRIBUTING.md) has the clone
-list and what the gates prove.
+`make` builds `bin/schema` and nothing else. Success is silent; `--verbose`
+lists every file written. The nine-language conformance chain is `make test`,
+which needs the serialize runtime checkouts beside this repo and the pinned
+Dart, Java and Elixir toolchains unpacked into `dist/`. The Makefile header
+carries every version and hash, and [CONTRIBUTING.md](docs/CONTRIBUTING.md) has
+the clone list.
 
 ## Documentation
 
 | Document | What's in it |
 |---|---|
 | **[USAGE.md](docs/USAGE.md)** | Every language feature, with the code it generates. Start here. |
-| **[USECASES.md](docs/USECASES.md)** | The use cases schema is designed for — the form that serves each one, the contract it carries, and the proof it has today. |
-| **[PERFORMANCE.md](docs/PERFORMANCE.md)** | Generated-code benchmarks, and how to read them honestly. |
-| **[SPEC.md](docs/SPEC.md)** | The normative reference — grammar, wire law, every edge case. |
-| **[COMPARISON.md](docs/COMPARISON.md)** | The same packet in schema, Cap'n Proto, Protobuf and FlatBuffers — 28 vs 52 vs 56 vs 72 bytes, measured, with a script to re-run it. |
-| **[FAQ.md](docs/FAQ.md)** | Isn't this just FlatBuffers / Protobuf / Cap'n Proto? And other blunt questions. |
-| **[VERSIONING.md](docs/VERSIONING.md)** | What a version number promises — chiefly that a 1.x upgrade will not move your wire. |
-| **[CONTRIBUTING.md](docs/CONTRIBUTING.md)** | How to build it, the gates a change has to pass, and what a golden change means. |
-| **[SECURITY.md](docs/SECURITY.md)** | The threat model, and how to report a vulnerability privately. |
+| **[USECASES.md](docs/USECASES.md)** | What people use schema for, in plain words. |
+| **[SPEC.md](docs/SPEC.md)** | The normative reference for the type wire: grammar, wire law, every edge case. |
+| **[SPEC-TABLES.md](docs/SPEC-TABLES.md)** | The normative reference for tables: the wire, the cook, the block form, reflection, the build version. |
+
+Beside them: [PERFORMANCE.md](docs/PERFORMANCE.md),
+[COMPARISON.md](docs/COMPARISON.md) (the same packet against Cap'n Proto, Protobuf
+and FlatBuffers), [FAQ.md](docs/FAQ.md), [VERSIONING.md](docs/VERSIONING.md),
+[CONTRIBUTING.md](docs/CONTRIBUTING.md) and [SECURITY.md](docs/SECURITY.md).
 
 Where a guide and a spec cover the same ground: the spec keeps the spelling a
 consumer needs to write from the page alone, even when USAGE also shows it.
 
 ## License
 
-**The compiler is AGPL-3.0 — and will stay that way. The code it generates is
+**The compiler is AGPL-3.0, and will stay that way. The code it generates is
 yours.**
 
-- The schema compiler (everything in this repository) is licensed under the
-  GNU Affero General Public License v3.0, with an **explicit additional
-  permission for generated output** written into [LICENSE](LICENSE) itself —
-  not only described here. Every generated file also carries that statement in
-  its own header. If you
-  modify the compiler and run it as a service or distribute it, the AGPL's
-  terms apply to those modifications.
-- **Generated code is explicitly NOT covered by the AGPL.** The output the
-  compiler produces from YOUR schema files belongs to YOU, under whatever
-  terms you choose — including in closed-source projects. Running the
-  compiler over schemas you own does not make your generated serializers
-  derivative works of the compiler,
-  and this grant is intentional and permanent: schema is meant to be useful
-  to people shipping proprietary software. Only the compiler itself is open
-  source.
+The compiler is licensed under the GNU Affero General Public License v3.0,
+with an explicit additional permission for generated output written into
+[LICENSE](LICENSE) itself and carried in every generated file's own header.
+The output the compiler produces from your schema files belongs to you, under
+whatever terms you choose, including in closed-source projects. That grant is
+intentional and permanent. If you modify the compiler and run it as a service
+or distribute it, the AGPL's terms apply to those modifications.
 
 ## Author
 


### PR DESCRIPTION
**Draft / raw material.** The prose is not finished writing — the design seat
rewrites it on this branch before it is read. What this PR carries is the
SHAPE (intro → use cases → examples → links → ladder → languages → install)
and, more importantly, the VERIFICATION: every declaration on the page
compiles, every generated identifier printed exists, every CLI line runs,
every link and §-citation resolves.

Section one is the existing README's bitpacked-types material, kept as it is
under a use-case heading, with the intro moved above it. One byte changed in
it: the `health` field's attribute column, which `schemafmt` rewrites (the
example on `main` is not formatter-canonical — see "Defects found" below).

## How the verification was run

`make` builds `bin/schema` at `v2.4.0-46-ge051ce3`. A Go scratch tool reads
`README.md`, extracts every bare fenced block that begins `package `, writes
each to its own unit, runs `bin/schema check` on it, and re-reads the file to
prove `schemafmt` did not rewrite it (every command formats in place, so a
non-canonical snippet is caught as a diff). The same tool resolves every
relative link — file AND anchor, against the target's own headings — and every
`SPEC.md §N` / `SPEC-TABLES.md §N` citation against those files' numbered
headings. Then each section's consumer snippet was compiled VERBATIM against
code generated from that section's own README block: C++ with
`c++ -std=c++17 -Wall -Wextra -Werror -ffp-contract=off` against
`../serialize`, C# with `dotnet build` against `../serialize.cs`.

Result: 7 schema blocks check OK and canonical, 22 links resolve, 9 citations
resolve, 7 consumer snippets compile, 6 CLI invocations run.

## Per section

**Intro — "What it is"**
- Nine languages, and the runtime column: SPEC.md §1's table; generating
  block 1 for all nine backends succeeds.
- "Two ids and no third": SPEC-TABLES.md §20 states it in those words.
- Allocation claim narrowed to what the tree supports: "nothing on any read
  path, in any language and any form, and nothing at all for types"
  (SPEC-TABLES.md "What allocates, and what never does").

**1. Serialized types with a protocol id** — kept from `main`
- Snippet: the existing `package example` unit (Vec3, Quaternion, ShipState
  with a ranged int, a flags field and an `if !at_rest` branch). `check` OK,
  canonical after the one-column fix.
- Generated call: `example::ProtocolId` (`Unit.h:15`,
  `0x87784f1dc10cac2c`), `example::ReadShipState` (`UnitWire.h:121`),
  `serialize::ReadStream`. Snippet compiles.
- Points at: USAGE.md#the-protocol-id, SPEC.md §3 — both resolve.

**2. Tables between tooling, websites and backends**
- Snippet: `package tools`, `enum Platform`, `table BuildRequest`. `check` OK,
  canonical.
- Generated call (C#): `Schema.BuildRequestMeasure`, `Schema.BuildRequestSave`,
  `Schema.BuildRequestLoad`, `TableReport` with `.Unknown`, `.KindMismatch`,
  `.Clamped` — all in the generated `UnitTable.cs`. Snippet compiles under
  `dotnet build`.
- Points at: USAGE.md#tables-data-that-outlives-builds, SPEC-TABLES.md §4.

**3. Save games that always load**
- Snippet: `package savegame`, `table Hero` with `| was = "velocity"`, root
  `table SaveGame`. `check` OK, canonical.
- Generated call (C++): `SaveGameLoad`, `TableReport`. Compiles.
- CLI: `schema tables-baseline --update --reason "..."` run in the block's own
  directory — writes `tables.baseline`. The refusal was exercised as a
  negative control on a scratch copy: editing `level int32 = 1` to `= 2` makes
  `schema check` exit 1 with *"specified default 1 -> 2 — this edit changes
  what data already written MEANS"*.
- Points at: USAGE.md#the-tables-baseline-…, SPEC-TABLES.md §18.

**4. Assets cooked to a build version**
- Snippet: `package assets`, `table Mesh`, `table MeshCatalogue`. `check` OK,
  canonical.
- CLI: `schema pack`, `schema cook` and `schema build-version` all run
  verbatim in the block's directory. The printed `0x6d7787f793cf0d6a` IS that
  unit's build version, from `schema build-version .`; `schema cook` stamps
  the same id, and `schema cook-check` reads it back.
- Generated call (C++): `MeshCatalogueOpen( mapped, length )` —
  `UnitTable.h:769`, returns `const MeshCatalogue *` or NULL. Compiles.
- Points at: USAGE.md#the-cooked-form-…, SPEC-TABLES.md §7 and §20.

**5. Render data written in C++ and read in C#**
- Snippet: `package renderdemo`, `table RenderShip`, `table RenderFrame` with
  one bounded array. `check` OK, canonical.
- Generated call (C#): `RenderFrameBlock.Open(out …, pointer, bytes)`,
  `block.ShipsSpan` as `ReadOnlySpan<RenderShipRow>`, and
  `foreach (ref readonly RenderShipRow ship in block.Ships)` — the enumerator's
  `Current` is `ref readonly T`, so that spelling is real. Compiles under
  `dotnet build` with `AllowUnsafeBlocks`.
- The C++ producer half was compiled too (not printed, for length):
  `RenderFrameBlockStorage::Create(TableBlockDefaultAllocator())`,
  `RenderFrameCounts`, `RenderFrameBlockBegin`, `RenderFrameShips` (returns
  `TableBlockRows<RenderShip>`, which converts implicitly to `RenderShip *`),
  `RenderFrameBlockBytes`.
- Points at: USAGE.md#the-block-form-…, SPEC-TABLES.md §19.

**6. JSON packed into binary tables**
- Snippet: `package configdemo`, `table WeaponConfig`, `table GameConfig`.
  `check` OK, canonical.
- CLI: `schema pack --root GameConfig --out Config.bin configs/ .` and
  `schema unpack … --one-file configs/ .` both run verbatim; the round trip
  reproduces the tree.
- Generated call (C++): `GameConfigLoad` and `GameConfigFromJson` —
  `UnitTable.h:871`. Compiles.
- Points at: USAGE.md#packing-a-directory-into-a-table, SPEC-TABLES.md §16
  and §17.

**7. Reflection for editors and debug views**
- Snippet: `package editor`, `enum Grade`, `table ShipConfig`. `check` OK,
  canonical.
- Generated call (C++): `ShipConfigTableType()` returning
  `const TableTypeInfo *`, and the walk over `type->num_fields` /
  `type->fields[i]` reading `.name`, `.type_name`, `.offset`, `.has_range`,
  `.range_min`, `.range_max`, `.enum_name` — every one of those is a member of
  the generated `TableFieldInfo` / `TableTypeInfo`. Compiles.
- Points at: USAGE.md#walking-fields-at-runtime, SPEC-TABLES.md §8.

**The ladder table** — every row is SPEC-TABLES.md's own "performance ladder"
and "What allocates, and what never does" restated; the fixed-table
allocation cell carries the union carve-out verbatim.

**The languages table** — generated mechanically, not from memory. Block 1
(types only) generates for all nine backends. Block 6 (tables) generates for
`cpp` and `cs` and is REFUSED by name for `c`, `dart`, `elixir`, `go`, `java`,
`js` and `rust`. `cpp` emits `UnitTable.*` + `UnitBlock.*`; `cs` emits
`UnitTable.cs` + `UnitBlock.cs` + `UnitCook.cs`. A pointered unit
(`tables/pointers`) under `--lang cs` emits `*Cook.cs` and `*Block.cs` and NO
`*Table.cs`, which is what the table's C# column says. `FromJson` appears in
the generated C++ and in no generated C#, which is what the JSON column says.
No generated file in any backend contains `CookMeasure`, which is what "a cook
is WRITTEN by `schema cook`" says.

## Could NOT verify

- **The performance table and the 28/52/56/72 byte comparison** are carried
  over from `main` unchanged. I did not re-run `./bench/run.sh` or
  `COMPARISON.md`'s script; these numbers are inherited, not re-measured.
- **"A one-megabyte cook and a one-gigabyte cook open in the same time"** is
  SPEC-TABLES.md §7's and USAGE.md's claim. The tree has
  `tables-cook-open-1gb` and `tables-cook-scale-1gb` targets that would prove
  it; I did not run them (they are heavy) — sourced, not measured.
- **"Every fixed table's row size and field offset asserted"** (section 5) is
  true of the block and cook closures on both backends; SPEC-TABLES.md §20's
  status list item 2 records that a record in a unit with NO accelerator
  reader is not asserted, and calls that question OPEN. The section's sentence
  is true as written for the block form it describes, but a reader could take
  it more widely than §20.3 supports.

## Defects found while verifying, NOT fixed here

- **`USAGE.md`'s "Messages: a union whose arms are tables" section does not
  compile.** Its example is refused by the compiler:
  `OpenDocument is a table, not a union payload — a payload is a declared
  \`type\`; tables nest in tables directly`. The construct is #258, and
  `USECASES.md` entry 2 says so; USAGE presents it as working. USAGE is
  another worker's file this hour, so I left it alone and used a plain fixed
  table for section 2 instead.
- **`USECASES.md` is stale against the tree in two places** — entry 4 says
  "the cook half is not built: no backend emits `Cook`, `CookMeasure` or
  `Open`, there is no cooked header, `schema cook-check` does not exist", and
  entry 5 says the block form is "designed, not yet built". Both are built
  today: `schema cook` / `cook-check` / `uncook` run, and the C++ `<Root>Open`
  and C# `<Root>Cook.Open` and both block backends are emitted. Also another
  worker's file.
- **The `health` line of the README example on `main` was not
  formatter-canonical.** One column of whitespace, fixed here.
- **SPEC-TABLES.md's "What allocates" carve-out** says a pseudo-union arm is
  "allocated on read and write". The emitted C# pre-allocates every arm at
  construction (`public Buff Buff = new Buff();`) and `TableReader` is a
  `ref struct`, so a union-bearing fixed table's `Load` makes no heap
  allocation. The spec sentence looks stale against the emitter.

## Judgments

- **446 lines, over the 350 the first brief set.** The later ruling to keep
  the existing bitpacked-types top AS IT IS costs ~60 lines against the
  trimmed version I had; the prose rewrite is where the rest comes back.
- **Kept from `main`, not asked for and not removed**: the badges, the
  supporter line, the performance table, the License section and the Author
  line. Removing any of them silently seemed worse than carrying them.
- **The Documentation table is the four pages the brief named**; the other six
  files follow in one line beneath so nothing becomes unreachable.
- **`make check` does not cover Markdown**, so there is no lint to run; the Go
  scratch tool above is the substitute. Scratch deleted.
