### PR TITLE
the keyed accessor refuses BOTH ends: a key past Max, in C++ (#377)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2406,6 +2406,44 @@ tables-keyed-none-refusal-negative-control: bin/schema test/tables/keyed_none_nd
 		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on the refusal"; cat build/keyed-none-assert-only.log; exit 1; }
 	@echo "negative control: a debug-only guard turns the -DNDEBUG refusal gate red"
 
+# THE OTHER END OF THE SAME REFUSAL, HELD UNDER -DNDEBUG (docs/SPEC-TABLES.md
+# §2.4, issue #377). The storage holds one slot per NAMED variant, so a key
+# past Max names a variant this enum does not have: the same program error as
+# None, refused at the same compare, in every configuration. A build that let
+# it through would read PAST THE END of the storage.
+.PHONY: tables-keyed-max-refusal-ndebug
+tables-keyed-max-refusal-ndebug: build/tables-generated/.stamp test/tables/keyed_max_ndebug_main.cpp
+	@mkdir -p build
+	$(CXX) $(TABLES_CXXFLAGS) -DNDEBUG -Ibuild/tables-generated/examples \
+		test/tables/keyed_max_ndebug_main.cpp -o build/schema_test_keyed_max_ndebug
+	./build/schema_test_keyed_max_ndebug
+
+# and its NEGATIVE CONTROL: put the accessor back to the None-ONLY compare —
+# what it refused before #377 — and the gate above must go RED, because a key
+# past Max then indexes past the end. Deleting the abort would turn both gates
+# red at once and prove nothing about THIS end, so the sabotage is the compare
+# itself.
+.PHONY: tables-keyed-max-refusal-negative-control
+tables-keyed-max-refusal-negative-control: bin/schema test/tables/keyed_max_ndebug_main.cpp
+	@mkdir -p build
+	@sed -e 's|        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )|        if ( key == E::None ) /* SABOTAGED: the None-only compare again */|' \
+		internal/codegen/cpptable/cpptable.go > build/cpptable-none-only.gotext
+	@grep -q SABOTAGED build/cpptable-none-only.gotext || \
+		{ echo "NEGATIVE CONTROL FAILED: the sabotage patched nothing"; exit 1; }
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/cpptable.go":"%s/build/cpptable-none-only.gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/cpptable-none-only-overlay.json
+	@go build -overlay=build/cpptable-none-only-overlay.json -o build/schema-none-only ./cmd/schema
+	@rm -rf build/tables-none-only && mkdir -p build/tables-none-only
+	@./build/schema-none-only generate --lang cpp --out build/tables-none-only tables/examples
+	@$(CXX) $(TABLES_CXXFLAGS) -DNDEBUG -Ibuild/tables-none-only \
+		test/tables/keyed_max_ndebug_main.cpp -o build/schema_test_keyed_max_none_only
+	@if ./build/schema_test_keyed_max_none_only > build/keyed-max-none-only.log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: a None-only compare left the past-Max gate GREEN"; exit 1; \
+	fi
+	@grep -q "the refusal was compiled out" build/keyed-max-none-only.log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on the refusal"; cat build/keyed-max-none-only.log; exit 1; }
+	@echo "negative control: the None-only compare turns the past-Max refusal gate red"
+
 # The NEGATIVE CONTROL for the SHIFT itself (docs/SPEC-TABLES.md §2.4, owner ruling
 # 2026-09-03). The storage holds E.Max slots with the key k at index k-1 and
 # nothing for None. Putting the None slot BACK — E.Max + 1 slots, no shift —
@@ -3157,6 +3195,8 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) tables-keyed-iteration-negative-control
 	$(MAKE) tables-keyed-none-refusal-ndebug
 	$(MAKE) tables-keyed-none-refusal-negative-control
+	$(MAKE) tables-keyed-max-refusal-ndebug
+	$(MAKE) tables-keyed-max-refusal-negative-control
 	$(MAKE) tables-keyed-shift-negative-control
 	$(MAKE) tables-clamp-limits
 	$(MAKE) tables-clamp-limits-negative-control

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -644,7 +644,8 @@ enum is keyed.
   descriptors' count column (§8.1) derives the same way.
 
   **The accessor is `operator[]( E )`**: it takes a runtime key, REFUSES
