### PR TITLE
certify green: zero-cost and build-version greps follow #386, cs-tables expects *T's own bytes, Go soak drops the pointered rows, Elixir ampersand check stays inside its heap pin

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -266,9 +266,15 @@ jobs:
   # every verdict pass is ahead-of-time disassembly, and a JIT has no
   # build-time artifact to gate — faking one would be a green light that
   # proves nothing.
+  #
+  # THE TIMEOUT COVERS THE `make test` PRECONDITION, not just the legs: that
+  # chain is ~22 minutes on either OS (run 33787248541: 1320 s on ubuntu, and
+  # the macOS test job the same), the selftest and the longest leg add ~5, and
+  # a saturated macOS pool stretches all of it. At 20 minutes four macOS legs
+  # died mid-chain with make still running and read as "cancelled".
   inline-gate:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -2687,11 +2687,15 @@ tables-cook-cli: bin/schema
 tables-block-zero-cost: build/tables-generated/.stamp build/tables-generated-cs/.stamp build/tables-generated-c/.stamp build/tables-generated-dart/.stamp
 	@for f in build/tables-generated/*/*Table.h build/tables-generated/*/*Table.cpp \
 	          build/tables-generated-cs/*/*Table.cs; do \
-		if grep -nE "TableBlock|[A-Za-z0-9_]Block" $$f; then \
+		if sed -E 's://.*$$::' $$f | grep -nE "TableBlock|[A-Za-z0-9_]Block"; then \
 			echo "BLOCK ZERO-COST GATE FAILED: the block form leaked into $$f"; exit 1; \
 		fi; \
 	done
 	@echo "block zero-cost gate: no Table source carries one symbol of the block form"
+# The grep runs over the CODE, with every // comment stripped first: what the
+# gate holds is that no block CONSTRUCT is in a Table source, and a comment
+# naming one (the arena runtime describes its allocator as the shape
+# TableBlockAllocator has, §19.1) is prose, not a symbol.
 # BuildVersion is NOT in that grep: it is not a block symbol — a build version
 # answers "which build?" and not "which form?", both accelerators carry it
 # (docs/SPEC-TABLES.md §20.6), and every C++ Table header carries it because every

--- a/Makefile
+++ b/Makefile
@@ -2757,7 +2757,7 @@ tables-block-zero-cost: build/tables-generated/.stamp build/tables-generated-cs/
 .PHONY: tables-block-build-version
 tables-block-build-version: bin/schema build/tables-generated/.stamp build/tables-generated-cs/.stamp
 	@v=$$(./bin/schema build-version tables/block); \
-		grep -q "inline constexpr uint64_t BuildVersion = $${v}ull;" build/tables-generated/block/RenderBlock.h || \
+		grep -q "static const uint64_t BuildVersion = $${v}ull;" build/tables-generated/block/RenderBlock.h || \
 			{ echo "BUILD VERSION GATE FAILED: the C++ constant is not $$v"; exit 1; }; \
 		grep -q "public const ulong BuildVersion = $${v}UL;" build/tables-generated-cs/block/*Block.cs || \
 			{ echo "BUILD VERSION GATE FAILED: the C# constant is not $$v"; exit 1; }; \

--- a/generated/bench/tables/elixir/TableRuntime.ex
+++ b/generated/bench/tables/elixir/TableRuntime.ex
@@ -969,7 +969,10 @@ defmodule Benchtable.TableRuntime do
         # THE AMPERSAND PREFIX IS RESERVED TO THE FORM (docs/SPEC-TABLES.md
         # 16.7): never a field this build lacks, always a construct it cannot
         # honor. Malformed and refused, never counted as unknown.
-        if String.starts_with?(key, "&"), do: bad(value, report)
+        # Two guard BIFs and not a binary match: matching the key would put a
+        # match context on the heap per key, and the read path's heap words are
+        # pinned (test/conformance/elixir/alloc-budget.txt).
+        if byte_size(key) > 0 and :binary.first(key) == ?&, do: bad(value, report)
 
         {value, pos, report, seen} =
           case Enum.find(type.fields, fn f -> f.json == key end) do

--- a/internal/codegen/elixirtable/runtime.go
+++ b/internal/codegen/elixirtable/runtime.go
@@ -1011,7 +1011,10 @@ const runtimeSource = `  @moduledoc """
         # THE AMPERSAND PREFIX IS RESERVED TO THE FORM (docs/SPEC-TABLES.md
         # 16.7): never a field this build lacks, always a construct it cannot
         # honor. Malformed and refused, never counted as unknown.
-        if String.starts_with?(key, "&"), do: bad(value, report)
+        # Two guard BIFs and not a binary match: matching the key would put a
+        # match context on the heap per key, and the read path's heap words are
+        # pinned (test/conformance/elixir/alloc-budget.txt).
+        if byte_size(key) > 0 and :binary.first(key) == ?&, do: bad(value, report)
 
         {value, pos, report, seen} =
           case Enum.find(type.fields, fn f -> f.json == key end) do

--- a/test/cs-tables/src/Program.cs
+++ b/test/cs-tables/src/Program.cs
@@ -1314,9 +1314,10 @@ static class Program
         Check(wrote > 0 && wrote == V2.Schema.CfgMeasure(v2), "v2_seams: measure == save");
         GoldenWire("v2_seams", new ReadOnlySpan<byte>(buffer, 0, (int)wrote));
 
-        // the three spellings over NON-DEFAULT content: byte-identical. C#
-        // carries T and ?T; *T is pointered, so this backend refuses it and
-        // the pointer's bytes come from the C++-pinned golden below.
+        // T and ?T over NON-DEFAULT content: byte-identical, one framing with
+        // two spellings. *T is NOT in that family — a pointer rides as a node
+        // index under its own kind (docs/SPEC-TABLES.md §2.3, §3.1); C# refuses
+        // the pointered unit, so its bytes come from the C++-pinned golden.
         P1.Chain value = new P1.Chain();
         BuildGoldenChainValue(value);
         long wValue = P1.Schema.ChainSave(value, buffer);
@@ -1333,8 +1334,8 @@ static class Program
         Check(wOpt == wValue && new ReadOnlySpan<byte>(other, 0, (int)wOpt).SequenceEqual(new ReadOnlySpan<byte>(buffer, 0, (int)wValue)),
             "?T and a plain nesting are byte-identical over non-default content");
         GoldenWire("chain_optional", new ReadOnlySpan<byte>(other, 0, (int)wOpt));
-        Check(new ReadOnlySpan<byte>(other, 0, (int)wOpt).SequenceEqual(ReadGolden("chain_pointer")),
-            "and so is *T — the pointer's bytes, written by C++");
+        Check(!new ReadOnlySpan<byte>(other, 0, (int)wOpt).SequenceEqual(ReadGolden("chain_pointer")),
+            "and *T is not — the pointer's bytes, written by C++, carry a node index and a node table");
 
         // the ASYMMETRY at the empty end: a by-value nesting at its defaults
         // writes nothing; a PRESENT optional writes its body anyway
@@ -1348,8 +1349,8 @@ static class Program
         long wOptEmpty = P3.Schema.ChainSave(optionalEmpty, other);
         Check(wOptEmpty > wValueEmpty, "chain_optional_empty: presence decides, not content");
         GoldenWire("chain_optional_empty", new ReadOnlySpan<byte>(other, 0, (int)wOptEmpty));
-        Check(new ReadOnlySpan<byte>(other, 0, (int)wOptEmpty).SequenceEqual(ReadGolden("chain_pointer_empty")),
-            "and a non-null pointer writes the same body — the empty end's asymmetry is shared");
+        Check(!new ReadOnlySpan<byte>(other, 0, (int)wOptEmpty).SequenceEqual(ReadGolden("chain_pointer_empty")),
+            "a non-null empty pointer shares the rule (presence decides) but not the bytes: it rides as an index and a node table");
     }
 
     // ---- gate: LOAD the C++-written seam bytes ----
@@ -1408,18 +1409,30 @@ static class Program
             Check(cfg.Ledger[(int)V2.Grade.Bronze] == 7 && cfg.Ledger[(int)V2.Grade.Gold] == 9,
                 "v2_seams: the keyed ledger");
         }
-        // the pointer's bytes, read by the two spellings C# carries
+        // the pointer's bytes, read by the two spellings C# carries: a REPORTED
+        // edit, not a decode. The pointer rides as a node index under kind 17,
+        // so a T or ?T reader counts one kind mismatch, leaves the field at its
+        // declared default and reads the rest of the body on; the node table
+        // rides under the reserved id 0xFFFF and is one unknown field to a
+        // reader that cannot name it (docs/SPEC-TABLES.md §2.3, §3.1)
         {
             byte[] golden = ReadGolden("chain_pointer");
             P1.TableReport r1 = new P1.TableReport();
             P1.Chain byValue = new P1.Chain();
+            byValue.Link.Value = 7; // junk the reset must erase
             Check(P1.Schema.ChainLoad(byValue, golden, r1), "chain_pointer loads into a by-value nesting");
-            Check(!r1.Malformed && GetString(byValue.Name, byValue.NameLength) == "chain" && byValue.Link.Value == 7,
-                "*T bytes decode as T");
+            Check(!r1.Malformed && r1.KindMismatch == 1 && r1.Unknown == 1,
+                "*T through T: one kind mismatch for the index, one unknown for the node table");
+            Check(GetString(byValue.Name, byValue.NameLength) == "chain" && byValue.Link.Value == 0,
+                "*T through T: the field takes its declared default and the rest of the body reads on");
             P3.TableReport r3 = new P3.TableReport();
             P3.Chain optional = new P3.Chain();
+            optional.LinkPresent = true; // junk the reset must erase
             Check(P3.Schema.ChainLoad(optional, golden, r3), "chain_pointer loads into an optional");
-            Check(!r3.Malformed && optional.LinkPresent && optional.Link.Value == 7, "*T bytes decode as ?T, and present");
+            Check(!r3.Malformed && r3.KindMismatch == 1 && r3.Unknown == 1,
+                "*T through ?T: one kind mismatch for the index, one unknown for the node table");
+            Check(!optional.LinkPresent && optional.Link.Value == 0 && GetString(optional.Name, optional.NameLength) == "chain",
+                "*T through ?T: absent, at its default, and the rest of the body reads on");
         }
         {
             byte[] golden = ReadGolden("chain_value_empty");
@@ -1434,7 +1447,8 @@ static class Program
             P1.TableReport r1 = new P1.TableReport();
             P1.Chain byValue = new P1.Chain();
             Check(P1.Schema.ChainLoad(byValue, golden, r1), "chain_pointer_empty loads into a by-value nesting");
-            Check(!r1.Malformed && byValue.Link.Value == 0, "a non-null empty pointee reads as the declared default by value");
+            Check(!r1.Malformed && r1.KindMismatch == 1 && r1.Unknown == 1 && byValue.Link.Value == 0,
+                "a non-null empty pointee is still an index: reported, and the field reads as the declared default by value");
         }
     }
 
@@ -1634,7 +1648,7 @@ static class Program
 
         V1.TableFieldInfo extra = V1Field(cfg, "extra");
         Check(extra != null && extra.Optional, "reflection: ?T is marked optional");
-        Check(extra.Kind == 13, "reflection: an optional table body is a table kind — the framing *T and T use");
+        Check(extra.Kind == 13, "reflection: an optional table body is a table kind — the framing ?T and T share");
         V1.TableFieldInfo tier = V1Field(cfg, "tier");
         Check(tier != null && tier.Optional && tier.Kind == 4, "reflection: an optional scalar");
         V1.TableFieldInfo grade = V1Field(cfg, "grade");

--- a/test/go-tables/soak_test.go
+++ b/test/go-tables/soak_test.go
@@ -145,17 +145,16 @@ func soakCorpus(t *testing.T) []soakCase {
 			tblv2.CfgFromJson, tblv2.CfgToJsonMeasure, tblv2.CfgToJson),
 		soakRow(t, "v2_seams", g+"v2_seams.bin", tblv2.CfgReset, tblv2.CfgLoad, tblv2.CfgMeasure, tblv2.CfgSave,
 			tblv2.CfgFromJson, tblv2.CfgToJsonMeasure, tblv2.CfgToJson),
+		// the pointered spellings (chain_pointer, chain_pointer_empty) have no Go
+		// codec and no text: Go refuses the pointered unit by name (§11), and
+		// their goldens are the C++ reference's
 		soakRow(t, "chain_value", g+"chain_value.bin", tblp1.ChainReset, tblp1.ChainLoad, tblp1.ChainMeasure,
 			tblp1.ChainSave, tblp1.ChainFromJson, tblp1.ChainToJsonMeasure, tblp1.ChainToJson),
 		soakRow(t, "chain_value_empty", g+"chain_value_empty.bin", tblp1.ChainReset, tblp1.ChainLoad,
 			tblp1.ChainMeasure, tblp1.ChainSave, tblp1.ChainFromJson, tblp1.ChainToJsonMeasure, tblp1.ChainToJson),
-		soakRow(t, "chain_pointer", g+"chain_pointer.bin", tblp1.ChainReset, tblp1.ChainLoad, tblp1.ChainMeasure,
-			tblp1.ChainSave, tblp1.ChainFromJson, tblp1.ChainToJsonMeasure, tblp1.ChainToJson),
 		soakRow(t, "chain_optional", g+"chain_optional.bin", tblp3.ChainReset, tblp3.ChainLoad, tblp3.ChainMeasure,
 			tblp3.ChainSave, tblp3.ChainFromJson, tblp3.ChainToJsonMeasure, tblp3.ChainToJson),
 		soakRow(t, "chain_optional_empty", g+"chain_optional_empty.bin", tblp3.ChainReset, tblp3.ChainLoad,
-			tblp3.ChainMeasure, tblp3.ChainSave, tblp3.ChainFromJson, tblp3.ChainToJsonMeasure, tblp3.ChainToJson),
-		soakRow(t, "chain_pointer_empty", g+"chain_pointer_empty.bin", tblp3.ChainReset, tblp3.ChainLoad,
 			tblp3.ChainMeasure, tblp3.ChainSave, tblp3.ChainFromJson, tblp3.ChainToJsonMeasure, tblp3.ChainToJson),
 	}
 }

--- a/test/java-tables/src/Main.java
+++ b/test/java-tables/src/Main.java
@@ -432,19 +432,31 @@ public final class Main {
     /** what a measured path costs over its window. */
     private interface Window { long bytes(); }
 
