### PR TITLE
Rust tables, after the blind read: the page's build version is gated, pack's tree argument is named, three comments say present state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -618,10 +618,11 @@ MIRI_MAX_SEED_BYTES ?= 4224
 # saving is opt-in.
 #
 # The gate is that all four combinations BUILD: a wire-only consumer, a cook
-# consumer, a block consumer, and everything. It is not a formality — the
-# first cut of it found two real couplings, the unit's BUILD VERSION and its
-# blittable RECORDS, each of which belongs to neither accelerator and had been
-# sitting inside one of them.
+# consumer, a block consumer, and everything. It is not a formality — a fact
+# that belongs to NEITHER accelerator, the unit's BUILD VERSION and its
+# blittable RECORDS among them, is unreachable from a wire-only build unless it
+# has an always-compiled home of its own, and only building that combination
+# says so.
 .PHONY: tables-rust-features
 tables-rust-features: build/tables-generated-rust/.stamp
 	@for unit in build/tables-generated-rust/*/; do \
@@ -706,10 +707,9 @@ tables-rust-alloc-audit: conformance
 # ITS NEGATIVE CONTROL, and the soak's. A gate that has never fired proves
 # nothing, and the LIVE-BYTE gate could not fire on this class at all: live
 # bytes answer "does this leak", and a path that allocates and frees the same
-# bytes every iteration reads +0 there forever — which is exactly how 74
-# allocations per ToJson sat under a green soak. SOAK_SABOTAGE puts ONE
-# allocation per iteration inside the measured region and both gates must go
-# red on it.
+# bytes every iteration reads +0 there forever, however many allocations it
+# makes. SOAK_SABOTAGE puts ONE allocation per iteration inside the measured
+# region and both gates must go red on it.
 .PHONY: tables-rust-alloc-negative-control
 tables-rust-alloc-negative-control: conformance
 	@if SOAK_SABOTAGE=1 ./build/conformance-rust build/conformance/manifest.txt alloc-audit \

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1479,7 +1479,7 @@ order) — plus the target's byte order.
 
 ```
 $ schema build-version tables/block/
-0xb34bc386659d9873
+0x863a8eebc1090dc6
 ```
 
 ```cpp
@@ -1872,12 +1872,20 @@ float. The text it does emit is always valid JSON and valid UTF-8.
 ### Packing a directory into a table
 
 `schema pack` builds ONE table instance from a directory tree that mirrors
-the root table, and writes the root's wire bytes:
+the root table, and writes the root's wire bytes. **The tree is a POSITIONAL
+argument, never a `--in`** — `--in` and `--out` name the wire FILE on both
+verbs, and the tree is what the verb walks:
 
 ```
-$ schema pack --root Config --out Config.bin configs/
-$ schema unpack --root Config --in Config.bin configs/
+$ schema pack   --root Config --out Config.bin  configs/    # tree -> wire file
+$ schema unpack --root Config --in  Config.bin  configs/    # wire file -> tree
 ```
+
+The unit's own schema files come after the tree, and with nothing there they
+are the working directory — so `schema pack --root Config --out Config.bin
+configs/ schema/` reads the declarations from `schema/` and the values from
+`configs/`. Every `schema` command ends with that same declarations argument;
+what `pack` and `unpack` put in front of it is the tree.
 
 A directory named after a field holds that field's value; an enum-keyed array
 takes one `<Variant>.json` per variant (there is no `None.json` — `None` keys

--- a/generated/bench/tables/rust/src/table_runtime.rs
+++ b/generated/bench/tables/rust/src/table_runtime.rs
@@ -934,12 +934,11 @@ fn table_json_write_signed(out: &mut TableJsonOut, value: i64) {
 // below -4 or at least the precision and style f otherwise, then strip the
 // fraction's trailing zeros and a bare decimal point. The exponent field
 // carries a sign and at least two digits.
-// THE NUMBER SINK, and it is a stack buffer because the alternative allocated.
-// This formatter used to build its digits with format!, which cost 74
-// allocations per ToJson of the corpus's root — against USAGE's own promise
-// that the text path allocates nothing beyond the instance the caller passed.
-// core::fmt writes a float through its own stack buffers, so a SINK that does
-// not allocate makes the whole formatter allocation-free.
+// THE NUMBER SINK, and it is a STACK buffer because docs/USAGE.md's promise is
+// that the text path allocates nothing beyond the instance and the buffers the
+// caller passed. core::fmt writes a float through its own stack buffers, so a
+// sink that does not allocate leaves the whole formatter allocation-free, and
+// make tables-rust-alloc-audit is what counts it.
 //
 // SIXTY-FOUR BYTES, the C++ walker's own char text[64], and it is provably
 // enough rather than generously chosen: style f is used only when the decimal

--- a/internal/codegen/rusttable/runtime.go
+++ b/internal/codegen/rusttable/runtime.go
@@ -978,12 +978,11 @@ fn table_json_write_signed(out: &mut TableJsonOut, value: i64) {
 // below -4 or at least the precision and style f otherwise, then strip the
 // fraction's trailing zeros and a bare decimal point. The exponent field
 // carries a sign and at least two digits.
-// THE NUMBER SINK, and it is a stack buffer because the alternative allocated.
-// This formatter used to build its digits with format!, which cost 74
-// allocations per ToJson of the corpus's root — against USAGE's own promise
-// that the text path allocates nothing beyond the instance the caller passed.
-// core::fmt writes a float through its own stack buffers, so a SINK that does
-// not allocate makes the whole formatter allocation-free.
+// THE NUMBER SINK, and it is a STACK buffer because docs/USAGE.md's promise is
+// that the text path allocates nothing beyond the instance and the buffers the
+// caller passed. core::fmt writes a float through its own stack buffers, so a
+// sink that does not allocate leaves the whole formatter allocation-free, and
+// make tables-rust-alloc-audit is what counts it.
 //
 // SIXTY-FOUR BYTES, the C++ walker's own char text[64], and it is provably
 // enough rather than generously chosen: style f is used only when the decimal

--- a/internal/goldens/goldens_test.go
+++ b/internal/goldens/goldens_test.go
@@ -299,3 +299,31 @@ func TestGoldenBuildVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestUsagePageBuildVersion holds the ONE build version docs/USAGE.md prints.
+// The page shows a worked `schema build-version tables/block/` run, and a
+// number pasted into prose moves with nothing — a reader who runs the command
+// beside the page has to get the page's answer, so the page is read back here
+// and compared against the unit itself.
+func TestUsagePageBuildVersion(t *testing.T) {
+	const command = "$ schema build-version tables/block/"
+	page, err := os.ReadFile("../../docs/USAGE.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(string(page), "\n")
+	printed := ""
+	for i, line := range lines {
+		if strings.TrimSpace(line) == command && i+1 < len(lines) {
+			printed = strings.TrimSpace(lines[i+1])
+			break
+		}
+	}
+	if printed == "" {
+		t.Fatalf("docs/USAGE.md no longer shows a %q run with its answer beneath it — this gate names a line that has moved", command)
+	}
+	want := fmt.Sprintf("0x%016x", ir.BuildVersion(loadCorpusDir(t, "../../tables/block")))
+	if printed != want {
+		t.Errorf("docs/USAGE.md prints %s for tables/block and the unit's build version is %s — paste the current one", printed, want)
+	}
+}


### PR DESCRIPTION
The blind read of #340 (comment 5522283372) listed three code defects and four
page defects. **Seven of them are already in `main`** — #340 landed its own
fixes in `4b3df89d` and `1e60789c` after the read was taken, and I re-ran every
gate on `main` before writing a line. What was still open is here: one page
number that had gone stale, one example a reader could parse two ways, and
three comments that described their own history instead of the code.

## What was already true on `main`, re-proved

| the blind read's defect | where it landed | what I ran |
|---|---|---|
| the text writer allocates (74/call) | `4b3df89d` — 64-byte stack sink | `make tables-rust-alloc-audit` — 0 on all 18 instances |
| the soak gates on live bytes, not the count | `4b3df89d` — per-iteration audit closure | `make tables-rust-alloc-negative-control` — both gates red under `SOAK_SABOTAGE` |
| nothing can be left uncompiled | `4b3df89d` — `block` / `cook` cargo features, default-on | `make tables-rust-features` — all four combinations build |
| the `unsafe` claim (USAGE §per-language, :1840) | `1e60789c` | four sites named, features named |
| §2.4 admits only C#'s `int` | `1e60789c` | Rust's `u64` is there |
| §8.1 puts projection columns on the field descriptor | `1e60789c` | `TableBlockFieldInfo`, and `type_name` as the `bytes(N)` discriminator |
| §8's one walker is one walker per unit | `1e60789c` | named as a Rust divergence |

```
alloc audit: load, measure, save, from_json, to_json_measure and to_json — 0 allocations, every instance
driver: root_full: the generated code made 2 allocation(s) on the read and write paths — ...
rust allocation negative control: one allocation per iteration turns BOTH gates red
rust feature gate: wire-only, cook-only, block-only and everything all build
```

`make conformance` is green on three legs beside them (wire 18/18, json-write
18/18, cook-forgery 111/111, every surface).

## What this PR changes

**The page's build version was not the unit's.** `docs/USAGE.md` shows a worked
run and printed `0xb34bc386659d9873`; `schema build-version tables/block/`
answers `0x863a8eebc1090dc6`, which is what
`testdata/golden/build-version/tables-block.txt` has pinned. That is the one
section whose whole subject is that this number is how a cooked-asset store is
keyed, so a reader running the command beside the page got a contradiction on
exactly the fact the page is teaching.

It is current now, and `TestUsagePageBuildVersion` reads the number back out of
the page and compares it against `ir.BuildVersion` — a re-pin that leaves the
page behind is red instead of quiet.

```
$ go test ./internal/goldens/ -run 'TestUsagePageBuildVersion|TestGoldenBuildVersion' -v
--- PASS: TestGoldenBuildVersion (0.01s)      [six units]
--- PASS: TestUsagePageBuildVersion (0.00s)

negative control — the old number pasted back into the page:
--- FAIL: TestUsagePageBuildVersion (0.00s)
    goldens_test.go:327: docs/USAGE.md prints 0xb34bc386659d9873 for tables/block
    and the unit's build version is 0x863a8eebc1090dc6 — paste the current one
```

**`schema pack` takes its tree positionally.** The example read

```
$ schema pack --root Config --out Config.bin configs/
$ schema unpack --root Config --in Config.bin configs/
```

and the three cook verbs on the same page end with the DECLARATIONS argument in
that trailing position — so `configs/` read as the unit. It is the tree. `--in`
and `--out` name the wire FILE on both verbs, the declarations come after the
tree, and with nothing there they are the working directory. Said outright, with
each line commented in the direction it runs. Verified against the CLI:

```
$ ./bin/schema pack --root PackConfig --out build/pagecheck.bin tables/pack/config tables/examples
$ ./bin/schema unpack --root PackConfig --in build/pagecheck.bin build/pagecheck-tree tables/examples
global.json  reserves.json  ships  thresholds  version.json
```

**Three comments described their own history.** The float formatter's block in
`internal/codegen/rusttable/runtime.go` said what it *used to* do with
`format!` and what that cost; two Makefile comments recorded what the feature
gate found on its first run and how 74 allocations sat under a green soak.
Present state now — the sink is a stack buffer because USAGE promises the text
path allocates nothing beyond what the caller passed, and
`make tables-rust-alloc-audit` is what counts it. `generated/` regenerated for
the comment; no other byte moves.

## Not touched

SPEC-TABLES §11's unconditional-claims paragraph (the blind read's
`SPEC-TABLES.md:3603-06`) — already corrected in `1e60789c`, and filed
separately either way. No wire byte and no golden changes.

## Local verification

`make test` green (its `generated-current` step then reported the one
regenerated file, which is this commit). `go test ./...` green. `make
conformance`, `tables-rust-alloc-audit`, `tables-rust-alloc-negative-control`
and `tables-rust-features` all green as quoted above.
