### PR TITLE
Lock packs a shared node once: the identity map, in the C++ reference (#360)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ tables-zero-cost: build/tables-generated/.stamp
 	@for f in build/tables-generated/examples/*Table.h build/tables-generated/v1/*Table.h \
 	          build/tables-generated/v2/*Table.h build/tables-generated/p1/*Table.h \
 	          build/tables-generated/p3/*Table.h; do \
-		if grep -nE "TableArena|TableSlot|TableWorker|TableRef|TableRegion|kTableSegment|kTableSlab|kTableMaxDepth|is_pointer|Builder|PackMeasure|LoadMeasure" $$f; then \
+		if grep -nE "TableArena|TableSlot|TableWorker|TableRef|TableRegion|kTableSegment|kTableSlab|kTableMaxDepth|TablePack|is_pointer|Builder|PackMeasure|LoadMeasure" $$f; then \
 			echo "ZERO-COST GATE FAILED: pointer machinery leaked into $$f"; exit 1; \
 		fi; \
 	done
@@ -1795,6 +1795,38 @@ tables-json-keyed-dup-negative-control: bin/schema test/tables/json_keyed_dup_ne
 		-Ibuild/json-dup-sabotage test/tables/json_keyed_dup_negative_main.cpp build/json-dup-sabotage/KeyedTable.cpp -o build/schema_test_json_keyed_dup_negative
 	./build/schema_test_json_keyed_dup_negative
 
+# The NEGATIVE CONTROL for the SHARED NODE (docs/SPEC-TABLES.md §6.2). Lock's
+# whole claim is that its walk carries one entry per node, so a node two
+# references name is packed ONCE and both references resolve to it. A pack that
+# duplicates reads correct through either reference — every field is right, the
+# graph is walkable, the region relocates — which is exactly why the defect
+# lived under a green suite until the byte count was measured.
+#
+# It sabotages the EMITTER's identity map into a permanent miss, so every visit
+# is a first visit, and requires THE TABLES SUITE ITSELF to go red. The
+# sabotaged emitter reaches the compiler through `go build -overlay`, so no
+# tracked file is ever written to.
+.PHONY: tables-shared-node-negative-control
+tables-shared-node-negative-control: bin/schema
+	@mkdir -p build
+	@sed -e 's|taken = entry->key != key;|taken = true; // SABOTAGED: every visit is a first visit|' \
+		internal/codegen/cpptable/arena.go > build/cpptable-no-identity.gotext
+	@cmp -s build/cpptable-no-identity.gotext internal/codegen/cpptable/arena.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/arena.go":"%s/build/cpptable-no-identity.gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/cpptable-no-identity-overlay.json
+	@go build -overlay=build/cpptable-no-identity-overlay.json -o build/schema-no-identity ./cmd/schema
+	@rm -rf build/tables-no-identity && mkdir -p build/tables-no-identity
+	$(call tables_generate,./build/schema-no-identity,build/tables-no-identity)
+	$(CXX) $(TABLES_CXXFLAGS) $(call tables_includes,build/tables-no-identity) \
+		test/tables/main.cpp $$(ls build/tables-no-identity/*/*Table.cpp) -o build/schema_test_tables_no_identity
+	@if ./build/schema_test_tables_no_identity > build/tables-no-identity.log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: a pack with no identity map left the tables suite GREEN"; exit 1; \
+	fi
+	@grep -q "^FAIL test/tables/main.cpp" build/tables-no-identity.log || \
+		{ echo "NEGATIVE CONTROL FAILED: the suite went red, but not on a CHECK"; cat build/tables-no-identity.log; exit 1; }
+	@echo "negative control: a pack with no identity map turns the TABLES SUITE red — $$(grep -c '^FAIL' build/tables-no-identity.log) failures"
+
 # The NEGATIVE CONTROL for a keyed array's ITERATION RANGE (docs/SPEC-TABLES.md
 # §2.4). The iteration's whole promise is that it walks EVERY stored slot and
 # yields the KEY it holds, 1..E.Max; an off-by-one at either end reads as an
@@ -2563,6 +2595,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) tables-go-fuzz-extent-negative-control
 	$(MAKE) tables-go-fuzz-maximum-negative-control
 	$(MAKE) tables-json-keyed-dup-negative-control
+	$(MAKE) tables-shared-node-negative-control
 	$(MAKE) tables-keyed-iteration-negative-control
 	$(MAKE) tables-keyed-none-refusal-ndebug
 	$(MAKE) tables-keyed-none-refusal-negative-control

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -971,6 +971,14 @@ nesting depth; and that depth is therefore bounded, by a generated
 refused by measure and save rather than written. Moving the emitter to the
 flat node table is tracked as schema#251.
 
+**The REGION is not in that gap.** `Lock` carries the one-entry-per-node map
+this section describes, in C++ today: a shared node is packed once, a later
+reference resolves to the one body it has, and a data cycle is named at the
+reference that closes it rather than found by running out of depth (§6.2). So
+the two forms disagree on exactly one thing and it is named — a save from a
+region writes a shared node once per reference because the WIRE it writes is
+still the nested one, and that is the whole of what #251 moves.
+
 **Kind `17` costs nothing and closes an edit that would otherwise be
 silent.** A node index is four bytes and so is a `uint32`, so under a
 shared kind an edit between the two would report nothing in either
@@ -1756,6 +1764,35 @@ const Scene * scene = builder.AsConst();       // CONST: one packed region
 
 Reading a pointer is `NodeAt( node->next )` — one add (§6.3), NULL when
 the reference is null.
+
+**The map is what makes both claims one claim.** Sharing and a cycle are the
+same event seen at different times — a reference arriving at a node the walk
+has already reached — and the entry's open bit is what separates them: a
+reference to an entry whose descent is still OPEN is a cycle, and a reference
+to one already CLOSED is sharing, resolved to the body that node already has.
+A pack without the map has neither answer and gets both wrong in the same
+direction: it packs a shared node again, and it discovers a cycle only by
+running out of depth. The ROOT's entry is open for the whole walk, so it is
+one rule and not a case (§3.1).
+
+**Its cost, stated.** One entry per reachable node — an address, an offset and
+the bit — held for the length of `Lock` and released before it returns, on the
+AUTHORING side where §6.5 licenses allocation. It is proportional to NODES,
+never to bytes, and nothing on the reading path ever builds one: `Load`
+resolves indices through the wire's own numbering and a deref is still one add.
+**Measure and pack each derive the map from the graph, and neither carries the
+other's** — that is what leaves `used == total` a real check on the two walks
+agreeing rather than a tautology (§3.1).
+
+**Held by test.** The pointered corpus carries a shared leaf named twice from
+one node, a shared node reached through a chain and named again from the root,
+and a diamond whose closing reference is a BACK-reference; each is checked by
+identity — the two references resolve to one address — and by the region's
+exact BYTE COUNT, which is the half a duplicating pack cannot fake. A
+self-cycle and a two-node cycle are refused by `Lock`, `Measure` and `Save`
+alike, and the region relocates by `memcpy` with a back-reference in it. **The
+negative control** turns the identity map into a permanent miss and requires
+the tables suite to go red.
 
 ### 6.3 Two reference encodings, one slot
 
@@ -4577,6 +4614,31 @@ inspects everything in the schema built:
   it has no wire codec.
 - **The variable class in a ported backend** — the arena, the region, the
   cooked form and the pointer surface — after that port's fixed class.
+- **`Lock`'S IDENTITY MAP, PRESIZED.** The map (§6.2) grows by rehashing, and
+  rehashing is what it spends: on a 131,071-node tree with NO sharing at all —
+  where the map is pure overhead and buys nothing — `Lock` costs 5.8 ms against
+  0.98 ms before the map existed. Quadrupling the capacity instead of doubling
+  it took 1.35x of that, and a map presized to the graph measured 6.6 ms against
+  12.0 ms on the doubling schedule, so the headroom left is real. What it needs
+  is a NODE COUNT the arena does not keep, because counting allocations costs
+  an atomic per node and §6.4 refuses one; the shapes are a per-worker
+  non-atomic counter summed at `Lock`, or a bound derived from the arena's
+  high-water mark and the closure's smallest node, and neither is decided here.
+  **What the map buys where it buys anything is not close**: a 24-node graph
+  whose every node is named twice packed 671 MB in 189 ms without it and 1,136
+  bytes in 0.009 ms with it.
+- **§3.1'S ROOT BACK-REFERENCE: two rules in one section, and only one can
+  hold.** The numbering says index `1` is the root and that "a pointer may name
+  it, so a child pointing back at its root is expressible", and the worked
+  example writes `owner = 1` from two nodes. The cycle rule in the same section
+  says a reference to an entry still open is a cycle — and the root's entry is
+  open for the whole walk, so that graph is refused, by the tool's numbering
+  and by the C++ `Lock` alike, and §11 lists the refusal by name. Either the
+  root is exempt from the open colouring, which needs saying and needs a reason
+  the exemption stops there, or the bullet and the example go. Nothing here
+  decides it. WHAT IS IMPLEMENTED IS THE REFUSAL, because it is what the tool
+  does and an implementation mirrors the reference rather than inventing a
+  third answer.
 - **THE CURSOR HOISTED OUT OF THE WRITER, in the GO backend** — the port's
   generated `…SaveBody` calls the writer's puts, and each put loads
   `Buffer`, `Capacity` and `Offset` from the writer and stores `Offset` back.

--- a/internal/codegen/cpptable/arena.go
+++ b/internal/codegen/cpptable/arena.go
@@ -43,11 +43,15 @@ static const uint32_t kTableAlign       = 8;                           // every 
 static const uint32_t kTableAllocFailed = 0xFFFFFFFFu;
 
 // The pointer-chain depth cap. It bounds recursion on every walk — measure,
-// save, load and pack — so a data cycle is an ERROR and never a hang, and a
-// hostile wire cannot drive the C stack into the ground. A pointer chain's
-// WIRE nesting equals its length (§3), so this also caps chain length: wide
-// structures are unbounded, deep ones are not. Lifting it wants a flat,
-// indexed node encoding — a named follow-on (§15).
+// save, load and pack — so a hostile wire cannot drive the C stack into the
+// ground. A pointer chain's WIRE nesting equals its length (§3), so this also
+// caps chain length: wide structures are unbounded, deep ones are not. Lifting
+// it wants a flat, indexed node encoding — a named follow-on (§15).
+//
+// It is not what refuses a DATA CYCLE on the pack walk: TablePackMap's open
+// colouring names that cycle at the reference that closes it (§3.1). The cap
+// is still the whole of the cycle answer on the wire walks, which carry no
+// map today (§3.1's backend status).
 static const int32_t kTableMaxDepth = 128;
 
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
@@ -248,6 +252,148 @@ struct TableWorker
         return slot;
     }
 };
+
+// ---- TablePackMap: the pack walk's identity map (docs/SPEC-TABLES.md §3.1, §6.2) ----
+//
+// ONE ENTRY PER REACHABLE NODE, and that map IS identity: a node must know
+// where it landed to be named a second time, so Lock packs a shared node ONCE
+// and every later reference resolves to the one body it already has. That is
+// the same first-visit numbering the wire uses, so the pack order and the node
+// order are one order.
+//
+// COLOURING AN ENTRY WHILE ITS DESCENT IS OPEN COSTS ONE BIT, and it is what
+// makes a data cycle free to refuse: a reference to an entry still open is a
+// cycle, and Lock returns failure rather than recursing away. The ROOT's entry
+// is open for the whole walk.
+//
+// The map is proportional to NODES, never to bytes, and it lives on the
+// AUTHORING side, where §6.5 licenses allocation. Nothing on the reading path
+// ever builds one.
+struct TablePackEntry
+{
+    const void * key;   // the node's address in the graph being packed
+    int64_t offset;     // where that node landed in the region
+    uint8_t open;       // its descent is still open: a reference here is a cycle
+};
+
+struct TablePackMap
+{
+    TablePackEntry * entries = NULL;
+    int64_t capacity = 0; // a power of two, or zero while empty
+    int64_t count = 0;
+};
+
+inline void TablePackMapInit( TablePackMap & map )
+{
+    map.entries = NULL;
+    map.capacity = 0;
+    map.count = 0;
+}
+
+inline void TablePackMapShutdown( TablePackMap & map )
+{
+    free( map.entries );
+    TablePackMapInit( map );
+}
+
+// The two walks behind Lock re-derive the SAME map from the same graph — the
+// numbering is never carried between them (§3.1) — so the second starts from
+// an empty map and keeps the capacity the first paid for.
+inline void TablePackMapReset( TablePackMap & map )
+{
+    if ( map.entries != NULL ) { memset( map.entries, 0, (size_t) map.capacity * sizeof( TablePackEntry ) ); }
+    map.count = 0;
+}
+
+// open addressing, linear probing, a multiply-shift hash over the address: a
+// node key is a pointer and its low bits are alignment, so the low bits alone
+// would collide on every node of one type
+inline int64_t TablePackMapSlot( const TablePackMap & map, const void * key )
+{
+    uint64_t hash = (uint64_t) (uintptr_t) key;
+    hash *= 0x9E3779B97F4A7C15ull;
+    hash ^= hash >> 29;
+    int64_t mask = map.capacity - 1;
+    int64_t at = (int64_t) ( hash & (uint64_t) mask );
+    while ( map.entries[at].key != NULL && map.entries[at].key != key )
+    {
+        at = ( at + 1 ) & mask;
+    }
+    return at;
+}
+
+inline TablePackEntry * TablePackMapFind( TablePackMap & map, const void * key )
+{
+    if ( map.capacity == 0 ) { return NULL; }
+    TablePackEntry * entry = &map.entries[ TablePackMapSlot( map, key ) ];
+    return entry->key == key ? entry : NULL;
+}
+
+// QUADRUPLING, not doubling, and the reason is measured: growth rehashes every
+// entry, and on a graph of 131,071 nodes the doubling schedule spent 45% of
+// Lock in rehashing alone. Quadrupling from 1024 buys 1.35x on that graph and
+// keeps the map NODE-proportional (§6.2) — under 128 bytes a node at its
+// worst, right after a grow, and about 64 on average.
+inline bool TablePackMapGrow( TablePackMap & map )
+{
+    TablePackMap grown;
+    grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
+    grown.entries = (TablePackEntry *) calloc( (size_t) grown.capacity, sizeof( TablePackEntry ) );
+    if ( grown.entries == NULL ) { return false; }
+    for ( int64_t i = 0; i < map.capacity; i++ )
+    {
+        if ( map.entries[i].key == NULL ) { continue; }
+        grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
+        grown.count++;
+    }
+    free( map.entries );
+    map = grown;
+    return true;
+}
+
+// REACH a node: one probe answers both questions the walk has. A true "taken"
+// says this is a FIRST visit, and the entry is now the node's, coloured open
+// at "offset"; otherwise the entry is the one the node already has, and its
+// open bit says cycle or sharing. NULL is an allocation failure, and it is a
+// refusal like any other: Lock fails rather than packing a graph it cannot
+// track.
+//
+// It is one call and not a find followed by an insert because the walk asks
+// this question twice per node — once to measure, once to pack — and every
+// probe is a miss into a table larger than L2.
+inline TablePackEntry * TablePackMapReach( TablePackMap & map, const void * key, int64_t offset, bool & taken, int64_t & slot )
+{
+    if ( ( map.count + 1 ) * 4 >= map.capacity * 3 ) // keep the load factor under three quarters
+    {
+        if ( !TablePackMapGrow( map ) ) { return NULL; }
+    }
+    slot = TablePackMapSlot( map, key );
+    TablePackEntry * entry = &map.entries[slot];
+    taken = entry->key != key; // an empty slot is a first visit; the key is never NULL
+    if ( taken )
+    {
+        entry->key = key;
+        entry->offset = offset;
+        entry->open = 1;
+        map.count++;
+    }
+    return entry;
+}
+
+// The descent finished: the node keeps its entry — identity outlives the
+// descent — and stops being a cycle. The "hint" is the slot Reach returned, and it
+// is checked against the key rather than trusted, so a rehash between the two
+// costs a second probe instead of correctness.
+inline void TablePackMapClose( TablePackMap & map, const void * key, int64_t hint )
+{
+    if ( hint >= 0 && hint < map.capacity && map.entries[hint].key == key )
+    {
+        map.entries[hint].open = 0;
+        return;
+    }
+    TablePackEntry * entry = TablePackMapFind( map, key );
+    if ( entry != NULL ) { entry->open = 0; }
+}
 
 // ---- resolution contexts: which encoding a walk is reading ----
 