-    // EVERY PATH IS MEASURED TWICE AND THE SECOND IS REPORTED, which is the
-    // bench's own "one warmup run, then the measured ones" applied to
-    // allocation rather than to time — and it earns its place: the typed
-    // accessor loop is a tight int loop C2 compiles LATE, and at a small window
-    // the compilation lands inside the first measured span and reads as a fixed
-    // ~576 bytes. It is a one-off and not a per-record cost (576 over 2500
-    // records is 0.23 bytes; the smallest object Java can allocate is sixteen),
-    // and measuring past it is how the number becomes the loop's own rather
-    // than the compiler's. A path that really allocated per record allocates in
-    // the second window too.
-    private static long twice(Window w) {
-        w.bytes();
-        return w.bytes();
+    // EVERY PATH IS MEASURED UNTIL TWO CONSECUTIVE WINDOWS AGREE, and that
+    // count is the one reported — the bench's own "one warmup run, then the
+    // measured ones" applied to allocation rather than to time. It earns its
+    // place: the typed accessor loop is a tight int loop C2 compiles LATE, and
+    // at a small window the compilation lands inside a measured span and reads
+    // as a fixed ~576 bytes; a deoptimization and its recompile land the same
+    // way and read as a few kilobytes. Those are one-offs and not per-record
+    // costs (576 over 2500 records is 0.23 bytes; the smallest object Java can
+    // allocate is sixteen), and no two windows carry the same one-off, so the
+    // number that repeats is the loop's own rather than the compiler's. A path
+    // that really allocates per record allocates the same amount in every
+    // window and is reported on the second. The count is bounded: a path
+    // whose allocation never settles is judged on its last window.
+    private static final int SETTLE_WINDOWS = 8;
+
+    private static long steady(Window w) {
+        long last = w.bytes();
+        for (int window = 1; window < SETTLE_WINDOWS; window++) {
+            long next = w.bytes();
+            if (next == last) {
+                return next;
+            }
+            last = next;
+        }
+        return last;
     }
 
     // one measured row: the total over `records`, the per-record number, and the
@@ -518,17 +530,17 @@ public final class Main {
 
         describe("the measured allocation window");
         boolean ok = true;
-        ok &= check(WIRE_READ, twice(() -> allocWireRead(bean, corpus, wirePasses)), (long) wirePasses * corpus.length);
-        ok &= check(WIRE_SAVE, twice(() -> allocWireSave(bean, corpus, wirePasses)), (long) wirePasses * corpus.length);
-        ok &= check(BLOCK_OPEN, twice(() -> allocBlockOpen(bean, block, wirePasses)), wirePasses);
-        ok &= check(BLOCK_READ, twice(() -> allocBlockRead(bean, blockHandle, formPasses)), formPasses);
-        ok &= check(BLOCK_TYPED, twice(() -> allocBlockTyped(bean, blockHandle, wirePasses)), wirePasses);
-        ok &= check(BLOCK_ROWS, twice(() -> allocBlockRows(bean, blockHandle, wirePasses)), wirePasses);
-        ok &= check(COOK_OPEN, twice(() -> allocCookOpen(bean, cook, wirePasses)), wirePasses);
-        ok &= check(COOK_READ, twice(() -> allocCookRead(bean, cookHandle, formPasses)), formPasses);
+        ok &= check(WIRE_READ, steady(() -> allocWireRead(bean, corpus, wirePasses)), (long) wirePasses * corpus.length);
+        ok &= check(WIRE_SAVE, steady(() -> allocWireSave(bean, corpus, wirePasses)), (long) wirePasses * corpus.length);
+        ok &= check(BLOCK_OPEN, steady(() -> allocBlockOpen(bean, block, wirePasses)), wirePasses);
+        ok &= check(BLOCK_READ, steady(() -> allocBlockRead(bean, blockHandle, formPasses)), formPasses);
+        ok &= check(BLOCK_TYPED, steady(() -> allocBlockTyped(bean, blockHandle, wirePasses)), wirePasses);
+        ok &= check(BLOCK_ROWS, steady(() -> allocBlockRows(bean, blockHandle, wirePasses)), wirePasses);
+        ok &= check(COOK_OPEN, steady(() -> allocCookOpen(bean, cook, wirePasses)), wirePasses);
+        ok &= check(COOK_READ, steady(() -> allocCookRead(bean, cookHandle, formPasses)), formPasses);
         ok &= check(JSON_WRITE, allocJsonWrite(bean, corpus, jsonScratch, formPasses),
                 (long) formPasses * corpus.length);
-        ok &= check(JSON_READ, twice(() -> allocJsonRead(bean, corpus, formPasses)), (long) formPasses * corpus.length);
+        ok &= check(JSON_READ, steady(() -> allocJsonRead(bean, corpus, formPasses)), (long) formPasses * corpus.length);
         return ok;
     }
 


### PR DESCRIPTION
## What was red

`certify.yml` has failed on main since 46b81725 (#386). Every `test` and `inline-gate` job first died at the Rust conformance driver's `alloc-audit` ("no codec for graphdemo.Scene"); #388 landed that fix on main, so this branch no longer carries it. Behind it, dispatching this branch and running the rest of the `make test` chain locally found five more, each from a merged PR whose gates were not run to the end of the chain:

1. `tables-block-zero-cost` greps every generated Table source for a block symbol. #386's arena runtime emits a comment saying "the shape `TableBlockAllocator` already has (§19.1)", and the grep matched the prose.
2. `tables-block-build-version` grepped for `inline constexpr uint64_t BuildVersion`; #386 spells it `static const uint64_t` in the C-like dialect.
3. `test/cs-tables` asserted `*T` bytes equal `?T` bytes. Since #376 a pointer rides as a node index under its own kind with a node table under the reserved id (docs/SPEC-TABLES.md §2.3, §3.1).
4. `test/go-tables` `TestSoak` hard-coded `chain_pointer` and `chain_pointer_empty` rows; #376 took those instances off the manifest and their text out of the corpus, so the test died opening `chain_pointer.json`.
5. `tables-elixir-alloc-audit`: #388's reserved-prefix refusal in the Elixir JSON reader, `String.starts_with?(key, "&")`, is a binary match per key and every match puts a match context on the heap — ~160 heap words per instance over the pinned budgets, which the audit holds to +64..66 words. All 16 cases went red on every leg (release-gates included).

Dispatching the branch again with those five fixed (run 33787248541) found three more, none of them visible while the earlier ones masked them:

6. `test` on both OSes: `generated/bench/tables/elixir/TableRuntime.ex` was stale — the ampersand check above moved in the emitter and only the corpus tree had been regenerated.
7. `inline-gate (macos, cs)`: `tables-java-alloc` read 5960 B over 15000 wire-read records against an exact-zero floor, a one-off the same target did not show in the `test (macos)` job minutes earlier. The harness reported the second of two windows, and a JIT deoptimization and recompile landing in that window reads as a fixed few kilobytes.
8. `inline-gate (macos, c/cpp/go/rust)`: all four "cancelled" at exactly 20 minutes with make still running — `timeout-minutes: 20` dates from #372 when the chain was shorter; `make test` is now ~22 minutes on either OS (1320 s on ubuntu in that run).

## What moved

- `Makefile`: the zero-cost grep runs over the code with `//` comments stripped (negative control: a real `TableBlockAllocator` line in a generated header still turns the gate red); the build-version grep follows #386's spelling.
- `test/cs-tables/src/Program.cs`: `*T` is expected to differ from `?T` on the wire; a `T`/`?T` reader over `*T` bytes reports one kind mismatch and one unknown, leaves the field at its default, and reads the rest of the body on.
- `test/go-tables/soak_test.go`: the two pointered rows are gone; Go refuses the pointered unit by name (§11) and their goldens are the C++ reference's.
- `internal/codegen/elixirtable/runtime.go`: the ampersand check is `byte_size(key) > 0 and :binary.first(key) == ?&` — two guard BIFs, no allocation. Measured with the driver directly: no check 21761 words on root_full, `starts_with?` 21923, `<<?&, _::binary>>` 22068, the BIF spelling 21763 against a pin of 21761 + 66. The pin stands; the sixteen hostile rows over the construct still refuse (json-hostile 68/68).

- `generated/bench/tables/elixir/TableRuntime.ex`: regenerated with the current compiler; the bench golden gate over it passes (64 variants at 2391 bytes).
- `test/java-tables/src/Main.java`: every exact-floor path is measured until two consecutive windows agree (bounded at eight) and that count is reported. A real per-record allocation is the same in every window and reports on the second; the negative control still turns the wire-read row red alone.
- `.github/workflows/certify.yml`: the inline-gate legs get 40 minutes, with the measurement in the comment.

## Run locally

`tables-block-zero-cost` (68 pins byte-identical against the current compiler), `tables-block-build-version`, the tables chain of `make test` from the Go soak through `tables-hostile-negative`, `tables-cs-json-walk`, `tables-cs-standalone`, `tables-cs-refuses-pointers`, `cd test/cs-tables && dotnet run`, `cd test/go-tables && go test`, `tables-rust-alloc-audit`, `tables-rust-alloc-negative-control`, `tables-rust-soak SOAK_SECONDS=3`, `tables-elixir-alloc-audit`, `conformance-harness run --only elixir`, `go test ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