-  `None`, and SUBTRACTS ONE. A key in a data-driven program IS a runtime
+  EVERY KEY THAT NAMES NO SLOT — `None` below the storage and anything past
+  `E.Max` above it — and SUBTRACTS ONE. A key in a data-driven program IS a runtime
   value — an enum field read out of a file, a key handed in by a tool, the
   key an iteration just yielded — so this is the form call sites use, and a
   compile-time accessor taking the key as a template parameter is not
@@ -653,27 +654,30 @@ enum is keyed.
   only place it appears.
 
   ```cpp
-  fleet.ships[ ship_type ]   // runtime key: refuses None, reads slots[ key - 1 ]
+  fleet.ships[ ship_type ]   // runtime key: refuses None and past Max, reads slots[ key - 1 ]
   ```
 
-  **THE REFUSAL STANDS IN EVERY BUILD, in every port.** It is not a debug
-  guard and `NDEBUG` does not remove it: **indexing by `None` is a PROGRAM
-  ERROR in every configuration**, and the accessor ends the program rather
-  than reading something. **There is NO undefined-behaviour path here in
-  any build** — which is the whole reason the compare is unconditional,
-  because the storage shifts left and holds no slot for `None` to land in,
-  so a build that skipped it would read one element BEFORE the array.
-  The cost is one perfectly-predicted compare on a path that reads config,
-  which is not a price worth a class of silent corruption.
+  **THE REFUSAL STANDS IN EVERY BUILD, in every port, AT BOTH ENDS.** It is
+  not a debug guard and `NDEBUG` does not remove it: **indexing by a key that
+  names no slot is a PROGRAM ERROR in every configuration**, and the accessor
+  ends the program rather than reading something. **THE GUARD IS SYMMETRIC**
+  because the storage is: one slot per NAMED variant and nothing else, so
+  `None` names none of them and neither does a key past `E.Max`. **There is
+  NO undefined-behaviour path here in any build** — which is the whole reason
+  the compare is unconditional, because a build that skipped it would read one
+  element BEFORE the array at one end and past its END at the other.
+  The cost is one perfectly-predicted compare on a path that reads config —
+  ONE compare covers both ends, since the storage index is `key − 1` and
+  `None`'s is `−1`, which wraps above the extent unsigned — and that is not a
+  price worth a class of silent corruption.
 
   What varies is only how a language ends a program: C++ asserts — for the
   message, where a debugger can read it — and then ABORTS, and the abort is
   what stands under `NDEBUG`; C# throws; Rust panics; Go panics too, and
   `-gcflags=all=-B` does not remove it because it is a written compare and not
-  a bounds check. **THE GUARD IS SYMMETRIC**: a key past `E.Max` is the same
-  program error as `None` for the same reason — the storage holds one slot per
-  NAMED variant and nothing else — so the accessor refuses both ends, in every
-  port.
+  a bounds check. A port that leans on its runtime's own bounds check has met
+  half the rule: the check must be the ACCESSOR's, so the behavior is the
+  reference's rather than whatever the language does at the end of an array.
 
   **AND WHAT THE KEY IS SPELLED AS varies too, because a language's own
   vocabulary decides it.** Every port indexes by the KEY and never by the
@@ -758,10 +762,12 @@ enum is keyed.
   one negative control moves `begin()` off the first stored slot and another
   restores the `None` slot — storage `E.Max + 1` with no shift — and the
   tables suite, the layout gate and the `sizeof` assertion go red. **The
-  refusal is held in the configuration that would drop it**: a translation
-  unit compiled `-DNDEBUG` indexes a keyed array by `None` and must die, so
-  a refusal that ever became an assert again fails the gate rather than the
-  reader.
+  refusal is held in the configuration that would drop it, at both ends**:
+  one translation unit compiled `-DNDEBUG` indexes a keyed array by `None`
+  and another by `E.Max + 1`, and both must die — so a refusal that ever
+  became an assert again, or narrowed back to `None` alone, fails the gate
+  rather than the reader. Each has its own negative control: the debug-only
+  guard for the first, the `None`-only compare for the second.
 
   The wire enforces the key rule from the other side regardless: a `None`
   key never rides (§3.2).

