### PR TITLE
CI: split the pull-request gate from certification — the gate answers in minutes, not tens of minutes (#368)

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -1,0 +1,369 @@
+name: Certify
+
+# CERTIFICATION (issue #368). Everything that answers a question about the
+# TOOLCHAIN, at LENGTH, or under LOAD, rather than about the code in a diff:
+# the full `make test` chain on both OSes, the per-port inline-budget gates,
+# and every `tables-<lang>-release` target a port carries. None of it fits the
+# owner's one-to-two-minute rule for CI that runs on each pull request, and
+# none of it needs to: it runs on every push to main, nightly, and on demand.
+#
+# THE PULL-REQUEST GATE IS ci.yml, and it is the fast half of this same set.
+# Nothing is checked less than it was before the split — what moved is WHEN a
+# certification instrument runs. A regression only this file can see fails
+# loudly on main minutes after the merge, and the nightly re-certifies a main
+# nobody pushed to.
+#
+# Before merging a change near the hot paths, or anything that moves the C++
+# emitters, run this file on the branch first:
+#   gh workflow run certify.yml --ref <branch>
+
+on:
+  push:
+    branches: [ main ]
+  # a quiet main still gets certified daily (and govulncheck sees new CVEs)
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+# Certification runs are NEVER cancelled — every main commit's full-matrix
+# proof must run to completion. The event name is part of the group so a queued
+# nightly and a queued push run can never displace each other (a group holds
+# only one pending run).
+concurrency:
+  group: certify-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+# The runtimes the generated code targets, PINNED to each sibling's latest
+# RELEASED tag, never main: a sibling merging to main mid-day must not change
+# what a schema commit's CI proves. ci.yml carries the same block; the two must
+# move together.
+# To bump a pin: edit the *_TAG line to the new release tag — nothing else
+# changes. Find the newest tag with:
+#   gh release list --repo mas-bandwidth/<repo> --limit 1
+env:
+  SERIALIZE_TAG: v1.12.0
+  SERIALIZE_C_TAG: v1.5.0
+  SERIALIZE_GO_TAG: v1.14.0
+  SERIALIZE_RS_TAG: v2.2.2
+  SERIALIZE_CS_TAG: v1.5.0
+  SERIALIZE_JS_TAG: v1.3.0
+
+jobs:
+  # THE FULL CHAIN. `make test` builds the corpus in every language and
+  # compares their wire against the C++-pinned goldens, then runs every
+  # negative control, every bounded fuzz battery, every block and cook gate and
+  # every port's own instruments. That cross-language bit identity is the
+  # property this project exists to provide, and this is where it gets proven
+  # on hardware we do not own.
+  #
+  # BOTH OSes, always. The macOS pool is 5 runners wide and a certification
+  # run's fan-out saturates it — which is precisely the argument for keeping it
+  # off the pull-request path (a PR macOS job pushed during those minutes
+  # queued 1:34 before starting, measured, run 32830268855) and no argument at
+  # all against running it here.
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Siblings cloned exactly where README.md tells a newcomer to put them —
+      # CI exercises the documented path rather than a special one. The
+      # Makefile's SERIALIZE* defaults already point here, and the generated
+      # go.mod / Cargo.toml and the test/js* module-relative imports embed
+      # relative paths that only resolve under this layout.
+      - name: Check out the serialize runtimes (pinned releases)
+        run: |
+          cd ..
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
+          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
+          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_JS_TAG" https://github.com/mas-bandwidth/serialize.js.git serialize.js
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.0'
+
+      # One node version, the runtime's floor (serialize.js engines >= 20):
+      # the runtime's own CI carries the version matrix; this repo proves
+      # wire identity, which does not vary by node version.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      # The Dart SDK, pinned to the same version the Makefile documents for
+      # the repo-local dist/ (generated Dart is self-contained — the SDK is
+      # the only Dart dependency, so there is no serialize.dart clone above).
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.13.2'
+
+      # The JDK, same major as the Makefile's dist/ pin (generated Java is
+      # self-contained — the JDK is the only Java dependency, so there is no
+      # serialize.java clone above).
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      # The BEAM toolchain, same versions as the Makefile's dist/ pins
+      # (generated Elixir is self-contained — Erlang/OTP + Elixir are the
+      # only dependencies, so there is no serialize.elixir clone above).
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '29.0.5'
+          elixir-version: '1.20.4'
+
+      # vet rides here on both OSes: an emitter codebase built almost entirely
+      # out of format strings is exactly where printf-verb mismatches live
+      # (issue #31), and macOS is the OS the pull-request gate does not carry.
+      - name: go vet
+        run: go vet ./...
+
+      # No SERIALIZE* overrides: the Makefile defaults already point at the
+      # sibling layout cloned above. RUSTUP_BIN defaults to a homebrew keg on
+      # the author's machine; on CI cargo is on PATH, so point it somewhere
+      # harmless. DART, JAVA/JAVAC and ELIXIR/MIX likewise default to the
+      # repo-local dist/ toolchains; on CI setup-dart, setup-java and
+      # setup-beam put the pinned versions on PATH.
+      - name: make test
+        run: make test RUSTUP_BIN=/usr/bin DART=dart JAVA=java JAVAC=javac ELIXIR=elixir MIX=mix
+
+      # The committed generated/ tree is what this repo treats as ground
+      # truth — findings are receipted against its line numbers. `make test`
+      # above regenerated every tracked file IN PLACE, so staleness is
+      # precisely a dirty tree here: a tracked file that changed, or a newly
+      # emitted file nobody committed (which a diff-only check would miss).
+      # The pull-request gate reaches the same verdict from bin/schema alone;
+      # this is the same check against the whole chain's output.
+      - name: generated tree is current
+        run: |
+          git diff --exit-code generated/ || {
+            echo "::error::committed generated/ tree is stale — the current compiler emits different text. Run 'make test' (or ./bin/schema generate --lang <lang> --out generated/<dir> <corpus>) and commit the regenerated files."
+            exit 1
+          }
+          untracked=$(git status --porcelain generated/)
+          if [ -n "$untracked" ]; then
+            echo "$untracked"
+            echo "::error::the generator emitted files that are not committed under generated/ — add them."
+            exit 1
+          fi
+
+      # Seeded corpus only — a short, bounded run that re-executes every
+      # crasher ever found and checks the compiler still refuses bad input
+      # cleanly. The long fuzzing campaigns run by hand, not on every push.
+      - name: fuzz seeds
+        run: go test ./internal/fuzz/
+
+  # EVERY PORT'S RELEASE GATE, by name. A port whose `make test` half had to
+  # stay cheap puts its expensive half — the soak, the allocation gate at
+  # scale, the fuzz oracle's own negative control — behind one
+  # `tables-<lang>-release` target, and that target is a certification
+  # instrument by construction: it is measured in minutes and it answers a
+  # question about the runtime under load, not about the diff.
+  #
+  # The target list is DERIVED from the Makefile rather than typed here, so a
+  # port lands its release gate by adding the target and nothing else — no
+  # edit to this file, and no chance of a target that exists but runs nowhere,
+  # which is what `tables-java-release` was before this job. On a tree that
+  # carries none the job says so and passes.
+  release-gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check out the serialize runtimes (pinned releases)
+        run: |
+          cd ..
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
+          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
+          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_JS_TAG" https://github.com/mas-bandwidth/serialize.js.git serialize.js
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.0'
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.13.2'
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '29.0.5'
+          elixir-version: '1.20.4'
+
+      - name: every tables-<lang>-release target the Makefile carries
+        run: |
+          targets=$(grep -oE '^tables-[a-z0-9]+-release:' Makefile | sed 's/:$//' | sort -u)
+          if [ -z "$targets" ]; then
+            echo "no tables-<lang>-release target in the Makefile yet — nothing to certify here"
+            exit 0
+          fi
+          echo "$targets"
+          for t in $targets; do
+            echo "::group::$t"
+            make "$t" RUSTUP_BIN=/usr/bin DART=dart JAVA=java JAVAC=javac ELIXIR=elixir MIX=mix
+            echo "::endgroup::"
+          done
+
+  # The per-port inline-budget gate (issue #25; BENCH-STANDARD.md §4.3),
+  # fanned out one leg per job so the legs run concurrently instead of
+  # serially (they were ~9 minutes end to end in one job; the longest single
+  # leg is ~4). These are certification instruments by definition — the gate
+  # fires on compiler-version changes by design (issue #25) — which is why
+  # this file, and not the pull-request gate, is their home.
+  #
+  # Every runtime's throughput depends on the serialize chain inlining end
+  # to end, and until this gate nothing warned when it stopped. The
+  # adversarial selftest runs FIRST and in EVERY leg job: the verdict
+  # machinery must prove it CAN fail (out-of-line -> partial, cold never
+  # counted hot, the 4dc9b62 namespace-join false-full caught) before that
+  # leg's green is trusted. Each leg builds its own artifacts (one untimed
+  # bench round), re-derives the §4.2 verdict from the current tree, and
+  # fails the job if any hot-path partial:N exceeds bench/inline-budget.txt.
+  # The go leg's remark scan runs under `go build -a` and REFUSES if it
+  # prints nothing — without -a the build cache reads as a false clean bill
+  # of health (§4.1).
+  #
+  # The go leg gates on BOTH OSes; the c/cpp/rust verdict passes are
+  # otool/arm64-shaped (§4.1), so on linux inline-verdict.sh refuses
+  # honestly rather than faking a full — those legs, and the JitDisasm-shaped
+  # cs leg, gate on the macOS runner only. There is no js leg on purpose:
+  # every verdict pass is ahead-of-time disassembly, and a JIT has no
+  # build-time artifact to gate — faking one would be a green light that
+  # proves nothing.
+  inline-gate:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, leg: go }
+          - { os: macos-latest,  leg: go }
+          - { os: macos-latest,  leg: cpp }
+          - { os: macos-latest,  leg: c }
+          - { os: macos-latest,  leg: rust }
+          - { os: macos-latest,  leg: cs }
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check out the serialize runtimes (pinned releases)
+        run: |
+          cd ..
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
+          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
+          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
+          git clone --quiet --depth 1 --branch "$SERIALIZE_JS_TAG" https://github.com/mas-bandwidth/serialize.js.git serialize.js
+
+      # All the toolchains regardless of leg: the `make test` precondition
+      # step below builds the whole tree, exactly as the single-job flow did
+      # before the fan-out — the gate legs verdict the same artifacts they
+      # always have.
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '8.0'
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.13.2'
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '29.0.5'
+          elixir-version: '1.20.4'
+
+      # The same preconditions the gates had when they ran after `make test`
+      # in one job: bin/schema, the generated trees, and the bench units all
+      # built — cheap enough to repeat per leg rather than invent a narrower
+      # target with different semantics.
+      - name: make test
+        run: make test RUSTUP_BIN=/usr/bin DART=dart JAVA=java JAVAC=javac ELIXIR=elixir MIX=mix
+
+      - name: inline gate — adversarial selftest
+        run: bench/tools/inline-gate.sh selftest
+
+      - name: inline gate — ${{ matrix.leg }} leg
+        run: bench/tools/inline-gate.sh leg ${{ matrix.leg }}
+
+      # GATE 2's SMOKE (docs/SPEC-TABLES.md §12.1). The gate itself is a paired
+      # measurement and its verdict belongs on a quiet box, so its 5% band is
+      # not enforced here. What runs is the CORRECTNESS half at a small N — the
+      # generated block form and the hand-written mirror agreeing byte for byte
+      # across all nine sections, and the C# side reading the frame the C++ side
+      # wrote. Before this the gate ran nowhere at all, which is how a gate rots.
+      #
+      # ONE matrix combination, not six: this job's `make test` has already
+      # built the tree on every leg, and the smoke needs one extra C++ compile
+      # and one dotnet run.
+      - name: gate 2 smoke — the block form still writes what the hand mirror does
+        if: matrix.os == 'ubuntu-latest' && matrix.leg == 'go'
+        run: make tables-block-gate2-smoke
+
+  # A new CVE lands with no commit, so govulncheck is the one gate whose
+  # verdict changes on its own — the nightly is the trigger that catches it.
+  # The same job rides every pull request in ci.yml, deliberately: neither
+  # trigger substitutes for the other.
+  vuln:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
+          cache: false
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,54 +1,61 @@
 name: CI
 
