### PR TITLE
docs/COMPETITION.md: schema against Protocol Buffers, FlatBuffers, Cap'n Proto and Avro

### DIFF
--- a/docs/COMPARISON-TABLES.md
+++ b/docs/COMPARISON-TABLES.md
@@ -118,7 +118,7 @@ the other format for this one thing.
 | 2 | **A service or SDK that only speaks Protobuf.** | certain, for that one edge | Never removable. A foreign endpoint's format is what you use at that endpoint. Tables inside, the foreign format only at the boundary. |
 | 3 | **Maps with string or integer keys.** Protobuf has `map<K,V>`; FlatBuffers has the sorted-vector idiom. | likely for a team raised on Protobuf | After 3.0.0, in tables only, never in types, and a map makes the table variable: it rides with the pointers, never in a fixed record ([#380](https://github.com/mas-bandwidth/schema/issues/380)). Enum keys are already better served by `[E]T` (§2.4). |
 | 4 | **Unbounded strings and bytes at used size.** | closed | Landed as `*bytes` and `*string`, the byte-buffer primitive (§2.5, [#259](https://github.com/mas-bandwidth/schema/issues/259)): an image lives inside a table at its own size and a mapped cook points at it with no copy. C++ and the tool carry it; the ports follow as a row on [#366](https://github.com/mas-bandwidth/schema/issues/366). |
-| 5 | **A verifier for untrusted bytes.** FlatBuffers ships a separate `Verifier` pass, in C++, C and Swift of its thirteen languages (FB-support). | possible | Table reads are untrusted: they arrive over the network and carry the type wire's security posture; only the cook open is trusted. So the tolerant read IS the verifier, in every language, and [#391](https://github.com/mas-bandwidth/schema/issues/391) is the fuzzer with an independent oracle that proves it in CI. Before 3.0.0, since the release makes the claim. |
+| 5 | **A verifier for untrusted bytes.** FlatBuffers ships a separate `Verifier` pass, in C++, C and Swift of its thirteen languages (FB-support), and in Rust, whose safe table functions "verify the data first" (FB-rust). | possible | Table reads are untrusted: they arrive over the network and carry the type wire's security posture; only the cook open is trusted. So the tolerant read IS the verifier, in every language, and the fuzzer with an independent oracle that proves it in CI runs against the C++ reference today ([#429](https://github.com/mas-bandwidth/schema/pull/429), §4.2); each port's leg is its PORTING.md I15 cell. Before 3.0.0, since the release makes the claim. |
 | 6 | **Every type in tables.** Nothing here is ahead of schema: `fixed`, `ufixed` and the 128-bit integers ride in a table under kinds of their own (§3), which is what a deterministic simulation's save holds. | closed | Landed in the C++ reference and the tool ([#390](https://github.com/mas-bandwidth/schema/issues/390)); the ports follow as a row on [#366](https://github.com/mas-bandwidth/schema/issues/366). |
 | 7 | **Sorted lookup inside a buffer.** FlatBuffers' `key` attribute and `LookupByKey`. | possible, for a large catalog opened by id | Library-side, after 3.0.0: a sort the cook writer holds and a generated `Find` over the cooked rows. Never stored semantics. |
 | 8 | **Reflection in more languages.** | possible, for an editor in Python or C# | Descriptors are built into every table's generated code with no schema files and no RTTI (§8). They reach every language with the parity matrix on [#366](https://github.com/mas-bandwidth/schema/issues/366). |
@@ -154,7 +154,7 @@ Each with the section that defines it and the reason a game cares.
 |---|---|---|
 | **Bounds in the type.** `\| min, max` is part of the type; the type wire sizes bits from it and the table wire clamps and counts on load. | SPEC §4.3, §4 | A health capped at 1000 is ten bits on a packet, and a save cannot carry an out-of-range value. |
 | **Two classes derived from the declaration.** A table with no pointer is a plain struct; one with a pointer gets an arena. A build-failing gate holds the fixed class to zero cost. | §2.2 | A config struct pays nothing for the machinery a scene graph needs. |
-| **No allocation on read, every class, every form, nine languages.** | ladder, §6.5 | No GC pressure and no allocator on the load path. |
+| **No allocation on read, every class, every form, in eight of the nine languages.** Elixir is the exception: a decoded BEAM term is an allocation and no buffer is caller-owned there, so that leg pins the per-case COUNT instead (PORTING.md M1). | ladder, §6.5 | No GC pressure and no allocator on the load path. |
 | **`Measure` equals `Save` at exact capacity**, held by a mandatory battery. | §9 | Caller-owned buffers, parallel scatter writes, never a realloc. |
 | **Pointers with sharing preserved.** A node written once however many times it is named; a flat node table, so a 260-node chain is not a recursion; cycles refused by name. | §2.1, §3.1 | Trees, graphs, palettes shared by many nodes. Neither competitor shares a node, and Protobuf has no pointer at all. |
 | **Enum-keyed arrays that ride by name** and refuse a bad key in every build. | §2.4, §3.2 | Per-ship-type config survives inserting a ship type in the middle. |
@@ -186,7 +186,7 @@ Each with the section that defines it and the reason a game cares.
 | Explicit or sparse enum values | both | On the table wire a variant rides by name, so its number is invisible (SPEC §9). |
 | Varint compaction | Protobuf | The type wire is the compact wire; tables trade bytes for tolerance by design, and the ladder states the price. |
 | Deprecation markers | both | Removal is free and reported, which is what deprecation exists to fake elsewhere. |
-| Reserved numbers | Protobuf | Ids are name hashes and cannot be reused by number. Re-adding a retired name with a new meaning is the baseline's job, and a retired-names list is a small addition to it after 3.0.0. |
+| Reserved numbers | Protobuf | Ids are name hashes and cannot be reused by number. Re-adding a retired name with a new meaning is the baseline's job, and the retired-names ledger it needs is [#441](https://github.com/mas-bandwidth/schema/issues/441), before 3.0.0. |
 | RPC and gRPC | both | Out of scope, by the owner's word. Add it on top if you care. |
 
 ## The feature table
@@ -222,7 +222,7 @@ the source list at the end.
 | Units and includes | one `package` per unit, all files compiled together, order-free; cross-file table references form a DAG (SPEC §3.2, §11) | `include`, nested `namespace` (FB-schema) | `import`, `import public`, `package` (PB-editions) |
 | Attributes | closed typed vocabulary right of `\|`; unknown is a compile error; type tags inert until claimed (SPEC §4.2) | user attributes declarable, read via reflection (FB-schema) | custom options with retention and targets (PB-editions) |
 | Doc comments | deferred, design pinned (SPEC §4.1) | `///` into generated code and the binary schema (FB-flatc) | the descriptor carries source info — `SourceCodeInfo`, whose `leading_comments` and `trailing_comments` a generator reads (PB-descriptor) |
-| Reserved names | after 3.0.0, a retired list in the baseline | — ; never remove, deprecate instead (FB-evolution) | `reserved` numbers and names (PB-proto3) |
+| Reserved names | the retired-names ledger in the baseline, before 3.0.0 ([#441](https://github.com/mas-bandwidth/schema/issues/441)) | — ; never remove, deprecate instead (FB-evolution) | `reserved` numbers and names (PB-proto3) |
 | Deprecation | — ; removal is free and counted | `(deprecated)`: accessors dropped, slot kept (FB-schema) | `[deprecated = true]` (PB-proto3) |
 | Required | — ; every field optional with a default (§4) | `(required)`, verifier-checked (FB-schema) | removed; `LEGACY_REQUIRED` only (PB-ed-overview) |
 | Rename | `\| was = "old"` keeps the id; a bare rename is a removal plus an addition, and a committed baseline warns on the pair (§5, §18.2) | free; names not serialized (FB-evolution) | free on binary; reserve the old name for JSON (PB-proto3) |
@@ -281,7 +281,7 @@ the source list at the end.
 |---|---|---|---|
 | Point at the bytes | the cook: `Open` is O(1), mmap-friendly, order settled offline (§7); the block: rows at a fixed pitch (§19); the tolerant wire always parses | always (FB-home) | never (PB-overview) |
 | Parse into a struct | `Load` into caller-owned storage; a fixed table is a struct (§6.1) | object API `UnPack()` into STL-backed classes (FB-cpp) | generated message classes (PB-message) |
-| Allocation on read | none, every class, every form (§6.5) | none in place; the object API allocates (FB-cpp) | per message, string and repeated field; arenas mitigate (PB-message) |
+| Allocation on read | none, every class, every form (§6.5), in eight of the nine backends; Elixir pins a per-case count instead, because a decoded BEAM term is an allocation (PORTING.md M1) | none in place; the object API allocates (FB-cpp) | per message, string and repeated field; arenas mitigate (PB-message) |
 | Allocation on write | fixed class none; variable class an arena in bulk, thread-local, never per node; block takes a caller allocator (§6.4, §6.5, §19.1) | the builder grows a buffer; custom allocator (FB-cpp) | into caller memory; the message objects allocate (PB-message) |
 | Exact size before writing | `Measure` equals `Save`, held by a battery (§9) | after `Finish` | `ByteSizeLong()` (PB-message) |
 | Mutate in place | — ; regenerate | `--gen-mutable` scalars; reflection resizes (FB-flatc) | — |
@@ -298,7 +298,7 @@ the source list at the end.
 
 | feature | schema tables | FlatBuffers | Protocol Buffers |
 |---|---|---|---|
-| Untrusted bytes on the tolerant wire | the read is the validator: every length bounds-checked against its body, counts against the body, ranges clamped, a bad level stops itself; `LoadMeasure` lets the caller refuse a region size before allocating (§4, §6.5). The independent-oracle fuzzer that proves it in every language is #391 | a separate `Verifier`, required before access, in C++, C and Swift (FB-support); `max_depth` 64, `max_tables` 1M (FB-cpp) | the parser validates structure; recursion limit 100; UTF-8 verify (PB-features) |
+| Untrusted bytes on the tolerant wire | the read is the validator: every length bounds-checked against its body, counts against the body, ranges clamped, a bad level stops itself; `LoadMeasure` lets the caller refuse a region size before allocating (§4, §6.5). The independent-oracle fuzzer that proves it runs against the C++ reference today (§4.2, [#429](https://github.com/mas-bandwidth/schema/pull/429)); each port's leg is its PORTING.md I15 cell | a separate `Verifier`, required before access, in C++, C and Swift (FB-support) and in Rust, whose safe table functions "verify the data first" (FB-rust); `max_depth` 64, `max_tables` 1M (FB-cpp) | the parser validates structure; recursion limit 100; UTF-8 verify (PB-features) |
 | Trusted fast path | cook and block are trusted by design; `Open` checks identity, not hostility; a signature over the file is the integrity answer (§7, §13.4) | skip the verifier for trusted buffers (FB-cpp) | — |
 | Value-range enforcement | clamp and count on the table wire; reject on the type wire (§4, SPEC §5) | — | — |
 | Depth and DoS bounds | by-value depth is fixed by the schema; a pointer graph is flat, so a chain is not a depth (§3.1) | verifier caps (FB-cpp) | recursion depth 100 (PB-limits) |
@@ -310,7 +310,7 @@ the source list at the end.
 |---|---|---|---|
 | Runtime reflection | descriptors in every table's generated header: name, kind, id, offset, bounds, guards, nesting; no schema files, no RTTI (§8.1); the type view and registry specified (§8) | binary schema plus `reflection.h` in C++, basic in C; mini-reflection (FB-IR, FB-support) | descriptors, `Reflection`, `DynamicMessage` (PB-message) |
 | Reflection cost | on the side; a game build never compiles the view (§8.4) | 2 to 6 bytes per field for mini-reflection (FB-cpp) | in the full runtime always |
-| Text form | JSON in and out by one walk, mapping pinned per kind, `\| json = "key"`, report counters; a shared node labeled `&node` (§16.7, landing with [#388](https://github.com/mas-bandwidth/schema/pull/388)) | JSON in `flatc`; parsing in C++ and C (FB-support) | ProtoJSON, whose own page lists the implementations that do not conform to it — C++, Java and Python as of v25.x; text format (PB-json, PB-text) |
+| Text form | JSON in and out by one walk, mapping pinned per kind, `\| json = "key"`, report counters; a shared node labeled `&node` (§16.7, landing with [#388](https://github.com/mas-bandwidth/schema/pull/388)) | JSON in `flatc`; parsing in C++, C and Lobster (FB-support) | ProtoJSON, whose own page lists the implementations that do not conform to it — C++, Java and Python as of v25.x; text format (PB-json, PB-text) |
 | Whole-tree packing | `schema pack` and `unpack`: a directory mirrors the root; keyed arrays as one file per variant; byte-stable both ways (§17) | `flatc -b` (FB-flatc) | `protoc --encode` and `--decode` |
 | Dump, diff, check | `cook-check`, `uncook`, `build-version --facts`, `projection` (§7, §20.7); generic dump and diff over the registry a follow-on (§15) | `flatc --json`, `FlatBufferToString` (FB-flatc) | `DebugString`, third-party explorers (PB-3p) |
 | Lint, breaking, registry | the baseline and the checker; no registry by design (§18) | `--conform` (FB-flatc) | `buf lint`, `buf breaking`, the BSR (buf) |
@@ -324,7 +324,7 @@ the source list at the end.
 
 Every FlatBuffers and Protocol Buffers claim above was read from one of these
 pages on 2026-09-03, and the rows citing PB-dos, PB-enum, PB-json,
-PB-descriptor, FB-support and FB-cpp were re-read on 2026-09-04.
+PB-descriptor, FB-support, FB-rust and FB-cpp were re-read on 2026-09-04.
 
 | short | page |
 |---|---|
@@ -335,6 +335,7 @@ PB-descriptor, FB-support and FB-cpp were re-read on 2026-09-04.
 | FB-flatc | https://flatbuffers.dev/flatc/ |
 | FB-flex | https://flatbuffers.dev/flexbuffers/ |
 | FB-support | https://flatbuffers.dev/support/ |
+| FB-rust | https://flatbuffers.dev/languages/rust/ |
 | FB-home | https://flatbuffers.dev/ |
 | FB-IR | https://flatbuffers.dev/intermediate_representation/ |
 | FB-64 | https://github.com/google/flatbuffers/issues/7537 and https://github.com/google/flatbuffers/issues/8555 |

--- a/docs/COMPETITION.md
+++ b/docs/COMPETITION.md
@@ -1,0 +1,551 @@
+# Schema against Protocol Buffers, FlatBuffers, Cap'n Proto and Avro
+
+The standing comparison. It is written to be checked: every cell about a
+competitor is cited to that project's own documentation, every cell about
+schema is cited to a specification section or an issue, and the same test is
+applied to all five columns. Row-level evidence for FlatBuffers and Protocol
+Buffers lives in [COMPARISON-TABLES.md](COMPARISON-TABLES.md); the packet-size
+measurement is [COMPARISON.md](COMPARISON.md); the versioning promises are
+[VERSIONING.md](VERSIONING.md). This page adds Cap'n Proto and Avro, a
+versioning group, and the summary a reader can take in ninety seconds.
+
+## What each of these is for
+
+No straw men. Each of the four makes a trade on purpose, and the trade is the
+thing to compare.
+
+**Protocol Buffers** identifies a field by a number you assign and never
+reuse, carries every field with a tag, preserves the fields it does not know
+through a read and a rewrite, and disclaims byte stability across builds. That
+is the right shape for a service API versioned independently over years by
+teams that never deploy together. Its own guidance is honest about the costs:
+never change a field's type, never change a default, reserve every retired
+number.
+
+**FlatBuffers** puts every scalar at its declared width and alignment behind a
+vtable so that a reader touches one field without parsing the buffer. The
+buffer is its own cooked form: little-endian, position-independent, build-
+independent, memory-mappable. The price is that a buffer from an untrusted
+source needs a separate verification pass before it is safe to touch, and the
+verifier ships in three of its thirteen languages.
+
+**Cap'n Proto** reads in place too, and adds an RPC system. Its message is a
+tree by construction, one pointer per object, which is what lets its reader
+bound traversal against a hostile message. Its scalars are stored XOR their
+declared default, so "unset" and "set to the default" are the same bytes and
+a default can never change. Those are not gaps; they are the encoding.
+
+**Avro** carries the writer's schema with the data, in the container file or
+as a fingerprint on each object, and resolves it against the reader's schema
+at read time. Nothing is elided, so a changed default can never reinterpret
+stored bytes. A mismatch fails the whole read, on purpose, because Avro's
+users are pipelines where a wrong row is worse than no row.
+
+**Schema** is for a game. A `type` produces a packet wire where the declared
+bounds decide the bits and both sides ship together, refusing each other on a
+protocol id if they do not match. A `table` produces a tolerant wire where a
+field is identified by the hash of its name, a reader counts what it could
+not understand and never fails on data from another build, and a committed
+baseline refuses at compile time the edits no reader could report. The same
+declaration cooks to a memory image the runtime opens with a header check and
+a pointer, and lays out as a row block one language writes and another reads
+at frame rate. One language, nine targets, one conformance corpus that every
+target must reproduce byte for byte.
+
+When to use theirs, in one line each, as the [FAQ](FAQ.md) already says: a
+service that versions independently of its callers is Protocol Buffers'
+case; in-place access to a large buffer you will not deserialize is
+FlatBuffers' or Cap'n Proto's; a data pipeline where the writer's schema must
+travel with the record is Avro's.
+
+## How to read the matrix
+
+One test for all five columns. A cell is ✅ when the feature exists in the
+format **and** in all of its official language implementations, 🔶 when it
+exists in the format but only some implementations carry it or it carries a
+material limitation (the footnote says which), ❌ when it is absent or
+declined on the record, and ? when the project's own documentation did not
+settle it and this page will not guess.
+
+Applied to schema that test is strict, and the page applies it anyway. The
+packet wire and the compiler are nine languages deep and held there by CI, so
+those rows are ✅. The table wire, the cook, the block and the text form are
+complete in the C++ reference and the compiler and are being carried to the
+other eight languages under one gate, full feature parity at each language's
+performance floor before 3.0.0 (#366). Every 🔶 in the schema column that
+cites #366 is that one gate, and when it closes the column is re-scored from
+CI, not by hand. A reader who wants the per-language state today reads
+[PORTING.md](PORTING.md), the register with a gate behind it.
+
+Nine rows where all five columns agree are listed at the end rather than
+shown. Editor support and big-endian hosts are not rows, because neither
+could be sourced across five columns.
+
+## The matrix
+
+### Declarations and the schema language
+
+| feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
+|---|---|---|---|---|---|
+| Numeric expressiveness beyond int32/int64/float/double: declared `min`/`max` bounds, sub-32-bit and 128-bit integers, fixed point | ✅ [s1] | ❌ [2] | 🔶 [3] | 🔶 [4] | 🔶 [5] |
+| Compile-time constants usable inside the schema | ✅ [s2] | ❌ [6] | ❌ [6] | ✅ [7] | ❌ [8] |
+| Nested value type with no per-instance framing | ✅ [s3] | ❌ [9] | ✅ [10] | 🔶 [11] | ✅ [12] |
+| Bit-flag sets as a declaration | ✅ [s4] | ❌ [13] | ✅ [14] | ❌ [15] | ❌ [8] |
+| Bounded arrays, strings and bytes: a declared capacity in the type | ✅ [s5] | ❌ [16] | 🔶 [17] | ❌ [18] | 🔶 [19] |
+| Enum-keyed arrays (`[E]T`, one slot per variant, by name) | ✅ [s6] | ❌ [20] | ❌ [21] | ❌ [15] | ❌ [8] |
+| Maps | 🔶 [s7] | ✅ [23] | 🔶 [24] | ❌ [25] | 🔶 [26] |
+| Shared subtrees: one node referenced by many parents, written once | 🔶 [s8] | ❌ [27] | 🔶 [28] | ❌ [29] | ❌ [30] |
+| Union arms may be any field type, not only a named record | 🔶 [s9] | 🔶 [32] | 🔶 [33] | ✅ [34] | ✅ [35] |
+| Defaults for strings, bytes and composites | 🔶 [s9] | 🔶 [36] | ❌ [37] | ✅ [38] | ✅ [39] |
+| Explicit presence on a scalar (set vs unset, distinct from the default) | ✅ [s10] | ✅ [40] | 🔶 [41] | ❌ [42] | 🔶 [43] |
+| Required fields: a read fails if the field is absent | ❌ [s11] | ❌ [45] | ✅ [46] | ❌ [47] | ✅ [48] |
+| Dynamic typing: generics, a type-erased `Any`, or schema-less values | ❌ [s12] | ✅ [50] | 🔶 [51] | ✅ [52] | ❌ [53] |
+| User-extensible annotations or custom options | ❌ [s13] | ✅ [55] | ✅ [56] | ✅ [57] | ? |
+
+### The wire
+
+| feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
+|---|---|---|---|---|---|
+| Self-describing: the bytes alone are enough to walk the data | 🔶 [s14] | 🔶 [59] | ❌ [60] | ❌ [61] | ✅ [62] |
+| Values compacted below their declared storage width | ✅ [s15] | ✅ [64] | ❌ [65] | 🔶 [66] | ✅ [67] |
+| Scalars aligned inside the buffer | 🔶 [s16] | ❌ [69] | ✅ [70] | ✅ [71] | ❌ [72] |
+| Data above 2 GiB | 🔶 [s17] | ❌ [74] | 🔶 [75] | 🔶 [76] | ✅ [77] |
+| Byte-identical output: one input, one schema, one byte sequence, across implementations | ✅ [s18] | ❌ [79] | ? [80] | 🔶 [81] | 🔶 [82] |
+
+### Evolution
+
+| feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
+|---|---|---|---|---|---|
+| Add, remove or reorder a field freely | 🔶 [s19] | 🔶 [83] | ❌ [84] | ❌ [85] | 🔶 [86] |
+| Rename a field without orphaning stored data | 🔶 [s20] | ✅ [88] | ✅ [89] | ✅ [90] | 🔶 [91] |
+| Change a field's type with no silent misdecode | 🔶 [s21] | ❌ [92] | ❌ [93] | ❌ [94] | ✅ [95] |
+| Change a declared default without reinterpreting stored bytes | 🔶 [s22] | ❌ [97] | ❌ [98] | ❌ [94] | ✅ [99] |
+| Unknown fields preserved through a read-and-rewrite | ❌ [s23] | ✅ [101] | 🔶 [102] | ? | ❌ [103] |
+| A per-event read report rather than pass/fail | 🔶 [s24] | ❌ [104] | ❌ [105] | ❌ [106] | ❌ [107] |
+| An unknown enum value has a defined, non-fatal landing | 🔶 [s25] | 🔶 [108] | 🔶 [109] | ? | 🔶 [110] |
+
+### Runtime forms, allocation, performance
+
+| feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
+|---|---|---|---|---|---|
+| Read one field without parsing the whole buffer | 🔶 [s26] | ❌ [112] | ✅ [113] | ✅ [114] | ❌ [115] |
+| No allocation on read | ✅ [s27] | ❌ [116] | 🔶 [117] | ✅ [118] | ❌ [115] |
+| Arena or single-buffer allocation on write, never per node | 🔶 [s28] | 🔶 [119] | 🔶 [120] | ✅ [121] | ? |
+| Exact serialized size known before writing | ✅ [s29] | ✅ [122] | ❌ [123] | ? | ? |
+| Mutate a serialized buffer in place | ❌ [s30] | ❌ [125] | 🔶 [126] | ✅ [127] | ? |
+| A same-build fast form: an O(1)-open cooked file and a fixed-stride cross-language row block | 🔶 [s31] | ❌ [128] | 🔶 [129] | 🔶 [130] | ❌ [115] |
+| Generated code with no library runtime to link | 🔶 [s32] | ❌ [131] | ✅ [132] | ❌ [133] | ? |
+
+### Validation of untrusted data
+
+| feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
+|---|---|---|---|---|---|
+| Untrusted bytes are safe with no separate verification pass | 🔶 [s33] | ✅ [135] | ❌ [136] | ✅ [137] | ? |
+| Value ranges enforced from the schema | ✅ [s1] | ❌ [2] | ❌ [3] | ❌ [4] | ❌ [5] |
+| Depth and resource bounds against a hostile message | 🔶 [s34] | 🔶 [139] | 🔶 [140] | 🔶 [141] | ? |
+| One cross-language conformance corpus that includes hostile cases | ✅ [s35] | 🔶 [142] | ? | ? | ? |
+
+### Reflection, text, tooling
+
+| feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
+|---|---|---|---|---|---|
+| Runtime reflection with no schema file present at runtime | 🔶 [s36] | ✅ [144] | ❌ [145] | 🔶 [146] | ✅ [147] |
+| JSON or text form, in and out | 🔶 [s37] | ✅ [149] | 🔶 [150] | 🔶 [151] | ✅ [152] |
+| Doc comments carried into generated code | ❌ [s38] | ✅ [154] | ✅ [155] | ? | ✅ [156] |
+| Official language implementations at feature parity | 🔶 [s39] | 🔶 [158] | ❌ [159] | ❌ [160] | 🔶 [161] |
+
+### Versioning
+
+| feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
+|---|---|---|---|---|---|
+| Rename an enum variant, union arm or named type without orphaning stored data | 🔶 [s40] | ✅ [88] | ✅ [89] | 🔶 [163] | 🔶 [91] |
+| A retired name or number cannot be silently reused | 🔶 [s41] | ✅ [165] | 🔶 [166] | 🔶 [167] | ❌ [168] |
+| Defined widening or promotion of a field's type on read | ❌ [s42] | 🔶 [170] | 🔶 [93] | 🔶 [171] | ✅ [172] |
+| The writer's schema is recoverable at read time | ❌ [s43] | ❌ [174] | 🔶 [175] | ❌ [61] | ✅ [176] |
+| A revision marker in the bytes says which format version wrote them | 🔶 [s44] | ❌ [178] | 🔶 [179] | ❌ [180] | ✅ [181] |
+| A first-party compile-time gate on breaking edits | ✅ [s45] | ❌ [183] | ✅ [184] | ❌ [185] | ? |
+| Wire bytes promised stable across releases of the compiler | 🔶 [s46] | ❌ [79] | ? | 🔶 [187] | 🔶 [82] |
+
+### Agreed, not shown
+
+All five have enums, a discriminated union, recursive declarations,
+multi-file schemas with imports, length-prefixed variable-length payloads,
+contiguous scalar arrays, little-endian fixed-width scalars, a code generator
+producing native types, and comments invisible to the wire.
+
+## Where they are ahead, and what happens about it
+
+- **Renames beyond fields.** Protocol Buffers, FlatBuffers and Cap'n Proto
+  rename a variant or a type freely because the wire carries numbers; schema's
+  `was` is a field attribute today. Tables get `was` under #396 and variants
+  and arms under #442, both before 3.0.0.
+- **Retired names.** Protocol Buffers' `reserved` is the right mechanism and
+  schema lacks it: a removed name can be re-added years later and decode old
+  bytes under a new meaning. The retired-names ledger in the baseline is
+  #441, before 3.0.0.
+- **Default changes.** Avro elides nothing, so a changed default cannot
+  reinterpret stored bytes. Schema elides a field equal to its default, which
+  is why its baseline refuses a default change at compile time; that is a
+  guard where Avro has a guarantee, and the guard is opt-in until the nudge
+  (#445) lands.
+- **Unknown fields through a rewrite.** Protocol Buffers keeps them; schema
+  drops them by decision (everything in schema has a schema) and counts them,
+  and the versioning page names the one rule a studio must write for it:
+  never overwrite a file whose read report is not silent.
+- **Promotion.** Avro promotes `int` to `long` on read; schema reads a
+  changed kind as the default and counts a kind mismatch. Declined, with the
+  reason below.
+- **Doc comments** reach generated code in three of the four; in schema they
+  are deferred with the design pinned (SPEC §4.1).
+- **Ecosystems.** Protocol Buffers has ten first-party languages and fifty-odd
+  third-party ones; FlatBuffers thirteen; Avro publishes six SDKs and claims
+  more. Schema has nine, and the claim it makes about them, byte-identical
+  output held by one corpus in CI, is the one none of the four makes.
+- **Tools.** `buf breaking`, `flatc --proto`, `capnp convert`. Schema's
+  compile-time gate is first-party (`tables.baseline`); an importer from
+  `.proto` or `.fbs` is not declined and not built (#467).
+
+## Where schema is ahead
+
+- **Bounds are bits.** `health int32 | min = 0, max = 1000` is ten bits on
+  the packet wire; 28 bytes for a packet the others encode in 52, 56 and 72
+  ([COMPARISON.md](COMPARISON.md)). None of the four can infer a range it was
+  never told.
+- **One language for all five kinds of data.** Packets, backend messages,
+  saves, render blocks and cooked assets from one declaration, so there is no
+  second copy of the types to drift.
+- **The read is the report.** Every load counts what it did not know, what
+  had the wrong kind, what it clamped and whether the bytes were malformed,
+  and never fails on data from another build. The others return a boolean or
+  throw.
+- **The silent class is enumerated and refused.** The edits no reader can
+  report, a changed default, a moved fixed-point scale, an enum respelled as
+  its integer, are refused at compile time by a committed baseline with a
+  reasoned, dated history. The nearest equivalents, `flatc --conform` and
+  `buf breaking`, check structure, not meaning.
+- **Shared subtrees on the wire.** A node written once and referenced many
+  times, which none of the four does by declaration. Cap'n Proto forbids it
+  to bound traversal; schema's flat node table materializes each node once
+  and `LoadMeasure` prices the region before allocation, and the bound is
+  being stated and tested as such (#466).
+- **Per-field tolerance.** Avro fails the whole read on a mismatch; schema
+  counts the field and reads the rest. The right answer for a save game and
+  the wrong one for a warehouse, and the page says which is which.
+
+## Judged not needed, with the reason
+
+| feature | who has it | why schema declines |
+|---|---|---|
+| Required fields | FlatBuffers, Avro in effect | Every field optional with a declared default is the ground rule. Protocol Buffers removed `required` and says why; schema never had it. |
+| `Any`, generics, schema-less values | Protocol Buffers, Cap'n Proto, FlexBuffers | The typed bag is a union whose arms are tables. A type-erased value is a type the compiler cannot check. |
+| Custom annotations | Protocol Buffers, FlatBuffers, Cap'n Proto | The attribute vocabulary is closed and an unknown attribute is a compile error; type tags are the claiming mechanism. |
+| Unknown fields preserved through a rewrite | Protocol Buffers | Everything in schema has a schema. The old file kept whole is the preservation, and the never-clobber rule is the policy. |
+| A widening path on read | Avro, Protocol Buffers' pairs | A whitelist of compatible pairs silently misdecodes everything outside it. A changed kind reads as the default and is counted; the pattern is a new field beside the old one and a load shim. |
+| The writer's schema travelling with the data | Avro | One schema per build, identified by the protocol id and the build version, neither of which rides in a file. A tolerant wire that skips by kind needs no schema to walk, and a file that must say what wrote it puts a `format` field on its root table. |
+| A canonical form of the data | Cap'n Proto | A load followed by a save through the reader's own schema is the canonical form: elision, order and duplicates are all resolved by it. Byte identity across schema's own writers is held by goldens. |
+| Mutating a serialized buffer in place | Cap'n Proto, FlatBuffers | A cook is immutable and regenerated by the cache; the block form is the every-frame mutable answer. |
+
+## Versioning, mechanism by mechanism
+
+Each competitor defends against a failure with a mechanism. The question for
+each is whether schema covers the same failure, declines it with a reason, or
+has a gap.
+
+**Protocol Buffers: field numbers, `reserved`, unknown-field preservation,
+open enums.** Numbers identify a field for life; `reserved` stops a retired
+number or name from being reused; unknown fields survive a rewrite; an open
+enum keeps a value it does not know. Schema covers identity with the name
+hash and `was`, and covers the unknown-value case with `None` counted. The
+retired-name ledger is the gap (#441). Unknown-field preservation is declined.
+
+**FlatBuffers: append-only tables, `deprecated` never removed, `--conform`,
+`file_identifier`.** Position is identity, so a field is never removed and
+new ones go at the end; `flatc --conform` refuses an edit that breaks the
+rule; a four-character identifier says which schema wrote a buffer. Schema
+covers the first two with name identity, which makes removal and reorder
+free, and the gate with the baseline. The identifier is covered by the
+`format` field pattern and, for the format's own revision, by the form byte
+(#435).
+
+**Cap'n Proto: ordinals, explicit type ids, the list-of-structs upgrade,
+canonicalization.** Ordinals never change; a renamed or moved type pins its
+id explicitly or silently gets a new one; one promotion path exists; a
+canonical form makes messages comparable. Schema covers ordinals with names,
+covers the type-id case with table `was` (#396), declines promotion, and
+answers canonicalization with load-then-save.
+
+**Avro: the writer's schema with the data, resolution, aliases, promotion,
+defaults that never reinterpret.** The reader always has the writer's schema
+and resolves against it; aliases carry renames; promotion widens on read; no
+elision means no default hazard. Schema declines carrying the schema, covers
+resolution with the tolerant read, covers aliases with `was` (fields today,
+every vocabulary before 3.0.0), declines promotion, and guards the default
+hazard with the baseline instead of a guarantee.
+
+The gaps, all before 3.0.0: the retired-names ledger (#441), `was` for
+variants and arms (#442), the form byte (#435). The one row where a
+competitor's guarantee is strictly stronger than schema's guard is Avro's on
+defaults, and the page says so above.
+
+## Footnotes
+
+Schema cells cite the specifications and issues; competitor cells cite the
+project's own documentation by the short names in the source list at the end,
+with the section that establishes the claim.
+
+**Schema**
+
+- s1. `| min, max` is part of the type; the type wire sizes bits from the bound and the table wire clamps and counts on load (SPEC §4.3, SPEC-TABLES §4). `fixed(I,F)`, `ufixed(I,F)`, int128 and uint128 ride under table-wire kinds of their own (SPEC-TABLES §3).
+- s2. `const`, folded at compile time and usable in bounds, defaults and capacities (SPEC §4.4).
+- s3. A `type` inside a `type`, or a fixed table inside a table, is inline storage with no framing on the packet wire; on the table wire a nested table is one length-framed node (SPEC-TABLES §3).
+- s4. `flags` declarations, one bit per variant (SPEC §4.2).
+- s5. `[N]T`, `[..N]T`, `string(N)`, `bytes(N)`: the capacity is in the type and the packet wire sizes the count from it (SPEC §4.3).
+- s6. `[E]T`, a slot per variant addressed by name, with a keyed wire kind (SPEC-TABLES §2.4, §3.2).
+- s7. Designed for tables after 3.0.0; a map makes the table variable (SPEC-TABLES §2.8, #380).
+- s8. A pointer field `*T` names a node once in a flat node table and every reference is an index (SPEC-TABLES §3.1). C++ reference and the compiler today; the other backends under #366. The amplification bound on an untrusted read is #466.
+- s9. Union arms of any field type and defaults for string, bytes and flags are decided and landing (#396).
+- s10. `?T` on both wires; on the packet wire it is one presence bit (SPEC §4.2).
+- s11. Declined: every field optional with a declared default (SPEC-TABLES §4).
+- s12. Declined on #396 and in COMPARISON-TABLES.md; the typed bag is a union whose arms are tables.
+- s13. Declined: the attribute vocabulary is closed and an unknown attribute is a compile error (SPEC §4.2).
+- s14. Kinds and lengths ride on the tolerant wire, so any reader skips anything it does not know; names ride as hashes, not text, so the bytes cannot be rendered with names without the schema (SPEC-TABLES §3). Table wire, #366.
+- s15. The packet wire sizes each field from its bounds (SPEC §4.3); the table wire deliberately does not compact.
+- s16. No alignment on the tolerant wire; the cook and the block are the aligned forms (SPEC-TABLES §7.2, §19.3). #366.
+- s17. Eight-byte region references and 64-bit cook part lengths, no aggregate ceiling (SPEC-TABLES §6.3, §7.1); the table wire's lengths go 64-bit under #435. Table forms, #366.
+- s18. The packet wire: one standard, nine languages, pinned goldens in CI, `Measure` equals `Save` (SPEC §3, VERSIONING.md). The table wire has the same rule in the C++ reference and the compiler, #366.
+- s19. Name identity: add anywhere, remove, reorder, all reported by the read (SPEC-TABLES §4). #366.
+- s20. `| was = "old"` keeps the wire id; a bare rename is a removal and an addition the compiler cannot see, and the baseline is being taught to warn on the pair (#444). Fields today; every vocabulary before 3.0.0 (#396, #442). #366.
+- s21. A changed kind reads as the default and is counted `kind_mismatch`; never truncated, never misread (SPEC-TABLES §4). #366.
+- s22. Silent on the wire, refused at compile time by a committed baseline (SPEC-TABLES §18); 🔶 because the baseline is opt-in until #445.
+- s23. Declined by decision; the read report counts what a rewrite would drop (VERSIONING.md, the never-clobber rule).
+- s24. Four counters and a `malformed` flag on every load (SPEC-TABLES §4). #366.
+- s25. An unknown variant reads `None` and is counted (SPEC-TABLES §4). #366.
+- s26. The cook: `Open` is a header match and a pointer (SPEC-TABLES §7). C++ reference and the compiler; #366.
+- s27. The packet wire reads into the caller's struct with no allocation, in every language, held by an allocation gate (PORTING.md I1, I12). The table wire's fixed class likewise; the variable class reads through a region the caller sizes with `LoadMeasure` (SPEC-TABLES §6.5).
+- s28. The variable class builds through an arena (SPEC-TABLES §9). C++ reference; #366.
+- s29. `Measure` before `Save`, both wires, equal by test (SPEC-TABLES §9).
+- s30. Declined: a cook is immutable and regenerated by the cache; the block form is the mutable answer (SPEC-TABLES §7, §19).
+- s31. The cook (SPEC-TABLES §7) and the block (§19), with the block's two-sided layout assertion at open. C++ writes and C# reads today; #366.
+- s32. Six of the nine targets link a small `serialize` runtime for the packet wire; Dart, Java and Elixir generate self-contained output (VERSIONING.md).
+- s33. The tolerant read is the validator: every length bounds-checked, every count against its body, ranges clamped, a bad sub-table stopping only itself (SPEC-TABLES §4, §6.5). The independent-oracle fuzzer that proves it is landing for the C++ reference (#429) and owed to every port (#391).
+- s34. By-value depth is fixed by the schema and the pointer graph is flat, so a long chain is not a recursion (SPEC-TABLES §3.1); the stated bound on materialization is #466. #366.
+- s35. One corpus, every language, hostile rows included; a port answers ABSENT per case where it lacks a construct rather than passing by omission (test/conformance, #383).
+- s36. Descriptors in every table's generated header, no schema files, no RTTI (SPEC-TABLES §8.1). #366.
+- s37. JSON in and out by one walk, `| json = "key"`, the read report, `&node` for a shared node (SPEC-TABLES §16). #366.
+- s38. Deferred with the design pinned (SPEC §4.1).
+- s39. Nine languages byte-identical on the packet wire in CI; tables carried under #366, which is the declared 3.0.0 gate and not the present state.
+- s40. Table `was` (#396) and variant and arm `was` (#442), before 3.0.0.
+- s41. The retired-names ledger in the baseline (#441), before 3.0.0.
+- s42. Declined, with the reason in the table above.
+- s43. Declined, with the reason in the table above.
+- s44. The form byte at the head of every table-wire file (#435), before 3.0.0; the cook and the block already refuse on the build version.
+- s45. `tables.baseline` with `--update --reason` (SPEC-TABLES §18) for the table wire; for the packet wire the protocol id and the pinned goldens.
+- s46. The promise is on VERSIONING.md and the goldens hold it across a schema's edits; across compiler releases it needs the codec-law line and the differential gate (#463).
+
+**Protocol Buffers, FlatBuffers, Cap'n Proto, Avro**
+
+2. Protocol Buffers has int32/int64/uint32/uint64/sint/fixed/sfixed/float/double/bool and no sub-32-bit integer, 128-bit integer, fixed point or declared range (PB-proto3, Scalar Value Types).
+3. FlatBuffers has `byte` through `ulong`, so sub-32-bit yes; no 128-bit, no fixed point, no range (FB-schema, Tables).
+4. Cap'n Proto has Int8 to Int64 and the unsigned set; no 128-bit, no fixed point, no range (CP-lang, Built-in Types).
+5. Avro's primitives stop at int, long, float, double; `decimal` is a logical type over bytes or fixed, an arbitrary-precision annotation whose per-language support varies (AV-spec, Primitive Types; Logical Types).
+6. Neither Protocol Buffers nor FlatBuffers has a constant declaration (PB-proto3 and FB-schema, top-level declaration lists).
+7. `const` exists and may be referenced inside another value including a field default (CP-lang, Constants).
+8. Avro's schema is JSON; no constant, flags or keyed-array construct exists in the specification (AV-spec, Complex Types).
+9. Every nested message is a length-delimited record: a tag and a length (PB-encoding, Length-Delimited Records).
+10. A FlatBuffers `struct` is stored inline in its parent (FB-internals, Structs).
+11. A Cap'n Proto struct field is a pointer into the message; structs are inline only as elements of a composite list, a deliberate trade for random access and the list-upgrade rule (CP-encoding, Structs; Lists).
+12. An Avro record is the concatenation of its fields' encodings with no framing (AV-spec, Binary Encoding).
+13. No flags construct; a bitmask is an integer by convention (PB-proto3).
+14. `bit_flags`: an unsigned value N in the schema represents 1<<N (FB-schema, attributes).
+15. No flags or keyed-array construct; enumerants are numbered from zero and are not numeric (CP-lang, Enums).
+16. `repeated`, `string` and `bytes` are unbounded up to the message ceiling (PB-proto3; PB-limits).
+17. `[T:N]` fixed-length arrays are supported only in a `struct` (FB-schema, Fixed-length Arrays).
+18. `List(T)`, `Text` and `Data` take no bound (CP-lang, Built-in Types).
+19. Avro's `fixed` is an exact-size byte type; `string`, `bytes`, `array` and `map` are unbounded (AV-spec, Fixed).
+20. Enum keys are refused in a map (PB-proto3, Maps).
+21. No enum-keyed array; the idiom is a sorted vector with `LookupByKey`, by value (FB-cpp, Sorting a vector of tables).
+23. `map<K,V>` in every official language; keys integral or string; iteration and wire order undefined (PB-proto3, Maps).
+24. No map type; the sorted-vector idiom is documented on the C++ page, not as a cross-language feature (FB-cpp; FB-schema, `key`).
+25. `Map(K,V)` appears only as an example of a user-defined generic (CP-lang, Generic Types).
+26. Map keys are strings (AV-spec, Maps).
+27. A tree of length-delimited records; no reference type (PB-encoding).
+28. A table may point at the same value twice if the builder serializes the same offset twice; object cycles are not allowed (FB-internals).
+29. One pointer per object, a tree not a graph; cyclic or overlapping pointers can send a reader into an infinite loop, which is what the traversal limit defends (CP-encoding, Messages).
+30. No reference type; recursion is a union naming the record, which yields a tree (AV-spec, Complex Types).
+32. `oneof` admits any type except map and repeated fields (PB-proto3, Oneof).
+33. Union members are tables; other member types and vectors of unions are experimental, the latter C++ only (FB-schema, Unions).
+34. A union is two or more fields sharing storage, so any field type is an arm, including `Void` (CP-lang, Unions).
+35. A union is a JSON array of schemas, any schema a branch, with two restrictions (AV-spec, Unions).
+36. proto3 has no user-declared defaults; proto2 and editions do (PB-proto3, Default Values; PB-presence).
+37. Only scalars take explicit defaults; strings, vectors and tables are null when absent (FB-schema, Tables).
+38. Defaults for `Text`, `Data`, `List` and nested structs (CP-lang, Structs).
+39. A default for every field type (AV-spec, Record).
+40. `optional` fields track presence (PB-proto3, Field Labels).
+41. Optional scalars via `= null`, marked No for Python, PHP and Dart in the support matrix (FB-schema, Optional Scalars; FB-support).
+42. No scalar presence: data-section fields are stored XOR their default, so unset and set-to-default are one encoding; a pointer's null is the only absence (CP-encoding, Value Encoding).
+43. The idiom is a union with `null`, a value not a presence flag (AV-spec, Unions).
+45. `required` was removed in proto3; the guidance is never to add one (PB-dos).
+46. `(required)` is checked by the verifier (FB-schema, attributes).
+47. No required marker (CP-lang).
+48. A reader field with no default and no writer counterpart signals an error for the whole read (AV-spec, Schema Resolution).
+50. `Any` with a type URL, and `Struct`/`Value` in the well-known types (PB-proto3, Any; PB-wkt).
+51. FlexBuffers, marked Yes for C++, Java, Rust and Swift and ? for most others (FB-support).
+52. Generics are first class; an omitted parameter is `AnyPointer` (CP-lang, Generic Types).
+53. No generics and no `Any`; the writer's schema is always available, a different solution to the same problem (AV-spec).
+55. Custom options with retention and target restrictions (PB-editions, Custom Options).
+56. User-defined attributes, declared, queryable from a parsed schema at runtime (FB-schema, Attributes).
+57. `annotation foo(struct, enum) :Text;` with fourteen targets plus `*` (CP-lang, Annotations).
+59. Field numbers and wire types ride; names and declared types need the definition; the overview lists "don't inherently self-describe" (PB-encoding, Message Structure; PB-overview).
+60. No format identification or versioning information in the buffer, by design (FB-internals).
+61. Field positions are computed from the schema; the message carries no field identity (CP-encoding).
+62. The container file embeds the writer's schema; single-object encoding carries `C3 01` plus a schema fingerprint. The bare value encoding is untagged (AV-spec, Object Container Files; Single Object Encoding; Binary Encoding).
+64. Varints and ZigZag (PB-encoding).
+65. Every scalar at its declared width, aligned; that is what buys in-place access (FB-internals).
+66. Packing is an optional pass over the unpacked layout (CP-encoding, Packing; CP-faq).
+67. int and long are zig-zag varints (AV-spec, Binary Encoding).
+69. No alignment (PB-encoding).
+70. Scalars aligned to their own size; `force_align` overrides (FB-internals; FB-schema).
+71. Objects aligned to word boundaries, primitives to a multiple of their size (CP-encoding).
+72. A byte stream with no alignment (AV-spec, Binary Encoding).
+74. A serialized proto must be under 2 GiB (PB-limits, Message Size).
+75. `uoffset_t` is a `uint32_t`; 64-bit offsets are C++ only (FB-internals; FB-64).
+76. Segment ids are 32 bits, so the aggregate is not 32-bit capped; a single list is capped at 2^29 elements; the C++ reader's traversal limit defaults to 64 MiB (CP-encoding, Lists; Far Pointers; CP-cxx, Security Tips).
+77. Block counts and lengths are 64-bit varints; the specification states no ceiling and per-implementation ceilings were not checked (AV-spec, Binary Encoding).
+79. Serialization stability is not guaranteed across binaries or builds, and default serialization is not deterministic (PB-dos; PB-encoding).
+80. No claim either way; the builder's freedom to share an offset means two conforming builders can emit different bytes for the same data (FB-internals). Marked ? rather than ❌ because it is an inference from absence.
+81. Canonicalization is fully specified and is a separate conversion, not the default output (CP-encoding, Canonicalization; CP-tool).
+82. A record's bytes are determined by the schema, but array and map block boundaries are the writer's choice; Avro's Parsing Canonical Form canonicalizes schemas, not data (AV-spec, Binary Encoding; Parsing Canonical Form).
+83. Adding and reordering are free; removal reserves the number forever, with the consequences of reuse spelled out (PB-proto3, Updating A Message Type; Reserved Fields).
+84. New fields go at the end and fields are never removed, unless `id` is used on every field (FB-evolution; FB-schema).
+85. New members take larger numbers; source order is free; numbers never change; no removal (CP-lang, Evolving Your Protocol).
+86. Fields match by name and a writer's extras are ignored, but a reader field without a default is a hard error against older data (AV-spec, Schema Resolution).
+88. Names are not on the binary wire; reusing an old name is generally safe except in TextProto and JSON (PB-proto3, Updating A Message Type).
+89. Renaming tables and fields is fine because names are not serialized; same JSON caveat (FB-evolution).
+90. Any symbolic name can change as long as the type id and ordinals stay (CP-lang, Evolving Your Protocol).
+91. Aliases exist on named types and fields; an implementation may optionally use them (AV-spec, Aliases).
+92. Almost never change a field's type; the compatible-pairs list is narrow and a change inside it can still truncate silently (PB-dos; PB-proto3, Updating A Message Type).
+93. Maybe OK, only for the same width (FB-evolution).
+94. A field's type or default value cannot change (CP-lang, Evolving Your Protocol).
+95. Resolution promotes or signals an error; never a misdecode, and the failure is the whole read (AV-spec, Schema Resolution).
+97. Almost never change a default; it causes version skew (PB-dos).
+98. Not OK: data written without the value relied on generated code for the default (FB-evolution).
+99. Every field is always written; a default is used only when the writer's schema lacks the field, so a default change cannot reinterpret stored bytes (AV-spec, Record).
+101. proto3 messages preserve unknown fields through parsing and serialization; lost through JSON (PB-proto3, Unknown Fields).
+102. A buffer forwarded whole keeps everything; the object API's unpack-and-repack does not (FB-evolution; FB-cpp).
+103. A writer's field not in the reader's record is ignored (AV-spec, Schema Resolution).
+104. Success or failure plus the unknown-field set (PB-proto3; PB-message).
+105. The verifier is a boolean (FB-cpp, Verifying a buffer).
+106. Limits throw; nothing reports what was skipped (CP-cxx, Security Tips).
+107. Errors are signalled; no counted report (AV-spec).
+108. Open enums keep the raw value; closed enums move it to unknown fields and re-serialize it out of place. C#, Go, JSPB and Ruby treat all enums as open and Dart as closed regardless of syntax (PB-enum).
+109. No defined landing; handling is the application's (FB-schema, Enums).
+110. A declared enum `default` is used, otherwise an error is signalled (AV-spec, Enums; Schema Resolution).
+112. Messages are parsed; equality requires full parsing (PB-overview).
+113. Access the data directly without unpacking or parsing (FB-home).
+114. No encoding step; one field readable without parsing the whole; mmap (CP-home).
+115. Values are variable-length and untagged, decoded into objects; no random access, no cooked form, deliberately (AV-spec, Binary Encoding).
+116. Per message, per string, per repeated field; arenas are C++ (PB-message; PB-arenas).
+117. No heap for in-place access; the object API unpacks into `std::string` and `std::vector` (FB-home; FB-cpp).
+118. Reads are pointer arithmetic over the buffer (CP-cxx).
+119. Arenas are a C++ feature (PB-arenas).
+120. The builder grows one buffer by reallocation (FB-cpp).
+121. Messages are built arena-style, sequentially in a segment (CP-cxx, Tips and Best Practices).
+122. `ByteSizeLong()` (PB-message).
+123. The size is known after `Finish` (FB-cpp).
+125. Parse, mutate the object, re-serialize; no in-place editing (PB-encoding; PB-message).
+126. `--gen-mutable` scalar mutators, Yes for C++, Java, C#, Go and Swift (FB-flatc; FB-support).
+127. Builders write in place; orphans move subtrees within a message (CP-cxx, Orphans).
+128. No cooked or block form (PB-overview; PB-encoding).
+129. The buffer is the cooked form; nothing asserts both languages' native layout at open (FB-internals).
+130. mmap is documented; there is no fixed-stride, layout-asserted row block (CP-home; CP-lang).
+131. Generated C++ derives from `Message` in `libprotobuf` (PB-message).
+132. The C++ library is header-only (FB-cpp).
+133. Link `libcapnp` and `libkj` (CP-cxx, Generating Code).
+135. The parser validates structure; UTF-8 is verified for `string`; recursion limits bound a hostile message (PB-encoding; PB-features; PB-limits).
+136. Offsets are not verified at run time and a malformed buffer can crash the reader; a separate verifier ships for C++, C and Swift of thirteen (FB-cpp, Verifying a buffer; FB-support).
+137. Designed to be safe against malicious input, with the caveat that it has not undergone a formal security review (CP-faq).
+139. Recursion limits vary: Java 100, C++ 100, Go 10,000 with a planned reduction (PB-limits).
+140. Verifier defaults of depth 64 and a million tables, where a verifier ships (FB-cpp).
+141. Nesting depth 64 and a 64 MiB traversal limit, documented for C++; other implementations unreviewed by the project (CP-cxx, Security Tips; CP-otherlang).
+142. A conformance suite exists; whether it carries hostile inputs is not established from the documentation (PB-conformance).
+144. `Reflection` and `DynamicMessage` are in the runtime (PB-message).
+145. Full reflection needs the binary schema as a separate artifact; C++, with Basic for C (FB-flatc, `--schema`; FB-support).
+146. `capnp/schema.h`, `capnp/dynamic.h` and `SchemaLoader`, documented for C++ (CP-cxx, Dynamic Reflection).
+147. The writer's schema is always present and the generic API reads any record without code generation (AV-java).
+149. ProtoJSON and the text format in every runtime (PB-json; PB-text).
+150. JSON parsing is Yes for C++, C and Lobster; `flatc --json` converts offline (FB-support; FB-flatc).
+151. `capnp convert` moves between binary, packed, flat, canonical, text and json, documented in the 0.7 release notes rather than the tool page; the library JSON is C++ (CP-tool; CP-0.7).
+152. The JSON encoding is part of the specification; `avro-tools` converts offline (AV-spec, JSON Encoding; AV-java).
+154. Comments are preserved in `SourceCodeInfo` and emitted by the generators (PB-wkt).
+155. `///` comments reach generated code and the binary schema (FB-schema, Comments & Documentation).
+156. The `doc` attribute on records and fields (AV-spec, Record).
+158. Ten first-party languages plus fifty-odd third-party ones, with the enum nonconformance documented by the project itself (PB-overview; PB-3p; PB-enum).
+159. Thirteen languages; JSON parsing in three, reflection in two, the verifier in three, mutation in five; C++ has the richest feature set (FB-support).
+160. The C++ reference is the only reviewed implementation; the C implementation is no longer maintained; several are serialization-only (CP-otherlang).
+161. Six documented SDKs and a home page claiming more; no per-feature matrix (AV-docs; AV-home).
+163. An omitted type id is derived from the parent scope's id and the declaration's name, so a rename or move silently changes it unless pinned explicitly (CP-lang, Unique IDs).
+165. `reserved` for numbers and names, with the consequences of reuse enumerated (PB-proto3, Reserved Fields).
+166. Removal is forbidden outright, so reuse cannot arise while the rule holds; no reserved list if it is broken (FB-evolution; FB-schema, `deprecated`).
+167. Ordinals never change and removal is not permitted; no reserved mechanism (CP-lang, Evolving Your Protocol).
+168. Aliases point forward; nothing marks a name retired (AV-spec, Aliases).
+170. The compatible-pairs list; a truncation inside it is silent (PB-proto3, Updating A Message Type).
+171. One path: a list of primitives may become a list of structs whose first field is that primitive (CP-lang, Evolving Your Protocol; CP-encoding, Lists).
+172. int to long, float or double; long to float or double; float to double; string and bytes either way (AV-spec, Schema Resolution).
+174. `Any` carries a type URL, a name resolved elsewhere (PB-proto3, Any).
+175. `flatc -b --schema` emits a binary schema as a separate artifact; `file_identifier` is four hand-chosen characters (FB-flatc; FB-schema).
+176. Container files embed the schema; single-object encoding carries its fingerprint (AV-spec).
+178. Six wire types, frozen; no revision marker, a deliberate trade (PB-encoding).
+179. `file_identifier` identifies the schema author's format, not the FlatBuffers revision (FB-schema).
+180. A segment table and segments; no magic, no version field (CP-encoding).
+181. Container files begin `Obj` `0x01`; single-object encoding begins `C3 01` and names its version (AV-spec).
+183. `buf breaking` is built by Buf Technologies, not the Protocol Buffers project, which offers prose guidance (buf; PB-3p).
+184. `flatc --conform` gives errors if a schema is not an evolution of the one given (FB-flatc).
+185. Evolution rules are prose; no tool checks them (CP-lang; CP-tool).
+187. The evolution rules preserve the canonical encoding across schema changes; no cross-release byte-stability promise is made (CP-lang, Evolving Your Protocol).
+
+## Sources
+
+All pages fetched 2026-09-04.
+
+| short | page |
+|---|---|
+| PB-proto3 | https://protobuf.dev/programming-guides/proto3/ |
+| PB-encoding | https://protobuf.dev/programming-guides/encoding/ |
+| PB-presence | https://protobuf.dev/programming-guides/field_presence/ |
+| PB-enum | https://protobuf.dev/programming-guides/enum/ |
+| PB-limits | https://protobuf.dev/programming-guides/proto-limits/ |
+| PB-overview | https://protobuf.dev/overview/ |
+| PB-dos | https://protobuf.dev/best-practices/dos-donts/ |
+| PB-editions | https://protobuf.dev/programming-guides/editions/ |
+| PB-features | https://protobuf.dev/editions/features/ |
+| PB-json | https://protobuf.dev/programming-guides/json/ |
+| PB-text | https://protobuf.dev/reference/protobuf/textformat-spec/ |
+| PB-wkt | https://protobuf.dev/reference/protobuf/google.protobuf/ |
+| PB-message | https://protobuf.dev/reference/cpp/api-docs/google.protobuf.message/ |
+| PB-arenas | https://protobuf.dev/reference/cpp/arenas/ |
+| PB-conformance | https://github.com/protocolbuffers/protobuf/tree/main/conformance |
+| PB-3p | https://github.com/protocolbuffers/protobuf/blob/main/docs/third_party.md |
+| buf | https://buf.build/docs/breaking/ |
+| FB-schema | https://flatbuffers.dev/schema/ |
+| FB-evolution | https://flatbuffers.dev/evolution/ |
+| FB-internals | https://flatbuffers.dev/internals/ |
+| FB-cpp | https://flatbuffers.dev/languages/cpp/ |
+| FB-flatc | https://flatbuffers.dev/flatc/ |
+| FB-support | https://flatbuffers.dev/support/ |
+| FB-home | https://flatbuffers.dev/ |
+| FB-64 | https://github.com/google/flatbuffers/issues/7537 |
+| CP-lang | https://capnproto.org/language.html |
+| CP-encoding | https://capnproto.org/encoding.html |
+| CP-cxx | https://capnproto.org/cxx.html |
+| CP-faq | https://capnproto.org/faq.html |
+| CP-otherlang | https://capnproto.org/otherlang.html |
+| CP-home | https://capnproto.org/ |
+| CP-tool | https://capnproto.org/capnp-tool.html |
+| CP-0.7 | https://capnproto.org/news/2018-08-28-capnproto-0.7.html |
+| AV-spec | https://avro.apache.org/docs/1.12.0/specification/ |
+| AV-java | https://avro.apache.org/docs/1.12.0/getting-started-java/ |
+| AV-docs | https://avro.apache.org/docs/1.12.0/ |
+| AV-home | https://avro.apache.org/ |
+
+A fact on this page lives here or in the page it links to, never in both. A
+pull request that changes a fact changes this page in the same pull request.

--- a/docs/COMPETITION.md
+++ b/docs/COMPETITION.md
@@ -6,15 +6,16 @@ schema is cited to a specification section, one of the repository's registers
 or an issue, and the same test is applied to all five columns. Row-level
 evidence for FlatBuffers and Protocol Buffers lives in
 [COMPARISON-TABLES.md](COMPARISON-TABLES.md) and those cells cite its rows
-rather than repeat them; the packet-size measurement is
+instead of repeating them; the packet-size measurement is
 [COMPARISON.md](COMPARISON.md); the versioning promises are
 [VERSIONING.md](VERSIONING.md). This page adds Cap'n Proto and Avro, a
-versioning group, and the summary a reader can take in ninety seconds.
+versioning group, and three lists at the end: where they are ahead, where
+schema is ahead, and what schema declines with the reason.
 
 ## What each of these is for
 
-No straw men. Each of the four makes a trade on purpose, and the trade is the
-thing to compare.
+Each of the four makes a trade on purpose, and the trade is the thing to
+compare.
 
 **Protocol Buffers** identifies a field by a number you assign and never
 reuse, carries every field with a tag, preserves the fields it does not know
@@ -26,16 +27,17 @@ number.
 
 **FlatBuffers** puts every scalar at its declared width and alignment behind a
 vtable so that a reader touches one field without parsing the buffer. The
-buffer is its own cooked form: little-endian, position-independent, build-
-independent, memory-mappable. The price is that a buffer from an untrusted
-source needs a separate verification pass before it is safe to touch, and the
-verifier does not ship in every one of its thirteen languages.
+buffer is its own cooked form: little-endian, position-independent,
+build-independent, memory-mappable. The price is that a buffer from an
+untrusted source needs a separate verification pass before it is safe to
+touch, and the verifier does not ship in every one of its thirteen languages.
 
 **Cap'n Proto** reads in place too, and adds an RPC system. Its message is a
-tree by construction, one pointer per object, which is what lets its reader
+tree by construction, one pointer per object, and that is what lets its reader
 bound traversal against a hostile message. Its scalars are stored XOR their
-declared default, so "unset" and "set to the default" are the same bytes and
-a default can never change. Those are not gaps; they are the encoding.
+declared default, so "unset" and "set to the default" are the same bytes and a
+default can never change. Both properties are the encoding doing its job, not
+gaps in it.
 
 **Avro** carries the writer's schema with the data, in the container file or
 as a fingerprint on each object, and resolves it against the reader's schema
@@ -43,24 +45,21 @@ at read time. Nothing is elided, so a changed default can never reinterpret
 stored bytes. A mismatch fails the whole read, on purpose, because Avro's
 users are pipelines where a wrong row is worse than no row.
 
-**Schema** is for a game. A `type` produces a packet wire where the declared
-bounds decide the bits and both sides ship together, refusing each other on a
-protocol id if they do not match. A `table` produces a tolerant wire where a
-field is identified by the hash of its name, a reader counts what it could
-not understand and never fails on data from another build, and an opt-in
-committed baseline refuses at compile time the edits no reader could report. The same
-declaration cooks to a memory image the runtime opens with a header check and
-a pointer, and lays out as a row block one language writes and another reads
-at frame rate. One language, nine targets, one conformance corpus every target
-is held to, case by case, with what a target cannot yet answer named rather
-than passed over.
+**Schema** is for a game. One declaration produces two wires and three runtime
+forms, so packets, backend messages, saves, render blocks and cooked assets
+come from one source with no second copy of the types to drift. One language,
+nine targets, one conformance corpus every target is held to case by case,
+with what a target cannot yet answer named instead of passed over. What the
+two wires are and how they are scored is the next section.
 
-When to use theirs, in one line each: a service that versions independently
-of its callers is Protocol Buffers' case; in-place access to a large buffer
-you will not deserialize is FlatBuffers' or Cap'n Proto's; a data pipeline
-where the writer's schema must travel with the record is Avro's.
+When to use theirs, in one line each: a service that versions independently of
+its callers is Protocol Buffers' case; in-place access to a large buffer you
+will not deserialize is FlatBuffers' or Cap'n Proto's; a data pipeline where
+the writer's schema must travel with the record is Avro's.
 
 ## How to read the matrix
+
+### The marks
 
 **One test for all five columns, and a row is answered from the wire the row
 is about.** A cell is ✅ when the feature exists in the format **and** in all
@@ -68,8 +67,8 @@ of that project's official language implementations, 🔶 when it exists but
 only some of them carry it or it carries a material limitation the footnote
 names, ❌ when it is absent or declined on the record, and ? when the
 project's own documentation neither makes the claim nor denies it. **Absence
-from a complete list in a project's own documentation** — a scalar table, a
-declaration list, a set of evolution rules — **is ❌, not ?**, and that
+from a complete list in a project's own documentation**, a scalar table, a
+declaration list or a set of evolution rules, **is ❌, not ?**, and that
 reading is the same in every column.
 
 **A feature that is decided but not built is ❌**, with the issue in the
@@ -77,7 +76,87 @@ footnote. 🔶 describes something shipped that falls short, never something on
 the way; the four competitors are scored on the format they ship and so is
 this one.
 
-**Schema has two wires, and each row says which one answers it.**
+**"All of a project's official implementations" means more than one only where
+there is more than one.** Cap'n Proto's official set is the C++ reference
+alone, by its own statement that implementations in other languages are
+maintained by their authors and unreviewed
+([CP-otherlang](https://capnproto.org/otherlang.html)). A property documented
+for C++ is therefore ✅ in that column, and the parity row, which asks how many
+official implementations there are, is where the single set is answered ❌.
+
+**On the add, remove and reorder row, a retired identifier is not the
+question.** Every one of the five keeps a retired field's identifier out of
+circulation, or fails to and says so: Protocol Buffers reserves the number,
+FlatBuffers deprecates and keeps the slot, Cap'n Proto's numbers only ever
+grow, Avro's aliases point forward, and schema frees the name hash and is ❌
+for it. That fact is the versioning group's own row, so no column is marked
+down for it twice. The add, remove and reorder row asks three things instead:
+whether a field can be added without moving anything else, whether it can stop
+being carried, and whether source order is free.
+
+### The words this page uses
+
+- **The packet wire** is what a `type` produces: the declared bounds decide
+  the bits, both sides ship together, and they refuse each other on a protocol
+  id if they do not match.
+- **The table wire** is what a `table` produces: a field is identified by the
+  hash of its name, a reader counts what it could not understand and never
+  fails on data from another build.
+- **Protocol id.** The number two peers compare before they talk. It versions
+  the packet wire and moves when a `type`, `enum`, `flags` or `union`
+  declaration moves ([VERSIONING.md](VERSIONING.md), promise 4).
+- **Kinds.** Every table-wire value rides behind a one-byte kind from a closed
+  numbered set (SPEC-TABLES §3), so a reader skips a value it does not know by
+  its stated length.
+- **The form byte** is the first byte of a table-wire file, naming the wire's
+  own revision so a reader that meets a later form refuses by name
+  ([#435](https://github.com/mas-bandwidth/schema/issues/435)).
+- **The committed baseline** is `tables.baseline`, a canonical text projection
+  of a unit's tables kept beside the schema. `schema check` compares the
+  declaration against it and refuses the edits the wire cannot report. It is
+  opt-in: no file, no check (SPEC-TABLES §18).
+- **The never-clobber rule**: a rewriting tool never overwrites a file whose
+  read report is not silent ([VERSIONING.md](VERSIONING.md)).
+- **The cook** is an offline memory image of one table tree. `Open` is a
+  header check and a pointer, with nothing per node (SPEC-TABLES §7).
+- **The row block** is a contiguous extent of fixed-size rows at a stride the
+  compiler computes, written by one language and read by another
+  (SPEC-TABLES §19).
+- **`LoadMeasure`** prices a wire's region before anything is allocated, so a
+  caller refuses a size instead of meeting it (SPEC-TABLES §6.5).
+- **Descriptors** are the constant tables of a declaration's facts, name,
+  kind, id, offset, bounds, guards and nesting, emitted into the generated
+  header so a walker reads any table with no schema file present
+  (SPEC-TABLES §8.1).
+- **Classes.** The compiler derives a table's class from its declaration
+  (SPEC-TABLES §2.2): a **fixed** table has no pointer and is a plain struct,
+  a **variable** table declares one. Three further groups of constructs are
+  named by the conformance corpus and scored separately here. The **message**
+  class is a union whose arms are tables, an array of unions and an optional
+  array (SPEC-TABLES §2.6, §2.3); the **wide** class is the 128-bit and
+  fixed-point scalars (§3); the **blob** class is the `*bytes` buffer node
+  (§2.5).
+- **The tool** is `schema`, the command-line compiler. **The reference** is
+  the C++ backend, first in the conformance harness's registry and the one
+  every other leg is compared against.
+- **A registered leg** is one backend's conformance driver, discovered by the
+  harness at `test/conformance/<lang>/driver`. A leg that does not carry a
+  construct answers **ABSENT** for that case instead of passing by omission,
+  and its cell reads `pass 16/16 +4a`. The reference leg may not answer ABSENT
+  at all.
+- **Goldens** are bytes pinned in the repository that the tests compare
+  against. A change that moves one is **stop-the-line**: the work stops until
+  the movement is explained and deliberately re-pinned (SPEC §3.2).
+- **The codec-law line** is the line a protocol id would need for a compiler
+  release that changes the bytes a schema produces to be visible in it
+  ([#463](https://github.com/mas-bandwidth/schema/issues/463)).
+- **3.0.0** is the release at which the table wire's promises are made; before
+  it that wire is pre-release ([VERSIONING.md](VERSIONING.md)).
+  [#366](https://github.com/mas-bandwidth/schema/issues/366) is its gate,
+  complete feature parity across all nine languages, each at its language's
+  performance floor.
+
+### Schema's two wires, and how the column is scored
 
 - **Declarations and the compiler** are nine languages deep, and a row is ✅
   when CI holds all nine.
@@ -86,29 +165,25 @@ this one.
   [PORTING.md](PORTING.md), the techniques register, which carries one cited
   cell per language and an issue behind every gap, and
   [the conformance contract](../test/conformance/README.md), which says which
-  surfaces and which cases each port answers. The **fixed class** is carried
-  by all nine on the wire, text, cook-open, block-read and descriptor
-  surfaces. The **variable class** (pointers), the **message class**, the
-  **wide scalars** and the runtime cook's **write** side are the C++
-  reference's alone, and the block's **builder** is C++ and C — the eight
-  ports answer ABSENT on twenty-eight wire cases and twenty-six text ones,
-  and that matrix is the completion tracker. So a table-wire row is ✅ only
-  where the register shows all nine, and 🔶 otherwise with the scope named:
-  which class, which languages, which issue.
-- **Where a feature is wire-specific** — schema has it on one wire and not
-  the other — the footnote says which wire, the mark is judged on that wire's
-  backends, and the cell is the honest one for the pair rather than the
-  better wire's.
+  surfaces and which cases each port answers. The fixed class is carried by
+  all nine on the wire, text, cook-open, block-read and descriptor surfaces.
+  The variable class, the message, wide and blob classes and the runtime
+  cook's write side are the reference's alone today, and the block's builder
+  is emitted by the C++ and C backends. So a table-wire row is ✅ only where
+  the register shows all nine, and 🔶 otherwise with the scope named: which
+  class, which languages, which issue.
+- **The eight ports answer ABSENT on twenty-eight wire cases and twenty-six
+  text ones**, and that matrix is the completion tracker
+  ([the conformance contract](../test/conformance/README.md),
+  [#349](https://github.com/mas-bandwidth/schema/issues/349)). A reader who
+  wants the per-language state today reads [PORTING.md](PORTING.md) and that
+  matrix instead of this page.
+- **Where a feature is wire-specific**, meaning schema has it on one wire and
+  not the other, the footnote says which wire the row is answered from and the
+  mark is judged on that wire's backends.
 
-A reader who wants the per-language state today reads
-[PORTING.md](PORTING.md) and the conformance matrix rather than this page.
-When #366 closes — full feature parity across all nine languages, each at its
-language's performance floor — the schema column is re-scored from those two,
-not by hand.
-
-Four rows where all five columns agree are listed at the end rather than
-shown. Editor support and big-endian hosts are not rows, because neither
-could be sourced across five columns.
+Editor support and big-endian hosts are not rows, because neither could be
+sourced across five columns.
 
 ## The matrix
 
@@ -118,7 +193,7 @@ could be sourced across five columns.
 |---|---|---|---|---|---|
 | Numeric expressiveness beyond int32/int64/float/double: declared `min`/`max` bounds, sub-32-bit and 128-bit integers, fixed point | ✅ [s1] | ❌ [2] | 🔶 [3] | 🔶 [4] | 🔶 [5] |
 | Compile-time constants usable inside the schema | ✅ [s2] | ❌ [6] | ❌ [6] | ✅ [7] | ❌ [8] |
-| Nested value type with no per-instance framing | 🔶 [s3] | ❌ [9] | ✅ [10] | ✅ [11] | ✅ [12] |
+| Nested value type with no per-instance framing | ✅ [s3] | ❌ [9] | ✅ [10] | ✅ [11] | ✅ [12] |
 | Bit-flag sets as a declaration | ✅ [s4] | ❌ [13] | ✅ [14] | ❌ [15] | ❌ [8] |
 | Bounded arrays, strings and bytes: a declared capacity in the type | ✅ [s5] | ❌ [16] | 🔶 [17] | ❌ [18] | 🔶 [19] |
 | Enum-keyed arrays (`[E]T`, one slot per variant, by name) | ✅ [s6] | ❌ [20] | ❌ [21] | ❌ [15] | ❌ [8] |
@@ -129,29 +204,29 @@ could be sourced across five columns.
 | Explicit presence on a scalar (set vs unset, distinct from the default) | ✅ [s10] | ✅ [40] | 🔶 [41] | ❌ [42] | 🔶 [43] |
 | Required fields: a read fails if the field is absent | ❌ [s11] | 🔶 [45] | 🔶 [46] | ❌ [47] | ✅ [48] |
 | Dynamic typing: generics, a type-erased `Any`, or schema-less values | ❌ [s12] | ✅ [50] | 🔶 [51] | ✅ [52] | ❌ [53] |
-| User-extensible annotations or custom options | ❌ [s13] | ✅ [55] | ✅ [56] | ✅ [57] | 🔶 [58] |
+| User-extensible annotations or custom options | 🔶 [s13] | ✅ [55] | ✅ [56] | ✅ [57] | 🔶 [58] |
 
 ### The wire
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
 | Self-describing: the bytes alone are enough to walk the data | 🔶 [s14] | 🔶 [59] | ❌ [60] | ❌ [61] | ✅ [62] |
-| Values compacted below their declared storage width | 🔶 [s15] | ✅ [64] | ❌ [65] | 🔶 [66] | ✅ [67] |
-| Scalars aligned inside the buffer | 🔶 [s16] | ❌ [69] | ✅ [70] | ✅ [71] | ❌ [72] |
-| Data above 2 GiB | 🔶 [s17] | ❌ [74] | 🔶 [75] | 🔶 [76] | 🔶 [77] |
-| Byte-identical output: one input, one schema, one byte sequence, across implementations | ✅ [s18] | ❌ [79] | ❌ [80] | 🔶 [81] | 🔶 [82] |
+| Values compacted below their declared storage width | ✅ [s15] | ✅ [64] | ❌ [65] | 🔶 [66] | ✅ [67] |
+| Scalars aligned inside the buffer | ✅ [s16] | ❌ [69] | ✅ [70] | ✅ [71] | ❌ [72] |
+| Data above 2 GiB | 🔶 [s17] | ❌ [74] | 🔶 [75] | 🔶 [76] | ✅ [77] |
+| Byte-identical output: one input, one schema, one byte sequence, across implementations | 🔶 [s18] | ❌ [79] | ❌ [80] | 🔶 [81] | 🔶 [82] |
 
 ### Evolution
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
-| Add, remove or reorder a field freely | ✅ [s19] | 🔶 [83] | 🔶 [84] | 🔶 [85] | 🔶 [86] |
+| Add, remove or reorder a field freely | ✅ [s19] | ✅ [83] | 🔶 [84] | 🔶 [85] | 🔶 [86] |
 | Rename a field without orphaning stored data | 🔶 [s20] | ✅ [88] | ✅ [89] | ✅ [90] | 🔶 [91] |
 | Change a field's type with no silent misdecode | 🔶 [s21] | ❌ [92] | ❌ [93] | ❌ [94] | ✅ [95] |
 | Change a declared default without reinterpreting stored bytes | 🔶 [s22] | 🔶 [97] | ❌ [98] | ❌ [94] | ✅ [99] |
 | Unknown fields preserved through a read-and-rewrite | ❌ [s23] | ✅ [101] | 🔶 [102] | 🔶 [100] | ❌ [103] |
 | A per-event read report rather than pass/fail | ✅ [s24] | ❌ [104] | ❌ [105] | ❌ [106] | ❌ [107] |
-| An unknown enum value has a defined, non-fatal landing | ✅ [s25] | 🔶 [108] | 🔶 [109] | ? | 🔶 [110] |
+| An unknown enum value has a defined, non-fatal landing | ✅ [s25] | 🔶 [108] | 🔶 [109] | 🔶 [111] | 🔶 [110] |
 
 ### Runtime forms, allocation, performance
 
@@ -160,17 +235,17 @@ could be sourced across five columns.
 | Read one field without parsing the whole buffer | ✅ [s26] | ❌ [112] | ✅ [113] | ✅ [114] | ❌ [115] |
 | No allocation on read | 🔶 [s27] | ❌ [116] | 🔶 [117] | ✅ [118] | ❌ [115] |
 | Arena or single-buffer allocation on write, never per node | 🔶 [s28] | 🔶 [119] | ✅ [120] | ✅ [121] | ? |
-| Exact serialized size known before writing | 🔶 [s29] | ✅ [122] | ❌ [123] | ? | ? |
+| Exact serialized size known before writing | ✅ [s29] | ✅ [122] | ❌ [123] | ? | ? |
 | Mutate a serialized buffer in place | ❌ [s30] | ❌ [125] | 🔶 [126] | ❌ [127] | ? |
 | Fixed-stride rows in one contiguous image, written by one language and read by another | 🔶 [s31] | ❌ [128] | ✅ [134] | ✅ [138] | ❌ [115] |
-| A layout assertion in generated code on both sides, refusing a producer that disagrees | 🔶 [s31b] | ❌ [128] | ❌ [129] | ❌ [130] | ❌ [115] |
+| Every field offset and every array pitch asserted in generated code on both sides, refusing a producer that disagrees | 🔶 [s31b] | ❌ [128] | 🔶 [129] | ❌ [130] | ❌ [115] |
 | Generated code with no library runtime to link | 🔶 [s32] | ❌ [131] | 🔶 [132] | ❌ [133] | ? |
 
 ### Validation of untrusted data
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
-| Untrusted bytes are safe with no separate verification pass | 🔶 [s33] | ✅ [135] | ❌ [136] | ✅ [137] | ? |
+| Untrusted bytes are safe with no separate verification pass | ✅ [s33] | ✅ [135] | ❌ [136] | ✅ [137] | ? |
 | Value ranges enforced from the schema | ✅ [s1] | ❌ [2] | ❌ [3] | ❌ [4] | ❌ [5] |
 | Depth and resource bounds against a hostile message | 🔶 [s34] | 🔶 [139] | 🔶 [140] | ✅ [141] | ? |
 | One cross-language conformance corpus that includes hostile cases | ✅ [s35] | ? [142] | ? | ? | ? |
@@ -180,8 +255,8 @@ could be sourced across five columns.
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
 | Runtime reflection with no schema file present at runtime | 🔶 [s36] | ✅ [144] | 🔶 [145] | ✅ [146] | ✅ [147] |
-| JSON or text form, in and out | ✅ [s37] | 🔶 [149] | 🔶 [150] | ✅ [151] | ✅ [152] |
-| Doc comments carried into generated code | ❌ [s38] | ? [154] | ✅ [155] | ? | ✅ [156] |
+| JSON or text form, in and out | 🔶 [s37] | 🔶 [149] | 🔶 [150] | ✅ [151] | ✅ [152] |
+| Doc comments carried into generated code | ❌ [s38] | 🔶 [154] | ✅ [155] | ? | 🔶 [156] |
 | Official language implementations at feature parity | 🔶 [s39] | 🔶 [158] | ❌ [159] | ❌ [160] | 🔶 [161] |
 
 ### Versioning
@@ -196,65 +271,60 @@ could be sourced across five columns.
 | A first-party compile-time gate on breaking edits | 🔶 [s45] | ❌ [183] | ✅ [184] | ❌ [185] | ? |
 | Wire bytes promised stable across releases of the compiler | 🔶 [s46] | ❌ [79] | ? | 🔶 [187] | 🔶 [82] |
 
-### Agreed, not shown
-
-All five have enums, a discriminated union, a code generator producing native
-types, and comments invisible to the wire.
-
 ## Where they are ahead
 
-- **Renames beyond fields.** Protocol Buffers and FlatBuffers rename a
-  variant or a named type freely because their wires carry numbers rather
-  than names, and Cap'n Proto does where the type pins an explicit id;
-  schema's `was` is a field attribute today [s40].
+- **Renames beyond fields.** Protocol Buffers and FlatBuffers rename a variant
+  or a named type freely because their wires carry numbers instead of names,
+  and Cap'n Proto does where the type pins an explicit id; schema's `was` is a
+  field attribute today [s40].
 - **Retired names.** Protocol Buffers' `reserved` is the right mechanism and
   schema lacks it, so a removed name can be re-added years later and decode
   old bytes under a new meaning [s41].
 - **Default changes.** Avro writes every field of the writer's schema, so a
-  changed default cannot reinterpret stored bytes, where schema elides a
-  field equal to its default and answers the hazard with a guard rather than
-  a guarantee [s22].
+  changed default cannot reinterpret stored bytes, where schema elides a field
+  equal to its default and answers the hazard with a guard instead of a
+  guarantee [s22].
 - **Unknown fields through a rewrite.** Protocol Buffers keeps them; schema
-  drops them by decision — everything in schema has a schema — and counts
-  what it dropped [s23].
-- **Promotion.** Avro promotes `int` to `long` on read; schema reads a
-  changed kind as the default and counts a kind mismatch [s42].
-- **Doc comments.** FlatBuffers and Avro both carry documentation from the
-  schema, and Protocol Buffers' and Cap'n Proto's own pages settle it neither
-  way; schema's are deferred [s38].
+  drops them by decision and counts what it dropped [s23]. The reason is
+  [COMPARISON-TABLES.md](COMPARISON-TABLES.md), "Unknown fields preserved on
+  write".
+- **Promotion.** Avro promotes `int` to `long` on read; schema reads a changed
+  kind as the default and counts a kind mismatch [s42].
+- **Doc comments.** FlatBuffers and Avro both carry documentation in the
+  schema, Protocol Buffers carries it in the descriptor, and Cap'n Proto's own
+  pages settle it neither way; schema's are deferred [s38].
 - **Ecosystems.** Protocol Buffers has ten first-party languages and
-  fifty-odd third-party ones, FlatBuffers thirteen of uneven coverage, and
+  forty-plus third-party ones, FlatBuffers thirteen of uneven coverage, and
   Avro six published SDKs; schema has nine [s39].
-- **Tools.** `buf breaking`, `flatc --proto` and `capnp convert` exist and
-  schema's own gate is first-party rather than an ecosystem [s45].
 
 ## Where schema is ahead
 
-- **Bounds are bits.** `health int32 | min = 0, max = 1000` is ten bits on
-  the packet wire, and the same gameplay packet measured against all four is
-  [COMPARISON.md](COMPARISON.md). None of the four can infer a range it was
-  never told.
+- **Bounds are bits.** `health int32 | min = 0, max = 1000` is sized on the
+  packet wire from its range and not from `int32`, and the same gameplay
+  packet measured against Cap'n Proto, Protocol Buffers and FlatBuffers is
+  [COMPARISON.md](COMPARISON.md), field by field. None of the four can infer a
+  range it was never told.
 - **One language for all five kinds of data.** Packets, backend messages,
-  saves, render blocks and cooked assets from one declaration, so there is no
-  second copy of the types to drift.
-- **The read is the report.** Every load counts what it did not know, what
-  had the wrong kind, what it clamped and whether the bytes were malformed,
-  and never fails on data from another build. The others return a boolean or
+  saves, render blocks and cooked assets from one declaration.
+- **The read is the report.** Every load counts what it did not know, what had
+  the wrong kind, what it clamped and whether the bytes were malformed, and
+  never fails on data from another build. The others return a boolean or
   throw.
 - **The silent class is enumerated and refused.** The edits no reader can
-  report — a changed default, a moved flags variant, a referent respelled as
-  something the kinds cannot tell apart, a moved fixed-point scale — are
+  report, a changed default, a moved flags variant, a referent respelled as
+  something the kinds cannot tell apart, a moved fixed-point scale, are
   refused at compile time by a committed baseline with a reasoned, dated
   history. The nearest equivalents, `flatc --conform` and `buf breaking`,
   check structure, not meaning.
 - **Shared subtrees on the wire.** A node written once and referenced many
-  times, which none of the four does by declaration. Cap'n Proto forbids it
-  to bound traversal; schema's flat node table materializes each node once
-  and `LoadMeasure` prices the region before allocation, and the bound is
-  being stated and tested as such (#466).
+  times, which none of the four does by declaration. Cap'n Proto forbids it to
+  bound traversal; schema's flat node table materializes each node once and
+  `LoadMeasure` prices the region before allocation, with the bound being
+  stated and tested as such
+  ([#466](https://github.com/mas-bandwidth/schema/issues/466)).
 - **Per-field tolerance.** Avro fails the whole read on a mismatch; schema
-  counts the field and reads the rest. The right answer for a save game and
-  the wrong one for a warehouse, and the page says which is which.
+  counts the field and reads the rest. That is the right answer for a save
+  game and the wrong one for a warehouse.
 
 ## Judged not needed, with the reason
 
@@ -262,176 +332,167 @@ types, and comments invisible to the wire.
 |---|---|---|
 | Required fields | FlatBuffers, Avro in effect, Protocol Buffers as a legacy carry-over | Every field optional with a declared default is the ground rule. Protocol Buffers removed `required` and says why; schema never had it. |
 | `Any`, generics, schema-less values | Protocol Buffers, Cap'n Proto, FlexBuffers | The typed bag is a union whose arms are tables. A type-erased value is a type the compiler cannot check. |
-| Custom annotations | Protocol Buffers, FlatBuffers, Cap'n Proto, Avro as tolerated metadata | The attribute vocabulary is closed and an unknown attribute is a compile error; type tags are the claiming mechanism. |
-| Unknown fields preserved through a rewrite | Protocol Buffers | Everything in schema has a schema. The old file kept whole is the preservation, and the never-clobber rule is the policy. |
-| A widening path on read | Avro, Protocol Buffers' pairs | A whitelist of compatible pairs silently misdecodes everything outside it. A changed kind reads as the default and is counted; the pattern is a new field beside the old one and a load shim. |
-| The writer's schema traveling with the data | Avro | One schema per build, identified by the protocol id and the build version, neither of which rides in a file. A tolerant wire that skips by kind needs no schema to walk, and a file that must say what wrote it puts a `format` field on its root table. |
+| Custom annotations on fields | Protocol Buffers, FlatBuffers, Cap'n Proto, Avro as tolerated metadata | The field-attribute vocabulary is closed on purpose ([COMPARISON-TABLES.md](COMPARISON-TABLES.md), "Extensions and custom options"). The open namespace is the type tag [s13]. |
+| Unknown fields preserved through a rewrite | Protocol Buffers | [COMPARISON-TABLES.md](COMPARISON-TABLES.md), "Unknown fields preserved on write". The old file kept whole is the preservation, under the never-clobber rule. |
+| A widening path on read | Avro, Protocol Buffers' pairs | Protocol Buffers' own list of compatible pairs silently misdecodes everything outside it [92]. A changed kind reads as the default and is counted; the pattern is a new field beside the old one and a load shim. |
+| The writer's schema traveling with the data | Avro | One schema per build, identified by the protocol id and the build version, neither of which rides in a file. A tolerant wire that skips by kind needs no schema to walk, and a file that must say what wrote it does so with the root-table `format` field [VERSIONING.md](VERSIONING.md) defines. |
 | A canonical form of the data | Cap'n Proto | A load followed by a save through the reader's own schema is the canonical form: elision, order and duplicates are all resolved by it. Byte identity across schema's own writers is held by goldens. |
-| Mutating a serialized buffer in place | FlatBuffers | A cook is immutable and regenerated by the cache; the block form is the every-frame mutable answer. |
+| Mutating a serialized buffer in place | FlatBuffers | [COMPARISON-TABLES.md](COMPARISON-TABLES.md), "In-place mutation of a serialized buffer". |
 
 ## Footnotes
 
 Schema cells cite a specification section, one of the repository's registers
 ([PORTING.md](PORTING.md), [the conformance contract](../test/conformance/README.md))
 or an issue. **FlatBuffers and Protocol Buffers cells cite the row that
-carries the evidence in [COMPARISON-TABLES.md](COMPARISON-TABLES.md)** rather
-than restating it; a footnote stays here only where that page does not carry
-the fact, and it says so. Cap'n Proto and Avro cells cite the project's own
-documentation by the short names in the source list at the end, with the
-section that establishes the claim.
+carries the evidence in [COMPARISON-TABLES.md](COMPARISON-TABLES.md)** instead
+of restating it; a footnote stays here only where that page does not carry the
+fact, and it says so. Cap'n Proto and Avro are not on that page, so their
+cells cite the project's own documentation by the short names in the source
+list at the end, with the section that establishes the claim.
 
 **Schema**
 
-- s1. `| min, max` is part of the type: the packet wire sizes the field's bits from the bound and refuses a value outside it, and the table wire clamps and counts `clamped` on load (SPEC §4.3, SPEC-TABLES §4). `fixed(I,F)`, `ufixed(I,F)`, `int128` and `uint128` ride on the packet wire in all nine targets, on the cross-language wire gate like any other unit (`examples128/Ludicrous.schema`, SPEC §4.3), and under table-wire kinds 18–29 (SPEC-TABLES §3), where the wide-scalar cases are the reference's alone today (#366).
-- s2. `const`, folded at compile time and usable in bounds, defaults and capacities (SPEC §4.2 — the `Const` production, and "Constants and enums are exported"; §4.4 is `if`, not constants).
-- s3. **Packet wire, not the table wire.** A `type` nested inside a `type` is inline storage with no framing at all (SPEC §4.3). On the table wire a nested table is kind `13` — a `u32` length, then the body — and a fixed table nested in a table rides the same way (SPEC-TABLES §3), which is the framing Protocol Buffers is marked ❌ [9] for. Two wires, two answers.
+- s1. `| min, max` is part of the type: the packet wire sizes the field's bits from the bound and refuses a value outside it, and the table wire clamps and counts `clamped` on load (SPEC §4.3, SPEC-TABLES §4). `fixed(I,F)`, `ufixed(I,F)`, `int128` and `uint128` are declared in all nine targets and ride the packet wire in all nine, on the cross-language wire gate like any other unit (`examples128/Ludicrous.schema`, SPEC §4.3). ✅ is the declaration and the packet wire, the two the row asks about. The same scalars have table-wire kinds 18 to 29 (SPEC-TABLES §3), where the three wide-class cases are answered by the reference and the eight ports answer ABSENT (SPEC-TABLES §15).
+- s2. `const`, folded at compile time and usable in bounds, defaults and capacities (SPEC §4.2, the `Const` production and "Constants and enums are exported").
+- s3. **The packet wire answers this row.** A `type` nested inside a `type` is inline storage with no framing at all (SPEC §4.3), carried by all nine. On the table wire a nested table is kind `13`, a `u32` length then the body, which is the framing Protocol Buffers is marked ❌ [9] for.
 - s4. `flags` declarations, one bit per variant (SPEC §4.2).
 - s5. `[N]T`, `[..N]T`, `string(N)`, `bytes(N)`: the capacity is in the type, and the packet wire sizes the count from it (SPEC §4.3).
-- s6. `[E]T`, a slot per variant addressed by name, under its own wire kind `16` (SPEC-TABLES §2.4, §3.2). The declaration and the keyed kind are fixed class and carried by all nine — the corpus's keyed instances are answered by every registered leg — while the accessor's both-ends refusal is untested in Java, Dart and Elixir and unchecked past `Max` in C (PORTING M5, #407, #377).
-- s7. Decided and not built. A map makes the table variable and lands after 3.0.0 (SPEC-TABLES §2.8, #380).
-- s8. A pointer field `*T` names a node once in a flat node table and every reference is an index (SPEC-TABLES §3.1). The variable class is the C++ reference's alone on the wire: PORTING M6 is ✅ for cpp and ❌ #349 in the other eight columns, and the eight ports answer ABSENT on the corpus's four pointered instances. The amplification bound on an untrusted read is #466.
-- s9. Decided and not built. Union arms of any field type, and defaults for `string`, `bytes` and `flags`, are #396; SPEC §4.2's `Default` production admits a constant expression or an identifier and nothing else.
-- s10. **Table wire only.** `?T` is the value plus a generated presence bool, so the holder stays fixed size (SPEC-TABLES §2.3). SPEC §4.2's grammar admits `?` in TABLE BODIES ONLY and a `type` body refuses one by name, so the packet wire has no presence at all — there is no presence bit there. On the table backends `?T` is fixed class and all nine carry it (`chain_optional` and `chain_optional_empty` in the conformance corpus); `?[N]T` is one of the message-class cases the reference answers alone (PORTING M16, #392).
+- s6. `[E]T`, a slot per variant addressed by name, under its own wire kind `16` (SPEC-TABLES §2.4, §3.2). The declaration and the keyed kind are fixed class and carried by all nine: the corpus's keyed instances are answered by every registered leg. The accessor's both-ends refusal is untested in Java, Dart and Elixir and unchecked past `Max` in C (PORTING M5, [#407](https://github.com/mas-bandwidth/schema/issues/407), [#377](https://github.com/mas-bandwidth/schema/issues/377)).
+- s7. Decided and not built. A map makes the table variable and lands after 3.0.0 (SPEC-TABLES §2.8, [#380](https://github.com/mas-bandwidth/schema/issues/380)).
+- s8. A pointer field `*T` names a node once in a flat node table and every reference is an index (SPEC-TABLES §3.1). The variable class has one wire implementation: PORTING M6 is ✅ for cpp, ❌ [#408](https://github.com/mas-bandwidth/schema/issues/408) for C, whose earlier nested form has a depth cap and no identity map, and ❌ [#349](https://github.com/mas-bandwidth/schema/issues/349) in the other seven columns; the eight ports answer ABSENT on the corpus's four pointered instances. The amplification bound on an untrusted read is [#466](https://github.com/mas-bandwidth/schema/issues/466).
+- s9. Decided and not built. Union arms of any field type, and defaults for `string`, `bytes` and `flags`, are [#396](https://github.com/mas-bandwidth/schema/issues/396); SPEC §4.2's `Default` production admits a constant expression or an identifier and nothing else.
+- s10. **The table wire answers this row**, because the packet wire has no presence at all. `?T` is the value plus a generated presence bool, so the holder stays fixed size (SPEC-TABLES §2.3). SPEC §4.2's grammar admits `?` in table bodies only, and a `type` body refuses one by name. On the table backends `?T` is fixed class and all nine carry it (`chain_optional` and `chain_optional_empty` in the conformance corpus); `?[N]T` is one of the message-class cases the reference answers alone (PORTING M16, [#392](https://github.com/mas-bandwidth/schema/issues/392)).
 - s11. Declined: every field optional with a declared default (SPEC-TABLES §4).
-- s12. Declined on #396 and in COMPARISON-TABLES.md; the typed bag is a union whose arms are tables.
-- s13. Declined: the attribute vocabulary is closed and an unknown attribute is a compile error (SPEC §4.2).
-- s14. The packet wire is not self-describing, by decision — a stated non-goal, with all knowledge in the generated code on both ends (SPEC §1). On the table wire kinds and lengths ride, so any reader skips anything it does not know (SPEC-TABLES §3); but a name rides as a 16-bit hash rather than as text (§5), so the bytes cannot be rendered with names without the schema.
-- s15. **Packet wire, not the table wire.** The packet wire sizes each field from its bounds (SPEC §4.3). The table wire deliberately does not compact — a scalar rides at its storage width and nothing is aligned or padded (SPEC-TABLES §3) — which is what FlatBuffers is marked ❌ [65] for.
-- s16. No alignment and no padding on the tolerant wire (SPEC-TABLES §3). The cook (§7.2) and the block (§19.3) are the aligned forms; their `Open` is carried by all nine (PORTING M8, M7) and the block's builder by the C++ and C backends (§19.1).
-- s17. Table wire. Eight-byte region references and 64-bit cook part lengths, with no aggregate ceiling (SPEC-TABLES §6.3, §7.1). The tolerant wire's own lengths and counts are `u32` today — a node body is capped at 4 GiB and refused at save (§2.1, §3) — and go uniformly 64-bit under #435.
-- s18. One standard, one corpus. The packet wire is bit-for-bit compatible across nine runtimes, pinned in CI with shared golden bytes, and a compiler change that breaks a wire golden is a stop-the-line event (SPEC §1, §3.2, §7.2). On the table wire the `wire` surface byte-compares every registered leg's `Save` against one golden, and `measure == save at exact capacity` is a hard invariant held by a mandatory battery (SPEC-TABLES §9). Constructs a leg does not carry are answered ABSENT per case rather than passed over, so no cell claims agreement it did not test.
-- s19. Table wire. Name identity: add anywhere, remove, reorder, each reported by the read rather than refused (SPEC-TABLES §4, §5). Carried by all nine — the `wire` and `report` surfaces over the fixed class are answered by every registered leg.
-- s20. `| was = "old"` keeps the wire id; a bare rename is a removal and an addition the compiler cannot see, and the baseline is being taught to warn on the pair (#444). Fields today; every other vocabulary is #396 and #442, which is why the versioning group's first row is ❌ rather than this one.
-- s21. A changed kind reads as the default and is counted `kind_mismatch` (SPEC-TABLES §4), in all nine over the fixed class. It is not the whole story, and SPEC-TABLES §4.1 item 3 says so: an enum-typed field respelled as its raw `uint16` rides under kind `7` either way, so the stored value is read as a variant hash and lands on `None` — or on a real variant — with no counter to fire. That respelling is guarded only by the opt-in baseline (§18) until #435 gives an enum a kind of its own.
-- s22. Silent on the wire, refused at compile time by a committed baseline (SPEC-TABLES §4.1, §18.2). 🔶 because the baseline is opt-in by design — "no file, no check" (§18.1) — and #445 adds a one-line notice to a unit that has none rather than a block, so the limitation does not close when it lands.
-- s23. Declined by decision; the read report counts what a rewrite would drop, and the one rule a studio writes for it is never to overwrite a file whose read report is not silent (VERSIONING.md).
-- s24. Four counters and a `malformed` flag on every load (SPEC-TABLES §4). Carried by all nine: the `report` surface is answered by every registered leg, and each leg with a text form carries its own walk negative control.
-- s25. An unknown variant reads `None` and is counted `unknown` (SPEC-TABLES §4, §5), in all nine on the `report` surface.
-- s26. The cook: `Open` is a header match and a pointer, with nothing per node (SPEC-TABLES §7). Carried by all nine — PORTING M8 is ✅ in every column, and a gigabyte cook opens in the same time as a small one. The cook's WRITE side is the C++ reference's and the tool's; every other language's writer is a named follow-on (§7.6, §15).
-- s27. The read path fills caller-owned storage and the reader is a cursor over the caller's buffer, never a sub-view (SPEC-TABLES §6.5, PORTING M1). 🔶 for three named reasons. Elixir cannot make the claim at all — a decoded BEAM term is an allocation and no buffer is caller-owned, so the leg pins the per-case count instead (M1's Elixir cell). The independent allocation gate does not yet run on the C++ or the C# read path (PORTING I1, #412). And a union inside a table allocates per arm in a backend whose language has no native union, the one carve-out §6.5 states.
-- s28. The fixed class writes into the caller's buffer and allocates nothing, in any backend. The variable class builds through an arena in bulk, thread-local, never per node (SPEC-TABLES §6.4, §9), and that arena is the C++ reference's (PORTING M6, #349); the block takes a caller-provided allocator once at build and never on the fill path (§19.1). The union carve-out (§6.5) is the one per-node allocation, and it belongs to the language rather than to the format.
-- s29. **Table wire, not the packet wire.** `Measure` computes a value's exact encoded size writing nothing, and `measure == save at exact capacity` is a hard invariant held by a mandatory battery across the corpus (SPEC-TABLES §9); all nine backends generate it. The packet wire has no exact measure and says so in terms — "There is no generated measure function" — `MaxBits`/`MaxBytes` are conservative worst-case constants for sizing a buffer, and `Write` returns the actual size afterwards (SPEC §6.1).
+- s12. Declined. SPEC §4.2 declares no generic parameter and no type-erased value, and the adoption question is closed on [#396](https://github.com/mas-bandwidth/schema/issues/396); the typed bag is a union whose arms are tables (SPEC-TABLES §2.6).
+- s13. The FIELD-attribute vocabulary is closed and an unknown attribute is a compile error (SPEC §4.2). The TYPE TAG is the open namespace beside it: "one user-chosen identifier, in its own namespace", any identifier legal there, parsed, carried through the IR and emitted as an annotation on the generated type, with the unit registry's `ViewType` listing a declaration's tags (SPEC §4.2, SPEC-TABLES §8.3). 🔶 because a tag is inert in v1 and changes zero generated code beyond the annotation, where the three ✅ columns let an annotation reach a runtime API. It is more than Avro's 🔶 [58], which requires only that an implementation tolerate the attribute.
+- s14. The packet wire is not self-describing, by decision, a stated non-goal with all knowledge in the generated code on both ends (SPEC §1). On the table wire kinds and lengths ride, so any reader skips anything it does not know (SPEC-TABLES §3); a name rides as a 16-bit hash and not as text (§5), so the bytes cannot be rendered with names without the schema.
+- s15. **The packet wire answers this row.** It sizes each field from its bounds (SPEC §4.3) in all nine targets. The table wire deliberately does not compact: a scalar rides at its storage width and nothing is aligned or padded (SPEC-TABLES §3), the property FlatBuffers is marked ❌ [65] for.
+- s16. **The cook and the block answer this row**, and they are the aligned forms (SPEC-TABLES §7.2, §19.3). The tolerant wire has no alignment and no padding (§3). All nine open both: the harness's `cook` and `block` surfaces are answered by every registered leg, and the cook's `Open` is PORTING M8, ✅ in every column. The block's row reach is M7, where Elixir allocates per row ([#409](https://github.com/mas-bandwidth/schema/issues/409)).
+- s17. Table wire. Eight-byte region references and 64-bit cook part lengths, with no aggregate ceiling in the format (SPEC-TABLES §6.3, §7.1). 🔶 for two reasons, one in the format and one in the implementations. The tolerant wire's own lengths and counts are `u32` today, so a node body is capped at 4 GiB and refused at save (§2.1, §3), and they go uniformly 64-bit under [#435](https://github.com/mas-bandwidth/schema/issues/435). And the two accelerators are read out of a `byte[]` in the managed ports, which stops at 2 GiB: SPEC-TABLES' ladder states it as the one Java divergence that costs a stated requirement, C# meets the same `int` ceiling on its span overload and answers it with the pointer form beside it, and the foreign-memory overload is a named follow-on (§15).
+- s18. One standard, one corpus, and byte identity is proven where nine backends produce bytes. The packet wire is bit-for-bit compatible across all nine runtimes, pinned in CI with shared golden bytes, and a compiler change that breaks a wire golden is stop-the-line (SPEC §1, §3.2, §7.2). On the table wire the `wire` surface byte-compares every registered leg's `Save` against one golden over the FIXED class, and `measure == save at exact capacity` is a hard invariant held by a mandatory battery (SPEC-TABLES §9). 🔶 because the variable, message, wide and blob classes have one writer: the eight ports produce no bytes for those cases and answer ABSENT per case, so no cell claims agreement it did not test.
+- s19. Table wire. Name identity: add anywhere, remove, reorder, each reported by the read instead of refused (SPEC-TABLES §4, §5). Carried by all nine, on the `wire` and `report` surfaces over the fixed class. Whether a retired name can be silently reused is [s41], not this row.
+- s20. `| was = "old"` keeps the wire id, and a bare rename is a removal and an addition the compiler cannot see. The committed baseline warns on that pair: `internal/baseline/diff.go`'s `renamePair` reports a wire id removed and a wire id added in one edit and names the `was` and `json =` spellings that keep the data ([#444](https://github.com/mas-bandwidth/schema/issues/444), SPEC-TABLES §5, §18.2). It warns and never refuses, because two independent edits in one commit are legitimate. 🔶 because `was` covers a table's own fields today: every other vocabulary is [#396](https://github.com/mas-bandwidth/schema/issues/396), [#442](https://github.com/mas-bandwidth/schema/issues/442) and [#478](https://github.com/mas-bandwidth/schema/issues/478), which is why the versioning group's first row is ❌ and this one is not.
+- s21. A changed kind reads as the default and is counted `kind_mismatch` (SPEC-TABLES §4), in all nine over the fixed class. It is not the whole story, and SPEC-TABLES §4.1 item 3 says so: an enum-typed field respelled as its raw `uint16` rides under kind `7` either way, so the stored value is read as a variant hash and lands on `None`, or on a real variant, with no counter to fire. That respelling is guarded only by the committed baseline (§18) until [#435](https://github.com/mas-bandwidth/schema/issues/435) settles the enum's own framing.
+- s22. Silent on the wire, refused at compile time by the committed baseline (SPEC-TABLES §4.1, §18.2). 🔶 because the baseline is opt-in by design, "no file, no check" (§18.1). A unit that declares a table and holds no baseline draws a one-line stderr notice from `schema check` naming what is unguarded and the command that commits one ([#445](https://github.com/mas-bandwidth/schema/issues/445), §18.1). The notice never touches the exit code, so the limitation stands.
+- s23. Declined by decision; the read report counts what a rewrite would drop, under the never-clobber rule ([VERSIONING.md](VERSIONING.md)).
+- s24. Four counters and a `malformed` flag on every load (SPEC-TABLES §4). Carried by all nine: the `report` surface is answered by every registered leg. The harness's per-leg negative control sabotages the emitter's walk and requires the matrix to localize it, and it is carried by seven of the nine, with cpp and rust at ❌ [#417](https://github.com/mas-bandwidth/schema/issues/417) (PORTING I11).
+- s25. An unknown variant reads `None` and is counted `unknown` (SPEC-TABLES §4, §5), in all nine on the `report` surface. The witness in the corpus is the evolution seam `v2_cfg_as_v1`: V2 adds `Silver` to `Grade` and `Omega` and `Sigma` to `Slot`, and V1 reading V2's `Cfg` counts 5 unknown, the number every registered leg must produce (`testdata/conformance/tables/MANIFEST.txt`, `reports.txt`).
+- s26. The cook: `Open` is a header match and a pointer, with nothing per node (SPEC-TABLES §7). Carried by all nine, PORTING M8 being ✅ in every column, and a gigabyte cook opens in the same time as a small one. The cook's write side is the reference's and the tool's; every other language's writer is a named follow-on (§7.6, §15).
+- s27. The read path fills caller-owned storage and the reader is a cursor over the caller's buffer, never a sub-view (SPEC-TABLES §6.5, PORTING M1). 🔶 for two reasons. Elixir cannot make the claim at all, because a decoded BEAM term is an allocation and no buffer is caller-owned, so that leg pins the per-case count instead (M1's Elixir cell). And a union inside a table allocates per arm in a backend whose language has no native union, the one carve-out §6.5 states.
+- s28. The fixed class writes into the caller's buffer and allocates nothing, in any backend. The variable class builds through an arena in bulk, thread-local, never per node (SPEC-TABLES §6.4, §9), and that arena is the reference's (PORTING M6); the block takes a caller-provided allocator once at build and never on the fill path (§19.1). The union carve-out (§6.5) is the one per-node allocation, and it belongs to the language and not to the format.
+- s29. **The table wire answers this row.** `Measure` computes a value's exact encoded size writing nothing, and `measure == save at exact capacity` is a hard invariant held by a mandatory battery across the corpus (SPEC-TABLES §9); all nine backends generate it. The packet wire has no exact measure and says so in terms, "There is no generated measure function": `MaxBits` and `MaxBytes` are conservative worst-case constants for sizing a buffer, and `Write` returns the actual size afterwards (SPEC §6.1).
 - s30. Declined: a cook is immutable and regenerated by the cache, and the block form is the mutable answer (SPEC-TABLES §7, §19).
-- s31. The block form: one contiguous extent of rows at a compiler-computed stride, every reference block-relative, so it relocates by `memcpy` with no fix-up (SPEC-TABLES §19, §19.1). Its READ half is generated by all nine backends, and PORTING M7 carries eight of them with Elixir's per-row allocation as #409. Its BUILDER is emitted by the C++ and C backends alone (§19.1).
-- s31b. Every cooked record and every block projection carries a compile-time assertion of size, alignment and every field offset against the numbers the compiler computed, each array's pitch constant included — two independent derivations held against each other, so a producer that disagrees is refused before a row is read (SPEC-TABLES §19.3). Seven backends carry it; Dart and Elixir have no second layout model to check against and hold the contract with the build version instead (PORTING M11).
-- s32. Six of the nine targets link a small `serialize` runtime for the packet wire; Dart, Java and Elixir generate self-contained output (VERSIONING.md). The C++ tables dialect takes no STL and routes every C-library call through a hook the program can define (SPEC-TABLES §13.9).
-- s33. The tolerant read is the validator: every length bounds-checked against its body, every count against the body, ranges clamped, a bad sub-table stopping only itself, and `LoadMeasure` letting the caller refuse a region size before anything is allocated (SPEC-TABLES §4, §6.5). The independent-oracle fuzzer that would prove it is landing for the C++ reference (#429) and owed to every port (#391), which is what holds this at 🔶.
-- s34. By-value depth is fixed by the schema and the pointer graph is flat, so a long chain is not a recursion (SPEC-TABLES §3.1). Until #466 states and tests the amplification bound, the bound is the caller's own refusal of `LoadMeasure`'s answer (§6.5) rather than a number the format states.
-- s35. One corpus, every registered leg, hostile rows included — two forgery batteries, the cook battery's 111 rows and the `json-hostile` trees, with seven negative controls behind the harness (test/conformance). A leg that lacks a construct answers ABSENT per case rather than passing by omission: the eight ports read `+28a` on the wire surfaces and `+26a` on the text surfaces today, and the matrix is the completion tracker (#383, #349).
-- s36. Static descriptors in every table's generated header — name, kind, id, offset, bounds, guards, nesting — with no schema file present and no RTTI (SPEC-TABLES §8.1), carried by all nine (PORTING M13; C# holds them in a cache rather than as constants, #411). The type view and the unit registry (§8.2, §8.3) are C++ and C# only, and every other backend emits no view file (§15).
-- s37. JSON in and out by one generic walk over the descriptors, `| json = "key"`, the read report on the way in, `&node` for a shared node (SPEC-TABLES §16). Carried by all nine (PORTING M9), with the text surfaces answered per case and a per-backend walk negative control behind each.
+- s31. The block form: one contiguous extent of rows at a compiler-computed stride, every reference block-relative, so it relocates by `memcpy` with no fix-up (SPEC-TABLES §19, §19.1). Its read half is generated by all nine backends, and PORTING M7 carries eight of them with Elixir's per-row allocation at [#409](https://github.com/mas-bandwidth/schema/issues/409).
+- s31b. Every cooked record and every block projection carries a compile-time assertion of size, alignment and every field offset against the numbers the compiler computed, each array's pitch constant included: two independent derivations held against each other, so a producer that disagrees is refused before a row is read (SPEC-TABLES §19.3). Seven backends carry it; Dart and Elixir have no second layout model to check against and hold the contract with the build version instead (PORTING M11).
+- s32. Six of the nine targets link a small `serialize` runtime for the packet wire; Dart, Java and Elixir generate self-contained output ([VERSIONING.md](VERSIONING.md)). The C++ tables dialect takes no STL and routes every C-library call through a hook the program can define (SPEC-TABLES §13.9).
+- s33. The tolerant read is the validator: every length bounds-checked against its body, every count against the body, ranges clamped, a bad sub-table stopping only itself, and `LoadMeasure` letting the caller refuse a region size before anything is allocated (SPEC-TABLES §4, §6.5). SPEC-TABLES §4.2 is the gate on that claim, "The read is the verifier": every pinned wire in the corpus, mutated by enumerated passes plus a seeded random pass, is read by the leg and by the compiler's own engine, an independent third reading of §3 no backend was written from, and four requirements per mutant must hold. C++ is proven, at 62,179 enumerated plus 3,000,000 random mutants over 63 seeds with 0 divergences, plain and under ASan/UBSan (`test/tables/wire_fuzz_main.cpp`, PORTING I15). The per-port carry is I15's ❌ cells.
+- s34. By-value depth is fixed by the schema and the pointer graph is flat, so a long chain is not a recursion (SPEC-TABLES §3.1). Until [#466](https://github.com/mas-bandwidth/schema/issues/466) states and tests the amplification bound, the bound is the caller's own refusal of `LoadMeasure`'s answer (§6.5) and not a number the format states.
+- s35. One corpus, every registered leg, hostile rows included: two forgery batteries, the cook battery's 111 rows and the `json-hostile` trees, with seven negative controls behind the harness (`test/conformance`). A leg that lacks a construct answers ABSENT per case instead of passing by omission.
+- s36. Static descriptors in every table's generated header, name, kind, id, offset, bounds, guards and nesting, with no schema file present and no RTTI (SPEC-TABLES §8.1), carried by all nine (PORTING M13; C# holds them in a cache and not as constants, [#411](https://github.com/mas-bandwidth/schema/issues/411)). The type view and the unit registry (§8.2, §8.3) are C++ and C# only, and every other backend emits no view file (§15).
+- s37. JSON in and out by one generic walk over the descriptors, `| json = "key"`, the read report on the way in, `&node` for a shared node (SPEC-TABLES §16). The walk itself is carried by all nine (PORTING M9), and each backend's is compared unit by unit. 🔶 because the text surfaces are where the eight ports answer ABSENT, on `json-read` and `json-write` alike: the message, wide, blob and variable classes have no port text form ([the conformance contract](../test/conformance/README.md), SPEC-TABLES §15).
 - s38. Deferred with the design pinned (SPEC §4.1); doc strings in the view are a named follow-on (SPEC-TABLES §15).
-- s39. Nine languages byte-identical on the packet wire in CI (SPEC §1). Tables are carried under #366 — the declared 3.0.0 gate, full feature parity across all nine languages at each language's performance floor — and PORTING.md, not this page, is the present state.
-- s40. Decided and not built. Table `was` is #396 and variant and arm `was` is #442, both before 3.0.0; `was` is a field attribute today (SPEC-TABLES §5).
-- s41. Decided and not built. The retired-names ledger in the baseline is #441, before 3.0.0; nothing today marks a removed name retired, so it can be re-added and decode old bytes under a new meaning.
+- s39. Nine languages byte-identical on the packet wire in CI (SPEC §1). Tables are carried under [#366](https://github.com/mas-bandwidth/schema/issues/366).
+- s40. Decided and not built. Table `was` is [#396](https://github.com/mas-bandwidth/schema/issues/396) and variant and arm `was` is [#442](https://github.com/mas-bandwidth/schema/issues/442), both before 3.0.0; `was` is a field attribute today (SPEC-TABLES §5).
+- s41. Decided and not built. The retired-names ledger in the baseline is [#441](https://github.com/mas-bandwidth/schema/issues/441), before 3.0.0; nothing today marks a removed name retired, so it can be re-added and decode old bytes under a new meaning.
 - s42. Declined, with the reason in the table above.
-- s43. Declined, with the reason in the table above: one schema per build, identified by the protocol id and the build version, neither of which rides in a file, and a file that must say what wrote it puts a `format` field on its root table.
-- s44. The cook's and the block's prologues carry the build version and refuse a file another build wrote (SPEC-TABLES §7.1, §19.1, §20), and all nine read them (PORTING M8, M7). The tolerant wire carries no marker of its own: the form byte at the head of every table-wire file is #435, before 3.0.0. It is also the answer to FlatBuffers' `file_identifier` [179] — the schema's own revision is a `format` field on the root table, the format's own revision is the form byte.
-- s45. `tables.baseline` with `--update --reason` and a dated history (SPEC-TABLES §18), first-party where `buf breaking` is not. 🔶 for the same reason as [s22]: the file is opt-in and no file means no check (§18.1). The packet wire has no compile-time gate at all — the protocol id refuses at connect time, which is a runtime refusal (SPEC §3) — and an importer from `.proto` or `.fbs` is neither declined nor built (#477).
-- s46. The promise is on VERSIONING.md, and SPEC §6.1 states it as a contract: for a given schema and target, equal post-quantization values produce identical bytes, deterministically, across compiler versions, held by the golden-wire gate across a schema's edits. Across compiler RELEASES it needs the codec-law line and an N-1 to N differential gate (#463).
+- s43. Declined, with the reason in the table above.
+- s44. The cook's and the block's prologues carry the build version and refuse a file another build wrote (SPEC-TABLES §7.1, §19.1, §20), and all nine read them (PORTING M8; the harness's `block` surface). The tolerant wire carries no marker of its own: the form byte is [#435](https://github.com/mas-bandwidth/schema/issues/435), before 3.0.0. It is also the answer to FlatBuffers' `file_identifier` [179]: the schema's own revision is the `format` field on the root table, the format's own revision is the form byte.
+- s45. `tables.baseline` with `--update --reason` and a dated history (SPEC-TABLES §18), first-party where `buf breaking` is not. 🔶 for the same reason as [s22]: the file is opt-in and no file means no check (§18.1). The packet wire has no compile-time gate at all, the protocol id refusing at connect time, which is a runtime refusal (SPEC §3).
+- s46. The promise is on [VERSIONING.md](VERSIONING.md), and SPEC §6.1 states it as a contract: for a given schema and target, equal post-quantization values produce identical bytes, deterministically, across compiler versions, held by the golden-wire gate across a schema's edits. Across compiler RELEASES it needs the codec-law line and an N-1 to N differential gate ([#463](https://github.com/mas-bandwidth/schema/issues/463)).
 
 **Protocol Buffers and FlatBuffers**
 
-Row-level evidence for these two lives in
-[COMPARISON-TABLES.md](COMPARISON-TABLES.md), and a citation below names its
-section and its row rather than repeating the quote. Where a mark here rests
-on a fact that page does not carry, the footnote says so and cites the
-project's own page directly.
-
-2. COMPARISON-TABLES.md, Declarations and the schema language — "Scalar types", "Declared numeric bounds", "Fixed point".
-3. COMPARISON-TABLES.md, Declarations and the schema language — "Scalar types", "Declared numeric bounds", "Fixed point"; sub-32-bit yes, no 128-bit, no fixed point, no declared range.
-6. COMPARISON-TABLES.md, Declarations and the schema language — "Constants" ("—" in both columns).
-9. COMPARISON-TABLES.md, Declarations and the schema language — "Inline struct" ("— ; every message is length-delimited").
-10. COMPARISON-TABLES.md, Declarations and the schema language — "Inline struct".
-13. COMPARISON-TABLES.md, Declarations and the schema language — "Flags" ("—").
-14. COMPARISON-TABLES.md, Declarations and the schema language — "Flags" (`enum (bit_flags)`).
-16. COMPARISON-TABLES.md, Declarations and the schema language — "Arrays", "Strings", "Bytes".
-17. COMPARISON-TABLES.md, Declarations and the schema language — "Arrays" (`[T:N]` in structs only).
-20. COMPARISON-TABLES.md, Declarations and the schema language — "Maps"; and "One scene, three ways" — "keyed by Slot" (enum keys refused).
-21. COMPARISON-TABLES.md, Declarations and the schema language — "Enum-keyed arrays" ("—"); "Sorted lookup in a buffer" gives the idiom, a sorted vector looked up by VALUE.
-23. COMPARISON-TABLES.md, Declarations and the schema language — "Maps".
-24. COMPARISON-TABLES.md, Declarations and the schema language — "Maps"; "Sorted lookup in a buffer".
-27. COMPARISON-TABLES.md, Declarations and the schema language — "Pointers, graphs, sharing" ("tree only; no sharing, no cycles").
-28. COMPARISON-TABLES.md, Declarations and the schema language — "Pointers, graphs, sharing" (an `Offset` may be reused by the builder; cycles impossible).
-32. COMPARISON-TABLES.md, Declarations and the schema language — "Union" (`oneof`). **Not carried there:** the arm restriction. `oneof` admits any type except map fields and repeated fields (PB-proto3, Oneof), which is what holds this at 🔶.
-33. COMPARISON-TABLES.md, Declarations and the schema language — "Union" (union of tables; structs and strings experimental; vectors of unions C++ only).
-36. COMPARISON-TABLES.md, Declarations and the schema language — "Defaults" (proto3 has none; proto2 and editions do).
-37. COMPARISON-TABLES.md, Declarations and the schema language — "Defaults" (scalar defaults); "Optional fields" (references null when absent).
-40. COMPARISON-TABLES.md, Declarations and the schema language — "Optional fields" (explicit presence: proto2 all, proto3 `optional`, editions explicit by default).
-41. COMPARISON-TABLES.md, Declarations and the schema language — "Optional fields" (optional scalars via `= null`). **Not carried there:** the per-language coverage. FB-support marks optional scalars Yes in ten of the thirteen languages listed and blank for Python, PHP and Dart — and that table says of itself "NOTE: this table is a start, it needs to be extended", so every count taken from it is a floor rather than a fact.
-45. COMPARISON-TABLES.md, Declarations and the schema language — "Required" (removed; `LEGACY_REQUIRED` only). 🔶 rather than ❌ because the construct exists on the record in two places: proto2's `required`, and editions' `features.field_presence = LEGACY_REQUIRED`, "required for parsing and serialization" (PB-features). The project's guidance is never to add one (PB-dos).
-46. COMPARISON-TABLES.md, Declarations and the schema language — "Required" (`(required)`, verifier-checked). 🔶 rather than ✅ because the check is the verifier's, and the verifier does not ship in every language [136].
-50. COMPARISON-TABLES.md, Declarations and the schema language — "Schema-less data" (`Struct`, `Value`); "Well-known types" (`Any`).
-51. COMPARISON-TABLES.md, Declarations and the schema language — "Schema-less data" (FlexBuffers). **Not carried there:** the coverage. FB-support marks FlexBuffers Yes for C++, Java, Rust and Swift of the thirteen listed, under that table's own caveat [41].
-55. COMPARISON-TABLES.md, Declarations and the schema language — "Attributes" (custom options with retention and targets).
-56. COMPARISON-TABLES.md, Declarations and the schema language — "Attributes" (user attributes declarable, read via reflection).
-59. COMPARISON-TABLES.md, The wire — "Self-describing" ("no; needs descriptors"). 🔶 rather than ❌ because field numbers and wire types do ride, so a parser skips what it does not know; names and declared types need the definition (PB-encoding, Message Structure).
-60. **Not carried in COMPARISON-TABLES.md** — that page's "Version identity" row covers `file_identifier`, not the format's own silence. FB-internals: the format "doesn't contain information for format identification and versioning, which is also by design".
-64. COMPARISON-TABLES.md, The wire — "Varint compaction" (varints, zigzag).
-65. COMPARISON-TABLES.md, The wire — "Varint compaction" ("—"); "Alignment" (every scalar aligned to its size), which is what buys in-place access.
-69. COMPARISON-TABLES.md, The wire — "Alignment" ("none").
-70. COMPARISON-TABLES.md, The wire — "Alignment" (aligned to size; `force_align`).
-74. COMPARISON-TABLES.md, The wire — "Size ceilings" (2 GiB).
-75. COMPARISON-TABLES.md, The wire — "Size ceilings" (32-bit offsets: 2 GiB; `vector64` for tail vectors, not in every port).
-79. COMPARISON-TABLES.md, The wire — "Byte-identical output across implementations" ("don't assume serialization stability across builds").
-80. COMPARISON-TABLES.md, The wire — "Byte-identical output across implementations" ("no cross-language claim"). ❌ and not ?, and the reason is **not carried there**: FB-internals states the denial outright — "This may mean two different implementations may produce different binaries given the same input values, and this is perfectly valid." That is the format declining the property on the record, not an inference from absence.
-83. COMPARISON-TABLES.md, Evolution — "Add a field", "Remove a field", "Reorder", "Rename" (add anywhere with an unused number; remove and reserve; reorder free).
-84. COMPARISON-TABLES.md, Evolution — "Add a field", "Remove a field", "Reorder". 🔶 and not ❌, on the same reading as [83] and [85]: new fields go at the end, `id` on every field makes source position free, and removal is forbidden with the slot kept by `deprecated`. All three formats add, all three reorder in source, and none of the three frees a retired slot; the differences are in the footnotes, not in the marks.
-85. **Not carried in COMPARISON-TABLES.md** (Cap'n Proto is not on that page). New members take numbers exceeding all previous ones, source position is free, numbers never change and there is no removal (CP-lang, Evolving Your Protocol). 🔶 on the same reading as [83] and [84].
-88. COMPARISON-TABLES.md, Declarations and the schema language — "Rename" (free on the binary wire; reserve the old name for JSON).
-89. COMPARISON-TABLES.md, Declarations and the schema language — "Rename" (free; names are not serialized).
-92. COMPARISON-TABLES.md, Evolution — "Change a type" (a fixed list of compatible pairs; anything else misdecodes silently).
-93. COMPARISON-TABLES.md, Evolution — "Change a type" (only at identical width, with careful handling).
-97. COMPARISON-TABLES.md, Evolution — "Change a default" (proto3 has none; proto2 reader-side). 🔶 rather than ❌, and the reason is **not carried there:** under explicit presence — proto2, and the default in every edition — "Any explicitly-set value is serialized onto the wire (even if it is the same as the default value)" (PB-features), so a changed default reinterprets only the fields a writer never set. Under implicit presence, proto3's default, a value equal to the default is elided and the hazard is whole. Avro keeps ✅ [99] because it writes every field of the writer's schema unconditionally, so no stored byte can be reinterpreted at all.
-98. COMPARISON-TABLES.md, Evolution — "Change a default" ("don't": V1 data that did not write the value relied on generated code for it).
-101. COMPARISON-TABLES.md, Evolution — "Unknown fields on read", "Unknown fields on rewrite" (retained and re-serialized).
-102. COMPARISON-TABLES.md, Evolution — "Unknown fields on rewrite" (the buffer keeps them if forwarded whole; the object API's unpack-and-repack does not).
-104. COMPARISON-TABLES.md, Evolution — "Read report" (success or failure, plus the unknown set).
-105. COMPARISON-TABLES.md, Evolution — "Read report" (verifier pass or fail).
-108. COMPARISON-TABLES.md, Evolution — "Enum evolution" (open enums keep the int; closed enums move it to unknown fields). **Not carried there:** the per-language divergence. C#, Go, JSPB and Ruby treat every enum as open and Dart as closed, whatever the syntax says (PB-enum).
-109. COMPARISON-TABLES.md, Evolution — "Enum evolution" (append or explicit values; the application handles unknowns itself).
-112. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Point at the bytes" ("never").
-113. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Point at the bytes" ("always").
-116. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on read" (per message, string and repeated field; arenas mitigate).
-117. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on read" (none in place; the object API allocates).
-119. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on write". **Not carried there:** arenas are a C++ feature (PB-arenas), which is what holds this at 🔶.
-120. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on write" (the builder grows a buffer; custom allocator). ✅ and not 🔶: one growable buffer with a caller's allocator is the row's property, and nothing is allocated per node — the same reading Cap'n Proto's segments get [121].
-122. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Exact size before writing" (`ByteSizeLong()`).
-123. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Exact size before writing" (after `Finish`).
-125. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Mutate in place" ("—").
-126. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Mutate in place" (`--gen-mutable` scalars; reflection resizes). **Not carried there:** the coverage. FB-support marks simple mutation Yes for C++, Java, C#, Go and Swift of the thirteen listed, under that table's own caveat [41].
-128. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Cross-language rows at a pitch" ("—"); "Offline cook for a build" ("—").
-129. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Cross-language rows at a pitch" (a vector of structs is inline, but the schema does not assert both sides' native layout).
-131. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Generated code dependencies" (`libprotobuf`).
-132. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Generated code dependencies" says "header-only runtime", and **no cited FlatBuffers page says it**; this footnote replaces that claim with what FB-cpp does say. The generated header "relies on `flatbuffers/flatbuffers.h`, which should be in your include path", so the C++ core is an include rather than a link; text and schema parsing "requires you to link a few more files into your program" (FB-cpp, Prerequisites; Text & schema parsing). Every other FlatBuffers language ships a runtime library, so the cell is 🔶.
-134. **Not carried in COMPARISON-TABLES.md**, whose row states only the second half. Structs "are always stored inline in their parent (a struct, table, or vector)", and their layout is defined "independent of the alignment rules of the underlying compiler to guarantee a cross platform compatible layout" (FB-internals, Structs), so a vector of structs is a fixed-stride row image two languages compute identically. That is this row's property, and it is ✅.
-135. COMPARISON-TABLES.md, Validation of untrusted data — "Untrusted bytes on the tolerant wire" (the parser validates structure; recursion limit; UTF-8 verify).
-136. COMPARISON-TABLES.md, Validation of untrusted data — "Untrusted bytes on the tolerant wire" (a separate `Verifier`, required before access). **Corrected here:** FB-support's matrix marks the buffer verifier Yes for C++, C and Swift of thirteen, and FB-rust adds a fourth the matrix does not show — "The safe Rust functions to interpret a slice as a table (`root`, `size_prefixed_root`, `root_with_opts`, and `size_prefixed_root_with_opts`) verify the data first." The count is at least four of thirteen, and FB-support says of itself "NOTE: this table is a start, it needs to be extended", so it is a floor.
-139. COMPARISON-TABLES.md, Validation of untrusted data — "Depth and DoS bounds" (recursion depth 100). **Not carried there:** the limits differ by implementation — Java 100, C++ 100, Go 10,000 with a planned reduction (PB-limits) — which is what holds this at 🔶.
-140. COMPARISON-TABLES.md, Validation of untrusted data — "Untrusted bytes on the tolerant wire" (`max_depth` 64, `max_tables` 1M), where a verifier ships [136].
-142. COMPARISON-TABLES.md, Validation of untrusted data — "Cross-language agreement on refusal" ("a conformance suite"). ? rather than 🔶: the suite's own page says it tests "completeness and correctness of Protocol Buffers implementations" and says nothing about malformed or hostile input either way (PB-conformance).
-144. COMPARISON-TABLES.md, Reflection, text, tooling — "Runtime reflection" (descriptors, `Reflection`, `DynamicMessage`).
-145. COMPARISON-TABLES.md, Reflection, text, tooling — "Runtime reflection" (binary schema plus `reflection.h` in C++, basic in C; MINI-REFLECTION). 🔶 rather than ❌ on the strength of that last: "A more limited form of reflection is available for direct inclusion in generated code, which doesn't do any (binary) schema access at all", behind `--reflect-types` and `--reflect-names` (FB-cpp, Mini Reflection).
-149. COMPARISON-TABLES.md, Reflection, text, tooling — "Text form" says "ProtoJSON in every runtime", and **no cited page establishes the count**; this footnote replaces it. PB-json specifies the format and names its own gaps — "As of v25.x, the C++, Java, and Python implementations are nonconformant" on one flag — so the mark is 🔶.
-150. COMPARISON-TABLES.md, Reflection, text, tooling — "Text form" (JSON in `flatc`; parsing in a few languages). **Corrected here:** FB-support marks JSON parsing Yes for C++, C and Lobster of thirteen, under that table's own caveat [41]; `flatc --json` converts offline (FB-flatc).
-154. COMPARISON-TABLES.md, Reflection, text, tooling — "Doc comments" says "preserved in descriptors' source info", and **no cited page carries it**; the source list's PB-wkt is the well-known types reference and does not contain `SourceCodeInfo`. PB-proto3's "Adding Comments" states the accepted comment styles and says nothing about generated code, and the C++ generated-code reference does not mention comments either (PB-proto3, Adding Comments; PB-cpp-gen). Neither made nor denied, so ? by the legend.
-155. COMPARISON-TABLES.md, Reflection, text, tooling — "Doc comments" (`///` into generated code and the binary schema).
-158. COMPARISON-TABLES.md, Reflection, text, tooling — "Languages" (ten first-party, forty-plus third-party). 🔶 because the project documents its own enum nonconformance across those runtimes (PB-enum).
-159. COMPARISON-TABLES.md, Reflection, text, tooling — "Languages" (thirteen listed, coverage uneven). **Not carried there:** the shape of the unevenness. Of the thirteen, FB-support marks JSON parsing in three, reflection in two, the verifier in three (four with FB-rust, [136]) and mutation in five, and says C++ "has the richest feature set, and is likely most robust" — all of it under that table's own caveat [41].
-165. COMPARISON-TABLES.md, Declarations and the schema language — "Reserved names" (`reserved` numbers and names).
-166. COMPARISON-TABLES.md, Declarations and the schema language — "Reserved names" ("— ; never remove, deprecate instead"); "Deprecation" (`(deprecated)`: accessors dropped, slot kept).
-170. COMPARISON-TABLES.md, Evolution — "Change a type" (the compatible-pairs list; a truncation inside it is silent).
-174. **Not carried in COMPARISON-TABLES.md.** The project documents a self-describing pattern — a message carrying a `FileDescriptorSet` beside the payload — and says in the same breath that "the reason that this functionality is not included in the Protocol Buffer library is because we have never had a use for it inside Google" (PB-techniques, Self-describing Messages). The schema is recoverable only out of band, which is the same shape as FlatBuffers' `.bfbs` [175] and takes the same mark.
-175. COMPARISON-TABLES.md, Reflection, text, tooling — "Runtime reflection" (the binary schema as a separate artifact); The wire — "Version identity" (`file_identifier`, four hand-chosen characters). Out of band, like [174], and the same mark.
-178. COMPARISON-TABLES.md, The wire — "Version identity" ("none; editions version the language"); the six wire types are frozen with no revision marker (PB-encoding).
-179. COMPARISON-TABLES.md, The wire — "Version identity" (`file_identifier`, by hand) — it identifies the schema author's format, not the FlatBuffers revision.
-183. COMPARISON-TABLES.md, Evolution — "Compile-time guard" (`buf breaking`, third party: built by Buf Technologies, not the Protocol Buffers project — buf).
-184. COMPARISON-TABLES.md, Evolution — "Compile-time guard" (`flatc --conform`).
+2. COMPARISON-TABLES.md, Declarations and the schema language, "Scalar types", "Declared numeric bounds", "Fixed point".
+3. COMPARISON-TABLES.md, Declarations and the schema language, "Scalar types", "Declared numeric bounds", "Fixed point": sub-32-bit yes, no 128-bit, no fixed point, no declared range.
+6. COMPARISON-TABLES.md, Declarations and the schema language, "Constants" ("—" in both columns).
+9. COMPARISON-TABLES.md, Declarations and the schema language, "Inline struct" ("— ; every message is length-delimited").
+10. COMPARISON-TABLES.md, Declarations and the schema language, "Inline struct".
+13. COMPARISON-TABLES.md, Declarations and the schema language, "Flags" ("—").
+14. COMPARISON-TABLES.md, Declarations and the schema language, "Flags" (`enum (bit_flags)`).
+16. COMPARISON-TABLES.md, Declarations and the schema language, "Arrays", "Strings", "Bytes".
+17. COMPARISON-TABLES.md, Declarations and the schema language, "Arrays" (`[T:N]` in structs only).
+20. COMPARISON-TABLES.md, Declarations and the schema language, "Maps"; and "One scene, three ways", "keyed by Slot" (enum keys refused).
+21. COMPARISON-TABLES.md, Declarations and the schema language, "Enum-keyed arrays" ("—"); "Sorted lookup in a buffer" gives the idiom, a sorted vector looked up by VALUE.
+23. COMPARISON-TABLES.md, Declarations and the schema language, "Maps".
+24. COMPARISON-TABLES.md, Declarations and the schema language, "Maps"; "Sorted lookup in a buffer".
+27. COMPARISON-TABLES.md, Declarations and the schema language, "Pointers, graphs, sharing" ("tree only; no sharing, no cycles").
+28. COMPARISON-TABLES.md, Declarations and the schema language, "Pointers, graphs, sharing" (an `Offset` may be reused by the builder; cycles impossible).
+32. COMPARISON-TABLES.md, Declarations and the schema language, "Union" (`oneof`). The arm restriction is not on that page: `oneof` admits any type except map fields and repeated fields (PB-proto3, Oneof), and that limitation holds this at 🔶.
+33. COMPARISON-TABLES.md, Declarations and the schema language, "Union" (union of tables; structs and strings experimental; vectors of unions C++ only).
+36. COMPARISON-TABLES.md, Declarations and the schema language, "Defaults" (proto3 has none; proto2 and editions do).
+37. COMPARISON-TABLES.md, Declarations and the schema language, "Defaults" (scalar defaults); "Optional fields" (references null when absent).
+40. COMPARISON-TABLES.md, Declarations and the schema language, "Optional fields" (explicit presence: proto2 all, proto3 `optional`, editions explicit by default).
+41. COMPARISON-TABLES.md, Declarations and the schema language, "Optional fields" (optional scalars via `= null`). The per-language coverage is not on that page: FB-support marks optional scalars Yes in ten of the thirteen languages listed and blank for Python, PHP and Dart, and that table says of itself "NOTE: this table is a start, it needs to be extended", so every count taken from it is a floor and not a fact.
+45. COMPARISON-TABLES.md, Declarations and the schema language, "Required" (removed; `LEGACY_REQUIRED` only). The construct exists on the record in two places, proto2's `required` and editions' `features.field_presence = LEGACY_REQUIRED`, "required for parsing and serialization" (PB-features), and the project's guidance is never to add one (PB-dos).
+46. COMPARISON-TABLES.md, Declarations and the schema language, "Required" (`(required)`, verifier-checked). The check is the verifier's, and the verifier does not ship in every language [136].
+50. COMPARISON-TABLES.md, Declarations and the schema language, "Schema-less data" (`Struct`, `Value`); "Well-known types" (`Any`).
+51. COMPARISON-TABLES.md, Declarations and the schema language, "Schema-less data" (FlexBuffers). The coverage is not on that page: FB-support marks FlexBuffers Yes for C++, Java, Rust and Swift of the thirteen listed, under that table's own caveat [41].
+55. COMPARISON-TABLES.md, Declarations and the schema language, "Attributes" (custom options with retention and targets).
+56. COMPARISON-TABLES.md, Declarations and the schema language, "Attributes" (user attributes declarable, read via reflection).
+59. COMPARISON-TABLES.md, The wire, "Self-describing" ("no; needs descriptors"). Field numbers and wire types do ride, so a parser skips what it does not know; names and declared types need the definition (PB-encoding, Message Structure).
+60. Not on COMPARISON-TABLES.md, whose "Version identity" row covers `file_identifier` and not the format's own silence. FB-internals: the format "doesn't contain information for format identification and versioning, which is also by design".
+64. COMPARISON-TABLES.md, The wire, "Varint compaction" (varints, zigzag).
+65. COMPARISON-TABLES.md, The wire, "Varint compaction" ("—"); "Alignment" (every scalar aligned to its size), the property that buys in-place access.
+69. COMPARISON-TABLES.md, The wire, "Alignment" ("none").
+70. COMPARISON-TABLES.md, The wire, "Alignment" (aligned to size; `force_align`).
+74. COMPARISON-TABLES.md, The wire, "Size ceilings" (2 GiB).
+75. COMPARISON-TABLES.md, The wire, "Size ceilings" (32-bit offsets: 2 GiB; `vector64` for tail vectors, not in every port).
+79. COMPARISON-TABLES.md, The wire, "Byte-identical output across implementations" ("don't assume serialization stability across builds").
+80. COMPARISON-TABLES.md, The wire, "Byte-identical output across implementations" ("no cross-language claim"). The denial itself is not on that page: FB-internals states it outright, "This may mean two different implementations may produce different binaries given the same input values, and this is perfectly valid." That is the format declining the property on the record, not an inference from absence.
+83. COMPARISON-TABLES.md, Evolution, "Add a field", "Remove a field", "Reorder": add anywhere with an unused number, remove and reserve, reorder free. All three of what the row asks are documented.
+84. COMPARISON-TABLES.md, Evolution, "Add a field", "Remove a field", "Reorder". 🔶: `id` on every field makes source position free, but a new field goes at the end without it, and the project's own evolution guidance is never to remove a field, deprecating it in place instead.
+85. Not on COMPARISON-TABLES.md; Cap'n Proto is not on that page. A new member's number must be larger than all previous members', so a field is added only at the top of the number space; members may be rearranged in source with their numbers preserved; and the evolution rules say nothing about removing a field at all, which is ❌ by this page's absence reading (CP-lang, Evolving Your Protocol).
+88. COMPARISON-TABLES.md, Declarations and the schema language, "Rename" (free on the binary wire; reserve the old name for JSON).
+89. COMPARISON-TABLES.md, Declarations and the schema language, "Rename" (free; names are not serialized).
+92. COMPARISON-TABLES.md, Evolution, "Change a type" (a fixed list of compatible pairs; anything else misdecodes silently).
+93. COMPARISON-TABLES.md, Evolution, "Change a type" (only at identical width, with careful handling).
+97. COMPARISON-TABLES.md, Evolution, "Change a default" (proto3 has none; proto2 reader-side). The reason for 🔶 is not on that page: under explicit presence, proto2 and the default in every edition, "Any explicitly-set value is serialized onto the wire (even if it is the same as the default value)" (PB-features), so a changed default reinterprets only the fields a writer never set. Under implicit presence, proto3's default, a value equal to the default is elided and the hazard is whole. Avro keeps ✅ [99] because it writes every field of the writer's schema unconditionally, so no stored byte can be reinterpreted at all.
+98. COMPARISON-TABLES.md, Evolution, "Change a default" ("don't": V1 data that did not write the value relied on generated code for it).
+101. COMPARISON-TABLES.md, Evolution, "Unknown fields on read", "Unknown fields on rewrite" (retained and re-serialized).
+102. COMPARISON-TABLES.md, Evolution, "Unknown fields on rewrite" (the buffer keeps them if forwarded whole; the object API's unpack-and-repack does not).
+104. COMPARISON-TABLES.md, Evolution, "Read report" (success or failure, plus the unknown set).
+105. COMPARISON-TABLES.md, Evolution, "Read report" (verifier pass or fail).
+108. COMPARISON-TABLES.md, Evolution, "Enum evolution" (open enums keep the int; closed enums move it to unknown fields). The per-language divergence is on that page's same row: C#, Go, JSPB and Ruby treat every enum as open and Dart as closed, whatever the syntax says (PB-enum).
+109. COMPARISON-TABLES.md, Evolution, "Enum evolution" (append or explicit values; the application handles unknowns itself).
+112. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Point at the bytes" ("never").
+113. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Point at the bytes" ("always").
+116. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Allocation on read" (per message, string and repeated field; arenas mitigate).
+117. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Allocation on read" (none in place; the object API allocates).
+119. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Allocation on write". Not on that page: arenas are a C++ feature (PB-arenas), and that limitation holds this at 🔶.
+120. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Allocation on write" (the builder grows a buffer; custom allocator). One growable buffer with a caller's allocator is the row's property, and nothing is allocated per node, the reading Cap'n Proto's segments also get [121].
+122. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Exact size before writing" (`ByteSizeLong()`).
+123. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Exact size before writing" (after `Finish`).
+125. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Mutate in place" ("—").
+126. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Mutate in place" (`--gen-mutable` scalars; reflection resizes). The coverage is not on that page: FB-support marks simple mutation Yes for C++, Java, C#, Go and Swift of the thirteen listed, under that table's own caveat [41].
+128. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Cross-language rows at a pitch" ("—"); "Offline cook for a build" ("—").
+129. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Cross-language rows at a pitch" (a vector of structs is inline, but the schema does not assert both sides' native layout). 🔶, and the half that is asserted is not on that page: a struct's layout is fixed "independent of the alignment rules of the underlying compiler", and "This layout is then enforced in the generated code" (FB-internals, Structs). The C++ generated struct is bracketed by `FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4)` and `FLATBUFFERS_STRUCT_END(Vec3, 12)`, which turns the compiler's padding off and asserts the struct's total SIZE. What schema asserts and FlatBuffers does not is every field's OFFSET and every array's PITCH, in both the producing and the consuming language's generated code, so the two sides refuse each other rather than agreeing only on a total [s31b].
+131. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Generated code dependencies" (`libprotobuf`).
+132. COMPARISON-TABLES.md, Runtime forms, allocation, performance, "Generated code dependencies". The generated header "relies on `flatbuffers/flatbuffers.h`, which should be in your include path", so the C++ core is an include and not a link; text and schema parsing "requires you to link a few more files into your program" (FB-cpp, Prerequisites; Text & schema parsing). Every other FlatBuffers language ships a runtime library, so the cell is 🔶.
+134. Not on COMPARISON-TABLES.md, whose row states only the second half. Structs "are always stored inline in their parent (a struct, table, or vector)", and their layout is defined "independent of the alignment rules of the underlying compiler to guarantee a cross platform compatible layout" (FB-internals, Structs), so a vector of structs is a fixed-stride row image two languages compute identically. That is this row's property.
+135. COMPARISON-TABLES.md, Validation of untrusted data, "Untrusted bytes on the tolerant wire" (the parser validates structure; recursion limit; UTF-8 verify).
+136. COMPARISON-TABLES.md, Validation of untrusted data, "Untrusted bytes on the tolerant wire" (a separate `Verifier`, required before access, in C++, C, Swift and Rust). FB-rust is the fourth, which FB-support's matrix does not show: "The safe Rust functions to interpret a slice as a table (`root`, `size_prefixed_root`, `root_with_opts`, and `size_prefixed_root_with_opts`) verify the data first." The count is at least four of thirteen, under that table's own caveat [41].
+139. COMPARISON-TABLES.md, Validation of untrusted data, "Depth and DoS bounds" (recursion depth 100). Not on that page: the limits differ by implementation, Java 100, C++ 100, Go 10,000 with a planned reduction (PB-limits), and that divergence holds this at 🔶.
+140. COMPARISON-TABLES.md, Validation of untrusted data, "Untrusted bytes on the tolerant wire" (`max_depth` 64, `max_tables` 1M), where a verifier ships [136].
+142. COMPARISON-TABLES.md, Validation of untrusted data, "Cross-language agreement on refusal" ("a conformance suite"). The suite's own page says it tests "completeness and correctness of Protocol Buffers implementations" and says nothing about malformed or hostile input either way (PB-conformance), so ? by the legend.
+144. COMPARISON-TABLES.md, Reflection, text, tooling, "Runtime reflection" (descriptors, `Reflection`, `DynamicMessage`).
+145. COMPARISON-TABLES.md, Reflection, text, tooling, "Runtime reflection" (binary schema plus `reflection.h` in C++, basic in C; MINI-REFLECTION). The last of those is what lifts this off ❌: "A more limited form of reflection is available for direct inclusion in generated code, which doesn't do any (binary) schema access at all", behind `--reflect-types` and `--reflect-names` (FB-cpp, Mini Reflection).
+149. COMPARISON-TABLES.md, Reflection, text, tooling, "Text form" (ProtoJSON, with the implementations that do not conform to it named; text format). PB-json specifies the format and names its own gaps, "As of v25.x, the C++, Java, and Python implementations are nonconformant" on one flag, so the mark is 🔶.
+150. COMPARISON-TABLES.md, Reflection, text, tooling, "Text form" (JSON in `flatc`; parsing in C++, C and Lobster of the thirteen listed, under that table's own caveat [41]); `flatc --json` converts offline (FB-flatc).
+154. COMPARISON-TABLES.md, Reflection, text, tooling, "Doc comments" (the descriptor carries source info). `SourceCodeInfo` in PB-descriptor carries "any comments appearing before and after the declaration which appear to be attached to the declaration", as `optional string leading_comments = 3`, `optional string trailing_comments = 4` and `repeated string leading_detached_comments = 6`. 🔶: the descriptor carries them and a generator may read them, and whether any generator emits them into generated code is undocumented on protobuf.dev.
+155. COMPARISON-TABLES.md, Reflection, text, tooling, "Doc comments" (`///` into generated code and the binary schema).
+158. COMPARISON-TABLES.md, Reflection, text, tooling, "Languages" (ten first-party, forty-plus third-party). 🔶 because the project documents its own enum nonconformance across those runtimes (PB-enum).
+159. COMPARISON-TABLES.md, Reflection, text, tooling, "Languages" (thirteen listed, coverage uneven). The shape of the unevenness is not on that page: of the thirteen, FB-support marks JSON parsing in three, reflection in two, the verifier in three (four with FB-rust, [136]) and mutation in five, and says C++ "has the richest feature set, and is likely most robust", all of it under that table's own caveat [41].
+165. COMPARISON-TABLES.md, Declarations and the schema language, "Reserved names" (`reserved` numbers and names).
+166. COMPARISON-TABLES.md, Declarations and the schema language, "Reserved names" ("— ; never remove, deprecate instead"); "Deprecation" (`(deprecated)`: accessors dropped, slot kept).
+170. COMPARISON-TABLES.md, Evolution, "Change a type" (the compatible-pairs list; a truncation inside it is silent).
+174. Not on COMPARISON-TABLES.md. The project documents a self-describing pattern, a message carrying a `FileDescriptorSet` beside the payload, and says in the same breath that "the reason that this functionality is not included in the Protocol Buffer library is because we have never had a use for it inside Google" (PB-techniques, Self-describing Messages). The schema is recoverable only out of band, the same shape as FlatBuffers' `.bfbs` [175] and the same mark.
+175. COMPARISON-TABLES.md, Reflection, text, tooling, "Runtime reflection" (the binary schema as a separate artifact); The wire, "Version identity" (`file_identifier`, four hand-chosen characters). Out of band, like [174], and the same mark.
+178. COMPARISON-TABLES.md, The wire, "Version identity" ("none; editions version the language"); the six wire types are frozen with no revision marker (PB-encoding).
+179. COMPARISON-TABLES.md, The wire, "Version identity" (`file_identifier`, by hand): it identifies the schema author's format, not the FlatBuffers revision.
+183. COMPARISON-TABLES.md, Evolution, "Compile-time guard" (`buf breaking`, third party: built by Buf Technologies and not by the Protocol Buffers project, buf).
+184. COMPARISON-TABLES.md, Evolution, "Compile-time guard" (`flatc --conform`).
 
 **Cap'n Proto and Avro**
-
-Neither is on COMPARISON-TABLES.md, so both cite their own documentation
-here.
 
 4. Cap'n Proto has Int8 to Int64 and the unsigned set; no 128-bit, no fixed point, no declared range (CP-lang, Built-in Types).
 5. Avro's primitives stop at int, long, float, double; `decimal` is a logical type over bytes or fixed, an arbitrary-precision annotation whose per-language support varies (AV-spec, Primitive Types; Logical Types).
@@ -444,20 +505,20 @@ here.
 19. Avro's `fixed` is an exact-size byte type; `string`, `bytes`, `array` and `map` are unbounded (AV-spec, Fixed).
 25. `Map(K,V)` appears only as an example of a user-defined generic (CP-lang, Generic Types).
 26. Map keys are strings (AV-spec, Maps).
-29. One pointer per object, a tree and not a graph; cyclic or overlapping pointers can send a reader into an infinite loop, which is what the traversal limit defends (CP-encoding, Messages).
+29. One pointer per object, a tree and not a graph; cyclic or overlapping pointers can send a reader into an infinite loop, and the traversal limit is what defends against that (CP-encoding, Messages).
 30. No reference type; recursion is a union naming the record, which yields a tree (AV-spec, Complex Types).
 34. A union is two or more fields sharing storage, so any field type is an arm, including `Void` (CP-lang, Unions).
 35. A union is a JSON array of schemas, any schema a branch, with two restrictions (AV-spec, Unions).
 38. Defaults for `Text`, `Data`, `List` and nested structs (CP-lang, Structs).
 39. A default for every field type (AV-spec, Record).
 42. No scalar presence: data-section fields are stored XOR their default, so unset and set-to-default are one encoding, and a pointer's null is the only absence (CP-encoding, Value Encoding).
-43. The idiom is a union with `null`, a value rather than a presence flag (AV-spec, Unions).
+43. The idiom is a union with `null`, a value and not a presence flag (AV-spec, Unions).
 47. No required marker (CP-lang).
 48. A reader field with no default and no writer counterpart signals an error for the whole read (AV-spec, Schema Resolution).
 52. Generics are first class; an omitted parameter is `AnyPointer` (CP-lang, Generic Types).
 53. No generics and no `Any`; the writer's schema is always available, a different solution to the same problem (AV-spec).
-57. `annotation foo(struct, enum) :Text;`, with twelve targets — `file`, `struct`, `field`, `union`, `group`, `enum`, `enumerant`, `interface`, `method`, `param`, `annotation`, `const` — and `*` to cover them all (CP-lang, Annotations).
-58. "Attributes not defined in this document are permitted as metadata, but must not affect the format of serialized data" (AV-spec, Schema Declaration). That is user-extensible annotation in the format, so not ❌; 🔶 rather than ✅ because the specification requires only that an implementation tolerate the attributes, not that it surface them to generated code or to a runtime API, which is what the other three columns' marks rest on.
+57. `annotation foo(struct, enum) :Text;`, declarable by the user with twelve targets (`file`, `struct`, `field`, `union`, `group`, `enum`, `enumerant`, `interface`, `method`, `param`, `annotation`, `const`) and `*` to cover them all (CP-lang, Annotations).
+58. "Attributes not defined in this document are permitted as metadata, but must not affect the format of serialized data" (AV-spec, Schema Declaration). That is user-extensible annotation in the format, so not ❌. 🔶 because the specification requires only that an implementation tolerate the attributes, not that it surface them to generated code or to a runtime API, and the three ✅ columns rest on exactly that.
 61. Field positions are computed from the schema; the message carries no field identity (CP-encoding).
 62. The container file embeds the writer's schema, and single-object encoding carries `C3 01` plus a schema fingerprint. The bare value encoding is untagged (AV-spec, Object Container Files; Single Object Encoding; Binary Encoding).
 66. Packing is an optional pass over the unpacked layout (CP-encoding, Packing; CP-faq).
@@ -465,39 +526,40 @@ here.
 71. Objects aligned to word boundaries, primitives to a multiple of their size (CP-encoding).
 72. A byte stream with no alignment (AV-spec, Binary Encoding).
 76. Segment ids are 32 bits, so the aggregate is not 32-bit capped; a single list is capped at 2^29 elements, and the C++ reader's traversal limit defaults to 64 MiB (CP-encoding, Lists; Far Pointers; CP-cxx, Security Tips).
-77. Array and map blocks carry `long` counts and file data blocks a `long` object count and byte size, and the specification states no aggregate ceiling (AV-spec, Binary Encoding; Object Container Files). 🔶 rather than ✅ because no per-implementation ceiling was sourced, and this page's test asks for the feature in every official implementation.
+77. Array and map blocks carry `long` counts, file data blocks carry a `long` object count and a `long` byte size, and the specification states no aggregate ceiling (AV-spec, Binary Encoding; Object Container Files). The specification is what every other Avro cell is answered from and it answers this one; no per-implementation ceiling was sourced either way.
 81. Canonicalization is fully specified and is a separate conversion, not the default output (CP-encoding, Canonicalization; CP-tool).
-82. A record's bytes are determined by the schema, but array and map block boundaries are the writer's choice, and Avro's Parsing Canonical Form canonicalizes schemas rather than data (AV-spec, Binary Encoding; Parsing Canonical Form).
+82. A record's bytes are determined by the schema, but array and map block boundaries are the writer's choice, and Avro's Parsing Canonical Form canonicalizes schemas and not data (AV-spec, Binary Encoding; Parsing Canonical Form).
 86. Fields match by name and a writer's extras are ignored, but a reader field without a default is a hard error against older data (AV-spec, Schema Resolution).
 90. Any symbolic name can change as long as the type id and the ordinals stay (CP-lang, Evolving Your Protocol).
 91. Aliases exist on named types and fields; "An implementation may optionally use aliases to map a writer's schema to the reader's" (AV-spec, Aliases).
 94. A field's type or default value cannot change (CP-lang, Evolving Your Protocol).
 95. Resolution promotes or signals an error, never a misdecode, and the failure is the whole read (AV-spec, Schema Resolution).
 99. "Avro encodes a field even if its value is equal to its default"; a default is used only when the writer's schema lacks the field, so a default change cannot reinterpret stored bytes (AV-spec, Record; Binary Encoding).
-100. Copying a struct with a `set` method keeps the original's size, because "the original could have been built with an older version of the protocol which lacked some fields", so fields the copier does not know ride through the copy (CP-cxx, Tips and Best Practices). 🔶 rather than ✅ because it is a property of that copy idiom rather than of every read-and-rewrite: a builder filled field by field keeps nothing.
+100. Copying a struct with a `set` method keeps the original's size, because "the original could have been built with an older version of the protocol which lacked some fields", so fields the copier does not know ride through the copy (CP-cxx, Tips and Best Practices). 🔶 because it is a property of that copy idiom and not of every read-and-rewrite: a builder filled field by field keeps nothing.
 103. A writer's field not in the reader's record is ignored (AV-spec, Schema Resolution).
 106. Limits throw; nothing reports what was skipped (CP-cxx, Security Tips).
 107. Errors are signaled; no counted report (AV-spec).
 110. A declared enum `default` is used, otherwise an error is signaled (AV-spec, Enums; Schema Resolution).
+111. The value survives the read: "In C++11, enums are allowed to have any value that is within the range of their base type, which for Cap'n Proto enums is `uint16_t`", and the project tells the caller to expect one, "Keep in mind when writing `switch` blocks that an enum read off the wire may have a numeric value that is not listed in its definition" (CP-cxx, Tips and Best Practices). 🔶 because the landing is defined and non-fatal but is the caller's own default case: nothing reports that an unlisted value arrived.
 114. No encoding step; one field readable without parsing the whole; mmap (CP-home).
 115. Values are variable-length and untagged, decoded into objects; no random access and no cooked form, deliberately (AV-spec, Binary Encoding).
 118. Reads are pointer arithmetic over the buffer (CP-cxx).
-121. Messages are built arena-style, sequentially in a segment, and a new segment is allocated when one fills — never per object (CP-cxx, Tips and Best Practices).
-127. ❌, corrected from ✅. Orphans move subtrees WITHIN a message and exist only in memory a `MessageBuilder` owns; the project states the limitation directly — Cap'n Proto "is not well-suited for _writing_ via `mmap()`, only reading", because no mutable segment framing format has been designed. A received message is read through a `MessageReader` and rebuilt through a builder to change it (CP-cxx, Orphans; Serialization/Deserialization).
+121. Messages are built arena-style, sequentially in a segment, and a new segment is allocated when one fills, never per object (CP-cxx, Tips and Best Practices).
+127. Orphans move subtrees WITHIN a message and exist only in memory a `MessageBuilder` owns; the project states the limitation directly: Cap'n Proto "is not well-suited for _writing_ via `mmap()`, only reading", because no mutable segment framing format has been designed. A received message is read through a `MessageReader` and rebuilt through a builder to change it (CP-cxx, Orphans; Serialization/Deserialization).
 130. mmap is documented and a composite list is structs at a fixed stride, but nothing asserts two languages' native layouts against each other at open (CP-home; CP-encoding, Lists).
 133. Link `libcapnp` and `libkj`, and `libcapnp-rpc` and `libkj-async` with RPC (CP-cxx, Generating Code).
 137. Designed to be safe against malicious input, with the caveat that it has not undergone a formal security review (CP-faq).
-138. A composite list is a tag word followed by its elements laid out inline at one stride, and a struct's layout is fixed by the encoding rather than by a compiler (CP-encoding, Lists; Structs), so a list of structs is a fixed-stride row image any implementation computes identically.
-141. Nesting depth 64 and a 64 MiB traversal limit, both configurable through `capnp::ReaderOptions` (CP-cxx, Security Tips). ✅ and not 🔶: "documented for C++" is not a limitation for this project, because the C++ reference IS the official implementation set — "Implementations in other languages are maintained by respective authors and have not been reviewed by me" (CP-otherlang).
-146. `capnp/schema.h`, `capnp/dynamic.h` and `SchemaLoader`, documented for C++ (CP-cxx, Dynamic Reflection) — the whole official set, as [141] says.
+138. A composite list is a tag word followed by its elements laid out inline at one stride, and a struct's layout is fixed by the encoding and not by a compiler (CP-encoding, Lists; Structs), so a list of structs is a fixed-stride row image any implementation computes identically.
+141. Nesting depth 64 and a 64 MiB traversal limit, both configurable through `capnp::ReaderOptions` (CP-cxx, Security Tips).
+146. `capnp/schema.h`, `capnp/dynamic.h` and `SchemaLoader`, documented for C++ (CP-cxx, Dynamic Reflection).
 147. The writer's schema is always present and the generic API reads any record without code generation (AV-java).
-151. `capnp convert` moves between binary, packed, flat, canonical, text and json, documented in the 0.7 release notes rather than the tool page, and the library JSON is C++ (CP-tool; CP-0.7) — the whole official set, as [141] says.
+151. `capnp convert` moves between binary, packed, flat, canonical, text and json, documented in the 0.7 release notes and not on the tool page, and the library JSON is C++ (CP-tool; CP-0.7).
 152. The JSON encoding is part of the specification; `avro-tools` converts offline (AV-spec, JSON Encoding; AV-java).
-156. The `doc` attribute on records and fields (AV-spec, Record).
-160. The C++ reference is the only reviewed implementation and every other is a third party's; the C implementation is "no longer maintained", one JavaScript implementation is "abandoned", and several are serialization-only (CP-otherlang).
+156. The `doc` attribute is defined on records, fields and enums, and the specification says a schema's `doc` fields are ignored for schema resolution (AV-spec, Record; Enum). 🔶 because the specification says nothing about emitting a `doc` string into generated code, and that is what this row asks.
+160. The C++ reference is the only reviewed implementation and every other is a third party's; the C implementation is "no longer maintained", one JavaScript implementation is "abandoned", and several are serialization-only (CP-otherlang). One official implementation is ❌ on a row asking for parity among several.
 161. Six documented SDKs and a home page claiming more; no per-feature matrix (AV-docs; AV-home).
-163. An omitted type id is derived from the parent scope's id and the declaration's name — "You cannot change the name of a type that doesn't have an explicit ID" — so a rename or a move changes it unless the id is pinned (CP-lang, Unique IDs).
-167. Ordinals never change and removal is not permitted; no reserved mechanism (CP-lang, Evolving Your Protocol).
+163. An omitted type id is derived from the parent scope's id and the declaration's name, "You cannot change the name of a type that doesn't have an explicit ID", so a rename or a move changes it unless the id is pinned (CP-lang, Unique IDs).
+167. A retired number cannot be reused, because every new member's number must be larger than all previous members' and no member's number may change (CP-lang, Evolving Your Protocol). 🔶 because that is the number space growing rather than a reserved mechanism: nothing records that a number was retired or why, and the rules say nothing about retiring one in the first place.
 168. Aliases point forward; nothing marks a name retired (AV-spec, Aliases).
 171. One path: a list of primitives may become a list of structs whose first field is that primitive (CP-lang, Evolving Your Protocol; CP-encoding, Lists).
 172. int to long, float or double; long to float or double; float to double; string and bytes either way (AV-spec, Schema Resolution).
@@ -520,10 +582,9 @@ All pages fetched 2026-09-04.
 | PB-dos | https://protobuf.dev/best-practices/dos-donts/ |
 | PB-features | https://protobuf.dev/editions/features/ |
 | PB-json | https://protobuf.dev/programming-guides/json/ |
-| PB-wkt | https://protobuf.dev/reference/protobuf/google.protobuf/ |
 | PB-arenas | https://protobuf.dev/reference/cpp/arenas/ |
 | PB-techniques | https://protobuf.dev/programming-guides/techniques/ |
-| PB-cpp-gen | https://protobuf.dev/reference/cpp/cpp-generated/ |
+| PB-descriptor | https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto |
 | PB-conformance | https://github.com/protocolbuffers/protobuf/tree/main/conformance |
 | buf | https://buf.build/docs/breaking/ |
 | FB-internals | https://flatbuffers.dev/internals/ |
@@ -543,6 +604,3 @@ All pages fetched 2026-09-04.
 | AV-java | https://avro.apache.org/docs/1.12.0/getting-started-java/ |
 | AV-docs | https://avro.apache.org/docs/1.12.0/ |
 | AV-home | https://avro.apache.org/ |
-
-A fact on this page lives here or in the page it links to, never in both. A
-pull request that changes a fact changes this page in the same pull request.

--- a/docs/COMPETITION.md
+++ b/docs/COMPETITION.md
@@ -203,7 +203,7 @@ producing native types, and comments invisible to the wire.
   output held by one corpus in CI, is the one none of the four makes.
 - **Tools.** `buf breaking`, `flatc --proto`, `capnp convert`. Schema's
   compile-time gate is first-party (`tables.baseline`); an importer from
-  `.proto` or `.fbs` is not declined and not built (#467).
+  `.proto` or `.fbs` is not declined and not built (#477).
 
 ## Where schema is ahead
 

--- a/docs/COMPETITION.md
+++ b/docs/COMPETITION.md
@@ -106,7 +106,7 @@ When #366 closes — full feature parity across all nine languages, each at its
 language's performance floor — the schema column is re-scored from those two,
 not by hand.
 
-Six rows where all five columns agree are listed at the end rather than
+Four rows where all five columns agree are listed at the end rather than
 shown. Editor support and big-endian hosts are not rows, because neither
 could be sourced across five columns.
 
@@ -198,9 +198,8 @@ could be sourced across five columns.
 
 ### Agreed, not shown
 
-All five have enums, a discriminated union, length-prefixed variable-length
-payloads, contiguous scalar arrays, a code generator producing native types,
-and comments invisible to the wire.
+All five have enums, a discriminated union, a code generator producing native
+types, and comments invisible to the wire.
 
 ## Where they are ahead
 

--- a/docs/COMPETITION.md
+++ b/docs/COMPETITION.md
@@ -2,10 +2,12 @@
 
 The standing comparison. It is written to be checked: every cell about a
 competitor is cited to that project's own documentation, every cell about
-schema is cited to a specification section or an issue, and the same test is
-applied to all five columns. Row-level evidence for FlatBuffers and Protocol
-Buffers lives in [COMPARISON-TABLES.md](COMPARISON-TABLES.md); the packet-size
-measurement is [COMPARISON.md](COMPARISON.md); the versioning promises are
+schema is cited to a specification section, one of the repository's registers
+or an issue, and the same test is applied to all five columns. Row-level
+evidence for FlatBuffers and Protocol Buffers lives in
+[COMPARISON-TABLES.md](COMPARISON-TABLES.md) and those cells cite its rows
+rather than repeat them; the packet-size measurement is
+[COMPARISON.md](COMPARISON.md); the versioning promises are
 [VERSIONING.md](VERSIONING.md). This page adds Cap'n Proto and Avro, a
 versioning group, and the summary a reader can take in ninety seconds.
 
@@ -27,7 +29,7 @@ vtable so that a reader touches one field without parsing the buffer. The
 buffer is its own cooked form: little-endian, position-independent, build-
 independent, memory-mappable. The price is that a buffer from an untrusted
 source needs a separate verification pass before it is safe to touch, and the
-verifier ships in three of its thirteen languages.
+verifier does not ship in every one of its thirteen languages.
 
 **Cap'n Proto** reads in place too, and adds an RPC system. Its message is a
 tree by construction, one pointer per object, which is what lets its reader
@@ -45,39 +47,66 @@ users are pipelines where a wrong row is worse than no row.
 bounds decide the bits and both sides ship together, refusing each other on a
 protocol id if they do not match. A `table` produces a tolerant wire where a
 field is identified by the hash of its name, a reader counts what it could
-not understand and never fails on data from another build, and a committed
-baseline refuses at compile time the edits no reader could report. The same
+not understand and never fails on data from another build, and an opt-in
+committed baseline refuses at compile time the edits no reader could report. The same
 declaration cooks to a memory image the runtime opens with a header check and
 a pointer, and lays out as a row block one language writes and another reads
-at frame rate. One language, nine targets, one conformance corpus that every
-target must reproduce byte for byte.
+at frame rate. One language, nine targets, one conformance corpus every target
+is held to, case by case, with what a target cannot yet answer named rather
+than passed over.
 
-When to use theirs, in one line each, as the [FAQ](FAQ.md) already says: a
-service that versions independently of its callers is Protocol Buffers'
-case; in-place access to a large buffer you will not deserialize is
-FlatBuffers' or Cap'n Proto's; a data pipeline where the writer's schema must
-travel with the record is Avro's.
+When to use theirs, in one line each: a service that versions independently
+of its callers is Protocol Buffers' case; in-place access to a large buffer
+you will not deserialize is FlatBuffers' or Cap'n Proto's; a data pipeline
+where the writer's schema must travel with the record is Avro's.
 
 ## How to read the matrix
 
-One test for all five columns. A cell is ✅ when the feature exists in the
-format **and** in all of its official language implementations, 🔶 when it
-exists in the format but only some implementations carry it or it carries a
-material limitation (the footnote says which), ❌ when it is absent or
-declined on the record, and ? when the project's own documentation did not
-settle it and this page will not guess.
+**One test for all five columns, and a row is answered from the wire the row
+is about.** A cell is ✅ when the feature exists in the format **and** in all
+of that project's official language implementations, 🔶 when it exists but
+only some of them carry it or it carries a material limitation the footnote
+names, ❌ when it is absent or declined on the record, and ? when the
+project's own documentation neither makes the claim nor denies it. **Absence
+from a complete list in a project's own documentation** — a scalar table, a
+declaration list, a set of evolution rules — **is ❌, not ?**, and that
+reading is the same in every column.
 
-Applied to schema that test is strict, and the page applies it anyway. The
-packet wire and the compiler are nine languages deep and held there by CI, so
-those rows are ✅. The table wire, the cook, the block and the text form are
-complete in the C++ reference and the compiler and are being carried to the
-other eight languages under one gate, full feature parity at each language's
-performance floor before 3.0.0 (#366). Every 🔶 in the schema column that
-cites #366 is that one gate, and when it closes the column is re-scored from
-CI, not by hand. A reader who wants the per-language state today reads
-[PORTING.md](PORTING.md), the register with a gate behind it.
+**A feature that is decided but not built is ❌**, with the issue in the
+footnote. 🔶 describes something shipped that falls short, never something on
+the way; the four competitors are scored on the format they ship and so is
+this one.
 
-Nine rows where all five columns agree are listed at the end rather than
+**Schema has two wires, and each row says which one answers it.**
+
+- **Declarations and the compiler** are nine languages deep, and a row is ✅
+  when CI holds all nine.
+- **The packet wire** is ✅ when all nine carry the construct.
+- **The table wire** is scored against the repository's own registers:
+  [PORTING.md](PORTING.md), the techniques register, which carries one cited
+  cell per language and an issue behind every gap, and
+  [the conformance contract](../test/conformance/README.md), which says which
+  surfaces and which cases each port answers. The **fixed class** is carried
+  by all nine on the wire, text, cook-open, block-read and descriptor
+  surfaces. The **variable class** (pointers), the **message class**, the
+  **wide scalars** and the runtime cook's **write** side are the C++
+  reference's alone, and the block's **builder** is C++ and C — the eight
+  ports answer ABSENT on twenty-eight wire cases and twenty-six text ones,
+  and that matrix is the completion tracker. So a table-wire row is ✅ only
+  where the register shows all nine, and 🔶 otherwise with the scope named:
+  which class, which languages, which issue.
+- **Where a feature is wire-specific** — schema has it on one wire and not
+  the other — the footnote says which wire, the mark is judged on that wire's
+  backends, and the cell is the honest one for the pair rather than the
+  better wire's.
+
+A reader who wants the per-language state today reads
+[PORTING.md](PORTING.md) and the conformance matrix rather than this page.
+When #366 closes — full feature parity across all nine languages, each at its
+language's performance floor — the schema column is re-scored from those two,
+not by hand.
+
+Six rows where all five columns agree are listed at the end rather than
 shown. Editor support and big-endian hosts are not rows, because neither
 could be sourced across five columns.
 
@@ -89,52 +118,53 @@ could be sourced across five columns.
 |---|---|---|---|---|---|
 | Numeric expressiveness beyond int32/int64/float/double: declared `min`/`max` bounds, sub-32-bit and 128-bit integers, fixed point | ✅ [s1] | ❌ [2] | 🔶 [3] | 🔶 [4] | 🔶 [5] |
 | Compile-time constants usable inside the schema | ✅ [s2] | ❌ [6] | ❌ [6] | ✅ [7] | ❌ [8] |
-| Nested value type with no per-instance framing | ✅ [s3] | ❌ [9] | ✅ [10] | 🔶 [11] | ✅ [12] |
+| Nested value type with no per-instance framing | 🔶 [s3] | ❌ [9] | ✅ [10] | ✅ [11] | ✅ [12] |
 | Bit-flag sets as a declaration | ✅ [s4] | ❌ [13] | ✅ [14] | ❌ [15] | ❌ [8] |
 | Bounded arrays, strings and bytes: a declared capacity in the type | ✅ [s5] | ❌ [16] | 🔶 [17] | ❌ [18] | 🔶 [19] |
 | Enum-keyed arrays (`[E]T`, one slot per variant, by name) | ✅ [s6] | ❌ [20] | ❌ [21] | ❌ [15] | ❌ [8] |
-| Maps | 🔶 [s7] | ✅ [23] | 🔶 [24] | ❌ [25] | 🔶 [26] |
+| Maps | ❌ [s7] | ✅ [23] | 🔶 [24] | ❌ [25] | 🔶 [26] |
 | Shared subtrees: one node referenced by many parents, written once | 🔶 [s8] | ❌ [27] | 🔶 [28] | ❌ [29] | ❌ [30] |
-| Union arms may be any field type, not only a named record | 🔶 [s9] | 🔶 [32] | 🔶 [33] | ✅ [34] | ✅ [35] |
-| Defaults for strings, bytes and composites | 🔶 [s9] | 🔶 [36] | ❌ [37] | ✅ [38] | ✅ [39] |
+| Union arms may be any field type, not only a named record | ❌ [s9] | 🔶 [32] | 🔶 [33] | ✅ [34] | ✅ [35] |
+| Defaults for strings, bytes and composites | ❌ [s9] | 🔶 [36] | ❌ [37] | ✅ [38] | ✅ [39] |
 | Explicit presence on a scalar (set vs unset, distinct from the default) | ✅ [s10] | ✅ [40] | 🔶 [41] | ❌ [42] | 🔶 [43] |
-| Required fields: a read fails if the field is absent | ❌ [s11] | ❌ [45] | ✅ [46] | ❌ [47] | ✅ [48] |
+| Required fields: a read fails if the field is absent | ❌ [s11] | 🔶 [45] | 🔶 [46] | ❌ [47] | ✅ [48] |
 | Dynamic typing: generics, a type-erased `Any`, or schema-less values | ❌ [s12] | ✅ [50] | 🔶 [51] | ✅ [52] | ❌ [53] |
-| User-extensible annotations or custom options | ❌ [s13] | ✅ [55] | ✅ [56] | ✅ [57] | ? |
+| User-extensible annotations or custom options | ❌ [s13] | ✅ [55] | ✅ [56] | ✅ [57] | 🔶 [58] |
 
 ### The wire
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
 | Self-describing: the bytes alone are enough to walk the data | 🔶 [s14] | 🔶 [59] | ❌ [60] | ❌ [61] | ✅ [62] |
-| Values compacted below their declared storage width | ✅ [s15] | ✅ [64] | ❌ [65] | 🔶 [66] | ✅ [67] |
+| Values compacted below their declared storage width | 🔶 [s15] | ✅ [64] | ❌ [65] | 🔶 [66] | ✅ [67] |
 | Scalars aligned inside the buffer | 🔶 [s16] | ❌ [69] | ✅ [70] | ✅ [71] | ❌ [72] |
-| Data above 2 GiB | 🔶 [s17] | ❌ [74] | 🔶 [75] | 🔶 [76] | ✅ [77] |
-| Byte-identical output: one input, one schema, one byte sequence, across implementations | ✅ [s18] | ❌ [79] | ? [80] | 🔶 [81] | 🔶 [82] |
+| Data above 2 GiB | 🔶 [s17] | ❌ [74] | 🔶 [75] | 🔶 [76] | 🔶 [77] |
+| Byte-identical output: one input, one schema, one byte sequence, across implementations | ✅ [s18] | ❌ [79] | ❌ [80] | 🔶 [81] | 🔶 [82] |
 
 ### Evolution
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
-| Add, remove or reorder a field freely | 🔶 [s19] | 🔶 [83] | ❌ [84] | ❌ [85] | 🔶 [86] |
+| Add, remove or reorder a field freely | ✅ [s19] | 🔶 [83] | 🔶 [84] | 🔶 [85] | 🔶 [86] |
 | Rename a field without orphaning stored data | 🔶 [s20] | ✅ [88] | ✅ [89] | ✅ [90] | 🔶 [91] |
 | Change a field's type with no silent misdecode | 🔶 [s21] | ❌ [92] | ❌ [93] | ❌ [94] | ✅ [95] |
-| Change a declared default without reinterpreting stored bytes | 🔶 [s22] | ❌ [97] | ❌ [98] | ❌ [94] | ✅ [99] |
-| Unknown fields preserved through a read-and-rewrite | ❌ [s23] | ✅ [101] | 🔶 [102] | ? | ❌ [103] |
-| A per-event read report rather than pass/fail | 🔶 [s24] | ❌ [104] | ❌ [105] | ❌ [106] | ❌ [107] |
-| An unknown enum value has a defined, non-fatal landing | 🔶 [s25] | 🔶 [108] | 🔶 [109] | ? | 🔶 [110] |
+| Change a declared default without reinterpreting stored bytes | 🔶 [s22] | 🔶 [97] | ❌ [98] | ❌ [94] | ✅ [99] |
+| Unknown fields preserved through a read-and-rewrite | ❌ [s23] | ✅ [101] | 🔶 [102] | 🔶 [100] | ❌ [103] |
+| A per-event read report rather than pass/fail | ✅ [s24] | ❌ [104] | ❌ [105] | ❌ [106] | ❌ [107] |
+| An unknown enum value has a defined, non-fatal landing | ✅ [s25] | 🔶 [108] | 🔶 [109] | ? | 🔶 [110] |
 
 ### Runtime forms, allocation, performance
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
-| Read one field without parsing the whole buffer | 🔶 [s26] | ❌ [112] | ✅ [113] | ✅ [114] | ❌ [115] |
-| No allocation on read | ✅ [s27] | ❌ [116] | 🔶 [117] | ✅ [118] | ❌ [115] |
-| Arena or single-buffer allocation on write, never per node | 🔶 [s28] | 🔶 [119] | 🔶 [120] | ✅ [121] | ? |
-| Exact serialized size known before writing | ✅ [s29] | ✅ [122] | ❌ [123] | ? | ? |
-| Mutate a serialized buffer in place | ❌ [s30] | ❌ [125] | 🔶 [126] | ✅ [127] | ? |
-| A same-build fast form: an O(1)-open cooked file and a fixed-stride cross-language row block | 🔶 [s31] | ❌ [128] | 🔶 [129] | 🔶 [130] | ❌ [115] |
-| Generated code with no library runtime to link | 🔶 [s32] | ❌ [131] | ✅ [132] | ❌ [133] | ? |
+| Read one field without parsing the whole buffer | ✅ [s26] | ❌ [112] | ✅ [113] | ✅ [114] | ❌ [115] |
+| No allocation on read | 🔶 [s27] | ❌ [116] | 🔶 [117] | ✅ [118] | ❌ [115] |
+| Arena or single-buffer allocation on write, never per node | 🔶 [s28] | 🔶 [119] | ✅ [120] | ✅ [121] | ? |
+| Exact serialized size known before writing | 🔶 [s29] | ✅ [122] | ❌ [123] | ? | ? |
+| Mutate a serialized buffer in place | ❌ [s30] | ❌ [125] | 🔶 [126] | ❌ [127] | ? |
+| Fixed-stride rows in one contiguous image, written by one language and read by another | 🔶 [s31] | ❌ [128] | ✅ [134] | ✅ [138] | ❌ [115] |
+| A layout assertion in generated code on both sides, refusing a producer that disagrees | 🔶 [s31b] | ❌ [128] | ❌ [129] | ❌ [130] | ❌ [115] |
+| Generated code with no library runtime to link | 🔶 [s32] | ❌ [131] | 🔶 [132] | ❌ [133] | ? |
 
 ### Validation of untrusted data
 
@@ -142,74 +172,68 @@ could be sourced across five columns.
 |---|---|---|---|---|---|
 | Untrusted bytes are safe with no separate verification pass | 🔶 [s33] | ✅ [135] | ❌ [136] | ✅ [137] | ? |
 | Value ranges enforced from the schema | ✅ [s1] | ❌ [2] | ❌ [3] | ❌ [4] | ❌ [5] |
-| Depth and resource bounds against a hostile message | 🔶 [s34] | 🔶 [139] | 🔶 [140] | 🔶 [141] | ? |
-| One cross-language conformance corpus that includes hostile cases | ✅ [s35] | 🔶 [142] | ? | ? | ? |
+| Depth and resource bounds against a hostile message | 🔶 [s34] | 🔶 [139] | 🔶 [140] | ✅ [141] | ? |
+| One cross-language conformance corpus that includes hostile cases | ✅ [s35] | ? [142] | ? | ? | ? |
 
 ### Reflection, text, tooling
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
-| Runtime reflection with no schema file present at runtime | 🔶 [s36] | ✅ [144] | ❌ [145] | 🔶 [146] | ✅ [147] |
-| JSON or text form, in and out | 🔶 [s37] | ✅ [149] | 🔶 [150] | 🔶 [151] | ✅ [152] |
-| Doc comments carried into generated code | ❌ [s38] | ✅ [154] | ✅ [155] | ? | ✅ [156] |
+| Runtime reflection with no schema file present at runtime | 🔶 [s36] | ✅ [144] | 🔶 [145] | ✅ [146] | ✅ [147] |
+| JSON or text form, in and out | ✅ [s37] | 🔶 [149] | 🔶 [150] | ✅ [151] | ✅ [152] |
+| Doc comments carried into generated code | ❌ [s38] | ? [154] | ✅ [155] | ? | ✅ [156] |
 | Official language implementations at feature parity | 🔶 [s39] | 🔶 [158] | ❌ [159] | ❌ [160] | 🔶 [161] |
 
 ### Versioning
 
 | feature | schema | Protocol Buffers | FlatBuffers | Cap'n Proto | Avro |
 |---|---|---|---|---|---|
-| Rename an enum variant, union arm or named type without orphaning stored data | 🔶 [s40] | ✅ [88] | ✅ [89] | 🔶 [163] | 🔶 [91] |
-| A retired name or number cannot be silently reused | 🔶 [s41] | ✅ [165] | 🔶 [166] | 🔶 [167] | ❌ [168] |
+| Rename an enum variant, union arm or named type without orphaning stored data | ❌ [s40] | ✅ [88] | ✅ [89] | 🔶 [163] | 🔶 [91] |
+| A retired name or number cannot be silently reused | ❌ [s41] | ✅ [165] | 🔶 [166] | 🔶 [167] | ❌ [168] |
 | Defined widening or promotion of a field's type on read | ❌ [s42] | 🔶 [170] | 🔶 [93] | 🔶 [171] | ✅ [172] |
-| The writer's schema is recoverable at read time | ❌ [s43] | ❌ [174] | 🔶 [175] | ❌ [61] | ✅ [176] |
+| The writer's schema is recoverable at read time | ❌ [s43] | 🔶 [174] | 🔶 [175] | ❌ [61] | ✅ [176] |
 | A revision marker in the bytes says which format version wrote them | 🔶 [s44] | ❌ [178] | 🔶 [179] | ❌ [180] | ✅ [181] |
-| A first-party compile-time gate on breaking edits | ✅ [s45] | ❌ [183] | ✅ [184] | ❌ [185] | ? |
+| A first-party compile-time gate on breaking edits | 🔶 [s45] | ❌ [183] | ✅ [184] | ❌ [185] | ? |
 | Wire bytes promised stable across releases of the compiler | 🔶 [s46] | ❌ [79] | ? | 🔶 [187] | 🔶 [82] |
 
 ### Agreed, not shown
 
-All five have enums, a discriminated union, recursive declarations,
-multi-file schemas with imports, length-prefixed variable-length payloads,
-contiguous scalar arrays, little-endian fixed-width scalars, a code generator
-producing native types, and comments invisible to the wire.
+All five have enums, a discriminated union, length-prefixed variable-length
+payloads, contiguous scalar arrays, a code generator producing native types,
+and comments invisible to the wire.
 
-## Where they are ahead, and what happens about it
+## Where they are ahead
 
-- **Renames beyond fields.** Protocol Buffers, FlatBuffers and Cap'n Proto
-  rename a variant or a type freely because the wire carries numbers; schema's
-  `was` is a field attribute today. Tables get `was` under #396 and variants
-  and arms under #442, both before 3.0.0.
+- **Renames beyond fields.** Protocol Buffers and FlatBuffers rename a
+  variant or a named type freely because their wires carry numbers rather
+  than names, and Cap'n Proto does where the type pins an explicit id;
+  schema's `was` is a field attribute today [s40].
 - **Retired names.** Protocol Buffers' `reserved` is the right mechanism and
-  schema lacks it: a removed name can be re-added years later and decode old
-  bytes under a new meaning. The retired-names ledger in the baseline is
-  #441, before 3.0.0.
-- **Default changes.** Avro elides nothing, so a changed default cannot
-  reinterpret stored bytes. Schema elides a field equal to its default, which
-  is why its baseline refuses a default change at compile time; that is a
-  guard where Avro has a guarantee, and the guard is opt-in until the nudge
-  (#445) lands.
+  schema lacks it, so a removed name can be re-added years later and decode
+  old bytes under a new meaning [s41].
+- **Default changes.** Avro writes every field of the writer's schema, so a
+  changed default cannot reinterpret stored bytes, where schema elides a
+  field equal to its default and answers the hazard with a guard rather than
+  a guarantee [s22].
 - **Unknown fields through a rewrite.** Protocol Buffers keeps them; schema
-  drops them by decision (everything in schema has a schema) and counts them,
-  and the versioning page names the one rule a studio must write for it:
-  never overwrite a file whose read report is not silent.
+  drops them by decision — everything in schema has a schema — and counts
+  what it dropped [s23].
 - **Promotion.** Avro promotes `int` to `long` on read; schema reads a
-  changed kind as the default and counts a kind mismatch. Declined, with the
-  reason below.
-- **Doc comments** reach generated code in three of the four; in schema they
-  are deferred with the design pinned (SPEC §4.1).
-- **Ecosystems.** Protocol Buffers has ten first-party languages and fifty-odd
-  third-party ones; FlatBuffers thirteen; Avro publishes six SDKs and claims
-  more. Schema has nine, and the claim it makes about them, byte-identical
-  output held by one corpus in CI, is the one none of the four makes.
-- **Tools.** `buf breaking`, `flatc --proto`, `capnp convert`. Schema's
-  compile-time gate is first-party (`tables.baseline`); an importer from
-  `.proto` or `.fbs` is not declined and not built (#477).
+  changed kind as the default and counts a kind mismatch [s42].
+- **Doc comments.** FlatBuffers and Avro both carry documentation from the
+  schema, and Protocol Buffers' and Cap'n Proto's own pages settle it neither
+  way; schema's are deferred [s38].
+- **Ecosystems.** Protocol Buffers has ten first-party languages and
+  fifty-odd third-party ones, FlatBuffers thirteen of uneven coverage, and
+  Avro six published SDKs; schema has nine [s39].
+- **Tools.** `buf breaking`, `flatc --proto` and `capnp convert` exist and
+  schema's own gate is first-party rather than an ecosystem [s45].
 
 ## Where schema is ahead
 
 - **Bounds are bits.** `health int32 | min = 0, max = 1000` is ten bits on
-  the packet wire; 28 bytes for a packet the others encode in 52, 56 and 72
-  ([COMPARISON.md](COMPARISON.md)). None of the four can infer a range it was
+  the packet wire, and the same gameplay packet measured against all four is
+  [COMPARISON.md](COMPARISON.md). None of the four can infer a range it was
   never told.
 - **One language for all five kinds of data.** Packets, backend messages,
   saves, render blocks and cooked assets from one declaration, so there is no
@@ -219,10 +243,11 @@ producing native types, and comments invisible to the wire.
   and never fails on data from another build. The others return a boolean or
   throw.
 - **The silent class is enumerated and refused.** The edits no reader can
-  report, a changed default, a moved fixed-point scale, an enum respelled as
-  its integer, are refused at compile time by a committed baseline with a
-  reasoned, dated history. The nearest equivalents, `flatc --conform` and
-  `buf breaking`, check structure, not meaning.
+  report — a changed default, a moved flags variant, a referent respelled as
+  something the kinds cannot tell apart, a moved fixed-point scale — are
+  refused at compile time by a committed baseline with a reasoned, dated
+  history. The nearest equivalents, `flatc --conform` and `buf breaking`,
+  check structure, not meaning.
 - **Shared subtrees on the wire.** A node written once and referenced many
   times, which none of the four does by declaration. Cap'n Proto forbids it
   to bound traversal; schema's flat node table materializes each node once
@@ -236,270 +261,250 @@ producing native types, and comments invisible to the wire.
 
 | feature | who has it | why schema declines |
 |---|---|---|
-| Required fields | FlatBuffers, Avro in effect | Every field optional with a declared default is the ground rule. Protocol Buffers removed `required` and says why; schema never had it. |
+| Required fields | FlatBuffers, Avro in effect, Protocol Buffers as a legacy carry-over | Every field optional with a declared default is the ground rule. Protocol Buffers removed `required` and says why; schema never had it. |
 | `Any`, generics, schema-less values | Protocol Buffers, Cap'n Proto, FlexBuffers | The typed bag is a union whose arms are tables. A type-erased value is a type the compiler cannot check. |
-| Custom annotations | Protocol Buffers, FlatBuffers, Cap'n Proto | The attribute vocabulary is closed and an unknown attribute is a compile error; type tags are the claiming mechanism. |
+| Custom annotations | Protocol Buffers, FlatBuffers, Cap'n Proto, Avro as tolerated metadata | The attribute vocabulary is closed and an unknown attribute is a compile error; type tags are the claiming mechanism. |
 | Unknown fields preserved through a rewrite | Protocol Buffers | Everything in schema has a schema. The old file kept whole is the preservation, and the never-clobber rule is the policy. |
 | A widening path on read | Avro, Protocol Buffers' pairs | A whitelist of compatible pairs silently misdecodes everything outside it. A changed kind reads as the default and is counted; the pattern is a new field beside the old one and a load shim. |
-| The writer's schema travelling with the data | Avro | One schema per build, identified by the protocol id and the build version, neither of which rides in a file. A tolerant wire that skips by kind needs no schema to walk, and a file that must say what wrote it puts a `format` field on its root table. |
+| The writer's schema traveling with the data | Avro | One schema per build, identified by the protocol id and the build version, neither of which rides in a file. A tolerant wire that skips by kind needs no schema to walk, and a file that must say what wrote it puts a `format` field on its root table. |
 | A canonical form of the data | Cap'n Proto | A load followed by a save through the reader's own schema is the canonical form: elision, order and duplicates are all resolved by it. Byte identity across schema's own writers is held by goldens. |
-| Mutating a serialized buffer in place | Cap'n Proto, FlatBuffers | A cook is immutable and regenerated by the cache; the block form is the every-frame mutable answer. |
-
-## Versioning, mechanism by mechanism
-
-Each competitor defends against a failure with a mechanism. The question for
-each is whether schema covers the same failure, declines it with a reason, or
-has a gap.
-
-**Protocol Buffers: field numbers, `reserved`, unknown-field preservation,
-open enums.** Numbers identify a field for life; `reserved` stops a retired
-number or name from being reused; unknown fields survive a rewrite; an open
-enum keeps a value it does not know. Schema covers identity with the name
-hash and `was`, and covers the unknown-value case with `None` counted. The
-retired-name ledger is the gap (#441). Unknown-field preservation is declined.
-
-**FlatBuffers: append-only tables, `deprecated` never removed, `--conform`,
-`file_identifier`.** Position is identity, so a field is never removed and
-new ones go at the end; `flatc --conform` refuses an edit that breaks the
-rule; a four-character identifier says which schema wrote a buffer. Schema
-covers the first two with name identity, which makes removal and reorder
-free, and the gate with the baseline. The identifier is covered by the
-`format` field pattern and, for the format's own revision, by the form byte
-(#435).
-
-**Cap'n Proto: ordinals, explicit type ids, the list-of-structs upgrade,
-canonicalization.** Ordinals never change; a renamed or moved type pins its
-id explicitly or silently gets a new one; one promotion path exists; a
-canonical form makes messages comparable. Schema covers ordinals with names,
-covers the type-id case with table `was` (#396), declines promotion, and
-answers canonicalization with load-then-save.
-
-**Avro: the writer's schema with the data, resolution, aliases, promotion,
-defaults that never reinterpret.** The reader always has the writer's schema
-and resolves against it; aliases carry renames; promotion widens on read; no
-elision means no default hazard. Schema declines carrying the schema, covers
-resolution with the tolerant read, covers aliases with `was` (fields today,
-every vocabulary before 3.0.0), declines promotion, and guards the default
-hazard with the baseline instead of a guarantee.
-
-The gaps, all before 3.0.0: the retired-names ledger (#441), `was` for
-variants and arms (#442), the form byte (#435). The one row where a
-competitor's guarantee is strictly stronger than schema's guard is Avro's on
-defaults, and the page says so above.
+| Mutating a serialized buffer in place | FlatBuffers | A cook is immutable and regenerated by the cache; the block form is the every-frame mutable answer. |
 
 ## Footnotes
 
-Schema cells cite the specifications and issues; competitor cells cite the
-project's own documentation by the short names in the source list at the end,
-with the section that establishes the claim.
+Schema cells cite a specification section, one of the repository's registers
+([PORTING.md](PORTING.md), [the conformance contract](../test/conformance/README.md))
+or an issue. **FlatBuffers and Protocol Buffers cells cite the row that
+carries the evidence in [COMPARISON-TABLES.md](COMPARISON-TABLES.md)** rather
+than restating it; a footnote stays here only where that page does not carry
+the fact, and it says so. Cap'n Proto and Avro cells cite the project's own
+documentation by the short names in the source list at the end, with the
+section that establishes the claim.
 
 **Schema**
 
-- s1. `| min, max` is part of the type; the type wire sizes bits from the bound and the table wire clamps and counts on load (SPEC §4.3, SPEC-TABLES §4). `fixed(I,F)`, `ufixed(I,F)`, int128 and uint128 ride under table-wire kinds of their own (SPEC-TABLES §3).
-- s2. `const`, folded at compile time and usable in bounds, defaults and capacities (SPEC §4.4).
-- s3. A `type` inside a `type`, or a fixed table inside a table, is inline storage with no framing on the packet wire; on the table wire a nested table is one length-framed node (SPEC-TABLES §3).
+- s1. `| min, max` is part of the type: the packet wire sizes the field's bits from the bound and refuses a value outside it, and the table wire clamps and counts `clamped` on load (SPEC §4.3, SPEC-TABLES §4). `fixed(I,F)`, `ufixed(I,F)`, `int128` and `uint128` ride on the packet wire in all nine targets, on the cross-language wire gate like any other unit (`examples128/Ludicrous.schema`, SPEC §4.3), and under table-wire kinds 18–29 (SPEC-TABLES §3), where the wide-scalar cases are the reference's alone today (#366).
+- s2. `const`, folded at compile time and usable in bounds, defaults and capacities (SPEC §4.2 — the `Const` production, and "Constants and enums are exported"; §4.4 is `if`, not constants).
+- s3. **Packet wire, not the table wire.** A `type` nested inside a `type` is inline storage with no framing at all (SPEC §4.3). On the table wire a nested table is kind `13` — a `u32` length, then the body — and a fixed table nested in a table rides the same way (SPEC-TABLES §3), which is the framing Protocol Buffers is marked ❌ [9] for. Two wires, two answers.
 - s4. `flags` declarations, one bit per variant (SPEC §4.2).
-- s5. `[N]T`, `[..N]T`, `string(N)`, `bytes(N)`: the capacity is in the type and the packet wire sizes the count from it (SPEC §4.3).
-- s6. `[E]T`, a slot per variant addressed by name, with a keyed wire kind (SPEC-TABLES §2.4, §3.2).
-- s7. Designed for tables after 3.0.0; a map makes the table variable (SPEC-TABLES §2.8, #380).
-- s8. A pointer field `*T` names a node once in a flat node table and every reference is an index (SPEC-TABLES §3.1). C++ reference and the compiler today; the other backends under #366. The amplification bound on an untrusted read is #466.
-- s9. Union arms of any field type and defaults for string, bytes and flags are decided and landing (#396).
-- s10. `?T` on both wires; on the packet wire it is one presence bit (SPEC §4.2).
+- s5. `[N]T`, `[..N]T`, `string(N)`, `bytes(N)`: the capacity is in the type, and the packet wire sizes the count from it (SPEC §4.3).
+- s6. `[E]T`, a slot per variant addressed by name, under its own wire kind `16` (SPEC-TABLES §2.4, §3.2). The declaration and the keyed kind are fixed class and carried by all nine — the corpus's keyed instances are answered by every registered leg — while the accessor's both-ends refusal is untested in Java, Dart and Elixir and unchecked past `Max` in C (PORTING M5, #407, #377).
+- s7. Decided and not built. A map makes the table variable and lands after 3.0.0 (SPEC-TABLES §2.8, #380).
+- s8. A pointer field `*T` names a node once in a flat node table and every reference is an index (SPEC-TABLES §3.1). The variable class is the C++ reference's alone on the wire: PORTING M6 is ✅ for cpp and ❌ #349 in the other eight columns, and the eight ports answer ABSENT on the corpus's four pointered instances. The amplification bound on an untrusted read is #466.
+- s9. Decided and not built. Union arms of any field type, and defaults for `string`, `bytes` and `flags`, are #396; SPEC §4.2's `Default` production admits a constant expression or an identifier and nothing else.
+- s10. **Table wire only.** `?T` is the value plus a generated presence bool, so the holder stays fixed size (SPEC-TABLES §2.3). SPEC §4.2's grammar admits `?` in TABLE BODIES ONLY and a `type` body refuses one by name, so the packet wire has no presence at all — there is no presence bit there. On the table backends `?T` is fixed class and all nine carry it (`chain_optional` and `chain_optional_empty` in the conformance corpus); `?[N]T` is one of the message-class cases the reference answers alone (PORTING M16, #392).
 - s11. Declined: every field optional with a declared default (SPEC-TABLES §4).
 - s12. Declined on #396 and in COMPARISON-TABLES.md; the typed bag is a union whose arms are tables.
 - s13. Declined: the attribute vocabulary is closed and an unknown attribute is a compile error (SPEC §4.2).
-- s14. Kinds and lengths ride on the tolerant wire, so any reader skips anything it does not know; names ride as hashes, not text, so the bytes cannot be rendered with names without the schema (SPEC-TABLES §3). Table wire, #366.
-- s15. The packet wire sizes each field from its bounds (SPEC §4.3); the table wire deliberately does not compact.
-- s16. No alignment on the tolerant wire; the cook and the block are the aligned forms (SPEC-TABLES §7.2, §19.3). #366.
-- s17. Eight-byte region references and 64-bit cook part lengths, no aggregate ceiling (SPEC-TABLES §6.3, §7.1); the table wire's lengths go 64-bit under #435. Table forms, #366.
-- s18. The packet wire: one standard, nine languages, pinned goldens in CI, `Measure` equals `Save` (SPEC §3, VERSIONING.md). The table wire has the same rule in the C++ reference and the compiler, #366.
-- s19. Name identity: add anywhere, remove, reorder, all reported by the read (SPEC-TABLES §4). #366.
-- s20. `| was = "old"` keeps the wire id; a bare rename is a removal and an addition the compiler cannot see, and the baseline is being taught to warn on the pair (#444). Fields today; every vocabulary before 3.0.0 (#396, #442). #366.
-- s21. A changed kind reads as the default and is counted `kind_mismatch`; never truncated, never misread (SPEC-TABLES §4). #366.
-- s22. Silent on the wire, refused at compile time by a committed baseline (SPEC-TABLES §18); 🔶 because the baseline is opt-in until #445.
-- s23. Declined by decision; the read report counts what a rewrite would drop (VERSIONING.md, the never-clobber rule).
-- s24. Four counters and a `malformed` flag on every load (SPEC-TABLES §4). #366.
-- s25. An unknown variant reads `None` and is counted (SPEC-TABLES §4). #366.
-- s26. The cook: `Open` is a header match and a pointer (SPEC-TABLES §7). C++ reference and the compiler; #366.
-- s27. The packet wire reads into the caller's struct with no allocation, in every language, held by an allocation gate (PORTING.md I1, I12). The table wire's fixed class likewise; the variable class reads through a region the caller sizes with `LoadMeasure` (SPEC-TABLES §6.5).
-- s28. The variable class builds through an arena (SPEC-TABLES §9). C++ reference; #366.
-- s29. `Measure` before `Save`, both wires, equal by test (SPEC-TABLES §9).
-- s30. Declined: a cook is immutable and regenerated by the cache; the block form is the mutable answer (SPEC-TABLES §7, §19).
-- s31. The cook (SPEC-TABLES §7) and the block (§19), with the block's two-sided layout assertion at open. C++ writes and C# reads today; #366.
-- s32. Six of the nine targets link a small `serialize` runtime for the packet wire; Dart, Java and Elixir generate self-contained output (VERSIONING.md).
-- s33. The tolerant read is the validator: every length bounds-checked, every count against its body, ranges clamped, a bad sub-table stopping only itself (SPEC-TABLES §4, §6.5). The independent-oracle fuzzer that proves it is landing for the C++ reference (#429) and owed to every port (#391).
-- s34. By-value depth is fixed by the schema and the pointer graph is flat, so a long chain is not a recursion (SPEC-TABLES §3.1); the stated bound on materialization is #466. #366.
-- s35. One corpus, every language, hostile rows included; a port answers ABSENT per case where it lacks a construct rather than passing by omission (test/conformance, #383).
-- s36. Descriptors in every table's generated header, no schema files, no RTTI (SPEC-TABLES §8.1). #366.
-- s37. JSON in and out by one walk, `| json = "key"`, the read report, `&node` for a shared node (SPEC-TABLES §16). #366.
-- s38. Deferred with the design pinned (SPEC §4.1).
-- s39. Nine languages byte-identical on the packet wire in CI; tables carried under #366, which is the declared 3.0.0 gate and not the present state.
-- s40. Table `was` (#396) and variant and arm `was` (#442), before 3.0.0.
-- s41. The retired-names ledger in the baseline (#441), before 3.0.0.
+- s14. The packet wire is not self-describing, by decision — a stated non-goal, with all knowledge in the generated code on both ends (SPEC §1). On the table wire kinds and lengths ride, so any reader skips anything it does not know (SPEC-TABLES §3); but a name rides as a 16-bit hash rather than as text (§5), so the bytes cannot be rendered with names without the schema.
+- s15. **Packet wire, not the table wire.** The packet wire sizes each field from its bounds (SPEC §4.3). The table wire deliberately does not compact — a scalar rides at its storage width and nothing is aligned or padded (SPEC-TABLES §3) — which is what FlatBuffers is marked ❌ [65] for.
+- s16. No alignment and no padding on the tolerant wire (SPEC-TABLES §3). The cook (§7.2) and the block (§19.3) are the aligned forms; their `Open` is carried by all nine (PORTING M8, M7) and the block's builder by the C++ and C backends (§19.1).
+- s17. Table wire. Eight-byte region references and 64-bit cook part lengths, with no aggregate ceiling (SPEC-TABLES §6.3, §7.1). The tolerant wire's own lengths and counts are `u32` today — a node body is capped at 4 GiB and refused at save (§2.1, §3) — and go uniformly 64-bit under #435.
+- s18. One standard, one corpus. The packet wire is bit-for-bit compatible across nine runtimes, pinned in CI with shared golden bytes, and a compiler change that breaks a wire golden is a stop-the-line event (SPEC §1, §3.2, §7.2). On the table wire the `wire` surface byte-compares every registered leg's `Save` against one golden, and `measure == save at exact capacity` is a hard invariant held by a mandatory battery (SPEC-TABLES §9). Constructs a leg does not carry are answered ABSENT per case rather than passed over, so no cell claims agreement it did not test.
+- s19. Table wire. Name identity: add anywhere, remove, reorder, each reported by the read rather than refused (SPEC-TABLES §4, §5). Carried by all nine — the `wire` and `report` surfaces over the fixed class are answered by every registered leg.
+- s20. `| was = "old"` keeps the wire id; a bare rename is a removal and an addition the compiler cannot see, and the baseline is being taught to warn on the pair (#444). Fields today; every other vocabulary is #396 and #442, which is why the versioning group's first row is ❌ rather than this one.
+- s21. A changed kind reads as the default and is counted `kind_mismatch` (SPEC-TABLES §4), in all nine over the fixed class. It is not the whole story, and SPEC-TABLES §4.1 item 3 says so: an enum-typed field respelled as its raw `uint16` rides under kind `7` either way, so the stored value is read as a variant hash and lands on `None` — or on a real variant — with no counter to fire. That respelling is guarded only by the opt-in baseline (§18) until #435 gives an enum a kind of its own.
+- s22. Silent on the wire, refused at compile time by a committed baseline (SPEC-TABLES §4.1, §18.2). 🔶 because the baseline is opt-in by design — "no file, no check" (§18.1) — and #445 adds a one-line notice to a unit that has none rather than a block, so the limitation does not close when it lands.
+- s23. Declined by decision; the read report counts what a rewrite would drop, and the one rule a studio writes for it is never to overwrite a file whose read report is not silent (VERSIONING.md).
+- s24. Four counters and a `malformed` flag on every load (SPEC-TABLES §4). Carried by all nine: the `report` surface is answered by every registered leg, and each leg with a text form carries its own walk negative control.
+- s25. An unknown variant reads `None` and is counted `unknown` (SPEC-TABLES §4, §5), in all nine on the `report` surface.
+- s26. The cook: `Open` is a header match and a pointer, with nothing per node (SPEC-TABLES §7). Carried by all nine — PORTING M8 is ✅ in every column, and a gigabyte cook opens in the same time as a small one. The cook's WRITE side is the C++ reference's and the tool's; every other language's writer is a named follow-on (§7.6, §15).
+- s27. The read path fills caller-owned storage and the reader is a cursor over the caller's buffer, never a sub-view (SPEC-TABLES §6.5, PORTING M1). 🔶 for three named reasons. Elixir cannot make the claim at all — a decoded BEAM term is an allocation and no buffer is caller-owned, so the leg pins the per-case count instead (M1's Elixir cell). The independent allocation gate does not yet run on the C++ or the C# read path (PORTING I1, #412). And a union inside a table allocates per arm in a backend whose language has no native union, the one carve-out §6.5 states.
+- s28. The fixed class writes into the caller's buffer and allocates nothing, in any backend. The variable class builds through an arena in bulk, thread-local, never per node (SPEC-TABLES §6.4, §9), and that arena is the C++ reference's (PORTING M6, #349); the block takes a caller-provided allocator once at build and never on the fill path (§19.1). The union carve-out (§6.5) is the one per-node allocation, and it belongs to the language rather than to the format.
+- s29. **Table wire, not the packet wire.** `Measure` computes a value's exact encoded size writing nothing, and `measure == save at exact capacity` is a hard invariant held by a mandatory battery across the corpus (SPEC-TABLES §9); all nine backends generate it. The packet wire has no exact measure and says so in terms — "There is no generated measure function" — `MaxBits`/`MaxBytes` are conservative worst-case constants for sizing a buffer, and `Write` returns the actual size afterwards (SPEC §6.1).
+- s30. Declined: a cook is immutable and regenerated by the cache, and the block form is the mutable answer (SPEC-TABLES §7, §19).
+- s31. The block form: one contiguous extent of rows at a compiler-computed stride, every reference block-relative, so it relocates by `memcpy` with no fix-up (SPEC-TABLES §19, §19.1). Its READ half is generated by all nine backends, and PORTING M7 carries eight of them with Elixir's per-row allocation as #409. Its BUILDER is emitted by the C++ and C backends alone (§19.1).
+- s31b. Every cooked record and every block projection carries a compile-time assertion of size, alignment and every field offset against the numbers the compiler computed, each array's pitch constant included — two independent derivations held against each other, so a producer that disagrees is refused before a row is read (SPEC-TABLES §19.3). Seven backends carry it; Dart and Elixir have no second layout model to check against and hold the contract with the build version instead (PORTING M11).
+- s32. Six of the nine targets link a small `serialize` runtime for the packet wire; Dart, Java and Elixir generate self-contained output (VERSIONING.md). The C++ tables dialect takes no STL and routes every C-library call through a hook the program can define (SPEC-TABLES §13.9).
+- s33. The tolerant read is the validator: every length bounds-checked against its body, every count against the body, ranges clamped, a bad sub-table stopping only itself, and `LoadMeasure` letting the caller refuse a region size before anything is allocated (SPEC-TABLES §4, §6.5). The independent-oracle fuzzer that would prove it is landing for the C++ reference (#429) and owed to every port (#391), which is what holds this at 🔶.
+- s34. By-value depth is fixed by the schema and the pointer graph is flat, so a long chain is not a recursion (SPEC-TABLES §3.1). Until #466 states and tests the amplification bound, the bound is the caller's own refusal of `LoadMeasure`'s answer (§6.5) rather than a number the format states.
+- s35. One corpus, every registered leg, hostile rows included — two forgery batteries, the cook battery's 111 rows and the `json-hostile` trees, with seven negative controls behind the harness (test/conformance). A leg that lacks a construct answers ABSENT per case rather than passing by omission: the eight ports read `+28a` on the wire surfaces and `+26a` on the text surfaces today, and the matrix is the completion tracker (#383, #349).
+- s36. Static descriptors in every table's generated header — name, kind, id, offset, bounds, guards, nesting — with no schema file present and no RTTI (SPEC-TABLES §8.1), carried by all nine (PORTING M13; C# holds them in a cache rather than as constants, #411). The type view and the unit registry (§8.2, §8.3) are C++ and C# only, and every other backend emits no view file (§15).
+- s37. JSON in and out by one generic walk over the descriptors, `| json = "key"`, the read report on the way in, `&node` for a shared node (SPEC-TABLES §16). Carried by all nine (PORTING M9), with the text surfaces answered per case and a per-backend walk negative control behind each.
+- s38. Deferred with the design pinned (SPEC §4.1); doc strings in the view are a named follow-on (SPEC-TABLES §15).
+- s39. Nine languages byte-identical on the packet wire in CI (SPEC §1). Tables are carried under #366 — the declared 3.0.0 gate, full feature parity across all nine languages at each language's performance floor — and PORTING.md, not this page, is the present state.
+- s40. Decided and not built. Table `was` is #396 and variant and arm `was` is #442, both before 3.0.0; `was` is a field attribute today (SPEC-TABLES §5).
+- s41. Decided and not built. The retired-names ledger in the baseline is #441, before 3.0.0; nothing today marks a removed name retired, so it can be re-added and decode old bytes under a new meaning.
 - s42. Declined, with the reason in the table above.
-- s43. Declined, with the reason in the table above.
-- s44. The form byte at the head of every table-wire file (#435), before 3.0.0; the cook and the block already refuse on the build version.
-- s45. `tables.baseline` with `--update --reason` (SPEC-TABLES §18) for the table wire; for the packet wire the protocol id and the pinned goldens.
-- s46. The promise is on VERSIONING.md and the goldens hold it across a schema's edits; across compiler releases it needs the codec-law line and the differential gate (#463).
+- s43. Declined, with the reason in the table above: one schema per build, identified by the protocol id and the build version, neither of which rides in a file, and a file that must say what wrote it puts a `format` field on its root table.
+- s44. The cook's and the block's prologues carry the build version and refuse a file another build wrote (SPEC-TABLES §7.1, §19.1, §20), and all nine read them (PORTING M8, M7). The tolerant wire carries no marker of its own: the form byte at the head of every table-wire file is #435, before 3.0.0. It is also the answer to FlatBuffers' `file_identifier` [179] — the schema's own revision is a `format` field on the root table, the format's own revision is the form byte.
+- s45. `tables.baseline` with `--update --reason` and a dated history (SPEC-TABLES §18), first-party where `buf breaking` is not. 🔶 for the same reason as [s22]: the file is opt-in and no file means no check (§18.1). The packet wire has no compile-time gate at all — the protocol id refuses at connect time, which is a runtime refusal (SPEC §3) — and an importer from `.proto` or `.fbs` is neither declined nor built (#477).
+- s46. The promise is on VERSIONING.md, and SPEC §6.1 states it as a contract: for a given schema and target, equal post-quantization values produce identical bytes, deterministically, across compiler versions, held by the golden-wire gate across a schema's edits. Across compiler RELEASES it needs the codec-law line and an N-1 to N differential gate (#463).
 
-**Protocol Buffers, FlatBuffers, Cap'n Proto, Avro**
+**Protocol Buffers and FlatBuffers**
 
-2. Protocol Buffers has int32/int64/uint32/uint64/sint/fixed/sfixed/float/double/bool and no sub-32-bit integer, 128-bit integer, fixed point or declared range (PB-proto3, Scalar Value Types).
-3. FlatBuffers has `byte` through `ulong`, so sub-32-bit yes; no 128-bit, no fixed point, no range (FB-schema, Tables).
-4. Cap'n Proto has Int8 to Int64 and the unsigned set; no 128-bit, no fixed point, no range (CP-lang, Built-in Types).
+Row-level evidence for these two lives in
+[COMPARISON-TABLES.md](COMPARISON-TABLES.md), and a citation below names its
+section and its row rather than repeating the quote. Where a mark here rests
+on a fact that page does not carry, the footnote says so and cites the
+project's own page directly.
+
+2. COMPARISON-TABLES.md, Declarations and the schema language — "Scalar types", "Declared numeric bounds", "Fixed point".
+3. COMPARISON-TABLES.md, Declarations and the schema language — "Scalar types", "Declared numeric bounds", "Fixed point"; sub-32-bit yes, no 128-bit, no fixed point, no declared range.
+6. COMPARISON-TABLES.md, Declarations and the schema language — "Constants" ("—" in both columns).
+9. COMPARISON-TABLES.md, Declarations and the schema language — "Inline struct" ("— ; every message is length-delimited").
+10. COMPARISON-TABLES.md, Declarations and the schema language — "Inline struct".
+13. COMPARISON-TABLES.md, Declarations and the schema language — "Flags" ("—").
+14. COMPARISON-TABLES.md, Declarations and the schema language — "Flags" (`enum (bit_flags)`).
+16. COMPARISON-TABLES.md, Declarations and the schema language — "Arrays", "Strings", "Bytes".
+17. COMPARISON-TABLES.md, Declarations and the schema language — "Arrays" (`[T:N]` in structs only).
+20. COMPARISON-TABLES.md, Declarations and the schema language — "Maps"; and "One scene, three ways" — "keyed by Slot" (enum keys refused).
+21. COMPARISON-TABLES.md, Declarations and the schema language — "Enum-keyed arrays" ("—"); "Sorted lookup in a buffer" gives the idiom, a sorted vector looked up by VALUE.
+23. COMPARISON-TABLES.md, Declarations and the schema language — "Maps".
+24. COMPARISON-TABLES.md, Declarations and the schema language — "Maps"; "Sorted lookup in a buffer".
+27. COMPARISON-TABLES.md, Declarations and the schema language — "Pointers, graphs, sharing" ("tree only; no sharing, no cycles").
+28. COMPARISON-TABLES.md, Declarations and the schema language — "Pointers, graphs, sharing" (an `Offset` may be reused by the builder; cycles impossible).
+32. COMPARISON-TABLES.md, Declarations and the schema language — "Union" (`oneof`). **Not carried there:** the arm restriction. `oneof` admits any type except map fields and repeated fields (PB-proto3, Oneof), which is what holds this at 🔶.
+33. COMPARISON-TABLES.md, Declarations and the schema language — "Union" (union of tables; structs and strings experimental; vectors of unions C++ only).
+36. COMPARISON-TABLES.md, Declarations and the schema language — "Defaults" (proto3 has none; proto2 and editions do).
+37. COMPARISON-TABLES.md, Declarations and the schema language — "Defaults" (scalar defaults); "Optional fields" (references null when absent).
+40. COMPARISON-TABLES.md, Declarations and the schema language — "Optional fields" (explicit presence: proto2 all, proto3 `optional`, editions explicit by default).
+41. COMPARISON-TABLES.md, Declarations and the schema language — "Optional fields" (optional scalars via `= null`). **Not carried there:** the per-language coverage. FB-support marks optional scalars Yes in ten of the thirteen languages listed and blank for Python, PHP and Dart — and that table says of itself "NOTE: this table is a start, it needs to be extended", so every count taken from it is a floor rather than a fact.
+45. COMPARISON-TABLES.md, Declarations and the schema language — "Required" (removed; `LEGACY_REQUIRED` only). 🔶 rather than ❌ because the construct exists on the record in two places: proto2's `required`, and editions' `features.field_presence = LEGACY_REQUIRED`, "required for parsing and serialization" (PB-features). The project's guidance is never to add one (PB-dos).
+46. COMPARISON-TABLES.md, Declarations and the schema language — "Required" (`(required)`, verifier-checked). 🔶 rather than ✅ because the check is the verifier's, and the verifier does not ship in every language [136].
+50. COMPARISON-TABLES.md, Declarations and the schema language — "Schema-less data" (`Struct`, `Value`); "Well-known types" (`Any`).
+51. COMPARISON-TABLES.md, Declarations and the schema language — "Schema-less data" (FlexBuffers). **Not carried there:** the coverage. FB-support marks FlexBuffers Yes for C++, Java, Rust and Swift of the thirteen listed, under that table's own caveat [41].
+55. COMPARISON-TABLES.md, Declarations and the schema language — "Attributes" (custom options with retention and targets).
+56. COMPARISON-TABLES.md, Declarations and the schema language — "Attributes" (user attributes declarable, read via reflection).
+59. COMPARISON-TABLES.md, The wire — "Self-describing" ("no; needs descriptors"). 🔶 rather than ❌ because field numbers and wire types do ride, so a parser skips what it does not know; names and declared types need the definition (PB-encoding, Message Structure).
+60. **Not carried in COMPARISON-TABLES.md** — that page's "Version identity" row covers `file_identifier`, not the format's own silence. FB-internals: the format "doesn't contain information for format identification and versioning, which is also by design".
+64. COMPARISON-TABLES.md, The wire — "Varint compaction" (varints, zigzag).
+65. COMPARISON-TABLES.md, The wire — "Varint compaction" ("—"); "Alignment" (every scalar aligned to its size), which is what buys in-place access.
+69. COMPARISON-TABLES.md, The wire — "Alignment" ("none").
+70. COMPARISON-TABLES.md, The wire — "Alignment" (aligned to size; `force_align`).
+74. COMPARISON-TABLES.md, The wire — "Size ceilings" (2 GiB).
+75. COMPARISON-TABLES.md, The wire — "Size ceilings" (32-bit offsets: 2 GiB; `vector64` for tail vectors, not in every port).
+79. COMPARISON-TABLES.md, The wire — "Byte-identical output across implementations" ("don't assume serialization stability across builds").
+80. COMPARISON-TABLES.md, The wire — "Byte-identical output across implementations" ("no cross-language claim"). ❌ and not ?, and the reason is **not carried there**: FB-internals states the denial outright — "This may mean two different implementations may produce different binaries given the same input values, and this is perfectly valid." That is the format declining the property on the record, not an inference from absence.
+83. COMPARISON-TABLES.md, Evolution — "Add a field", "Remove a field", "Reorder", "Rename" (add anywhere with an unused number; remove and reserve; reorder free).
+84. COMPARISON-TABLES.md, Evolution — "Add a field", "Remove a field", "Reorder". 🔶 and not ❌, on the same reading as [83] and [85]: new fields go at the end, `id` on every field makes source position free, and removal is forbidden with the slot kept by `deprecated`. All three formats add, all three reorder in source, and none of the three frees a retired slot; the differences are in the footnotes, not in the marks.
+85. **Not carried in COMPARISON-TABLES.md** (Cap'n Proto is not on that page). New members take numbers exceeding all previous ones, source position is free, numbers never change and there is no removal (CP-lang, Evolving Your Protocol). 🔶 on the same reading as [83] and [84].
+88. COMPARISON-TABLES.md, Declarations and the schema language — "Rename" (free on the binary wire; reserve the old name for JSON).
+89. COMPARISON-TABLES.md, Declarations and the schema language — "Rename" (free; names are not serialized).
+92. COMPARISON-TABLES.md, Evolution — "Change a type" (a fixed list of compatible pairs; anything else misdecodes silently).
+93. COMPARISON-TABLES.md, Evolution — "Change a type" (only at identical width, with careful handling).
+97. COMPARISON-TABLES.md, Evolution — "Change a default" (proto3 has none; proto2 reader-side). 🔶 rather than ❌, and the reason is **not carried there:** under explicit presence — proto2, and the default in every edition — "Any explicitly-set value is serialized onto the wire (even if it is the same as the default value)" (PB-features), so a changed default reinterprets only the fields a writer never set. Under implicit presence, proto3's default, a value equal to the default is elided and the hazard is whole. Avro keeps ✅ [99] because it writes every field of the writer's schema unconditionally, so no stored byte can be reinterpreted at all.
+98. COMPARISON-TABLES.md, Evolution — "Change a default" ("don't": V1 data that did not write the value relied on generated code for it).
+101. COMPARISON-TABLES.md, Evolution — "Unknown fields on read", "Unknown fields on rewrite" (retained and re-serialized).
+102. COMPARISON-TABLES.md, Evolution — "Unknown fields on rewrite" (the buffer keeps them if forwarded whole; the object API's unpack-and-repack does not).
+104. COMPARISON-TABLES.md, Evolution — "Read report" (success or failure, plus the unknown set).
+105. COMPARISON-TABLES.md, Evolution — "Read report" (verifier pass or fail).
+108. COMPARISON-TABLES.md, Evolution — "Enum evolution" (open enums keep the int; closed enums move it to unknown fields). **Not carried there:** the per-language divergence. C#, Go, JSPB and Ruby treat every enum as open and Dart as closed, whatever the syntax says (PB-enum).
+109. COMPARISON-TABLES.md, Evolution — "Enum evolution" (append or explicit values; the application handles unknowns itself).
+112. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Point at the bytes" ("never").
+113. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Point at the bytes" ("always").
+116. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on read" (per message, string and repeated field; arenas mitigate).
+117. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on read" (none in place; the object API allocates).
+119. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on write". **Not carried there:** arenas are a C++ feature (PB-arenas), which is what holds this at 🔶.
+120. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Allocation on write" (the builder grows a buffer; custom allocator). ✅ and not 🔶: one growable buffer with a caller's allocator is the row's property, and nothing is allocated per node — the same reading Cap'n Proto's segments get [121].
+122. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Exact size before writing" (`ByteSizeLong()`).
+123. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Exact size before writing" (after `Finish`).
+125. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Mutate in place" ("—").
+126. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Mutate in place" (`--gen-mutable` scalars; reflection resizes). **Not carried there:** the coverage. FB-support marks simple mutation Yes for C++, Java, C#, Go and Swift of the thirteen listed, under that table's own caveat [41].
+128. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Cross-language rows at a pitch" ("—"); "Offline cook for a build" ("—").
+129. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Cross-language rows at a pitch" (a vector of structs is inline, but the schema does not assert both sides' native layout).
+131. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Generated code dependencies" (`libprotobuf`).
+132. COMPARISON-TABLES.md, Runtime forms, allocation, performance — "Generated code dependencies" says "header-only runtime", and **no cited FlatBuffers page says it**; this footnote replaces that claim with what FB-cpp does say. The generated header "relies on `flatbuffers/flatbuffers.h`, which should be in your include path", so the C++ core is an include rather than a link; text and schema parsing "requires you to link a few more files into your program" (FB-cpp, Prerequisites; Text & schema parsing). Every other FlatBuffers language ships a runtime library, so the cell is 🔶.
+134. **Not carried in COMPARISON-TABLES.md**, whose row states only the second half. Structs "are always stored inline in their parent (a struct, table, or vector)", and their layout is defined "independent of the alignment rules of the underlying compiler to guarantee a cross platform compatible layout" (FB-internals, Structs), so a vector of structs is a fixed-stride row image two languages compute identically. That is this row's property, and it is ✅.
+135. COMPARISON-TABLES.md, Validation of untrusted data — "Untrusted bytes on the tolerant wire" (the parser validates structure; recursion limit; UTF-8 verify).
+136. COMPARISON-TABLES.md, Validation of untrusted data — "Untrusted bytes on the tolerant wire" (a separate `Verifier`, required before access). **Corrected here:** FB-support's matrix marks the buffer verifier Yes for C++, C and Swift of thirteen, and FB-rust adds a fourth the matrix does not show — "The safe Rust functions to interpret a slice as a table (`root`, `size_prefixed_root`, `root_with_opts`, and `size_prefixed_root_with_opts`) verify the data first." The count is at least four of thirteen, and FB-support says of itself "NOTE: this table is a start, it needs to be extended", so it is a floor.
+139. COMPARISON-TABLES.md, Validation of untrusted data — "Depth and DoS bounds" (recursion depth 100). **Not carried there:** the limits differ by implementation — Java 100, C++ 100, Go 10,000 with a planned reduction (PB-limits) — which is what holds this at 🔶.
+140. COMPARISON-TABLES.md, Validation of untrusted data — "Untrusted bytes on the tolerant wire" (`max_depth` 64, `max_tables` 1M), where a verifier ships [136].
+142. COMPARISON-TABLES.md, Validation of untrusted data — "Cross-language agreement on refusal" ("a conformance suite"). ? rather than 🔶: the suite's own page says it tests "completeness and correctness of Protocol Buffers implementations" and says nothing about malformed or hostile input either way (PB-conformance).
+144. COMPARISON-TABLES.md, Reflection, text, tooling — "Runtime reflection" (descriptors, `Reflection`, `DynamicMessage`).
+145. COMPARISON-TABLES.md, Reflection, text, tooling — "Runtime reflection" (binary schema plus `reflection.h` in C++, basic in C; MINI-REFLECTION). 🔶 rather than ❌ on the strength of that last: "A more limited form of reflection is available for direct inclusion in generated code, which doesn't do any (binary) schema access at all", behind `--reflect-types` and `--reflect-names` (FB-cpp, Mini Reflection).
+149. COMPARISON-TABLES.md, Reflection, text, tooling — "Text form" says "ProtoJSON in every runtime", and **no cited page establishes the count**; this footnote replaces it. PB-json specifies the format and names its own gaps — "As of v25.x, the C++, Java, and Python implementations are nonconformant" on one flag — so the mark is 🔶.
+150. COMPARISON-TABLES.md, Reflection, text, tooling — "Text form" (JSON in `flatc`; parsing in a few languages). **Corrected here:** FB-support marks JSON parsing Yes for C++, C and Lobster of thirteen, under that table's own caveat [41]; `flatc --json` converts offline (FB-flatc).
+154. COMPARISON-TABLES.md, Reflection, text, tooling — "Doc comments" says "preserved in descriptors' source info", and **no cited page carries it**; the source list's PB-wkt is the well-known types reference and does not contain `SourceCodeInfo`. PB-proto3's "Adding Comments" states the accepted comment styles and says nothing about generated code, and the C++ generated-code reference does not mention comments either (PB-proto3, Adding Comments; PB-cpp-gen). Neither made nor denied, so ? by the legend.
+155. COMPARISON-TABLES.md, Reflection, text, tooling — "Doc comments" (`///` into generated code and the binary schema).
+158. COMPARISON-TABLES.md, Reflection, text, tooling — "Languages" (ten first-party, forty-plus third-party). 🔶 because the project documents its own enum nonconformance across those runtimes (PB-enum).
+159. COMPARISON-TABLES.md, Reflection, text, tooling — "Languages" (thirteen listed, coverage uneven). **Not carried there:** the shape of the unevenness. Of the thirteen, FB-support marks JSON parsing in three, reflection in two, the verifier in three (four with FB-rust, [136]) and mutation in five, and says C++ "has the richest feature set, and is likely most robust" — all of it under that table's own caveat [41].
+165. COMPARISON-TABLES.md, Declarations and the schema language — "Reserved names" (`reserved` numbers and names).
+166. COMPARISON-TABLES.md, Declarations and the schema language — "Reserved names" ("— ; never remove, deprecate instead"); "Deprecation" (`(deprecated)`: accessors dropped, slot kept).
+170. COMPARISON-TABLES.md, Evolution — "Change a type" (the compatible-pairs list; a truncation inside it is silent).
+174. **Not carried in COMPARISON-TABLES.md.** The project documents a self-describing pattern — a message carrying a `FileDescriptorSet` beside the payload — and says in the same breath that "the reason that this functionality is not included in the Protocol Buffer library is because we have never had a use for it inside Google" (PB-techniques, Self-describing Messages). The schema is recoverable only out of band, which is the same shape as FlatBuffers' `.bfbs` [175] and takes the same mark.
+175. COMPARISON-TABLES.md, Reflection, text, tooling — "Runtime reflection" (the binary schema as a separate artifact); The wire — "Version identity" (`file_identifier`, four hand-chosen characters). Out of band, like [174], and the same mark.
+178. COMPARISON-TABLES.md, The wire — "Version identity" ("none; editions version the language"); the six wire types are frozen with no revision marker (PB-encoding).
+179. COMPARISON-TABLES.md, The wire — "Version identity" (`file_identifier`, by hand) — it identifies the schema author's format, not the FlatBuffers revision.
+183. COMPARISON-TABLES.md, Evolution — "Compile-time guard" (`buf breaking`, third party: built by Buf Technologies, not the Protocol Buffers project — buf).
+184. COMPARISON-TABLES.md, Evolution — "Compile-time guard" (`flatc --conform`).
+
+**Cap'n Proto and Avro**
+
+Neither is on COMPARISON-TABLES.md, so both cite their own documentation
+here.
+
+4. Cap'n Proto has Int8 to Int64 and the unsigned set; no 128-bit, no fixed point, no declared range (CP-lang, Built-in Types).
 5. Avro's primitives stop at int, long, float, double; `decimal` is a logical type over bytes or fixed, an arbitrary-precision annotation whose per-language support varies (AV-spec, Primitive Types; Logical Types).
-6. Neither Protocol Buffers nor FlatBuffers has a constant declaration (PB-proto3 and FB-schema, top-level declaration lists).
-7. `const` exists and may be referenced inside another value including a field default (CP-lang, Constants).
+7. `const` exists and may be referenced inside another value, including a field default (CP-lang, Constants).
 8. Avro's schema is JSON; no constant, flags or keyed-array construct exists in the specification (AV-spec, Complex Types).
-9. Every nested message is a length-delimited record: a tag and a length (PB-encoding, Length-Delimited Records).
-10. A FlatBuffers `struct` is stored inline in its parent (FB-internals, Structs).
-11. A Cap'n Proto struct field is a pointer into the message; structs are inline only as elements of a composite list, a deliberate trade for random access and the list-upgrade rule (CP-encoding, Structs; Lists).
+11. A GROUP's fields "are numbered in the same space as the containing struct's fields, and are laid out exactly the same as if they hadn't been grouped at all" (CP-lang, Groups), which is a nested value with no framing of its own; a struct as an element of a composite list is inline too (CP-encoding, Lists). A struct FIELD is a pointer into the message, the deliberate trade for random access and the list-upgrade rule (CP-encoding, Structs).
 12. An Avro record is the concatenation of its fields' encodings with no framing (AV-spec, Binary Encoding).
-13. No flags construct; a bitmask is an integer by convention (PB-proto3).
-14. `bit_flags`: an unsigned value N in the schema represents 1<<N (FB-schema, attributes).
 15. No flags or keyed-array construct; enumerants are numbered from zero and are not numeric (CP-lang, Enums).
-16. `repeated`, `string` and `bytes` are unbounded up to the message ceiling (PB-proto3; PB-limits).
-17. `[T:N]` fixed-length arrays are supported only in a `struct` (FB-schema, Fixed-length Arrays).
 18. `List(T)`, `Text` and `Data` take no bound (CP-lang, Built-in Types).
 19. Avro's `fixed` is an exact-size byte type; `string`, `bytes`, `array` and `map` are unbounded (AV-spec, Fixed).
-20. Enum keys are refused in a map (PB-proto3, Maps).
-21. No enum-keyed array; the idiom is a sorted vector with `LookupByKey`, by value (FB-cpp, Sorting a vector of tables).
-23. `map<K,V>` in every official language; keys integral or string; iteration and wire order undefined (PB-proto3, Maps).
-24. No map type; the sorted-vector idiom is documented on the C++ page, not as a cross-language feature (FB-cpp; FB-schema, `key`).
 25. `Map(K,V)` appears only as an example of a user-defined generic (CP-lang, Generic Types).
 26. Map keys are strings (AV-spec, Maps).
-27. A tree of length-delimited records; no reference type (PB-encoding).
-28. A table may point at the same value twice if the builder serializes the same offset twice; object cycles are not allowed (FB-internals).
-29. One pointer per object, a tree not a graph; cyclic or overlapping pointers can send a reader into an infinite loop, which is what the traversal limit defends (CP-encoding, Messages).
+29. One pointer per object, a tree and not a graph; cyclic or overlapping pointers can send a reader into an infinite loop, which is what the traversal limit defends (CP-encoding, Messages).
 30. No reference type; recursion is a union naming the record, which yields a tree (AV-spec, Complex Types).
-32. `oneof` admits any type except map and repeated fields (PB-proto3, Oneof).
-33. Union members are tables; other member types and vectors of unions are experimental, the latter C++ only (FB-schema, Unions).
 34. A union is two or more fields sharing storage, so any field type is an arm, including `Void` (CP-lang, Unions).
 35. A union is a JSON array of schemas, any schema a branch, with two restrictions (AV-spec, Unions).
-36. proto3 has no user-declared defaults; proto2 and editions do (PB-proto3, Default Values; PB-presence).
-37. Only scalars take explicit defaults; strings, vectors and tables are null when absent (FB-schema, Tables).
 38. Defaults for `Text`, `Data`, `List` and nested structs (CP-lang, Structs).
 39. A default for every field type (AV-spec, Record).
-40. `optional` fields track presence (PB-proto3, Field Labels).
-41. Optional scalars via `= null`, marked No for Python, PHP and Dart in the support matrix (FB-schema, Optional Scalars; FB-support).
-42. No scalar presence: data-section fields are stored XOR their default, so unset and set-to-default are one encoding; a pointer's null is the only absence (CP-encoding, Value Encoding).
-43. The idiom is a union with `null`, a value not a presence flag (AV-spec, Unions).
-45. `required` was removed in proto3; the guidance is never to add one (PB-dos).
-46. `(required)` is checked by the verifier (FB-schema, attributes).
+42. No scalar presence: data-section fields are stored XOR their default, so unset and set-to-default are one encoding, and a pointer's null is the only absence (CP-encoding, Value Encoding).
+43. The idiom is a union with `null`, a value rather than a presence flag (AV-spec, Unions).
 47. No required marker (CP-lang).
 48. A reader field with no default and no writer counterpart signals an error for the whole read (AV-spec, Schema Resolution).
-50. `Any` with a type URL, and `Struct`/`Value` in the well-known types (PB-proto3, Any; PB-wkt).
-51. FlexBuffers, marked Yes for C++, Java, Rust and Swift and ? for most others (FB-support).
 52. Generics are first class; an omitted parameter is `AnyPointer` (CP-lang, Generic Types).
 53. No generics and no `Any`; the writer's schema is always available, a different solution to the same problem (AV-spec).
-55. Custom options with retention and target restrictions (PB-editions, Custom Options).
-56. User-defined attributes, declared, queryable from a parsed schema at runtime (FB-schema, Attributes).
-57. `annotation foo(struct, enum) :Text;` with fourteen targets plus `*` (CP-lang, Annotations).
-59. Field numbers and wire types ride; names and declared types need the definition; the overview lists "don't inherently self-describe" (PB-encoding, Message Structure; PB-overview).
-60. No format identification or versioning information in the buffer, by design (FB-internals).
+57. `annotation foo(struct, enum) :Text;`, with twelve targets — `file`, `struct`, `field`, `union`, `group`, `enum`, `enumerant`, `interface`, `method`, `param`, `annotation`, `const` — and `*` to cover them all (CP-lang, Annotations).
+58. "Attributes not defined in this document are permitted as metadata, but must not affect the format of serialized data" (AV-spec, Schema Declaration). That is user-extensible annotation in the format, so not ❌; 🔶 rather than ✅ because the specification requires only that an implementation tolerate the attributes, not that it surface them to generated code or to a runtime API, which is what the other three columns' marks rest on.
 61. Field positions are computed from the schema; the message carries no field identity (CP-encoding).
-62. The container file embeds the writer's schema; single-object encoding carries `C3 01` plus a schema fingerprint. The bare value encoding is untagged (AV-spec, Object Container Files; Single Object Encoding; Binary Encoding).
-64. Varints and ZigZag (PB-encoding).
-65. Every scalar at its declared width, aligned; that is what buys in-place access (FB-internals).
+62. The container file embeds the writer's schema, and single-object encoding carries `C3 01` plus a schema fingerprint. The bare value encoding is untagged (AV-spec, Object Container Files; Single Object Encoding; Binary Encoding).
 66. Packing is an optional pass over the unpacked layout (CP-encoding, Packing; CP-faq).
 67. int and long are zig-zag varints (AV-spec, Binary Encoding).
-69. No alignment (PB-encoding).
-70. Scalars aligned to their own size; `force_align` overrides (FB-internals; FB-schema).
 71. Objects aligned to word boundaries, primitives to a multiple of their size (CP-encoding).
 72. A byte stream with no alignment (AV-spec, Binary Encoding).
-74. A serialized proto must be under 2 GiB (PB-limits, Message Size).
-75. `uoffset_t` is a `uint32_t`; 64-bit offsets are C++ only (FB-internals; FB-64).
-76. Segment ids are 32 bits, so the aggregate is not 32-bit capped; a single list is capped at 2^29 elements; the C++ reader's traversal limit defaults to 64 MiB (CP-encoding, Lists; Far Pointers; CP-cxx, Security Tips).
-77. Block counts and lengths are 64-bit varints; the specification states no ceiling and per-implementation ceilings were not checked (AV-spec, Binary Encoding).
-79. Serialization stability is not guaranteed across binaries or builds, and default serialization is not deterministic (PB-dos; PB-encoding).
-80. No claim either way; the builder's freedom to share an offset means two conforming builders can emit different bytes for the same data (FB-internals). Marked ? rather than ❌ because it is an inference from absence.
+76. Segment ids are 32 bits, so the aggregate is not 32-bit capped; a single list is capped at 2^29 elements, and the C++ reader's traversal limit defaults to 64 MiB (CP-encoding, Lists; Far Pointers; CP-cxx, Security Tips).
+77. Array and map blocks carry `long` counts and file data blocks a `long` object count and byte size, and the specification states no aggregate ceiling (AV-spec, Binary Encoding; Object Container Files). 🔶 rather than ✅ because no per-implementation ceiling was sourced, and this page's test asks for the feature in every official implementation.
 81. Canonicalization is fully specified and is a separate conversion, not the default output (CP-encoding, Canonicalization; CP-tool).
-82. A record's bytes are determined by the schema, but array and map block boundaries are the writer's choice; Avro's Parsing Canonical Form canonicalizes schemas, not data (AV-spec, Binary Encoding; Parsing Canonical Form).
-83. Adding and reordering are free; removal reserves the number forever, with the consequences of reuse spelled out (PB-proto3, Updating A Message Type; Reserved Fields).
-84. New fields go at the end and fields are never removed, unless `id` is used on every field (FB-evolution; FB-schema).
-85. New members take larger numbers; source order is free; numbers never change; no removal (CP-lang, Evolving Your Protocol).
+82. A record's bytes are determined by the schema, but array and map block boundaries are the writer's choice, and Avro's Parsing Canonical Form canonicalizes schemas rather than data (AV-spec, Binary Encoding; Parsing Canonical Form).
 86. Fields match by name and a writer's extras are ignored, but a reader field without a default is a hard error against older data (AV-spec, Schema Resolution).
-88. Names are not on the binary wire; reusing an old name is generally safe except in TextProto and JSON (PB-proto3, Updating A Message Type).
-89. Renaming tables and fields is fine because names are not serialized; same JSON caveat (FB-evolution).
-90. Any symbolic name can change as long as the type id and ordinals stay (CP-lang, Evolving Your Protocol).
-91. Aliases exist on named types and fields; an implementation may optionally use them (AV-spec, Aliases).
-92. Almost never change a field's type; the compatible-pairs list is narrow and a change inside it can still truncate silently (PB-dos; PB-proto3, Updating A Message Type).
-93. Maybe OK, only for the same width (FB-evolution).
+90. Any symbolic name can change as long as the type id and the ordinals stay (CP-lang, Evolving Your Protocol).
+91. Aliases exist on named types and fields; "An implementation may optionally use aliases to map a writer's schema to the reader's" (AV-spec, Aliases).
 94. A field's type or default value cannot change (CP-lang, Evolving Your Protocol).
-95. Resolution promotes or signals an error; never a misdecode, and the failure is the whole read (AV-spec, Schema Resolution).
-97. Almost never change a default; it causes version skew (PB-dos).
-98. Not OK: data written without the value relied on generated code for the default (FB-evolution).
-99. Every field is always written; a default is used only when the writer's schema lacks the field, so a default change cannot reinterpret stored bytes (AV-spec, Record).
-101. proto3 messages preserve unknown fields through parsing and serialization; lost through JSON (PB-proto3, Unknown Fields).
-102. A buffer forwarded whole keeps everything; the object API's unpack-and-repack does not (FB-evolution; FB-cpp).
+95. Resolution promotes or signals an error, never a misdecode, and the failure is the whole read (AV-spec, Schema Resolution).
+99. "Avro encodes a field even if its value is equal to its default"; a default is used only when the writer's schema lacks the field, so a default change cannot reinterpret stored bytes (AV-spec, Record; Binary Encoding).
+100. Copying a struct with a `set` method keeps the original's size, because "the original could have been built with an older version of the protocol which lacked some fields", so fields the copier does not know ride through the copy (CP-cxx, Tips and Best Practices). 🔶 rather than ✅ because it is a property of that copy idiom rather than of every read-and-rewrite: a builder filled field by field keeps nothing.
 103. A writer's field not in the reader's record is ignored (AV-spec, Schema Resolution).
-104. Success or failure plus the unknown-field set (PB-proto3; PB-message).
-105. The verifier is a boolean (FB-cpp, Verifying a buffer).
 106. Limits throw; nothing reports what was skipped (CP-cxx, Security Tips).
-107. Errors are signalled; no counted report (AV-spec).
-108. Open enums keep the raw value; closed enums move it to unknown fields and re-serialize it out of place. C#, Go, JSPB and Ruby treat all enums as open and Dart as closed regardless of syntax (PB-enum).
-109. No defined landing; handling is the application's (FB-schema, Enums).
-110. A declared enum `default` is used, otherwise an error is signalled (AV-spec, Enums; Schema Resolution).
-112. Messages are parsed; equality requires full parsing (PB-overview).
-113. Access the data directly without unpacking or parsing (FB-home).
+107. Errors are signaled; no counted report (AV-spec).
+110. A declared enum `default` is used, otherwise an error is signaled (AV-spec, Enums; Schema Resolution).
 114. No encoding step; one field readable without parsing the whole; mmap (CP-home).
-115. Values are variable-length and untagged, decoded into objects; no random access, no cooked form, deliberately (AV-spec, Binary Encoding).
-116. Per message, per string, per repeated field; arenas are C++ (PB-message; PB-arenas).
-117. No heap for in-place access; the object API unpacks into `std::string` and `std::vector` (FB-home; FB-cpp).
+115. Values are variable-length and untagged, decoded into objects; no random access and no cooked form, deliberately (AV-spec, Binary Encoding).
 118. Reads are pointer arithmetic over the buffer (CP-cxx).
-119. Arenas are a C++ feature (PB-arenas).
-120. The builder grows one buffer by reallocation (FB-cpp).
-121. Messages are built arena-style, sequentially in a segment (CP-cxx, Tips and Best Practices).
-122. `ByteSizeLong()` (PB-message).
-123. The size is known after `Finish` (FB-cpp).
-125. Parse, mutate the object, re-serialize; no in-place editing (PB-encoding; PB-message).
-126. `--gen-mutable` scalar mutators, Yes for C++, Java, C#, Go and Swift (FB-flatc; FB-support).
-127. Builders write in place; orphans move subtrees within a message (CP-cxx, Orphans).
-128. No cooked or block form (PB-overview; PB-encoding).
-129. The buffer is the cooked form; nothing asserts both languages' native layout at open (FB-internals).
-130. mmap is documented; there is no fixed-stride, layout-asserted row block (CP-home; CP-lang).
-131. Generated C++ derives from `Message` in `libprotobuf` (PB-message).
-132. The C++ library is header-only (FB-cpp).
-133. Link `libcapnp` and `libkj` (CP-cxx, Generating Code).
-135. The parser validates structure; UTF-8 is verified for `string`; recursion limits bound a hostile message (PB-encoding; PB-features; PB-limits).
-136. Offsets are not verified at run time and a malformed buffer can crash the reader; a separate verifier ships for C++, C and Swift of thirteen (FB-cpp, Verifying a buffer; FB-support).
+121. Messages are built arena-style, sequentially in a segment, and a new segment is allocated when one fills — never per object (CP-cxx, Tips and Best Practices).
+127. ❌, corrected from ✅. Orphans move subtrees WITHIN a message and exist only in memory a `MessageBuilder` owns; the project states the limitation directly — Cap'n Proto "is not well-suited for _writing_ via `mmap()`, only reading", because no mutable segment framing format has been designed. A received message is read through a `MessageReader` and rebuilt through a builder to change it (CP-cxx, Orphans; Serialization/Deserialization).
+130. mmap is documented and a composite list is structs at a fixed stride, but nothing asserts two languages' native layouts against each other at open (CP-home; CP-encoding, Lists).
+133. Link `libcapnp` and `libkj`, and `libcapnp-rpc` and `libkj-async` with RPC (CP-cxx, Generating Code).
 137. Designed to be safe against malicious input, with the caveat that it has not undergone a formal security review (CP-faq).
-139. Recursion limits vary: Java 100, C++ 100, Go 10,000 with a planned reduction (PB-limits).
-140. Verifier defaults of depth 64 and a million tables, where a verifier ships (FB-cpp).
-141. Nesting depth 64 and a 64 MiB traversal limit, documented for C++; other implementations unreviewed by the project (CP-cxx, Security Tips; CP-otherlang).
-142. A conformance suite exists; whether it carries hostile inputs is not established from the documentation (PB-conformance).
-144. `Reflection` and `DynamicMessage` are in the runtime (PB-message).
-145. Full reflection needs the binary schema as a separate artifact; C++, with Basic for C (FB-flatc, `--schema`; FB-support).
-146. `capnp/schema.h`, `capnp/dynamic.h` and `SchemaLoader`, documented for C++ (CP-cxx, Dynamic Reflection).
+138. A composite list is a tag word followed by its elements laid out inline at one stride, and a struct's layout is fixed by the encoding rather than by a compiler (CP-encoding, Lists; Structs), so a list of structs is a fixed-stride row image any implementation computes identically.
+141. Nesting depth 64 and a 64 MiB traversal limit, both configurable through `capnp::ReaderOptions` (CP-cxx, Security Tips). ✅ and not 🔶: "documented for C++" is not a limitation for this project, because the C++ reference IS the official implementation set — "Implementations in other languages are maintained by respective authors and have not been reviewed by me" (CP-otherlang).
+146. `capnp/schema.h`, `capnp/dynamic.h` and `SchemaLoader`, documented for C++ (CP-cxx, Dynamic Reflection) — the whole official set, as [141] says.
 147. The writer's schema is always present and the generic API reads any record without code generation (AV-java).
-149. ProtoJSON and the text format in every runtime (PB-json; PB-text).
-150. JSON parsing is Yes for C++, C and Lobster; `flatc --json` converts offline (FB-support; FB-flatc).
-151. `capnp convert` moves between binary, packed, flat, canonical, text and json, documented in the 0.7 release notes rather than the tool page; the library JSON is C++ (CP-tool; CP-0.7).
+151. `capnp convert` moves between binary, packed, flat, canonical, text and json, documented in the 0.7 release notes rather than the tool page, and the library JSON is C++ (CP-tool; CP-0.7) — the whole official set, as [141] says.
 152. The JSON encoding is part of the specification; `avro-tools` converts offline (AV-spec, JSON Encoding; AV-java).
-154. Comments are preserved in `SourceCodeInfo` and emitted by the generators (PB-wkt).
-155. `///` comments reach generated code and the binary schema (FB-schema, Comments & Documentation).
 156. The `doc` attribute on records and fields (AV-spec, Record).
-158. Ten first-party languages plus fifty-odd third-party ones, with the enum nonconformance documented by the project itself (PB-overview; PB-3p; PB-enum).
-159. Thirteen languages; JSON parsing in three, reflection in two, the verifier in three, mutation in five; C++ has the richest feature set (FB-support).
-160. The C++ reference is the only reviewed implementation; the C implementation is no longer maintained; several are serialization-only (CP-otherlang).
+160. The C++ reference is the only reviewed implementation and every other is a third party's; the C implementation is "no longer maintained", one JavaScript implementation is "abandoned", and several are serialization-only (CP-otherlang).
 161. Six documented SDKs and a home page claiming more; no per-feature matrix (AV-docs; AV-home).
-163. An omitted type id is derived from the parent scope's id and the declaration's name, so a rename or move silently changes it unless pinned explicitly (CP-lang, Unique IDs).
-165. `reserved` for numbers and names, with the consequences of reuse enumerated (PB-proto3, Reserved Fields).
-166. Removal is forbidden outright, so reuse cannot arise while the rule holds; no reserved list if it is broken (FB-evolution; FB-schema, `deprecated`).
+163. An omitted type id is derived from the parent scope's id and the declaration's name — "You cannot change the name of a type that doesn't have an explicit ID" — so a rename or a move changes it unless the id is pinned (CP-lang, Unique IDs).
 167. Ordinals never change and removal is not permitted; no reserved mechanism (CP-lang, Evolving Your Protocol).
 168. Aliases point forward; nothing marks a name retired (AV-spec, Aliases).
-170. The compatible-pairs list; a truncation inside it is silent (PB-proto3, Updating A Message Type).
 171. One path: a list of primitives may become a list of structs whose first field is that primitive (CP-lang, Evolving Your Protocol; CP-encoding, Lists).
 172. int to long, float or double; long to float or double; float to double; string and bytes either way (AV-spec, Schema Resolution).
-174. `Any` carries a type URL, a name resolved elsewhere (PB-proto3, Any).
-175. `flatc -b --schema` emits a binary schema as a separate artifact; `file_identifier` is four hand-chosen characters (FB-flatc; FB-schema).
 176. Container files embed the schema; single-object encoding carries its fingerprint (AV-spec).
-178. Six wire types, frozen; no revision marker, a deliberate trade (PB-encoding).
-179. `file_identifier` identifies the schema author's format, not the FlatBuffers revision (FB-schema).
 180. A segment table and segments; no magic, no version field (CP-encoding).
 181. Container files begin `Obj` `0x01`; single-object encoding begins `C3 01` and names its version (AV-spec).
-183. `buf breaking` is built by Buf Technologies, not the Protocol Buffers project, which offers prose guidance (buf; PB-3p).
-184. `flatc --conform` gives errors if a schema is not an evolution of the one given (FB-flatc).
 185. Evolution rules are prose; no tool checks them (CP-lang; CP-tool).
 187. The evolution rules preserve the canonical encoding across schema changes; no cross-release byte-stability promise is made (CP-lang, Evolving Your Protocol).
 
@@ -511,29 +516,22 @@ All pages fetched 2026-09-04.
 |---|---|
 | PB-proto3 | https://protobuf.dev/programming-guides/proto3/ |
 | PB-encoding | https://protobuf.dev/programming-guides/encoding/ |
-| PB-presence | https://protobuf.dev/programming-guides/field_presence/ |
 | PB-enum | https://protobuf.dev/programming-guides/enum/ |
 | PB-limits | https://protobuf.dev/programming-guides/proto-limits/ |
-| PB-overview | https://protobuf.dev/overview/ |
 | PB-dos | https://protobuf.dev/best-practices/dos-donts/ |
-| PB-editions | https://protobuf.dev/programming-guides/editions/ |
 | PB-features | https://protobuf.dev/editions/features/ |
 | PB-json | https://protobuf.dev/programming-guides/json/ |
-| PB-text | https://protobuf.dev/reference/protobuf/textformat-spec/ |
 | PB-wkt | https://protobuf.dev/reference/protobuf/google.protobuf/ |
-| PB-message | https://protobuf.dev/reference/cpp/api-docs/google.protobuf.message/ |
 | PB-arenas | https://protobuf.dev/reference/cpp/arenas/ |
+| PB-techniques | https://protobuf.dev/programming-guides/techniques/ |
+| PB-cpp-gen | https://protobuf.dev/reference/cpp/cpp-generated/ |
 | PB-conformance | https://github.com/protocolbuffers/protobuf/tree/main/conformance |
-| PB-3p | https://github.com/protocolbuffers/protobuf/blob/main/docs/third_party.md |
 | buf | https://buf.build/docs/breaking/ |
-| FB-schema | https://flatbuffers.dev/schema/ |
-| FB-evolution | https://flatbuffers.dev/evolution/ |
 | FB-internals | https://flatbuffers.dev/internals/ |
 | FB-cpp | https://flatbuffers.dev/languages/cpp/ |
 | FB-flatc | https://flatbuffers.dev/flatc/ |
 | FB-support | https://flatbuffers.dev/support/ |
-| FB-home | https://flatbuffers.dev/ |
-| FB-64 | https://github.com/google/flatbuffers/issues/7537 |
+| FB-rust | https://flatbuffers.dev/languages/rust/ |
 | CP-lang | https://capnproto.org/language.html |
 | CP-encoding | https://capnproto.org/encoding.html |
 | CP-cxx | https://capnproto.org/cxx.html |

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1054,7 +1054,7 @@ check removed reds on the report.
 
 | cpp | c | rust | go | cs | java | js | dart | elixir |
 |---|---|---|---|---|---|---|---|---|
-| ✅ `tables-wire-fuzz` `tables-wire-fuzz-negative-control` | ❌ #391 | ❌ #391 | ❌ #391 | ❌ #391 | ❌ #391 | ❌ #391 | ❌ #391 | ❌ #391 |
+| ✅ `tables-wire-fuzz` `tables-wire-fuzz-negative-control` | ❌ #492 | ❌ #492 | ❌ #492 | ❌ #492 | ❌ #492 | ❌ #492 | ❌ #492 | ❌ #492 |
 
 ### J1 — Accessor and descriptor agreement
 


### PR DESCRIPTION
The standing competitive page: what each of the four is for, in its own terms; a 48-row matrix in seven groups (declarations, wire, evolution, runtime, validation, tooling, versioning) with five columns scored by ONE test — a feature counts when it is in the format and in all of its official language implementations — so schema's own column shows 🔶 wherever the table work has not yet reached all nine languages, every such cell citing the 3.0.0 parity gate (#366); where they are ahead and what happens about it (issues named); where schema is ahead; the declines with reasons; and versioning mechanism by mechanism from the red/blue campaign's competitor map (#464). Every competitor cell is cited to that project's own documentation (URL and section, fetched 2026-09-04); every schema cell to a spec section or an issue; sixteen cells the competitors' docs do not settle are shown as ? rather than guessed. One-source rule: row-level FlatBuffers/Protobuf evidence stays in COMPARISON-TABLES.md, the packet measurement in COMPARISON.md, the promises in VERSIONING.md.

Two findings from the gather ride as issues rather than prose: the amplification bound on an untrusted pointer-graph read (#466, the one place a competitor's deliberate limit is a direct challenge to a schema advantage) and an importer as an adoption lever (#477). Four corrections to COMPARISON-TABLES.md's existing cells are on #460's docs-fix scope.

Draft until its cold read returns.