--- a/internal/codegen/cpptable/cpptable.go
+++ b/internal/codegen/cpptable/cpptable.go
@@ -172,7 +172,9 @@ const tableKeyedStorage = `
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -187,28 +189,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/test/tables/keyed_max_ndebug_main.cpp
+++ b/test/tables/keyed_max_ndebug_main.cpp
@@ -1,0 +1,63 @@
+// THE OTHER END OF THE SAME REFUSAL, HELD IN THE CONFIGURATION THAT WOULD DROP
+// IT (docs/SPEC-TABLES.md §2.4). An enum-keyed array holds one slot per NAMED
+// variant, so a key past Max names a variant this enum does not have: it is
+// the same program error as None, and it is refused the same way in EVERY
+// build. A build that let it through would read past the end of the storage.
+//
+// The suite's own fork test proves the refusal fires, but it is compiled with
+// asserts LIVE — so it cannot tell an unconditional refusal from an assert.
+// This translation unit is compiled -DNDEBUG, which is exactly the
+// configuration a game ships and exactly the one that removes an assert. The
+// child must still die. Its Makefile gate requires that.
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "KeyedTable.h"
+
+int main()
+{
+#ifndef NDEBUG
+    printf( "FAILED: this gate is meaningless without -DNDEBUG\n" );
+    return 1;
+#else
+    fflush( stdout );
+    pid_t child = fork();
+    if ( child == 0 )
+    {
+        // the abort message is the point of the child, not of this log
+        FILE * quiet = freopen( "/dev/null", "w", stderr );
+        (void) quiet;
+        tabledemo::KeyedConfig cfg;
+        // Max + 1: the key an older writer's extra variant arrives as, which is
+        // how a key past the end reaches an accessor in a real program
+        tabledemo::Team key = (tabledemo::Team) ( (int32_t) tabledemo::Team::Max + 1 );
+        tabledemo::TeamConfig & past = cfg.teams[key];
+        past.spawn_count = 1; // never reached: the accessor refused
+        _exit( 0 );
+    }
+    if ( child < 0 )
+    {
+        printf( "FAILED: fork\n" );
+        return 1;
+    }
+    int status = 0;
+    if ( waitpid( child, &status, 0 ) != child )
+    {
+        printf( "FAILED: waitpid\n" );
+        return 1;
+    }
+    if ( !WIFSIGNALED( status ) )
+    {
+        printf( "FAILED: under -DNDEBUG a key past Max did NOT end the program — "
+                "the refusal was compiled out, and a shipped build would read "
+                "past the end of the storage (docs/SPEC-TABLES.md §2.4)\n" );
+        return 1;
+    }
+    printf( "keyed past-Max refusal under -DNDEBUG: the index ended the program (signal %d)\n",
+            WTERMSIG( status ) );
+    return 0;
+#endif
+}

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -2474,6 +2474,41 @@ static void test_keyed_none_index_refused()
     }
 }
 
+// ---- and operator[] REFUSES A KEY PAST Max, the same way (docs/SPEC-TABLES.md §2.4) ----
+//
+// The storage holds one slot per NAMED variant, so a key above Max names a
+// variant this enum does not have and there is no slot for it to land in: the
+// same program error as None, refused at the same compare, in every build.
+// `make tables-keyed-max-refusal-ndebug` is the half that proves NDEBUG does
+// not remove it, and its own negative control proves that gate has teeth.
+
+static void test_keyed_past_max_index_refused()
+{
+    fflush( stdout );
+    pid_t child = fork();
+    if ( child == 0 )
+    {
+        // the abort message is the point of the child, not of this log
+        FILE * quiet = freopen( "/dev/null", "w", stderr );
+        (void) quiet;
+        tabledemo::KeyedConfig cfg;
+        tabledemo::Team key = (tabledemo::Team) ( (int32_t) tabledemo::Team::Max + 1 );
+        tabledemo::TeamConfig & past = cfg.teams[key];
+        past.spawn_count = 1; // never reached: the accessor refused
+        _exit( 0 );
+    }
+    CHECK( child > 0 );
+    int status = 0;
+    CHECK( waitpid( child, &status, 0 ) == child );
+    CHECK( WIFSIGNALED( status ) ); // the refusal ended the child
+    if ( WIFEXITED( status ) )
+    {
+        printf( "FAIL keyed past-Max index: the child returned %d — the refusal is gone\n",
+                WEXITSTATUS( status ) );
+        failures++;
+    }
+}
+
 // ---- the edit that breaks a positional slot array: V2 REMOVES Gamma and
 // ---- INSERTS Omega in the middle, so Beta slides from ordinal 2 to 3. Every
 // ---- surviving slot lands by NAME, in both directions.
@@ -5245,6 +5280,7 @@ int main()
     test_keyed_round_trip();
     test_keyed_iteration();
     test_keyed_none_index_refused();
+    test_keyed_past_max_index_refused();
     test_keyed_evolution_old_data();
     test_keyed_evolution_new_data();
     test_keyed_versus_positional_is_a_kind_mismatch();

--- a/testdata/golden/tables/block/PaddedTable.h
+++ b/testdata/golden/tables/block/PaddedTable.h
@@ -231,7 +231,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -246,28 +248,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/block/RenderTable.h
+++ b/testdata/golden/tables/block/RenderTable.h
@@ -230,7 +230,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -245,28 +247,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/examples/GuardedTable.h
+++ b/testdata/golden/tables/examples/GuardedTable.h
@@ -230,7 +230,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -245,28 +247,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/examples/KeyedTable.h
+++ b/testdata/golden/tables/examples/KeyedTable.h
@@ -230,7 +230,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -245,28 +247,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/examples/NestedTable.h
+++ b/testdata/golden/tables/examples/NestedTable.h
@@ -231,7 +231,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -246,28 +248,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/examples/PackTable.h
+++ b/testdata/golden/tables/examples/PackTable.h
@@ -230,7 +230,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -245,28 +247,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/examples/RangesTable.h
+++ b/testdata/golden/tables/examples/RangesTable.h
@@ -230,7 +230,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -245,28 +247,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/examples/TablesTable.h
+++ b/testdata/golden/tables/examples/TablesTable.h
@@ -230,7 +230,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -245,28 +247,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/examples/WideTable.h
+++ b/testdata/golden/tables/examples/WideTable.h
@@ -230,7 +230,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -245,28 +247,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -242,7 +242,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -257,28 +259,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -239,7 +239,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -254,28 +256,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }

--- a/testdata/golden/tables/pointers/PartsTable.h
+++ b/testdata/golden/tables/pointers/PartsTable.h
@@ -239,7 +239,9 @@ struct TableReader
 // NONE IS THE NULL KEY: it names no slot, it never rides on the wire, a stored
 // key of 0 is malformed, and INDEXING BY IT IS A PROGRAM ERROR IN EVERY
 // CONFIGURATION — caught by operator[], which cannot see a runtime key any
-// earlier, and REFUSED UNCONDITIONALLY. NDEBUG does not remove the compare:
+// earlier, and REFUSED UNCONDITIONALLY. A KEY PAST Max IS THE SAME ERROR for
+// the same reason — it names a variant this enum does not have — so the
+// accessor refuses BOTH ENDS. NDEBUG does not remove the compare:
 // there is NO UB PATH here in any build. ITERATION is still the surface a
 // consumer of the whole array wants: begin()/end() walk every stored slot and
 // yield the KEY, 1..E.Max, so a call site writes no bound, no cast, no shift
@@ -254,28 +256,32 @@ struct TableKeyed
 
     T & operator[]( E key )
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
     const T & operator[]( E key ) const
     {
-        RefuseNone( key );
+        RefuseKey( key );
         return slots[ (int32_t) key - 1 ];
     }
 
-    // THE REFUSAL, and it stands in EVERY BUILD. The storage shifts left and
-    // holds no slot for None, so a build that skipped this compare would index
-    // one element BEFORE the array — undefined behaviour in the configuration
-    // a game ships. A None key is a program error, so the accessor ends the
-    // program rather than reading something. The assert carries the message
-    // where a debugger can read it and NDEBUG removes that; the abort is what
-    // stands after it. The cost is one perfectly-predicted compare, on a path
-    // that reads config.
-    static void RefuseNone( E key )
+    // THE REFUSAL, and it stands in EVERY BUILD, AT BOTH ENDS. The storage
+    // holds one slot per NAMED variant: nothing for None below it and nothing
+    // above Max, so a build that skipped this compare would index one element
+    // BEFORE the array or past its end — undefined behaviour in the
+    // configuration a game ships. Either key is a program error, so the
+    // accessor ends the program rather than reading something. The assert
+    // carries the message where a debugger can read it and NDEBUG removes
+    // that; the abort is what stands after it.
+    //
+    // ONE UNSIGNED COMPARE COVERS BOTH ENDS: the storage index is key - 1, and
+    // None's is -1, which wraps above kSlots unsigned. The cost is one
+    // perfectly-predicted compare, on a path that reads config.
+    static void RefuseKey( E key )
     {
-        if ( key == E::None )
+        if ( (uint32_t) ( (int32_t) key - 1 ) >= (uint32_t) kSlots )
         {
-            assert( false && "None is the null key of an enum-keyed array: it keys no slot" );
+            assert( false && "an enum-keyed array holds one slot per named variant: None keys none, and neither does a key past Max" );
             abort();
         }
     }


### PR DESCRIPTION
Closes the C++ half of #377: the enum-keyed accessor refused `None` and nothing
else, so a key past `E.Max` — an enum value that does not exist — indexed past
the end of the storage in every build.

**The change is the compare.** `TableKeyed::operator[]` routed through
`RefuseNone`, which compared against `E::None` alone; it now routes through
`RefuseKey`, which refuses every key that names no slot at BOTH ENDS in ONE
unsigned compare — the storage index is `key - 1`, and `None`'s is `-1`, which
wraps above `kSlots` unsigned. The refusal is what it always was: an assert for
the message, then an `abort()` that stands under `NDEBUG`. The cost stays one
perfectly-predicted compare on a path that reads config.

Nothing on the read or write path moved: the generated codecs index
`.slots[...]` directly with a slot the wire already validated, never through
`operator[]`, so a malformed key off the wire is still a counted refusal and
never an abort.

**§2.4 states it** — the accessor's contract now names both ends where a reader
meets it, rather than only in a sentence about how each language ends a program,
and the "held by test" paragraph names the two `-DNDEBUG` gates and their two
negative controls.

**Held by test, with a negative control that localises THIS end:**

- `test/tables/main.cpp` forks a child that indexes by `Max + 1` and requires it
  to die, beside the `None` child that was already there.
- `make tables-keyed-max-refusal-ndebug` compiles one translation unit
  `-DNDEBUG` — the configuration a game ships, and the one that removes an
  assert — and requires the same death there.
- `make tables-keyed-max-refusal-negative-control` puts the accessor back to the
  `None`-only compare in a copy of the emitter, regenerates the corpus from it,
  and requires the gate above to go RED. Deleting the abort would turn both
  gates red at once and prove nothing about this end, so the sabotage is the
  COMPARE itself. Both new targets run in `make test`.

**C is not in this PR.** `ctable.go`'s `table_keyed_slot( key )` takes no
extent — C's storage IS the array, so there is no wrapper carrying `E.Max` —
and passing one means changing `SCHEMA_TABLE_KEYED_AT`, which is a documented
user-facing macro (USAGE.md). That is not the one line #377 allowed for it, so
C stays on the issue with C#, Rust and the four ports that check theirs against
this line.

Goldens re-pinned for the emitter change (the fourteen C++ table headers).
`make test` green locally.