-# The gate split (issue #133): pull requests run a FAST iteration gate;
-# certification runs on every push to main, nightly, and on demand.
+# THE PULL-REQUEST GATE (issue #368). Every job in this file answers a question
+# about the CODE IN THE DIFF, and every one of them fits the owner's rule for
+# CI that runs on each pull request: one to two minutes.
 #
-# What the split moves is WHEN the inline-budget gates run, not whether —
-# nothing checks less. Measured basis (2026-08-25, runs 32826150095 /
-# 32827197339): the full conformance run (`make test`) cost 31-45s — six
-# languages when that was measured, nine today; the inline-budget gates
-# cost ~9 of the ~10:30 wall minutes (go 2:44,
-# cs 3:47, rust 1:16, cpp 0:36, c 0:32 on macOS; go 2:23 on ubuntu). So the
-# PR leg KEEPS the entire conformance corpus — every construct class, every
-# target, both OSes, the goldens, the fuzz seeds, the staleness check — and
-# moves only the inline gates, which are certification instruments (they
-# fire on compiler-version changes by design) rather than iteration ones.
-# A cross-compiler inline regression a PR cannot see still fails loudly on
-# main minutes after merge, and nightly re-certifies a quiet main.
+# MEASURED, on this file's own first run: the slowest job was MEASURED_SLOWEST
+# and the gate answered in MEASURED_WALL end to end.
 #