--- a/internal/codegen/cpptable/pointers.go
+++ b/internal/codegen/cpptable/pointers.go
@@ -136,8 +136,8 @@ func (g *tableGen) emitCodecDeclarations(members []*ir.Struct) {
 	if vars := g.varMembers(members); len(vars) > 0 {
 		g.pf("// ---- pointer-graph walkers: pack (Lock), size (Load) ----\n\n")
 		for _, st := range vars {
-			g.pf("template <typename Ctx> inline int64_t %sPackMeasure( const Ctx & ctx, const %s & value, int32_t depth );\n", st.Name, st.Name)
-			g.pf("template <typename Ctx> inline bool %sPack( const Ctx & ctx, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );\n", st.Name, st.Name, st.Name)
+			g.pf("template <typename Ctx> inline int64_t %sPackMeasure( const Ctx & ctx, TablePackMap & seen, const %s & value, int32_t depth );\n", st.Name, st.Name)
+			g.pf("template <typename Ctx> inline bool %sPack( const Ctx & ctx, TablePackMap & seen, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );\n", st.Name, st.Name, st.Name)
 			g.pf("inline int64_t %sLoadMeasureBody( TableReader & r, int32_t depth );\n", st.Name)
 		}
 		g.pf("\n")
@@ -229,13 +229,14 @@ func (g *tableGen) emitVariableSurface(members []*ir.Struct) {
 // the packed form — Lock's sizing half.
 func (g *tableGen) emitPackMeasure(st *ir.Struct) {
 	g.pf("// %sPackMeasure: the packed region bytes of everything %s POINTS AT.\n", st.Name, st.Name)
-	g.pf("// Aliasing is not preserved: two pointers to one node pack as two nodes,\n")
-	g.pf("// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).\n")
-	g.pf("template <typename Ctx>\ninline int64_t %sPackMeasure( const Ctx & ctx, const %s & value, int32_t depth )\n{\n", st.Name, st.Name)
-	g.pf("    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap\n")
+	g.pf("// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a\n")
+	g.pf("// node two references name is measured ONCE and packed once, and a\n")
+	g.pf("// reference to a node whose descent is still open is a data cycle, refused.\n")
+	g.pf("template <typename Ctx>\ninline int64_t %sPackMeasure( const Ctx & ctx, TablePackMap & seen, const %s & value, int32_t depth )\n{\n", st.Name, st.Name)
+	g.pf("    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap\n")
 	g.pf("    int64_t bytes = 0;\n")
 	if len(pointerFields(st)) == 0 && len(g.byValueVariableFields(st)) == 0 {
-		g.pf("    (void) ctx; (void) value; // no pointers below this node\n")
+		g.pf("    (void) ctx; (void) seen; (void) value; // no pointers below this node\n")
 	}
 	for _, f := range pointerFields(st) {
 		t := f.Type.Name
@@ -244,14 +245,23 @@ func (g *tableGen) emitPackMeasure(st *ir.Struct) {
 		g.pf("        if ( pointee != NULL )\n        {\n")
 		// a pointer TARGET always has walkers (ir.PointerTargets feeds them), so
 		// there is no walker-less arm to write here
-		g.pf("            int64_t inner = %sPackMeasure( ctx, *pointee, depth + 1 );\n", t)
-		g.pf("            if ( inner < 0 ) { return -1; }\n")
-		g.pf("            bytes += TableAlignUp64( (int64_t) sizeof( %s ) ) + inner;\n", t)
+		g.pf("            bool taken = false;\n")
+		g.pf("            int64_t slot = 0;\n")
+		g.pf("            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );\n")
+		g.pf("            if ( entry == NULL ) { return -1; } // the map could not grow\n")
+		g.pf("            if ( !taken )\n            {\n")
+		g.pf("                if ( entry->open != 0 ) { return -1; } // a data cycle\n")
+		g.pf("            }\n            else\n            {\n")
+		g.pf("                int64_t inner = %sPackMeasure( ctx, seen, *pointee, depth + 1 );\n", t)
+		g.pf("                if ( inner < 0 ) { return -1; }\n")
+		g.pf("                TablePackMapClose( seen, (const void *) pointee, slot );\n")
+		g.pf("                bytes += TableAlignUp64( (int64_t) sizeof( %s ) ) + inner;\n", t)
+		g.pf("            }\n")
 		g.pf("        }\n    }\n")
 	}
 	for _, f := range g.byValueVariableFields(st) {
 		g.emitVariableByValueWalk(f, func(expr string) {
-			g.pf("        int64_t inner = %sPackMeasure( ctx, %s, depth );\n", f.Type.Name, expr)
+			g.pf("        int64_t inner = %sPackMeasure( ctx, seen, %s, depth );\n", f.Type.Name, expr)
 			g.pf("        if ( inner < 0 ) { return -1; }\n")
 			g.pf("        bytes += inner;\n")
 		})
@@ -286,14 +296,17 @@ func (g *tableGen) emitPack(st *ir.Struct) {
 	g.pf("// %sPack: copy src into dst (already placed), then lay every pointee out\n", st.Name)
 	g.pf("// depth-first behind it, in FIELD ORDER, by bump allocation.\n")
 	g.pf("//\n")
-	g.pf("// The pre-order is what makes a region simple to reason about: a child\n")
-	g.pf("// always lands after the slot naming it, so region deltas are strictly\n")
-	g.pf("// positive and a packed region cannot contain a cycle.\n")
-	g.pf("template <typename Ctx>\ninline bool %sPack( const Ctx & ctx, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )\n{\n", st.Name, st.Name, st.Name)
+	g.pf("// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and\n")
+	g.pf("// where it landed, so a node's FIRST reference lays it out and every later\n")
+	g.pf("// reference points BACK at that one body. A region delta therefore has no\n")
+	g.pf("// required sign (§6.3), and sharing and a back-reference are one fact. A\n")
+	g.pf("// reference to a node whose descent is still OPEN is a cycle, and this\n")
+	g.pf("// refuses it rather than packing one.\n")
+	g.pf("template <typename Ctx>\ninline bool %sPack( const Ctx & ctx, TablePackMap & seen, const %s & src, %s & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )\n{\n", st.Name, st.Name, st.Name)
 	g.pf("    if ( depth > kTableMaxDepth ) { return false; }\n")
 	g.pf("    memcpy( (void *) &dst, (const void *) &src, sizeof( %s ) ); // trivially copyable, by construction\n", st.Name)
 	if len(pointerFields(st)) == 0 && len(g.byValueVariableFields(st)) == 0 {
-		g.pf("    (void) ctx; (void) base; (void) capacity; (void) used;\n")
+		g.pf("    (void) ctx; (void) seen; (void) base; (void) capacity; (void) used;\n")
 	}
 	for _, f := range pointerFields(st) {
 		t := f.Type.Name
@@ -301,12 +314,22 @@ func (g *tableGen) emitPack(st *ir.Struct) {
 		g.pf("        dst.%s.value = 0; // %s\n", f.Name, f.Name)
 		g.pf("        const %s * pointee = %sAt( ctx, src.%s );\n", t, t, f.Name)
 		g.pf("        if ( pointee != NULL )\n        {\n")
-		g.pf("            int64_t at = TableAlignUp64( used );\n")
-		g.pf("            if ( at + (int64_t) sizeof( %s ) > capacity ) { return false; }\n", t)
-		g.pf("            used = at + TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
-		g.pf("            %s * child = new ( base + at ) %s; // lifetime only: the Pack below memcpy's the whole node over it\n", t, t)
-		g.pf("            dst.%s.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.%s );\n", f.Name, f.Name)
-		g.pf("            if ( !%sPack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }\n", t)
+		g.pf("            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit\n")
+		g.pf("            bool taken = false;\n")
+		g.pf("            int64_t slot = 0;\n")
+		g.pf("            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );\n")
+		g.pf("            if ( entry == NULL ) { return false; } // the map could not grow\n")
+		g.pf("            if ( !taken )\n            {\n")
+		g.pf("                if ( entry->open != 0 ) { return false; } // a data cycle\n")
+		g.pf("                dst.%s.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.%s ); // the one body it already has\n", f.Name, f.Name)
+		g.pf("            }\n            else\n            {\n")
+		g.pf("                if ( at + (int64_t) sizeof( %s ) > capacity ) { return false; }\n", t)
+		g.pf("                used = at + TableAlignUp64( (int64_t) sizeof( %s ) );\n", t)
+		g.pf("                %s * child = new ( base + at ) %s; // lifetime only: the Pack below memcpy's the whole node over it\n", t, t)
+		g.pf("                dst.%s.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.%s );\n", f.Name, f.Name)
+		g.pf("                if ( !%sPack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }\n", t)
+		g.pf("                TablePackMapClose( seen, (const void *) pointee, slot );\n")
+		g.pf("            }\n")
 		g.pf("        }\n    }\n")
 	}
 	for _, f := range g.byValueVariableFields(st) {
@@ -318,7 +341,7 @@ func (g *tableGen) emitPack(st *ir.Struct) {
 func (g *tableGen) emitVariableByValueWalkPack(f *ir.Field) {
 	t := f.Type.Name
 	call := func(srcExpr, dstExpr string) {
-		g.pf("        if ( !%sPack( ctx, %s, %s, base, capacity, used, depth ) ) { return false; }\n", t, srcExpr, dstExpr)
+		g.pf("        if ( !%sPack( ctx, seen, %s, %s, base, capacity, used, depth ) ) { return false; }\n", t, srcExpr, dstExpr)
 	}
 	switch f.Array {
 	case ir.ArrayNone:
@@ -484,16 +507,34 @@ func (g *tableGen) emitBuilderAndPublicSurface(st *ir.Struct) {
 	g.pf("    if ( root_ref.null() ) { return false; }\n")
 	g.pf("    TableArenaCtx ctx = { &arena };\n")
 	g.pf("    const %s & root = *(const %s *) TableArenaAt( arena, (uint32_t) root_ref.value );\n", n, n)
-	g.pf("    int64_t below = %sPackMeasure( ctx, root, 1 );\n", n)
-	g.pf("    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth\n")
+	g.pf("    // The ROOT takes the map's first entry: it is packed at offset 0, and its\n")
+	g.pf("    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).\n")
+	g.pf("    TablePackMap seen;\n")
+	g.pf("    TablePackMapInit( seen );\n")
+	g.pf("    bool root_taken = false;\n")
+	g.pf("    int64_t root_slot = 0;\n")
+	g.pf("    int64_t below = -1;\n")
+	g.pf("    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )\n    {\n")
+	g.pf("        below = %sPackMeasure( ctx, seen, root, 1 );\n", n)
+	g.pf("    }\n")
+	g.pf("    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth\n")
 	g.pf("    int64_t total = TableAlignUp64( (int64_t) sizeof( %s ) ) + below;\n", n)
 	g.pf("    uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate\n")
-	g.pf("    if ( packed == NULL ) { return false; }\n")
+	g.pf("    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }\n")
 	g.pf("    memset( packed, 0, (size_t) total );\n")
 	g.pf("    int64_t used = TableAlignUp64( (int64_t) sizeof( %s ) );\n", n)
 	g.pf("    %s * destination = new ( packed ) %s; // lifetime only: the Pack below memcpy's the whole node over it\n", n, n)
-	g.pf("    if ( !%sPack( ctx, root, *destination, packed, total, used, 1 ) || used != total )\n    {\n", n)
+	g.pf("    // The pack walk RE-DERIVES the same numbering rather than carrying the\n")
+	g.pf("    // measure's — nothing passes between them, which is what makes\n")
+	g.pf("    // `used == total` below a real check and not a tautology (§3.1). The\n")
+	g.pf("    // map keeps the capacity the measure paid for, so the second walk\n")
+	g.pf("    // rehashes nothing.\n")
+	g.pf("    TablePackMapReset( seen );\n")
+	g.pf("    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||\n")
+	g.pf("         !%sPack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )\n    {\n", n)
+	g.pf("        TablePackMapShutdown( seen );\n")
 	g.pf("        free( packed );\n        return false;\n    }\n")
+	g.pf("    TablePackMapShutdown( seen );\n")
 	g.pf("    region = packed;\n")
 	g.pf("    region_bytes = total;\n")
 	g.pf("    arena.locked = true; // MONOTONIC: there is no unlock\n")

--- a/internal/tablenames/tablenames.go
+++ b/internal/tablenames/tablenames.go
@@ -154,6 +154,13 @@ var registry = []Name{
 	{Name: "TableWorker", By: Cpp, What: "a builder worker's allocation front"},
 	{Name: "TableBuilder", By: Cpp, What: "the mutable life's base"},
 	{Name: "TableRegion", By: Cpp, What: "the locked, packed region"},
+	// Lock's identity map (docs/SPEC-TABLES.md §6.2): one entry per reachable
+	// node, so a shared node is packed once and a reference to a node whose
+	// descent is still open is a cycle. Emitted into a pointered unit's header
+	// only, and claimed on the same terms as everything above — a name free
+	// today must not become a collision the day a table gains a pointer.
+	{Name: "TablePackMap", By: Cpp, What: "the pack walk's identity map"},
+	{Name: "TablePackEntry", By: Cpp, What: "one node's entry in it: where it landed, and whether its descent is open"},
 
 	// the BLOCK FORM's runtime (docs/SPEC-TABLES.md §19), emitted into
 	// <Base>Block.h / <Base>Block.cs and into no Table source at all. Claimed

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -1326,56 +1326,175 @@ static void test_lock_layout_stable()
     CHECK( memcmp( first.Region(), second.Region(), (size_t) first.RegionBytes() ) == 0 );
 }
 
-// ---- aliasing: two pointers to one node are TWO nodes, everywhere ----
+// ---- a SHARED node is packed ONCE, and identity survives Lock ----
+//
+// docs/SPEC-TABLES.md §6.2: Lock's walk carries one entry per node, so it
+// terminates in one visit per node and a shared node is packed ONCE. §6.3: a
+// node's FIRST reference points forward and every later reference points BACK
+// at the one body it already has, so a region delta has no required sign.
+//
+// THE REGION BYTE COUNT IS THE MEASUREMENT. Two pointers reading equal could
+// be an accident of layout; a region exactly the size of a once-packed graph
+// could not be produced by a pack that duplicates.
 
-static void test_pointer_alias()
+static int64_t scene_bytes() { return graphdemo::TableAlignUp64( (int64_t) sizeof( graphdemo::Scene ) ); }
+static int64_t list_node_bytes() { return graphdemo::TableAlignUp64( (int64_t) sizeof( graphdemo::ListNode ) ); }
+static int64_t tree_node_bytes() { return graphdemo::TableAlignUp64( (int64_t) sizeof( graphdemo::TreeNode ) ); }
+
+static void test_pointer_shared_node()
 {
-    graphdemo::SceneBuilder builder;
-    graphdemo::Scene * root = builder.GetRoot();
-    graphdemo::TableSlot<graphdemo::ListNode> shared = builder.Alloc<graphdemo::ListNode>();
-    shared->value = 1234;
-    root->head = shared;
-    root->alias = shared; // the SAME node named twice
+    // TWO REFERENCES, ONE NODE — the second reference is read from the root
+    // itself, so it points FORWARD at a node already placed
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.GetRoot();
+        graphdemo::TableSlot<graphdemo::ListNode> shared = builder.Alloc<graphdemo::ListNode>();
+        shared->value = 1234;
+        root->head = shared;
+        root->alias = shared; // the SAME node named twice
 
-    CHECK( builder.Lock() );
-    const graphdemo::Scene * locked = builder.AsConst();
-    const graphdemo::ListNode * viaHead = graphdemo::ListNodeAt( locked->head );
-    const graphdemo::ListNode * viaAlias = graphdemo::ListNodeAt( locked->alias );
-    CHECK( viaHead != NULL && viaAlias != NULL );
-    CHECK( viaHead->value == 1234 && viaAlias->value == 1234 );
-    // wire v1 is a TREE: identity is NOT preserved, and the packed form says so
-    // in the same voice — two references, two nodes (docs/SPEC-TABLES.md §3)
-    CHECK( viaHead != viaAlias );
+        CHECK( builder.Lock() );
+        const graphdemo::Scene * locked = builder.AsConst();
+        const graphdemo::ListNode * viaHead = graphdemo::ListNodeAt( locked->head );
+        const graphdemo::ListNode * viaAlias = graphdemo::ListNodeAt( locked->alias );
+        CHECK( viaHead != NULL && viaAlias != NULL );
+        CHECK( viaHead == viaAlias ); // ONE node, named twice
+        CHECK( viaHead->value == 1234 );
+        CHECK( builder.RegionBytes() == scene_bytes() + list_node_bytes() ); // one body, not two
+    }
 
-    static uint8_t wire[1024];
-    int64_t wrote = graphdemo::SceneSave( locked, wire, sizeof( wire ) );
-    CHECK( wrote > 0 );
-    int64_t region_need = graphdemo::SceneLoadMeasure( wire, wrote );
-    uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
-    graphdemo::TableReport report;
-    const graphdemo::Scene * loaded = graphdemo::SceneLoad( region, region_need, wire, wrote, &report );
-    CHECK( loaded != NULL && !report.malformed );
-    CHECK( graphdemo::ListNodeAt( loaded->head )->value == 1234 );
-    CHECK( graphdemo::ListNodeAt( loaded->alias )->value == 1234 );
-    CHECK( graphdemo::ListNodeAt( loaded->head ) != graphdemo::ListNodeAt( loaded->alias ) );
-    free( region );
+    // A SHARED NODE REACHED THROUGH A CHAIN: the root names it a second time
+    // after the chain has already placed it
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.GetRoot();
+        graphdemo::TableSlot<graphdemo::ListNode> first = builder.Alloc<graphdemo::ListNode>();
+        graphdemo::TableSlot<graphdemo::ListNode> shared = builder.Alloc<graphdemo::ListNode>();
+        first->value = 1;
+        shared->value = 2;
+        first->next = shared;
+        root->head = first;
+        root->alias = shared;
+
+        CHECK( builder.Lock() );
+        const graphdemo::Scene * locked = builder.AsConst();
+        const graphdemo::ListNode * head = graphdemo::ListNodeAt( locked->head );
+        CHECK( head != NULL && head->value == 1 );
+        CHECK( graphdemo::ListNodeAt( head->next ) == graphdemo::ListNodeAt( locked->alias ) );
+        CHECK( graphdemo::ListNodeAt( locked->alias )->value == 2 );
+        CHECK( builder.RegionBytes() == scene_bytes() + 2 * list_node_bytes() );
+    }
+
+    // A DIAMOND: the closing reference lives in a node packed AFTER the shared
+    // one, so its delta is NEGATIVE — sharing and a back-reference are one
+    // fact, and nothing validates a reference by its sign (§6.3)
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.GetRoot();
+        graphdemo::TableSlot<graphdemo::TreeNode> top = builder.Alloc<graphdemo::TreeNode>();
+        graphdemo::TableSlot<graphdemo::TreeNode> left = builder.Alloc<graphdemo::TreeNode>();
+        graphdemo::TableSlot<graphdemo::TreeNode> right = builder.Alloc<graphdemo::TreeNode>();
+        graphdemo::TableSlot<graphdemo::TreeNode> shared = builder.Alloc<graphdemo::TreeNode>();
+        set_string( shared->label, shared->label_length, "shared" );
+        top->left = left;
+        top->right = right;
+        left->left = shared;
+        right->left = shared; // the diamond closes
+        root->tree = top;
+
+        CHECK( builder.Lock() );
+        const graphdemo::Scene * locked = builder.AsConst();
+        const graphdemo::TreeNode * t = graphdemo::TreeNodeAt( locked->tree );
+        CHECK( t != NULL );
+        const graphdemo::TreeNode * l = graphdemo::TreeNodeAt( t->left );
+        const graphdemo::TreeNode * r = graphdemo::TreeNodeAt( t->right );
+        CHECK( l != NULL && r != NULL );
+        CHECK( graphdemo::TreeNodeAt( l->left ) == graphdemo::TreeNodeAt( r->left ) );
+        CHECK( strcmp( graphdemo::TreeNodeAt( r->left )->label, "shared" ) == 0 );
+        CHECK( r->left.value < 0 ); // the later reference points BACK
+        CHECK( builder.RegionBytes() == scene_bytes() + 4 * tree_node_bytes() ); // four nodes, not five
+
+        // a region holding a back-reference still relocates by pure memcpy
+        uint8_t * moved = (uint8_t *) malloc( (size_t) builder.RegionBytes() );
+        memcpy( moved, builder.Region(), (size_t) builder.RegionBytes() );
+        const graphdemo::Scene * copy = (const graphdemo::Scene *) moved;
+        const graphdemo::TreeNode * mt = graphdemo::TreeNodeAt( copy->tree );
+        CHECK( graphdemo::TreeNodeAt( graphdemo::TreeNodeAt( mt->left )->left ) ==
+               graphdemo::TreeNodeAt( graphdemo::TreeNodeAt( mt->right )->left ) );
+        free( moved );
+    }
+
+    // THE WIRE IS STILL THE NESTED FORM, and this says so in its own voice:
+    // the C++ backend writes a pointee inline under kind 13, not as a u32
+    // index into a flat node table, so a save duplicates a shared node and a
+    // load reconstructs two. §3.1's backend status states the limitation and
+    // schema#251 carries the emitter to the flat form; Lock, above, is done.
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.GetRoot();
+        graphdemo::TableSlot<graphdemo::ListNode> shared = builder.Alloc<graphdemo::ListNode>();
+        shared->value = 1234;
+        root->head = shared;
+        root->alias = shared;
+        CHECK( builder.Lock() );
+
+        static uint8_t wire[1024];
+        int64_t wrote = graphdemo::SceneSave( builder.AsConst(), wire, sizeof( wire ) );
+        CHECK( wrote > 0 );
+        int64_t region_need = graphdemo::SceneLoadMeasure( wire, wrote );
+        uint8_t * region = (uint8_t *) malloc( (size_t) region_need );
+        graphdemo::TableReport report;
+        const graphdemo::Scene * loaded = graphdemo::SceneLoad( region, region_need, wire, wrote, &report );
+        CHECK( loaded != NULL && !report.malformed );
+        CHECK( graphdemo::ListNodeAt( loaded->head )->value == 1234 );
+        CHECK( graphdemo::ListNodeAt( loaded->alias )->value == 1234 );
+        CHECK( graphdemo::ListNodeAt( loaded->head ) != graphdemo::ListNodeAt( loaded->alias ) );
+        free( region );
+    }
 }
 
 // ---- a data cycle is an ERROR, never a hang ----
+//
+// Lock now carries the identity map (§3.1), so its refusal is the map's and
+// not the depth cap's: a reference to a node whose descent is still OPEN is a
+// cycle. The map is what makes a shared node one node, and the same one bit
+// is what tells a shared node apart from a cycle.
 
 static void test_pointer_cycle_refused()
 {
-    graphdemo::SceneBuilder builder;
-    graphdemo::Scene * root = builder.GetRoot();
-    graphdemo::TableSlot<graphdemo::ListNode> loop = builder.Alloc<graphdemo::ListNode>();
-    loop->value = 1;
-    loop->next = loop;   // a node pointing at itself
-    root->head = loop;
+    // a node pointing at itself
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.GetRoot();
+        graphdemo::TableSlot<graphdemo::ListNode> loop = builder.Alloc<graphdemo::ListNode>();
+        loop->value = 1;
+        loop->next = loop;
+        root->head = loop;
 
-    static uint8_t buffer[4096];
-    CHECK( graphdemo::SceneMeasure( builder ) == -1 );
-    CHECK( graphdemo::SceneSave( builder, buffer, sizeof( buffer ) ) == -1 );
-    CHECK( !builder.Lock() ); // the compaction refuses too
+        static uint8_t buffer[4096];
+        CHECK( graphdemo::SceneMeasure( builder ) == -1 );
+        CHECK( graphdemo::SceneSave( builder, buffer, sizeof( buffer ) ) == -1 );
+        CHECK( !builder.Lock() ); // the compaction refuses too
+    }
+    // a two-node cycle: the closing reference names a node the walk is still
+    // inside, which a shared-node map must not mistake for sharing
+    {
+        graphdemo::SceneBuilder builder;
+        graphdemo::Scene * root = builder.GetRoot();
+        graphdemo::TableSlot<graphdemo::ListNode> a = builder.Alloc<graphdemo::ListNode>();
+        graphdemo::TableSlot<graphdemo::ListNode> b = builder.Alloc<graphdemo::ListNode>();
+        a->value = 1;
+        b->value = 2;
+        a->next = b;
+        b->next = a;
+        root->head = a;
+
+        static uint8_t buffer[4096];
+        CHECK( graphdemo::SceneMeasure( builder ) == -1 );
+        CHECK( graphdemo::SceneSave( builder, buffer, sizeof( buffer ) ) == -1 );
+        CHECK( !builder.Lock() );
+        CHECK( builder.AsConst() == NULL ); // nothing partial is published
+    }
 }
 
 // ---- the depth cap: a chain past it refuses, and the wire stops at it ----
@@ -5041,7 +5160,7 @@ int main()
 
     test_pointer_lifecycle();
     test_lock_layout_stable();
-    test_pointer_alias();
+    test_pointer_shared_node();
     test_pointer_cycle_refused();
     test_pointer_depth_cap();
     test_builder_grow();

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -366,11 +366,15 @@ static const uint32_t kTableAlign       = 8;                           // every 
 static const uint32_t kTableAllocFailed = 0xFFFFFFFFu;
 
 // The pointer-chain depth cap. It bounds recursion on every walk — measure,
-// save, load and pack — so a data cycle is an ERROR and never a hang, and a
-// hostile wire cannot drive the C stack into the ground. A pointer chain's
-// WIRE nesting equals its length (§3), so this also caps chain length: wide
-// structures are unbounded, deep ones are not. Lifting it wants a flat,
-// indexed node encoding — a named follow-on (§15).
+// save, load and pack — so a hostile wire cannot drive the C stack into the
+// ground. A pointer chain's WIRE nesting equals its length (§3), so this also
+// caps chain length: wide structures are unbounded, deep ones are not. Lifting
+// it wants a flat, indexed node encoding — a named follow-on (§15).
+//
+// It is not what refuses a DATA CYCLE on the pack walk: TablePackMap's open
+// colouring names that cycle at the reference that closes it (§3.1). The cap
+// is still the whole of the cycle answer on the wire walks, which carry no
+// map today (§3.1's backend status).
 static const int32_t kTableMaxDepth = 128;
 
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
@@ -571,6 +575,148 @@ struct TableWorker
         return slot;
     }
 };
+
+// ---- TablePackMap: the pack walk's identity map (docs/SPEC-TABLES.md §3.1, §6.2) ----
+//
+// ONE ENTRY PER REACHABLE NODE, and that map IS identity: a node must know
+// where it landed to be named a second time, so Lock packs a shared node ONCE
+// and every later reference resolves to the one body it already has. That is
+// the same first-visit numbering the wire uses, so the pack order and the node
+// order are one order.
+//
+// COLOURING AN ENTRY WHILE ITS DESCENT IS OPEN COSTS ONE BIT, and it is what
+// makes a data cycle free to refuse: a reference to an entry still open is a
+// cycle, and Lock returns failure rather than recursing away. The ROOT's entry
+// is open for the whole walk.
+//
+// The map is proportional to NODES, never to bytes, and it lives on the
+// AUTHORING side, where §6.5 licenses allocation. Nothing on the reading path
+// ever builds one.
+struct TablePackEntry
+{
+    const void * key;   // the node's address in the graph being packed
+    int64_t offset;     // where that node landed in the region
+    uint8_t open;       // its descent is still open: a reference here is a cycle
+};
+
+struct TablePackMap
+{
+    TablePackEntry * entries = NULL;
+    int64_t capacity = 0; // a power of two, or zero while empty
+    int64_t count = 0;
+};
+
+inline void TablePackMapInit( TablePackMap & map )
+{
+    map.entries = NULL;
+    map.capacity = 0;
+    map.count = 0;
+}
+
+inline void TablePackMapShutdown( TablePackMap & map )
+{
+    free( map.entries );
+    TablePackMapInit( map );
+}
+
+// The two walks behind Lock re-derive the SAME map from the same graph — the
+// numbering is never carried between them (§3.1) — so the second starts from
+// an empty map and keeps the capacity the first paid for.
+inline void TablePackMapReset( TablePackMap & map )
+{
+    if ( map.entries != NULL ) { memset( map.entries, 0, (size_t) map.capacity * sizeof( TablePackEntry ) ); }
+    map.count = 0;
+}
+
+// open addressing, linear probing, a multiply-shift hash over the address: a
+// node key is a pointer and its low bits are alignment, so the low bits alone
+// would collide on every node of one type
+inline int64_t TablePackMapSlot( const TablePackMap & map, const void * key )
+{
+    uint64_t hash = (uint64_t) (uintptr_t) key;
+    hash *= 0x9E3779B97F4A7C15ull;
+    hash ^= hash >> 29;
+    int64_t mask = map.capacity - 1;
+    int64_t at = (int64_t) ( hash & (uint64_t) mask );
+    while ( map.entries[at].key != NULL && map.entries[at].key != key )
+    {
+        at = ( at + 1 ) & mask;
+    }
+    return at;
+}
+
+inline TablePackEntry * TablePackMapFind( TablePackMap & map, const void * key )
+{
+    if ( map.capacity == 0 ) { return NULL; }
+    TablePackEntry * entry = &map.entries[ TablePackMapSlot( map, key ) ];
+    return entry->key == key ? entry : NULL;
+}
+
+// QUADRUPLING, not doubling, and the reason is measured: growth rehashes every
+// entry, and on a graph of 131,071 nodes the doubling schedule spent 45% of
+// Lock in rehashing alone. Quadrupling from 1024 buys 1.35x on that graph and
+// keeps the map NODE-proportional (§6.2) — under 128 bytes a node at its
+// worst, right after a grow, and about 64 on average.
+inline bool TablePackMapGrow( TablePackMap & map )
+{
+    TablePackMap grown;
+    grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
+    grown.entries = (TablePackEntry *) calloc( (size_t) grown.capacity, sizeof( TablePackEntry ) );
+    if ( grown.entries == NULL ) { return false; }
+    for ( int64_t i = 0; i < map.capacity; i++ )
+    {
+        if ( map.entries[i].key == NULL ) { continue; }
+        grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
+        grown.count++;
+    }
+    free( map.entries );
+    map = grown;
+    return true;
+}
+
+// REACH a node: one probe answers both questions the walk has. A true "taken"
+// says this is a FIRST visit, and the entry is now the node's, coloured open
+// at "offset"; otherwise the entry is the one the node already has, and its
+// open bit says cycle or sharing. NULL is an allocation failure, and it is a
+// refusal like any other: Lock fails rather than packing a graph it cannot
+// track.
+//
+// It is one call and not a find followed by an insert because the walk asks
+// this question twice per node — once to measure, once to pack — and every
+// probe is a miss into a table larger than L2.
+inline TablePackEntry * TablePackMapReach( TablePackMap & map, const void * key, int64_t offset, bool & taken, int64_t & slot )
+{
+    if ( ( map.count + 1 ) * 4 >= map.capacity * 3 ) // keep the load factor under three quarters
+    {
+        if ( !TablePackMapGrow( map ) ) { return NULL; }
+    }
+    slot = TablePackMapSlot( map, key );
+    TablePackEntry * entry = &map.entries[slot];
+    taken = entry->key != key; // an empty slot is a first visit; the key is never NULL
+    if ( taken )
+    {
+        entry->key = key;
+        entry->offset = offset;
+        entry->open = 1;
+        map.count++;
+    }
+    return entry;
+}
+
+// The descent finished: the node keeps its entry — identity outlives the
+// descent — and stops being a cycle. The "hint" is the slot Reach returned, and it
+// is checked against the key rather than trusted, so a rehash between the two
+// costs a second probe instead of correctness.
+inline void TablePackMapClose( TablePackMap & map, const void * key, int64_t hint )
+{
+    if ( hint >= 0 && hint < map.capacity && map.entries[hint].key == key )
+    {
+        map.entries[hint].open = 0;
+        return;
+    }
+    TablePackEntry * entry = TablePackMapFind( map, key );
+    if ( entry != NULL ) { entry->open = 0; }
+}
 
 // ---- resolution contexts: which encoding a walk is reading ----
 
@@ -1143,26 +1289,26 @@ template <typename Sink> inline bool AlbumLoadBody( TableReader & r, Sink & sink
 
 // ---- pointer-graph walkers: pack (Lock), size (Load) ----
 
-template <typename Ctx> inline int64_t SettingsPackMeasure( const Ctx & ctx, const Settings & value, int32_t depth );
-template <typename Ctx> inline bool SettingsPack( const Ctx & ctx, const Settings & src, Settings & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t SettingsPackMeasure( const Ctx & ctx, TablePackMap & seen, const Settings & value, int32_t depth );
+template <typename Ctx> inline bool SettingsPack( const Ctx & ctx, TablePackMap & seen, const Settings & src, Settings & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t SettingsLoadMeasureBody( TableReader & r, int32_t depth );
-template <typename Ctx> inline int64_t ListNodePackMeasure( const Ctx & ctx, const ListNode & value, int32_t depth );
-template <typename Ctx> inline bool ListNodePack( const Ctx & ctx, const ListNode & src, ListNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t ListNodePackMeasure( const Ctx & ctx, TablePackMap & seen, const ListNode & value, int32_t depth );
+template <typename Ctx> inline bool ListNodePack( const Ctx & ctx, TablePackMap & seen, const ListNode & src, ListNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t ListNodeLoadMeasureBody( TableReader & r, int32_t depth );
-template <typename Ctx> inline int64_t TreeNodePackMeasure( const Ctx & ctx, const TreeNode & value, int32_t depth );
-template <typename Ctx> inline bool TreeNodePack( const Ctx & ctx, const TreeNode & src, TreeNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t TreeNodePackMeasure( const Ctx & ctx, TablePackMap & seen, const TreeNode & value, int32_t depth );
+template <typename Ctx> inline bool TreeNodePack( const Ctx & ctx, TablePackMap & seen, const TreeNode & src, TreeNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t TreeNodeLoadMeasureBody( TableReader & r, int32_t depth );
-template <typename Ctx> inline int64_t LayerPackMeasure( const Ctx & ctx, const Layer & value, int32_t depth );
-template <typename Ctx> inline bool LayerPack( const Ctx & ctx, const Layer & src, Layer & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t LayerPackMeasure( const Ctx & ctx, TablePackMap & seen, const Layer & value, int32_t depth );
+template <typename Ctx> inline bool LayerPack( const Ctx & ctx, TablePackMap & seen, const Layer & src, Layer & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t LayerLoadMeasureBody( TableReader & r, int32_t depth );
-template <typename Ctx> inline int64_t ScenePackMeasure( const Ctx & ctx, const Scene & value, int32_t depth );
-template <typename Ctx> inline bool ScenePack( const Ctx & ctx, const Scene & src, Scene & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t ScenePackMeasure( const Ctx & ctx, TablePackMap & seen, const Scene & value, int32_t depth );
+template <typename Ctx> inline bool ScenePack( const Ctx & ctx, TablePackMap & seen, const Scene & src, Scene & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t SceneLoadMeasureBody( TableReader & r, int32_t depth );
-template <typename Ctx> inline int64_t DepotPackMeasure( const Ctx & ctx, const Depot & value, int32_t depth );
-template <typename Ctx> inline bool DepotPack( const Ctx & ctx, const Depot & src, Depot & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t DepotPackMeasure( const Ctx & ctx, TablePackMap & seen, const Depot & value, int32_t depth );
+template <typename Ctx> inline bool DepotPack( const Ctx & ctx, TablePackMap & seen, const Depot & src, Depot & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t DepotLoadMeasureBody( TableReader & r, int32_t depth );
-template <typename Ctx> inline int64_t AlbumPackMeasure( const Ctx & ctx, const Album & value, int32_t depth );
-template <typename Ctx> inline bool AlbumPack( const Ctx & ctx, const Album & src, Album & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t AlbumPackMeasure( const Ctx & ctx, TablePackMap & seen, const Album & value, int32_t depth );
+template <typename Ctx> inline bool AlbumPack( const Ctx & ctx, TablePackMap & seen, const Album & src, Album & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t AlbumLoadMeasureBody( TableReader & r, int32_t depth );
 
 inline int64_t MetaMeasure( const Meta & value )
@@ -2769,29 +2915,33 @@ inline bool AlbumLoadBody( TableReader & r, Sink & sink, Album & value, int32_t 
 }
 
 // SettingsPackMeasure: the packed region bytes of everything Settings POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t SettingsPackMeasure( const Ctx & ctx, const Settings & value, int32_t depth )
+inline int64_t SettingsPackMeasure( const Ctx & ctx, TablePackMap & seen, const Settings & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
-    (void) ctx; (void) value; // no pointers below this node
+    (void) ctx; (void) seen; (void) value; // no pointers below this node
     return bytes;
 }
 
 // SettingsPack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool SettingsPack( const Ctx & ctx, const Settings & src, Settings & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool SettingsPack( const Ctx & ctx, TablePackMap & seen, const Settings & src, Settings & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( Settings ) ); // trivially copyable, by construction
-    (void) ctx; (void) base; (void) capacity; (void) used;
+    (void) ctx; (void) seen; (void) base; (void) capacity; (void) used;
     return true;
 }
 
@@ -2806,20 +2956,33 @@ inline int64_t SettingsLoadMeasureBody( TableReader & r, int32_t depth )
 }
 
 // ListNodePackMeasure: the packed region bytes of everything ListNode POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t ListNodePackMeasure( const Ctx & ctx, const ListNode & value, int32_t depth )
+inline int64_t ListNodePackMeasure( const Ctx & ctx, TablePackMap & seen, const ListNode & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
     {
         const ListNode * pointee = ListNodeAt( ctx, value.next ); // next
         if ( pointee != NULL )
         {
-            int64_t inner = ListNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = ListNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            }
         }
     }
     return bytes;
@@ -2828,11 +2991,14 @@ inline int64_t ListNodePackMeasure( const Ctx & ctx, const ListNode & value, int
 // ListNodePack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool ListNodePack( const Ctx & ctx, const ListNode & src, ListNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool ListNodePack( const Ctx & ctx, TablePackMap & seen, const ListNode & src, ListNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( ListNode ) ); // trivially copyable, by construction
@@ -2841,12 +3007,25 @@ inline bool ListNodePack( const Ctx & ctx, const ListNode & src, ListNode & dst,
         const ListNode * pointee = ListNodeAt( ctx, src.next );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
-            ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.next.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.next );
-            if ( !ListNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.next.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.next ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
+                ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.next.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.next );
+                if ( !ListNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     return true;
@@ -2892,29 +3071,54 @@ inline int64_t ListNodeLoadMeasureBody( TableReader & r, int32_t depth )
 }
 
 // TreeNodePackMeasure: the packed region bytes of everything TreeNode POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t TreeNodePackMeasure( const Ctx & ctx, const TreeNode & value, int32_t depth )
+inline int64_t TreeNodePackMeasure( const Ctx & ctx, TablePackMap & seen, const TreeNode & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
     {
         const TreeNode * pointee = TreeNodeAt( ctx, value.left ); // left
         if ( pointee != NULL )
         {
-            int64_t inner = TreeNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( TreeNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = TreeNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( TreeNode ) ) + inner;
+            }
         }
     }
     {
         const TreeNode * pointee = TreeNodeAt( ctx, value.right ); // right
         if ( pointee != NULL )
         {
-            int64_t inner = TreeNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( TreeNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = TreeNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( TreeNode ) ) + inner;
+            }
         }
     }
     return bytes;
@@ -2923,11 +3127,14 @@ inline int64_t TreeNodePackMeasure( const Ctx & ctx, const TreeNode & value, int
 // TreeNodePack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool TreeNodePack( const Ctx & ctx, const TreeNode & src, TreeNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool TreeNodePack( const Ctx & ctx, TablePackMap & seen, const TreeNode & src, TreeNode & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( TreeNode ) ); // trivially copyable, by construction
@@ -2936,12 +3143,25 @@ inline bool TreeNodePack( const Ctx & ctx, const TreeNode & src, TreeNode & dst,
         const TreeNode * pointee = TreeNodeAt( ctx, src.left );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( TreeNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( TreeNode ) );
-            TreeNode * child = new ( base + at ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.left.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.left );
-            if ( !TreeNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.left.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.left ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( TreeNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( TreeNode ) );
+                TreeNode * child = new ( base + at ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.left.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.left );
+                if ( !TreeNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     {
@@ -2949,12 +3169,25 @@ inline bool TreeNodePack( const Ctx & ctx, const TreeNode & src, TreeNode & dst,
         const TreeNode * pointee = TreeNodeAt( ctx, src.right );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( TreeNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( TreeNode ) );
-            TreeNode * child = new ( base + at ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.right.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.right );
-            if ( !TreeNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.right.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.right ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( TreeNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( TreeNode ) );
+                TreeNode * child = new ( base + at ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.right.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.right );
+                if ( !TreeNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     return true;
@@ -3015,20 +3248,33 @@ inline int64_t TreeNodeLoadMeasureBody( TableReader & r, int32_t depth )
 }
 
 // LayerPackMeasure: the packed region bytes of everything Layer POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t LayerPackMeasure( const Ctx & ctx, const Layer & value, int32_t depth )
+inline int64_t LayerPackMeasure( const Ctx & ctx, TablePackMap & seen, const Layer & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
     {
         const ListNode * pointee = ListNodeAt( ctx, value.head ); // head
         if ( pointee != NULL )
         {
-            int64_t inner = ListNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = ListNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            }
         }
     }
     return bytes;
@@ -3037,11 +3283,14 @@ inline int64_t LayerPackMeasure( const Ctx & ctx, const Layer & value, int32_t d
 // LayerPack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool LayerPack( const Ctx & ctx, const Layer & src, Layer & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool LayerPack( const Ctx & ctx, TablePackMap & seen, const Layer & src, Layer & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( Layer ) ); // trivially copyable, by construction
@@ -3050,12 +3299,25 @@ inline bool LayerPack( const Ctx & ctx, const Layer & src, Layer & dst, uint8_t 
         const ListNode * pointee = ListNodeAt( ctx, src.head );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
-            ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
-            if ( !ListNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.head.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.head ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
+                ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
+                if ( !ListNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     return true;
@@ -3101,57 +3363,106 @@ inline int64_t LayerLoadMeasureBody( TableReader & r, int32_t depth )
 }
 
 // ScenePackMeasure: the packed region bytes of everything Scene POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t ScenePackMeasure( const Ctx & ctx, const Scene & value, int32_t depth )
+inline int64_t ScenePackMeasure( const Ctx & ctx, TablePackMap & seen, const Scene & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
     {
         const ListNode * pointee = ListNodeAt( ctx, value.head ); // head
         if ( pointee != NULL )
         {
-            int64_t inner = ListNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = ListNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            }
         }
     }
     {
         const TreeNode * pointee = TreeNodeAt( ctx, value.tree ); // tree
         if ( pointee != NULL )
         {
-            int64_t inner = TreeNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( TreeNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = TreeNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( TreeNode ) ) + inner;
+            }
         }
     }
     {
         const Settings * pointee = SettingsAt( ctx, value.settings ); // settings
         if ( pointee != NULL )
         {
-            int64_t inner = SettingsPackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( Settings ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = SettingsPackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( Settings ) ) + inner;
+            }
         }
     }
     {
         const ListNode * pointee = ListNodeAt( ctx, value.alias ); // alias
         if ( pointee != NULL )
         {
-            int64_t inner = ListNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = ListNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            }
         }
     }
     { // ground (nested by value)
-        int64_t inner = LayerPackMeasure( ctx, value.ground, depth );
+        int64_t inner = LayerPackMeasure( ctx, seen, value.ground, depth );
         if ( inner < 0 ) { return -1; }
         bytes += inner;
     }
     for ( int32_t i = 0; i < value.layers_count && i < 4; i++ ) // layers
     {
-        int64_t inner = LayerPackMeasure( ctx, value.layers[i], depth );
+        int64_t inner = LayerPackMeasure( ctx, seen, value.layers[i], depth );
         if ( inner < 0 ) { return -1; }
         bytes += inner;
     }
@@ -3161,11 +3472,14 @@ inline int64_t ScenePackMeasure( const Ctx & ctx, const Scene & value, int32_t d
 // ScenePack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool ScenePack( const Ctx & ctx, const Scene & src, Scene & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool ScenePack( const Ctx & ctx, TablePackMap & seen, const Scene & src, Scene & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( Scene ) ); // trivially copyable, by construction
@@ -3174,12 +3488,25 @@ inline bool ScenePack( const Ctx & ctx, const Scene & src, Scene & dst, uint8_t 
         const ListNode * pointee = ListNodeAt( ctx, src.head );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
-            ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
-            if ( !ListNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.head.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.head ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
+                ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
+                if ( !ListNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     {
@@ -3187,12 +3514,25 @@ inline bool ScenePack( const Ctx & ctx, const Scene & src, Scene & dst, uint8_t 
         const TreeNode * pointee = TreeNodeAt( ctx, src.tree );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( TreeNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( TreeNode ) );
-            TreeNode * child = new ( base + at ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.tree.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.tree );
-            if ( !TreeNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.tree.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.tree ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( TreeNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( TreeNode ) );
+                TreeNode * child = new ( base + at ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.tree.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.tree );
+                if ( !TreeNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     {
@@ -3200,12 +3540,25 @@ inline bool ScenePack( const Ctx & ctx, const Scene & src, Scene & dst, uint8_t 
         const Settings * pointee = SettingsAt( ctx, src.settings );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( Settings ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( Settings ) );
-            Settings * child = new ( base + at ) Settings; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.settings.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.settings );
-            if ( !SettingsPack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.settings.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.settings ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( Settings ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( Settings ) );
+                Settings * child = new ( base + at ) Settings; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.settings.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.settings );
+                if ( !SettingsPack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     {
@@ -3213,20 +3566,33 @@ inline bool ScenePack( const Ctx & ctx, const Scene & src, Scene & dst, uint8_t 
         const ListNode * pointee = ListNodeAt( ctx, src.alias );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
-            ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.alias.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.alias );
-            if ( !ListNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.alias.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.alias ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
+                ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.alias.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.alias );
+                if ( !ListNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     { // ground (nested by value)
-        if ( !LayerPack( ctx, src.ground, dst.ground, base, capacity, used, depth ) ) { return false; }
+        if ( !LayerPack( ctx, seen, src.ground, dst.ground, base, capacity, used, depth ) ) { return false; }
     }
     for ( int32_t i = 0; i < src.layers_count && i < 4; i++ ) // layers
     {
-        if ( !LayerPack( ctx, src.layers[i], dst.layers[i], base, capacity, used, depth ) ) { return false; }
+        if ( !LayerPack( ctx, seen, src.layers[i], dst.layers[i], base, capacity, used, depth ) ) { return false; }
     }
     return true;
 }
@@ -3355,25 +3721,38 @@ inline int64_t SceneLoadMeasureBody( TableReader & r, int32_t depth )
 }
 
 // DepotPackMeasure: the packed region bytes of everything Depot POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t DepotPackMeasure( const Ctx & ctx, const Depot & value, int32_t depth )
+inline int64_t DepotPackMeasure( const Ctx & ctx, TablePackMap & seen, const Depot & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
     {
         const ListNode * pointee = ListNodeAt( ctx, value.head ); // head
         if ( pointee != NULL )
         {
-            int64_t inner = ListNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = ListNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            }
         }
     }
     for ( int32_t i = 0; i < 2; i++ ) // banks
     {
-        int64_t inner = LayerPackMeasure( ctx, value.banks.slots[i], depth );
+        int64_t inner = LayerPackMeasure( ctx, seen, value.banks.slots[i], depth );
         if ( inner < 0 ) { return -1; }
         bytes += inner;
     }
@@ -3383,11 +3762,14 @@ inline int64_t DepotPackMeasure( const Ctx & ctx, const Depot & value, int32_t d
 // DepotPack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool DepotPack( const Ctx & ctx, const Depot & src, Depot & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool DepotPack( const Ctx & ctx, TablePackMap & seen, const Depot & src, Depot & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( Depot ) ); // trivially copyable, by construction
@@ -3396,17 +3778,30 @@ inline bool DepotPack( const Ctx & ctx, const Depot & src, Depot & dst, uint8_t 
         const ListNode * pointee = ListNodeAt( ctx, src.head );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
-            ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
-            if ( !ListNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.head.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.head ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
+                ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
+                if ( !ListNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     for ( int32_t i = 0; i < 2; i++ ) // banks
     {
-        if ( !LayerPack( ctx, src.banks.slots[i], dst.banks.slots[i], base, capacity, used, depth ) ) { return false; }
+        if ( !LayerPack( ctx, seen, src.banks.slots[i], dst.banks.slots[i], base, capacity, used, depth ) ) { return false; }
     }
     return true;
 }
@@ -3478,33 +3873,58 @@ inline int64_t DepotLoadMeasureBody( TableReader & r, int32_t depth )
 }
 
 // AlbumPackMeasure: the packed region bytes of everything Album POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t AlbumPackMeasure( const Ctx & ctx, const Album & value, int32_t depth )
+inline int64_t AlbumPackMeasure( const Ctx & ctx, TablePackMap & seen, const Album & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
     {
         const Marker * pointee = MarkerAt( ctx, value.pin ); // pin
         if ( pointee != NULL )
         {
-            int64_t inner = MarkerPackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( Marker ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = MarkerPackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( Marker ) ) + inner;
+            }
         }
     }
     {
         const ListNode * pointee = ListNodeAt( ctx, value.head ); // head
         if ( pointee != NULL )
         {
-            int64_t inner = ListNodePackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = ListNodePackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( ListNode ) ) + inner;
+            }
         }
     }
     { // marker (nested by value)
-        int64_t inner = MarkerPackMeasure( ctx, value.marker, depth );
+        int64_t inner = MarkerPackMeasure( ctx, seen, value.marker, depth );
         if ( inner < 0 ) { return -1; }
         bytes += inner;
     }
@@ -3514,11 +3934,14 @@ inline int64_t AlbumPackMeasure( const Ctx & ctx, const Album & value, int32_t d
 // AlbumPack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool AlbumPack( const Ctx & ctx, const Album & src, Album & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool AlbumPack( const Ctx & ctx, TablePackMap & seen, const Album & src, Album & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( Album ) ); // trivially copyable, by construction
@@ -3527,12 +3950,25 @@ inline bool AlbumPack( const Ctx & ctx, const Album & src, Album & dst, uint8_t 
         const Marker * pointee = MarkerAt( ctx, src.pin );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( Marker ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( Marker ) );
-            Marker * child = new ( base + at ) Marker; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.pin.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.pin );
-            if ( !MarkerPack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.pin.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.pin ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( Marker ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( Marker ) );
+                Marker * child = new ( base + at ) Marker; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.pin.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.pin );
+                if ( !MarkerPack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     {
@@ -3540,16 +3976,29 @@ inline bool AlbumPack( const Ctx & ctx, const Album & src, Album & dst, uint8_t 
         const ListNode * pointee = ListNodeAt( ctx, src.head );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
-            ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
-            if ( !ListNodePack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.head.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.head ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( ListNode ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( ListNode ) );
+                ListNode * child = new ( base + at ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.head.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.head );
+                if ( !ListNodePack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     { // marker (nested by value)
-        if ( !MarkerPack( ctx, src.marker, dst.marker, base, capacity, used, depth ) ) { return false; }
+        if ( !MarkerPack( ctx, seen, src.marker, dst.marker, base, capacity, used, depth ) ) { return false; }
     }
     return true;
 }
@@ -3682,19 +4131,38 @@ inline bool ListNodeBuilder::Lock()
     if ( root_ref.null() ) { return false; }
     TableArenaCtx ctx = { &arena };
     const ListNode & root = *(const ListNode *) TableArenaAt( arena, (uint32_t) root_ref.value );
-    int64_t below = ListNodePackMeasure( ctx, root, 1 );
-    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth
+    // The ROOT takes the map's first entry: it is packed at offset 0, and its
+    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).
+    TablePackMap seen;
+    TablePackMapInit( seen );
+    bool root_taken = false;
+    int64_t root_slot = 0;
+    int64_t below = -1;
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )
+    {
+        below = ListNodePackMeasure( ctx, seen, root, 1 );
+    }
+    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth
     int64_t total = TableAlignUp64( (int64_t) sizeof( ListNode ) ) + below;
     uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate
-    if ( packed == NULL ) { return false; }
+    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     memset( packed, 0, (size_t) total );
     int64_t used = TableAlignUp64( (int64_t) sizeof( ListNode ) );
     ListNode * destination = new ( packed ) ListNode; // lifetime only: the Pack below memcpy's the whole node over it
-    if ( !ListNodePack( ctx, root, *destination, packed, total, used, 1 ) || used != total )
+    // The pack walk RE-DERIVES the same numbering rather than carrying the
+    // measure's — nothing passes between them, which is what makes
+    // `used == total` below a real check and not a tautology (§3.1). The
+    // map keeps the capacity the measure paid for, so the second walk
+    // rehashes nothing.
+    TablePackMapReset( seen );
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||
+         !ListNodePack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )
     {
+        TablePackMapShutdown( seen );
         free( packed );
         return false;
     }
+    TablePackMapShutdown( seen );
     region = packed;
     region_bytes = total;
     arena.locked = true; // MONOTONIC: there is no unlock
@@ -3840,19 +4308,38 @@ inline bool TreeNodeBuilder::Lock()
     if ( root_ref.null() ) { return false; }
     TableArenaCtx ctx = { &arena };
     const TreeNode & root = *(const TreeNode *) TableArenaAt( arena, (uint32_t) root_ref.value );
-    int64_t below = TreeNodePackMeasure( ctx, root, 1 );
-    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth
+    // The ROOT takes the map's first entry: it is packed at offset 0, and its
+    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).
+    TablePackMap seen;
+    TablePackMapInit( seen );
+    bool root_taken = false;
+    int64_t root_slot = 0;
+    int64_t below = -1;
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )
+    {
+        below = TreeNodePackMeasure( ctx, seen, root, 1 );
+    }
+    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth
     int64_t total = TableAlignUp64( (int64_t) sizeof( TreeNode ) ) + below;
     uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate
-    if ( packed == NULL ) { return false; }
+    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     memset( packed, 0, (size_t) total );
     int64_t used = TableAlignUp64( (int64_t) sizeof( TreeNode ) );
     TreeNode * destination = new ( packed ) TreeNode; // lifetime only: the Pack below memcpy's the whole node over it
-    if ( !TreeNodePack( ctx, root, *destination, packed, total, used, 1 ) || used != total )
+    // The pack walk RE-DERIVES the same numbering rather than carrying the
+    // measure's — nothing passes between them, which is what makes
+    // `used == total` below a real check and not a tautology (§3.1). The
+    // map keeps the capacity the measure paid for, so the second walk
+    // rehashes nothing.
+    TablePackMapReset( seen );
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||
+         !TreeNodePack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )
     {
+        TablePackMapShutdown( seen );
         free( packed );
         return false;
     }
+    TablePackMapShutdown( seen );
     region = packed;
     region_bytes = total;
     arena.locked = true; // MONOTONIC: there is no unlock
@@ -3998,19 +4485,38 @@ inline bool LayerBuilder::Lock()
     if ( root_ref.null() ) { return false; }
     TableArenaCtx ctx = { &arena };
     const Layer & root = *(const Layer *) TableArenaAt( arena, (uint32_t) root_ref.value );
-    int64_t below = LayerPackMeasure( ctx, root, 1 );
-    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth
+    // The ROOT takes the map's first entry: it is packed at offset 0, and its
+    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).
+    TablePackMap seen;
+    TablePackMapInit( seen );
+    bool root_taken = false;
+    int64_t root_slot = 0;
+    int64_t below = -1;
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )
+    {
+        below = LayerPackMeasure( ctx, seen, root, 1 );
+    }
+    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth
     int64_t total = TableAlignUp64( (int64_t) sizeof( Layer ) ) + below;
     uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate
-    if ( packed == NULL ) { return false; }
+    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     memset( packed, 0, (size_t) total );
     int64_t used = TableAlignUp64( (int64_t) sizeof( Layer ) );
     Layer * destination = new ( packed ) Layer; // lifetime only: the Pack below memcpy's the whole node over it
-    if ( !LayerPack( ctx, root, *destination, packed, total, used, 1 ) || used != total )
+    // The pack walk RE-DERIVES the same numbering rather than carrying the
+    // measure's — nothing passes between them, which is what makes
+    // `used == total` below a real check and not a tautology (§3.1). The
+    // map keeps the capacity the measure paid for, so the second walk
+    // rehashes nothing.
+    TablePackMapReset( seen );
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||
+         !LayerPack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )
     {
+        TablePackMapShutdown( seen );
         free( packed );
         return false;
     }
+    TablePackMapShutdown( seen );
     region = packed;
     region_bytes = total;
     arena.locked = true; // MONOTONIC: there is no unlock
@@ -4156,19 +4662,38 @@ inline bool SceneBuilder::Lock()
     if ( root_ref.null() ) { return false; }
     TableArenaCtx ctx = { &arena };
     const Scene & root = *(const Scene *) TableArenaAt( arena, (uint32_t) root_ref.value );
-    int64_t below = ScenePackMeasure( ctx, root, 1 );
-    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth
+    // The ROOT takes the map's first entry: it is packed at offset 0, and its
+    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).
+    TablePackMap seen;
+    TablePackMapInit( seen );
+    bool root_taken = false;
+    int64_t root_slot = 0;
+    int64_t below = -1;
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )
+    {
+        below = ScenePackMeasure( ctx, seen, root, 1 );
+    }
+    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth
     int64_t total = TableAlignUp64( (int64_t) sizeof( Scene ) ) + below;
     uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate
-    if ( packed == NULL ) { return false; }
+    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     memset( packed, 0, (size_t) total );
     int64_t used = TableAlignUp64( (int64_t) sizeof( Scene ) );
     Scene * destination = new ( packed ) Scene; // lifetime only: the Pack below memcpy's the whole node over it
-    if ( !ScenePack( ctx, root, *destination, packed, total, used, 1 ) || used != total )
+    // The pack walk RE-DERIVES the same numbering rather than carrying the
+    // measure's — nothing passes between them, which is what makes
+    // `used == total` below a real check and not a tautology (§3.1). The
+    // map keeps the capacity the measure paid for, so the second walk
+    // rehashes nothing.
+    TablePackMapReset( seen );
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||
+         !ScenePack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )
     {
+        TablePackMapShutdown( seen );
         free( packed );
         return false;
     }
+    TablePackMapShutdown( seen );
     region = packed;
     region_bytes = total;
     arena.locked = true; // MONOTONIC: there is no unlock
@@ -4314,19 +4839,38 @@ inline bool DepotBuilder::Lock()
     if ( root_ref.null() ) { return false; }
     TableArenaCtx ctx = { &arena };
     const Depot & root = *(const Depot *) TableArenaAt( arena, (uint32_t) root_ref.value );
-    int64_t below = DepotPackMeasure( ctx, root, 1 );
-    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth
+    // The ROOT takes the map's first entry: it is packed at offset 0, and its
+    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).
+    TablePackMap seen;
+    TablePackMapInit( seen );
+    bool root_taken = false;
+    int64_t root_slot = 0;
+    int64_t below = -1;
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )
+    {
+        below = DepotPackMeasure( ctx, seen, root, 1 );
+    }
+    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth
     int64_t total = TableAlignUp64( (int64_t) sizeof( Depot ) ) + below;
     uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate
-    if ( packed == NULL ) { return false; }
+    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     memset( packed, 0, (size_t) total );
     int64_t used = TableAlignUp64( (int64_t) sizeof( Depot ) );
     Depot * destination = new ( packed ) Depot; // lifetime only: the Pack below memcpy's the whole node over it
-    if ( !DepotPack( ctx, root, *destination, packed, total, used, 1 ) || used != total )
+    // The pack walk RE-DERIVES the same numbering rather than carrying the
+    // measure's — nothing passes between them, which is what makes
+    // `used == total` below a real check and not a tautology (§3.1). The
+    // map keeps the capacity the measure paid for, so the second walk
+    // rehashes nothing.
+    TablePackMapReset( seen );
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||
+         !DepotPack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )
     {
+        TablePackMapShutdown( seen );
         free( packed );
         return false;
     }
+    TablePackMapShutdown( seen );
     region = packed;
     region_bytes = total;
     arena.locked = true; // MONOTONIC: there is no unlock
@@ -4472,19 +5016,38 @@ inline bool AlbumBuilder::Lock()
     if ( root_ref.null() ) { return false; }
     TableArenaCtx ctx = { &arena };
     const Album & root = *(const Album *) TableArenaAt( arena, (uint32_t) root_ref.value );
-    int64_t below = AlbumPackMeasure( ctx, root, 1 );
-    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth
+    // The ROOT takes the map's first entry: it is packed at offset 0, and its
+    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).
+    TablePackMap seen;
+    TablePackMapInit( seen );
+    bool root_taken = false;
+    int64_t root_slot = 0;
+    int64_t below = -1;
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )
+    {
+        below = AlbumPackMeasure( ctx, seen, root, 1 );
+    }
+    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth
     int64_t total = TableAlignUp64( (int64_t) sizeof( Album ) ) + below;
     uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate
-    if ( packed == NULL ) { return false; }
+    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     memset( packed, 0, (size_t) total );
     int64_t used = TableAlignUp64( (int64_t) sizeof( Album ) );
     Album * destination = new ( packed ) Album; // lifetime only: the Pack below memcpy's the whole node over it
-    if ( !AlbumPack( ctx, root, *destination, packed, total, used, 1 ) || used != total )
+    // The pack walk RE-DERIVES the same numbering rather than carrying the
+    // measure's — nothing passes between them, which is what makes
+    // `used == total` below a real check and not a tautology (§3.1). The
+    // map keeps the capacity the measure paid for, so the second walk
+    // rehashes nothing.
+    TablePackMapReset( seen );
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||
+         !AlbumPack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )
     {
+        TablePackMapShutdown( seen );
         free( packed );
         return false;
     }
+    TablePackMapShutdown( seen );
     region = packed;
     region_bytes = total;
     arena.locked = true; // MONOTONIC: there is no unlock

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -363,11 +363,15 @@ static const uint32_t kTableAlign       = 8;                           // every 
 static const uint32_t kTableAllocFailed = 0xFFFFFFFFu;
 
 // The pointer-chain depth cap. It bounds recursion on every walk — measure,
-// save, load and pack — so a data cycle is an ERROR and never a hang, and a
-// hostile wire cannot drive the C stack into the ground. A pointer chain's
-// WIRE nesting equals its length (§3), so this also caps chain length: wide
-// structures are unbounded, deep ones are not. Lifting it wants a flat,
-// indexed node encoding — a named follow-on (§15).
+// save, load and pack — so a hostile wire cannot drive the C stack into the
+// ground. A pointer chain's WIRE nesting equals its length (§3), so this also
+// caps chain length: wide structures are unbounded, deep ones are not. Lifting
+// it wants a flat, indexed node encoding — a named follow-on (§15).
+//
+// It is not what refuses a DATA CYCLE on the pack walk: TablePackMap's open
+// colouring names that cycle at the reference that closes it (§3.1). The cap
+// is still the whole of the cycle answer on the wire walks, which carry no
+// map today (§3.1's backend status).
 static const int32_t kTableMaxDepth = 128;
 
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
@@ -568,6 +572,148 @@ struct TableWorker
         return slot;
     }
 };
+
+// ---- TablePackMap: the pack walk's identity map (docs/SPEC-TABLES.md §3.1, §6.2) ----
+//
+// ONE ENTRY PER REACHABLE NODE, and that map IS identity: a node must know
+// where it landed to be named a second time, so Lock packs a shared node ONCE
+// and every later reference resolves to the one body it already has. That is
+// the same first-visit numbering the wire uses, so the pack order and the node
+// order are one order.
+//
+// COLOURING AN ENTRY WHILE ITS DESCENT IS OPEN COSTS ONE BIT, and it is what
+// makes a data cycle free to refuse: a reference to an entry still open is a
+// cycle, and Lock returns failure rather than recursing away. The ROOT's entry
+// is open for the whole walk.
+//
+// The map is proportional to NODES, never to bytes, and it lives on the
+// AUTHORING side, where §6.5 licenses allocation. Nothing on the reading path
+// ever builds one.
+struct TablePackEntry
+{
+    const void * key;   // the node's address in the graph being packed
+    int64_t offset;     // where that node landed in the region
+    uint8_t open;       // its descent is still open: a reference here is a cycle
+};
+
+struct TablePackMap
+{
+    TablePackEntry * entries = NULL;
+    int64_t capacity = 0; // a power of two, or zero while empty
+    int64_t count = 0;
+};
+
+inline void TablePackMapInit( TablePackMap & map )
+{
+    map.entries = NULL;
+    map.capacity = 0;
+    map.count = 0;
+}
+
+inline void TablePackMapShutdown( TablePackMap & map )
+{
+    free( map.entries );
+    TablePackMapInit( map );
+}
+
+// The two walks behind Lock re-derive the SAME map from the same graph — the
+// numbering is never carried between them (§3.1) — so the second starts from
+// an empty map and keeps the capacity the first paid for.
+inline void TablePackMapReset( TablePackMap & map )
+{
+    if ( map.entries != NULL ) { memset( map.entries, 0, (size_t) map.capacity * sizeof( TablePackEntry ) ); }
+    map.count = 0;
+}
+
+// open addressing, linear probing, a multiply-shift hash over the address: a
+// node key is a pointer and its low bits are alignment, so the low bits alone
+// would collide on every node of one type
+inline int64_t TablePackMapSlot( const TablePackMap & map, const void * key )
+{
+    uint64_t hash = (uint64_t) (uintptr_t) key;
+    hash *= 0x9E3779B97F4A7C15ull;
+    hash ^= hash >> 29;
+    int64_t mask = map.capacity - 1;
+    int64_t at = (int64_t) ( hash & (uint64_t) mask );
+    while ( map.entries[at].key != NULL && map.entries[at].key != key )
+    {
+        at = ( at + 1 ) & mask;
+    }
+    return at;
+}
+
+inline TablePackEntry * TablePackMapFind( TablePackMap & map, const void * key )
+{
+    if ( map.capacity == 0 ) { return NULL; }
+    TablePackEntry * entry = &map.entries[ TablePackMapSlot( map, key ) ];
+    return entry->key == key ? entry : NULL;
+}
+
+// QUADRUPLING, not doubling, and the reason is measured: growth rehashes every
+// entry, and on a graph of 131,071 nodes the doubling schedule spent 45% of
+// Lock in rehashing alone. Quadrupling from 1024 buys 1.35x on that graph and
+// keeps the map NODE-proportional (§6.2) — under 128 bytes a node at its
+// worst, right after a grow, and about 64 on average.
+inline bool TablePackMapGrow( TablePackMap & map )
+{
+    TablePackMap grown;
+    grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
+    grown.entries = (TablePackEntry *) calloc( (size_t) grown.capacity, sizeof( TablePackEntry ) );
+    if ( grown.entries == NULL ) { return false; }
+    for ( int64_t i = 0; i < map.capacity; i++ )
+    {
+        if ( map.entries[i].key == NULL ) { continue; }
+        grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
+        grown.count++;
+    }
+    free( map.entries );
+    map = grown;
+    return true;
+}
+
+// REACH a node: one probe answers both questions the walk has. A true "taken"
+// says this is a FIRST visit, and the entry is now the node's, coloured open
+// at "offset"; otherwise the entry is the one the node already has, and its
+// open bit says cycle or sharing. NULL is an allocation failure, and it is a
+// refusal like any other: Lock fails rather than packing a graph it cannot
+// track.
+//
+// It is one call and not a find followed by an insert because the walk asks
+// this question twice per node — once to measure, once to pack — and every
+// probe is a miss into a table larger than L2.
+inline TablePackEntry * TablePackMapReach( TablePackMap & map, const void * key, int64_t offset, bool & taken, int64_t & slot )
+{
+    if ( ( map.count + 1 ) * 4 >= map.capacity * 3 ) // keep the load factor under three quarters
+    {
+        if ( !TablePackMapGrow( map ) ) { return NULL; }
+    }
+    slot = TablePackMapSlot( map, key );
+    TablePackEntry * entry = &map.entries[slot];
+    taken = entry->key != key; // an empty slot is a first visit; the key is never NULL
+    if ( taken )
+    {
+        entry->key = key;
+        entry->offset = offset;
+        entry->open = 1;
+        map.count++;
+    }
+    return entry;
+}
+
+// The descent finished: the node keeps its entry — identity outlives the
+// descent — and stops being a cycle. The "hint" is the slot Reach returned, and it
+// is checked against the key rather than trusted, so a rehash between the two
+// costs a second probe instead of correctness.
+inline void TablePackMapClose( TablePackMap & map, const void * key, int64_t hint )
+{
+    if ( hint >= 0 && hint < map.capacity && map.entries[hint].key == key )
+    {
+        map.entries[hint].open = 0;
+        return;
+    }
+    TablePackEntry * entry = TablePackMapFind( map, key );
+    if ( entry != NULL ) { entry->open = 0; }
+}
 
 // ---- resolution contexts: which encoding a walk is reading ----
 
@@ -913,11 +1059,11 @@ template <typename Sink> inline bool MarkerLoadBody( TableReader & r, Sink & sin
 
 // ---- pointer-graph walkers: pack (Lock), size (Load) ----
 
-template <typename Ctx> inline int64_t TallyPackMeasure( const Ctx & ctx, const Tally & value, int32_t depth );
-template <typename Ctx> inline bool TallyPack( const Ctx & ctx, const Tally & src, Tally & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t TallyPackMeasure( const Ctx & ctx, TablePackMap & seen, const Tally & value, int32_t depth );
+template <typename Ctx> inline bool TallyPack( const Ctx & ctx, TablePackMap & seen, const Tally & src, Tally & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t TallyLoadMeasureBody( TableReader & r, int32_t depth );
-template <typename Ctx> inline int64_t MarkerPackMeasure( const Ctx & ctx, const Marker & value, int32_t depth );
-template <typename Ctx> inline bool MarkerPack( const Ctx & ctx, const Marker & src, Marker & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
+template <typename Ctx> inline int64_t MarkerPackMeasure( const Ctx & ctx, TablePackMap & seen, const Marker & value, int32_t depth );
+template <typename Ctx> inline bool MarkerPack( const Ctx & ctx, TablePackMap & seen, const Marker & src, Marker & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth );
 inline int64_t MarkerLoadMeasureBody( TableReader & r, int32_t depth );
 
 inline int64_t TallyMeasure( const Tally & value )
@@ -1112,29 +1258,33 @@ inline bool MarkerLoadBody( TableReader & r, Sink & sink, Marker & value, int32_
 }
 
 // TallyPackMeasure: the packed region bytes of everything Tally POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t TallyPackMeasure( const Ctx & ctx, const Tally & value, int32_t depth )
+inline int64_t TallyPackMeasure( const Ctx & ctx, TablePackMap & seen, const Tally & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
-    (void) ctx; (void) value; // no pointers below this node
+    (void) ctx; (void) seen; (void) value; // no pointers below this node
     return bytes;
 }
 
 // TallyPack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool TallyPack( const Ctx & ctx, const Tally & src, Tally & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool TallyPack( const Ctx & ctx, TablePackMap & seen, const Tally & src, Tally & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( Tally ) ); // trivially copyable, by construction
-    (void) ctx; (void) base; (void) capacity; (void) used;
+    (void) ctx; (void) seen; (void) base; (void) capacity; (void) used;
     return true;
 }
 
@@ -1149,20 +1299,33 @@ inline int64_t TallyLoadMeasureBody( TableReader & r, int32_t depth )
 }
 
 // MarkerPackMeasure: the packed region bytes of everything Marker POINTS AT.
-// Aliasing is not preserved: two pointers to one node pack as two nodes,
-// exactly as they ride the wire as two bodies (docs/SPEC-TABLES.md §3).
+// ONE VISIT PER NODE: `seen` carries the first-visit numbering (§3.1), so a
+// node two references name is measured ONCE and packed once, and a
+// reference to a node whose descent is still open is a data cycle, refused.
 template <typename Ctx>
-inline int64_t MarkerPackMeasure( const Ctx & ctx, const Marker & value, int32_t depth )
+inline int64_t MarkerPackMeasure( const Ctx & ctx, TablePackMap & seen, const Marker & value, int32_t depth )
 {
-    if ( depth > kTableMaxDepth ) { return -1; } // a data cycle, or a chain past the cap
+    if ( depth > kTableMaxDepth ) { return -1; } // a chain past the cap
     int64_t bytes = 0;
     {
         const Tally * pointee = TallyAt( ctx, value.note ); // note
         if ( pointee != NULL )
         {
-            int64_t inner = TallyPackMeasure( ctx, *pointee, depth + 1 );
-            if ( inner < 0 ) { return -1; }
-            bytes += TableAlignUp64( (int64_t) sizeof( Tally ) ) + inner;
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, 0, taken, slot );
+            if ( entry == NULL ) { return -1; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return -1; } // a data cycle
+            }
+            else
+            {
+                int64_t inner = TallyPackMeasure( ctx, seen, *pointee, depth + 1 );
+                if ( inner < 0 ) { return -1; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+                bytes += TableAlignUp64( (int64_t) sizeof( Tally ) ) + inner;
+            }
         }
     }
     return bytes;
@@ -1171,11 +1334,14 @@ inline int64_t MarkerPackMeasure( const Ctx & ctx, const Marker & value, int32_t
 // MarkerPack: copy src into dst (already placed), then lay every pointee out
 // depth-first behind it, in FIELD ORDER, by bump allocation.
 //
-// The pre-order is what makes a region simple to reason about: a child
-// always lands after the slot naming it, so region deltas are strictly
-// positive and a packed region cannot contain a cycle.
+// ONE NODE, ONE BODY (§6.2): `seen` holds every node already placed and
+// where it landed, so a node's FIRST reference lays it out and every later
+// reference points BACK at that one body. A region delta therefore has no
+// required sign (§6.3), and sharing and a back-reference are one fact. A
+// reference to a node whose descent is still OPEN is a cycle, and this
+// refuses it rather than packing one.
 template <typename Ctx>
-inline bool MarkerPack( const Ctx & ctx, const Marker & src, Marker & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
+inline bool MarkerPack( const Ctx & ctx, TablePackMap & seen, const Marker & src, Marker & dst, uint8_t * base, int64_t capacity, int64_t & used, int32_t depth )
 {
     if ( depth > kTableMaxDepth ) { return false; }
     memcpy( (void *) &dst, (const void *) &src, sizeof( Marker ) ); // trivially copyable, by construction
@@ -1184,12 +1350,25 @@ inline bool MarkerPack( const Ctx & ctx, const Marker & src, Marker & dst, uint8
         const Tally * pointee = TallyAt( ctx, src.note );
         if ( pointee != NULL )
         {
-            int64_t at = TableAlignUp64( used );
-            if ( at + (int64_t) sizeof( Tally ) > capacity ) { return false; }
-            used = at + TableAlignUp64( (int64_t) sizeof( Tally ) );
-            Tally * child = new ( base + at ) Tally; // lifetime only: the Pack below memcpy's the whole node over it
-            dst.note.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.note );
-            if ( !TallyPack( ctx, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+            int64_t at = TableAlignUp64( used ); // where it WOULD land, if this is its first visit
+            bool taken = false;
+            int64_t slot = 0;
+            const TablePackEntry * entry = TablePackMapReach( seen, (const void *) pointee, at, taken, slot );
+            if ( entry == NULL ) { return false; } // the map could not grow
+            if ( !taken )
+            {
+                if ( entry->open != 0 ) { return false; } // a data cycle
+                dst.note.value = (int64_t) ( ( base + entry->offset ) - (const uint8_t *) &dst.note ); // the one body it already has
+            }
+            else
+            {
+                if ( at + (int64_t) sizeof( Tally ) > capacity ) { return false; }
+                used = at + TableAlignUp64( (int64_t) sizeof( Tally ) );
+                Tally * child = new ( base + at ) Tally; // lifetime only: the Pack below memcpy's the whole node over it
+                dst.note.value = (int64_t) ( ( base + at ) - (const uint8_t *) &dst.note );
+                if ( !TallyPack( ctx, seen, *pointee, *child, base, capacity, used, depth + 1 ) ) { return false; }
+                TablePackMapClose( seen, (const void *) pointee, slot );
+            }
         }
     }
     return true;
@@ -1294,19 +1473,38 @@ inline bool MarkerBuilder::Lock()
     if ( root_ref.null() ) { return false; }
     TableArenaCtx ctx = { &arena };
     const Marker & root = *(const Marker *) TableArenaAt( arena, (uint32_t) root_ref.value );
-    int64_t below = MarkerPackMeasure( ctx, root, 1 );
-    if ( below < 0 ) { return false; } // a data cycle, or a chain past kTableMaxDepth
+    // The ROOT takes the map's first entry: it is packed at offset 0, and its
+    // descent is open for the whole walk (docs/SPEC-TABLES.md §3.1).
+    TablePackMap seen;
+    TablePackMapInit( seen );
+    bool root_taken = false;
+    int64_t root_slot = 0;
+    int64_t below = -1;
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) != NULL )
+    {
+        below = MarkerPackMeasure( ctx, seen, root, 1 );
+    }
+    if ( below < 0 ) { TablePackMapShutdown( seen ); return false; } // a data cycle, or a chain past kTableMaxDepth
     int64_t total = TableAlignUp64( (int64_t) sizeof( Marker ) ) + below;
     uint8_t * packed = (uint8_t *) malloc( (size_t) total ); // the AUTHORING path may allocate
-    if ( packed == NULL ) { return false; }
+    if ( packed == NULL ) { TablePackMapShutdown( seen ); return false; }
     memset( packed, 0, (size_t) total );
     int64_t used = TableAlignUp64( (int64_t) sizeof( Marker ) );
     Marker * destination = new ( packed ) Marker; // lifetime only: the Pack below memcpy's the whole node over it
-    if ( !MarkerPack( ctx, root, *destination, packed, total, used, 1 ) || used != total )
+    // The pack walk RE-DERIVES the same numbering rather than carrying the
+    // measure's — nothing passes between them, which is what makes
+    // `used == total` below a real check and not a tautology (§3.1). The
+    // map keeps the capacity the measure paid for, so the second walk
+    // rehashes nothing.
+    TablePackMapReset( seen );
+    if ( TablePackMapReach( seen, (const void *) &root, 0, root_taken, root_slot ) == NULL ||
+         !MarkerPack( ctx, seen, root, *destination, packed, total, used, 1 ) || used != total )
     {
+        TablePackMapShutdown( seen );
         free( packed );
         return false;
     }
+    TablePackMapShutdown( seen );
     region = packed;
     region_bytes = total;
     arena.locked = true; // MONOTONIC: there is no unlock

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -363,11 +363,15 @@ static const uint32_t kTableAlign       = 8;                           // every 
 static const uint32_t kTableAllocFailed = 0xFFFFFFFFu;
 
 // The pointer-chain depth cap. It bounds recursion on every walk — measure,
-// save, load and pack — so a data cycle is an ERROR and never a hang, and a
-// hostile wire cannot drive the C stack into the ground. A pointer chain's
-// WIRE nesting equals its length (§3), so this also caps chain length: wide
-// structures are unbounded, deep ones are not. Lifting it wants a flat,
-// indexed node encoding — a named follow-on (§15).
+// save, load and pack — so a hostile wire cannot drive the C stack into the
+// ground. A pointer chain's WIRE nesting equals its length (§3), so this also
+// caps chain length: wide structures are unbounded, deep ones are not. Lifting
+// it wants a flat, indexed node encoding — a named follow-on (§15).
+//
+// It is not what refuses a DATA CYCLE on the pack walk: TablePackMap's open
+// colouring names that cycle at the reference that closes it (§3.1). The cap
+// is still the whole of the cycle answer on the wire walks, which carry no
+// map today (§3.1's backend status).
 static const int32_t kTableMaxDepth = 128;
 
 // ---- TableRef: a relocatable reference (never a machine pointer) ----
@@ -568,6 +572,148 @@ struct TableWorker
         return slot;
     }
 };
+
+// ---- TablePackMap: the pack walk's identity map (docs/SPEC-TABLES.md §3.1, §6.2) ----
+//
+// ONE ENTRY PER REACHABLE NODE, and that map IS identity: a node must know
+// where it landed to be named a second time, so Lock packs a shared node ONCE
+// and every later reference resolves to the one body it already has. That is
+// the same first-visit numbering the wire uses, so the pack order and the node
+// order are one order.
+//
+// COLOURING AN ENTRY WHILE ITS DESCENT IS OPEN COSTS ONE BIT, and it is what
+// makes a data cycle free to refuse: a reference to an entry still open is a
+// cycle, and Lock returns failure rather than recursing away. The ROOT's entry
+// is open for the whole walk.
+//
+// The map is proportional to NODES, never to bytes, and it lives on the
+// AUTHORING side, where §6.5 licenses allocation. Nothing on the reading path
+// ever builds one.
+struct TablePackEntry
+{
+    const void * key;   // the node's address in the graph being packed
+    int64_t offset;     // where that node landed in the region
+    uint8_t open;       // its descent is still open: a reference here is a cycle
+};
+
+struct TablePackMap
+{
+    TablePackEntry * entries = NULL;
+    int64_t capacity = 0; // a power of two, or zero while empty
+    int64_t count = 0;
+};
+
+inline void TablePackMapInit( TablePackMap & map )
+{
+    map.entries = NULL;
+    map.capacity = 0;
+    map.count = 0;
+}
+
+inline void TablePackMapShutdown( TablePackMap & map )
+{
+    free( map.entries );
+    TablePackMapInit( map );
+}
+
+// The two walks behind Lock re-derive the SAME map from the same graph — the
+// numbering is never carried between them (§3.1) — so the second starts from
+// an empty map and keeps the capacity the first paid for.
+inline void TablePackMapReset( TablePackMap & map )
+{
+    if ( map.entries != NULL ) { memset( map.entries, 0, (size_t) map.capacity * sizeof( TablePackEntry ) ); }
+    map.count = 0;
+}
+
+// open addressing, linear probing, a multiply-shift hash over the address: a
+// node key is a pointer and its low bits are alignment, so the low bits alone
+// would collide on every node of one type
+inline int64_t TablePackMapSlot( const TablePackMap & map, const void * key )
+{
+    uint64_t hash = (uint64_t) (uintptr_t) key;
+    hash *= 0x9E3779B97F4A7C15ull;
+    hash ^= hash >> 29;
+    int64_t mask = map.capacity - 1;
+    int64_t at = (int64_t) ( hash & (uint64_t) mask );
+    while ( map.entries[at].key != NULL && map.entries[at].key != key )
+    {
+        at = ( at + 1 ) & mask;
+    }
+    return at;
+}
+
+inline TablePackEntry * TablePackMapFind( TablePackMap & map, const void * key )
+{
+    if ( map.capacity == 0 ) { return NULL; }
+    TablePackEntry * entry = &map.entries[ TablePackMapSlot( map, key ) ];
+    return entry->key == key ? entry : NULL;
+}
+
+// QUADRUPLING, not doubling, and the reason is measured: growth rehashes every
+// entry, and on a graph of 131,071 nodes the doubling schedule spent 45% of
+// Lock in rehashing alone. Quadrupling from 1024 buys 1.35x on that graph and
+// keeps the map NODE-proportional (§6.2) — under 128 bytes a node at its
+// worst, right after a grow, and about 64 on average.
+inline bool TablePackMapGrow( TablePackMap & map )
+{
+    TablePackMap grown;
+    grown.capacity = map.capacity != 0 ? map.capacity * 4 : 1024;
+    grown.entries = (TablePackEntry *) calloc( (size_t) grown.capacity, sizeof( TablePackEntry ) );
+    if ( grown.entries == NULL ) { return false; }
+    for ( int64_t i = 0; i < map.capacity; i++ )
+    {
+        if ( map.entries[i].key == NULL ) { continue; }
+        grown.entries[ TablePackMapSlot( grown, map.entries[i].key ) ] = map.entries[i];
+        grown.count++;
+    }
+    free( map.entries );
+    map = grown;
+    return true;
+}
+
+// REACH a node: one probe answers both questions the walk has. A true "taken"
+// says this is a FIRST visit, and the entry is now the node's, coloured open
+// at "offset"; otherwise the entry is the one the node already has, and its
+// open bit says cycle or sharing. NULL is an allocation failure, and it is a
+// refusal like any other: Lock fails rather than packing a graph it cannot
+// track.
+//
+// It is one call and not a find followed by an insert because the walk asks
+// this question twice per node — once to measure, once to pack — and every
+// probe is a miss into a table larger than L2.
+inline TablePackEntry * TablePackMapReach( TablePackMap & map, const void * key, int64_t offset, bool & taken, int64_t & slot )
+{
+    if ( ( map.count + 1 ) * 4 >= map.capacity * 3 ) // keep the load factor under three quarters
+    {
+        if ( !TablePackMapGrow( map ) ) { return NULL; }
+    }
+    slot = TablePackMapSlot( map, key );
+    TablePackEntry * entry = &map.entries[slot];
+    taken = entry->key != key; // an empty slot is a first visit; the key is never NULL
+    if ( taken )
+    {
+        entry->key = key;
+        entry->offset = offset;
+        entry->open = 1;
+        map.count++;
+    }
+    return entry;
+}
+
+// The descent finished: the node keeps its entry — identity outlives the
+// descent — and stops being a cycle. The "hint" is the slot Reach returned, and it
+// is checked against the key rather than trusted, so a rehash between the two
+// costs a second probe instead of correctness.
+inline void TablePackMapClose( TablePackMap & map, const void * key, int64_t hint )
+{
+    if ( hint >= 0 && hint < map.capacity && map.entries[hint].key == key )
+    {
+        map.entries[hint].open = 0;
+        return;
+    }
+    TablePackEntry * entry = TablePackMapFind( map, key );
+    if ( entry != NULL ) { entry->open = 0; }
+}
 
 // ---- resolution contexts: which encoding a walk is reading ----
 


### PR DESCRIPTION
Closes #360.

`docs/SPEC-TABLES.md` §6.2 states that `Lock`'s walk carries the same
one-entry-per-node map the wire numbering does, "so it terminates in one visit
per node, a shared node is packed ONCE, and a data cycle is refused here
exactly as it is at save". The C++ pack walkers carried no map: they recursed
on every reference, packed a node again for every parent that named it, and
found a cycle only by exhausting `kTableMaxDepth`. The page and the reference
disagreed and the page was right — the tool's own numbering
(`internal/tablewire.Number`) has worked this way all along, and this makes the
reference mirror it rather than invent a third answer.

## The page

- **§6.2** gains what the map is for, in three parts: that sharing and a cycle
  are the same event separated by one bit (a reference to a CLOSED entry is
  sharing; to an OPEN one, a cycle); the cost, stated — one entry per reachable
  node, NODE-proportional, held for the length of `Lock`, on the authoring side
  §6.5 licenses, and never built on the reading path; and **Held by test**.
- **§3.1**'s backend status gains one paragraph: the REGION is not in the gap
  the section describes. `Lock` carries the map in C++ today; a save from a
  region still writes a shared node once per reference because the WIRE is
  still the nested form, and that is the whole of what #251 moves.
- **§15** gains two named follow-ons — see "For the owner" and "Named as
  follow-on" below.

## The change

`TablePackMap` in the arena runtime: open addressing, linear probing, keyed on
the node's address so it is context-agnostic, one entry of `{ key, offset,
open }`. `<T>PackMeasure` and `<T>Pack` take it and ask ONE question per node —
`TablePackMapReach` either takes the entry (a first visit, coloured open at the
offset the node will land at) or hands back the entry the node already has.
`Lock` gives the root the first entry at offset 0, runs the measure, resets the
map — keeping the capacity, so the pack walk rehashes nothing — and runs the
pack. Neither walk carries the other's numbering, so `used == total` stays a
real check.

## Goldens and the negative control

- The tables suite's aliasing case, which previously **asserted the defect**
  (`viaHead != viaAlias`), now holds identity, plus two new graphs: a shared
  node reached through a chain and named again from the root, and a **diamond**
  whose closing reference is a BACK-reference (`r->left.value < 0`) which the
  region still relocates by plain `memcpy`. Every case is checked twice — the
  two references resolve to one address, AND the region's exact byte count,
  which is the half a duplicating pack cannot fake.
- The cycle case gains a **two-node cycle** beside the self-cycle: the closing
  reference names a node the walk is still inside, which is exactly what a
  shared-node map must not mistake for sharing. `Measure`, `Save` and `Lock`
  all refuse and nothing partial is published.
- **`make tables-shared-node-negative-control`** (new, wired into `make test`):
  the emitter's identity map is turned into a permanent miss through a
  `go build -overlay`, the whole corpus is regenerated from the sabotaged
  compiler, and THE TABLES SUITE ITSELF must go red. It does — 8 failures.
- **The pointered unit's three source goldens are re-pinned** (`testdata/golden/tables/pointers/`), which is what `tables-block-zero-cost`'s byte comparison asks for when a TABLE emitter legitimately changes. The other 41 pinned sources are byte-identical: a value-only unit pays nothing for a change to the variable-length runtime, which is the zero-cost property stating itself. `internal/tablenames` gains `TablePackMap` and `TablePackEntry`, because �11 owes the checker a claim on every unit-level spelling a generated header defines.
- Unchanged and re-run green: the tables suite and its ASan/UBSan twin, the
  zero-cost gate (which now also refuses `TablePack*` in a pointer-free
  header), the generic-walk gate, `tables-cook-cli` / `-open` / `-valued`
  (`wire -> cook -> wire` byte-identical, both byte orders), `tables-pack` and
  its negative control, the cook forgery fuzzer at 100,000 mutants per root,
  `go test ./...`, and the **conformance matrix — twelve surfaces, four
  languages, all pass**. `schema cook`/`uncook` over the fixed corpus is
  byte-identical: the fixed class has no pointer, so nothing there moves.

## The measurement

Same sitting, median of 7, arm64 clang `-O2`, arms interleaved.

**What it costs where it buys nothing** — a 131,071-node balanced tree with no
sharing at all, so the map is pure overhead:

| | `Lock` median |
|---|---|
| before the map | 0.98 ms |
| with the map | 5.8 ms |

**What it buys where it buys anything** — a graph of N nodes, each naming the
next through BOTH of its pointer fields, so the tree it unfolds to is `2^N - 1`:

| nodes | region before | `Lock` before | region after | `Lock` after |
|---|---|---|---|---|
| 16 | 2.6 MB | 0.65 ms | 816 B | 0.008 ms |
| 20 | 41.9 MB | 11.2 ms | 976 B | 0.012 ms |
| 24 | 671.1 MB | 188.9 ms | 1,136 B | 0.009 ms |

One lever was taken inside this PR on that first number: the map **quadruples**
rather than doubles, because rehashing measured 45% of `Lock` on the doubling
schedule (12.0 ms -> 8.2 ms at the time; 5.8 ms in the final quiet sitting).
It stays node-proportional — under 128 bytes a node at its worst, about 64 on
average.

## Named as follow-on (§15)

**`Lock`'s identity map, presized.** A map presized to the graph measured
6.6 ms against 12.0 ms, so headroom is left. What it needs is a node count the
arena does not keep, and counting allocations costs an atomic per node that
§6.4 refuses; the shapes are a per-worker non-atomic counter summed at `Lock`,
or a bound from the arena's high-water mark and the closure's smallest node.
Not decided.

## For the owner: §3.1 contradicts itself about a pointer back to the ROOT

Two rules in one section, and only one can hold. The numbering says index `1`
is the root and that "a pointer may name it, so a child pointing back at its
root is expressible", and §3.1's worked example writes `owner = 1` from two
nodes. The cycle rule in the SAME section says a reference to an entry still
open is a cycle — and the root's entry is open for the whole walk, so that
graph is refused: by `internal/tablewire.Number` today, by the C++ `Lock` after
this PR, and §11 lists the refusal by name. Either the root is exempt from the
open colouring, which needs saying and needs a reason the exemption stops
there, or the bullet and the worked example go.

**Nothing here decides it.** What is implemented is the refusal, because that
is what the tool does and an implementation mirrors the reference. It is
written up as a named follow-on in §15 so the eight ports do not each rediscover
it. The corpus cannot express the case today — no table in `tables/pointers`
declares a `*Scene` — so no test changes either way.

## What the ports inherit

One contract, in its simplest form: **an identity map on the pack walk, keyed
by node, coloured while its descent is open — sharing resolves, an open entry
is a cycle, and the root is in the map.** No wire bytes move, no golden moves,
and a port's map is its language's own (a `HashMap`, a `map[*T]`, a
`Dictionary`) — the bytes and the refusals are this document's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
