### PR TITLE
cpptable: the table wire's write and read do no redundant work — the inliner's budget removed; the tolerant wire's measured cost is 0.51x per byte (#343)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,18 @@ numbers §1–§9 and the §9 q-rows are frozen — code, corpus and docs cite t
   SPEC §5 semantics, guarded by the stale-leak pinned test). C# batch emission: cores are
   INLINE-ONLY (an address-exposed ref-struct measured WORSE than no batch) and OPT-IN by
   scalar density (bulk-dominated types lose; rule in `internal/codegen/csharp/batch.go`).
+- **A generated codec must not depend on the compiler's INLINING BUDGET.** A
+  table of a realistic field count emits one large body per type; clang's
+  inliner ran out partway through `TableMixedSaveBody` and left the writer
+  primitives and the nested bodies out of line, and from there the cursor
+  round-tripped through memory at every put — a `uint8_t *` store may alias the
+  writer, so `offset` and `capacity` were re-read after each one. Force-inlining
+  the primitives ALONE bought 24% and the bodies alone 19%; both together bought
+  5.4x, because only a call-free body lets the cursor stay in registers and
+  adjacent constant framing bytes merge. The qualifier is portable through a
+  per-package macro (`__forceinline` / `always_inline` / `inline`) and stops at
+  the class whose call graph cannot cycle. Read the emitted assembly for `bl` to
+  a primitive before believing a header-only codec is inlined.
 - **Instrument honesty**: harness defects crowned the wrong winner once (v1's "C# beats
   C++ batch read" was a per-iteration alloc in every OTHER runner) — the harness is code
   and rots too. Relative tables move when the DENOMINATOR moves (v4's widening was C++

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -403,11 +403,15 @@ func TestPointerSurfaceEmitted(t *testing.T) {
 			t.Errorf("a value-only table in a pointered unit grew %q", absent)
 		}
 	}
-	// its codecs are the by-value ones, character for character
+	// its codecs are the by-value ones, character for character — including
+	// the force-inline qualifier the FIXED class carries and the
+	// variable-length templates do not (schema#343): the two classes differ in
+	// what the compiler is allowed to leave out of line, and that difference is
+	// per table, exactly as the parameter list is.
 	for _, want := range []string{
 		"inline int64_t PlainMeasure( const Plain & value )",
-		"inline bool PlainSaveBody( TableWriter & w, const Plain & value )",
-		"inline bool PlainLoadBody( TableReader & r, Plain & value )",
+		"PROBE_TABLE_INLINE bool PlainSaveBody( TableWriter & w, const Plain & value )",
+		"PROBE_TABLE_INLINE bool PlainLoadBody( TableReader & r, Plain & value )",
 		"inline bool PlainLoad( Plain & value, const uint8_t * buffer, int64_t bytes, TableReport * report )",
 	} {
 		if !strings.Contains(header, want) {
@@ -425,6 +429,23 @@ func TestPointerSurfaceEmitted(t *testing.T) {
 	// a variable-length table is never held by value: no by-value Load
 	if strings.Contains(header, "inline bool RootLoad( Root & value") {
 		t.Error("a pointer-bearing table emitted a by-value Load")
+	}
+	// THE RECURSION GUARD (schema#343). The force-inline qualifier stops at the
+	// fixed class because that is the class whose save/load call graph cannot
+	// hold a cycle: a fixed table nests by value, and a by-value cycle is an
+	// infinite `sizeof`. The variable-length form reaches its pointee through
+	// the depth-carrying template, which a self-referential declaration makes
+	// directly recursive — and a recursive always_inline does not compile under
+	// gcc. Every line carrying the qualifier must therefore be a non-template
+	// one, or the emitter has emitted source no gcc build can compile.
+	for _, line := range strings.Split(header, "\n") {
+		if strings.Contains(line, "PROBE_TABLE_INLINE") && strings.Contains(line, "template") {
+			t.Errorf("the force-inline qualifier reached a template — recursion is possible there: %q", line)
+		}
+	}
+	if strings.Contains(header, "PROBE_TABLE_INLINE bool RootSaveBody") ||
+		strings.Contains(header, "PROBE_TABLE_INLINE bool NodeSaveBody") {
+		t.Error("a variable-length table's body was force-inlined; its pointer walk can recurse")
 	}
 }
 

--- a/compiler/tables_test.go
+++ b/compiler/tables_test.go
@@ -438,7 +438,7 @@ func TestPointerSurfaceEmitted(t *testing.T) {
 	// directly recursive — and a recursive always_inline does not compile under
 	// gcc. Every line carrying the qualifier must therefore be a non-template
 	// one, or the emitter has emitted source no gcc build can compile.
-	for _, line := range strings.Split(header, "\n") {
+	for line := range strings.SplitSeq(header, "\n") {
 		if strings.Contains(line, "PROBE_TABLE_INLINE") && strings.Contains(line, "template") {
 			t.Errorf("the force-inline qualifier reached a template — recursion is possible there: %q", line)
 		}

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -94,6 +94,18 @@ the three fast paths do not spend. That is the trade this document exists to
 make, and it is why the fast paths are accelerators BESIDE the wire rather
 than replacements for it.
 
+**How much slower is a BYTE COUNT, and the count is measured.** The tables
+bench's one shape, `TableMixed`, mirrors the type corpus's `BenchMixed` field
+for field, so the two wires carry the same declared content and the ratio
+between them is the price of tolerance and nothing else
+(`bench/tables/README.md`). A record rides in **2391 bytes against the type
+wire's 438**, and **1487 of those 2391 — 62% — are framing**: field ids, kind
+bytes, lengths, element counts and body terminators, not values. That count is
+the trade, and it is where the per-MESSAGE factor comes from. What it does not
+license is a codec slower than those bytes require: the fixed-table rung above
+holds the per-BYTE cost to the bench, so a per-byte gap is a defect to explain
+or close and never the wire's price.
+
 **And one path is generic on purpose and may allocate** — the reflection
 surface (§8): the field walk, the text form (§16), the packer (§17), a
 viewer. In the owner's words: *"we also have the flexibility of the

--- a/generated/bench/tables/cpp/BenchTableTable.h
+++ b/generated/bench/tables/cpp/BenchTableTable.h
@@ -18,6 +18,22 @@
 #ifndef BENCHTABLE_SCHEMA_TABLE_PRIMITIVES
 #define BENCHTABLE_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define BENCHTABLE_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define BENCHTABLE_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define BENCHTABLE_TABLE_INLINE inline
+#endif
+
 namespace benchtable {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -138,17 +154,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    BENCHTABLE_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    BENCHTABLE_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    BENCHTABLE_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    BENCHTABLE_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    BENCHTABLE_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    BENCHTABLE_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -166,11 +182,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    BENCHTABLE_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    BENCHTABLE_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    BENCHTABLE_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    BENCHTABLE_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    BENCHTABLE_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -593,23 +609,23 @@ inline void TablePickupEventReset( TablePickupEvent & value ) { value = TablePic
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t TableEntityMeasure( const TableEntity & value );
-inline bool TableEntitySaveBody( TableWriter & w, const TableEntity & value );
-inline bool TableEntityLoadBody( TableReader & r, TableEntity & value );
+BENCHTABLE_TABLE_INLINE bool TableEntitySaveBody( TableWriter & w, const TableEntity & value );
+BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity & value );
 inline int64_t TableStatMeasure( const TableStat & value );
-inline bool TableStatSaveBody( TableWriter & w, const TableStat & value );
-inline bool TableStatLoadBody( TableReader & r, TableStat & value );
+BENCHTABLE_TABLE_INLINE bool TableStatSaveBody( TableWriter & w, const TableStat & value );
+BENCHTABLE_TABLE_INLINE bool TableStatLoadBody( TableReader & r, TableStat & value );
 inline int64_t TableMixedMeasure( const TableMixed & value );
-inline bool TableMixedSaveBody( TableWriter & w, const TableMixed & value );
-inline bool TableMixedLoadBody( TableReader & r, TableMixed & value );
+BENCHTABLE_TABLE_INLINE bool TableMixedSaveBody( TableWriter & w, const TableMixed & value );
+BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & value );
 inline int64_t TableHitEventMeasure( const TableHitEvent & value );
-inline bool TableHitEventSaveBody( TableWriter & w, const TableHitEvent & value );
-inline bool TableHitEventLoadBody( TableReader & r, TableHitEvent & value );
+BENCHTABLE_TABLE_INLINE bool TableHitEventSaveBody( TableWriter & w, const TableHitEvent & value );
+BENCHTABLE_TABLE_INLINE bool TableHitEventLoadBody( TableReader & r, TableHitEvent & value );
 inline int64_t TableChatEventMeasure( const TableChatEvent & value );
-inline bool TableChatEventSaveBody( TableWriter & w, const TableChatEvent & value );
-inline bool TableChatEventLoadBody( TableReader & r, TableChatEvent & value );
+BENCHTABLE_TABLE_INLINE bool TableChatEventSaveBody( TableWriter & w, const TableChatEvent & value );
+BENCHTABLE_TABLE_INLINE bool TableChatEventLoadBody( TableReader & r, TableChatEvent & value );
 inline int64_t TablePickupEventMeasure( const TablePickupEvent & value );
-inline bool TablePickupEventSaveBody( TableWriter & w, const TablePickupEvent & value );
-inline bool TablePickupEventLoadBody( TableReader & r, TablePickupEvent & value );
+BENCHTABLE_TABLE_INLINE bool TablePickupEventSaveBody( TableWriter & w, const TablePickupEvent & value );
+BENCHTABLE_TABLE_INLINE bool TablePickupEventLoadBody( TableReader & r, TablePickupEvent & value );
 
 inline int64_t TableEntityMeasure( const TableEntity & value )
 {
@@ -636,7 +652,7 @@ inline int64_t TableEntityMeasure( const TableEntity & value )
     return bytes;
 }
 
-inline bool TableEntitySaveBody( TableWriter & w, const TableEntity & value )
+BENCHTABLE_TABLE_INLINE bool TableEntitySaveBody( TableWriter & w, const TableEntity & value )
 {
     if ( value.entity_id != 0 )
     {
@@ -721,7 +737,7 @@ inline int64_t TableEntitySave( const TableEntity & value, uint8_t * buffer, int
     return w.offset; // == TableEntityMeasure( value )
 }
 
-inline bool TableEntityLoadBody( TableReader & r, TableEntity & value )
+BENCHTABLE_TABLE_INLINE bool TableEntityLoadBody( TableReader & r, TableEntity & value )
 {
     TableEntityReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -961,7 +977,7 @@ inline int64_t TableStatMeasure( const TableStat & value )
     return bytes;
 }
 
-inline bool TableStatSaveBody( TableWriter & w, const TableStat & value )
+BENCHTABLE_TABLE_INLINE bool TableStatSaveBody( TableWriter & w, const TableStat & value )
 {
     if ( value.stat_id != 0 )
     {
@@ -984,7 +1000,7 @@ inline int64_t TableStatSave( const TableStat & value, uint8_t * buffer, int64_t
     return w.offset; // == TableStatMeasure( value )
 }
 
-inline bool TableStatLoadBody( TableReader & r, TableStat & value )
+BENCHTABLE_TABLE_INLINE bool TableStatLoadBody( TableReader & r, TableStat & value )
 {
     TableStatReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1135,7 +1151,7 @@ inline int64_t TableMixedMeasure( const TableMixed & value )
     return bytes;
 }
 
-inline bool TableMixedSaveBody( TableWriter & w, const TableMixed & value )
+BENCHTABLE_TABLE_INLINE bool TableMixedSaveBody( TableWriter & w, const TableMixed & value )
 {
     if ( value.protocol_magic != 0 )
     {
@@ -1348,7 +1364,7 @@ inline int64_t TableMixedSave( const TableMixed & value, uint8_t * buffer, int64
     return w.offset; // == TableMixedMeasure( value )
 }
 
-inline bool TableMixedLoadBody( TableReader & r, TableMixed & value )
+BENCHTABLE_TABLE_INLINE bool TableMixedLoadBody( TableReader & r, TableMixed & value )
 {
     TableMixedReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1912,7 +1928,7 @@ inline int64_t TableHitEventMeasure( const TableHitEvent & value )
     return bytes;
 }
 
-inline bool TableHitEventSaveBody( TableWriter & w, const TableHitEvent & value )
+BENCHTABLE_TABLE_INLINE bool TableHitEventSaveBody( TableWriter & w, const TableHitEvent & value )
 {
     if ( value.target_id != 0 )
     {
@@ -1945,7 +1961,7 @@ inline int64_t TableHitEventSave( const TableHitEvent & value, uint8_t * buffer,
     return w.offset; // == TableHitEventMeasure( value )
 }
 
-inline bool TableHitEventLoadBody( TableReader & r, TableHitEvent & value )
+BENCHTABLE_TABLE_INLINE bool TableHitEventLoadBody( TableReader & r, TableHitEvent & value )
 {
     TableHitEventReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2038,7 +2054,7 @@ inline int64_t TableChatEventMeasure( const TableChatEvent & value )
     return bytes;
 }
 
-inline bool TableChatEventSaveBody( TableWriter & w, const TableChatEvent & value )
+BENCHTABLE_TABLE_INLINE bool TableChatEventSaveBody( TableWriter & w, const TableChatEvent & value )
 {
     if ( value.channel != 0 )
     {
@@ -2061,7 +2077,7 @@ inline int64_t TableChatEventSave( const TableChatEvent & value, uint8_t * buffe
     return w.offset; // == TableChatEventMeasure( value )
 }
 
-inline bool TableChatEventLoadBody( TableReader & r, TableChatEvent & value )
+BENCHTABLE_TABLE_INLINE bool TableChatEventLoadBody( TableReader & r, TableChatEvent & value )
 {
     TableChatEventReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2127,7 +2143,7 @@ inline int64_t TablePickupEventMeasure( const TablePickupEvent & value )
     return bytes;
 }
 
-inline bool TablePickupEventSaveBody( TableWriter & w, const TablePickupEvent & value )
+BENCHTABLE_TABLE_INLINE bool TablePickupEventSaveBody( TableWriter & w, const TablePickupEvent & value )
 {
     if ( value.item_id != 0 )
     {
@@ -2150,7 +2166,7 @@ inline int64_t TablePickupEventSave( const TablePickupEvent & value, uint8_t * b
     return w.offset; // == TablePickupEventMeasure( value )
 }
 
-inline bool TablePickupEventLoadBody( TableReader & r, TablePickupEvent & value )
+BENCHTABLE_TABLE_INLINE bool TablePickupEventLoadBody( TableReader & r, TablePickupEvent & value )
 {
     TablePickupEventReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/internal/codegen/cpptable/codecs.go
+++ b/internal/codegen/cpptable/codecs.go
@@ -669,6 +669,15 @@ func (g *tableGen) emitEnumElementCheck(f *ir.Field, expr, count, ind, onBad str
 
 // ---- write / save ----
 
+// The FIXED class's bodies are force-inlined and the VARIABLE-LENGTH class's
+// are not, and the line between them is the one place a table's save/load call
+// graph can hold a cycle. A fixed table has no pointer in its by-value closure,
+// so its bodies nest by value and a cycle would make `sizeof` infinite — the
+// graph is a DAG by construction and forcing it flat always terminates. A
+// pointered body reaches its pointee through the depth-carrying template form
+// (docs/SPEC-TABLES.md §3.1), which a self-referential declaration makes
+// directly recursive, and a recursive always_inline is a compile error under
+// gcc. So the switch that already separates the two classes is the guard.
 func (g *tableGen) emitTableWrite(st *ir.Struct) {
 	if g.isVar(st.Name) {
 		g.pf("template <typename Ctx>\ninline bool %sSaveBody( const Ctx & ctx, TableWriter & w, const %s & value, int32_t depth )\n{\n", st.Name, st.Name)
@@ -677,7 +686,7 @@ func (g *tableGen) emitTableWrite(st *ir.Struct) {
 			g.pf("    (void) ctx;\n")
 		}
 	} else {
-		g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value )\n{\n", st.Name, st.Name)
+		g.pf("%s bool %sSaveBody( TableWriter & w, const %s & value )\n{\n", tableInlineMacro(g.unit.Package), st.Name, st.Name)
 	}
 	if len(st.Fields) == 0 {
 		g.pf("    (void) value; // empty type: presence is the payload\n")
@@ -925,7 +934,7 @@ func (g *tableGen) emitTableRead(st *ir.Struct) {
 			g.pf("    (void) sink; (void) depth;\n")
 		}
 	} else {
-		g.pf("inline bool %sLoadBody( TableReader & r, %s & value )\n{\n", st.Name, st.Name)
+		g.pf("%s bool %sLoadBody( TableReader & r, %s & value )\n{\n", tableInlineMacro(g.unit.Package), st.Name, st.Name)
 	}
 	// `<T>Reset`, NOT `value = T{}` and not `new ( &value ) T{}`: assignment
 	// materializes a temporary, and generated types can be large — a stack

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -267,12 +267,19 @@ struct TableKeyed
 // tablePrimitives is the shared runtime, emitted into every Table.h behind a
 // per-package guard — one definition per TU whatever the include order, and a
 // lone Table.h works standalone.
+// tableInlineMacro names the unit's force-inline macro. It is package-scoped
+// for the same reason the primitives guard is: a consumer compiles several
+// packages' Table.h files in one TU, and a macro every one of them spelled the
+// same way would be a redefinition.
+func tableInlineMacro(pkg string) string { return strings.ToUpper(pkg) + "_TABLE_INLINE" }
+
 func tablePrimitives(pkg string, anyVariable bool, anyKeyed bool) string {
 	keyedStorage := ""
 	if anyKeyed {
 		keyedStorage = tableKeyedStorage
 	}
 	guard := strings.ToUpper(pkg) + "_SCHEMA_TABLE_PRIMITIVES"
+	forceInline := tableInlineMacro(pkg)
 	// the two pointer-era descriptor members exist only in a unit that HAS
 	// pointers: a unit of value-only tables emits the descriptor surface it
 	// always emitted, to the byte (docs/SPEC-TABLES.md §2, the zero-cost gate)
@@ -286,6 +293,22 @@ func tablePrimitives(pkg string, anyVariable bool, anyKeyed bool) string {
 	}
 	return `#ifndef ` + guard + `
 #define ` + guard + `
+
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's ` + "`TableWriter`" + `: across a call boundary
+// that cursor round-trips through memory, and a ` + "`uint8_t *`" + ` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define ` + forceInline + ` __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define ` + forceInline + ` inline __attribute__(( always_inline ))
+#else
+#define ` + forceInline + ` inline
+#endif
 
 namespace ` + pkg + ` {
 
@@ -407,17 +430,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    ` + forceInline + ` void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    ` + forceInline + ` void put8( uint8_t v )   { raw( &v, 1 ); }
+    ` + forceInline + ` void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    ` + forceInline + ` void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    ` + forceInline + ` void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    ` + forceInline + ` void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -435,11 +458,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    ` + forceInline + ` bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    ` + forceInline + ` uint8_t get8()   { return buffer[offset++]; }
+    ` + forceInline + ` uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    ` + forceInline + ` uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    ` + forceInline + ` uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -129,8 +129,8 @@ func (g *tableGen) emitCodecDeclarations(members []*ir.Struct) {
 			continue
 		}
 		g.pf("inline int64_t %sMeasure( const %s & value );\n", st.Name, st.Name)
-		g.pf("inline bool %sSaveBody( TableWriter & w, const %s & value );\n", st.Name, st.Name)
-		g.pf("inline bool %sLoadBody( TableReader & r, %s & value );\n", st.Name, st.Name)
+		g.pf("%s bool %sSaveBody( TableWriter & w, const %s & value );\n", tableInlineMacro(g.unit.Package), st.Name, st.Name)
+		g.pf("%s bool %sLoadBody( TableReader & r, %s & value );\n", tableInlineMacro(g.unit.Package), st.Name, st.Name)
 	}
 	g.pf("\n")
 	if vars := g.varMembers(members); len(vars) > 0 {

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -22,6 +22,22 @@
 #ifndef BLOCKDEMO_SCHEMA_TABLE_PRIMITIVES
 #define BLOCKDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define BLOCKDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define BLOCKDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define BLOCKDEMO_TABLE_INLINE inline
+#endif
+
 namespace blockdemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -142,17 +158,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    BLOCKDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    BLOCKDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    BLOCKDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    BLOCKDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    BLOCKDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    BLOCKDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -170,11 +186,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    BLOCKDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    BLOCKDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    BLOCKDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    BLOCKDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    BLOCKDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -590,11 +606,11 @@ inline void PaddedFrameReset( PaddedFrame & value )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t PaddedRowMeasure( const PaddedRow & value );
-inline bool PaddedRowSaveBody( TableWriter & w, const PaddedRow & value );
-inline bool PaddedRowLoadBody( TableReader & r, PaddedRow & value );
+BLOCKDEMO_TABLE_INLINE bool PaddedRowSaveBody( TableWriter & w, const PaddedRow & value );
+BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & value );
 inline int64_t PaddedFrameMeasure( const PaddedFrame & value );
-inline bool PaddedFrameSaveBody( TableWriter & w, const PaddedFrame & value );
-inline bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & value );
+BLOCKDEMO_TABLE_INLINE bool PaddedFrameSaveBody( TableWriter & w, const PaddedFrame & value );
+BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & value );
 
 inline int64_t PaddedRowMeasure( const PaddedRow & value )
 {
@@ -631,7 +647,7 @@ inline int64_t PaddedRowMeasure( const PaddedRow & value )
     return bytes;
 }
 
-inline bool PaddedRowSaveBody( TableWriter & w, const PaddedRow & value )
+BLOCKDEMO_TABLE_INLINE bool PaddedRowSaveBody( TableWriter & w, const PaddedRow & value )
 {
     if ( value.tag != 0 )
     {
@@ -724,7 +740,7 @@ inline int64_t PaddedRowSave( const PaddedRow & value, uint8_t * buffer, int64_t
     return w.offset; // == PaddedRowMeasure( value )
 }
 
-inline bool PaddedRowLoadBody( TableReader & r, PaddedRow & value )
+BLOCKDEMO_TABLE_INLINE bool PaddedRowLoadBody( TableReader & r, PaddedRow & value )
 {
     PaddedRowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -945,7 +961,7 @@ inline int64_t PaddedFrameMeasure( const PaddedFrame & value )
     return bytes;
 }
 
-inline bool PaddedFrameSaveBody( TableWriter & w, const PaddedFrame & value )
+BLOCKDEMO_TABLE_INLINE bool PaddedFrameSaveBody( TableWriter & w, const PaddedFrame & value )
 {
     if ( value.marker != 0 )
     {
@@ -992,7 +1008,7 @@ inline int64_t PaddedFrameSave( const PaddedFrame & value, uint8_t * buffer, int
     return w.offset; // == PaddedFrameMeasure( value )
 }
 
-inline bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & value )
+BLOCKDEMO_TABLE_INLINE bool PaddedFrameLoadBody( TableReader & r, PaddedFrame & value )
 {
     PaddedFrameReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -21,6 +21,22 @@
 #ifndef BLOCKDEMO_SCHEMA_TABLE_PRIMITIVES
 #define BLOCKDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define BLOCKDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define BLOCKDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define BLOCKDEMO_TABLE_INLINE inline
+#endif
+
 namespace blockdemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -141,17 +157,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    BLOCKDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    BLOCKDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    BLOCKDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    BLOCKDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    BLOCKDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    BLOCKDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -169,11 +185,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    BLOCKDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    BLOCKDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    BLOCKDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    BLOCKDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    BLOCKDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -963,41 +979,41 @@ inline void RenderQuaternionReset( RenderQuaternion & value ) { value = RenderQu
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t RenderCameraMeasure( const RenderCamera & value );
-inline bool RenderCameraSaveBody( TableWriter & w, const RenderCamera & value );
-inline bool RenderCameraLoadBody( TableReader & r, RenderCamera & value );
+BLOCKDEMO_TABLE_INLINE bool RenderCameraSaveBody( TableWriter & w, const RenderCamera & value );
+BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera & value );
 inline int64_t RenderShipMeasure( const RenderShip & value );
-inline bool RenderShipSaveBody( TableWriter & w, const RenderShip & value );
-inline bool RenderShipLoadBody( TableReader & r, RenderShip & value );
+BLOCKDEMO_TABLE_INLINE bool RenderShipSaveBody( TableWriter & w, const RenderShip & value );
+BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & value );
 inline int64_t RenderTurretMeasure( const RenderTurret & value );
-inline bool RenderTurretSaveBody( TableWriter & w, const RenderTurret & value );
-inline bool RenderTurretLoadBody( TableReader & r, RenderTurret & value );
+BLOCKDEMO_TABLE_INLINE bool RenderTurretSaveBody( TableWriter & w, const RenderTurret & value );
+BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret & value );
 inline int64_t RenderMissileMeasure( const RenderMissile & value );
-inline bool RenderMissileSaveBody( TableWriter & w, const RenderMissile & value );
-inline bool RenderMissileLoadBody( TableReader & r, RenderMissile & value );
+BLOCKDEMO_TABLE_INLINE bool RenderMissileSaveBody( TableWriter & w, const RenderMissile & value );
+BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissile & value );
 inline int64_t RenderDynamicPropMeasure( const RenderDynamicProp & value );
-inline bool RenderDynamicPropSaveBody( TableWriter & w, const RenderDynamicProp & value );
-inline bool RenderDynamicPropLoadBody( TableReader & r, RenderDynamicProp & value );
+BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropSaveBody( TableWriter & w, const RenderDynamicProp & value );
+BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDynamicProp & value );
 inline int64_t RenderStaticPropMeasure( const RenderStaticProp & value );
-inline bool RenderStaticPropSaveBody( TableWriter & w, const RenderStaticProp & value );
-inline bool RenderStaticPropLoadBody( TableReader & r, RenderStaticProp & value );
+BLOCKDEMO_TABLE_INLINE bool RenderStaticPropSaveBody( TableWriter & w, const RenderStaticProp & value );
+BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderStaticProp & value );
 inline int64_t RenderCosmeticPropMeasure( const RenderCosmeticProp & value );
-inline bool RenderCosmeticPropSaveBody( TableWriter & w, const RenderCosmeticProp & value );
-inline bool RenderCosmeticPropLoadBody( TableReader & r, RenderCosmeticProp & value );
+BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropSaveBody( TableWriter & w, const RenderCosmeticProp & value );
+BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderCosmeticProp & value );
 inline int64_t RenderLaserMeasure( const RenderLaser & value );
-inline bool RenderLaserSaveBody( TableWriter & w, const RenderLaser & value );
-inline bool RenderLaserLoadBody( TableReader & r, RenderLaser & value );
+BLOCKDEMO_TABLE_INLINE bool RenderLaserSaveBody( TableWriter & w, const RenderLaser & value );
+BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & value );
 inline int64_t RenderExplosionMeasure( const RenderExplosion & value );
-inline bool RenderExplosionSaveBody( TableWriter & w, const RenderExplosion & value );
-inline bool RenderExplosionLoadBody( TableReader & r, RenderExplosion & value );
+BLOCKDEMO_TABLE_INLINE bool RenderExplosionSaveBody( TableWriter & w, const RenderExplosion & value );
+BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExplosion & value );
 inline int64_t RenderFrameMeasure( const RenderFrame & value );
-inline bool RenderFrameSaveBody( TableWriter & w, const RenderFrame & value );
-inline bool RenderFrameLoadBody( TableReader & r, RenderFrame & value );
+BLOCKDEMO_TABLE_INLINE bool RenderFrameSaveBody( TableWriter & w, const RenderFrame & value );
+BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & value );
 inline int64_t RenderVector3Measure( const RenderVector3 & value );
-inline bool RenderVector3SaveBody( TableWriter & w, const RenderVector3 & value );
-inline bool RenderVector3LoadBody( TableReader & r, RenderVector3 & value );
+BLOCKDEMO_TABLE_INLINE bool RenderVector3SaveBody( TableWriter & w, const RenderVector3 & value );
+BLOCKDEMO_TABLE_INLINE bool RenderVector3LoadBody( TableReader & r, RenderVector3 & value );
 inline int64_t RenderQuaternionMeasure( const RenderQuaternion & value );
-inline bool RenderQuaternionSaveBody( TableWriter & w, const RenderQuaternion & value );
-inline bool RenderQuaternionLoadBody( TableReader & r, RenderQuaternion & value );
+BLOCKDEMO_TABLE_INLINE bool RenderQuaternionSaveBody( TableWriter & w, const RenderQuaternion & value );
+BLOCKDEMO_TABLE_INLINE bool RenderQuaternionLoadBody( TableReader & r, RenderQuaternion & value );
 
 inline int64_t RenderCameraMeasure( const RenderCamera & value )
 {
@@ -1019,7 +1035,7 @@ inline int64_t RenderCameraMeasure( const RenderCamera & value )
     return bytes;
 }
 
-inline bool RenderCameraSaveBody( TableWriter & w, const RenderCamera & value )
+BLOCKDEMO_TABLE_INLINE bool RenderCameraSaveBody( TableWriter & w, const RenderCamera & value )
 {
     {
         int64_t body_position = RenderVector3Measure( value.position );
@@ -1072,7 +1088,7 @@ inline int64_t RenderCameraSave( const RenderCamera & value, uint8_t * buffer, i
     return w.offset; // == RenderCameraMeasure( value )
 }
 
-inline bool RenderCameraLoadBody( TableReader & r, RenderCamera & value )
+BLOCKDEMO_TABLE_INLINE bool RenderCameraLoadBody( TableReader & r, RenderCamera & value )
 {
     RenderCameraReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1223,7 +1239,7 @@ inline int64_t RenderShipMeasure( const RenderShip & value )
     return bytes;
 }
 
-inline bool RenderShipSaveBody( TableWriter & w, const RenderShip & value )
+BLOCKDEMO_TABLE_INLINE bool RenderShipSaveBody( TableWriter & w, const RenderShip & value )
 {
     {
         int64_t body_position = RenderVector3Measure( value.position );
@@ -1305,7 +1321,7 @@ inline int64_t RenderShipSave( const RenderShip & value, uint8_t * buffer, int64
     return w.offset; // == RenderShipMeasure( value )
 }
 
-inline bool RenderShipLoadBody( TableReader & r, RenderShip & value )
+BLOCKDEMO_TABLE_INLINE bool RenderShipLoadBody( TableReader & r, RenderShip & value )
 {
     RenderShipReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1520,7 +1536,7 @@ inline int64_t RenderTurretMeasure( const RenderTurret & value )
     return bytes;
 }
 
-inline bool RenderTurretSaveBody( TableWriter & w, const RenderTurret & value )
+BLOCKDEMO_TABLE_INLINE bool RenderTurretSaveBody( TableWriter & w, const RenderTurret & value )
 {
     {
         int64_t body_rotation = RenderQuaternionMeasure( value.rotation );
@@ -1585,7 +1601,7 @@ inline int64_t RenderTurretSave( const RenderTurret & value, uint8_t * buffer, i
     return w.offset; // == RenderTurretMeasure( value )
 }
 
-inline bool RenderTurretLoadBody( TableReader & r, RenderTurret & value )
+BLOCKDEMO_TABLE_INLINE bool RenderTurretLoadBody( TableReader & r, RenderTurret & value )
 {
     RenderTurretReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1772,7 +1788,7 @@ inline int64_t RenderMissileMeasure( const RenderMissile & value )
     return bytes;
 }
 
-inline bool RenderMissileSaveBody( TableWriter & w, const RenderMissile & value )
+BLOCKDEMO_TABLE_INLINE bool RenderMissileSaveBody( TableWriter & w, const RenderMissile & value )
 {
     {
         int64_t body_position = RenderVector3Measure( value.position );
@@ -1834,7 +1850,7 @@ inline int64_t RenderMissileSave( const RenderMissile & value, uint8_t * buffer,
     return w.offset; // == RenderMissileMeasure( value )
 }
 
-inline bool RenderMissileLoadBody( TableReader & r, RenderMissile & value )
+BLOCKDEMO_TABLE_INLINE bool RenderMissileLoadBody( TableReader & r, RenderMissile & value )
 {
     RenderMissileReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2007,7 +2023,7 @@ inline int64_t RenderDynamicPropMeasure( const RenderDynamicProp & value )
     return bytes;
 }
 
-inline bool RenderDynamicPropSaveBody( TableWriter & w, const RenderDynamicProp & value )
+BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropSaveBody( TableWriter & w, const RenderDynamicProp & value )
 {
     {
         int64_t body_position = RenderVector3Measure( value.position );
@@ -2069,7 +2085,7 @@ inline int64_t RenderDynamicPropSave( const RenderDynamicProp & value, uint8_t *
     return w.offset; // == RenderDynamicPropMeasure( value )
 }
 
-inline bool RenderDynamicPropLoadBody( TableReader & r, RenderDynamicProp & value )
+BLOCKDEMO_TABLE_INLINE bool RenderDynamicPropLoadBody( TableReader & r, RenderDynamicProp & value )
 {
     RenderDynamicPropReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2242,7 +2258,7 @@ inline int64_t RenderStaticPropMeasure( const RenderStaticProp & value )
     return bytes;
 }
 
-inline bool RenderStaticPropSaveBody( TableWriter & w, const RenderStaticProp & value )
+BLOCKDEMO_TABLE_INLINE bool RenderStaticPropSaveBody( TableWriter & w, const RenderStaticProp & value )
 {
     {
         int64_t body_position = RenderVector3Measure( value.position );
@@ -2304,7 +2320,7 @@ inline int64_t RenderStaticPropSave( const RenderStaticProp & value, uint8_t * b
     return w.offset; // == RenderStaticPropMeasure( value )
 }
 
-inline bool RenderStaticPropLoadBody( TableReader & r, RenderStaticProp & value )
+BLOCKDEMO_TABLE_INLINE bool RenderStaticPropLoadBody( TableReader & r, RenderStaticProp & value )
 {
     RenderStaticPropReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2477,7 +2493,7 @@ inline int64_t RenderCosmeticPropMeasure( const RenderCosmeticProp & value )
     return bytes;
 }
 
-inline bool RenderCosmeticPropSaveBody( TableWriter & w, const RenderCosmeticProp & value )
+BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropSaveBody( TableWriter & w, const RenderCosmeticProp & value )
 {
     {
         int64_t body_position = RenderVector3Measure( value.position );
@@ -2544,7 +2560,7 @@ inline int64_t RenderCosmeticPropSave( const RenderCosmeticProp & value, uint8_t
     return w.offset; // == RenderCosmeticPropMeasure( value )
 }
 
-inline bool RenderCosmeticPropLoadBody( TableReader & r, RenderCosmeticProp & value )
+BLOCKDEMO_TABLE_INLINE bool RenderCosmeticPropLoadBody( TableReader & r, RenderCosmeticProp & value )
 {
     RenderCosmeticPropReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2728,7 +2744,7 @@ inline int64_t RenderLaserMeasure( const RenderLaser & value )
     return bytes;
 }
 
-inline bool RenderLaserSaveBody( TableWriter & w, const RenderLaser & value )
+BLOCKDEMO_TABLE_INLINE bool RenderLaserSaveBody( TableWriter & w, const RenderLaser & value )
 {
     {
         int64_t body_start = RenderVector3Measure( value.start );
@@ -2785,7 +2801,7 @@ inline int64_t RenderLaserSave( const RenderLaser & value, uint8_t * buffer, int
     return w.offset; // == RenderLaserMeasure( value )
 }
 
-inline bool RenderLaserLoadBody( TableReader & r, RenderLaser & value )
+BLOCKDEMO_TABLE_INLINE bool RenderLaserLoadBody( TableReader & r, RenderLaser & value )
 {
     RenderLaserReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2944,7 +2960,7 @@ inline int64_t RenderExplosionMeasure( const RenderExplosion & value )
     return bytes;
 }
 
-inline bool RenderExplosionSaveBody( TableWriter & w, const RenderExplosion & value )
+BLOCKDEMO_TABLE_INLINE bool RenderExplosionSaveBody( TableWriter & w, const RenderExplosion & value )
 {
     {
         int64_t body_position = RenderVector3Measure( value.position );
@@ -3006,7 +3022,7 @@ inline int64_t RenderExplosionSave( const RenderExplosion & value, uint8_t * buf
     return w.offset; // == RenderExplosionMeasure( value )
 }
 
-inline bool RenderExplosionLoadBody( TableReader & r, RenderExplosion & value )
+BLOCKDEMO_TABLE_INLINE bool RenderExplosionLoadBody( TableReader & r, RenderExplosion & value )
 {
     RenderExplosionReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -3253,7 +3269,7 @@ inline int64_t RenderFrameMeasure( const RenderFrame & value )
     return bytes;
 }
 
-inline bool RenderFrameSaveBody( TableWriter & w, const RenderFrame & value )
+BLOCKDEMO_TABLE_INLINE bool RenderFrameSaveBody( TableWriter & w, const RenderFrame & value )
 {
     if ( value.version != 0 )
     {
@@ -3415,7 +3431,7 @@ inline int64_t RenderFrameSave( const RenderFrame & value, uint8_t * buffer, int
     return w.offset; // == RenderFrameMeasure( value )
 }
 
-inline bool RenderFrameLoadBody( TableReader & r, RenderFrame & value )
+BLOCKDEMO_TABLE_INLINE bool RenderFrameLoadBody( TableReader & r, RenderFrame & value )
 {
     RenderFrameReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -3844,7 +3860,7 @@ inline int64_t RenderVector3Measure( const RenderVector3 & value )
     return bytes;
 }
 
-inline bool RenderVector3SaveBody( TableWriter & w, const RenderVector3 & value )
+BLOCKDEMO_TABLE_INLINE bool RenderVector3SaveBody( TableWriter & w, const RenderVector3 & value )
 {
     if ( value.x != 0.0 )
     {
@@ -3872,7 +3888,7 @@ inline int64_t RenderVector3Save( const RenderVector3 & value, uint8_t * buffer,
     return w.offset; // == RenderVector3Measure( value )
 }
 
-inline bool RenderVector3LoadBody( TableReader & r, RenderVector3 & value )
+BLOCKDEMO_TABLE_INLINE bool RenderVector3LoadBody( TableReader & r, RenderVector3 & value )
 {
     RenderVector3Reset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -3947,7 +3963,7 @@ inline int64_t RenderQuaternionMeasure( const RenderQuaternion & value )
     return bytes;
 }
 
-inline bool RenderQuaternionSaveBody( TableWriter & w, const RenderQuaternion & value )
+BLOCKDEMO_TABLE_INLINE bool RenderQuaternionSaveBody( TableWriter & w, const RenderQuaternion & value )
 {
     if ( value.x != 0.0 )
     {
@@ -3980,7 +3996,7 @@ inline int64_t RenderQuaternionSave( const RenderQuaternion & value, uint8_t * b
     return w.offset; // == RenderQuaternionMeasure( value )
 }
 
-inline bool RenderQuaternionLoadBody( TableReader & r, RenderQuaternion & value )
+BLOCKDEMO_TABLE_INLINE bool RenderQuaternionLoadBody( TableReader & r, RenderQuaternion & value )
 {
     RenderQuaternionReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/blockhome/ConstantsTable.h
+++ b/testdata/golden/tables/blockhome/ConstantsTable.h
@@ -18,6 +18,22 @@
 #ifndef BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 #define BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define BLOCKHOME_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define BLOCKHOME_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define BLOCKHOME_TABLE_INLINE inline
+#endif
+
 namespace blockhome {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -138,17 +154,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    BLOCKHOME_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    BLOCKHOME_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    BLOCKHOME_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    BLOCKHOME_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    BLOCKHOME_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    BLOCKHOME_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -166,11 +182,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    BLOCKHOME_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    BLOCKHOME_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    BLOCKHOME_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    BLOCKHOME_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    BLOCKHOME_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )

--- a/testdata/golden/tables/blockhome/DataTable.h
+++ b/testdata/golden/tables/blockhome/DataTable.h
@@ -18,6 +18,22 @@
 #ifndef BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 #define BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define BLOCKHOME_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define BLOCKHOME_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define BLOCKHOME_TABLE_INLINE inline
+#endif
+
 namespace blockhome {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -138,17 +154,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    BLOCKHOME_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    BLOCKHOME_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    BLOCKHOME_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    BLOCKHOME_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    BLOCKHOME_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    BLOCKHOME_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -166,11 +182,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    BLOCKHOME_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    BLOCKHOME_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    BLOCKHOME_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    BLOCKHOME_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    BLOCKHOME_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -409,17 +425,17 @@ inline void GunnerSettingsReset( GunnerSettings & value ) { value = GunnerSettin
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t ArmorPlateMeasure( const ArmorPlate & value );
-inline bool ArmorPlateSaveBody( TableWriter & w, const ArmorPlate & value );
-inline bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & value );
+BLOCKHOME_TABLE_INLINE bool ArmorPlateSaveBody( TableWriter & w, const ArmorPlate & value );
+BLOCKHOME_TABLE_INLINE bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & value );
 inline int64_t ArmorConfigMeasure( const ArmorConfig & value );
-inline bool ArmorConfigSaveBody( TableWriter & w, const ArmorConfig & value );
-inline bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & value );
+BLOCKHOME_TABLE_INLINE bool ArmorConfigSaveBody( TableWriter & w, const ArmorConfig & value );
+BLOCKHOME_TABLE_INLINE bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & value );
 inline int64_t FiringGroupMeasure( const FiringGroup & value );
-inline bool FiringGroupSaveBody( TableWriter & w, const FiringGroup & value );
-inline bool FiringGroupLoadBody( TableReader & r, FiringGroup & value );
+BLOCKHOME_TABLE_INLINE bool FiringGroupSaveBody( TableWriter & w, const FiringGroup & value );
+BLOCKHOME_TABLE_INLINE bool FiringGroupLoadBody( TableReader & r, FiringGroup & value );
 inline int64_t GunnerSettingsMeasure( const GunnerSettings & value );
-inline bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value );
-inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value );
+BLOCKHOME_TABLE_INLINE bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value );
+BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value );
 
 inline int64_t ArmorPlateMeasure( const ArmorPlate & value )
 {
@@ -430,7 +446,7 @@ inline int64_t ArmorPlateMeasure( const ArmorPlate & value )
     return bytes;
 }
 
-inline bool ArmorPlateSaveBody( TableWriter & w, const ArmorPlate & value )
+BLOCKHOME_TABLE_INLINE bool ArmorPlateSaveBody( TableWriter & w, const ArmorPlate & value )
 {
     if ( value.thickness != 0.0 )
     {
@@ -458,7 +474,7 @@ inline int64_t ArmorPlateSave( const ArmorPlate & value, uint8_t * buffer, int64
     return w.offset; // == ArmorPlateMeasure( value )
 }
 
-inline bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & value )
+BLOCKHOME_TABLE_INLINE bool ArmorPlateLoadBody( TableReader & r, ArmorPlate & value )
 {
     ArmorPlateReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -543,7 +559,7 @@ inline int64_t ArmorConfigMeasure( const ArmorConfig & value )
     return bytes;
 }
 
-inline bool ArmorConfigSaveBody( TableWriter & w, const ArmorConfig & value )
+BLOCKHOME_TABLE_INLINE bool ArmorConfigSaveBody( TableWriter & w, const ArmorConfig & value )
 {
     {
         int64_t body_front = ArmorPlateMeasure( value.front );
@@ -586,7 +602,7 @@ inline int64_t ArmorConfigSave( const ArmorConfig & value, uint8_t * buffer, int
     return w.offset; // == ArmorConfigMeasure( value )
 }
 
-inline bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & value )
+BLOCKHOME_TABLE_INLINE bool ArmorConfigLoadBody( TableReader & r, ArmorConfig & value )
 {
     ArmorConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -684,7 +700,7 @@ inline int64_t FiringGroupMeasure( const FiringGroup & value )
     return bytes;
 }
 
-inline bool FiringGroupSaveBody( TableWriter & w, const FiringGroup & value )
+BLOCKHOME_TABLE_INLINE bool FiringGroupSaveBody( TableWriter & w, const FiringGroup & value )
 {
     if ( value.barrel != 0 )
     {
@@ -707,7 +723,7 @@ inline int64_t FiringGroupSave( const FiringGroup & value, uint8_t * buffer, int
     return w.offset; // == FiringGroupMeasure( value )
 }
 
-inline bool FiringGroupLoadBody( TableReader & r, FiringGroup & value )
+BLOCKHOME_TABLE_INLINE bool FiringGroupLoadBody( TableReader & r, FiringGroup & value )
 {
     FiringGroupReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -791,7 +807,7 @@ inline int64_t GunnerSettingsMeasure( const GunnerSettings & value )
     return bytes;
 }
 
-inline bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value )
+BLOCKHOME_TABLE_INLINE bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value )
 {
     if ( value.firing_groups_count < 0 || value.firing_groups_count > 32 ) { return false; } // storage invariant
     if ( value.firing_groups_count > 0 )
@@ -846,7 +862,7 @@ inline int64_t GunnerSettingsSave( const GunnerSettings & value, uint8_t * buffe
     return w.offset; // == GunnerSettingsMeasure( value )
 }
 
-inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value )
+BLOCKHOME_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value )
 {
     GunnerSettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/blockhome/FrameTable.h
+++ b/testdata/golden/tables/blockhome/FrameTable.h
@@ -19,6 +19,22 @@
 #ifndef BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 #define BLOCKHOME_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define BLOCKHOME_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define BLOCKHOME_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define BLOCKHOME_TABLE_INLINE inline
+#endif
+
 namespace blockhome {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -139,17 +155,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    BLOCKHOME_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    BLOCKHOME_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    BLOCKHOME_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    BLOCKHOME_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    BLOCKHOME_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    BLOCKHOME_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -167,11 +183,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    BLOCKHOME_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    BLOCKHOME_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    BLOCKHOME_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    BLOCKHOME_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    BLOCKHOME_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -433,11 +449,11 @@ inline void PartFrameReset( PartFrame & value )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t PartRowMeasure( const PartRow & value );
-inline bool PartRowSaveBody( TableWriter & w, const PartRow & value );
-inline bool PartRowLoadBody( TableReader & r, PartRow & value );
+BLOCKHOME_TABLE_INLINE bool PartRowSaveBody( TableWriter & w, const PartRow & value );
+BLOCKHOME_TABLE_INLINE bool PartRowLoadBody( TableReader & r, PartRow & value );
 inline int64_t PartFrameMeasure( const PartFrame & value );
-inline bool PartFrameSaveBody( TableWriter & w, const PartFrame & value );
-inline bool PartFrameLoadBody( TableReader & r, PartFrame & value );
+BLOCKHOME_TABLE_INLINE bool PartFrameSaveBody( TableWriter & w, const PartFrame & value );
+BLOCKHOME_TABLE_INLINE bool PartFrameLoadBody( TableReader & r, PartFrame & value );
 
 inline int64_t PartRowMeasure( const PartRow & value )
 {
@@ -457,7 +473,7 @@ inline int64_t PartRowMeasure( const PartRow & value )
     return bytes;
 }
 
-inline bool PartRowSaveBody( TableWriter & w, const PartRow & value )
+BLOCKHOME_TABLE_INLINE bool PartRowSaveBody( TableWriter & w, const PartRow & value )
 {
     {
         int64_t body_armor = ArmorConfigMeasure( value.armor );
@@ -500,7 +516,7 @@ inline int64_t PartRowSave( const PartRow & value, uint8_t * buffer, int64_t cap
     return w.offset; // == PartRowMeasure( value )
 }
 
-inline bool PartRowLoadBody( TableReader & r, PartRow & value )
+BLOCKHOME_TABLE_INLINE bool PartRowLoadBody( TableReader & r, PartRow & value )
 {
     PartRowReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -609,7 +625,7 @@ inline int64_t PartFrameMeasure( const PartFrame & value )
     return bytes;
 }
 
-inline bool PartFrameSaveBody( TableWriter & w, const PartFrame & value )
+BLOCKHOME_TABLE_INLINE bool PartFrameSaveBody( TableWriter & w, const PartFrame & value )
 {
     if ( value.version != 0 )
     {
@@ -643,7 +659,7 @@ inline int64_t PartFrameSave( const PartFrame & value, uint8_t * buffer, int64_t
     return w.offset; // == PartFrameMeasure( value )
 }
 
-inline bool PartFrameLoadBody( TableReader & r, PartFrame & value )
+BLOCKHOME_TABLE_INLINE bool PartFrameLoadBody( TableReader & r, PartFrame & value )
 {
     PartFrameReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -21,6 +21,22 @@
 #ifndef TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 #define TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define TABLEDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define TABLEDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define TABLEDEMO_TABLE_INLINE inline
+#endif
+
 namespace tabledemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -141,17 +157,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    TABLEDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    TABLEDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    TABLEDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    TABLEDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    TABLEDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    TABLEDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -169,11 +185,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    TABLEDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    TABLEDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    TABLEDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    TABLEDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    TABLEDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -541,8 +557,8 @@ inline void PatrolReset( Patrol & value )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t PatrolMeasure( const Patrol & value );
-inline bool PatrolSaveBody( TableWriter & w, const Patrol & value );
-inline bool PatrolLoadBody( TableReader & r, Patrol & value );
+TABLEDEMO_TABLE_INLINE bool PatrolSaveBody( TableWriter & w, const Patrol & value );
+TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value );
 
 inline int64_t PatrolMeasure( const Patrol & value )
 {
@@ -572,7 +588,7 @@ inline int64_t PatrolMeasure( const Patrol & value )
     return bytes;
 }
 
-inline bool PatrolSaveBody( TableWriter & w, const Patrol & value )
+TABLEDEMO_TABLE_INLINE bool PatrolSaveBody( TableWriter & w, const Patrol & value )
 {
     if ( value.active != false )
     {
@@ -632,7 +648,7 @@ inline int64_t PatrolSave( const Patrol & value, uint8_t * buffer, int64_t capac
     return w.offset; // == PatrolMeasure( value )
 }
 
-inline bool PatrolLoadBody( TableReader & r, Patrol & value )
+TABLEDEMO_TABLE_INLINE bool PatrolLoadBody( TableReader & r, Patrol & value )
 {
     PatrolReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -21,6 +21,22 @@
 #ifndef TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 #define TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define TABLEDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define TABLEDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define TABLEDEMO_TABLE_INLINE inline
+#endif
+
 namespace tabledemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -141,17 +157,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    TABLEDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    TABLEDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    TABLEDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    TABLEDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    TABLEDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    TABLEDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -169,11 +185,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    TABLEDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    TABLEDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    TABLEDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    TABLEDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    TABLEDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -678,23 +694,23 @@ inline void ScoreBoardReset( ScoreBoard & value ) { value = ScoreBoard(); }
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t TeamConfigMeasure( const TeamConfig & value );
-inline bool TeamConfigSaveBody( TableWriter & w, const TeamConfig & value );
-inline bool TeamConfigLoadBody( TableReader & r, TeamConfig & value );
+TABLEDEMO_TABLE_INLINE bool TeamConfigSaveBody( TableWriter & w, const TeamConfig & value );
+TABLEDEMO_TABLE_INLINE bool TeamConfigLoadBody( TableReader & r, TeamConfig & value );
 inline int64_t GunnerConfigMeasure( const GunnerConfig & value );
-inline bool GunnerConfigSaveBody( TableWriter & w, const GunnerConfig & value );
-inline bool GunnerConfigLoadBody( TableReader & r, GunnerConfig & value );
+TABLEDEMO_TABLE_INLINE bool GunnerConfigSaveBody( TableWriter & w, const GunnerConfig & value );
+TABLEDEMO_TABLE_INLINE bool GunnerConfigLoadBody( TableReader & r, GunnerConfig & value );
 inline int64_t TurretConfigMeasure( const TurretConfig & value );
-inline bool TurretConfigSaveBody( TableWriter & w, const TurretConfig & value );
-inline bool TurretConfigLoadBody( TableReader & r, TurretConfig & value );
+TABLEDEMO_TABLE_INLINE bool TurretConfigSaveBody( TableWriter & w, const TurretConfig & value );
+TABLEDEMO_TABLE_INLINE bool TurretConfigLoadBody( TableReader & r, TurretConfig & value );
 inline int64_t HullConfigMeasure( const HullConfig & value );
-inline bool HullConfigSaveBody( TableWriter & w, const HullConfig & value );
-inline bool HullConfigLoadBody( TableReader & r, HullConfig & value );
+TABLEDEMO_TABLE_INLINE bool HullConfigSaveBody( TableWriter & w, const HullConfig & value );
+TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & value );
 inline int64_t KeyedConfigMeasure( const KeyedConfig & value );
-inline bool KeyedConfigSaveBody( TableWriter & w, const KeyedConfig & value );
-inline bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & value );
+TABLEDEMO_TABLE_INLINE bool KeyedConfigSaveBody( TableWriter & w, const KeyedConfig & value );
+TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & value );
 inline int64_t ScoreBoardMeasure( const ScoreBoard & value );
-inline bool ScoreBoardSaveBody( TableWriter & w, const ScoreBoard & value );
-inline bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & value );
+TABLEDEMO_TABLE_INLINE bool ScoreBoardSaveBody( TableWriter & w, const ScoreBoard & value );
+TABLEDEMO_TABLE_INLINE bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & value );
 
 inline int64_t TeamConfigMeasure( const TeamConfig & value )
 {
@@ -705,7 +721,7 @@ inline int64_t TeamConfigMeasure( const TeamConfig & value )
     return bytes;
 }
 
-inline bool TeamConfigSaveBody( TableWriter & w, const TeamConfig & value )
+TABLEDEMO_TABLE_INLINE bool TeamConfigSaveBody( TableWriter & w, const TeamConfig & value )
 {
     if ( value.spawn_count != 4 )
     {
@@ -730,7 +746,7 @@ inline int64_t TeamConfigSave( const TeamConfig & value, uint8_t * buffer, int64
     return w.offset; // == TeamConfigMeasure( value )
 }
 
-inline bool TeamConfigLoadBody( TableReader & r, TeamConfig & value )
+TABLEDEMO_TABLE_INLINE bool TeamConfigLoadBody( TableReader & r, TeamConfig & value )
 {
     TeamConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -801,7 +817,7 @@ inline int64_t GunnerConfigMeasure( const GunnerConfig & value )
     return bytes;
 }
 
-inline bool GunnerConfigSaveBody( TableWriter & w, const GunnerConfig & value )
+TABLEDEMO_TABLE_INLINE bool GunnerConfigSaveBody( TableWriter & w, const GunnerConfig & value )
 {
     if ( value.reaction != 0.2f )
     {
@@ -824,7 +840,7 @@ inline int64_t GunnerConfigSave( const GunnerConfig & value, uint8_t * buffer, i
     return w.offset; // == GunnerConfigMeasure( value )
 }
 
-inline bool GunnerConfigLoadBody( TableReader & r, GunnerConfig & value )
+TABLEDEMO_TABLE_INLINE bool GunnerConfigLoadBody( TableReader & r, GunnerConfig & value )
 {
     GunnerConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -891,7 +907,7 @@ inline int64_t TurretConfigMeasure( const TurretConfig & value )
     return bytes;
 }
 
-inline bool TurretConfigSaveBody( TableWriter & w, const TurretConfig & value )
+TABLEDEMO_TABLE_INLINE bool TurretConfigSaveBody( TableWriter & w, const TurretConfig & value )
 {
     if ( value.damage != 10.0f )
     {
@@ -922,7 +938,7 @@ inline int64_t TurretConfigSave( const TurretConfig & value, uint8_t * buffer, i
     return w.offset; // == TurretConfigMeasure( value )
 }
 
-inline bool TurretConfigLoadBody( TableReader & r, TurretConfig & value )
+TABLEDEMO_TABLE_INLINE bool TurretConfigLoadBody( TableReader & r, TurretConfig & value )
 {
     TurretConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1015,7 +1031,7 @@ inline int64_t HullConfigMeasure( const HullConfig & value )
     return bytes;
 }
 
-inline bool HullConfigSaveBody( TableWriter & w, const HullConfig & value )
+TABLEDEMO_TABLE_INLINE bool HullConfigSaveBody( TableWriter & w, const HullConfig & value )
 {
     if ( value.health != 100.0f )
     {
@@ -1075,7 +1091,7 @@ inline int64_t HullConfigSave( const HullConfig & value, uint8_t * buffer, int64
     return w.offset; // == HullConfigMeasure( value )
 }
 
-inline bool HullConfigLoadBody( TableReader & r, HullConfig & value )
+TABLEDEMO_TABLE_INLINE bool HullConfigLoadBody( TableReader & r, HullConfig & value )
 {
     HullConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1217,7 +1233,7 @@ inline int64_t KeyedConfigMeasure( const KeyedConfig & value )
     return bytes;
 }
 
-inline bool KeyedConfigSaveBody( TableWriter & w, const KeyedConfig & value )
+TABLEDEMO_TABLE_INLINE bool KeyedConfigSaveBody( TableWriter & w, const KeyedConfig & value )
 {
     {
         uint32_t pairs_teams = 0;
@@ -1314,7 +1330,7 @@ inline int64_t KeyedConfigSave( const KeyedConfig & value, uint8_t * buffer, int
     return w.offset; // == KeyedConfigMeasure( value )
 }
 
-inline bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & value )
+TABLEDEMO_TABLE_INLINE bool KeyedConfigLoadBody( TableReader & r, KeyedConfig & value )
 {
     KeyedConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1482,7 +1498,7 @@ inline int64_t ScoreBoardMeasure( const ScoreBoard & value )
     return bytes;
 }
 
-inline bool ScoreBoardSaveBody( TableWriter & w, const ScoreBoard & value )
+TABLEDEMO_TABLE_INLINE bool ScoreBoardSaveBody( TableWriter & w, const ScoreBoard & value )
 {
     {
         uint32_t pairs_per_team = 0;
@@ -1528,7 +1544,7 @@ inline int64_t ScoreBoardSave( const ScoreBoard & value, uint8_t * buffer, int64
     return w.offset; // == ScoreBoardMeasure( value )
 }
 
-inline bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & value )
+TABLEDEMO_TABLE_INLINE bool ScoreBoardLoadBody( TableReader & r, ScoreBoard & value )
 {
     ScoreBoardReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/examples/NestedTable.h
+++ b/testdata/golden/tables/examples/NestedTable.h
@@ -22,6 +22,22 @@
 #ifndef TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 #define TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define TABLEDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define TABLEDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define TABLEDEMO_TABLE_INLINE inline
+#endif
+
 namespace tabledemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -142,17 +158,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    TABLEDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    TABLEDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    TABLEDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    TABLEDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    TABLEDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    TABLEDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -170,11 +186,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    TABLEDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    TABLEDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    TABLEDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    TABLEDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    TABLEDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -520,8 +536,8 @@ inline void ArchiveConfigReset( ArchiveConfig & value )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t ArchiveConfigMeasure( const ArchiveConfig & value );
-inline bool ArchiveConfigSaveBody( TableWriter & w, const ArchiveConfig & value );
-inline bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfig & value );
+TABLEDEMO_TABLE_INLINE bool ArchiveConfigSaveBody( TableWriter & w, const ArchiveConfig & value );
+TABLEDEMO_TABLE_INLINE bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfig & value );
 
 inline int64_t ArchiveConfigMeasure( const ArchiveConfig & value )
 {
@@ -535,7 +551,7 @@ inline int64_t ArchiveConfigMeasure( const ArchiveConfig & value )
     return bytes;
 }
 
-inline bool ArchiveConfigSaveBody( TableWriter & w, const ArchiveConfig & value )
+TABLEDEMO_TABLE_INLINE bool ArchiveConfigSaveBody( TableWriter & w, const ArchiveConfig & value )
 {
     {
         int64_t body_root = RootConfigMeasure( value.root );
@@ -563,7 +579,7 @@ inline int64_t ArchiveConfigSave( const ArchiveConfig & value, uint8_t * buffer,
     return w.offset; // == ArchiveConfigMeasure( value )
 }
 
-inline bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfig & value )
+TABLEDEMO_TABLE_INLINE bool ArchiveConfigLoadBody( TableReader & r, ArchiveConfig & value )
 {
     ArchiveConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -21,6 +21,22 @@
 #ifndef TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 #define TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define TABLEDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define TABLEDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define TABLEDEMO_TABLE_INLINE inline
+#endif
+
 namespace tabledemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -141,17 +157,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    TABLEDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    TABLEDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    TABLEDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    TABLEDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    TABLEDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    TABLEDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -169,11 +185,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    TABLEDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    TABLEDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    TABLEDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    TABLEDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    TABLEDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -651,17 +667,17 @@ inline void PackConfigReset( PackConfig & value )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t GunnerSettingsMeasure( const GunnerSettings & value );
-inline bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value );
-inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value );
+TABLEDEMO_TABLE_INLINE bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value );
+TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value );
 inline int64_t ShipEntryMeasure( const ShipEntry & value );
-inline bool ShipEntrySaveBody( TableWriter & w, const ShipEntry & value );
-inline bool ShipEntryLoadBody( TableReader & r, ShipEntry & value );
+TABLEDEMO_TABLE_INLINE bool ShipEntrySaveBody( TableWriter & w, const ShipEntry & value );
+TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & value );
 inline int64_t GlobalSettingsMeasure( const GlobalSettings & value );
-inline bool GlobalSettingsSaveBody( TableWriter & w, const GlobalSettings & value );
-inline bool GlobalSettingsLoadBody( TableReader & r, GlobalSettings & value );
+TABLEDEMO_TABLE_INLINE bool GlobalSettingsSaveBody( TableWriter & w, const GlobalSettings & value );
+TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSettings & value );
 inline int64_t PackConfigMeasure( const PackConfig & value );
-inline bool PackConfigSaveBody( TableWriter & w, const PackConfig & value );
-inline bool PackConfigLoadBody( TableReader & r, PackConfig & value );
+TABLEDEMO_TABLE_INLINE bool PackConfigSaveBody( TableWriter & w, const PackConfig & value );
+TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & value );
 
 inline int64_t GunnerSettingsMeasure( const GunnerSettings & value )
 {
@@ -673,7 +689,7 @@ inline int64_t GunnerSettingsMeasure( const GunnerSettings & value )
     return bytes;
 }
 
-inline bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value )
+TABLEDEMO_TABLE_INLINE bool GunnerSettingsSaveBody( TableWriter & w, const GunnerSettings & value )
 {
     if ( value.reaction != 0.2f )
     {
@@ -703,7 +719,7 @@ inline int64_t GunnerSettingsSave( const GunnerSettings & value, uint8_t * buffe
     return w.offset; // == GunnerSettingsMeasure( value )
 }
 
-inline bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value )
+TABLEDEMO_TABLE_INLINE bool GunnerSettingsLoadBody( TableReader & r, GunnerSettings & value )
 {
     GunnerSettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -796,7 +812,7 @@ inline int64_t ShipEntryMeasure( const ShipEntry & value )
     return bytes;
 }
 
-inline bool ShipEntrySaveBody( TableWriter & w, const ShipEntry & value )
+TABLEDEMO_TABLE_INLINE bool ShipEntrySaveBody( TableWriter & w, const ShipEntry & value )
 {
     if ( value.display_name_length < 0 || value.display_name_length > 32 ) { return false; } // storage invariant
     if ( value.display_name_length > 0 )
@@ -846,7 +862,7 @@ inline int64_t ShipEntrySave( const ShipEntry & value, uint8_t * buffer, int64_t
     return w.offset; // == ShipEntryMeasure( value )
 }
 
-inline bool ShipEntryLoadBody( TableReader & r, ShipEntry & value )
+TABLEDEMO_TABLE_INLINE bool ShipEntryLoadBody( TableReader & r, ShipEntry & value )
 {
     ShipEntryReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -999,7 +1015,7 @@ inline int64_t GlobalSettingsMeasure( const GlobalSettings & value )
     return bytes;
 }
 
-inline bool GlobalSettingsSaveBody( TableWriter & w, const GlobalSettings & value )
+TABLEDEMO_TABLE_INLINE bool GlobalSettingsSaveBody( TableWriter & w, const GlobalSettings & value )
 {
     if ( value.tick_rate != 60 )
     {
@@ -1046,7 +1062,7 @@ inline int64_t GlobalSettingsSave( const GlobalSettings & value, uint8_t * buffe
     return w.offset; // == GlobalSettingsMeasure( value )
 }
 
-inline bool GlobalSettingsLoadBody( TableReader & r, GlobalSettings & value )
+TABLEDEMO_TABLE_INLINE bool GlobalSettingsLoadBody( TableReader & r, GlobalSettings & value )
 {
     GlobalSettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1208,7 +1224,7 @@ inline int64_t PackConfigMeasure( const PackConfig & value )
     return bytes;
 }
 
-inline bool PackConfigSaveBody( TableWriter & w, const PackConfig & value )
+TABLEDEMO_TABLE_INLINE bool PackConfigSaveBody( TableWriter & w, const PackConfig & value )
 {
     if ( value.version != 1 )
     {
@@ -1322,7 +1338,7 @@ inline int64_t PackConfigSave( const PackConfig & value, uint8_t * buffer, int64
     return w.offset; // == PackConfigMeasure( value )
 }
 
-inline bool PackConfigLoadBody( TableReader & r, PackConfig & value )
+TABLEDEMO_TABLE_INLINE bool PackConfigLoadBody( TableReader & r, PackConfig & value )
 {
     PackConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/examples/RangesTable.h
+++ b/testdata/golden/tables/examples/RangesTable.h
@@ -21,6 +21,22 @@
 #ifndef TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 #define TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define TABLEDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define TABLEDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define TABLEDEMO_TABLE_INLINE inline
+#endif
+
 namespace tabledemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -141,17 +157,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    TABLEDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    TABLEDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    TABLEDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    TABLEDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    TABLEDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    TABLEDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -169,11 +185,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    TABLEDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    TABLEDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    TABLEDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    TABLEDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    TABLEDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -619,14 +635,14 @@ inline void RangedWidthsReset( RangedWidths & value )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t RangedSignedMeasure( const RangedSigned & value );
-inline bool RangedSignedSaveBody( TableWriter & w, const RangedSigned & value );
-inline bool RangedSignedLoadBody( TableReader & r, RangedSigned & value );
+TABLEDEMO_TABLE_INLINE bool RangedSignedSaveBody( TableWriter & w, const RangedSigned & value );
+TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned & value );
 inline int64_t RangedUnsignedMeasure( const RangedUnsigned & value );
-inline bool RangedUnsignedSaveBody( TableWriter & w, const RangedUnsigned & value );
-inline bool RangedUnsignedLoadBody( TableReader & r, RangedUnsigned & value );
+TABLEDEMO_TABLE_INLINE bool RangedUnsignedSaveBody( TableWriter & w, const RangedUnsigned & value );
+TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsigned & value );
 inline int64_t RangedWidthsMeasure( const RangedWidths & value );
-inline bool RangedWidthsSaveBody( TableWriter & w, const RangedWidths & value );
-inline bool RangedWidthsLoadBody( TableReader & r, RangedWidths & value );
+TABLEDEMO_TABLE_INLINE bool RangedWidthsSaveBody( TableWriter & w, const RangedWidths & value );
+TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths & value );
 
 inline int64_t RangedSignedMeasure( const RangedSigned & value )
 {
@@ -655,7 +671,7 @@ inline int64_t RangedSignedMeasure( const RangedSigned & value )
     return bytes;
 }
 
-inline bool RangedSignedSaveBody( TableWriter & w, const RangedSigned & value )
+TABLEDEMO_TABLE_INLINE bool RangedSignedSaveBody( TableWriter & w, const RangedSigned & value )
 {
     if ( value.i8_span != 0 )
     {
@@ -760,7 +776,7 @@ inline int64_t RangedSignedSave( const RangedSigned & value, uint8_t * buffer, i
     return w.offset; // == RangedSignedMeasure( value )
 }
 
-inline bool RangedSignedLoadBody( TableReader & r, RangedSigned & value )
+TABLEDEMO_TABLE_INLINE bool RangedSignedLoadBody( TableReader & r, RangedSigned & value )
 {
     RangedSignedReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1077,7 +1093,7 @@ inline int64_t RangedUnsignedMeasure( const RangedUnsigned & value )
     return bytes;
 }
 
-inline bool RangedUnsignedSaveBody( TableWriter & w, const RangedUnsigned & value )
+TABLEDEMO_TABLE_INLINE bool RangedUnsignedSaveBody( TableWriter & w, const RangedUnsigned & value )
 {
     if ( value.u8_span != 0 )
     {
@@ -1182,7 +1198,7 @@ inline int64_t RangedUnsignedSave( const RangedUnsigned & value, uint8_t * buffe
     return w.offset; // == RangedUnsignedMeasure( value )
 }
 
-inline bool RangedUnsignedLoadBody( TableReader & r, RangedUnsigned & value )
+TABLEDEMO_TABLE_INLINE bool RangedUnsignedLoadBody( TableReader & r, RangedUnsigned & value )
 {
     RangedUnsignedReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1484,7 +1500,7 @@ inline int64_t RangedWidthsMeasure( const RangedWidths & value )
     return bytes;
 }
 
-inline bool RangedWidthsSaveBody( TableWriter & w, const RangedWidths & value )
+TABLEDEMO_TABLE_INLINE bool RangedWidthsSaveBody( TableWriter & w, const RangedWidths & value )
 {
     if ( value.b8 != 0 )
     {
@@ -1527,7 +1543,7 @@ inline int64_t RangedWidthsSave( const RangedWidths & value, uint8_t * buffer, i
     return w.offset; // == RangedWidthsMeasure( value )
 }
 
-inline bool RangedWidthsLoadBody( TableReader & r, RangedWidths & value )
+TABLEDEMO_TABLE_INLINE bool RangedWidthsLoadBody( TableReader & r, RangedWidths & value )
 {
     RangedWidthsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -21,6 +21,22 @@
 #ifndef TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 #define TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define TABLEDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define TABLEDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define TABLEDEMO_TABLE_INLINE inline
+#endif
+
 namespace tabledemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -141,17 +157,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    TABLEDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    TABLEDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    TABLEDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    TABLEDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    TABLEDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    TABLEDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -169,11 +185,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    TABLEDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    TABLEDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    TABLEDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    TABLEDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    TABLEDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -662,26 +678,26 @@ inline void DebuffReset( Debuff & value ) { value = Debuff(); }
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t WeaponConfigMeasure( const WeaponConfig & value );
-inline bool WeaponConfigSaveBody( TableWriter & w, const WeaponConfig & value );
-inline bool WeaponConfigLoadBody( TableReader & r, WeaponConfig & value );
+TABLEDEMO_TABLE_INLINE bool WeaponConfigSaveBody( TableWriter & w, const WeaponConfig & value );
+TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig & value );
 inline int64_t LoadoutConfigMeasure( const LoadoutConfig & value );
-inline bool LoadoutConfigSaveBody( TableWriter & w, const LoadoutConfig & value );
-inline bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfig & value );
+TABLEDEMO_TABLE_INLINE bool LoadoutConfigSaveBody( TableWriter & w, const LoadoutConfig & value );
+TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfig & value );
 inline int64_t ProfileConfigMeasure( const ProfileConfig & value );
-inline bool ProfileConfigSaveBody( TableWriter & w, const ProfileConfig & value );
-inline bool ProfileConfigLoadBody( TableReader & r, ProfileConfig & value );
+TABLEDEMO_TABLE_INLINE bool ProfileConfigSaveBody( TableWriter & w, const ProfileConfig & value );
+TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfig & value );
 inline int64_t RootConfigMeasure( const RootConfig & value );
-inline bool RootConfigSaveBody( TableWriter & w, const RootConfig & value );
-inline bool RootConfigLoadBody( TableReader & r, RootConfig & value );
+TABLEDEMO_TABLE_INLINE bool RootConfigSaveBody( TableWriter & w, const RootConfig & value );
+TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & value );
 inline int64_t AttachmentMeasure( const Attachment & value );
-inline bool AttachmentSaveBody( TableWriter & w, const Attachment & value );
-inline bool AttachmentLoadBody( TableReader & r, Attachment & value );
+TABLEDEMO_TABLE_INLINE bool AttachmentSaveBody( TableWriter & w, const Attachment & value );
+TABLEDEMO_TABLE_INLINE bool AttachmentLoadBody( TableReader & r, Attachment & value );
 inline int64_t BuffMeasure( const Buff & value );
-inline bool BuffSaveBody( TableWriter & w, const Buff & value );
-inline bool BuffLoadBody( TableReader & r, Buff & value );
+TABLEDEMO_TABLE_INLINE bool BuffSaveBody( TableWriter & w, const Buff & value );
+TABLEDEMO_TABLE_INLINE bool BuffLoadBody( TableReader & r, Buff & value );
 inline int64_t DebuffMeasure( const Debuff & value );
-inline bool DebuffSaveBody( TableWriter & w, const Debuff & value );
-inline bool DebuffLoadBody( TableReader & r, Debuff & value );
+TABLEDEMO_TABLE_INLINE bool DebuffSaveBody( TableWriter & w, const Debuff & value );
+TABLEDEMO_TABLE_INLINE bool DebuffLoadBody( TableReader & r, Debuff & value );
 
 inline int64_t WeaponConfigMeasure( const WeaponConfig & value )
 {
@@ -713,7 +729,7 @@ inline int64_t WeaponConfigMeasure( const WeaponConfig & value )
     return bytes;
 }
 
-inline bool WeaponConfigSaveBody( TableWriter & w, const WeaponConfig & value )
+TABLEDEMO_TABLE_INLINE bool WeaponConfigSaveBody( TableWriter & w, const WeaponConfig & value )
 {
     if ( value.damage != 21.0f )
     {
@@ -771,7 +787,7 @@ inline int64_t WeaponConfigSave( const WeaponConfig & value, uint8_t * buffer, i
     return w.offset; // == WeaponConfigMeasure( value )
 }
 
-inline bool WeaponConfigLoadBody( TableReader & r, WeaponConfig & value )
+TABLEDEMO_TABLE_INLINE bool WeaponConfigLoadBody( TableReader & r, WeaponConfig & value )
 {
     WeaponConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -966,7 +982,7 @@ inline int64_t LoadoutConfigMeasure( const LoadoutConfig & value )
     return bytes;
 }
 
-inline bool LoadoutConfigSaveBody( TableWriter & w, const LoadoutConfig & value )
+TABLEDEMO_TABLE_INLINE bool LoadoutConfigSaveBody( TableWriter & w, const LoadoutConfig & value )
 {
     if ( value.grade != Grade::Silver )
     {
@@ -1066,7 +1082,7 @@ inline int64_t LoadoutConfigSave( const LoadoutConfig & value, uint8_t * buffer,
     return w.offset; // == LoadoutConfigMeasure( value )
 }
 
-inline bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfig & value )
+TABLEDEMO_TABLE_INLINE bool LoadoutConfigLoadBody( TableReader & r, LoadoutConfig & value )
 {
     LoadoutConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1344,7 +1360,7 @@ inline int64_t ProfileConfigMeasure( const ProfileConfig & value )
     return bytes;
 }
 
-inline bool ProfileConfigSaveBody( TableWriter & w, const ProfileConfig & value )
+TABLEDEMO_TABLE_INLINE bool ProfileConfigSaveBody( TableWriter & w, const ProfileConfig & value )
 {
     if ( value.name_length < 0 || value.name_length > 32 ) { return false; } // storage invariant
     if ( value.name_length > 0 )
@@ -1445,7 +1461,7 @@ inline int64_t ProfileConfigSave( const ProfileConfig & value, uint8_t * buffer,
     return w.offset; // == ProfileConfigMeasure( value )
 }
 
-inline bool ProfileConfigLoadBody( TableReader & r, ProfileConfig & value )
+TABLEDEMO_TABLE_INLINE bool ProfileConfigLoadBody( TableReader & r, ProfileConfig & value )
 {
     ProfileConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1726,7 +1742,7 @@ inline int64_t RootConfigMeasure( const RootConfig & value )
     return bytes;
 }
 
-inline bool RootConfigSaveBody( TableWriter & w, const RootConfig & value )
+TABLEDEMO_TABLE_INLINE bool RootConfigSaveBody( TableWriter & w, const RootConfig & value )
 {
     if ( value.version_note_length < 0 || value.version_note_length > 16 ) { return false; } // storage invariant
     if ( value.version_note_length > 0 )
@@ -1778,7 +1794,7 @@ inline int64_t RootConfigSave( const RootConfig & value, uint8_t * buffer, int64
     return w.offset; // == RootConfigMeasure( value )
 }
 
-inline bool RootConfigLoadBody( TableReader & r, RootConfig & value )
+TABLEDEMO_TABLE_INLINE bool RootConfigLoadBody( TableReader & r, RootConfig & value )
 {
     RootConfigReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1918,7 +1934,7 @@ inline int64_t AttachmentMeasure( const Attachment & value )
     return bytes;
 }
 
-inline bool AttachmentSaveBody( TableWriter & w, const Attachment & value )
+TABLEDEMO_TABLE_INLINE bool AttachmentSaveBody( TableWriter & w, const Attachment & value )
 {
     if ( value.slot != 0 )
     {
@@ -1941,7 +1957,7 @@ inline int64_t AttachmentSave( const Attachment & value, uint8_t * buffer, int64
     return w.offset; // == AttachmentMeasure( value )
 }
 
-inline bool AttachmentLoadBody( TableReader & r, Attachment & value )
+TABLEDEMO_TABLE_INLINE bool AttachmentLoadBody( TableReader & r, Attachment & value )
 {
     AttachmentReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2004,7 +2020,7 @@ inline int64_t BuffMeasure( const Buff & value )
     return bytes;
 }
 
-inline bool BuffSaveBody( TableWriter & w, const Buff & value )
+TABLEDEMO_TABLE_INLINE bool BuffSaveBody( TableWriter & w, const Buff & value )
 {
     if ( value.multiplier != 1.0f )
     {
@@ -2022,7 +2038,7 @@ inline int64_t BuffSave( const Buff & value, uint8_t * buffer, int64_t capacity 
     return w.offset; // == BuffMeasure( value )
 }
 
-inline bool BuffLoadBody( TableReader & r, Buff & value )
+TABLEDEMO_TABLE_INLINE bool BuffLoadBody( TableReader & r, Buff & value )
 {
     BuffReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -2070,7 +2086,7 @@ inline int64_t DebuffMeasure( const Debuff & value )
     return bytes;
 }
 
-inline bool DebuffSaveBody( TableWriter & w, const Debuff & value )
+TABLEDEMO_TABLE_INLINE bool DebuffSaveBody( TableWriter & w, const Debuff & value )
 {
     if ( value.amount != 0 )
     {
@@ -2088,7 +2104,7 @@ inline int64_t DebuffSave( const Debuff & value, uint8_t * buffer, int64_t capac
     return w.offset; // == DebuffMeasure( value )
 }
 
-inline bool DebuffLoadBody( TableReader & r, Debuff & value )
+TABLEDEMO_TABLE_INLINE bool DebuffLoadBody( TableReader & r, Debuff & value )
 {
     DebuffReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -21,6 +21,22 @@
 #ifndef TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 #define TABLEDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define TABLEDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define TABLEDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define TABLEDEMO_TABLE_INLINE inline
+#endif
+
 namespace tabledemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -141,17 +157,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    TABLEDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    TABLEDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    TABLEDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    TABLEDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    TABLEDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    TABLEDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -169,11 +185,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    TABLEDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    TABLEDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    TABLEDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    TABLEDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    TABLEDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -527,8 +543,8 @@ inline void WideBlobReset( WideBlob & value )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t WideBlobMeasure( const WideBlob & value );
-inline bool WideBlobSaveBody( TableWriter & w, const WideBlob & value );
-inline bool WideBlobLoadBody( TableReader & r, WideBlob & value );
+TABLEDEMO_TABLE_INLINE bool WideBlobSaveBody( TableWriter & w, const WideBlob & value );
+TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value );
 
 inline int64_t WideBlobMeasure( const WideBlob & value )
 {
@@ -545,7 +561,7 @@ inline int64_t WideBlobMeasure( const WideBlob & value )
     return bytes;
 }
 
-inline bool WideBlobSaveBody( TableWriter & w, const WideBlob & value )
+TABLEDEMO_TABLE_INLINE bool WideBlobSaveBody( TableWriter & w, const WideBlob & value )
 {
     if ( value.label_length < 0 || value.label_length > 70000 ) { return false; } // storage invariant
     if ( value.label_length > 0 )
@@ -585,7 +601,7 @@ inline int64_t WideBlobSave( const WideBlob & value, uint8_t * buffer, int64_t c
     return w.offset; // == WideBlobMeasure( value )
 }
 
-inline bool WideBlobLoadBody( TableReader & r, WideBlob & value )
+TABLEDEMO_TABLE_INLINE bool WideBlobLoadBody( TableReader & r, WideBlob & value )
 {
     WideBlobReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -27,6 +27,22 @@
 #ifndef GRAPHDEMO_SCHEMA_TABLE_PRIMITIVES
 #define GRAPHDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define GRAPHDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define GRAPHDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define GRAPHDEMO_TABLE_INLINE inline
+#endif
+
 namespace graphdemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -153,17 +169,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    GRAPHDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    GRAPHDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    GRAPHDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    GRAPHDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    GRAPHDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    GRAPHDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -181,11 +197,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    GRAPHDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    GRAPHDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    GRAPHDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    GRAPHDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    GRAPHDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -1101,11 +1117,11 @@ inline TreeNode * TreeNodeEmplace( TableWorker & worker, TableRef & slot )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t MetaMeasure( const Meta & value );
-inline bool MetaSaveBody( TableWriter & w, const Meta & value );
-inline bool MetaLoadBody( TableReader & r, Meta & value );
+GRAPHDEMO_TABLE_INLINE bool MetaSaveBody( TableWriter & w, const Meta & value );
+GRAPHDEMO_TABLE_INLINE bool MetaLoadBody( TableReader & r, Meta & value );
 inline int64_t SettingsMeasure( const Settings & value );
-inline bool SettingsSaveBody( TableWriter & w, const Settings & value );
-inline bool SettingsLoadBody( TableReader & r, Settings & value );
+GRAPHDEMO_TABLE_INLINE bool SettingsSaveBody( TableWriter & w, const Settings & value );
+GRAPHDEMO_TABLE_INLINE bool SettingsLoadBody( TableReader & r, Settings & value );
 template <typename Ctx> inline int64_t ListNodeMeasureBody( const Ctx & ctx, const ListNode & value, int32_t depth );
 template <typename Ctx> inline bool ListNodeSaveBody( const Ctx & ctx, TableWriter & w, const ListNode & value, int32_t depth );
 template <typename Sink> inline bool ListNodeLoadBody( TableReader & r, Sink & sink, ListNode & value, int32_t depth );
@@ -1158,7 +1174,7 @@ inline int64_t MetaMeasure( const Meta & value )
     return bytes;
 }
 
-inline bool MetaSaveBody( TableWriter & w, const Meta & value )
+GRAPHDEMO_TABLE_INLINE bool MetaSaveBody( TableWriter & w, const Meta & value )
 {
     if ( value.build != 1 )
     {
@@ -1183,7 +1199,7 @@ inline int64_t MetaSave( const Meta & value, uint8_t * buffer, int64_t capacity 
     return w.offset; // == MetaMeasure( value )
 }
 
-inline bool MetaLoadBody( TableReader & r, Meta & value )
+GRAPHDEMO_TABLE_INLINE bool MetaLoadBody( TableReader & r, Meta & value )
 {
     MetaReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -1255,7 +1271,7 @@ inline int64_t SettingsMeasure( const Settings & value )
     return bytes;
 }
 
-inline bool SettingsSaveBody( TableWriter & w, const Settings & value )
+GRAPHDEMO_TABLE_INLINE bool SettingsSaveBody( TableWriter & w, const Settings & value )
 {
     if ( value.quality != 2 )
     {
@@ -1280,7 +1296,7 @@ inline int64_t SettingsSave( const Settings & value, uint8_t * buffer, int64_t c
     return w.offset; // == SettingsMeasure( value )
 }
 
-inline bool SettingsLoadBody( TableReader & r, Settings & value )
+GRAPHDEMO_TABLE_INLINE bool SettingsLoadBody( TableReader & r, Settings & value )
 {
     SettingsReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -24,6 +24,22 @@
 #ifndef GRAPHDEMO_SCHEMA_TABLE_PRIMITIVES
 #define GRAPHDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define GRAPHDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define GRAPHDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define GRAPHDEMO_TABLE_INLINE inline
+#endif
+
 namespace graphdemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -150,17 +166,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    GRAPHDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    GRAPHDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    GRAPHDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    GRAPHDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    GRAPHDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    GRAPHDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -178,11 +194,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    GRAPHDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    GRAPHDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    GRAPHDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    GRAPHDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    GRAPHDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -889,8 +905,8 @@ inline Marker * MarkerEmplace( TableWorker & worker, TableRef & slot )
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t TallyMeasure( const Tally & value );
-inline bool TallySaveBody( TableWriter & w, const Tally & value );
-inline bool TallyLoadBody( TableReader & r, Tally & value );
+GRAPHDEMO_TABLE_INLINE bool TallySaveBody( TableWriter & w, const Tally & value );
+GRAPHDEMO_TABLE_INLINE bool TallyLoadBody( TableReader & r, Tally & value );
 template <typename Ctx> inline int64_t MarkerMeasureBody( const Ctx & ctx, const Marker & value, int32_t depth );
 template <typename Ctx> inline bool MarkerSaveBody( const Ctx & ctx, TableWriter & w, const Marker & value, int32_t depth );
 template <typename Sink> inline bool MarkerLoadBody( TableReader & r, Sink & sink, Marker & value, int32_t depth );
@@ -911,7 +927,7 @@ inline int64_t TallyMeasure( const Tally & value )
     return bytes;
 }
 
-inline bool TallySaveBody( TableWriter & w, const Tally & value )
+GRAPHDEMO_TABLE_INLINE bool TallySaveBody( TableWriter & w, const Tally & value )
 {
     if ( value.hits != 0 )
     {
@@ -929,7 +945,7 @@ inline int64_t TallySave( const Tally & value, uint8_t * buffer, int64_t capacit
     return w.offset; // == TallyMeasure( value )
 }
 
-inline bool TallyLoadBody( TableReader & r, Tally & value )
+GRAPHDEMO_TABLE_INLINE bool TallyLoadBody( TableReader & r, Tally & value )
 {
     TallyReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -24,6 +24,22 @@
 #ifndef GRAPHDEMO_SCHEMA_TABLE_PRIMITIVES
 #define GRAPHDEMO_SCHEMA_TABLE_PRIMITIVES
 
+// THE CODEC DOES NOT DEPEND ON THE COMPILER'S INLINING BUDGET. A table of a
+// realistic field count emits one large body per type, and the cursor a body
+// writes through lives in the caller's `TableWriter`: across a call boundary
+// that cursor round-trips through memory, and a `uint8_t *` store may alias the
+// writer itself, so every put reloads it. When a budget runs out mid-body the
+// codec silently degrades to that shape. Forcing the primitives and the
+// fixed-class bodies inline is what keeps the cursor in registers and lets
+// adjacent constant framing bytes merge into one store.
+#if defined( _MSC_VER )
+#define GRAPHDEMO_TABLE_INLINE __forceinline
+#elif defined( __GNUC__ ) || defined( __clang__ )
+#define GRAPHDEMO_TABLE_INLINE inline __attribute__(( always_inline ))
+#else
+#define GRAPHDEMO_TABLE_INLINE inline
+#endif
+
 namespace graphdemo {
 
 // The table-wire read report — the permissive contract's ledger. Silence
@@ -150,17 +166,17 @@ struct TableWriter
     // is a header a consumer compiles under its OWN flags
     TableWriter( uint8_t * to_buffer, int64_t to_capacity ) : buffer( to_buffer ), capacity( to_capacity ) {}
 
-    void raw( const void * data, int64_t bytes )
+    GRAPHDEMO_TABLE_INLINE void raw( const void * data, int64_t bytes )
     {
         if ( offset + bytes > capacity ) { overflow = true; return; }
         memcpy( buffer + offset, data, (size_t) bytes );
         offset += bytes;
     }
-    void put8( uint8_t v )   { raw( &v, 1 ); }
-    void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
-    void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
-    void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
-    void patch32( int64_t at, uint32_t v )
+    GRAPHDEMO_TABLE_INLINE void put8( uint8_t v )   { raw( &v, 1 ); }
+    GRAPHDEMO_TABLE_INLINE void put16( uint16_t v ) { uint8_t b[2] = { uint8_t( v ), uint8_t( v >> 8 ) }; raw( b, 2 ); }
+    GRAPHDEMO_TABLE_INLINE void put32( uint32_t v ) { uint8_t b[4] = { uint8_t( v ), uint8_t( v >> 8 ), uint8_t( v >> 16 ), uint8_t( v >> 24 ) }; raw( b, 4 ); }
+    GRAPHDEMO_TABLE_INLINE void put64( uint64_t v ) { put32( uint32_t( v ) ); put32( uint32_t( v >> 32 ) ); }
+    GRAPHDEMO_TABLE_INLINE void patch32( int64_t at, uint32_t v )
     {
         if ( at + 4 > capacity ) { overflow = true; return; }
         buffer[at] = uint8_t( v ); buffer[at+1] = uint8_t( v >> 8 );
@@ -178,11 +194,11 @@ struct TableReader
     TableReader( const uint8_t * from_buffer, int64_t from_size, TableReport * to_report )
         : buffer( from_buffer ), size( from_size ), report( to_report ) {}
 
-    bool has( int64_t bytes ) const { return offset + bytes <= size; }
-    uint8_t get8()   { return buffer[offset++]; }
-    uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
-    uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
-    uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
+    GRAPHDEMO_TABLE_INLINE bool has( int64_t bytes ) const { return offset + bytes <= size; }
+    GRAPHDEMO_TABLE_INLINE uint8_t get8()   { return buffer[offset++]; }
+    GRAPHDEMO_TABLE_INLINE uint16_t get16() { uint16_t v = uint16_t( buffer[offset] ) | uint16_t( buffer[offset+1] ) << 8; offset += 2; return v; }
+    GRAPHDEMO_TABLE_INLINE uint32_t get32() { uint32_t v = uint32_t( buffer[offset] ) | uint32_t( buffer[offset+1] ) << 8 | uint32_t( buffer[offset+2] ) << 16 | uint32_t( buffer[offset+3] ) << 24; offset += 4; return v; }
+    GRAPHDEMO_TABLE_INLINE uint64_t get64() { uint64_t lo = get32(); uint64_t hi = get32(); return lo | ( hi << 32 ); }
 
     // skip one payload by kind; false = framing damage
     bool skip( uint8_t kind )
@@ -790,11 +806,11 @@ inline void TableReset( Colour & value ) { ColourReset( value ); }
 // ---- codecs: measure/save/load per closure member ----
 
 inline int64_t StampMeasure( const Stamp & value );
-inline bool StampSaveBody( TableWriter & w, const Stamp & value );
-inline bool StampLoadBody( TableReader & r, Stamp & value );
+GRAPHDEMO_TABLE_INLINE bool StampSaveBody( TableWriter & w, const Stamp & value );
+GRAPHDEMO_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value );
 inline int64_t ColourMeasure( const Colour & value );
-inline bool ColourSaveBody( TableWriter & w, const Colour & value );
-inline bool ColourLoadBody( TableReader & r, Colour & value );
+GRAPHDEMO_TABLE_INLINE bool ColourSaveBody( TableWriter & w, const Colour & value );
+GRAPHDEMO_TABLE_INLINE bool ColourLoadBody( TableReader & r, Colour & value );
 
 inline int64_t StampMeasure( const Stamp & value )
 {
@@ -805,7 +821,7 @@ inline int64_t StampMeasure( const Stamp & value )
     return bytes;
 }
 
-inline bool StampSaveBody( TableWriter & w, const Stamp & value )
+GRAPHDEMO_TABLE_INLINE bool StampSaveBody( TableWriter & w, const Stamp & value )
 {
     if ( value.tag_length < 0 || value.tag_length > 8 ) { return false; } // storage invariant
     if ( value.tag_length > 0 )
@@ -830,7 +846,7 @@ inline int64_t StampSave( const Stamp & value, uint8_t * buffer, int64_t capacit
     return w.offset; // == StampMeasure( value )
 }
 
-inline bool StampLoadBody( TableReader & r, Stamp & value )
+GRAPHDEMO_TABLE_INLINE bool StampLoadBody( TableReader & r, Stamp & value )
 {
     StampReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )
@@ -902,7 +918,7 @@ inline int64_t ColourMeasure( const Colour & value )
     return bytes;
 }
 
-inline bool ColourSaveBody( TableWriter & w, const Colour & value )
+GRAPHDEMO_TABLE_INLINE bool ColourSaveBody( TableWriter & w, const Colour & value )
 {
     if ( value.r != 0 )
     {
@@ -930,7 +946,7 @@ inline int64_t ColourSave( const Colour & value, uint8_t * buffer, int64_t capac
     return w.offset; // == ColourMeasure( value )
 }
 
-inline bool ColourLoadBody( TableReader & r, Colour & value )
+GRAPHDEMO_TABLE_INLINE bool ColourLoadBody( TableReader & r, Colour & value )
 {
     ColourReset( value ); // prefill declared defaults in place, then overlay
     for ( ;; )


### PR DESCRIPTION
Closes the profiling half of #343. **Draft: the numbers are PAIRING CHECKS on a MacBook Air with three other workers on it, not a sitting.** Every arm below ran interleaved in ONE window, and the BEFORE arm reproduces #343's own ratios in that window, which is what makes the AFTER arm's ratio legitimate.

## The finding, in one line

**The generated C++ table codec depended on the compiler's INLINING BUDGET, and on a table of a realistic field count the budget ran out.**

`TableMixedSaveBody` is one large function. clang stopped inlining partway through it: the nested `TableEntitySaveBody` / `TableStatSaveBody` calls stayed out of line — **88 calls per record** — and so did fifteen `TableWriter::put32` / `put64` calls in the tail. That is visible in the emitted arm64 and it is the whole of the defect. Every put, out of line, looks like this:

```
LBB1_6:
	ldr	x9, [x0]          ; reload buffer
	strh	w10, [x9, x8]     ; store 2 bytes
	ldp	x9, x8, [x0, #8]  ; RELOAD capacity and offset
	add	x8, x8, #2
	str	x8, [x0, #16]     ; store offset back
	cmp	x8, x9
	b.ge	LBB1_3
```

Seven instructions of bookkeeping per two-byte store. The reload is not laziness — a `uint8_t *` store may alias the `TableWriter` itself, so with the writer behind a reference the compiler is *obliged* to re-read `buffer`, `capacity` and `offset` after every write.

## The paired board

MacBook Air (M2), interactive desktop, **three other workers building and soaking on the same machine** — load average 8–19 for the whole window. Four arms alternate invocation by invocation, five rounds, each invocation the runner's own 1 warmup + 7 measured runs. Medians of the five invocation medians. `corpus_id 2f7567e1e25ba918`, 2391 B/record.

**Absolute rates here are ~2.4x below #339's board because the machine was loaded; only the same-window ratios mean anything.** The reproduction control is that the BEFORE arm reproduces #343's own per-byte figures in this window.

| arm | path | M msg/s | MB/s | vs BEFORE |
|---|---|---:|---:|---:|
| cpp table BEFORE | write | 0.194 | 443 | 1.00 |
| **cpp table AFTER** | write | **1.033** | **2356** | **5.31x** |
| cpp table BEFORE | round_trip | 0.139 | 316 | 1.00 |
| **cpp table AFTER** | round_trip | **0.333** | **759** | **2.40x** |
| cs table (untouched, control) | write | 0.134 | 305 | — |
| cs table (untouched, control) | round_trip | 0.081 | 184 | — |
| cpp TYPE wire (denominator) | write | 2.899 | 1211 | — |
| cpp TYPE wire (denominator) | round_trip | 1.315 | 549 | — |

**The per-BYTE column #343 was opened about** — type wire against table wire, same window, same shape mirrored field for field:

| | #343 / #339's board | this window, BEFORE | this window, AFTER |
|---|---:|---:|---:|
| cpp write, per byte | 2.90x | **2.73x** | **0.51x** |
| cpp round_trip, per byte | 1.99x | **1.74x** | **0.72x** |

The BEFORE column reproducing 2.73x and 1.74x against the issue's 2.90x and 1.99x is what licenses the AFTER column. **The tolerant wire's codec now costs LESS per byte than the bitpacked type wire's** — 0.51x on write — which is the expected shape once the byte copies stop round-tripping a cursor through memory: a byte-oriented codec should beat a bit-oriented one per byte, and it now does. Per MESSAGE the table wire is 2.8x the type wire on write, down from 14.9x, and what remains of that is the 5.46x byte count, not the codec.

**The C# arm is the control and did not move**: 0.134 M msg/s write here against #339's 0.327 on a quiet machine — the same 2.4x the window took off every other arm. Not one line of `internal/codegen/cstable` is in this diff.

## The term table

One process, one namespace-per-arm copy of the generated header, every arm interleaved, median of 9, every arm passing the bench's own golden gate (byte-identical output, `measure == save`) before any clock. ns per 2391-byte record.

| write ablation | ns/op | vs baseline |
|---|---:|---:|
| baseline save | 3303 | — |
| − the per-put capacity check | 2607 | −21% |
| − the presence compares (all 92 forced true) | 3392 | **+3% — not a term** |
| + force-inline the `put*` primitives only | 2498 | −24% |
| + force-inline the top-level body only | 2627 | −20% |
| + force-inline the nested bodies only | 2680 | −19% |
| + force-inline every body, primitives out of line | 2667 | −19% |
| **+ force-inline primitives AND bodies** | **538** | **−84%** |
| `Measure` alone (Save never calls it) | 75 | 2% if it did |

| read ablation | ns/op | vs baseline |
|---|---:|---:|
| reset + load (the bench's read arm) | 1523 | — |
| `Reset` alone — all 88 nested records | 33 | **2.2% of the read** |
| load alone (its own internal Reset, no harness Reset) | 1511 | the harness Reset is 12–33 ns |
| + force-inline every `LoadBody` | 1032 | **−32%** |

**The two halves multiply, they do not add.** Primitives alone −24%, bodies alone −19%, both together −84%. Only a body with no call boundary in it lets the cursor stay in registers, lets the constant `id`/`kind` bytes merge into wide stores, and lets the capacity checks hoist.

## Three of #339's and #343's candidates are REFUTED

- **`Reset` inside the clock is not the read arm's cost.** It is 33 ns of ~1520 — **2.2%** — and the 88 nested records are a vectorised store run, not a walk. #339's judgment 3 does not hold.
- **The presence compares against declared defaults are free.** Forcing all 92 of them to `true` (byte-identical on this corpus, where every field is off its default) measured **3% slower**, not faster. There is no term to remove.
- **`restrict` is not the lever here.** serialize #30 restrict-qualified the type writer's `this` for +152% composed on this same arm64 clang. On the table writer it moved 7% — as a member qualifier, as `this`, and as a local on the store target. The type wire's fix does not transfer.
- **The writer never measures twice.** `Save` does not call `Measure` at all; the lengths are written as zero and patched. The #343 candidate "the writer measuring twice" describes code that is not there.

## What lands

A per-package force-inline macro on the `TableWriter` / `TableReader` primitives and on the **fixed class's** `SaveBody` / `LoadBody`.

```c++
#if defined( _MSC_VER )
#define BENCHTABLE_TABLE_INLINE __forceinline
#elif defined( __GNUC__ ) || defined( __clang__ )
#define BENCHTABLE_TABLE_INLINE inline __attribute__(( always_inline ))
#else
#define BENCHTABLE_TABLE_INLINE inline
#endif
```

Package-scoped for the reason the primitives guard is — several packages' `Table.h` compile in one TU — and an extension emulated rather than required, per the estate's Visual C++ rule.

**THE RECURSION GUARD is the class line that already exists.** A fixed table nests by value, so its save/load call graph is a DAG: a by-value cycle would be an infinite `sizeof`, and forcing it flat always terminates. The variable-length class reaches a pointee through the depth-carrying template form (§3.1), which a self-referential declaration makes directly recursive — and a recursive `always_inline` is a compile error under gcc. So `isVar` is the guard, and `TestPointerSurfaceEmitted` holds it mechanically. **Negative control run:** putting the qualifier on the variable-length body reds the test with "a variable-length table's body was force-inlined; its pointer walk can recurse"; reverting greens it.

**No byte moves.** Every wire golden is untouched — `git status` after `make update-goldens` shows nothing under `testdata/wire/` — the tables bench's golden gate and 64-variant round-trip pass unchanged at `corpus_id 2f7567e1e25ba918`, and `measure == save` still holds at exact capacity. What moved is the 16 generated **source** pins, which is the emitter changing spelling.

**It costs neither code size nor compile time**, which the estate cares about here more than most places (the union-vs-variant ruling, the tables-walk move to a `.cpp`). The binary got **SMALLER**: `build/schema_tables_bench_cpp` 90280 → 89256 bytes, −1.1% — force-inlining removed the out-of-line copies rather than duplicating them, because a body inlined into a loop appears once, not once per iteration. Compile time, paired and alternating on the real TU: before 1.83/2.14/2.80 s against after 2.36/2.28/2.62 s — overlapping ranges on a contended machine, no measurable change. A TU that only includes the header is 0.21 s either way.

## Gates

- `make test` — green, including the tables suite under ASan/UBSan, the hostile and pack batteries, the block and cook fuzzers and their negative controls.
- `make shape-gate` — clean, 27 ledger entries.
- `go test ./...`, `gofmt`, `go vet` — green. `compiler/tables_test.go` gains the recursion guard and its negative control.
- The C# emitter is **untouched**, and the C# arm is on the board as the control.

## The measured cost of tolerance, on the page

`docs/SPEC-TABLES.md`'s ladder said the tolerant wire is "slower on purpose" and did not say by how much. It now carries the byte count, which is the part that is a property of the wire rather than of a machine: **1487 of `TableMixed`'s 2391 bytes — 62% — are framing** (field ids, kind bytes, lengths, element counts, body terminators), against **438 bytes** for the same declared content on the type wire. That count is the trade. The per-BYTE cost is held to the bench, and a gap there is a defect to explain or close — which is what this PR did.

The 62% is measured by a decoder written from §3 alone that knows no schema, and its walk lands exactly on the record boundary.

## Named follow-ons, not built here

- **The read is now the round-trip's larger half** (~900 ns against the write's ~440). Its remaining shape is the `switch ( field_id )` over 28 sparse 16-bit ids — a binary search per field, ~250 fields per record. This writer emits fields in declaration order, so trying the next expected id before the switch is legal under §3's "field ORDER is not part of the contract" and costs one compare when it hits. Unmeasured; a round of its own.
- **The tables bench's read arm resets, and the generated `Load` resets again.** One of the two is removable — `TableMixedLoadBody` opens with `TableMixedReset( value )`, so a caller's reset before `Load` is redundant. It is 2.2% of the read and the bench is this PR's control, so it does not move here.
- **`inline` stays `unknown` on the tables board.** The §4 verdict pass has no branch for the generated table codec — which is exactly the instrument that would have caught this defect the day it appeared, since `bench/inline-budget.txt` exists to fail on a hot out-of-line call. #339 already named it.
- **The other backends.** C# was left alone deliberately as the control; whether RyuJIT has the same budget cliff on `TableMixedSaveBody` is a measurement nobody has made.