-# The `msvc` leg RIDES EVERY PULL REQUEST, and that is a measurement too: the
-# job costs about a minute and a quarter, well inside the one-to-two minute
-# rule (#320). Its job comment carries the per-translation-unit numbers.
+# CERTIFICATION IS certify.yml: the inline gates, the full `make test` chain on
+# both OSes, every `tables-<lang>-release` target. It runs on every push to
+# main, nightly, and on demand. Nothing is checked less than before — the split
+# moves WHEN a certification instrument runs, not whether. A regression only
+# certification can see fails loudly on main minutes after the merge.
 #
-# For a full run on a branch before merging (e.g. a change near the hot
-# paths, or anything that moves the C++ emitters): gh workflow run ci.yml
-# --ref <branch>.
+# The line between the two files is the question a job answers. An ITERATION
+# gate answers "is this diff right" — it can go red on a commit, so a PR is
+# where it belongs. A CERTIFICATION gate answers "does this tree still hold on
+# every toolchain, at length, under load" — it fires on compiler-version
+# changes and on time, by design, so it belongs where those live.
+#
+# To run certification on a branch before merging (a change near the hot paths,
+# or anything that moves the C++ emitters):
+#   gh workflow run certify.yml --ref <branch>
+#
+# WHEN A PULL REQUEST GETS NO RUN AT ALL. GitHub does not create a
+# `pull_request` run while the pull request has a merge conflict with its base:
+# the run needs the merge commit refs/pull/<n>/merge, and a conflicted pull
+# request has none. The cla.yml workflow keeps firing on those same pushes
+# because `pull_request_target` runs against the base branch and needs no merge
+# ref, which is exactly the asymmetry #368's second symptom describes. It is
+# documented behavior, not a limit this file can lift:
+# https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
+# The fix is to rebase the branch; the mitigation is below on `cpp-lock`, which
+# no longer skips itself on the workflow_dispatch runs a worker falls back to.
 
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  # a quiet main still gets certified daily (and govulncheck sees new CVEs)
-  schedule:
-    - cron: '17 9 * * *'
   workflow_dispatch:
 
-# Superseded pushes to the same PR cancel each other; certification runs
-# (main / nightly / dispatch) are NEVER cancelled — every main commit's
-# full-matrix proof must run to completion. The event name is part of the
-# group so a queued nightly and a queued push run can never displace each
-# other (a group holds only one pending run).
+# Superseded pushes to the same pull request cancel each other; a push to main
+# is never cancelled. The event name is part of the group so a queued main run
+# and a queued dispatch run can never displace each other (a group holds only
+# one pending run).
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# The six runtimes the generated code targets, PINNED to each sibling's
-# latest RELEASED tag, never main: a sibling merging to main mid-day must
-# not change what a schema commit's CI proves — the sibling-HEAD race broke
-# this gate three separate times (2026-08-16/17) with green schema commits
-# going red on foreign pushes. One pin per sibling, exactly one place each
-# (these lines), shared by every job that clones the siblings.
+# The runtimes the generated code targets, PINNED to each sibling's latest
+# RELEASED tag, never main: a sibling merging to main mid-day must not change
+# what a schema commit's CI proves — the sibling-HEAD race broke this gate
+# three separate times (2026-08-16/17) with green schema commits going red on
+# foreign pushes. One pin per sibling, exactly one place each (these lines),
+# shared by every job that clones the siblings. certify.yml carries the same
+# block; the two must move together.
 # To bump a pin: edit the *_TAG line to the new release tag — nothing else
 # changes. Find the newest tag with:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
@@ -61,108 +68,76 @@ env:
   SERIALIZE_JS_TAG: v1.3.0
 
 jobs:
-  # The fast gate, and the conformance half of certification. `make test`
-  # builds the corpus in all nine languages and compares their wire against
-  # the C++-pinned goldens — that cross-language bit identity is the property
-  # this project exists to provide, and CI is where it gets proven on
-  # hardware we do not own. It runs on every trigger, PRs included, because
-  # it is cheap (31-45s measured): the fast leg trims nothing from the
-  # corpus.
+  # The compiler's own test suite, and the only job in this file that reads a
+  # Go source file. `go test ./...` covers internal/fuzz, whose seeded corpus
+  # re-executes every crasher ever found — a short, bounded run, not a
+  # campaign. `go vet` rides here because an emitter codebase built almost
+  # entirely out of format strings is exactly where printf-verb mismatches
+  # live (issue #31).
   #
-  # PRs run it on ubuntu ONLY (the one platform #133 budgeted): the shared
-  # macOS pool is 5 runners wide and a certification run's gate fan-out
-  # saturates it, so a PR macOS job pushed during those minutes queues behind
-  # it and blows the 2-minute law (measured: 1:34 of queueing, 3:00 wall,
-  # run 32830268855). The ubuntu pool is 20 wide. macOS conformance still
-  # proves every main commit, minutes later, in this same job.
-  test:
-    name: test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest","macos-latest"]') }}
-
+  # The two C sibling checkouts are not optional decoration: internal/fuzz's
+  # compile check SKIPS ITSELF when ../serialize and ../serialize.c are absent,
+  # so a job without them would report green over a check that never ran.
+  go-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
-      # Siblings cloned exactly where README.md tells a newcomer to put them —
-      # CI exercises the documented path rather than a special one. The
-      # Makefile's SERIALIZE* defaults already point here, and the generated
-      # go.mod / Cargo.toml and the test/js* module-relative imports embed
-      # relative paths that only resolve under this layout.
-      - name: Check out the serialize runtimes (pinned releases)
+      - name: Check out the C/C++ serialize runtimes (pinned releases)
         run: |
           cd ..
