### PR TITLE
docs/PORTING.md: the techniques register, with its gate (#389)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ bin/schema generate --lang c|cpp|cs|dart|elixir|go|java|js|rust --out <outdir> <
 | **[SPEC.md](docs/SPEC.md)** | The normative reference for the type wire: grammar, wire law, every edge case. |
 | **[SPEC-TABLES.md](docs/SPEC-TABLES.md)** | The normative reference for tables: the wire, the cook, the block form, reflection, the build version. |
 
-Beside them: [PERFORMANCE.md](docs/PERFORMANCE.md),
+Beside them: [PORTING.md](docs/PORTING.md) (the techniques register: every
+method and instrument a table backend carries, with a cell per language and a
+gate), [PERFORMANCE.md](docs/PERFORMANCE.md),
 [COMPARISON-TABLES.md](docs/COMPARISON-TABLES.md) (tables against FlatBuffers and
 Protobuf, feature by feature, with the verdict on every gap),
 [COMPARISON.md](docs/COMPARISON.md) (the same packet against Cap'n Proto, Protobuf

--- a/compiler/porting_test.go
+++ b/compiler/porting_test.go
@@ -1,0 +1,583 @@
+// The gate on docs/PORTING.md, the techniques register. Every language the
+// conformance harness discovers has a column; a carried cell names what
+// proves it — a Makefile target the tree RUNS (from `make test`, from a
+// `tables-<lang>-release` target, or by name from a workflow) or a Go test
+// that exists — and in a section with a Makefile-checkable form it must name
+// at least one; a not-yet cell cites its carry-across issue; a cannot cell
+// states its reason. The register's grammar is stated on the page.
+package compiler
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// portingLanguages is the column order the register uses; the reference is
+// first because its target names carry no language segment.
+var portingLanguages = []string{"cpp", "c", "rust", "go", "cs", "java", "js", "dart", "elixir"}
+
+// portingRow is one technique section of the register: its heading, the
+// target slugs its `Targets:` line names (none for a method the tree holds
+// by inspection), and one cell per language column.
+type portingRow struct {
+	Title string
+	Slugs []string
+	Cells map[string]string
+}
+
+var (
+	portingHeading  = regexp.MustCompile(`^### (.+)$`)
+	portingTargets  = regexp.MustCompile(`^\*\*Targets:\*\* (.+)$`)
+	portingIssue    = regexp.MustCompile(`#[0-9]+`)
+	portingBacktick = regexp.MustCompile("`([^`]+)`")
+	portingTestName = regexp.MustCompile(`^Test[A-Za-z0-9_]+$`)
+	makeRuleHeader  = regexp.MustCompile(`^([^\t#:=][^:=]*):(.*)$`)
+	makeVarAssign   = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*)\s*[+:?]?=(.*)$`)
+	makeVarRef      = regexp.MustCompile(`\$\(([A-Za-z_][A-Za-z0-9_]*)\)`)
+	makeRecipeMake  = regexp.MustCompile(`\$\(MAKE\)((?:\s+[^\s;&|]+)+)`)
+	workflowMake    = regexp.MustCompile(`\bmake((?:\s+[^\s;&|]+)+)`)
+	goTestFunc      = regexp.MustCompile(`(?m)^func (Test[A-Za-z0-9_]+)\(`)
+)
+
+// parsePortingRegister reads the register's technique sections. A section is
+// a `### ` heading, a `**Targets:**` line, and a table whose header row names
+// the language columns and whose single data row holds the cells.
+func parsePortingRegister(text string) ([]portingRow, error) {
+	var rows []portingRow
+	var cur *portingRow
+	lines := strings.Split(text, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimRight(lines[i], "\r")
+		if m := portingHeading.FindStringSubmatch(line); m != nil {
+			rows = append(rows, portingRow{Title: m[1]})
+			cur = &rows[len(rows)-1]
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		if m := portingTargets.FindStringSubmatch(line); m != nil {
+			spec := strings.TrimSpace(m[1])
+			if spec != "none" {
+				for s := range strings.SplitSeq(spec, ",") {
+					s = strings.Trim(strings.TrimSpace(s), "`")
+					if s == "" {
+						return nil, fmt.Errorf("%s: empty target slug in %q", cur.Title, line)
+					}
+					cur.Slugs = append(cur.Slugs, s)
+				}
+			}
+			continue
+		}
+		if cur.Cells != nil || !strings.HasPrefix(line, "|") {
+			continue
+		}
+		header := splitTableRow(line)
+		if len(header) != len(portingLanguages) {
+			return nil, fmt.Errorf("%s: the table has %d columns, the register has %d languages", cur.Title, len(header), len(portingLanguages))
+		}
+		for j, h := range header {
+			if strings.TrimSpace(h) != portingLanguages[j] {
+				return nil, fmt.Errorf("%s: column %d is %q, want %q", cur.Title, j, strings.TrimSpace(h), portingLanguages[j])
+			}
+		}
+		if i+2 >= len(lines) {
+			return nil, fmt.Errorf("%s: the table has no data row", cur.Title)
+		}
+		data := splitTableRow(strings.TrimRight(lines[i+2], "\r"))
+		if len(data) != len(portingLanguages) {
+			return nil, fmt.Errorf("%s: the data row has %d cells, want %d", cur.Title, len(data), len(portingLanguages))
+		}
+		cur.Cells = map[string]string{}
+		for j, lang := range portingLanguages {
+			cur.Cells[lang] = strings.TrimSpace(data[j])
+		}
+		i += 2
+	}
+	for _, r := range rows {
+		if r.Cells == nil {
+			return nil, fmt.Errorf("%s: no cell table", r.Title)
+		}
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("no technique sections found")
+	}
+	return rows, nil
+}
+
+// splitTableRow splits one Markdown table row into its cells, dropping the
+// outer pipes. A backtick span may carry a pipe, and the register does not.
+func splitTableRow(line string) []string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "|")
+	line = strings.TrimSuffix(line, "|")
+	return strings.Split(line, "|")
+}
+
+// makeTargetsAfter reads the target names that follow `make` or `$(MAKE)` on
+// one line: flags, variable assignments and shell substitutions are skipped.
+func makeTargetsAfter(args string) []string {
+	var out []string
+	for tok := range strings.FieldsSeq(args) {
+		if strings.HasPrefix(tok, "-") || strings.ContainsAny(tok, "=$\"'{}") {
+			continue
+		}
+		out = append(out, tok)
+	}
+	return out
+}
+
+// makefileReach parses the rules of the Makefile and of every make/<lang>.mk
+// it includes, and answers which targets exist and which the tree runs: a
+// prerequisite of a reached target, or a `$(MAKE) <target>` line in a reached
+// target's recipe — including one that runs every value of a list variable,
+// as `test` runs `$(TEST_LEGS)` — transitively, from the roots: `test`, every
+// `tables-<lang>-release` target (which certify.yml discovers from the same
+// files and runs by name) and every target a workflow under .github/workflows
+// invokes as `make <target>`.
+func makefileReach(texts []string, workflowRoots []string) (exists, reached map[string]bool) {
+	exists = map[string]bool{}
+	edges := map[string][]string{}
+	vars := map[string][]string{}
+	type recipeRef struct{ targets, refs []string }
+	var listRuns []recipeRef // recipe lines that run every value of a variable
+	for _, text := range texts {
+		// join continuation lines so a rule header's prerequisites are one line
+		var lines []string
+		for raw := range strings.SplitSeq(text, "\n") {
+			raw = strings.TrimRight(raw, "\r")
+			if n := len(lines); n > 0 && strings.HasSuffix(lines[n-1], "\\") {
+				lines[n-1] = strings.TrimSuffix(lines[n-1], "\\") + " " + strings.TrimSpace(raw)
+				continue
+			}
+			lines = append(lines, raw)
+		}
+		var current []string
+		for _, line := range lines {
+			if strings.HasPrefix(line, "\t") {
+				if !strings.Contains(line, "$(MAKE)") {
+					continue
+				}
+				for _, m := range makeRecipeMake.FindAllStringSubmatch(line, -1) {
+					for _, t := range current {
+						edges[t] = append(edges[t], makeTargetsAfter(m[1])...)
+					}
+				}
+				var refs []string
+				for _, m := range makeVarRef.FindAllStringSubmatch(line, -1) {
+					if m[1] != "MAKE" {
+						refs = append(refs, m[1])
+					}
+				}
+				if len(refs) > 0 {
+					listRuns = append(listRuns, recipeRef{targets: current, refs: refs})
+				}
+				continue
+			}
+			if strings.HasPrefix(line, "define ") || line == "endef" {
+				current = nil // a define's body is not a recipe
+				continue
+			}
+			if m := makeVarAssign.FindStringSubmatch(line); m != nil {
+				vars[m[1]] = append(vars[m[1]], strings.Fields(strings.SplitN(m[2], "#", 2)[0])...)
+				continue
+			}
+			m := makeRuleHeader.FindStringSubmatch(line)
+			if m == nil || strings.HasPrefix(m[2], "=") {
+				continue // not a rule, or an assignment
+			}
+			targets := strings.Fields(m[1])
+			if len(targets) == 0 || strings.HasPrefix(targets[0], ".") {
+				current = nil
+				continue
+			}
+			prereqs := strings.Fields(strings.SplitN(m[2], "#", 2)[0])
+			current = targets
+			for _, t := range targets {
+				exists[t] = true
+				edges[t] = append(edges[t], prereqs...)
+			}
+		}
+	}
+	for _, run := range listRuns {
+		for _, ref := range run.refs {
+			for _, t := range run.targets {
+				edges[t] = append(edges[t], vars[ref]...)
+			}
+		}
+	}
+	reached = map[string]bool{}
+	var walk func(string)
+	walk = func(t string) {
+		if reached[t] {
+			return
+		}
+		reached[t] = true
+		for _, next := range edges[t] {
+			walk(next)
+		}
+	}
+	walk("test")
+	for t := range exists {
+		if strings.HasPrefix(t, "tables-") && strings.HasSuffix(t, "-release") {
+			walk(t)
+		}
+	}
+	for _, t := range workflowRoots {
+		walk(t)
+	}
+	return exists, reached
+}
+
+// workflowMakeTargets reads every `make <target>` a workflow invokes by name.
+func workflowMakeTargets(workflows []string) []string {
+	var roots []string
+	for _, text := range workflows {
+		for line := range strings.SplitSeq(text, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "#") {
+				continue
+			}
+			for _, m := range workflowMake.FindAllStringSubmatch(line, -1) {
+				roots = append(roots, makeTargetsAfter(m[1])...)
+			}
+		}
+	}
+	return roots
+}
+
+// discoverDrivers reads the languages the conformance harness registers: one
+// `test/conformance/<lang>/driver` per language, and, on a tree that still
+// lists them, the lines of `test/conformance/drivers.txt`.
+func discoverDrivers(root string) ([]string, error) {
+	names, err := filepath.Glob(filepath.Join(root, "test", "conformance", "*", "driver"))
+	if err != nil {
+		return nil, err
+	}
+	var langs []string
+	for _, n := range names {
+		langs = append(langs, filepath.Base(filepath.Dir(n)))
+	}
+	if len(langs) > 0 {
+		sort.Strings(langs)
+		return langs, nil
+	}
+	b, err := os.ReadFile(filepath.Join(root, "test", "conformance", "drivers.txt"))
+	if err != nil {
+		return nil, err
+	}
+	for line := range strings.SplitSeq(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		langs = append(langs, strings.Fields(line)[0])
+	}
+	return langs, nil
+}
+
+// goTestNames reads every `func Test…(` in a `_test.go` file `make test`
+// runs: the root module (`go test ./...`) and test/go-tables (its own line).
+// Generated trees and other nested modules are not scanned.
+func goTestNames(root string) (map[string]bool, error) {
+	names := map[string]bool{}
+	skip := map[string]bool{".git": true, "build": true, "dist": true, "generated": true, "node_modules": true}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		if d.IsDir() {
+			if skip[d.Name()] && path != root {
+				return filepath.SkipDir
+			}
+			// a nested module is its own `go test`; only test/go-tables rides make test
+			if path != root && rel != filepath.Join("test", "go-tables") {
+				if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, m := range goTestFunc.FindAllStringSubmatch(string(b), -1) {
+			names[m[1]] = true
+		}
+		return nil
+	})
+	return names, err
+}
+
+// conventionalTargets is the register's naming convention: the reference
+// spells `tables-<slug>`, every other language `tables-<lang>-<slug>`.
+func conventionalTargets(lang string, slugs []string) []string {
+	var out []string
+	for _, s := range slugs {
+		if lang == "cpp" {
+			out = append(out, "tables-"+s)
+		} else {
+			out = append(out, "tables-"+lang+"-"+s)
+		}
+	}
+	return out
+}
+
+// cellNames reads what a carried cell names in backticks: the Makefile
+// targets and the Go tests. Source paths are cited, not checked.
+func cellNames(cell string) (targets, tests []string) {
+	for _, m := range portingBacktick.FindAllStringSubmatch(cell, -1) {
+		name := m[1]
+		switch {
+		case strings.HasPrefix(name, "tables-") || strings.HasPrefix(name, "conformance-"):
+			targets = append(targets, name)
+		case portingTestName.MatchString(name):
+			tests = append(tests, name)
+		}
+	}
+	return targets, tests
+}
+
+// portingTree is what the register is held to.
+type portingTree struct {
+	registry []string
+	exists   map[string]bool
+	reached  map[string]bool
+	tests    map[string]bool
+}
+
+// checkPortingRegister holds the register to the tree. Every finding is one
+// string naming the technique, the language and what is wrong.
+func checkPortingRegister(rows []portingRow, tree portingTree) []string {
+	var findings []string
+	registered := map[string]bool{}
+	for _, lang := range tree.registry {
+		registered[lang] = true
+		found := false
+		for _, l := range portingLanguages {
+			if l == lang {
+				found = true
+			}
+		}
+		if !found {
+			findings = append(findings, fmt.Sprintf("registry language %q has no column in the register", lang))
+		}
+	}
+	for _, row := range rows {
+		for _, lang := range portingLanguages {
+			cell := row.Cells[lang]
+			switch {
+			case strings.HasPrefix(cell, "✅"):
+				targets, tests := cellNames(cell)
+				if len(row.Slugs) > 0 && registered[lang] && len(targets) == 0 && len(tests) == 0 {
+					targets = conventionalTargets(lang, row.Slugs)
+				}
+				for _, name := range targets {
+					switch {
+					case !tree.exists[name]:
+						findings = append(findings, fmt.Sprintf("%s / %s: carried, but the Makefile has no target %q", row.Title, lang, name))
+					case !tree.reached[name]:
+						findings = append(findings, fmt.Sprintf("%s / %s: target %q exists but nothing reaches it — not `make test`, not a release target, not a workflow", row.Title, lang, name))
+					}
+				}
+				for _, name := range tests {
+					if !tree.tests[name] {
+						findings = append(findings, fmt.Sprintf("%s / %s: carried, but no Go test %q exists where `make test` runs one", row.Title, lang, name))
+					}
+				}
+			case strings.HasPrefix(cell, "❌"):
+				if !portingIssue.MatchString(cell) {
+					findings = append(findings, fmt.Sprintf("%s / %s: not yet, with no carry-across issue (#NNN)", row.Title, lang))
+				}
+			case strings.HasPrefix(cell, "—"):
+				reason := strings.TrimSpace(strings.TrimPrefix(cell, "—"))
+				if len(strings.Fields(reason)) < 2 {
+					findings = append(findings, fmt.Sprintf("%s / %s: cannot, with no stated reason", row.Title, lang))
+				}
+			default:
+				findings = append(findings, fmt.Sprintf("%s / %s: cell %q starts with none of ✅ ❌ —", row.Title, lang, cell))
+			}
+		}
+	}
+	sort.Strings(findings)
+	return findings
+}
+
+func readPortingInputs(t *testing.T) (register string, tree portingTree) {
+	t.Helper()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := func(rel string) string {
+		b, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	names, err := filepath.Glob(filepath.Join(root, ".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflows []string
+	for _, n := range names {
+		b, err := os.ReadFile(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		workflows = append(workflows, string(b))
+	}
+	makefiles := []string{read("Makefile")}
+	included, err := filepath.Glob(filepath.Join(root, "make", "*.mk"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(included)
+	for _, n := range included {
+		b, err := os.ReadFile(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		makefiles = append(makefiles, string(b))
+	}
+	tree.exists, tree.reached = makefileReach(makefiles, workflowMakeTargets(workflows))
+	if !tree.exists["test"] {
+		t.Fatal("the Makefile parse found no `test` rule")
+	}
+	tree.registry, err = discoverDrivers(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tree.registry) == 0 {
+		t.Fatal("the harness discovers no driver")
+	}
+	tree.tests, err = goTestNames(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return read("docs/PORTING.md"), tree
+}
+
+// TestPortingRegisterHoldsTheTree is the gate: the register as committed,
+// against the Makefile, the workflows, the Go tests and the driver registry
+// as committed.
+func TestPortingRegisterHoldsTheTree(t *testing.T) {
+	register, tree := readPortingInputs(t)
+	rows, err := parsePortingRegister(register)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range checkPortingRegister(rows, tree) {
+		t.Error(f)
+	}
+	carried, notYet, cannot := 0, 0, 0
+	for _, r := range rows {
+		for _, c := range r.Cells {
+			switch {
+			case strings.HasPrefix(c, "✅"):
+				carried++
+			case strings.HasPrefix(c, "❌"):
+				notYet++
+			case strings.HasPrefix(c, "—"):
+				cannot++
+			}
+		}
+	}
+	t.Logf("%d techniques, %d registered languages, %d cells: %d carried, %d not yet, %d cannot; %d Makefile targets reached",
+		len(rows), len(tree.registry), carried+notYet+cannot, carried, notYet, cannot, len(tree.reached))
+}
+
+// TestPortingRegisterGateGoesRed is the gate's own negative control: a copy of
+// the register with one cell sabotaged each way must produce the finding that
+// names it, and only that finding.
+func TestPortingRegisterGateGoesRed(t *testing.T) {
+	register, tree := readPortingInputs(t)
+	rows, err := parsePortingRegister(register)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(checkPortingRegister(rows, tree)); n != 0 {
+		t.Fatalf("the committed register has %d findings; the control needs a green baseline", n)
+	}
+
+	// the row the plants go into: one with a Makefile-checkable form
+	checkable := -1
+	for i, r := range rows {
+		if len(r.Slugs) > 0 {
+			checkable = i
+			break
+		}
+	}
+	if checkable < 0 {
+		t.Fatal("no technique in the register has a Makefile-checkable form")
+	}
+	lang := tree.registry[0]
+
+	// a target that exists and that nothing runs, for the reach plant
+	const unreached = "tables-planted-unreached-gate"
+	tree.exists[unreached] = true
+
+	plant := func(name, cell string, want string) {
+		t.Helper()
+		copied := make([]portingRow, len(rows))
+		for i, r := range rows {
+			cells := map[string]string{}
+			maps.Copy(cells, r.Cells)
+			copied[i] = portingRow{Title: r.Title, Slugs: r.Slugs, Cells: cells}
+		}
+		copied[checkable].Cells[lang] = cell
+		findings := checkPortingRegister(copied, tree)
+		if len(findings) != 1 || !strings.Contains(findings[0], want) {
+			t.Errorf("%s: want one finding containing %q, got %q", name, want, findings)
+		}
+	}
+	plant("a carried cell naming no existing target", "✅ `tables-"+lang+"-no-such-gate`", "has no target")
+	plant("a carried cell naming a target nothing reaches", "✅ `"+unreached+"`", "nothing reaches it")
+	plant("a carried cell naming no test that exists", "✅ `TestNoSuchGate`", "no Go test")
+	plant("a carried cell naming nothing, held to the convention", "✅ carried by hand", "has no target")
+	plant("a bare not-yet cell", "❌", "no carry-across issue")
+	plant("a cannot cell with no reason", "— ", "no stated reason")
+	plant("a cell with no marker", "carried", "starts with none of")
+
+	// the parser's own controls: a column renamed, and a section with no table
+	if _, err := parsePortingRegister(strings.Replace(register, "| cpp |", "| c++ |", 1)); err == nil {
+		t.Error("the parser accepted a register whose first column is not cpp")
+	}
+	if _, err := parsePortingRegister(register + "\n### A technique with no table\n\n**Targets:** none\n"); err == nil {
+		t.Error("the parser accepted a section with no cell table")
+	}
+
+	// the reach walk's own controls: a `make` line with flags and variables
+	// still yields the target, a workflow comment yields nothing, and a leg
+	// registered through a list variable in an included file is reached from
+	// `test` — while one registered in no list is not
+	if got := makeTargetsAfter(` -j"$(nproc)" tables-big-endian-negative BE_CXX=g++ `); len(got) != 1 || got[0] != "tables-big-endian-negative" {
+		t.Errorf("makeTargetsAfter read %q, want the one target", got)
+	}
+	if got := workflowMakeTargets([]string{"# 87 s of its 109 is `make tables-big-endian-negative`\n"}); len(got) != 0 {
+		t.Errorf("a workflow comment counted as a root: %q", got)
+	}
+	exists, reached := makefileReach([]string{
+		"test:\n\t@set -e; for leg in $(TEST_LEGS); do $(MAKE) $$leg; done\n",
+		"tables-zz-gate:\n\techo\ntest-zz: tables-zz-gate\n\t$(MAKE) tables-zz-other\nTEST_LEGS += test-zz\ntables-zz-other:\n\techo\ntables-zz-orphan:\n\techo\n",
+	}, nil)
+	for _, want := range []string{"tables-zz-gate", "tables-zz-other"} {
+		if !exists[want] || !reached[want] {
+			t.Errorf("%s: an included leg's target is not reached from `test` through TEST_LEGS", want)
+		}
+	}
+	if !exists["tables-zz-orphan"] || reached["tables-zz-orphan"] {
+		t.Error("a target no leg runs counted as reached")
+	}
+}

--- a/compiler/porting_test.go
+++ b/compiler/porting_test.go
@@ -13,14 +13,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
 )
-
-// portingLanguages is the column order the register uses; the reference is
-// first because its target names carry no language segment.
-var portingLanguages = []string{"cpp", "c", "rust", "go", "cs", "java", "js", "dart", "elixir"}
 
 // portingRow is one technique section of the register: its heading, the
 // target slugs its `Targets:` line names (none for a method the tree holds
@@ -29,6 +26,14 @@ type portingRow struct {
 	Title string
 	Slugs []string
 	Cells map[string]string
+}
+
+// portingRegister is the parsed page: the column order its first table
+// declares — the reference first, because its target names carry no language
+// segment — and every technique section, each holding exactly those columns.
+type portingRegister struct {
+	Languages []string
+	Rows      []portingRow
 }
 
 var (
@@ -47,8 +52,10 @@ var (
 
 // parsePortingRegister reads the register's technique sections. A section is
 // a `### ` heading, a `**Targets:**` line, and a table whose header row names
-// the language columns and whose single data row holds the cells.
-func parsePortingRegister(text string) ([]portingRow, error) {
+// the language columns and whose single data row holds the cells. The first
+// table's header is the column order; every later table must repeat it.
+func parsePortingRegister(text string) (*portingRegister, error) {
+	reg := &portingRegister{}
 	var rows []portingRow
 	var cur *portingRow
 	lines := strings.Split(text, "\n")
@@ -78,24 +85,31 @@ func parsePortingRegister(text string) ([]portingRow, error) {
 		if cur.Cells != nil || !strings.HasPrefix(line, "|") {
 			continue
 		}
-		header := splitTableRow(line)
-		if len(header) != len(portingLanguages) {
-			return nil, fmt.Errorf("%s: the table has %d columns, the register has %d languages", cur.Title, len(header), len(portingLanguages))
+		var header []string
+		for _, h := range splitTableRow(line) {
+			header = append(header, strings.TrimSpace(h))
 		}
-		for j, h := range header {
-			if strings.TrimSpace(h) != portingLanguages[j] {
-				return nil, fmt.Errorf("%s: column %d is %q, want %q", cur.Title, j, strings.TrimSpace(h), portingLanguages[j])
+		if reg.Languages == nil {
+			seen := map[string]bool{}
+			for _, h := range header {
+				if h == "" || seen[h] {
+					return nil, fmt.Errorf("%s: the first table's header names %q twice or names an empty column", cur.Title, h)
+				}
+				seen[h] = true
 			}
+			reg.Languages = header
+		} else if strings.Join(header, "|") != strings.Join(reg.Languages, "|") {
+			return nil, fmt.Errorf("%s: the table's columns are %q, the register's are %q", cur.Title, header, reg.Languages)
 		}
 		if i+2 >= len(lines) {
 			return nil, fmt.Errorf("%s: the table has no data row", cur.Title)
 		}
 		data := splitTableRow(strings.TrimRight(lines[i+2], "\r"))
-		if len(data) != len(portingLanguages) {
-			return nil, fmt.Errorf("%s: the data row has %d cells, want %d", cur.Title, len(data), len(portingLanguages))
+		if len(data) != len(reg.Languages) {
+			return nil, fmt.Errorf("%s: the data row has %d cells, want %d", cur.Title, len(data), len(reg.Languages))
 		}
 		cur.Cells = map[string]string{}
-		for j, lang := range portingLanguages {
+		for j, lang := range reg.Languages {
 			cur.Cells[lang] = strings.TrimSpace(data[j])
 		}
 		i += 2
@@ -108,7 +122,8 @@ func parsePortingRegister(text string) ([]portingRow, error) {
 	if len(rows) == 0 {
 		return nil, fmt.Errorf("no technique sections found")
 	}
-	return rows, nil
+	reg.Rows = rows
+	return reg, nil
 }
 
 // splitTableRow splits one Markdown table row into its cells, dropping the
@@ -334,8 +349,9 @@ func conventionalTargets(lang string, slugs []string) []string {
 }
 
 // cellNames reads what a carried cell names in backticks: the Makefile
-// targets and the Go tests. Source paths are cited, not checked.
-func cellNames(cell string) (targets, tests []string) {
+// targets, the Go tests, and the source paths (a path with its `:line`
+// citation stripped — a line may drift, a path may not).
+func cellNames(cell string) (targets, tests, paths []string) {
 	for _, m := range portingBacktick.FindAllStringSubmatch(cell, -1) {
 		name := m[1]
 		switch {
@@ -343,13 +359,16 @@ func cellNames(cell string) (targets, tests []string) {
 			targets = append(targets, name)
 		case portingTestName.MatchString(name):
 			tests = append(tests, name)
+		case strings.Contains(name, "/"):
+			paths = append(paths, strings.SplitN(name, ":", 2)[0])
 		}
 	}
-	return targets, tests
+	return targets, tests, paths
 }
 
 // portingTree is what the register is held to.
 type portingTree struct {
+	root     string
 	registry []string
 	exists   map[string]bool
 	reached  map[string]bool
@@ -358,29 +377,33 @@ type portingTree struct {
 
 // checkPortingRegister holds the register to the tree. Every finding is one
 // string naming the technique, the language and what is wrong.
-func checkPortingRegister(rows []portingRow, tree portingTree) []string {
+func checkPortingRegister(reg *portingRegister, tree portingTree) []string {
 	var findings []string
 	registered := map[string]bool{}
 	for _, lang := range tree.registry {
 		registered[lang] = true
-		found := false
-		for _, l := range portingLanguages {
-			if l == lang {
-				found = true
-			}
-		}
-		if !found {
+		if !slices.Contains(reg.Languages, lang) {
 			findings = append(findings, fmt.Sprintf("registry language %q has no column in the register", lang))
 		}
 	}
-	for _, row := range rows {
-		for _, lang := range portingLanguages {
+	for _, lang := range reg.Languages {
+		if !registered[lang] {
+			findings = append(findings, fmt.Sprintf("register column %q is no language the harness discovers", lang))
+		}
+	}
+	for _, row := range reg.Rows {
+		for _, lang := range reg.Languages {
 			cell := row.Cells[lang]
 			switch {
 			case strings.HasPrefix(cell, "✅"):
-				targets, tests := cellNames(cell)
+				targets, tests, paths := cellNames(cell)
 				if len(row.Slugs) > 0 && registered[lang] && len(targets) == 0 && len(tests) == 0 {
 					targets = conventionalTargets(lang, row.Slugs)
+				}
+				for _, p := range paths {
+					if _, err := os.Stat(filepath.Join(tree.root, filepath.FromSlash(p))); err != nil {
+						findings = append(findings, fmt.Sprintf("%s / %s: carried, but the cited path %q is not in the tree", row.Title, lang, p))
+					}
 				}
 				for _, name := range targets {
 					switch {
@@ -455,6 +478,7 @@ func readPortingInputs(t *testing.T) (register string, tree portingTree) {
 	if !tree.exists["test"] {
 		t.Fatal("the Makefile parse found no `test` rule")
 	}
+	tree.root = root
 	tree.registry, err = discoverDrivers(root)
 	if err != nil {
 		t.Fatal(err)
@@ -474,13 +498,14 @@ func readPortingInputs(t *testing.T) (register string, tree portingTree) {
 // as committed.
 func TestPortingRegisterHoldsTheTree(t *testing.T) {
 	register, tree := readPortingInputs(t)
-	rows, err := parsePortingRegister(register)
+	reg, err := parsePortingRegister(register)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, f := range checkPortingRegister(rows, tree) {
+	for _, f := range checkPortingRegister(reg, tree) {
 		t.Error(f)
 	}
+	rows := reg.Rows
 	carried, notYet, cannot := 0, 0, 0
 	for _, r := range rows {
 		for _, c := range r.Cells {
@@ -503,13 +528,14 @@ func TestPortingRegisterHoldsTheTree(t *testing.T) {
 // names it, and only that finding.
 func TestPortingRegisterGateGoesRed(t *testing.T) {
 	register, tree := readPortingInputs(t)
-	rows, err := parsePortingRegister(register)
+	reg, err := parsePortingRegister(register)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n := len(checkPortingRegister(rows, tree)); n != 0 {
+	if n := len(checkPortingRegister(reg, tree)); n != 0 {
 		t.Fatalf("the committed register has %d findings; the control needs a green baseline", n)
 	}
+	rows := reg.Rows
 
 	// the row the plants go into: one with a Makefile-checkable form
 	checkable := -1
@@ -537,11 +563,13 @@ func TestPortingRegisterGateGoesRed(t *testing.T) {
 			copied[i] = portingRow{Title: r.Title, Slugs: r.Slugs, Cells: cells}
 		}
 		copied[checkable].Cells[lang] = cell
-		findings := checkPortingRegister(copied, tree)
+		findings := checkPortingRegister(&portingRegister{Languages: reg.Languages, Rows: copied}, tree)
 		if len(findings) != 1 || !strings.Contains(findings[0], want) {
 			t.Errorf("%s: want one finding containing %q, got %q", name, want, findings)
 		}
 	}
+	tree.exists["tables-"+lang+"-planted"], tree.reached["tables-"+lang+"-planted"] = true, true
+	plant("a carried cell citing a path not in the tree", "✅ `internal/codegen/gotable/nonesuch.go:717` `tables-"+lang+"-planted`", "is not in the tree")
 	plant("a carried cell naming no existing target", "✅ `tables-"+lang+"-no-such-gate`", "has no target")
 	plant("a carried cell naming a target nothing reaches", "✅ `"+unreached+"`", "nothing reaches it")
 	plant("a carried cell naming no test that exists", "✅ `TestNoSuchGate`", "no Go test")
@@ -550,9 +578,21 @@ func TestPortingRegisterGateGoesRed(t *testing.T) {
 	plant("a cannot cell with no reason", "— ", "no stated reason")
 	plant("a cell with no marker", "carried", "starts with none of")
 
-	// the parser's own controls: a column renamed, and a section with no table
+	// the registry's own controls: a discovered language with no column, and a
+	// column no driver backs, each named by the finding
+	extra := portingTree{root: tree.root, registry: append(slices.Clone(tree.registry), "zig"), exists: tree.exists, reached: tree.reached, tests: tree.tests}
+	if f := checkPortingRegister(reg, extra); len(f) != 1 || !strings.Contains(f[0], `"zig" has no column`) {
+		t.Errorf("a tenth driver with no column: want one finding naming it, got %q", f)
+	}
+	fewer := portingTree{root: tree.root, registry: tree.registry[1:], exists: tree.exists, reached: tree.reached, tests: tree.tests}
+	if f := checkPortingRegister(reg, fewer); len(f) != 1 || !strings.Contains(f[0], `"`+tree.registry[0]+`" is no language`) {
+		t.Errorf("a column with no driver: want one finding naming it, got %q", f)
+	}
+
+	// the parser's own controls: a column renamed in one table, and a section
+	// with no table
 	if _, err := parsePortingRegister(strings.Replace(register, "| cpp |", "| c++ |", 1)); err == nil {
-		t.Error("the parser accepted a register whose first column is not cpp")
+		t.Error("the parser accepted a register whose tables do not agree on the columns")
 	}
 	if _, err := parsePortingRegister(register + "\n### A technique with no table\n\n**Targets:** none\n"); err == nil {
 		t.Error("the parser accepted a section with no cell table")

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -121,7 +121,11 @@ of the tree and requires the harness, the CI matrix, the bench pass and the
 Makefile to find it with no shared file edited. If a port needs to edit a file
 that lists languages, that is a defect in the registry, not a step.
 
-**Two shared edits are tolerated, and are the whole list.** A toolchain with
+**Three shared edits are tolerated, and are the whole list.** The port's
+column on [PORTING.md](PORTING.md), the techniques register, is written by
+hand — every technique carried, cited or stated impossible — and its gate
+reads the columns from the page and holds them to the discovered drivers, so
+the column is the edit and no other file lists the language; a toolchain with
 no step yet in `.github/workflows/ci.yml` (and the `test` job of
 `certify.yml`) adds one step, keyed on a new `ci.json` field; and the
 per-language prose in [SPEC.md](SPEC.md), [SPEC-TABLES.md](SPEC-TABLES.md)

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,0 +1,1024 @@
+# Porting: the techniques register
+
+This page is the register of techniques the nine table backends carry. A
+technique is a METHOD OF IMPLEMENTATION first — how a read path is made
+allocation-free, how a 64-bit value avoids boxing, how a codec is shaped for
+the optimizer, how a keyed array indexes — and an instrument or a gate second.
+Each has one section here: the method in a paragraph, where it lives in the
+reference, the language it was proven in, its measured effect where one was
+taken, its negative control, and a cell per language saying whether that
+language carries it.
+
+**The law, in the owner's words:** *"Make sure we don't do silly things again
+like, put some cool technique in language X, and then forget it for all other
+languages and we have to rediscover it."* A technique proven in one language's
+port belongs to every language. When it lands anywhere, it is written into
+this register the same day, and every other port either carries it or states
+here why the platform cannot.
+
+**How the page is used.** It is read BEFORE a port brief is written, so the
+brief carries every row and the port PR is not ready until its column is
+filled. It is read BEFORE a performance round is started, so a lever found in
+one language is tried in every language that can express it, and its absence
+elsewhere is a stated decision rather than an oversight. And it is read by
+every blind reader, who checks the column against the tree and not against
+memory. A lever proven in one language is only a THEORY in the next — the
+register says where to look, and the port's own measurement says whether it
+holds there.
+
+The evidence the page was written from: the independent allocation instrument
+was discovered by the Dart reader, then again by the Elixir reader, then again
+by the JavaScript reader — three discoveries of one technique, each costing a
+read cycle, because nothing carried it from the first port to the next brief.
+
+## How a technique enters
+
+Three rules, and the gate holds the second.
+
+1. **Same-PR entry.** A port PR or a reference PR that uses a method this
+   register lacks adds the method's section in that PR — its own cell carried,
+   the rest not yet — exactly as a spec section lands with its code. A
+   technique with no section is a technique the next port will rediscover.
+2. **A not-yet cell cites the carry-across.** Every ❌ cell names the issue
+   that carries the technique to that language (`❌ #NNN`), or the cell is a
+   `—` with the reason the platform cannot. The gate goes red on a bare ❌.
+   Adding a section therefore files the carry-across issue at the moment of
+   discovery, titled `<technique>: carry to <languages>`, naming the proving
+   language and the reference site in the body.
+3. **Every blind read reports two lists against this register:** methods the
+   port uses that the register lacks (rule 1 applies — they enter in the fix
+   reply), and methods the register has that the port lacks (rule 2 applies —
+   each becomes a carried cell or a cited one). `test/conformance/README.md`
+   says so where it points ports at this page.
+
+## The grammar the gate reads
+
+`compiler/porting_test.go` parses this page, the `Makefile` and every
+`make/<lang>.mk` it includes, the driver registry and the workflows, and holds
+them to each other. Its own negative
+control plants a carried cell naming no target, a carried cell naming a target
+nothing runs, a bare ❌ and a `—` with no reason into a copy of the register,
+and requires the finding that names each.
+
+- A technique is a `###` section. Its **Targets:** line names the slugs of its
+  Makefile-checkable form, or `none` for a method the tree holds by inspection
+  and by the instruments of other sections.
+- The cell table has the nine columns in this order: `cpp`, `c`, `rust`, `go`,
+  `cs`, `java`, `js`, `dart`, `elixir` — the languages the conformance harness
+  discovers as `test/conformance/<lang>/driver`.
+- A cell starts with one of three marks. **✅** carried — followed by what
+  proves it. **❌ #NNN** not yet — the carry-across issue. **—** the platform
+  cannot — followed by the reason.
+- **What a carried cell names.** In backticks: a Makefile target
+  (`tables-…`, `conformance-…`), a Go test (`TestName`, in the root module or
+  in `test/go-tables`, both of which `make test` runs), or a source path. The
+  gate holds every named target to exist and to be RUN by the tree, and every
+  named test to exist. In a section whose Targets line is not `none`, a
+  carried cell must name at least one target or test; a cell that names none
+  is held to the conventional names, `tables-<lang>-<slug>` for a port and
+  `tables-<slug>` for the reference.
+- **A target counts only if the tree RUNS it**: reached from `make test` (a
+  prerequisite, or a `$(MAKE) <target>` line, transitively — every leg's
+  `test-<lang>` is one, through `TEST_LEGS`), from a `tables-<lang>-release`
+  target (which `certify.yml` discovers from the same files and runs by
+  name), or by name from a workflow. A target that exists
+  and runs nowhere is a green light nobody has tested, and the gate says so.
+- **A measured row with a null ceiling cites why.** An allocation gate that
+  reports a path without gating it names the allocation it licenses at the
+  row, and the sentence is re-read when the emitter moves: the JavaScript
+  `Scene head deref` row carried a BigInt rationale for a path that had
+  stopped reading BigInts.
+
+## The register
+
+### M1 — The read path allocates nothing
+
+**Method.** Load fills caller-owned storage; the reader is a cursor over the
+caller's buffer, with no per-field object and no sub-view. A nested body is
+bounded by narrowing the reader's LIMIT and restoring it after — never by
+slicing a new view, because in a managed language a sub-view is an allocation
+and a limit is an integer. Where the language can hold a reader on the stack
+(a C++ value, a C struct, a Rust reborrow, a C# `ref struct`), a stack-value
+sub-reader costs nothing and the reference uses one. Where it cannot (Java,
+Dart, JavaScript), the limit is the technique in its stated form.
+
+**Reference.** `internal/codegen/cpptable/cpptable.go:499-513` (the reader is
+`buffer/size/offset`); the stack sub-reader at
+`internal/codegen/cpptable/codecs.go:1145`. The limit form:
+`internal/codegen/javatable/runtime.go:151-186`, with the reason written at
+`:151-158`.
+
+**Proven in.** C++; the limit form in Java, then JavaScript and Dart.
+
+**Measured effect.** Exact zero on Load, Measure and Save in Go
+(`testing.AllocsPerRun`), Java (`getCurrentThreadAllocatedBytes`), JavaScript
+(0.0 bytes per iteration on KeyedConfig Load/Measure/Save at 300k iterations)
+and Dart (0 scavenges over 20,000 × 8 records under AOT). The instrument is
+M1's second half, section I1.
+
+**Negative control.** I1's: a planted allocation per record turns the gate
+red on the one row it was planted in.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/codecs.go:1145` | ✅ `internal/codegen/ctable/codecs.go:1074` | ✅ `internal/codegen/rusttable/runtime.go:364` | ✅ `internal/codegen/gotable/gotable.go:717` | ✅ `internal/codegen/cstable/cstable.go:958` (a `ref struct`) | ✅ `internal/codegen/javatable/codecs.go:1016` (the limit) | ✅ `internal/codegen/jstable/jstable.go:960` (the limit) | ✅ `internal/codegen/darttable/codecs.go:762` (the limit) | — a decoded BEAM term is an allocation and no buffer is caller-owned; the leg pins the per-case COUNT instead (`tables-elixir-alloc-audit`, docs/SPEC-TABLES.md) |
+
+### M2 — 64-bit values without boxing
+
+**Method.** A 64-bit word on the wire is read and written as two composed
+32-bit halves, so a language that boxes wide integers never sees one on the
+hot path. The reference does it too, though C++ boxes nothing: the composed
+form is byte-order-neutral by construction (M12) and one shape ports mirror.
+On an accelerator path (a block's `offset_of`, a cook's self-relative delta)
+the composed form is what keeps a deref allocation-free in JavaScript.
+
+**Reference.** `internal/codegen/cpptable/cpptable.go:490` (`put64` as two
+`put32`) and `:513` (`get64` as two `get32`). The JavaScript accelerator
+paths: `internal/codegen/jstable/block.go:384` (`offset_of` from two u32
+reads, the reason at `:375-382`) and `internal/codegen/jstable/cook.go:513-517`
+(the delta from a u32 low half and an i32 high half).
+
+**Proven in.** C++; measured in JavaScript.
+
+**Measured effect.** JavaScript's `Scene head deref` row went from a BigInt
+per edge to 0.7 bytes per iteration (ceiling 8) once the delta was composed.
+
+**Negative control.** The JavaScript allocation gate's row for the path: a
+`getBigUint64` on it reads as bytes per iteration.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/cpptable.go:490` | ✅ `internal/codegen/ctable/ctable.go:514-518` | ✅ `internal/codegen/rusttable/runtime.go:352-356` (one `from_le_bytes`; nothing boxes) | ✅ `internal/codegen/gotable/gotable.go:710-714` | ✅ `internal/codegen/cstable/cstable.go:986-991` | ✅ `internal/codegen/javatable/runtime.go:206-210` | — the accelerator paths compose (`internal/codegen/jstable/block.go:384`, `cook.go:513`); a 64-bit wire FIELD's value is a BigInt or loses precision, so those rows read one under a stated ceiling (`test/js-tables/main.mjs`, the RootConfig rows) | — an `int` is a 64-bit machine word and nothing boxes (`internal/codegen/darttable/block.go:213`) | ❌ #403 |
+
+### M3 — A float never crosses a call
+
+**Method.** The generated body reads the bits through the view and bit-casts
+inline; only integers cross into the reader and writer. There is no `getF32`
+primitive, because a double crossing a call boundary on a JIT threshold boxes,
+and a generated codec must not depend on the compiler's inlining budget.
+
+**Reference.** `internal/codegen/cpptable/cpptable.go:543-546`
+(`table_bits_to_float` and its three siblings, `inline` free functions over
+`get32`/`get64`). The JavaScript statement of the rule:
+`internal/codegen/jstable/jstable.go:979-985` and `codecs.go:897-902`; elevated
+to a cross-port rule at docs/SPEC-TABLES.md's JavaScript allocation paragraph.
+
+**Proven in.** C++; measured in JavaScript.
+
+**Measured effect.** On the pinned node major a float crossing a helper was
+steady at sixteen bytes a call, and invisible on a newer V8 — which is why the
+gate is pinned (I14).
+
+**Negative control.** The allocation gate's wire rows: a helper put back
+reads as bytes per iteration on the pinned runtime.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/cpptable.go:543-546` | ✅ `internal/codegen/ctable/ctable.go:565-568` | ✅ `internal/codegen/rusttable/runtime.go:181-199` | ✅ `internal/codegen/gotable/codecs.go:781-786` | ❌ #404 | ✅ `internal/codegen/javatable/codecs.go:919-921` | ✅ `internal/codegen/jstable/codecs.go:1209-1219` | ❌ #404 | — a BEAM float is a boxed term whatever the call shape; `R.f32_bits` costs what the term costs |
+
+### M4 — The codec is shaped for the optimizer
+
+**Method.** The read and write primitives and the FIXED-class bodies are
+force-inlined, so the cursor stays in registers across a body, and the
+directive stops at the variable class, where a recursive `always_inline` is a
+compile error. Measure is left plain. Where the language has an aliasing
+qualifier or gives noalias by construction (Rust's `&mut`), the body takes it.
+Where the language has neither a directive nor a qualifier, the shape it can
+take is M4b's.
+
+**Reference.** `internal/codegen/cpptable/cpptable.go:353-359` (the macro,
+with the reason at `:344-352`) and `codecs.go:672-679` (the stop at the
+variable class). Rust: `internal/codegen/rusttable/runtime.go:220-363` and
+`codecs.go:663-669`. C: `internal/codegen/ctable/ctable.go:275-283`, pinned by
+`TestCForceInlineStopsAtTheVariableClass`.
+
+**Proven in.** C++ (#350).
+
+**Measured effect.** #350's arm is the C++ reference every pairing board
+measures against. The lever did not transfer to Go as written: the Go leg
+writes at 0.20× C++ after #350, and the Go-shaped restructure measured 1.42×
+(#362). A lever is a theory in the next language.
+
+**Negative control.** `TestCForceInlineStopsAtTheVariableClass` and
+`TestPointerSurfaceEmitted`: the macro on a variable-class body, or missing
+from a fixed one, is red.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/cpptable.go:353-359` `TestPointerSurfaceEmitted` | ✅ `internal/codegen/ctable/ctable.go:275-283` `TestCForceInlineStopsAtTheVariableClass` | ✅ `internal/codegen/rusttable/runtime.go:220` (`#[inline(always)]`; noalias by construction) | ❌ #362 | ❌ #405 | — the JIT takes no inlining directive and no aliasing qualifier; M4b is the shape | — no inlining directive and no aliasing qualifier for V8; M4b is the shape | — no inlining directive and no aliasing qualifier for the AOT compiler; M4b is the shape | — no inlining directive and no aliasing qualifier for the BEAM; M4b is the shape |
+
+### M4b — The codec is self-contained
+
+**Method.** The VM-class twin of M4: the generated unit stands alone on its
+platform library — no import of a sibling runtime, no import outside the unit
+— and the bit machinery a body needs is emitted with the unit rather than
+reached through a dependency, so the JIT's inlining budget is spent inside one
+compilation unit. A `standalone` gate compiles the generated sources against
+the platform alone.
+
+**Reference.** `tables-cs-standalone` (a `<Package>Table.cs` against the BCL
+alone); `tables-js-standalone` (no `import` of `serialize`, none outside the
+unit); `tables-dart-standalone` and its control. The Elixir form inlines the
+bitstring segments into the body itself
+(`internal/codegen/elixirtable/elixirtable.go:12-13`).
+
+**Proven in.** C#.
+
+**Measured effect.** Structural: the gate holds a property, and the read
+floors of I1 are measured over the unit it holds.
+
+**Negative control.** `tables-dart-standalone-negative-control` plants a
+`package:` import and requires red.
+
+**Targets:** standalone
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| — native class: the primitives are force-inlined instead (M4) | — native class: the primitives are force-inlined instead (M4) | — native class: `#[inline(always)]` on the primitives instead (M4) | ❌ #406 | ✅ `tables-cs-standalone` | ✅ `tables-java-standalone` | ✅ `tables-js-standalone` | ✅ `tables-dart-standalone` `tables-dart-standalone-negative-control` | ❌ #406 |
+
+### M5 — Keyed arrays index by key, refused at both ends
+
+**Method.** An enum-keyed array has one slot per named variant: key 1 lives in
+slot 0, `E.Max` in the last, and the accessor refuses None (key 0) and any key
+past `E.Max` in EVERY build — an unsigned compare covering both ends, then an
+abort that survives NDEBUG. Iteration yields the key beside the element, so
+the caller never does the shift. The runtime's own bounds check is not the
+technique: it is absent in C, silent past the array in JavaScript, and names
+an index rather than a key everywhere else.
+
+**Reference.** `internal/codegen/cpptable/cpptable.go:228-278`
+(`TableKeyed<T,E>`, `RefuseKey`); golden
+`testdata/golden/tables/examples/KeyedTable.h:241-286`.
+
+**Proven in.** C++; the None-only guard was found and fixed in JavaScript
+(#377 names the same gap in C).
+
+**Measured effect.** Structural. JavaScript's `get(4)` on a three-variant
+enum answered `undefined` before the guard was made symmetric.
+
+**Negative control.** `tables-keyed-none-refusal-negative-control`,
+`tables-keyed-max-refusal-negative-control` and
+`tables-keyed-shift-negative-control` in the reference;
+`tables-js-keyed-negative-control` puts a None-only guard back and requires
+"accepted E.Max + 1 as a key".
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-keyed-none-refusal-ndebug` `tables-keyed-max-refusal-ndebug` | ❌ #377 (None refused; past Max is an unchecked plain array) | ✅ `internal/codegen/rusttable/runtime.go:133-169` (panics in every build) | ✅ `TestKeyedRefusesNone` `TestKeyedRefusesPastMax` `TestKeyedPlacesByKey` | ✅ `test/cs-tables/src/Program.cs:1672` (None refused; past Max is the CLR's, always on) | ❌ #407 (refuses both ends; no test holds it) | ✅ `tables-js-keyed-negative-control` | ❌ #407 (refuses both ends; no test holds it) | ❌ #407 (guards refuse both ends; no test holds it) |
+
+### M6 — The variable class on the wire: a flat node table and an identity map
+
+**Method.** A pointered root packs as ONE flat node table under the reserved
+id `0xFFFF`, every node numbered depth-first in pre-order at first visit, and a
+pointer on the wire is a u32 node index under kind 17. The pack walk keeps an
+identity map from node address to index, so a node shared by two pointers is
+written once and a cycle is refused at an OPEN entry rather than by a depth
+cap. A fixed-class reader that has no variable class still carries kind 17 in
+its fixed-width skip row, so a pointered wire reads as unknown fields rather
+than as damage.
+
+**Reference.** `internal/codegen/cpptable/pointers.go:525-530` (the table),
+`:245` (the numbering), `:257-388` (the map and the OPEN refusal);
+`TablePackMap` at `internal/codegen/cpptable/arena.go:315-318`. The skip row:
+`case 4: case 8: case 10: case 17:` in every fixed-class runtime.
+
+**Proven in.** C++ (#373 the identity map, #376 the flat table).
+
+**Measured effect.** The wire is byte-identical between the C++ codec and
+the compiler's Go engine in both directions (`tables-flat-wire`), which the
+nested form could not be.
+
+**Negative control.** `tables-flat-wire-negative-control` numbers the nodes
+in post-order in the emitter and requires the lock red;
+`tables-shared-node-negative-control` writes a shared node twice.
+
+**Targets:** flat-wire
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-flat-wire` `tables-flat-wire-negative-control` | ❌ #408 (the earlier nested form: a depth cap, no identity map) | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 |
+
+### M7 — A block row is reached by stride, with no per-row object
+
+**Method.** A block array is `(base, count, stride)`; reaching row i is
+`base + i * stride`, and iterating is advancing by the stride. No handle is
+built per row. In a managed language the same shape is an offset (`<F>At(i)`
+returning an integer) or one caller-owned cursor moved per row — a
+per-row object is what the technique excludes, and where a convenience
+iterator allocates one, the emitter says so at the site and offers the
+allocation-free spelling beside it.
+
+**Reference.** `internal/codegen/cpptable/block.go:114-139`
+(`TableBlockRows<T>`, `:626-631` the accessor). The managed spellings:
+`internal/codegen/javatable/block.go:420-432` (`<F>Count()`/`<F>At(int)` as an
+offset; the allocating record iterator named at `:130-136`),
+`internal/codegen/darttable/block.go:217-247` (`<F>Cursor()`, `<F>At(i,
+cursor)`), `internal/codegen/jstable/block.go:382-386` (an offset).
+
+**Proven in.** C++.
+
+**Measured effect.** The block row walk is exactly 0 in Java's allocation
+table and 0.0 bytes per iteration in JavaScript's (`RenderFrame ships walk`).
+
+**Negative control.** I1's rows for the walk.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/block.go:114-139` | ✅ `internal/codegen/ctable/block.go:109-125` | ✅ `internal/codegen/rusttable/block.go:583-598` (a slice over the region) | ✅ `internal/codegen/gotable/block.go:243-256` | ✅ `internal/codegen/cstable/block.go:781-790` | ✅ `internal/codegen/javatable/block.go:420-432` | ✅ `internal/codegen/jstable/block.go:382-386` | ✅ `internal/codegen/darttable/block.go:217-247` | ❌ #409 (an eager list of `count` sub-binaries per call) |
+
+### M8 — The cook opens in O(1)
+
+**Method.** Open reads the magic in the machine's own order and compares,
+then the order word, the build version, both reserved words, the alignment
+word (a power of two, in range, a multiple of the root's), DERIVES the data
+offset rather than reading it, checks the file equation over both part lengths
+by subtraction, requires the data part to hold the root, and checks the base's
+alignment as a residue. Nothing per node. A deref is bounded where the
+language gives the reader a region to bound it against.
+
+**Reference.** `internal/codegen/cpptable/cook.go:150-173`; golden
+`testdata/golden/tables/examples/TablesTable.h:461-518`.
+
+**Proven in.** C++.
+
+**Measured effect.** `tables-cook-open-1gb` and `tables-cook-open-cs-1gb`
+open a gigabyte cook in the same time as a small one.
+
+**Negative control.** `tables-cook-open-lengths-negative-control` and
+`tables-cook-open-root-negative-control` remove one check each in the emitter;
+the harness's cook forgery battery (111 rows) holds every port.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/cook.go:150-173` `tables-cook-open` | ✅ `internal/codegen/ctable/cook.go:157-178` | ✅ `internal/codegen/rusttable/cook.go:206` | ✅ `internal/codegen/gotable/cook.go:542-624` | ✅ `internal/codegen/cstable/cook.go:575-660` `tables-cook-open-cs` | ✅ `internal/codegen/javatable/cook.go:372-455` (an offset residue; the deref bounded to the record) | ✅ `internal/codegen/jstable/cook.go:438-483` | ✅ `internal/codegen/darttable/cook.go:390-446` (an offset residue) | ✅ `internal/codegen/elixirtable/cook.go:145` (a `lead` parameter; a binary has no address) |
+
+### M9 — One text walk for the whole unit
+
+**Method.** The text form is one generic walk over the descriptors, emitted
+once per unit and identical across every unit of the corpus, rather than a
+codec per table. A byte comparison across units holds it. The variable class
+rides the same walk through adapters (#388), with a shared node labeled once
+as `&node` and named by its label after (M14).
+
+**Reference.** `internal/codegen/cpptable/json.go:91-1695` between the
+`---- json walk: begin/end ----` markers; `tables-json-walk` compares every
+generated unit's walk; `tables-json-graph-walk` the variable class's.
+
+**Proven in.** C++.
+
+**Measured effect.** Structural; the walk's cost is I1's text rows.
+
+**Negative control.** `tables-json-negative-control` sabotages the walk's
+offset arithmetic and requires red.
+
+**Targets:** json-walk
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-json-walk` `tables-json-graph-walk` | ✅ `tables-c-json-walk` | ✅ `tables-rust-walk` | ✅ `tables-go-json-walk` | ✅ `tables-cs-json-walk` | ✅ `tables-java-json-walk` | ✅ `tables-js-json-walk` | ✅ `tables-dart-json-walk` | ✅ `tables-elixir-walk` |
+
+### M10 — Hooks and the allocator contract
+
+**Method.** `schema_assert` and `schema_fatal` are overridable behind
+`#ifndef`; `schema_allocate` and `schema_release` are emitted only into a unit
+with a variable-length table; every allocation on the pointer path goes
+through the caller's alloc/free pair with a context, and a counting test
+proves nothing falls through to the default. Who calls the allocator is per
+form (docs/SPEC-TABLES.md): the block form takes a caller-provided allocator;
+a managed backend allocates inside its runtime and says so.
+
+**Reference.** `internal/codegen/cpptable/cpptable.go:141-174`;
+`TableAllocator` at `internal/codegen/cpptable/arena.go:59-77`;
+`test/tables/hooks_main.cpp:40-70, 183-209`.
+
+**Proven in.** C++ (#386).
+
+**Measured effect.** Structural.
+
+**Negative control.** `tables-cook-write-hooks-negative-control`.
+
+**Targets:** hooks
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-hooks` | ❌ #410 (raw `calloc`/`free` on the pointer path) | — no allocating path exists: a pointered unit's wire is refused and the fixed class allocates nothing (`tables-rust-alloc-audit`) | — the runtime allocates inside itself and says so (docs/SPEC-TABLES.md, "who calls the allocator is per form") | — the runtime allocates inside itself and says so (docs/SPEC-TABLES.md) | — the runtime allocates inside itself and says so; where it does is named per path at `tables-java-alloc` | — the runtime allocates inside itself and says so; every unavoidable allocation is named in the floor (docs/SPEC-TABLES.md) | — the runtime allocates inside itself and says so (docs/SPEC-TABLES.md) | — the BEAM allocates every term; the count is pinned instead (docs/SPEC-TABLES.md) |
+
+### M11 — The layout contract is asserted in generated code
+
+**Method.** Every cooked record and every block projection carries a
+compile-time (or first-open) assertion of size, alignment and every field
+offset against the numbers the compiler computed, including each array's pitch
+constant against the row's own size — two independent derivations held against
+each other. A producer that disagrees is refused before any row is read.
+
+**Reference.** `internal/codegen/cpptable/cook.go:334-341` and
+`block.go:491-533` (`static_assert`); C's C89-portable macro at
+`internal/codegen/ctable/ctable.go:288-298`.
+
+**Proven in.** C++.
+
+**Measured effect.** Structural; `tables-rust-big-endian` checks the Rust
+asserts on a foreign target.
+
+**Negative control.** `tables-block-layout-model-negative-control` and
+`tables-block-pitch-negative-control`.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/cook.go:334-341` | ✅ `internal/codegen/ctable/ctable.go:288-298` | ✅ `internal/codegen/rusttable/block.go:87-93` `TestCookLayoutIsAssertedAtCompileTime` | ✅ `internal/codegen/gotable/block.go:491-572` (at package init) | ✅ `internal/codegen/cstable/block.go:431-437` | ✅ `internal/codegen/javatable/block.go:479` | ✅ `internal/codegen/jstable/block.go:610-639` | — no second model to check against: the generated offsets ARE the model and the build version refuses a producer that disagrees (docs/SPEC-TABLES.md) | — no struct layout control, so the accelerators are read-only at the compiler's offsets and the build version is the contract (`internal/codegen/elixirtable/elixirtable.go:15-18`) |
+
+### M12 — Byte order is the reader's, not the host's
+
+**Method.** Every multi-byte wire read and write is explicit little-endian
+byte composition; the host's order is never consulted. An accelerator refuses
+a foreign file twice over: the magic, read in the machine's own order and
+compared, and then the order word. The cook writer takes the target's order
+as a parameter.
+
+**Reference.** `internal/codegen/cpptable/cpptable.go:490-513`; the cook
+magic and order word at `testdata/golden/tables/examples/TablesTable.h:404-419`
+and `:469-471`.
+
+**Proven in.** C++ (#303).
+
+**Measured effect.** The s390x battery (`tables-big-endian`, `conformance-big-endian`)
+is green under emulation.
+
+**Negative control.** `tables-big-endian-negative` puts one store back to
+host order and requires red on the target while green on the host.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `internal/codegen/cpptable/cpptable.go:490-513` | ✅ `internal/codegen/ctable/ctable.go:503-518` | ✅ `internal/codegen/rusttable/runtime.go:334-354` | ✅ `internal/codegen/gotable/gotable.go:698-714` | ✅ `internal/codegen/cstable/cstable.go:971-991` | ✅ `internal/codegen/javatable/block.go:101-117` | ✅ `internal/codegen/jstable/jstable.go` (every DataView read passes `true`) | ✅ `internal/codegen/darttable/runtime.go` (`Endian.little` on every read) | ✅ `internal/codegen/elixirtable/block.go:242` (every segment names `little`) |
+
+### M13 — Descriptors are constants
+
+**Method.** The reflection descriptors — field tables, type info, the block
+and cook graphs — are constants in the binary or safely published finals:
+read without allocation, initialized without a lazy path, and immutable. Where
+a language needs a factory to break an initialization cycle, the factory is
+the one exception and is named. The plain-cache idiom (read a static, build on
+null, store back, no lock) is banned by name.
+
+**Reference.** `testdata/golden/tables/examples/KeyedTable.h:2199-2206`
+(`static const` inside an `inline` accessor). The safe-publication form:
+`internal/codegen/javatable/codecs.go:1334` (the holder class), gated by
+`TestJavaDescriptorsAreSafelyPublished`.
+
+**Proven in.** C++; the publication hazard found and fixed in Java.
+
+**Measured effect.** `TestToJsonAllocatesNothing` / `TestFromJsonAllocatesNothing`
+exact zero in Go; the Go soak found a lazily built descriptor once.
+
+**Negative control.** `TestJavaDescriptorsAreSafelyPublished` fails on the
+plain-cache line.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `testdata/golden/tables/examples/KeyedTable.h:2199-2206` | ✅ `internal/codegen/ctable/ctable.go:45-50` (defined in `<Base>Table.c`) | ✅ `internal/codegen/rusttable/descriptors.go` (`&'static`) | ✅ `internal/codegen/gotable/codecs.go:1116-1138` | ❌ #411 (the plain-cache idiom) | ✅ `TestJavaDescriptorsAreSafelyPublished` | ✅ `internal/codegen/jstable/codecs.go:1301-1324` (built once on first use, frozen; one thread) | ✅ `docs/SPEC-TABLES.md` (const descriptors, static tear-offs in the constant pool) | ✅ `internal/codegen/elixirtable/descriptors.go:4-12` (module attributes) |
+
+### M14 — The `&node` label in the text form
+
+**Method.** A pointered tree reads and writes as nested tables; a node shared
+by two pointers is written once, labeled `&node` at its first appearance, and
+named by its label after, so the text form round-trips the graph's identity
+without a node-table syntax the reader has to learn.
+
+**Reference.** `internal/codegen/cpptable/json.go`, the variable-class
+adapters; `tables-json-graph-walk`.
+
+**Proven in.** C++ (#388).
+
+**Measured effect.** Structural.
+
+**Negative control.** `tables-shared-node-negative-control`.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-json-graph-walk` | ❌ #408 | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 | ❌ #349 |
+
+### I1 — The independent allocation gate
+
+**Method.** The read path's "allocates nothing" is MEASURED, with an
+instrument the emitter cannot influence: the runtime's own allocation counter
+(Go `AllocsPerRun`, Java `getCurrentThreadAllocatedBytes`, a Rust counting
+global allocator, C's interposed `malloc`), or where the platform has no
+per-thread counter, its garbage collector observed over a steady phase against
+an idle loop of the same shape (JavaScript's sampled heap at a calibrated
+interval, warmed until the rate settles; Dart's scavenge count under
+`--verbose_gc` with the semi-space pinned to 1 MB so one small object per
+record is a collection every ~30,000 records; Elixir's per-process
+`garbage_collection` trace and `binary_alloc` calls). The gate is split by
+build configuration where the language ships one and develops in another:
+gated under AOT, printed under the JIT. A row reported without a ceiling
+cites why.
+
+**Reference.** `test/go-tables/alloc_test.go:1-13` (why a grep proves
+nothing); `test/java-tables/src/Main.java:209-223`;
+`test/js-tables/main.mjs:1124-1153` (settle); `test/dart-tables/gcgate.dart`
+and `DART_GC_FLAGS` in the Makefile; `test/conformance/elixir/driver_impl.ex:1032-1086`.
+
+**Proven in.** Go; rediscovered in Dart, Elixir and JavaScript — the evidence
+this page was written from.
+
+**Measured effect.** Go: exact 0 on six paths. Java: wire read/save exactly
+0, block row walk and cook read exactly 0, open one handle per file. JavaScript:
+0.0 bytes per iteration on the KeyedConfig rows, 67 on RootConfig Load (a
+stated ceiling of 512). Dart: 0/0/0/0/0 scavenges under AOT over 20,000 × 8
+records. Elixir: heap words within ±11 of the pin against a tolerance of 64.
+
+**Negative control.** One planted allocation per record, and LOCALIZATION:
+the row it was planted in goes red and the row beside it stays green
+(`tables-java-alloc-negative-control` requires wire-read red and wire-save
+green; Go's `TestAllocationGateCanGoRed` plants two escapes and must see both).
+
+**Targets:** alloc, alloc-negative-control
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #412 (the cook WRITE is counted under `tables-cook-write`; the read path is a static scan) | ✅ `tables-c-soak` `tables-c-soak-negative-control` | ✅ `tables-rust-alloc-audit` `tables-rust-alloc-negative-control` | ✅ `TestLoadAllocatesNothing` `TestRoundTripAllocatesNothing` `TestAllocationGateCanGoRed` | ❌ #412 | ✅ `tables-java-alloc` `tables-java-alloc-negative-control` | ✅ `tables-js-alloc` `tables-js-alloc-negative-control` | ✅ `tables-dart-alloc` `tables-dart-alloc-negative-control` | ✅ `tables-elixir-alloc-audit` `tables-elixir-alloc-negative-control` |
+
+### I2 — Emitter sabotage through `go build -overlay`
+
+**Method.** A negative control sabotages the EMITTER, not the driver and not
+a generated file: a `sed` over a copy of one emitter source, checked to have
+matched (a sed that silently matched nothing is a green light and not a
+control), `go build -overlay` into a private compiler, the corpus regenerated
+from it, and the gate required red — on the named finding, with the rows
+beside it green. No tracked file is written, so an interrupt leaves no
+sabotaged tree. Where a control must sabotage something else (an environment
+flag in a leg, a byte of a fixture), the target says why.
+
+**Reference.** `tables-flat-wire-negative-control`,
+`tables-keyed-*-negative-control`, `tables-block-fuzz-*-negative-control` in
+the Makefile; Elixir's named macro `ELIXIR_SABOTAGED_BUILD`, which four
+controls share.
+
+**Proven in.** C++.
+
+**Measured effect.** Structural.
+
+**Negative control.** Is one.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-flat-wire-negative-control` | ✅ `conformance-negative-control-c` | ✅ `tables-rust-names-negative-control` | ✅ `tables-go-fuzz-extent-negative-control` | ✅ `conformance-negative-control-cs` | ✅ `tables-java-fuzz-negative-control` | ✅ `tables-js-accessor-negative-control` | ✅ `tables-dart-fuzz-negative-control` | ✅ `tables-elixir-alloc-negative-control` |
+
+### I3 — The forgery fuzz oracle walks what it opened
+
+**Method.** A mutated block or cook must REFUSE, or OPEN and be WHOLE: the
+oracle re-derives every row's bounds from the descriptors, never from Open's
+own arithmetic, and reads every byte of every row of anything that opened.
+`SEED` and `N` are knobs, and the leg prints the seed it ran. The control
+removes BOTH halves of the extent bound, because removing the rows bound alone
+leaves the reader correct — the padding check downstream computes `bytes -
+used` and refuses on the negative slack — and a control whose verdict depends
+on which mutant the seed reaches first is not a control.
+
+**Reference.** `test/tables/block_fuzz_main.cpp:1-25`; the both-bounds sed
+`BLOCK_FUZZ_SED_CPP_extent` in the Makefile; the reason stated at
+`tables-c-fuzz-negative-control` and `ELIXIR_FUZZ_SED`.
+
+**Proven in.** C++; the both-bounds rule measured in C, Java and Elixir.
+
+**Measured effect.** Elixir: 20,000 mutants over 7 fixtures, 9,641 opened and
+walked inside the buffer, none escaped. JavaScript: 12,519 refused / 7,481
+opened at the pinned seed. Rust: 409,746 mutants on the leg's long form.
+
+**Negative control.** The both-bounds sabotage; red is required on the named
+walk finding (or under ASan as a `heap-buffer-overflow` in C).
+
+**Targets:** fuzz, fuzz-negative-control
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-block-fuzz` `tables-block-fuzz-extent-negative-control` | ✅ `tables-c-fuzz` `tables-c-fuzz-negative-control` | ❌ #413 (the oracle and both-bounds sabotage exist in `tables-rust-fuzz`; nothing runs it) | ✅ `tables-go-fuzz` `tables-go-fuzz-extent-negative-control` | ✅ `tables-block-fuzz` `tables-block-fuzz-extent-negative-control` | ✅ `tables-java-fuzz` `tables-java-fuzz-negative-control` | ✅ `tables-js-fuzz` `tables-js-fuzz-negative-control` | ❌ #413 (the oracle runs; the control removes one bound) | ✅ `tables-elixir-fuzz` `tables-elixir-fuzz-negative-control` |
+
+### I4 — Per-case absent
+
+**Method.** A driver that cannot answer one case of a surface it otherwise
+implements writes `<case>.absent` — an empty file beside where the answer
+would go — and the harness counts it: `pass 16/16 +4a`. A missing FEATURE per
+case, not a failing test, so a backend with no variable class still answers
+the wire surface over every fixed instance. The reference leg may not answer
+absent: an absence from the first driver in the registry is the corpus losing
+its own expectation.
+
+**Reference.** `test/conformance/README.md`; `test/conformance/harness/run.go:35-42`.
+
+**Proven in.** C# (the first port with a text surface absent).
+
+**Measured effect.** Structural; the matrix is the completion tracker.
+
+**Negative control.** `conformance-negative-control-absent`.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| — the reference leg may not answer absent (`test/conformance/README.md`) | ✅ `test/conformance/c/main.c:224-230` | ✅ `test/conformance/rust/src/main.rs:337-342` | ✅ `test/conformance/go/main.go:147` | ✅ `test/conformance/cs/src/Program.cs:54` | ✅ `test/conformance/java/src/Driver.java:216` | ✅ `test/conformance/js/main.mjs:74-76` | ✅ `test/conformance/dart/main.dart:337` | ✅ `test/conformance/elixir/driver_impl.ex:687` |
+
+### I5 — The block lead gate
+
+**Method.** Every committed block image is placed at every lead 0..64 past
+an aligned base, and the reader must open at 0 and 64 and refuse 1..63 by
+name — a base-alignment check that is never exercised is dead code as far as
+any gate is concerned, and unaligned reads succeed on every host this repo
+builds on, so the fuzz oracle alone cannot see the check go missing. The cook's
+lead is held for every port by the harness's `cook_lead_1..63` forgery rows;
+the block's is not (#387), so a port holds it itself.
+
+**Reference.** `test/conformance/elixir/driver_impl.ex:1298`
+(`BlockLead.run/1`: every image × every lead); the enumerated pass in the
+reference fuzzer at `test/tables/block_fuzz_main.cpp:939-942`.
+
+**Proven in.** Elixir (#369).
+
+**Measured effect.** 2 block images × 65 leads — 0 and 64 open, 1..63 refuse.
+
+**Negative control.** `tables-elixir-block-lead-negative-control` rewrites
+the residue check to `lead < 0` in the emitter and requires "block_render at
+lead 1 answered open, wanted refuse".
+
+**Targets:** block-lead
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-block-fuzz` (the enumerated 1..63 pass, `test/tables/block_fuzz_main.cpp:939`) | ❌ #387 (a random lead one mutant in four) | ❌ #387 (enumerated in the unreached `tables-rust-fuzz`) | ❌ #387 (a random lead; the oracle cannot see the check go missing) | ✅ `tables-block-fuzz` (`test/cs-block/src/Fuzz.cs:749-753`) | ❌ #387 (every `open` in the leg passes offset 0) | ❌ #387 (the block battery's pointer column is 0) | ❌ #387 (same) | ✅ `tables-elixir-block-lead` `tables-elixir-block-lead-negative-control` |
+
+### I6 — Claimed names, both ways, with a control
+
+**Method.** Every name the generated runtime spells at package or module
+scope is registered in `internal/tablenames`, and a schema that declares one
+is refused beside a table and kept in a table-free unit. The scan runs both
+ways — every emitted name registered, every registered name emitted, because a
+claim nothing needs takes a name away from every schema for free — in every
+spelling the language maps to (Go's unexported package-scope names, Elixir's
+unscoped one and two added, Dart's per-library privacy, JavaScript's every
+module-scope binding). A negative control plants an unregistered runtime name
+and requires the scan to see it.
+
+**Reference.** `internal/tablenames/tablenames.go`;
+`TestTableRuntimeNamesAreClaimed` (`compiler/tables_test.go:918`, with the
+refusal loop for every language); `TestJavaRuntimeNameScanGoesRed`.
+
+**Proven in.** C++; the control in Java.
+
+**Measured effect.** A blind Rust scan left 44 crate items unregistered
+before `tables-rust-names-negative-control` (the Makefile records it).
+
+**Negative control.** A planted unregistered name; `go test -overlay` with
+the claim loop emptied.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #414 (the scan, no control) | ❌ #414 (the scan, no control) | ✅ `tables-rust-names-negative-control` | ❌ #414 (the scan, no control) | ❌ #414 (the scan, no control) | ✅ `TestJavaRuntimeNameScanGoesRed` | ✅ `TestJsModuleScopeScanSeesEveryConvention` | ✅ `tables-dart-names-negative-control` | ✅ `TestElixirRuntimeNameCollisionRepro` |
+
+### I7 — Cross-endian refusal as a named gate
+
+**Method.** The two foreign surfaces (`cook-foreign`, `block-foreign`) are
+the refusal every leg can answer on any host: the driver reverses the magic
+and opens. Beside them, a NAMED per-language gate holds the half no harness
+surface forges — a file whose magic is intact and whose order word says the
+other order, exactly the file a reader leaning on one check would open — or
+the register states why the platform needs none.
+
+**Reference.** `tables-big-endian` (wire, block both ways, cook accept and
+refuse, under s390x emulation); `tables-java-order`;
+`test/js-tables/main.mjs:417` (`checkForeignByteOrder`, the gap named at
+`:382-386`).
+
+**Proven in.** C++ (#303); the order-word half in Java and JavaScript.
+
+**Measured effect.** Structural.
+
+**Negative control.** `tables-big-endian-negative`;
+`conformance-negative-control-c-foreign` neuters the byte swap and requires
+both foreign rows red with `cook` and `block` green.
+
+**Targets:** order
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-big-endian` | ✅ `tables-c-big-endian` `conformance-negative-control-c-foreign` | ✅ `tables-rust-big-endian` (a `cargo check` for s390x; skips cleanly without the target) | ✅ `conformance-big-endian` (the Go driver under qemu-s390x) | ✅ `tables-cook-open-cs` (the refuse half; the native big-endian half is stated unproven until a big-endian .NET exists) | ✅ `tables-java-order` | ✅ `tables-js-leg` | ❌ #415 (reads `Endian.little`; the order word is untested and no sentence says why) | — the host's order is never consulted and no platform query exists for a gate to catch; the two foreign surfaces hold it (docs/SPEC-TABLES.md) |
+
+### I8 — A bench row is labeled a pairing check
+
+**Method.** A bench board taken on a laptop, or on any box that was not
+quiet and blessed, says so in its first line — "PAIRING CHECK, not a sitting"
+— and "it certifies nothing" in its third. The row proves the leg pairs with
+the reference on the same numbers; a sitting on the box is what certifies.
+
+**Reference.** `bench/tables/results/2026-09-03-pairing-arm64-macbook.md:1-3`;
+`bench/tables/legs.txt`.
+
+**Proven in.** C++ and C# (the first board).
+
+**Measured effect.** Structural.
+
+**Negative control.** None; a board without the label is a review finding.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `bench/tables/results/2026-09-03-pairing-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-pairing-c-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-rust-inline-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-pairing-go2-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-pairing-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-java-port-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-pairing-js2-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-pairing-dart-arm64-macbook.md` | ✅ `bench/tables/results/2026-09-03-pairing-elixir-arm64-macbook.md` |
+
+### I9 — The soak is gated on the allocation count or a floor
+
+**Method.** A soak that gates only on heap drift cannot see a path that
+allocates and frees the same bytes every iteration: it reads +0 forever. The
+soak gates on the allocation COUNT re-measured every sample (or the rate
+before and after in the same process, or the live-heap and binary-memory
+FLOORS, which a carrier cannot move), with drift kept beside it as the weaker
+instrument that sees retention. Two seconds ride `make test`; the hour is the
+release act.
+
+**Reference.** `test/c-tables/soak_main.c:262-334` (allocator calls counted
+over the measured loop); `test/go-tables/soak_test.go:216-264` (`Mallocs`
+with site classification); `tables-java-soak`'s comment in the Makefile;
+`test/js-tables/main.mjs:1457` (the rate before and after);
+`test/conformance/elixir/driver_impl.ex:922-964` (the floors).
+
+**Proven in.** C.
+
+**Measured effect.** The Go soak found a lazily built descriptor (M13);
+the Rust one is what made the audit's count exact.
+
+**Negative control.** A matched `malloc`/`free` pair per iteration
+(`tables-c-soak-negative-control`): the drift gate stays silent and the count
+goes red. Elixir's is a RETAINING sabotage, deliberately different from the
+audit's freed one, and requires both floors to rise.
+
+**Targets:** soak
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #416 | ✅ `tables-c-soak` `tables-c-soak-negative-control` | ❌ #416 (`tables-rust-soak` gates on the count; nothing runs it) | ✅ `TestSoak` `TestSoakIdentifierCanGoRed` | ❌ #416 | ✅ `tables-java-soak` `tables-java-soak-negative-control` | ✅ `tables-js-soak` | ✅ `tables-dart-soak` `tables-dart-soak-negative-control` (correctness under reuse; the allocation gate runs inside it) | ✅ `tables-elixir-soak` `tables-elixir-soak-negative-control` |
+
+### I10 — The zero-cost gate
+
+**Method.** Adding a table to a unit changes not one byte of the non-table
+generated code, and grows only the table, block and cook files; a table-free
+unit emits none of them; no Table source carries one symbol of either
+accelerator. Two forms: the byte-identity test in the compiler package and the
+symbol scan over the generated tree.
+
+**Reference.** `TestTablesMoveNoGeneratedPacketByte`
+(`compiler/tables_test.go:464`); `tables-zero-cost`; `tables-block-zero-cost`.
+
+**Proven in.** C++.
+
+**Measured effect.** Structural.
+
+**Negative control.** `TestZeroCostForValueOnlyTables`.
+
+**Targets:** zero-cost
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-zero-cost` `tables-block-zero-cost` `TestTablesMoveNoGeneratedPacketByte` | ✅ `tables-c-zero-cost` `TestCEmitsTableSources` | ✅ `tables-rust-features` `TestTableFreeUnitEmitsNothing` | ✅ `TestTablesMoveNoGeneratedGoByte` `TestGoEmitsTableSources` | ✅ `tables-block-zero-cost` `TestCsEmitsTableSources` | ✅ `tables-java-zero-cost` `TestJavaTablesMoveNoGeneratedPacketByte` | ✅ `TestJsEmitsTableSources` `tables-js-standalone` | ✅ `tables-block-zero-cost` `TestDartEmitsTableSources` | ✅ `TestElixirEmitsTableModules` |
+
+### I11 — The conformance negative control sabotages the emitter
+
+**Method.** The harness's per-leg control breaks the leg's WALK in the
+emitter (I2), regenerates, and requires exactly `<lang> / json-read` red while
+`json-write` and `wire` stay green — so the break is the reader's and the
+matrix localizes it. A control that sabotages a copy of the driver localizes
+the text form but cannot show the harness finding a defect in GENERATED code.
+
+**Reference.** `conformance-negative-control-c` (the field index in the C
+walk); `conformance-negative-control-go-walk`; `test/conformance/README.md`'s
+table of controls.
+
+**Proven in.** C#.
+
+**Measured effect.** Structural.
+
+**Negative control.** Is one.
+
+**Targets:** conformance-negative-control
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #417 (`conformance-negative-control` sabotages a copy of the driver) | ✅ `conformance-negative-control-c` | ❌ #417 (no conformance control) | ✅ `conformance-negative-control-go-walk` | ✅ `conformance-negative-control-cs` | ✅ `conformance-negative-control-java` | ✅ `conformance-negative-control-js` | ✅ `conformance-negative-control-dart` | ✅ `conformance-negative-control-elixir` |
+
+### I12 — The documented surface compiles and runs
+
+**Method.** `docs/USAGE.md`'s example for the language is compiled and run
+by a gate, so the documented surface goes red with the code rather than
+drifting from it.
+
+**Reference.** `test/tables/cook_main.cpp:1026-1094` (the `usage` mode,
+under `tables-cook-open`); `tables-dart-usage` runs the page's Dart verbatim
+against the golden.
+
+**Proven in.** C++.
+
+**Measured effect.** The Elixir reader ran the page's example by hand and
+found a module name the packet emitter refuses — the drift a gate catches.
+
+**Negative control.** None beyond the example itself.
+
+**Targets:** usage
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ✅ `tables-cook-open` | ❌ #418 | ❌ #418 | ❌ #418 | ✅ `tables-cook-open-cs` | ❌ #418 | ❌ #418 | ✅ `tables-dart-usage` | ❌ #418 |
+
+### I13 — The text differential against a third implementation
+
+**Method.** The leg emits N random instances as (wire, text); the compiler's
+own Go engine (`schema unpack`, written from the spec and from neither
+backend) reads the same wire and writes its text; the two texts are
+byte-compared, then the other direction. Pinned goldens reach eighteen
+instances; a random differential reaches the float ties they never do.
+
+**Reference.** `tables-js-json-differential` and its control in the
+Makefile; the engine in `internal/tabletext`.
+
+**Proven in.** JavaScript.
+
+**Measured effect.** Twelve of forty instances differed on the first run —
+a float32 at `-266744.625` rendering as an eight-digit tie.
+
+**Negative control.** `tables-js-json-differential-negative-control` restores
+the magnitude tie-break and requires red (19 of 60 on the pinned seed).
+
+**Targets:** json-differential
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #419 (a WIRE differential, `tables-flat-wire`; no text one) | ❌ #419 | ❌ #419 | ❌ #419 | ❌ #419 | ❌ #419 | ✅ `tables-js-json-differential` `tables-js-json-differential-negative-control` | ❌ #419 | ❌ #419 |
+
+### I14 — The allocation gate refuses to certify off the pinned runtime
+
+**Method.** The gate reads the runtime's version and, on any other than the
+pinned one, sets failed and returns without measuring; an escape hatch reports
+and does not certify. A newer JIT optimizes generated bodies an older one
+leaves on its threshold, where a double store boxes, so a floor measured on
+whatever binary a PATH lookup found says nothing about the runtime the claim
+is for. A native codec's allocations are in its source and a compiler adds
+none, so the native legs state that reason here rather than a pin.
+
+**Reference.** `test/js-tables/main.mjs:1412-1430` (`PinnedNodeMajor`, the
+refusal, `SCHEMA_JS_ALLOC_ANY_NODE`).
+
+**Proven in.** JavaScript.
+
+**Measured effect.** The allocation the gate exists to catch was invisible
+on a newer V8 and steady at sixteen bytes a call on the pinned one; measuring
+on whatever `node` a PATH lookup found is how it hid for three CI reds.
+
+**Negative control.** Running the gate on another major must refuse.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| — a native codec's allocations are in its source; the counting allocator sees the same calls under any compiler | — a native codec's allocations are in its source; the interposed allocator sees the same calls under any compiler | — a native codec's allocations are in its source; the counting global allocator sees the same calls under any toolchain | ❌ #420 (escape analysis moves between compiler versions; nothing pins it) | ❌ #420 | ❌ #420 (pinned JDK; the gate SKIPS rather than refuses without the counter) | ✅ `test/js-tables/main.mjs:1412` | ❌ #420 (pinned SDK; nothing refuses off it) | ❌ #420 (pinned OTP; the audit does not read it) |
+
+### J1 — Accessor and descriptor agreement
+
+**Method.** The leg reads every row and every node of the block and cook
+fixtures both ways — through the generated accessor and through the
+descriptor — and requires agreement. Two independent derivations of one
+layout, held against each other, so a moved accessor or a moved descriptor
+offset is seen without a pinned dump that happens to cover the field.
+
+**Reference.** `test/js-tables/main.mjs` (the leg's two-way read);
+`tables-js-accessor-negative-control` and `tables-js-slot-negative-control`.
+
+**Proven in.** JavaScript.
+
+**Measured effect.** Structural.
+
+**Negative control.** A scalar accessor moved four bytes in
+`internal/codegen/jstable/record.go`, and a pointer slot's offset moved eight,
+each through `go build -overlay`; each must turn the leg red.
+
+**Targets:** accessor-negative-control
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #421 | ❌ #421 | ❌ #421 | ❌ #421 | ❌ #421 | ❌ #421 | ✅ `tables-js-accessor-negative-control` `tables-js-slot-negative-control` | ❌ #421 | ❌ #421 |
+
+### J2 — The runtime home, with a file-order control
+
+**Method.** A unit's shared runtime lives in one file named by the PACKAGE
+(`<Package>Table.cs`, `<Package>Table.js`), never by the file that happens to
+sort first, so a schema file that sorts earlier relocates nothing and the
+table runtime is byte-identical across the two trees. The gate adds such a
+file to a copy of the unit and requires the homes not to move; the control
+puts the file-order rule back and requires them to move (#347).
+
+**Reference.** `tables-runtime-home` and `tables-runtime-home-negative-control`
+in the Makefile; `tables-js-runtime-home` and its control.
+
+**Proven in.** C#.
+
+**Measured effect.** Adding a file that sorted earlier relocated ~2,000
+lines of correct output into a diff nobody could read (#347).
+
+**Negative control.** The file-order rule put back.
+
+**Targets:** runtime-home
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #422 | ❌ #422 | ❌ #422 | ❌ #422 | ✅ `tables-runtime-home` `tables-runtime-home-negative-control` | ❌ #422 | ✅ `tables-js-runtime-home` `tables-js-runtime-home-negative-control` | ❌ #422 | ❌ #422 |
+
+### J3 — The release tier
+
+**Method.** A port whose `make test` half must stay cheap puts its expensive
+half — the hour soak, the fuzz oracle's own control, the allocation gate at
+scale, a second fuzz seed — behind one `tables-<lang>-release` target that
+SCALES the PR-tier instruments rather than adding new ones. `certify.yml`
+derives the list from the Makefile, so a port lands its release gate by adding
+the target and nothing else, and no target exists that runs nowhere.
+
+**Reference.** `tables-java-release` (the first); the derivation in
+`.github/workflows/certify.yml`.
+
+**Proven in.** Java.
+
+**Measured effect.** `tables-java-release` was a target that ran nowhere
+before the job derived it.
+
+**Negative control.** The certify job on a tree with no release target says
+so and passes.
+
+**Targets:** release
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #423 | ❌ #423 | ❌ #423 | ❌ #423 | ❌ #423 | ✅ `tables-java-release` | ✅ `tables-js-release` | ✅ `tables-dart-release` | ✅ `tables-elixir-release` |
+
+### J4 — Emitted text is analyzer-clean and format-canonical
+
+**Method.** Every generated table unit is held to what the language's
+analyzer or linter accepts and what its formatter writes, as a gate — so an
+emitter that drifts from the language's own conventions goes red on the
+diff rather than on a reviewer.
+
+**Reference.** `tables-dart-clean` (analyzer and `dart format
+--set-exit-if-changed`); `tables-rust-clippy`.
+
+**Proven in.** Dart.
+
+**Measured effect.** Structural.
+
+**Negative control.** None; the formatter is its own oracle.
+
+**Targets:** clean
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #424 | ❌ #424 | ✅ `tables-rust-clippy` | ❌ #424 | ❌ #424 | ❌ #424 | ❌ #424 | ✅ `tables-dart-clean` | ❌ #424 (the packet units are format-checked; the table units are not) |
+
+### J5 — The bench leg's golden gate runs before the clock
+
+**Method.** Before any timing, the bench leg round-trips every variant of
+the corpus and byte-compares against the golden; a leg whose codec does not
+reproduce the corpus refuses to time it rather than posting a number.
+
+**Reference.** `tables-elixir-bench-gate` (`leg run --gate`, all 64 variants);
+the Dart leg's `WIRE GOLDEN MISMATCH` in `bench/tables/dart/leg`.
+
+**Proven in.** Elixir.
+
+**Measured effect.** Structural.
+
+**Negative control.** None beyond the golden itself.
+
+**Targets:** none
+
+| cpp | c | rust | go | cs | java | js | dart | elixir |
+|---|---|---|---|---|---|---|---|---|
+| ❌ #425 | ❌ #425 | ❌ #425 | ❌ #425 | ❌ #425 | ❌ #425 | ❌ #425 | ✅ `bench/tables/dart/leg` | ✅ `tables-elixir-bench-gate` |

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -26,11 +26,6 @@ memory. A lever proven in one language is only a THEORY in the next — the
 register says where to look, and the port's own measurement says whether it
 holds there.
 
-The evidence the page was written from: the independent allocation instrument
-was discovered by the Dart reader, then again by the Elixir reader, then again
-by the JavaScript reader — three discoveries of one technique, each costing a
-read cycle, because nothing carried it from the first port to the next brief.
-
 ## How a technique enters
 
 Three rules, and the gate holds the second.
@@ -39,6 +34,8 @@ Three rules, and the gate holds the second.
    register lacks adds the method's section in that PR — its own cell carried,
    the rest not yet — exactly as a spec section lands with its code. A
    technique with no section is a technique the next port will rediscover.
+   A new section takes the next free number of its run: methods continue
+   `M`, instruments continue `I`, gates a port found continue `J`.
 2. **A not-yet cell cites the carry-across.** Every ❌ cell names the issue
    that carries the technique to that language (`❌ #NNN`), or the cell is a
    `—` with the reason the platform cannot. The gate goes red on a bare ❌.
@@ -63,17 +60,19 @@ and requires the finding that names each.
 - A technique is a `###` section. Its **Targets:** line names the slugs of its
   Makefile-checkable form, or `none` for a method the tree holds by inspection
   and by the instruments of other sections.
-- The cell table has the nine columns in this order: `cpp`, `c`, `rust`, `go`,
-  `cs`, `java`, `js`, `dart`, `elixir` — the languages the conformance harness
-  discovers as `test/conformance/<lang>/driver`.
+- The cell table's header names the columns, the reference first; the first
+  table's header is the order every table repeats, and its set is exactly the
+  languages the harness discovers as `test/conformance/<lang>/driver` — a
+  port's column is one of the shared edits docs/CONTRIBUTING.md tolerates.
 - A cell starts with one of three marks. **✅** carried — followed by what
   proves it. **❌ #NNN** not yet — the carry-across issue. **—** the platform
   cannot — followed by the reason.
 - **What a carried cell names.** In backticks: a Makefile target
   (`tables-…`, `conformance-…`), a Go test (`TestName`, in the root module or
-  in `test/go-tables`, both of which `make test` runs), or a source path. The
-  gate holds every named target to exist and to be RUN by the tree, and every
-  named test to exist. In a section whose Targets line is not `none`, a
+  in `test/go-tables`, both of which `make test` runs), or a source path with its
+  `:line` citation. The gate holds every named target to exist and to be RUN
+  by the tree, every named test to exist, and every cited path to be in the
+  tree — a line may drift, a path may not. In a section whose Targets line is not `none`, a
   carried cell must name at least one target or test; a cell that names none
   is held to the conventional names, `tables-<lang>-<slug>` for a port and
   `tables-<slug>` for the reference.
@@ -102,9 +101,9 @@ and a limit is an integer. Where the language can hold a reader on the stack
 sub-reader costs nothing and the reference uses one. Where it cannot (Java,
 Dart, JavaScript), the limit is the technique in its stated form.
 
-**Reference.** `internal/codegen/cpptable/cpptable.go:499-513` (the reader is
+**Reference.** `internal/codegen/cpptable/cpptable.go:524-538` (the reader is
 `buffer/size/offset`); the stack sub-reader at
-`internal/codegen/cpptable/codecs.go:1145`. The limit form:
+`internal/codegen/cpptable/codecs.go:1113`. The limit form:
 `internal/codegen/javatable/runtime.go:151-186`, with the reason written at
 `:151-158`.
 
@@ -123,7 +122,7 @@ red on the one row it was planted in.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `internal/codegen/cpptable/codecs.go:1145` | ✅ `internal/codegen/ctable/codecs.go:1074` | ✅ `internal/codegen/rusttable/runtime.go:364` | ✅ `internal/codegen/gotable/gotable.go:717` | ✅ `internal/codegen/cstable/cstable.go:958` (a `ref struct`) | ✅ `internal/codegen/javatable/codecs.go:1016` (the limit) | ✅ `internal/codegen/jstable/jstable.go:960` (the limit) | ✅ `internal/codegen/darttable/codecs.go:762` (the limit) | — a decoded BEAM term is an allocation and no buffer is caller-owned; the leg pins the per-case COUNT instead (`tables-elixir-alloc-audit`, docs/SPEC-TABLES.md) |
+| ✅ `internal/codegen/cpptable/codecs.go:1113` | ✅ `internal/codegen/ctable/codecs.go:1074` | ✅ `internal/codegen/rusttable/runtime.go:364` | ✅ `internal/codegen/gotable/gotable.go:717` | ✅ `internal/codegen/cstable/cstable.go:958` (a `ref struct`) | ✅ `internal/codegen/javatable/codecs.go:1016` (the limit) | ✅ `internal/codegen/jstable/jstable.go:960` (the limit) | ✅ `internal/codegen/darttable/codecs.go:762` (the limit) | — a decoded BEAM term is an allocation and no buffer is caller-owned; the leg pins the per-case COUNT instead (`tables-elixir-alloc-audit`, docs/SPEC-TABLES.md) |
 
 ### M2 — 64-bit values without boxing
 
@@ -134,8 +133,8 @@ form is byte-order-neutral by construction (M12) and one shape ports mirror.
 On an accelerator path (a block's `offset_of`, a cook's self-relative delta)
 the composed form is what keeps a deref allocation-free in JavaScript.
 
-**Reference.** `internal/codegen/cpptable/cpptable.go:490` (`put64` as two
-`put32`) and `:513` (`get64` as two `get32`). The JavaScript accelerator
+**Reference.** `internal/codegen/cpptable/cpptable.go:513` (`put64` as two
+`put32`) and `:538` (`get64` as two `get32`). The JavaScript accelerator
 paths: `internal/codegen/jstable/block.go:384` (`offset_of` from two u32
 reads, the reason at `:375-382`) and `internal/codegen/jstable/cook.go:513-517`
 (the delta from a u32 low half and an i32 high half).
@@ -152,7 +151,7 @@ per edge to 0.7 bytes per iteration (ceiling 8) once the delta was composed.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `internal/codegen/cpptable/cpptable.go:490` | ✅ `internal/codegen/ctable/ctable.go:514-518` | ✅ `internal/codegen/rusttable/runtime.go:352-356` (one `from_le_bytes`; nothing boxes) | ✅ `internal/codegen/gotable/gotable.go:710-714` | ✅ `internal/codegen/cstable/cstable.go:986-991` | ✅ `internal/codegen/javatable/runtime.go:206-210` | — the accelerator paths compose (`internal/codegen/jstable/block.go:384`, `cook.go:513`); a 64-bit wire FIELD's value is a BigInt or loses precision, so those rows read one under a stated ceiling (`test/js-tables/main.mjs`, the RootConfig rows) | — an `int` is a 64-bit machine word and nothing boxes (`internal/codegen/darttable/block.go:213`) | ❌ #403 |
+| ✅ `internal/codegen/cpptable/cpptable.go:513` | ✅ `internal/codegen/ctable/ctable.go:514-518` | ✅ `internal/codegen/rusttable/runtime.go:352-356` (one `from_le_bytes`; nothing boxes) | ✅ `internal/codegen/gotable/gotable.go:710-714` | ✅ `internal/codegen/cstable/cstable.go:986-991` | ✅ `internal/codegen/javatable/runtime.go:206-210` | — the accelerator paths compose (`internal/codegen/jstable/block.go:384`, `cook.go:513`); a 64-bit wire FIELD's value is a BigInt or loses precision, so those rows read one under a stated ceiling (`test/js-tables/main.mjs`, the RootConfig rows) | — an `int` is a 64-bit machine word and nothing boxes (`internal/codegen/darttable/block.go:213`) | ❌ #403 |
 
 ### M3 — A float never crosses a call
 
@@ -161,7 +160,7 @@ inline; only integers cross into the reader and writer. There is no `getF32`
 primitive, because a double crossing a call boundary on a JIT threshold boxes,
 and a generated codec must not depend on the compiler's inlining budget.
 
-**Reference.** `internal/codegen/cpptable/cpptable.go:543-546`
+**Reference.** `internal/codegen/cpptable/cpptable.go:572-573`
 (`table_bits_to_float` and its three siblings, `inline` free functions over
 `get32`/`get64`). The JavaScript statement of the rule:
 `internal/codegen/jstable/jstable.go:979-985` and `codecs.go:897-902`; elevated
@@ -180,7 +179,7 @@ reads as bytes per iteration on the pinned runtime.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `internal/codegen/cpptable/cpptable.go:543-546` | ✅ `internal/codegen/ctable/ctable.go:565-568` | ✅ `internal/codegen/rusttable/runtime.go:181-199` | ✅ `internal/codegen/gotable/codecs.go:781-786` | ❌ #404 | ✅ `internal/codegen/javatable/codecs.go:919-921` | ✅ `internal/codegen/jstable/codecs.go:1209-1219` | ❌ #404 | — a BEAM float is a boxed term whatever the call shape; `R.f32_bits` costs what the term costs |
+| ✅ `internal/codegen/cpptable/cpptable.go:572-573` | ✅ `internal/codegen/ctable/ctable.go:565-568` | ✅ `internal/codegen/rusttable/runtime.go:181-199` | ✅ `internal/codegen/gotable/codecs.go:781-786` | ❌ #404 | ✅ `internal/codegen/javatable/codecs.go:919-921` | ✅ `internal/codegen/jstable/codecs.go:1209-1219` | ❌ #404 | — a BEAM float is a boxed term whatever the call shape; `R.f32_bits` costs what the term costs |
 
 ### M4 — The codec is shaped for the optimizer
 
@@ -192,8 +191,8 @@ qualifier or gives noalias by construction (Rust's `&mut`), the body takes it.
 Where the language has neither a directive nor a qualifier, the shape it can
 take is M4b's.
 
-**Reference.** `internal/codegen/cpptable/cpptable.go:353-359` (the macro,
-with the reason at `:344-352`) and `codecs.go:672-679` (the stop at the
+**Reference.** `internal/codegen/cpptable/cpptable.go:358-364` (the macro,
+with the reason at `:350-357`) and `codecs.go:732` (the stop at the
 variable class). Rust: `internal/codegen/rusttable/runtime.go:220-363` and
 `codecs.go:663-669`. C: `internal/codegen/ctable/ctable.go:275-283`, pinned by
 `TestCForceInlineStopsAtTheVariableClass`.
@@ -213,7 +212,7 @@ from a fixed one, is red.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `internal/codegen/cpptable/cpptable.go:353-359` `TestPointerSurfaceEmitted` | ✅ `internal/codegen/ctable/ctable.go:275-283` `TestCForceInlineStopsAtTheVariableClass` | ✅ `internal/codegen/rusttable/runtime.go:220` (`#[inline(always)]`; noalias by construction) | ❌ #362 | ❌ #405 | — the JIT takes no inlining directive and no aliasing qualifier; M4b is the shape | — no inlining directive and no aliasing qualifier for V8; M4b is the shape | — no inlining directive and no aliasing qualifier for the AOT compiler; M4b is the shape | — no inlining directive and no aliasing qualifier for the BEAM; M4b is the shape |
+| ✅ `internal/codegen/cpptable/cpptable.go:358-364` `TestPointerSurfaceEmitted` | ✅ `internal/codegen/ctable/ctable.go:275-283` `TestCForceInlineStopsAtTheVariableClass` | ✅ `internal/codegen/rusttable/runtime.go:220` (`#[inline(always)]`; noalias by construction) | ❌ #362 | ❌ #405 | — the JIT takes no inlining directive and no aliasing qualifier; M4b is the shape | — no inlining directive and no aliasing qualifier for V8; M4b is the shape | — no inlining directive and no aliasing qualifier for the AOT compiler; M4b is the shape | — no inlining directive and no aliasing qualifier for the BEAM; M4b is the shape |
 
 ### M4b — The codec is self-contained
 
@@ -254,9 +253,9 @@ the caller never does the shift. The runtime's own bounds check is not the
 technique: it is absent in C, silent past the array in JavaScript, and names
 an index rather than a key everywhere else.
 
-**Reference.** `internal/codegen/cpptable/cpptable.go:228-278`
+**Reference.** `internal/codegen/cpptable/cpptable.go:222-260`
 (`TableKeyed<T,E>`, `RefuseKey`); golden
-`testdata/golden/tables/examples/KeyedTable.h:241-286`.
+`testdata/golden/tables/examples/KeyedTable.h:279-333`.
 
 **Proven in.** C++; the None-only guard was found and fixed in JavaScript
 (#377 names the same gap in C).
@@ -287,9 +286,9 @@ cap. A fixed-class reader that has no variable class still carries kind 17 in
 its fixed-width skip row, so a pointered wire reads as unknown fields rather
 than as damage.
 
-**Reference.** `internal/codegen/cpptable/pointers.go:525-530` (the table),
-`:245` (the numbering), `:257-388` (the map and the OPEN refusal);
-`TablePackMap` at `internal/codegen/cpptable/arena.go:315-318`. The skip row:
+**Reference.** `internal/codegen/cpptable/pointers.go:545` (the table),
+`:245` (the numbering), `:257-394` (the map and the OPEN refusal);
+`TablePackMap` at `internal/codegen/cpptable/arena.go:310`. The skip row:
 `case 4: case 8: case 10: case 17:` in every fixed-class runtime.
 
 **Proven in.** C++ (#373 the identity map, #376 the flat table).
@@ -318,8 +317,8 @@ per-row object is what the technique excludes, and where a convenience
 iterator allocates one, the emitter says so at the site and offers the
 allocation-free spelling beside it.
 
-**Reference.** `internal/codegen/cpptable/block.go:114-139`
-(`TableBlockRows<T>`, `:626-631` the accessor). The managed spellings:
+**Reference.** `internal/codegen/cpptable/block.go:120`
+(`TableBlockRows<T>`, `:626-627` the accessor). The managed spellings:
 `internal/codegen/javatable/block.go:420-432` (`<F>Count()`/`<F>At(int)` as an
 offset; the allocating record iterator named at `:130-136`),
 `internal/codegen/darttable/block.go:217-247` (`<F>Cursor()`, `<F>At(i,
@@ -336,7 +335,7 @@ table and 0.0 bytes per iteration in JavaScript's (`RenderFrame ships walk`).
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `internal/codegen/cpptable/block.go:114-139` | ✅ `internal/codegen/ctable/block.go:109-125` | ✅ `internal/codegen/rusttable/block.go:583-598` (a slice over the region) | ✅ `internal/codegen/gotable/block.go:243-256` | ✅ `internal/codegen/cstable/block.go:781-790` | ✅ `internal/codegen/javatable/block.go:420-432` | ✅ `internal/codegen/jstable/block.go:382-386` | ✅ `internal/codegen/darttable/block.go:217-247` | ❌ #409 (an eager list of `count` sub-binaries per call) |
+| ✅ `internal/codegen/cpptable/block.go:120` | ✅ `internal/codegen/ctable/block.go:109-125` | ✅ `internal/codegen/rusttable/block.go:583-598` (a slice over the region) | ✅ `internal/codegen/gotable/block.go:243-256` | ✅ `internal/codegen/cstable/block.go:781-790` | ✅ `internal/codegen/javatable/block.go:420-432` | ✅ `internal/codegen/jstable/block.go:382-386` | ✅ `internal/codegen/darttable/block.go:217-247` | ❌ #409 (an eager list of `count` sub-binaries per call) |
 
 ### M8 — The cook opens in O(1)
 
@@ -349,7 +348,7 @@ alignment as a residue. Nothing per node. A deref is bounded where the
 language gives the reader a region to bound it against.
 
 **Reference.** `internal/codegen/cpptable/cook.go:150-173`; golden
-`testdata/golden/tables/examples/TablesTable.h:461-518`.
+`testdata/golden/tables/examples/TablesTable.h:492-540`.
 
 **Proven in.** C++.
 
@@ -374,7 +373,7 @@ codec per table. A byte comparison across units holds it. The variable class
 rides the same walk through adapters (#388), with a shared node labeled once
 as `&node` and named by its label after (M14).
 
-**Reference.** `internal/codegen/cpptable/json.go:91-1695` between the
+**Reference.** `internal/codegen/cpptable/json.go:166-2192` between the
 `---- json walk: begin/end ----` markers; `tables-json-walk` compares every
 generated unit's walk; `tables-json-graph-walk` the variable class's.
 
@@ -401,9 +400,9 @@ proves nothing falls through to the default. Who calls the allocator is per
 form (docs/SPEC-TABLES.md): the block form takes a caller-provided allocator;
 a managed backend allocates inside its runtime and says so.
 
-**Reference.** `internal/codegen/cpptable/cpptable.go:141-174`;
-`TableAllocator` at `internal/codegen/cpptable/arena.go:59-77`;
-`test/tables/hooks_main.cpp:40-70, 183-209`.
+**Reference.** `internal/codegen/cpptable/cpptable.go:141-168`;
+`TableAllocator` at `internal/codegen/cpptable/arena.go:59-74`;
+`test/tables/hooks_main.cpp:18-90`.
 
 **Proven in.** C++ (#386).
 
@@ -425,9 +424,9 @@ offset against the numbers the compiler computed, including each array's pitch
 constant against the row's own size — two independent derivations held against
 each other. A producer that disagrees is refused before any row is read.
 
-**Reference.** `internal/codegen/cpptable/cook.go:334-341` and
-`block.go:491-533` (`static_assert`); C's C89-portable macro at
-`internal/codegen/ctable/ctable.go:288-298`.
+**Reference.** `internal/codegen/cpptable/cook.go:334-336` and
+`block.go:491-492` (`static_assert`); C's C89-portable macro at
+`internal/codegen/ctable/ctable.go:291-293`.
 
 **Proven in.** C++.
 
@@ -441,7 +440,7 @@ asserts on a foreign target.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `internal/codegen/cpptable/cook.go:334-341` | ✅ `internal/codegen/ctable/ctable.go:288-298` | ✅ `internal/codegen/rusttable/block.go:87-93` `TestCookLayoutIsAssertedAtCompileTime` | ✅ `internal/codegen/gotable/block.go:491-572` (at package init) | ✅ `internal/codegen/cstable/block.go:431-437` | ✅ `internal/codegen/javatable/block.go:479` | ✅ `internal/codegen/jstable/block.go:610-639` | — no second model to check against: the generated offsets ARE the model and the build version refuses a producer that disagrees (docs/SPEC-TABLES.md) | — no struct layout control, so the accelerators are read-only at the compiler's offsets and the build version is the contract (`internal/codegen/elixirtable/elixirtable.go:15-18`) |
+| ✅ `internal/codegen/cpptable/cook.go:334-336` | ✅ `internal/codegen/ctable/ctable.go:291-293` | ✅ `internal/codegen/rusttable/block.go:87-93` `TestCookLayoutIsAssertedAtCompileTime` | ✅ `internal/codegen/gotable/block.go:491-572` (at package init) | ✅ `internal/codegen/cstable/block.go:431-437` | ✅ `internal/codegen/javatable/block.go:479` | ✅ `internal/codegen/jstable/block.go:610-639` | — no second model to check against: the generated offsets ARE the model and the build version refuses a producer that disagrees (docs/SPEC-TABLES.md) | — no struct layout control, so the accelerators are read-only at the compiler's offsets and the build version is the contract (`internal/codegen/elixirtable/elixirtable.go:15-18`) |
 
 ### M12 — Byte order is the reader's, not the host's
 
@@ -451,9 +450,9 @@ a foreign file twice over: the magic, read in the machine's own order and
 compared, and then the order word. The cook writer takes the target's order
 as a parameter.
 
-**Reference.** `internal/codegen/cpptable/cpptable.go:490-513`; the cook
-magic and order word at `testdata/golden/tables/examples/TablesTable.h:404-419`
-and `:469-471`.
+**Reference.** `internal/codegen/cpptable/cpptable.go:513-538`; the cook
+magic and order word at `testdata/golden/tables/examples/TablesTable.h:435-449`
+and `:501-502`.
 
 **Proven in.** C++ (#303).
 
@@ -467,7 +466,7 @@ host order and requires red on the target while green on the host.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `internal/codegen/cpptable/cpptable.go:490-513` | ✅ `internal/codegen/ctable/ctable.go:503-518` | ✅ `internal/codegen/rusttable/runtime.go:334-354` | ✅ `internal/codegen/gotable/gotable.go:698-714` | ✅ `internal/codegen/cstable/cstable.go:971-991` | ✅ `internal/codegen/javatable/block.go:101-117` | ✅ `internal/codegen/jstable/jstable.go` (every DataView read passes `true`) | ✅ `internal/codegen/darttable/runtime.go` (`Endian.little` on every read) | ✅ `internal/codegen/elixirtable/block.go:242` (every segment names `little`) |
+| ✅ `internal/codegen/cpptable/cpptable.go:513-538` | ✅ `internal/codegen/ctable/ctable.go:503-518` | ✅ `internal/codegen/rusttable/runtime.go:334-354` | ✅ `internal/codegen/gotable/gotable.go:698-714` | ✅ `internal/codegen/cstable/cstable.go:971-991` | ✅ `internal/codegen/javatable/block.go:101-117` | ✅ `internal/codegen/jstable/jstable.go` (every DataView read passes `true`) | ✅ `internal/codegen/darttable/block.go` `internal/codegen/darttable/cook.go` (`Endian.little` on every read) | ✅ `internal/codegen/elixirtable/block.go:242` (every segment names `little`) |
 
 ### M13 — Descriptors are constants
 
@@ -478,7 +477,7 @@ a language needs a factory to break an initialization cycle, the factory is
 the one exception and is named. The plain-cache idiom (read a static, build on
 null, store back, no lock) is banned by name.
 
-**Reference.** `testdata/golden/tables/examples/KeyedTable.h:2199-2206`
+**Reference.** `testdata/golden/tables/examples/KeyedTable.h:2245-2249`
 (`static const` inside an `inline` accessor). The safe-publication form:
 `internal/codegen/javatable/codecs.go:1334` (the holder class), gated by
 `TestJavaDescriptorsAreSafelyPublished`.
@@ -495,7 +494,7 @@ plain-cache line.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `testdata/golden/tables/examples/KeyedTable.h:2199-2206` | ✅ `internal/codegen/ctable/ctable.go:45-50` (defined in `<Base>Table.c`) | ✅ `internal/codegen/rusttable/descriptors.go` (`&'static`) | ✅ `internal/codegen/gotable/codecs.go:1116-1138` | ❌ #411 (the plain-cache idiom) | ✅ `TestJavaDescriptorsAreSafelyPublished` | ✅ `internal/codegen/jstable/codecs.go:1301-1324` (built once on first use, frozen; one thread) | ✅ `docs/SPEC-TABLES.md` (const descriptors, static tear-offs in the constant pool) | ✅ `internal/codegen/elixirtable/descriptors.go:4-12` (module attributes) |
+| ✅ `testdata/golden/tables/examples/KeyedTable.h:2245-2249` | ✅ `internal/codegen/ctable/ctable.go:45-50` (defined in `<Base>Table.c`) | ✅ `internal/codegen/rusttable/descriptors.go` (`&'static`) | ✅ `internal/codegen/gotable/codecs.go:1116-1138` | ❌ #411 (the plain-cache idiom) | ✅ `TestJavaDescriptorsAreSafelyPublished` | ✅ `internal/codegen/jstable/codecs.go:1301-1324` (built once on first use, frozen; one thread) | ✅ `internal/codegen/darttable/descriptors.go:75` (`const` descriptors, static tear-offs in the constant pool) | ✅ `internal/codegen/elixirtable/descriptors.go:4-12` (module attributes) |
 
 ### M14 — The `&node` label in the text form
 
@@ -540,8 +539,7 @@ nothing); `test/java-tables/src/Main.java:209-223`;
 `test/js-tables/main.mjs:1124-1153` (settle); `test/dart-tables/gcgate.dart`
 and `DART_GC_FLAGS` in the Makefile; `test/conformance/elixir/driver_impl.ex:1032-1086`.
 
-**Proven in.** Go; rediscovered in Dart, Elixir and JavaScript — the evidence
-this page was written from.
+**Proven in.** Go; the managed forms in Java, JavaScript, Dart and Elixir.
 
 **Measured effect.** Go: exact 0 on six paths. Java: wire read/save exactly
 0, block row walk and cook read exactly 0, open one handle per file. JavaScript:
@@ -654,7 +652,7 @@ the block's is not (#387), so a port holds it itself.
 
 **Reference.** `test/conformance/elixir/driver_impl.ex:1298`
 (`BlockLead.run/1`: every image × every lead); the enumerated pass in the
-reference fuzzer at `test/tables/block_fuzz_main.cpp:939-942`.
+reference fuzzer at `test/tables/block_fuzz_main.cpp:940`.
 
 **Proven in.** Elixir (#369).
 
@@ -835,7 +833,7 @@ table of controls.
 by a gate, so the documented surface goes red with the code rather than
 drifting from it.
 
-**Reference.** `test/tables/cook_main.cpp:1026-1094` (the `usage` mode,
+**Reference.** `test/tables/cook_main.cpp:1394` (`mode_usage`,
 under `tables-cook-open`); `tables-dart-usage` runs the page's Dart verbatim
 against the golden.
 
@@ -892,9 +890,8 @@ refusal, `SCHEMA_JS_ALLOC_ANY_NODE`).
 
 **Proven in.** JavaScript.
 
-**Measured effect.** The allocation the gate exists to catch was invisible
-on a newer V8 and steady at sixteen bytes a call on the pinned one; measuring
-on whatever `node` a PATH lookup found is how it hid for three CI reds.
+**Measured effect.** The allocation the gate exists to catch is invisible on
+a newer V8 and steady at sixteen bytes a call on the pinned one.
 
 **Negative control.** Running the gate on another major must refuse.
 

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -1,6 +1,11 @@
 # The tables conformance harness — the driver contract
 
-A port of the tables layer is **"make the driver pass"**.
+A port of the tables layer is **"make the driver pass"** — and fill its column
+on [docs/PORTING.md](../../docs/PORTING.md), the techniques register. The
+register is read before the port brief is written; the port PR is not ready
+until every technique on it is carried or cited in the port's column; and a
+blind read of the port reports two lists against it — methods the port uses
+that the register lacks, and methods the register has that the port lacks.
 
 The data lives under `testdata/conformance/tables` and names no language
 (`FORMAT.md` there states every file shape). This page states what a language's
@@ -214,6 +219,8 @@ gap is real and the matrix says so rather than a parser papering over it.
 2. Write `test/conformance/<lang>/ci.json`, the leg's row in the pull-request
    matrix.
 3. `make conformance`.
+4. Fill the language's column on `docs/PORTING.md`; `go test ./compiler`
+   holds it to the tree.
 
 **THE REGISTRY IS DISCOVERED, NOT LISTED.** The harness reads every
 `test/conformance/<lang>/driver` that exists, and `harness matrix` reads every


### PR DESCRIPTION
## What it is

`docs/PORTING.md`, the register #389 names: every method of implementation and every instrument the nine table backends carry, one section each — the method in a paragraph, where it lives in the reference, the language it was proven in, its measured effect, its negative control — and a nine-column row of `✅ (what proves it)` / `— the platform reason` / `❌ #NNN (the carry-across issue)`. Then "How a technique enters" (same-PR entry; a ❌ cites its carry-across; every blind read reports two lists) and the grammar the gate reads.

The rows: the fourteen methods from the owner's comment (M1 allocation-free read through M14 the `&node` label), the fourteen instruments from the issue body (I1 the independent allocation gate through I14 the unpinned-runtime refusal), and five the JavaScript and Dart confirming reads found the list lacked (accessor/descriptor agreement, the runtime home, the release tier, analyzer-clean emitted text, the bench leg's pre-clock golden gate). The Dart AOT/JIT split, the both-ways name scan and the second fuzz seed fold into I1, I6 and J3; "a measured row with a null ceiling cites why" is in the grammar.

## The count

34 techniques × 9 languages = 306 cells: **178 carried, 103 not yet, 25 the platform cannot**. Every ❌ cites an issue — 23 filed from this PR (#403–#425, titled `<technique>: carry to <languages>`, each naming the proving language and the reference site), the rest existing ones (#349 the variable class, #362 the Go codec shape, #377 C's keyed upper bound, #387 the block lead).

## Unverified cells

- Every cpp/c/rust/go/cs/java cell and every js/dart/elixir cell of M1–I14 comes from the three per-language verification reports (every cell, file:line). The js/dart/elixir cells were re-read against main after the three ports merged where the confirming reads said something moved (the JS keyed guard and fuzz control, the Dart allocation gate, usage, standalone, json-walk, names control and board, the Elixir block lead); source line numbers elsewhere are the reports' and may drift by a few lines.
- The five J rows' ❌ cells outside their proving languages are **inferred from the reports not finding such a gate**, not from a per-language search; each ❌ cites its issue, whose body says "verify or carry".
- Three findings from the reports the register records and the tree does not yet fix: `tables-rust-fuzz` and `tables-rust-soak` exist and nothing runs them (I3, I9 → #413, #416); Dart's fuzz control removes one bound (I3 → #413).

## What the gate holds

`compiler/porting_test.go`, under `go test ./compiler` (the last line of `make test`):

- every language the harness discovers (`test/conformance/<lang>/driver`, falling back to `drivers.txt` on a tree that still has one) has a column;
- a carried cell's named Makefile target exists and is RUN — reached from `make test` (transitively, through `TEST_LEGS` and every `make/<lang>.mk`), from a `tables-<lang>-release` target, or by name from a workflow — and its named Go test exists where `make test` runs one; in a section with a Makefile-checkable form a carried cell must name at least one, else it is held to `tables-<lang>-<slug>`;
- a bare ❌ is red; a `—` with no reason is red;
- its negative control plants each defect into a copy of the register and requires exactly the finding that names it, plus parser and reach-walk controls (a renamed column, a section with no table, a flagged `make` line, a workflow comment, an included leg reached through `TEST_LEGS` and an orphan not).

`README.md` links the page; `test/conformance/README.md` points ports at it and states the two lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