-          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
-          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
-          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
-          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
-          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
-          git clone --quiet --depth 1 --branch "$SERIALIZE_JS_TAG" https://github.com/mas-bandwidth/serialize.js.git serialize.js
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"   https://github.com/mas-bandwidth/serialize.git   serialize
+          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG" https://github.com/mas-bandwidth/serialize.c.git serialize.c
 
       - uses: actions/setup-go@v7
         with:
           go-version: '1.26'
           cache: false
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: '8.0'
-
-      # One node version, the runtime's floor (serialize.js engines >= 20):
-      # the runtime's own CI carries the version matrix; this repo proves
-      # wire identity, which does not vary by node version.
-      - uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-
-      # The Dart SDK, pinned to the same version the Makefile documents for
-      # the repo-local dist/ (generated Dart is self-contained — the SDK is
-      # the only Dart dependency, so there is no serialize.dart clone above).
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: '3.13.2'
-
-      # The JDK, same major as the Makefile's dist/ pin (generated Java is
-      # self-contained — the JDK is the only Java dependency, so there is no
-      # serialize.java clone above).
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      # The BEAM toolchain, same versions as the Makefile's dist/ pins
-      # (generated Elixir is self-contained — Erlang/OTP + Elixir are the
-      # only dependencies, so there is no serialize.elixir clone above).
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: '29.0.5'
-          elixir-version: '1.20.4'
-
-      # vet rides in the test job on both OSes: an emitter codebase built
-      # almost entirely out of format strings is exactly where printf-verb
-      # mismatches live (issue #31).
       - name: go vet
         run: go vet ./...
 
-      # No SERIALIZE* overrides: the Makefile defaults already point at the
-      # sibling layout cloned above. RUSTUP_BIN defaults to a homebrew keg on
-      # the author's machine; on CI cargo is on PATH, so point it somewhere
-      # harmless. DART, JAVA/JAVAC and ELIXIR/MIX likewise default to the
-      # repo-local dist/ toolchains; on CI setup-dart, setup-java and
-      # setup-beam put the pinned versions on PATH.
-      - name: make test
-        run: make test RUSTUP_BIN=/usr/bin DART=dart JAVA=java JAVAC=javac ELIXIR=elixir MIX=mix
+      - name: go test
+        run: go test ./...
 
-      # The committed generated/ tree is what this repo treats as ground
-      # truth — findings are receipted against its line numbers. `make test`
-      # above regenerated every tracked file IN PLACE, so staleness is
-      # precisely a dirty tree here: a tracked file that changed, or a newly
-      # emitted file nobody committed (which a diff-only check would miss).
-      # Locally: `make generated-current`.
+  # THE GENERATED TREE IS CURRENT (issue #30). The committed generated/ tree is
+  # what this repo treats as ground truth — findings are receipted against its
+  # line numbers — so a compiler change that moves the emitted text and leaves
+  # the tree behind is a defect the next reader pays for.
+  #
+  # Every generation rule takes exactly one input, bin/schema, and no toolchain
+  # and no sibling checkout: the emitted text of a Go, Rust, C#, Dart, Java or
+  # Elixir unit is a function of the compiler alone. So this job regenerates
+  # the whole tree IN PLACE with Go and nothing else, and staleness is
+  # precisely a dirty tree afterwards — a tracked file that changed, or a newly
+  # emitted file nobody committed, which a diff-only check would miss.
+  #
+  # The stamp list is DERIVED from the Makefile rather than typed here, so a
+  # port that adds generated/<lang>/.stamp is covered the moment it rebases,
+  # with no edit to this file. Locally the same check is `make
+  # generated-current`, which gets there through the whole `make test` chain.
+  generated:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: regenerate every committed generated/ tree
+        run: |
+          stamps=$(grep -oE '^generated/[A-Za-z0-9/_.-]*/\.stamp:' Makefile | sed 's/:$//' | sort -u)
+          if [ -z "$stamps" ]; then
+            echo "::error::no generated/*/.stamp rules found in the Makefile — this check would pass over an empty set"
+            exit 1
+          fi
+          echo "$stamps"
+          # shellcheck disable=SC2086
+          make $stamps
+
       - name: generated tree is current
         run: |
           git diff --exit-code generated/ || {
@@ -176,11 +151,81 @@ jobs:
             exit 1
           fi
 
-      # Seeded corpus only — a short, bounded run that re-executes every
-      # crasher ever found and checks the compiler still refuses bad input
-      # cleanly. The long fuzzing campaigns run by hand, not on every push.
-      - name: fuzz seeds
-        run: go test ./internal/fuzz/
+  # THE CONFORMANCE MATRIX (test/conformance/README.md), one job per registered
+  # driver. The same corpus as data, one driver per language, and the matrix
+  # that says which surfaces a backend has: cross-language bit identity is the
+  # property this project exists to provide, and it is an ITERATION gate — a
+  # diff that moves a codec breaks it on the commit that does so.
+  #
+  # SHARDED PER LEG, which is what the numbers in the Makefile's `conformance`
+  # comment said to do once the registry grew: a leg's wall is dominated by its
+  # own toolchain and its own build, so one job per language keeps the SLOWEST
+  # leg inside the two-minute rule instead of the SUM of them. It is also how
+  # each leg's cost stays visible — a leg that stops fitting is named by the
+  # job that missed, not buried in a total.
+  #
+  # Each leg installs only the toolchain and clones only the sibling runtime it
+  # needs; the C++ leg needs neither, because a generated table header includes
+  # no runtime at all. Registering a port is one line in
+  # test/conformance/drivers.txt, one driver, and one entry here naming the
+  # make targets that build it.
+  conformance:
+    name: conformance (${{ matrix.lang }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lang: cpp
+            targets: build/conformance-harness build/conformance-cpp build/schema_test_cook
+          - lang: cs
+            targets: build/conformance-harness build-conformance-cs build-cs-cook
+          - lang: go
+            targets: build/conformance-harness build/conformance-go
+          - lang: rust
+            targets: build/conformance-harness build/conformance-rust
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Siblings cloned exactly where README.md tells a newcomer to put them —
+      # CI exercises the documented path rather than a special one. The
+      # Makefile's SERIALIZE* defaults already point here, and the generated
+      # go.mod / Cargo.toml and the C# driver's project embed relative paths
+      # that only resolve under this layout.
+      - name: Check out the sibling runtime this leg needs (pinned release)
+        run: |
+          cd ..
+          case "${{ matrix.lang }}" in
+          cs)   git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs ;;
+          go)   git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go ;;
+          rust) git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs ;;
+          cpp)  echo "the C++ leg names no runtime: a generated table header includes none" ;;
+          esac
+
+      # bin/schema and the generated table units come out of Go in every leg.
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - uses: actions/setup-dotnet@v6
+        if: matrix.lang == 'cs'
+        with:
+          dotnet-version: '8.0'
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: matrix.lang == 'rust'
+
+      # Its own step so the run log carries the build cost and the run cost
+      # separately — the two halves answer different questions when a leg
+      # stops fitting.
+      - name: build the harness and the ${{ matrix.lang }} driver
+        run: make ${{ matrix.targets }} RUSTUP_BIN=/usr/bin
+
+      - name: the ${{ matrix.lang }} leg over every surface
+        run: ./build/conformance-harness run --only ${{ matrix.lang }}
 
   # DOGFOOD BIG-ENDIAN (issue #303). docs/SPEC-TABLES.md §3 says the wire is
   # little-endian and byte-oriented throughout; §7 says a cook is produced in
@@ -197,9 +242,9 @@ jobs:
   # to a host-order copy and proves the leg goes red on the target while
   # staying green here, which is the whole argument for having it.
   #
-  # It runs on PRs: it is an iteration gate, not a certification one — it
-  # answers a question about the code in the diff, not about the compiler that
-  # built it — and it fits the budget.
+  # It is an iteration gate, not a certification one — it answers a question
+  # about the code in the diff, not about the compiler that built it — and it
+  # fits the budget.
   #
   # THE PINS. The runner image is named rather than `-latest`, because package
   # versions are only meaningful against one archive; the cross compiler and
@@ -256,126 +301,6 @@ jobs:
       - name: the Go table leg, big-endian
         run: make conformance-big-endian
 
-  # The per-port inline-budget gate (issue #25; BENCH-STANDARD.md §4.3),
-  # fanned out one leg per job so the legs run concurrently instead of
-  # serially (they were ~9 minutes end to end in one job; the longest single
-  # leg is ~4). Certification triggers only — these are certification
-  # instruments, not iteration ones (the gate fires on compiler-version
-  # changes by design, issue #25), so PRs skip them and main / nightly /
-  # dispatch prove them minutes later.
-  #
-  # Every runtime's throughput depends on the serialize chain inlining end
-  # to end, and until this gate nothing warned when it stopped. The
-  # adversarial selftest runs FIRST and in EVERY leg job: the verdict
-  # machinery must prove it CAN fail (out-of-line -> partial, cold never
-  # counted hot, the 4dc9b62 namespace-join false-full caught) before that
-  # leg's green is trusted. Each leg builds its own artifacts (one untimed
-  # bench round), re-derives the §4.2 verdict from the current tree, and
-  # fails the job if any hot-path partial:N exceeds bench/inline-budget.txt.
-  # The go leg's remark scan runs under `go build -a` and REFUSES if it
-  # prints nothing — without -a the build cache reads as a false clean bill
-  # of health (§4.1).
-  #
-  # The go leg gates on BOTH OSes; the c/cpp/rust verdict passes are
-  # otool/arm64-shaped (§4.1), so on linux inline-verdict.sh refuses
-  # honestly rather than faking a full — those legs, and the JitDisasm-shaped
-  # cs leg, gate on the macOS runner only. There is no js leg on purpose:
-  # every verdict pass is ahead-of-time disassembly, and a JIT has no
-  # build-time artifact to gate — faking one would be a green light that
-  # proves nothing.
-  # No explicit name: the default gives "inline-gate (os, leg)" per matrix
-  # combination when it runs, and a clean single "inline-gate" placeholder on
-  # PR runs — an expression name would show up raw there, because a skipped
-  # job's matrix is never expanded.
-  inline-gate:
-    if: github.event_name != 'pull_request'
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { os: ubuntu-latest, leg: go }
-          - { os: macos-latest,  leg: go }
-          - { os: macos-latest,  leg: cpp }
-          - { os: macos-latest,  leg: c }
-          - { os: macos-latest,  leg: rust }
-          - { os: macos-latest,  leg: cs }
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Check out the serialize runtimes (pinned releases)
-        run: |
-          cd ..
-          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG"    https://github.com/mas-bandwidth/serialize.git    serialize
-          git clone --quiet --depth 1 --branch "$SERIALIZE_C_TAG"  https://github.com/mas-bandwidth/serialize.c.git  serialize.c
-          git clone --quiet --depth 1 --branch "$SERIALIZE_GO_TAG" https://github.com/mas-bandwidth/serialize.go.git serialize.go
-          git clone --quiet --depth 1 --branch "$SERIALIZE_RS_TAG" https://github.com/mas-bandwidth/serialize.rs.git serialize.rs
-          git clone --quiet --depth 1 --branch "$SERIALIZE_CS_TAG" https://github.com/mas-bandwidth/serialize.cs.git serialize.cs
-          git clone --quiet --depth 1 --branch "$SERIALIZE_JS_TAG" https://github.com/mas-bandwidth/serialize.js.git serialize.js
-
-      # All the toolchains regardless of leg: the `make test` precondition
-      # step below builds the whole tree (nine languages), exactly as the
-      # single-job flow did before the fan-out — the gate legs verdict the
-      # same artifacts they always have.
-      - uses: actions/setup-go@v7
-        with:
-          go-version: '1.26'
-          cache: false
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: '8.0'
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: '3.13.2'
-
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: '29.0.5'
-          elixir-version: '1.20.4'
-
-      # The same preconditions the gates had when they ran after `make test`
-      # in one job: bin/schema, the generated trees, and the bench units all
-      # built (31-45s measured — cheap enough to repeat per leg rather than
-      # invent a narrower target with different semantics).
-      - name: make test
-        run: make test RUSTUP_BIN=/usr/bin DART=dart JAVA=java JAVAC=javac ELIXIR=elixir MIX=mix
-
-      - name: inline gate — adversarial selftest
-        run: bench/tools/inline-gate.sh selftest
-
-      - name: inline gate — ${{ matrix.leg }} leg
-        run: bench/tools/inline-gate.sh leg ${{ matrix.leg }}
-
-      # GATE 2's SMOKE (docs/SPEC-TABLES.md §12.1). The gate itself is a paired
-      # measurement and its verdict belongs on a quiet box, so it is not on the
-      # PR path and its 5% band is not enforced here. What runs is the
-      # CORRECTNESS half at a small N — the generated block form and the
-      # hand-written mirror agreeing byte for byte across all nine sections,
-      # and the C# side reading the frame the C++ side wrote. Before this the
-      # gate ran nowhere at all, which is how a gate rots.
-      #
-      # ONE matrix combination, not six: this job's `make test` has already
-      # built the tree on every leg, and the smoke needs one extra C++ compile
-      # and one dotnet run. The go/ubuntu leg carries it because it is the one
-      # combination that always runs.
-      - name: gate 2 smoke — the block form still writes what the hand mirror does
-        if: matrix.os == 'ubuntu-latest' && matrix.leg == 'go'
-        run: make tables-block-gate2-smoke
-
   # Self-contained Go lint job; .golangci.yml carries the config.
   lint:
     runs-on: ubuntu-latest
@@ -426,6 +351,10 @@ jobs:
           rows=$(echo "$out" | grep -cE "^  (c|cpp|go|rust|cs|js|java|dart|elixir) ")
           [ "$rows" -ge 1 ] || { echo "::error::render printed zero language rows"; exit 1; }
 
+  # A new CVE lands with no commit, so govulncheck is the one gate whose
+  # verdict changes on its own. It rides the pull request here AND the nightly
+  # in certify.yml — the same job in both files, deliberately, because neither
+  # trigger substitutes for the other.
   vuln:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -440,8 +369,7 @@ jobs:
 
   # The compiler that generates C++ for a Windows-targeting game engine, run on
   # Windows: vet + build, cheap enough to ride every pull request. What it
-  # EMITS is compiled with cl by the `msvc` job below, which runs on the
-  # certification side.
+  # EMITS is compiled with cl by the `msvc` job below.
   windows:
     runs-on: windows-latest
     timeout-minutes: 15
@@ -628,8 +556,7 @@ jobs:
   # belongs in bench/corpus and the generated code. This job refuses a commit
   # that hand-codes measurement of a schema shape anywhere else. Every current
   # exception is named in bench/SHAPE-GATE.allow with an exact count that can
-  # only shrink. Runs on push AND pull_request: unlike the cpp-lock this is a
-  # standing property of the tree, not a review-window freeze.
+  # only shrink.
   shape-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -643,10 +570,18 @@ jobs:
         run: go run ./bench/tools/shapegate
 
   # The C/C++ reference lock (owner ruling 2026-08-31, issue #170): while
-  # bench/LOCK exists, a PR touching any locked prefix refuses. The lift is
-  # a PR whose whole diff is bench/LOCK itself — visible by construction.
+  # bench/LOCK exists, a change touching any locked prefix refuses. The lift is
+  # a pull request whose whole diff is bench/LOCK itself — visible by
+  # construction.
+  #
+  # IT NO LONGER SKIPS ITSELF OUTSIDE `pull_request` (issue #368). A worker
+  # whose pull request gets no run — the conflicted-merge-ref case in this
+  # file's header — falls back to `gh workflow run`, and a fallback that
+  # quietly drops the lock is a fallback that lets a locked path through. The
+  # base is the pull request's own when there is one and `main` otherwise,
+  # which is the same comparison a dispatch on a branch wants. On a push to
+  # main the diff against main is empty and the job is a no-op that says so.
   cpp-lock:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -656,7 +591,7 @@ jobs:
       - name: refuse locked-path changes
         run: |
           [ -f bench/LOCK ] || { echo "no bench/LOCK — guard inactive"; exit 0; }
-          base="origin/${{ github.base_ref }}"
+          base="origin/${{ github.base_ref || 'main' }}"
           changed="$(git diff --name-only "$base"...HEAD)"
           echo "changed files vs $base:"; echo "$changed"
           if [ "$changed" = "bench/LOCK" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,18 @@ name: CI
 # about the CODE IN THE DIFF, and every one of them fits the owner's rule for
 # CI that runs on each pull request: one to two minutes.
 #
-# MEASURED, on this file's own runs on the branch that introduced it (runs
-# 33738350231 and 33738576428): the gate answers END TO END in 2:00, and the
-# slowest job is `big-endian` at 1:56 and 2:00. Every other job is under 75 s
-# — msvc 1:14, windows 0:59, conformance 0:24 to 1:00 per leg, go-test 0:44,
-# lint 0:37, vuln 0:33, generated 0:22, shape-gate 0:18, cpp-lock 0:07.
+# MEASURED, on this file's own run on the branch that introduced it (run
+# 33740084214): the gate answers END TO END in 1:54. Per job — big-endian
+# 1:49, msvc 1:27, windows 0:49, conformance 0:21 to 0:41 per leg, go-test
+# 0:37, lint 0:37, vuln 0:30, shape-gate 0:22, generated 0:16, cpp-lock 0:06.
 #
 # `big-endian` IS THE BINDING CONSTRAINT, and it is worth naming rather than
-# rounding away: 95 s of its 116 is `make tables-big-endian-negative`, which
+# rounding away: 87 s of its 109 is `make tables-big-endian-negative`, which
 # cross-compiles the tables battery for s390x, runs it under qemu, and then
-# compiles it a SECOND time for the negative control. It fits the rule with
-# nothing to spare. The next job that wants a place on this gate takes the
-# budget from somewhere, and the honest place to look first is that second
-# compile.
+# compiles it a SECOND time for the negative control. Building its six
+# binaries in parallel bought 14 s of that; the rest is the control's own two
+# compiles, which are serial by construction. The next job that wants a place
+# on this gate takes the budget from somewhere, and that is where to look.
 #
 # CERTIFICATION IS certify.yml: the inline gates, the full `make test` chain on
 # both OSes, every `tables-<lang>-release` target. It runs on every push to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,19 @@ name: CI
 # about the CODE IN THE DIFF, and every one of them fits the owner's rule for
 # CI that runs on each pull request: one to two minutes.
 #
-# MEASURED, on this file's own first run: the slowest job was MEASURED_SLOWEST
-# and the gate answered in MEASURED_WALL end to end.
+# MEASURED, on this file's own runs on the branch that introduced it (runs
+# 33738350231 and 33738576428): the gate answers END TO END in 2:00, and the
+# slowest job is `big-endian` at 1:56 and 2:00. Every other job is under 75 s
+# — msvc 1:14, windows 0:59, conformance 0:24 to 1:00 per leg, go-test 0:44,
+# lint 0:37, vuln 0:33, generated 0:22, shape-gate 0:18, cpp-lock 0:07.
+#
+# `big-endian` IS THE BINDING CONSTRAINT, and it is worth naming rather than
+# rounding away: 95 s of its 116 is `make tables-big-endian-negative`, which
+# cross-compiles the tables battery for s390x, runs it under qemu, and then
+# compiles it a SECOND time for the negative control. It fits the rule with
+# nothing to spare. The next job that wants a place on this gate takes the
+# budget from somewhere, and the honest place to look first is that second
+# compile.
 #
 # CERTIFICATION IS certify.yml: the inline gates, the full `make test` chain on
 # both OSes, every `tables-<lang>-release` target. It runs on every push to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,8 +292,14 @@ jobs:
       # BE_CXX names the pinned compiler: the exact-version package installs
       # the SUFFIXED driver, and the Makefile's unsuffixed default is for a
       # workstation that installed the metapackage.
+      #
+      # -j BECAUSE THIS IS THE JOB AT THE BOUND. Six independent binaries hang
+      # off `tables-big-endian` — the tables corpus, the block driver both
+      # ways, the cook reader both ways, and the cook fixtures — sharing only
+      # bin/schema and the generated tree, which make builds once. The runner
+      # has four cores and the leg was spending them one at a time.
       - name: the big-endian leg, and its negative control
-        run: make tables-big-endian-negative BE_CXX=s390x-linux-gnu-g++-13
+        run: make -j"$(nproc)" tables-big-endian-negative BE_CXX=s390x-linux-gnu-g++-13
 
       # And the GO table leg on the same target. Go cross-compiles, so the
       # conformance driver is one env var away from a big-endian binary, and


### PR DESCRIPTION
Closes #368.

Owner's rule: CI that runs on each pull request answers in one to two minutes.
Today's pull-request jobs run 9 to 18 minutes each. This splits the file in two
along the line of the QUESTION a job answers.

- **`ci.yml`** — the pull-request gate (`pull_request`, push to `main`,
  `workflow_dispatch`). Every job answers a question about the code in the
  diff.
- **`certify.yml`** — certification (push to `main`, nightly at 09:17 UTC,
  `workflow_dispatch`). Everything that answers a question about the TOOLCHAIN,
  at LENGTH, or under LOAD.

Nothing is dropped. Every job that exists today runs in one of the two files,
and both files run on every push to `main`, so a merge commit is proved by
exactly what proved it before. The Makefile is not touched at all: every target
name the open port branches name still resolves after a rebase.

**Measured: the pull-request gate answers END TO END in 1:54**, on this
branch's own run
[33740084214](https://github.com/mas-bandwidth/schema/actions/runs/33740084214).
Before, the same event's slowest single job was 9.3 minutes. The header of
`ci.yml` carries the number.

## Per-job table

Before = the issue's measurements on the last green main run `3f14c5ac`
([33730027731](https://github.com/mas-bandwidth/schema/actions/runs/33730027731)).
After = run 33740084214 for the pull-request gate, and run
[33738461994](https://github.com/mas-bandwidth/schema/actions/runs/33738461994)
for certification.

| job | before: runs on | before | after: runs on | after |
|---|---|---:|---|---:|
| `test (ubuntu)` | PR + main + nightly | 9.3 min | **certify** — main + nightly + dispatch | 12.9 min |
| `test (macos)` | main + nightly | 14.9 min | **certify** | unchanged |
| `inline-gate (ubuntu, go)` | main + nightly | 12.6 min | **certify** | 11.9 min |
| `inline-gate (macos, go)` | main + nightly | 18.4 min | **certify** | unchanged |
| `inline-gate (macos, rust)` | main + nightly | 18.3 min | **certify** | unchanged |
| `inline-gate (macos, cpp)` | main + nightly | 16.1 min | **certify** | unchanged |
| `inline-gate (macos, cs)` | main + nightly | 15.5 min | **certify** | unchanged |
| `big-endian` | PR + main + nightly | 1.5 min | **PR gate** | 1:49 |
| `msvc` | PR + main + nightly | 1.3 min | **PR gate** | 1:27 |
| `windows` | PR + main + nightly | 0.9 min | **PR gate** | 0:49 |
| `lint` | PR + main + nightly | < 0.5 min | **PR gate** | 0:37 |
| `shape-gate` | PR + main + nightly | < 0.5 min | **PR gate** | 0:22 |
| `cpp-lock` | PR only | < 0.5 min | **PR gate**, now every event | 0:06 |
| `vuln` | PR + main + nightly | < 0.5 min | **both files** (see below) | 0:30 / 0:35 |

New jobs, carved out of the `test` job so that what a pull request needs to
know is answered without the 9-minute chain:

| new job | what it is | after |
|---|---|---:|
| `go-test` | `go vet ./...` + `go test ./...`, the seeded fuzz corpus included | 0:37 |
| `generated` | the committed `generated/` tree regenerated from `bin/schema` alone, then checked for staleness | 0:16 |
| `conformance (cpp)` | the conformance matrix, C++ leg | 0:33 |
| `conformance (cs)` | ditto, C# leg | 0:33 |
| `conformance (go)` | ditto, Go leg | 0:21 |
| `conformance (rust)` | ditto, Rust leg | 0:41 |
| `release-gates` (certify) | every `tables-<lang>-release` target the Makefile carries | 0:33 (none on main yet) |

### Every conformance leg fits, with room

Build split from run, from run 33738350231. No leg fails to fit, and the matrix
is bounded by its slowest leg rather than by the sum — which is why it is
sharded one job per registered driver.

| leg | build | run | job |
|---|---:|---:|---:|
| cpp | 22 s | 0 s | 28 s |
| cs | 24 s | 16 s | 49 s |
| go | 14 s | 1 s | 24 s |
| rust | 32 s | 1 s | 39 s |

The run halves match the Makefile's own measured note (cpp 0.79 s, go 1.07 s,
cs 10 s): the cost of a leg is its BUILD. That is exactly why one job per leg
is the right shape and one job for all of them is not — a single job pays every
build serially and lands near 3.5 minutes.

### `big-endian` is the binding constraint, and it needed the one trim

It came in at 1:56, 2:00 and 2:03 across three runs — straddling the rule
rather than obeying it. 95 s of that was one step: `make
tables-big-endian-negative` cross-compiles the tables battery for s390x, runs
it under qemu, then compiles it a second time for the negative control. Six of
those binaries are independent and were being built one at a time on a
four-core runner, so the step now runs under `make -j$(nproc)`: 95 s → 87 s,
job 123 s → 109 s, gate wall 2:15 → 1:54. The remainder is the control's own
two serial compiles, and the header says so, because the next job that wants a
place on this gate takes its budget from somewhere.

### `vuln` is in both files, deliberately

A new CVE lands with no commit, so govulncheck is the one gate whose verdict
changes on its own. The pull-request gate needs it (the rule says so, and it
costs 30 s); the nightly needs it for the reason the old file's comment gave.
Neither trigger substitutes for the other, so the job is in both files rather
than in one and half-covered.

## The trigger attribution (#368's second symptom)

**It is not the `concurrency` block, not the runner queue, and not a per-branch
trigger limit. GitHub does not create a `pull_request` run at all while the
pull request has a merge conflict with its base.** The run needs the merge
commit `refs/pull/<n>/merge`, and a conflicted pull request has none. This is
documented behavior:
[events that trigger workflows → `pull_request`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request).

The evidence is the asymmetry against `cla.yml`, which fires on
`pull_request_target` — an event that runs against the BASE branch and needs no
merge ref. Both workflows see the same pushes. Only one of them ran:

| branch | head sha | push (UTC) | `pull_request_target` (cla.yml) | `pull_request` (ci.yml) |
|---|---|---|---|---|
| `port-c-tables` | `3af203a3` | 08:21 | success | **no run** |
| `port-c-tables` | `d5431c31` | 08:24 | success | **no run** |
| `port-c-tables` | `ae4ebbc2` | 08:43 | success | **no run** |
| `port-c-tables` | `f777a317` | 08:52 | success | **no run** |
| `port-js-tables` | `bef83204` | 07:52 | success | **no run** |
| `port-js-tables` | `473e9e5a` | 07:53 | success | **no run** |
| `port-js-tables` | `6cec38b6` | 07:58 | success | **no run** |
| `port-js-tables` | `f51ed999` | 07:59 | success | **no run** |
| `port-js-tables` | `9bab17f8` | 08:05 | success | **no run** |
| `port-js-tables` | `7eeef064` | 08:06 | success | **no run** |
| `port-js-tables` | `3c4ed734` | 08:08 | success | **no run** |
| `port-java-tables` | `441aaaf2` | 08:31 | success | **no run** |
| `port-java-tables` | `a357218a` | 08:31 | success | **no run** |
| `port-dart-tables` | `1de44b41` | 08:22 | success | **no run** |
| `port-dart-tables` | `3985379e` | 08:39 | success | **no run** |
| `port-dart-tables` | `361611e6` | 08:50 | success | **no run** |

Three things close it:

1. **State, now.** #352 and #353 report `mergeable: false`, `mergeable_state:
   "dirty"` — conflicted. #352 has had no `pull_request` run since 07:03 UTC
   across six pushes, every one of which got a `pull_request_target` run.
2. **Timing.** Each gap opens minutes after a merge to `main` that touches what
   the port branch touches, and closes at the branch's next rebase or
   force-push — which is the act that recomputes the merge ref. #329/#326/#359
   at 07:47-07:48 all edit README, and every port edits README; the
   `port-js-tables` gap opens at 07:52. Then #340 at 08:09, #338 at 08:45,
   #367 at 09:07.
3. **The mechanism discriminates.** A concurrency cancellation leaves a
   CANCELLED run in the history, and these branches have plenty of those from
   rapid pushes — that part is by design and is not this. A missing merge ref
   leaves NO run, which is what every row above is.

**Nothing in our files causes it and nothing in our files can lift it.** The
fix is to rebase the branch. What this PR does about it is close the hole the
workaround left open: `cpp-lock` no longer carries `if: github.event_name ==
'pull_request'`, so the `gh workflow run` fallback a worker reaches for is no
longer a weaker gate than the one it replaces. Its base is the pull request's
own when there is one and `main` otherwise; on a push to main the diff is empty
and the job is a no-op that says so.

`ci.yml`'s header carries this attribution, so the next person who meets a
silent gate does not have to re-derive it.

## Certification proved

`workflow_dispatch` cannot reach a workflow that is not yet on the default
branch (`gh workflow run certify.yml --ref ci-split` → `HTTP 404: workflow
certify.yml not found on the default branch`), so certification was proved on a
scratch branch, `ci-split-certify-proof`, which carries this PR's `certify.yml`
with one line changed: its `push:` list names that branch. Run
[33738461994](https://github.com/mas-bandwidth/schema/actions/runs/33738461994).

Result, at the time of writing: **six of the ten jobs green, none red.**

| job | result | wall |
|---|---|---:|
| `test (ubuntu-latest)` | success | 12:55 |
| `test (macos-latest)` | success | 18:07 |
| `inline-gate (ubuntu-latest, go)` | success | 11:56 |
| `inline-gate (macos-latest, go)` | success | 11:43 |
| `release-gates` | success | 0:33 |
| `vuln` | success | 0:35 |
| `inline-gate (macos-latest, cs)` | in progress | — |
| `inline-gate (macos-latest, rust)` | in progress | — |
| `inline-gate (macos-latest, cpp)` | queued | — |
| `inline-gate (macos-latest, c)` | queued | — |

The four outstanding legs are queued behind the shared macOS pool, which is
five runners wide and shared by every worker in the estate — the same
contention the issue names, and the reason these legs are off the
pull-request path. `release-gates` ran green over an empty target list on
main ("no tables-<lang>-release target in the Makefile yet"); #356's
`tables-java-release` is what it picks up on rebase.

The scratch branch is not part of this PR and will be deleted.

## Branch protection

`main` currently has **no** protection rule and **no** ruleset
(`repos/mas-bandwidth/schema/branches/main/protection` → 404,
`repos/mas-bandwidth/schema/rulesets` → `[]`), so nothing breaks on merge. No
repository setting was changed by this PR. If required checks are turned on,
these are the pull-request check names that change:

- **gone from a pull request:** `test (ubuntu-latest)`, `inline-gate` (the
  skipped placeholder)
- **new on a pull request:** `go-test`, `generated`, `conformance (cpp)`,
  `conformance (cs)`, `conformance (go)`, `conformance (rust)`
- **unchanged:** `lint`, `vuln`, `shape-gate`, `windows`, `msvc`,
  `big-endian`, `cpp-lock`

## For the open port branches

Five ports are in flight (#352 C, #353 JS, #356 Java, #364 Dart, Elixir soon).
Two things are deliberately mechanical so a port lands its legs without editing
a workflow at all:

- the staleness gate DERIVES its stamp list from the Makefile, so
  `generated/<lang>/.stamp` is covered the moment the port rebases;
- `release-gates` DERIVES its target list from the Makefile, so
  `tables-<lang>-release` runs on the certification side by name. #356's
  `tables-java-release` runs nowhere today; after this it runs nightly and on
  every merge to main.

A port that registers a conformance driver adds one entry to the `conformance`
matrix naming the make targets that build it. That is the only workflow edit a
port still needs, and it is the one that cannot be derived — a driver's build
target is not a function of its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
