### PR TITLE
tables: three baseline mechanisms — range facts, `was` misuse and the rename pair, the no-baseline notice (#443, #444, #445)

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -68,7 +68,23 @@ func main() {
 		fs.BoolVar(&verbose, "verbose", false, "report the package and protocol id on success")
 		_ = fs.Parse(os.Args[2:]) // ExitOnError: Parse never returns an error
 		c.TablesBaseline = true
-		unit := loadUnit(c, fs.Args())
+		paths, err := compiler.GatherPaths(fs.Args())
+		if err != nil {
+			fail(err)
+		}
+		unit, err := c.Load(paths)
+		if err != nil {
+			fail(err)
+		}
+		// THE NO-BASELINE NOTICE (docs/SPEC-TABLES.md §18.1). The baseline is
+		// opt-in, so a unit that declares tables and never committed one is
+		// unguarded against every edit §4.1 marks silent — and nothing else in
+		// the tool would ever mention it. One line, on stderr, and the exit
+		// code is untouched: it is a nudge, not a gate, and committing a
+		// baseline silences it.
+		if notice := compiler.TablesBaselineNudge(unit, paths); notice != "" {
+			fmt.Fprintln(os.Stderr, "notice: "+notice)
+		}
 		if verbose {
 			fmt.Printf("ok: package %s, protocol id 0x%016x\n", unit.Package, unit.ProtocolId)
 		}

--- a/compiler/baseline.go
+++ b/compiler/baseline.go
@@ -17,6 +17,20 @@ func TablesBaselineText(u *ir.Unit) string {
 	return baseline.Render(u).Text()
 }
 
+// TablesBaselineNudge is the one line to print for a unit that declares tables
+// and has committed no tables.baseline (docs/SPEC-TABLES.md §18.1): the
+// baseline is opt-in, so such a unit is unguarded against every edit the table
+// wire cannot report, and nothing else would say so. It returns "" when there
+// is nothing to say — a unit with no tables, or one that has a baseline.
+//
+// It is a NOTICE, never a refusal: the CLI's `schema check` writes it to
+// stderr and leaves the exit code alone.
+//
+// paths are the unit's *.schema files, as [GatherPaths] returns them.
+func TablesBaselineNudge(u *ir.Unit, paths []string) string {
+	return baseline.Nudge(u, paths)
+}
+
 // UpdateTablesBaseline rewrites the unit's committed baseline — the
 // tables.baseline beside its schema files — and appends a dated entry to the
 // history section inside it naming every edit that changed what already-written

--- a/docs/COMPARISON-TABLES.md
+++ b/docs/COMPARISON-TABLES.md
@@ -225,7 +225,7 @@ the source list at the end.
 | Reserved names | after 3.0.0, a retired list in the baseline | — ; never remove, deprecate instead (FB-evolution) | `reserved` numbers and names (PB-proto3) |
 | Deprecation | — ; removal is free and counted | `(deprecated)`: accessors dropped, slot kept (FB-schema) | `[deprecated = true]` (PB-proto3) |
 | Required | — ; every field optional with a default (§4) | `(required)`, verifier-checked (FB-schema) | removed; `LEGACY_REQUIRED` only (PB-ed-overview) |
-| Rename | `\| was = "old"` keeps the id; bare rename refused (§5) | free; names not serialized (FB-evolution) | free on binary; reserve the old name for JSON (PB-proto3) |
+| Rename | `\| was = "old"` keeps the id; a bare rename is a removal plus an addition, and a committed baseline warns on the pair (§5, §18.2) | free; names not serialized (FB-evolution) | free on binary; reserve the old name for JSON (PB-proto3) |
 | Field identity | `fold16(fnv1a32(name))`; collisions refused at compile time (§5, §3.1) | vtable position or explicit `id` (FB-evolution) | hand-assigned number 1 to 536,870,911 (PB-proto3) |
 | Root identity | none prescribed; any table is a root (§1, §17.3) | `root_type`, four-char `file_identifier`, size prefix (FB-schema) | none; `Any` carries a type URL (PB-proto3) |
 | RPC | — ; out of scope | `rpc_service`, `flatc --grpc` (FB-flatc) | `service` (PB-3p) |

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -2793,11 +2793,12 @@ only.
 | a field's REFERENT dropped, or swapped for one that cannot stand in | silent | **refuses** | **moves** |
 | a field's wire KIND, or an array's ELEMENT kind, changed | `kind_mismatch` | **refuses** | **moves** |
 | an array changed between keyed and positional, or its KEY enum swapped | `kind_mismatch` | **refuses** | **moves** |
-| a declared RANGE tightened | `clamped` | passes | **moves** |
+| a declared RANGE tightened — a maximum lowered, a minimum raised, or a range declared where the field had none | `clamped` | **warns** — the `min=`/`max=` tokens are extents like a capacity (§18.1) | **moves** |
 | a fixed field's `F` moved under the same storage width | silent — the kind carries the width and the signedness, and `F` is a declaration-side fact like a resolution (§3) | **refuses** — the `frac=` token is a fixed fact (§18.1) | **moves** |
 | an `enum`'s or a `union`'s variant order or names moved | `unknown` for a name this reader lacks; a reorder is silent and safe | warns on a removal or a vanished name | **moves** |
-| a field added, removed or reordered | `unknown` for an id this reader lacks; an absent field defaults | passes | **moves** |
-| a field renamed under `was` | silent, and nothing is lost | passes | no — `was` holds the wire id fixed |
+| a field added, removed or reordered | `unknown` for an id this reader lacks; an absent field defaults | passes; a removal AND an addition in one table in one edit **warn** as the pair a bare rename leaves (§18.2) | **moves** |
+| a field renamed under `was` | silent, and nothing is lost | passes; the edit that ADDS the `was` hints the `json =` pairing, because the wire id survives the rename and the text key does not (§16.4) | no — `was` holds the wire id fixed |
+| a field renamed a SECOND time, the new `was` naming the INTERMEDIATE spelling instead of the first | `unknown` on every old file; the new id was never written to | **refuses** — `was` names the first wire name, forever (§5) | **moves** |
 | an array BOUND or a string/`bytes` capacity moved | `clamped` past the reader's bound | warns on a shrink | **moves** |
 | a field moved between `T` and `?T` | silent — no byte moves | passes | **moves** — the presence companion is storage |
 | a field moved to or from `*T` | `kind_mismatch` | passes | **moves** |
@@ -7668,13 +7669,19 @@ file, no check.** It is a canonical text projection of the closure — the
 members sorted, each member's fields in declaration order, one fact per
 line: name, wire id, kind, an array's ELEMENT kind, array shape (fixed,
 bounded or enum-keyed, with the bound's EVALUATED value and, for a keyed
-array, the KEY enum it names), string and bytes capacity, presence of an
-optional, a fixed field's `F` (`frac=`, the one wire-invisible fact a wide
-kind has, §4.1), the specified default as exact canonical text — a fixed
-default as the RAW integer its storage holds — and the `was`
-alias; then each enum's variants in order with their ids, each flags'
+array, the KEY enum it names), string and bytes capacity, the declared
+RANGE (`min=` and `max=`), presence of an optional, a fixed field's `F`
+(`frac=`, the one wire-invisible fact a wide kind has, §4.1), the specified
+default as exact canonical text — a fixed default as the RAW integer its
+storage holds — and the `was` alias; then each enum's variants in order with their ids, each flags'
 variants in positional order, and each union's arms in order with their ids
 and payloads.
+
+**Its ABSENCE is said out loud, once.** `schema check` prints one line to
+stderr for a unit that declares a table and holds no baseline: that its
+save-game evolution is unguarded, and the command that commits one. It is a
+notice, never a block — the exit code is untouched, and committing a
+baseline silences it.
 
 **A field that names a declaration records WHICH KIND of declaration it
 names** — a table, an `enum`, a `flags` or a `union` — because those four
@@ -7692,6 +7699,15 @@ and flows through an expression into a default shows up as the value it now
 produces, which is the whole point — the projection records what data will
 mean, not how it was spelled.
 
+**A RANGE IS AN EXTENT, and it is recorded like a capacity.** A reader
+clamps a stored value to its OWN declared bounds and counts `clamped` (§4),
+so a tightened range is a data edit — every stored value past the new bound
+reads back as the bound, and the next save writes that. Only a DECLARED
+range is recorded: `bits(N)`'s implied `[0, 2^N − 1]` is its WIDTH, and the
+width is the `kind` this file already holds fixed. A fixed field's bounds
+are its WHOLE-UNIT bounds, recorded beside the `frac=` that puts them on the
+raw scale (§4).
+
 **Presence is RECORDED and judged on nothing.** An optional's presence
 companion is a fact in the file so a person reading a diff can see it, but
 a field moving between `T`, `?T` and `*T` moves no byte (§3.1) and passes
@@ -7702,13 +7718,14 @@ It carries no protocol id and no packet fact: the type wire, the wire-shape
 projection and the protocol id are untouched by all of it (§10).
 
 ```
-schema-tables-baseline 2
+schema-tables-baseline 4
 package shipdemo
 
 table ShipConfig
     field damage id=0x15a9 kind=10 default=21.0
     field speed id=0x2e46 kind=10 default=500.0 was=velocity
     field name id=0x30df kind=12 size=32
+    field armour id=0xf2f0 kind=4 min=0 max=1000 default=100
 
 ## history
 ### 2026-09-02 — first baseline before 1.0 ships
@@ -7730,17 +7747,30 @@ committed file whenever one is there, and:
   or an enum-keyed array's KEY enum swapped for another; a field's REFERENT
   dropped, or replaced by one that cannot STAND IN for it — every identity
   survives AND, for a table or a union arm's payload, the facts under the
-  shared field ids are unchanged (§18.3).
-- **WARNS** — an array bound or a string/bytes capacity shrunk; an enum
-  variant or a union arm removed; a DECLARATION renamed, or otherwise no
-  longer in the closure under its baseline name (§18.3). The data survives
-  and the read report already counts what is lost (`clamped`, `unknown`), so
-  this reports rather than stops.
+  shared field ids are unchanged (§18.3); a `was` that names a field which
+  ITSELF rode under a `was` — `was` names the FIRST wire name, forever (§5),
+  so a second one aimed at the intermediate spelling hashes a name no byte
+  was ever written under, and the refusal names both spellings and the one
+  that is correct.
+- **WARNS** — an array bound or a string/bytes capacity shrunk; a declared
+  RANGE tightened, from either end, or declared where the field had none; an
+  enum variant or a union arm removed; a DECLARATION renamed, or otherwise no
+  longer in the closure under its baseline name (§18.3); a field REMOVED and
+  a field ADDED in one table in one edit, which is the shape a bare rename
+  leaves — the warning names both and says how to declare it, and it is a
+  warning rather than a refusal because two independent edits in one commit
+  are legitimate. The data survives and the read report already counts what
+  is lost (`clamped`, `unknown`), so this reports rather than stops.
+- **HINTS, once** — a `was` ADDED to a field that carries no `json =` key.
+  The rename keeps the WIRE id and moves the TEXT key, which is the field's
+  own name (§16.4), so an existing text keyed on the old name stops matching.
+  It is said at the edit that adds the `was` and not on every check after it,
+  and a field that already pairs its key is told nothing.
 - **PASSES, in silence** — everything the wire absorbs: fields added,
   removed, reordered or renamed under `was`; enum variants and union arms
-  added anywhere; flags variants APPENDED at the end; bounds and capacities
-  grown; a bounded array made fixed or the reverse; a field moved between
-  `T`, `?T` and `*T`.
+  added anywhere; flags variants APPENDED at the end; bounds, capacities and
+  ranges grown; a bounded array made fixed or the reverse; a field moved
+  between `T`, `?T` and `*T`.
 
 **The BLOCK FORM takes no row here at all** (§18.1). A table's layout is a
 same-build contract that a compiler holds (§19.3), so an edit that moves an
@@ -7852,9 +7882,18 @@ it. The created file says so in its own first history entry.
 
 Each refusal class has a fixture pair and its negative control — remove the
 check and the edit passes. The projection over the corpus regenerates
-byte-identical. The warn class warns and does not refuse. `--update`
-without `--reason` refuses, and `--update` over an unreadable baseline
-repairs it while keeping every history line.
+byte-identical. The warn class warns and does not refuse. A tightened range
+warns from either end and a loosened one is silent, over a ranged integer, a
+fixed field's whole-unit bounds and a compressed float's. The `was` chain
+refuses and names both spellings, while the same second rename carrying the
+FIRST name forward is silent. A bare rename's removal-and-addition pair
+warns, and each half alone is silent. A `was` added without a `json =` key
+hints the pairing once and says nothing on the check after it. A
+table-bearing unit with no baseline draws the notice and one that has a
+baseline draws nothing. `--update` without `--reason` refuses, and
+`--update` over an unreadable baseline — including one written under the
+rendering version before this one — repairs it while keeping every history
+line.
 
 
 ## 19. The block form

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2275,6 +2275,16 @@ Old files that carry `velocity` load into `speed`; new files keep writing the
 old id. The compiler refuses `was` naming the field's own current name, and
 refuses any two fields of one table whose effective ids collide.
 
+**`was` names the FIRST wire name, forever.** Rename `speed` again and the
+attribute does not move with it — it still says `was = "velocity"`, because
+that is the name every stored byte was written under. Aiming the new one at
+the intermediate spelling instead (`max_speed | was = "speed"`) hashes a name
+no file ever carried, and every stored value orphans; a committed baseline
+refuses exactly that and names the spelling that is right. And `was` keeps
+the WIRE id, not the TEXT key — the JSON key is the field's own name (see the
+text form) — so pair `json = "velocity"` when an existing text file has to
+keep reading.
+
 ### The tables baseline: catching the edits the wire cannot report
 
 Think of a save game. A player's file was written two years ago by a build
@@ -2354,11 +2364,20 @@ both ride as kind 7. **"Stand in" means every identity survives AND, for a
 table, the facts under the shared field ids are unchanged**: a twin
 declaration carrying the same id under a different default is refused,
 because every stored body's elided value would quietly change meaning.
+Also refused: a second `was` aimed at the field's intermediate spelling,
+naming both names and the one that is correct.
 Warned, because the read report already counts what is lost: a bound or a
-string capacity shrunk, an enum variant or a union arm removed, a declaration
-renamed or otherwise no longer covered. Passed in silence, because the wire
-absorbs it: fields added, removed, reordered or renamed under `was`; variants
-added anywhere; flags variants APPENDED; bounds grown.
+string capacity shrunk, a declared range tightened from either end (or
+declared where the field had none — every stored value outside it clamps on
+load, and the next save writes the clamped value), an enum variant or a union
+arm removed, a declaration renamed or otherwise no longer covered. Warned
+too, because it is the shape a bare rename leaves: a field removed AND a
+field added in one table in one edit, naming both and suggesting the `was`
+and `json =` that declare it — a warning and not a refusal, because two
+independent edits in one commit are perfectly ordinary. Passed in silence,
+because the wire absorbs it: fields added, removed, reordered or renamed
+under `was`; variants added anywhere; flags variants APPENDED; bounds,
+capacities and ranges grown.
 
 Renaming a declaration never raises a verdict of its own: it warns, saying
 which declaration carries the old one's contents on, and the contents keep
@@ -2367,7 +2386,18 @@ whether or not its enum was renamed in the same edit.
 
 The whole thing is opt-in — no `tables.baseline`, no check — and the first
 one you write covers only what comes after it: data written before it existed
-was written against a shape nobody recorded.
+was written against a shape nobody recorded. So `schema check` says so once
+for a unit that declares a table and has no baseline:
+
+```
+$ schema check configs/
+notice: shipdemo declares 1 table and configs holds no tables.baseline — save-game
+evolution is unguarded (SPEC-TABLES.md §18); commit one with: schema tables-baseline
+--update --reason "first baseline" configs
+```
+
+That is a notice, not a failure: the exit code is untouched, and committing a
+baseline silences it.
 
 ### Going wide
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -164,14 +164,20 @@ name. That one decision produces the whole evolution story:
 - **Rename with `was`.** `speed float32 | was = "velocity"` keeps the wire id
   `hash("velocity")` forever; the source name is for people. **`was` names the
   field's first wire name, forever.** A second rename keeps the same `was`; it
-  is never re-pointed at an intermediate name.
+  is never re-pointed at an intermediate name, and a committed baseline
+  refuses one that is — the intermediate spelling hashes an id no byte was
+  ever written under. `was` keeps the wire id and not the TEXT key, which is
+  the field's own name, so the edit that adds a `was` also draws a one-line
+  hint to pair `json = "velocity"` when the field has no key of its own.
 - **A rename without `was` is the edit to fear, and the compiler cannot see
   it.** The compiler retains nothing between builds; to it a bare rename is a
   removal and an addition, both of which pass. Every value stored under the
   old name reads as the default from then on, counted `unknown`, and nothing
   reports that the two names were one field. A committed baseline is the one
-  place the shape of a rename is visible, a removal and an addition in one
-  table in one edit, and it will warn on that pair (#444).
+  place the shape of a rename is visible — a removal and an addition in one
+  table in one edit — and it warns on that pair, naming both and the `was`
+  and `json =` that declare it. Two independent edits in one commit are
+  legitimate, so it is a warning and never a refusal.
 - **Collisions are refused at compile time.** Two names in one vocabulary
   whose hashes coincide, or a `was` colliding with a live name, are a compile
   error naming both, and the refusal fires when the *new* name is added,
@@ -221,14 +227,15 @@ does today.
 
 | the edit | the read report | the baseline | the build version |
 |---|---|---|---|
-| a field added, removed or reordered | `unknown` on the side that lacks it | passes | moves (the record's layout moved) |
-| a field renamed under `was` | nothing | passes | **nothing**: keyed by wire id, not source name |
-| a field renamed bare | `unknown` on every old file; the new field reads its default | passes, in silence: a removal and an addition (#444 adds a warning on the pair) | moves |
+| a field added, removed or reordered | `unknown` on the side that lacks it | passes; a removal AND an addition in one table in one edit is the bare-rename row below | moves (the record's layout moved) |
+| a field renamed under `was` | nothing | passes; the edit that adds the `was` hints the `json =` pairing | **nothing**: keyed by wire id, not source name |
+| a field renamed a second time, the new `was` naming the INTERMEDIATE spelling instead of the first | `unknown` on every old file; the new id was never written to | **refuses** | moves |
+| a field renamed bare | `unknown` on every old file; the new field reads its default | warns: a removal and an addition in one table in one edit is the shape of a rename | moves |
 | a field of a `type` that a table reaches, renamed | `unknown` on every old file; `was` is refused there today (#478) | passes, in silence | moves, and so does the protocol id |
 | a scalar's default changed | **silent**: the same bytes mean something else | **refuses** | moves (a meaning fact) |
 | a string, bytes or flags default changed | silent | refuses once #396 lands; not declarable today | moves |
 | a bound raised or lowered, a capacity or array bound grown | `clamped` where a stored value exceeds it | passes; warns on a shrink | moves |
-| a range tightened | `clamped` | passes; a warning is #443 | moves |
+| a range tightened | `clamped` | warns | moves |
 | a field's kind changed (`int32`→`int64`, `T`→`*T`, `string`→`bytes`, `bits(8)`→`bits(9)`) | `kind_mismatch`; the value reads as the default | **refuses** | moves |
 | `T`→`?T`, `?T`→`T` | nothing: one framing. An old file's elided default reads as *absent* under `?T` | passes | moves (the presence flag is storage) |
 | an enum variant added or removed | `unknown` where a stored name is gone | passes; warns on a removal | moves, and so does the protocol id |
@@ -281,16 +288,21 @@ of every field, evaluated, keyed by wire id. `schema check` (and so
 `generate`) diffs the current schema against it and **refuses any edit that
 would make data already written unreadable or quietly change what it means**:
 the silent class above, plus kind changes, keyed-array respellings and
-referent drops. It warns on shrinks, removals and declaration renames, and
-passes in silence on everything the wire reports. `schema tables-baseline`
-prints the projection, and with `--update` rewrites the file.
+referent drops, and a second `was` aimed at a field's intermediate spelling.
+It warns on shrinks, tightened ranges, removals, declaration renames and the
+removal-and-addition pair a bare rename leaves, hints the `json =` pairing at
+the edit that adds a `was`, and passes in silence on everything the wire
+reports. `schema tables-baseline` prints the projection, and with `--update`
+rewrites the file.
 
 **Commit one.** The baseline is opt-in, no file, no check, and every
 "refuses" in the table above holds only for a unit that has one. A unit whose
 data leaves the building commits its baseline the day the first such build
 ships, because **the first baseline covers only what comes after it**: data
-written before that day was written against a shape nobody recorded. A
-warning from `check` for a table-bearing unit with no baseline is #445.
+written before that day was written against a shape nobody recorded. `schema
+check` says so: a unit that declares a table and holds no baseline draws one
+line on stderr naming the command that commits one, with the exit code
+untouched, and committing one silences it.
 
 **Moving it is explicit and reasoned.** A refused edit that is nonetheless
 intended is accepted with `--update --reason "..."`, which rewrites the file
@@ -312,9 +324,7 @@ read, salvaging the history. The window during which that repair runs is the
 one window the check is off, marked in the history as "could not be diffed";
 review the schema diff of that commit by hand.
 
-**Before 3.0.0's evolution claims:** the retired-names ledger (#441), range
-facts (#443), `was` misuse and the rename-pair warning (#444), the nudge
-(#445).
+**Before 3.0.0's evolution claims:** the retired-names ledger (#441).
 
 ## The build version
 
@@ -613,7 +623,9 @@ still open.
   value is the default either way; a game that branches on presence sees
   every existing player as "never set."
 - **A tightened range clamps on load and the next save writes the clamped
-  value.** A narrowing is a data edit; back the files up first.
+  value.** A narrowing is a data edit; back the files up first. A committed
+  baseline warns on it, from either end and on a range declared where the
+  field had none, but the warning is a report and not a rescue.
 - **`None` means both "unknown variant" and "never set."** A retired variant
   and an unset field read the same; a game that must tell them apart keeps a
   separate presence field.
@@ -675,8 +687,6 @@ repository not yet behind it. The 3.0.0 release holds the list at zero.
 - #441: the retired-names ledger.
 - #442: `was` for variants and arms; #478: `was` for the fields of a `type`
   that a table reaches.
-- #443, #444, #445: range facts, `was` misuse and the rename-pair warning,
-  the baseline nudge.
 - #446: the evolution table's fixtures.
 - #439 and #460: the standard's own contradictions on `T`→`*T`, the flags
   row, writer misuse, the declaration-rename row, the count of silent edits,

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -51,11 +51,11 @@ import (
 //
 // THE RULE FOR BUMPING IT: any NEW JUDGED TOKEN bumps the version. A token
 // this rendering emits and an older one did not reads as an ADDITION to every
-// older file, and the added-token branch of the diff refuses an addition on
+// older file, and the added-token branch of the diff judges an addition on
 // every judged row — so an unbumped rendering greets an untouched schema with
-// a refusal per field. Recording a fact nothing judges (an `optional`) does
+// a diagnostic per field. Recording a fact nothing judges (an `optional`) does
 // not need a bump; adding a rule does.
-const Version = 3
+const Version = 4
 
 // FileName is the baseline's name in the unit directory. Its presence is what
 // turns the check on: no file, no check.
@@ -99,6 +99,14 @@ type Field struct {
 	Name   string
 	Id     uint16
 	Tokens []Token
+
+	// JsonKey is the field's `json = "key"` text key, and it is the one fact
+	// here the FILE DOES NOT CARRY: a text key moves no wire byte
+	// (docs/SPEC-TABLES.md §16.4), so it is never rendered and never parsed.
+	// [Render] fills it on the live projection alone, where the rename hint
+	// reads it — adding a `was` keeps the wire id and moves the TEXT key, and
+	// a field with no key of its own is the one that needs telling.
+	JsonKey string
 }
 
 // A Token is one `key=value` wire fact on a field's line. The key is what
@@ -233,7 +241,7 @@ func renderUnion(un *ir.Union) Union {
 // renderField lists a field's wire facts. The token ORDER here is the file's
 // column order; every key it can emit has a row in [DefaultTokenPolicy].
 func renderField(f *ir.Field) Field {
-	out := Field{Name: f.Name, Id: ir.TableFieldId(f)}
+	out := Field{Name: f.Name, Id: ir.TableFieldId(f), JsonKey: f.JsonKey}
 	add := func(k, v string) { out.Tokens = append(out.Tokens, Token{Key: k, Value: v}) }
 
 	add("kind", strconv.Itoa(ir.TableFieldKind(f)))
@@ -299,6 +307,23 @@ func renderField(f *ir.Field) Field {
 	if f.Type.Size != 0 {
 		add("size", strconv.FormatInt(f.Type.Size, 10))
 	}
+	// THE EFFECTIVE RANGE, as DECLARED. A reader clamps a stored value to its
+	// own declared bounds and counts `clamped` (docs/SPEC-TABLES.md §4), so a
+	// tightened range is a data edit the wire reports but the baseline is
+	// where it is seen BEFORE it ships — an extent like a capacity, judged the
+	// same way. Only a declared range is recorded: `bits(N)`'s implied
+	// [0, 2^N - 1] is its WIDTH, and the width is the `kind` token, which is
+	// already a fixed fact.
+	switch {
+	case f.HasIntRange && f.IntMin != nil && f.IntMax != nil:
+		// a fixed field's bounds are its WHOLE-UNIT bounds, as declared; the
+		// raw scale is `frac`, recorded beside them
+		add("min", f.IntMin.String())
+		add("max", f.IntMax.String())
+	case f.HasFloatRange:
+		add("min", floatText(f.FMin))
+		add("max", floatText(f.FMax))
+	}
 	if f.HasDefault {
 		add("default", DefaultText(f))
 	}
@@ -320,15 +345,19 @@ func DefaultText(f *ir.Field) string {
 	case f.Type.Kind == ir.TBool:
 		return strconv.FormatBool(f.DefBool)
 	default:
-		// shortest round-tripping form: exact, and stable across builds. The
-		// trailing ".0" is put back on a whole number so a float default
-		// never reads as an integer one.
-		s := strconv.FormatFloat(f.DefFloat, 'g', -1, 64)
-		if !strings.ContainsAny(s, ".eEnN") {
-			s += ".0"
-		}
-		return s
+		return floatText(f.DefFloat)
 	}
+}
+
+// floatText is the shortest round-tripping form of a float fact: exact, and
+// stable across builds. The trailing ".0" is put back on a whole number so a
+// float never reads as an integer one.
+func floatText(v float64) string {
+	s := strconv.FormatFloat(v, 'g', -1, 64)
+	if !strings.ContainsAny(s, ".eEnN") {
+		s += ".0"
+	}
+	return s
 }
 
 // Text renders the baseline as the committed file: the projection, then the

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -141,10 +141,16 @@ func diff(t *testing.T, edited string, policy map[string]baseline.TokenRule) []b
 // about what it changed.
 func replace(t *testing.T, old, new string) string {
 	t.Helper()
-	if strings.Count(baseSrc, old) != 1 {
-		t.Fatalf("fixture edit %q does not appear exactly once in the base schema", old)
+	return editOf(t, baseSrc, old, new)
+}
+
+// editOf is replace over any fixture unit.
+func editOf(t *testing.T, src, old, new string) string {
+	t.Helper()
+	if strings.Count(src, old) != 1 {
+		t.Fatalf("fixture edit %q does not appear exactly once in the fixture", old)
 	}
-	return strings.Replace(baseSrc, old, new, 1)
+	return strings.Replace(src, old, new, 1)
 }
 
 // find reports whether a finding of this verdict mentions both fragments.
@@ -190,12 +196,16 @@ func TestRefusals(t *testing.T) {
 		control string // an edit of the same shape the wire absorbs
 	}{
 		{
-			name:    "a specified default changed",
-			edited:  replace(t, "damage  float32 = 21.0", "damage  float32 = 25.0"),
-			where:   "Config.damage",
-			what:    "specified default 21.0 -> 25.0",
-			token:   "default",
-			control: replace(t, "damage  float32 = 21.0", "damage  float32 = 21.0 | min = 0.0, max = 100.0, resolution = 0.01"),
+			name:   "a specified default changed",
+			edited: replace(t, "damage  float32 = 21.0", "damage  float32 = 25.0"),
+			where:  "Config.damage",
+			what:   "specified default 21.0 -> 25.0",
+			token:  "default",
+			// the absorbed edit of the same shape: the same default DECLARED,
+			// on a field nothing has ever written. (Adding a range to the
+			// field instead would not do: a declared range is an extent, and
+			// adding one narrows the kind's whole domain — see TestRangeFacts.)
+			control: replace(t, "damage  float32 = 21.0", "damage  float32 = 21.0\n    bonus   float32 = 25.0"),
 		},
 		{
 			name:    "a specified default removed",
@@ -807,7 +817,10 @@ func TestAbsorbedEdits(t *testing.T) {
 		{"a field added", replace(t, "    hits    int32", "    hits    int32\n    added   int32")},
 		{"a field removed", replace(t, "    hits    int32\n", "")},
 		{"fields reordered", replace(t, "    damage  float32 = 21.0\n    heading int16", "    heading int16\n    damage  float32 = 21.0")},
-		{"a field renamed under was", replace(t, "hits    int32", "strikes int32 | was = \"hits\"")},
+		// the wire id survives, and the pairing that keeps the TEXT key is
+		// declared beside it — the hint in TestRenameHintsTheJsonPairing is
+		// exactly what a bare `was` draws instead
+		{"a field renamed under was, with the text key paired", replace(t, "hits    int32", "strikes int32 | was = \"hits\", json = \"hits\"")},
 		{"a flags variant appended", replace(t, "flags Perks { Shielded, Cloaked, Turbo }", "flags Perks { Shielded, Cloaked, Turbo, Hardened }")},
 		{"an enum variant inserted in the middle", replace(t, "enum Grade { Bronze, Silver, Gold }", "enum Grade { Bronze, Argent, Silver, Gold }")},
 		{"an array bound grown", replace(t, "const Slots = 8", "const Slots = 64")},
@@ -1162,5 +1175,384 @@ func TestCheckRefusesAForeignBaseline(t *testing.T) {
 				t.Fatalf("wanted a refusal mentioning %q, got %v", tc.want, errs)
 			}
 		})
+	}
+}
+
+// ---- the range facts (docs/SPEC-TABLES.md §18.1, §18.2) ----
+
+// rangeSrc is the ranged fixture: one field per family the table wire clamps
+// on load — a ranged integer, a fixed-point field whose bounds are its
+// WHOLE-UNIT ones, and a compressed float — with an unranged integer beside
+// them, so a case can move one range and leave the rest still. Every default
+// sits well inside its bounds, so an edit here moves the range and nothing
+// else.
+const rangeSrc = `package ranged
+
+table Ship
+{
+    hull  int32 = 50          | min = 0, max = 1000
+    angle fixed(16, 16) = 0   | min = -180, max = 180
+    speed float32 = 1.0       | min = 0.0, max = 100.0, resolution = 0.01
+    tally int32 = 0
+}
+`
+
+// rangeDiff judges an edit of rangeSrc.
+func rangeDiff(t *testing.T, edited string, policy map[string]baseline.TokenRule) []baseline.Finding {
+	t.Helper()
+	return baseline.Diff(committed(t, rangeSrc), baseline.Render(unit(t, edited)), policy)
+}
+
+// TestRangeFacts is #443 made a gate. A tightened range CLAMPS every stored
+// value past the new bound on load, counted once and permanent on the next
+// save (docs/SPEC-TABLES.md §4) — and until the range was in the file the
+// baseline passed it in silence, because the file carried no range token at
+// all. It warns rather than refuses, for the reason every extent does: the
+// data survives and the read report counts what was lost.
+func TestRangeFacts(t *testing.T) {
+	cases := []struct {
+		name    string
+		edited  string
+		where   string
+		what    string
+		token   string
+		control string // the same extent moved the way the wire absorbs
+	}{
+		{
+			name:    "a maximum lowered",
+			edited:  editOf(t, rangeSrc, "hull  int32 = 50          | min = 0, max = 1000", "hull  int32 = 50          | min = 0, max = 100"),
+			where:   "Ship.hull",
+			what:    "declared maximum 1000 -> 100 (a stored value above the new maximum reads back AS the maximum and counts clamped)",
+			token:   "max",
+			control: editOf(t, rangeSrc, "hull  int32 = 50          | min = 0, max = 1000", "hull  int32 = 50          | min = 0, max = 10000"),
+		},
+		{
+			name:    "a minimum raised",
+			edited:  editOf(t, rangeSrc, "hull  int32 = 50          | min = 0, max = 1000", "hull  int32 = 50          | min = 10, max = 1000"),
+			where:   "Ship.hull",
+			what:    "declared minimum 0 -> 10 (a stored value below the new minimum reads back AS the minimum and counts clamped)",
+			token:   "min",
+			control: editOf(t, rangeSrc, "hull  int32 = 50          | min = 0, max = 1000", "hull  int32 = 50          | min = -10, max = 1000"),
+		},
+		{
+			// a FIXED field's declared bounds are whole units and the raw
+			// scale is `frac`, recorded beside them: narrowing the units
+			// narrows the raw range at the same F, with no kind to report it
+			name:    "a fixed field's whole-unit bounds narrowed",
+			edited:  editOf(t, rangeSrc, "angle fixed(16, 16) = 0   | min = -180, max = 180", "angle fixed(16, 16) = 0   | min = -90, max = 180"),
+			where:   "Ship.angle",
+			what:    "declared minimum -180 -> -90",
+			token:   "min",
+			control: editOf(t, rangeSrc, "angle fixed(16, 16) = 0   | min = -180, max = 180", "angle fixed(16, 16) = 0   | min = -360, max = 180"),
+		},
+		{
+			// the compressed float's bounds are FLOATS, so the comparison is
+			// not an integer one — the fact is exact either way
+			name:    "a compressed float's maximum lowered",
+			edited:  editOf(t, rangeSrc, "speed float32 = 1.0       | min = 0.0, max = 100.0, resolution = 0.01", "speed float32 = 1.0       | min = 0.0, max = 10.5, resolution = 0.01"),
+			where:   "Ship.speed",
+			what:    "declared maximum 100.0 -> 10.5",
+			token:   "max",
+			control: editOf(t, rangeSrc, "speed float32 = 1.0       | min = 0.0, max = 100.0, resolution = 0.01", "speed float32 = 1.0       | min = 0.0, max = 1000.5, resolution = 0.01"),
+		},
+		{
+			// a range where the declaration had none narrows the kind's WHOLE
+			// domain onto a slice of it: the same clamp, from the widest
+			// possible starting point
+			name:    "a range added where the field had none",
+			edited:  editOf(t, rangeSrc, "tally int32 = 0", "tally int32 = 0           | min = 0, max = 10"),
+			where:   "Ship.tally",
+			what:    "declared maximum 10 added (a stored value above the new maximum reads back AS the maximum and counts clamped)",
+			token:   "max",
+			control: editOf(t, rangeSrc, "tally int32 = 0", "tally int32 = 0\n    extra int32 = 0     | min = 0, max = 10"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := rangeDiff(t, tc.edited, baseline.DefaultTokenPolicy)
+			if !find(got, baseline.Warn, tc.where, tc.what) {
+				t.Fatalf("a tightened range must warn; wanted %s: %s, got:%s", tc.where, tc.what, summary(got))
+			}
+			if refusals, _ := baseline.Split(got); len(refusals) != 0 {
+				t.Errorf("a tightened range warns and does not refuse, got:%s", summary(refusals))
+			}
+			// the DISCRIMINATION control: the same extent LOOSENED, which
+			// nothing already written falls outside of
+			if ctrl := rangeDiff(t, tc.control, baseline.DefaultTokenPolicy); len(ctrl) != 0 {
+				t.Errorf("a loosened range is absorbed; the baseline must be silent, got:%s", summary(ctrl))
+			}
+			// the ATTRIBUTION control
+			if got := rangeDiff(t, tc.edited, without(tc.token)); find(got, baseline.Warn, tc.where, tc.what) {
+				t.Errorf("with the %q rule removed the warning should be gone, got:%s", tc.token, summary(got))
+			}
+		})
+	}
+}
+
+// TestRangeRemovedIsAbsorbed: dropping a declared range widens the field to
+// its kind's whole domain, and nothing already written sits outside that.
+func TestRangeRemovedIsAbsorbed(t *testing.T) {
+	edited := editOf(t, rangeSrc, "hull  int32 = 50          | min = 0, max = 1000", "hull  int32 = 50")
+	if got := rangeDiff(t, edited, baseline.DefaultTokenPolicy); len(got) != 0 {
+		t.Errorf("a dropped range loosens; the baseline must be silent, got:%s", summary(got))
+	}
+}
+
+// TestRangeIsRecorded: the projection carries the EVALUATED bounds, which is
+// what lets the check see a range that moved through a constant.
+func TestRangeIsRecorded(t *testing.T) {
+	text := baseline.Render(unit(t, rangeSrc)).Text()
+	for _, want := range []string{
+		"field hull id=0x1612 kind=4 min=0 max=1000 default=50",
+		"min=-180 max=180",
+		"min=0.0 max=100.0",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("the projection must record %q:\n%s", want, text)
+		}
+	}
+
+	// and it is the EVALUATED value: a const that moves moves the fact
+	const constSrc = `package ranged
+
+const MaxHull = 1000
+
+table Ship
+{
+    hull int32 = 50 | min = 0, max = MaxHull
+}
+`
+	edited := editOf(t, constSrc, "const MaxHull = 1000", "const MaxHull = 100")
+	got := baseline.Diff(committed(t, constSrc), baseline.Render(unit(t, edited)), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "Ship.hull", "declared maximum 1000 -> 100") {
+		t.Errorf("a range tightened through its constant must warn, got:%s", summary(got))
+	}
+}
+
+// ---- `was` misuse and the rename pair (docs/SPEC-TABLES.md §5, §18.2) ----
+
+// wasSrc is the twice-renamed fixture: a field that has ALREADY been renamed
+// once and rides under the first name's hash.
+const wasSrc = `package renaming
+
+table Ship
+{
+    speed float32 = 500.0 | was = "velocity"
+    hull  int32 = 50      | min = 0, max = 1000
+}
+`
+
+// TestWasChainIsRefused is #444's flagship. `was` names the FIRST wire name,
+// forever: once `velocity` became `speed | was = "velocity"` the field rides
+// under hash("velocity"), so a later `max_speed | was = "speed"` hashes a name
+// no byte was ever written under and every stored value orphans — with nothing
+// on the wire to report it, because the reader simply finds no such id.
+func TestWasChainIsRefused(t *testing.T) {
+	edited := editOf(t, wasSrc, `speed float32 = 500.0 | was = "velocity"`, `max_speed float32 = 500.0 | was = "speed"`)
+	got := baseline.Diff(committed(t, wasSrc), baseline.Render(unit(t, edited)), baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Refuse, "Ship.max_speed",
+		`was = "speed" names speed, which itself rode under was = "velocity" — `+"`was`"+` names the FIRST wire name, forever`) {
+		t.Fatalf("a second `was` naming the field's own current spelling must be refused, got:%s", summary(got))
+	}
+	if !find(got, baseline.Refuse, "Ship.max_speed", `write was = "velocity"`) {
+		t.Errorf("the refusal must name the spelling that is correct, got:%s", summary(got))
+	}
+
+	// the DISCRIMINATION control: the second rename done RIGHT — the first
+	// wire name carried forward — moves no byte and says nothing
+	right := editOf(t, wasSrc, `speed float32 = 500.0 | was = "velocity"`, `max_speed float32 = 500.0 | was = "velocity"`)
+	if ctrl := baseline.Diff(committed(t, wasSrc), baseline.Render(unit(t, right)), baseline.DefaultTokenPolicy); len(ctrl) != 0 {
+		t.Errorf("carrying the first wire name forward is the whole point of `was`; it must be silent, got:%s", summary(ctrl))
+	}
+	// the ATTRIBUTION control
+	if got := baseline.Diff(committed(t, wasSrc), baseline.Render(unit(t, edited)), without("was-chain")); len(got) != 0 {
+		t.Errorf("with the \"was-chain\" rule removed the edit passes as it did before, got:%s", summary(got))
+	}
+}
+
+// TestRenameHintsTheJsonPairing is #444's second half. A `was` keeps the WIRE
+// id through a rename and does not keep the TEXT key, which is the field's name
+// (docs/SPEC-TABLES.md §16.4) — so an existing JSON file keyed on the old name
+// stops matching. The hint is said once, at the edit that adds the `was`, and
+// only to a field with no key of its own.
+func TestRenameHintsTheJsonPairing(t *testing.T) {
+	edited := replace(t, "hits    int32", `strikes int32 | was = "hits"`)
+	got := diff(t, edited, baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "Config.strikes", `renamed under was = "hits", which keeps the wire id and NOT the text key — the JSON key is now "strikes"; pair json = "hits"`) {
+		t.Fatalf("a bare rename must hint the text-key pairing, got:%s", summary(got))
+	}
+	if refusals, _ := baseline.Split(got); len(refusals) != 0 {
+		t.Errorf("a hint is a hint: it must not refuse, got:%s", summary(refusals))
+	}
+
+	// the DISCRIMINATION control: the pairing DECLARED beside the rename
+	paired := replace(t, "hits    int32", `strikes int32 | was = "hits", json = "hits"`)
+	if ctrl := diff(t, paired, baseline.DefaultTokenPolicy); len(ctrl) != 0 {
+		t.Errorf("a field that already pairs its text key has answered the question, got:%s", summary(ctrl))
+	}
+	// SAID ONCE: with the rename committed, the next check is silent
+	if again := baseline.Diff(committed(t, edited), baseline.Render(unit(t, edited)), baseline.DefaultTokenPolicy); len(again) != 0 {
+		t.Errorf("the hint belongs to the edit that renames, not to every check after it, got:%s", summary(again))
+	}
+	// the ATTRIBUTION control
+	if got := diff(t, edited, without("was-json")); find(got, baseline.Warn, "Config.strikes", "pair json =") {
+		t.Errorf("with the \"was-json\" rule removed the hint should be gone, got:%s", summary(got))
+	}
+}
+
+// TestRemovalAndAdditionWarnAsAPossibleRename is #444's third half, and the one
+// mechanism that can see a BARE rename at all. To the compiler a rename with no
+// `was` is a removal plus an addition, and §18.2 passes both in silence; the
+// baseline is the one place the PAIR is visible. Two independent edits in one
+// commit are legitimate, so it warns and never refuses.
+func TestRemovalAndAdditionWarnAsAPossibleRename(t *testing.T) {
+	renamed := replace(t, "hits    int32", "strikes int32")
+	got := diff(t, renamed, baseline.DefaultTokenPolicy)
+	if !find(got, baseline.Warn, "table Config",
+		"hits removed and strikes added in one edit — if that is a rename the wire id moved with the name and every stored value orphans") {
+		t.Fatalf("a removal and an addition in one table must warn, got:%s", summary(got))
+	}
+	if !find(got, baseline.Warn, "table Config", "declare it `strikes ... | was = \"hits\"`, and pair `json = \"hits\"` if the text key must survive") {
+		t.Errorf("the warning must name both remedies, got:%s", summary(got))
+	}
+	if refusals, _ := baseline.Split(got); len(refusals) != 0 {
+		t.Errorf("two independent edits in one commit are legitimate: this warns, never refuses, got:%s", summary(refusals))
+	}
+
+	// THE NEGATIVE CONTROLS the issue names: each half alone is an ordinary
+	// edit the wire absorbs, and must stay silent
+	for _, tc := range []struct{ name, edited string }{
+		{"a removal alone", replace(t, "    hits    int32\n", "")},
+		{"an addition alone", replace(t, "    hits    int32", "    hits    int32\n    strikes int32")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if ctrl := diff(t, tc.edited, baseline.DefaultTokenPolicy); len(ctrl) != 0 {
+				t.Errorf("half of the pair is not the pair; the baseline must be silent, got:%s", summary(ctrl))
+			}
+		})
+	}
+	// a rename that DECLARES its `was` keeps the id, so there is no pair to see
+	declared := replace(t, "hits    int32", `strikes int32 | was = "hits", json = "hits"`)
+	if ctrl := diff(t, declared, baseline.DefaultTokenPolicy); len(ctrl) != 0 {
+		t.Errorf("a declared rename moves no id and draws no pair warning, got:%s", summary(ctrl))
+	}
+	// the ATTRIBUTION control
+	if got := diff(t, renamed, without("field-pair")); find(got, baseline.Warn, "table Config", "removed and strikes added") {
+		t.Errorf("with the \"field-pair\" rule removed the warning should be gone, got:%s", summary(got))
+	}
+}
+
+// ---- the no-baseline notice (docs/SPEC-TABLES.md §18.1) ----
+
+// TestNudge is #445. The baseline is opt-in — no file, no check — so the
+// DEFAULT posture of a save-game unit is unguarded against every edit §4.1
+// marks silent, and nothing said so. One line says it, and committing a
+// baseline silences it.
+func TestNudge(t *testing.T) {
+	dir, paths := writeUnit(t, baseSrc)
+	msg := baseline.Nudge(unit(t, baseSrc), paths)
+	for _, want := range []string{
+		"fixture declares 1 table and",
+		"holds no tables.baseline",
+		"save-game evolution is unguarded (docs/SPEC-TABLES.md §18)",
+		`commit one with: schema tables-baseline --update --reason "first baseline"`,
+		dir,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the notice must carry %q, got: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "\n") {
+		t.Errorf("the notice is ONE line, got: %q", msg)
+	}
+
+	// COMMITTING A BASELINE SILENCES IT — the whole point of a nudge
+	if _, _, err := baseline.Update(unit(t, baseSrc), paths, "the first baseline"); err != nil {
+		t.Fatal(err)
+	}
+	if msg := baseline.Nudge(unit(t, baseSrc), paths); msg != "" {
+		t.Errorf("a unit with a baseline is guarded and must be told nothing, got: %s", msg)
+	}
+}
+
+// TestNudgeIsAboutTABLES: a unit that declares no table has no table wire to
+// guard, so it is told nothing however long it lives without a baseline.
+func TestNudgeIsAboutTables(t *testing.T) {
+	const noTables = `package plain
+
+type Vec3
+{
+    x float32
+    y float32
+    z float32
+}
+`
+	_, paths := writeUnit(t, noTables)
+	if msg := baseline.Nudge(unit(t, noTables), paths); msg != "" {
+		t.Errorf("a unit with no tables has nothing to guard, got: %s", msg)
+	}
+}
+
+// TestPreBumpBaselineRepairs is the version bump's own path, run on the shape
+// every committed baseline in an estate takes the day a new judged token lands
+// (#443's range facts are that token): the file is a rendering this compiler
+// does not read, the check refuses and names `--update` as the remedy, and the
+// remedy regenerates the projection in the CURRENT rendering while carrying
+// every history line across verbatim.
+func TestPreBumpBaselineRepairs(t *testing.T) {
+	dir, paths := writeUnit(t, rangeSrc)
+	path := filepath.Join(dir, baseline.FileName)
+
+	// a baseline in the rendering BEFORE this one: the projection as it was
+	// written, with no range facts in it
+	stale := fmt.Sprintf(`schema-tables-baseline %d
+package ranged
+
+table Ship
+    field hull id=0x1612 kind=4 default=50
+
+%s
+### 2024-01-01 — the break we are never allowed to forget
+- Ship.hull: specified default 10 -> 50 [refuse]
+`, baseline.Version-1, baseline.HistoryHeading)
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, errs := baseline.Check(unit(t, rangeSrc), paths)
+	if len(errs) != 1 {
+		t.Fatalf("a baseline in an older rendering must refuse exactly once, got %v", errs)
+	}
+	for _, want := range []string{
+		fmt.Sprintf("baseline version %d, this compiler writes %d", baseline.Version-1, baseline.Version),
+		"--update --reason",
+	} {
+		if !strings.Contains(errs[0].Error(), want) {
+			t.Errorf("the refusal must mention %q, got: %v", want, errs[0])
+		}
+	}
+
+	if _, rewrote, err := baseline.Update(unit(t, rangeSrc), paths, "the range facts landed"); err != nil || !rewrote {
+		t.Fatalf("the advertised remedy must work: %v (rewrote=%v)", err, rewrote)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		fmt.Sprintf("schema-tables-baseline %d", baseline.Version),
+		"field hull id=0x1612 kind=4 min=0 max=1000 default=50", // the new judged token
+		"### 2024-01-01 — the break we are never allowed to forget",
+		"- Ship.hull: specified default 10 -> 50 [refuse]", // salvaged verbatim
+		"the range facts landed",
+		"baseline REGENERATED over an unreadable one",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("the repaired baseline must carry %q:\n%s", want, data)
+		}
+	}
+	if warns, errs := baseline.Check(unit(t, rangeSrc), paths); len(warns) != 0 || len(errs) != 0 {
+		t.Errorf("after the repair the check must pass: %v %v", warns, errs)
 	}
 }

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -40,8 +40,8 @@ package baseline
 
 import (
 	"fmt"
+	"math/big"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -77,8 +77,12 @@ const (
 	RulePass TokenRule = iota
 	// RuleFixed — any change, addition or removal is a refusal.
 	RuleFixed
-	// RuleShrink — a smaller value warns; a larger one passes.
+	// RuleShrink — a smaller value warns; a larger one passes. The extent
+	// the token names got tighter, and a stored value past it clamps.
 	RuleShrink
+	// RuleRaise — a larger value warns; a smaller one passes. RuleShrink's
+	// mirror, for the bottom end of a range: raising a minimum tightens it.
+	RuleRaise
 	// RuleLoss — something present in the baseline is gone; it warns.
 	RuleLoss
 	// RuleRefs — the token names another declaration. Dropping it refuses;
@@ -97,8 +101,15 @@ var DefaultTokenPolicy = map[string]TokenRule{
 	"frac":    RuleFixed,  // a fixed field's raw value under a moved F is a different number, and no counter can fire
 	"bound":   RuleShrink, // a count past the reader's bound keeps the prefix and counts clamped
 	"size":    RuleShrink, // a string/bytes capacity is a bound like any other
-	"array":   RulePass,   // fixed and bounded frame identically on the wire (docs/SPEC-TABLES.md §3)
-	"was":     RulePass,   // `was` is the rename that PRESERVES identity — that is its whole job
+	// THE DECLARED RANGE, judged from both ends: a reader clamps a stored
+	// value to its own bounds and counts `clamped` (docs/SPEC-TABLES.md §4), so
+	// a tightened range is an extent shrinking like any other — a maximum
+	// lowered or a minimum raised. Loosening passes: nothing already written
+	// falls outside a wider range.
+	"max":   RuleShrink,
+	"min":   RuleRaise,
+	"array": RulePass, // fixed and bounded frame identically on the wire (docs/SPEC-TABLES.md §3)
+	"was":   RulePass, // `was` is the rename that PRESERVES identity — that is its whole job
 	// PRESENCE IS RECORDED AND JUDGED ON NOTHING: T, ?T and *T are one
 	// framing, so a field moving between them moves no byte (§3.1, §18.1)
 	"optional": RulePass,
@@ -125,6 +136,19 @@ var DefaultTokenPolicy = map[string]TokenRule{
 	"flags-position": RuleFixed, // bit i is variant i, and the order IS the fact
 	"enum-variant":   RuleLoss,  // stored values naming a dropped variant read as None
 	"union-arm":      RuleLoss,  // stored bodies naming a dropped arm are skipped
+	// `was` NAMES THE FIRST WIRE NAME, FOREVER (docs/SPEC-TABLES.md §5). A
+	// second rename that names the field's own CURRENT spelling hashes a name
+	// no byte was ever written under, and every stored value orphans in
+	// silence. The baseline is what remembers the first name.
+	"was-chain": RuleFixed,
+	// A `was` ADDED keeps the wire id and moves the TEXT key with the field's
+	// name (§16.4), so the rename hint says so once, at the edit that does it.
+	"was-json": RuleLoss,
+	// A REMOVAL AND AN ADDITION in one table in one edit is the shape a bare
+	// rename leaves: the compiler sees two absorbed edits, and the baseline
+	// sees the pair. Two independent edits in one commit are legitimate, so it
+	// warns and never refuses.
+	"field-pair": RuleLoss,
 }
 
 // A Finding is one difference between the committed baseline and the unit as
@@ -461,6 +485,7 @@ func (d *differ) diffTables() []Finding {
 		for _, f := range lt.Fields {
 			liveFields[f.Id] = f
 		}
+		var gone []string
 		for _, bf := range bt.Fields {
 			// FIELDS MATCH BY WIRE ID, not by name: the id is the identity a
 			// reader keys on, and `was` is exactly the tool for keeping it
@@ -468,12 +493,89 @@ func (d *differ) diffTables() []Finding {
 			// removal is absorbed — the reader defaults it.
 			lf, ok := liveFields[bf.Id]
 			if !ok {
+				gone = append(gone, bf.Name)
 				continue
 			}
 			out = append(out, d.diffTokens(lt.Name+"."+lf.Name, bf, lf)...)
 		}
+		out = append(out, d.wasChain(bt, lt)...)
+		out = append(out, d.renamePair(bt, lt, gone)...)
 	}
 	return out
+}
+
+// wasChain refuses a SECOND rename aimed at the INTERMEDIATE spelling
+// (docs/SPEC-TABLES.md §5). `was` names the FIRST wire name, forever: once
+// `velocity` became `speed | was = "velocity"`, the field rides under
+// hash("velocity") and hash("speed") is an id no byte was ever written under.
+// A later `max_speed | was = "speed"` therefore orphans every stored value,
+// and nothing on the wire says so — the reader simply finds no such id and
+// defaults the field. The baseline is the one place that remembers the first
+// name, which is why this refusal lives here rather than in the checker,
+// which refuses only the case it can see on its own: a `was` naming the
+// field's own current name.
+func (d *differ) wasChain(bt, lt Table) []Finding {
+	if d.policy["was-chain"] != RuleFixed {
+		return nil
+	}
+	// the baseline's fields by the name they were DECLARED under, which is
+	// what a second `was` names when the author reaches for the wrong one
+	byName := map[string]Field{}
+	for _, f := range bt.Fields {
+		byName[f.Name] = f
+	}
+	var out []Finding
+	for _, lf := range lt.Fields {
+		now, has := lf.Get("was")
+		if !has {
+			continue
+		}
+		bf, known := byName[now]
+		if !known {
+			continue
+		}
+		first, chained := bf.Get("was")
+		if !chained || first == now {
+			continue
+		}
+		out = append(out, Finding{Refuse, lt.Name + "." + lf.Name, fmt.Sprintf(
+			"was = %q names %s, which itself rode under was = %q — `was` names the FIRST wire name, forever, so this field now rides under id 0x%04x, an id no byte was ever written under; write was = %q",
+			now, now, first, lf.Id, first)})
+	}
+	return out
+}
+
+// renamePair warns on the shape a BARE rename leaves behind: a wire id
+// removed and a wire id added in one table in one edit. The compiler retains
+// nothing and sees two edits it absorbs (docs/SPEC-TABLES.md §5, §18.2); the
+// baseline sees the pair. Two independent edits in one commit are perfectly
+// legitimate, so this warns and never refuses — and a live field that already
+// declares a `was` is not counted as an addition, because its author has
+// answered this question already (rightly, or by the refusal above).
+func (d *differ) renamePair(bt, lt Table, gone []string) []Finding {
+	if d.policy["field-pair"] != RuleLoss || len(gone) == 0 {
+		return nil
+	}
+	baseIds := map[uint16]bool{}
+	for _, f := range bt.Fields {
+		baseIds[f.Id] = true
+	}
+	var added []string
+	for _, lf := range lt.Fields {
+		if baseIds[lf.Id] {
+			continue
+		}
+		if _, declared := lf.Get("was"); declared {
+			continue
+		}
+		added = append(added, lf.Name)
+	}
+	if len(added) == 0 {
+		return nil
+	}
+	return []Finding{{Warn, "table " + lt.Name, fmt.Sprintf(
+		"%s removed and %s added in one edit — if that is a rename the wire id moved with the name and every stored value orphans: declare it `%s ... | was = %q`, and pair `json = %q` if the text key must survive (docs/SPEC-TABLES.md §5, §16.4)",
+		strings.Join(gone, ", "), strings.Join(added, ", "), added[0], gone[0], gone[0])}}
 }
 
 func (d *differ) diffTokens(where string, bf, lf Field) []Finding {
@@ -490,7 +592,7 @@ func (d *differ) diffTokens(where string, bf, lf Field) []Finding {
 			case lv != bt.Value:
 				out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s -> %s", tokenNoun(bt.Key), bt.Value, lv)})
 			}
-		case RuleShrink:
+		case RuleShrink, RuleRaise:
 			if !present || lv == bt.Value {
 				continue
 			}
@@ -503,19 +605,18 @@ func (d *differ) diffTokens(where string, bf, lf Field) []Finding {
 			if shape, _ := bf.Get("array"); shape == "keyed" {
 				continue
 			}
-			was, err1 := strconv.ParseInt(bt.Value, 10, 64)
-			now, err2 := strconv.ParseInt(lv, 10, 64)
-			if err1 != nil || err2 != nil || now >= was {
+			if !tightened(d.policy[bt.Key], bt.Value, lv) {
 				continue
 			}
-			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s -> %s (%s)", tokenNoun(bt.Key), bt.Value, lv, shrinkNote(bt.Key))})
+			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s -> %s (%s)", tokenNoun(bt.Key), bt.Value, lv, tightenNote(bt.Key))})
 		case RuleRefs:
 			out = append(out, d.refsFindings(where, bt.Key, bt.Value, lv, present)...)
 		}
 	}
-	// a fact the live projection carries and the baseline does not: only the
-	// refusing rules care, and only because ADDING a default is as much a
-	// semantic edit as changing one
+	// a fact the live projection carries and the baseline does not: ADDING a
+	// default is as much a semantic edit as changing one, and adding a bound
+	// where the declaration had none is a tightening from the kind's whole
+	// domain onto a narrower one.
 	for _, lt := range lf.Tokens {
 		if seen[lt.Key] {
 			continue
@@ -523,9 +624,40 @@ func (d *differ) diffTokens(where string, bf, lf Field) []Finding {
 		switch d.policy[lt.Key] {
 		case RuleFixed, RuleRefs:
 			out = append(out, Finding{Refuse, where, fmt.Sprintf("%s %s added", tokenNoun(lt.Key), lt.Value)})
+		case RuleShrink, RuleRaise:
+			out = append(out, Finding{Warn, where, fmt.Sprintf("%s %s added (%s)", tokenNoun(lt.Key), lt.Value, tightenNote(lt.Key))})
+		}
+	}
+	// THE RENAME HINT (docs/SPEC-TABLES.md §16.4). A `was` added to a field
+	// keeps its wire id and moves its TEXT key, because the key is the field's
+	// NAME and the rename moved that. It is said once, at the edit that does
+	// it, and only to a field with no key of its own — a field that already
+	// carries `json =` has already answered the question.
+	if _, had := bf.Get("was"); !had && d.policy["was-json"] == RuleLoss {
+		if now, has := lf.Get("was"); has && lf.JsonKey == "" {
+			out = append(out, Finding{Warn, where, fmt.Sprintf(
+				"renamed under was = %q, which keeps the wire id and NOT the text key — the JSON key is now %q; pair json = %q if an existing text must still read (docs/SPEC-TABLES.md §16.4)",
+				now, lf.Name, now)})
 		}
 	}
 	return out
+}
+
+// tightened reports whether a numeric extent moved in the direction that
+// costs stored data: smaller under RuleShrink, larger under RuleRaise. The
+// comparison is exact and shape-agnostic — a bound is an integer, a
+// compressed float's range is not — so a value neither side can read as a
+// number is left alone rather than guessed at.
+func tightened(rule TokenRule, was, now string) bool {
+	before, ok1 := new(big.Rat).SetString(was)
+	after, ok2 := new(big.Rat).SetString(now)
+	if !ok1 || !ok2 {
+		return false
+	}
+	if rule == RuleRaise {
+		return after.Cmp(before) > 0
+	}
+	return after.Cmp(before) < 0
 }
 
 // refsFindings judges a token that NAMES another declaration.
@@ -718,14 +850,18 @@ func armNames(u *Unit, name string) map[string]bool {
 	return nil
 }
 
-// shrinkNote says what a reader loses when one of the shrinkable extents
-// shrinks — the runtime event is the same (clamped), the loss is not.
-func shrinkNote(key string) string {
+// tightenNote says what a reader loses when one of the extents tightens — the
+// runtime event is the same (clamped), the loss is not.
+func tightenNote(key string) string {
 	switch key {
 	case "bound":
 		return "a stored count past the new bound keeps the bounded prefix and counts clamped"
 	case "size":
 		return "a stored value longer than the new capacity is truncated and counts clamped"
+	case "min":
+		return "a stored value below the new minimum reads back AS the minimum and counts clamped"
+	case "max":
+		return "a stored value above the new maximum reads back AS the maximum and counts clamped"
 	}
 	return "stored values past the new limit are clamped"
 }
@@ -747,6 +883,10 @@ func tokenNoun(key string) string {
 		return "capacity"
 	case "key":
 		return "array key enum"
+	case "min":
+		return "declared minimum"
+	case "max":
+		return "declared maximum"
 	case "optional":
 		return "presence"
 	case "type":

--- a/internal/baseline/file.go
+++ b/internal/baseline/file.go
@@ -95,6 +95,43 @@ func Check(u *ir.Unit, paths []string) (warnings []string, errs []error) {
 	return warnings, errs
 }
 
+// Nudge is the one line `schema check` prints for a unit that declares tables
+// and has committed no baseline (docs/SPEC-TABLES.md §18.1). The baseline is
+// opt-in — no file, no check — so the DEFAULT posture of a save-game unit is
+// unguarded against every edit §4.1 marks silent, and nothing said so. This
+// says it: a notice, never a block, and committing a baseline silences it.
+//
+// It returns "" when there is nothing to say — a unit with no tables has no
+// table wire to guard, and a unit with a baseline is already guarded.
+func Nudge(u *ir.Unit, paths []string) string {
+	if len(u.Tables) == 0 {
+		return ""
+	}
+	path, ok, err := Locate(paths)
+	if err != nil {
+		// the unit's files span directories that hold several baselines;
+		// Check reports that as the error it is, and a nudge on top would
+		// only bury it
+		return ""
+	}
+	// a unit is one directory (SPEC §3.2), so the ordinary answer names it;
+	// the sentence still stands for the unit whose files span several, where
+	// there is no one directory to name
+	where, arg := "this unit's directory", "<unit dir>"
+	if ok {
+		if _, statErr := os.Stat(path); statErr == nil {
+			return ""
+		}
+		where, arg = filepath.Dir(path), filepath.Dir(path)
+	}
+	noun := "tables"
+	if len(u.Tables) == 1 {
+		noun = "table"
+	}
+	return fmt.Sprintf("%s declares %d %s and %s holds no %s — save-game evolution is unguarded (docs/SPEC-TABLES.md §18); commit one with: schema tables-baseline --update --reason \"first baseline\" %s",
+		u.Package, len(u.Tables), noun, where, FileName, arg)
+}
+
 // Update rewrites the unit's baseline and appends a dated entry to its history
 // naming every edit it recorded and the reason for them. The reason is
 // MANDATORY — the owner's ruling: an intentional break is declared, never

--- a/tables/examples/tables.baseline
+++ b/tables/examples/tables.baseline
@@ -1,22 +1,22 @@
-schema-tables-baseline 3
+schema-tables-baseline 4
 package tabledemo
 
 table ArchiveConfig
     field root id=0x2eb8 kind=13 type=RootConfig
-    field count id=0xe445 kind=4 default=1
+    field count id=0xe445 kind=4 min=0 max=100 default=1
 
 table Attachment
-    field slot id=0x37e4 kind=4 default=0
+    field slot id=0x37e4 kind=4 min=0 max=7 default=0
     field power id=0xd609 kind=10 default=1.0
 
 table Buff
     field multiplier id=0x32e0 kind=10 default=1.0
 
 table Debuff
-    field amount id=0x39cc kind=4 default=0
+    field amount id=0x39cc kind=4 min=0 max=100 default=0
 
 table GlobalSettings
-    field tick_rate id=0x1953 kind=8 default=60
+    field tick_rate id=0x1953 kind=8 min=1 max=240 default=60
     field difficulty id=0xd53f kind=7 enum=Difficulty default=Normal
     field build_note id=0xb2d4 kind=12 size=48
     field spawn_delays id=0x7c01 kind=14 elem=10 array=fixed bound=3
@@ -53,14 +53,14 @@ table PackConfig
     field version id=0xe8e6 kind=8 default=1
     field global id=0x1b51 kind=13 type=GlobalSettings
     field ships id=0x2d39 kind=16 elem=13 type=ShipEntry array=keyed bound=3 key=ShipType
-    field thresholds id=0xb2eb kind=16 elem=4 array=keyed bound=3 key=Difficulty
+    field thresholds id=0xb2eb kind=16 elem=4 array=keyed bound=3 key=Difficulty min=0 max=1000
     field reserves id=0x049d kind=14 elem=13 type=ShipEntry array=bounded bound=3
 
 table Patrol
     field active id=0x405a kind=1
     field speed id=0xbc00 kind=10 default=1.0
     field has_target id=0xb0a7 kind=1
-    field target_id id=0xdf6a kind=4 default=0
+    field target_id id=0xdf6a kind=4 min=0 max=1000 default=0
     field wander id=0x832f kind=10 default=0.5
     field note id=0x9da7 kind=12 size=8
 
@@ -80,42 +80,42 @@ table ProfileConfig
     field loadout id=0x9f78 kind=13 type=LoadoutConfig
 
 table RangedSigned
-    field i8_span id=0x8d4f kind=2
-    field i8_low id=0xe337 kind=2
-    field i8_high id=0x6a5f kind=2
-    field i8_inside id=0x8eee kind=2
-    field i16_span id=0x0a1e kind=3
-    field i16_low id=0xaaae kind=3
-    field i16_high id=0xe8f2 kind=3
-    field i16_inside id=0x1a0e kind=3
-    field i32_span id=0x6bd1 kind=4
-    field i32_low id=0xb8e0 kind=4
-    field i32_high id=0x3806 kind=4
-    field i32_inside id=0x9a24 kind=4
-    field i64_span id=0xf086 kind=5
-    field i64_low id=0xc705 kind=5
-    field i64_high id=0x328e kind=5
-    field i64_inside id=0x7d51 kind=5
-    field edges id=0xb1cb kind=14 elem=3 array=bounded bound=4
+    field i8_span id=0x8d4f kind=2 min=-128 max=127
+    field i8_low id=0xe337 kind=2 min=-128 max=126
+    field i8_high id=0x6a5f kind=2 min=-127 max=127
+    field i8_inside id=0x8eee kind=2 min=-127 max=126
+    field i16_span id=0x0a1e kind=3 min=-32768 max=32767
+    field i16_low id=0xaaae kind=3 min=-32768 max=32766
+    field i16_high id=0xe8f2 kind=3 min=-32767 max=32767
+    field i16_inside id=0x1a0e kind=3 min=-32767 max=32766
+    field i32_span id=0x6bd1 kind=4 min=-2147483648 max=2147483647
+    field i32_low id=0xb8e0 kind=4 min=-2147483648 max=2147483646
+    field i32_high id=0x3806 kind=4 min=-2147483647 max=2147483647
+    field i32_inside id=0x9a24 kind=4 min=-2147483647 max=2147483646
+    field i64_span id=0xf086 kind=5 min=-9223372036854775808 max=9223372036854775807
+    field i64_low id=0xc705 kind=5 min=-9223372036854775808 max=9223372036854775806
+    field i64_high id=0x328e kind=5 min=-9223372036854775807 max=9223372036854775807
+    field i64_inside id=0x7d51 kind=5 min=-9223372036854775807 max=9223372036854775806
+    field edges id=0xb1cb kind=14 elem=3 array=bounded bound=4 min=-32768 max=32767
 
 table RangedUnsigned
-    field u8_span id=0x6434 kind=6
-    field u8_low id=0xb24e kind=6
-    field u8_high id=0x202a kind=6 default=1
-    field u8_inside id=0x8fbf kind=6 default=1
-    field u16_span id=0xd410 kind=7
-    field u16_low id=0x6f72 kind=7
-    field u16_high id=0x1364 kind=7 default=1
-    field u16_inside id=0xbf32 kind=7 default=1
-    field u32_span id=0x0513 kind=8
-    field u32_low id=0x4cce kind=8
-    field u32_high id=0xa2da kind=8 default=1
-    field u32_inside id=0xf596 kind=8 default=1
-    field u64_span id=0x6e8d kind=9
-    field u64_low id=0x95b5 kind=9
-    field u64_high id=0x15e4 kind=9 default=1
-    field u64_inside id=0x2ce0 kind=9 default=1
-    field counts id=0xe27a kind=14 elem=9 array=bounded bound=4
+    field u8_span id=0x6434 kind=6 min=0 max=255
+    field u8_low id=0xb24e kind=6 min=0 max=254
+    field u8_high id=0x202a kind=6 min=1 max=255 default=1
+    field u8_inside id=0x8fbf kind=6 min=1 max=254 default=1
+    field u16_span id=0xd410 kind=7 min=0 max=65535
+    field u16_low id=0x6f72 kind=7 min=0 max=65534
+    field u16_high id=0x1364 kind=7 min=1 max=65535 default=1
+    field u16_inside id=0xbf32 kind=7 min=1 max=65534 default=1
+    field u32_span id=0x0513 kind=8 min=0 max=4294967295
+    field u32_low id=0x4cce kind=8 min=0 max=4294967294
+    field u32_high id=0xa2da kind=8 min=1 max=4294967295 default=1
+    field u32_inside id=0xf596 kind=8 min=1 max=4294967294 default=1
+    field u64_span id=0x6e8d kind=9 min=0 max=18446744073709551615
+    field u64_low id=0x95b5 kind=9 min=0 max=18446744073709551614
+    field u64_high id=0x15e4 kind=9 min=1 max=18446744073709551615 default=1
+    field u64_inside id=0x2ce0 kind=9 min=1 max=18446744073709551614 default=1
+    field counts id=0xe27a kind=14 elem=9 array=bounded bound=4 min=0 max=18446744073709551615
 
 table RangedWidths
     field b8 id=0xa7cb kind=6
@@ -131,17 +131,17 @@ table RootConfig
     field profiles id=0x73fd kind=14 elem=13 type=ProfileConfig array=bounded bound=4
 
 table ScoreBoard
-    field per_team id=0x443f kind=16 elem=4 array=keyed bound=3 key=Team
+    field per_team id=0x443f kind=16 elem=4 array=keyed bound=3 key=Team min=0 max=100000
 
 table ShipEntry
     field display_name id=0xcb8b kind=12 size=32
     field health id=0x8617 kind=10 default=100.0
     field mass id=0xe7a6 kind=10 default=1.0
-    field hardpoints id=0xc4b2 kind=14 elem=4 array=bounded bound=4
+    field hardpoints id=0xc4b2 kind=14 elem=4 array=bounded bound=4 min=0 max=8
     field gunner id=0x2bc9 kind=13 type=GunnerSettings optional=true
 
 table TeamConfig
-    field spawn_count id=0x3668 kind=4 default=4
+    field spawn_count id=0x3668 kind=4 min=0 max=64 default=4
     field banner id=0x80e4 kind=12 size=16
 
 table TurretConfig
@@ -152,7 +152,7 @@ table TurretConfig
 table WeaponConfig
     field damage id=0x15a9 kind=10 default=21.0
     field speed id=0x2e46 kind=10 default=500.0 was=velocity
-    field penetration id=0x6557 kind=4 default=1
+    field penetration id=0x6557 kind=4 min=0 max=10 default=1
     field channel id=0x7366 kind=6
     field homing id=0xab40 kind=1
     field effect id=0xe33a kind=15 union=Effect
@@ -216,3 +216,6 @@ union Effect
 
 ### 2026-09-03 — the clamp-at-storage-limits corpus (#342): RangedSigned, RangedUnsigned and RangedWidths join the corpus — new declarations only, so nothing already written moves
 - no compatibility-affecting edits; the wire absorbs the rest
+
+### 2026-09-04 — schema#443: the baseline records each ranged field's effective min and max, so a tightened range is seen before it ships; the rendering version moves to 4 and this file is regenerated with its history intact
+- baseline REGENERATED over an unreadable one (baseline version 3, this compiler writes 4); the projection is this unit as it stands and the history above is preserved, but the previous projection could not be diffed, so no per-edit lines follow

--- a/tables/pointers/tables.baseline
+++ b/tables/pointers/tables.baseline
@@ -1,4 +1,4 @@
-schema-tables-baseline 3
+schema-tables-baseline 4
 package graphdemo
 
 table Album
@@ -21,7 +21,7 @@ table Depot
     field head id=0x79aa kind=17 type=ListNode
 
 table Layer
-    field depth id=0x609f kind=4 default=0
+    field depth id=0x609f kind=4 min=0 max=64 default=0
     field head id=0x79aa kind=17 type=ListNode
 
 table ListNode
@@ -34,12 +34,12 @@ table Marker
     field note id=0x9da7 kind=17 type=Tally
 
 table Meta
-    field build id=0x3138 kind=4 default=1
+    field build id=0x3138 kind=4 min=0 max=1000 default=1
     field tag id=0xbc64 kind=12 size=8
 
 table Scene
     field name id=0x30df kind=12 size=24
-    field version id=0xe8e6 kind=4 default=1
+    field version id=0xe8e6 kind=4 min=0 max=99 default=1
     field head id=0x79aa kind=17 type=ListNode
     field tree id=0x595e kind=17 type=TreeNode
     field settings id=0x130e kind=17 type=Settings
@@ -49,15 +49,15 @@ table Scene
     field meta id=0xcea6 kind=13 type=Meta
 
 table Settings
-    field quality id=0xcaf3 kind=4 default=2
+    field quality id=0xcaf3 kind=4 min=0 max=4 default=2
     field label id=0xe16a kind=12 size=16
 
 table Stamp
     field tag id=0xbc64 kind=12 size=8
-    field seq id=0xc29b kind=4 default=0
+    field seq id=0xc29b kind=4 min=0 max=1000 default=0
 
 table Tally
-    field hits id=0xb723 kind=4 default=0
+    field hits id=0xb723 kind=4 min=0 max=10000 default=0
 
 table TreeNode
     field label id=0xe16a kind=12 size=12
@@ -88,3 +88,6 @@ enum Tier
 - Scene.alias: wire kind 13 -> 17 [refuse]
 - TreeNode.left: wire kind 13 -> 17 [refuse]
 - TreeNode.right: wire kind 13 -> 17 [refuse]
+
+### 2026-09-04 — schema#443: the baseline records each ranged field's effective min and max, so a tightened range is seen before it ships; the rendering version moves to 4 and this file is regenerated with its history intact
+- baseline REGENERATED over an unreadable one (baseline version 3, this compiler writes 4); the projection is this unit as it stands and the history above is preserved, but the previous projection could not be diffed, so no per-edit lines follow


### PR DESCRIPTION
Three small baseline mechanisms, spec first, in one PR. Each is a fixture plus
two controls — the same edit in the direction the wire absorbs, and the same
edit with its policy row dropped — and each was additionally ablated in source
and watched go red.

## #443 — range facts in the baseline

The rendering gains the EFFECTIVE declared range per ranged field, evaluated:
`min=` and `max=` for a declared integer range, for a fixed field's whole-unit
bounds (beside the `frac=` that scales them onto the raw wire value), and for a
compressed float's triple. Only a declared range is recorded — `bits(N)`'s
implied `[0, 2^N − 1]` is its width, and the width is the `kind` token the file
already holds fixed.

`min` is judged by a new `RuleRaise` and `max` by the existing `RuleShrink`, so
a TIGHTENING from either end warns and a loosening passes in silence. A range
DECLARED where the field had none warns too: it narrows the kind's whole domain.
The numeric comparison went from `strconv.ParseInt` to `big.Rat`, so a
compressed float's bounds compare exactly, like an integer bound.

Diagnostic text:

```
Ship.hull: declared maximum 1000 -> 100 (a stored value above the new maximum reads back AS the maximum and counts clamped)
Ship.hull: declared minimum 0 -> 10 (a stored value below the new minimum reads back AS the minimum and counts clamped)
Ship.tally: declared maximum 10 added (a stored value above the new maximum reads back AS the maximum and counts clamped)
```

**The rendering version moves 3 → 4**, per §18's rule (any new judged token
bumps it). Both committed corpus baselines were repaired through the advertised
remedy, on the real pre-bump files:

```
$ ./bin/schema check tables/examples
tables/examples/tables.baseline: baseline version 3, this compiler writes 4 — regenerate it with: schema tables-baseline --update --reason "...", which preserves the ## history section (docs/SPEC-TABLES.md §18.4)
schema: 1 error(s)

$ ./bin/schema tables-baseline --update --reason "schema#443: ..." tables/examples
$ ./bin/schema check tables/examples          # silent, exit 0
```

Every history line came across verbatim and the update appended its own entry
saying the previous projection could not be diffed. `TestPreBumpBaselineRepairs`
holds that path at `Version-1` with a ranged fixture, asserting the salvaged
history lines AND the new `min=0 max=1000` token in the regenerated file.

## #444 — `was` misuse, the `json =` hint, the rename pair

**(a) A second `was` aimed at the intermediate spelling is refused.** `was`
names the FIRST wire name, forever; the baseline is the one place that
remembers it. Refusal text:

```
Ship.max_speed: was = "speed" names speed, which itself rode under was = "velocity" — `was` names the FIRST wire name, forever, so this field now rides under id 0x2e46, an id no byte was ever written under; write was = "velocity"
```

The discrimination control is the same second rename done right —
`max_speed | was = "velocity"` — which is silent.

**(b) At rename time, the `json =` pairing is hinted, once.** A `was` ADDED to
a field with no text key of its own keeps the wire id and moves the JSON key,
which is the field's name. Said at the edit that adds the `was` and not on
every check after it (the test asserts the second check is silent), and never
to a field that already pairs its key:

```
Config.strikes: renamed under was = "hits", which keeps the wire id and NOT the text key — the JSON key is now "strikes"; pair json = "hits" if an existing text must still read (docs/SPEC-TABLES.md §16.4)
```

The live projection carries the field's `json` key in memory only — a text key
moves no wire byte, so it is never rendered into the file and never parsed.

**(c) A removal and an addition in one table in one edit warn as a possible
bare rename.** One warning, naming both and both remedies. A live field that
already declares a `was` is not counted as an addition, so (a)'s refusal is
never doubled by a warning telling the author to do what they did:

```
table Config: hits removed and strikes added in one edit — if that is a rename the wire id moved with the name and every stored value orphans: declare it `strikes ... | was = "hits"`, and pair `json = "hits"` if the text key must survive (docs/SPEC-TABLES.md §5, §16.4)
```

A warning, never a refusal: two independent edits in one commit are legitimate.
The controls the issue names are both in the test — a removal alone and an
addition alone are each silent.

## #445 — the no-baseline notice

`schema check` on a unit that declares at least one table and holds no
`tables.baseline` prints one line to stderr; the exit code is untouched, and
committing a baseline silences it. A unit with a baseline, and a unit with no
tables, print nothing.

```
$ ./bin/schema check tables/messages
notice: messagedemo declares 10 tables and tables/messages holds no tables.baseline — save-game evolution is unguarded (docs/SPEC-TABLES.md §18); commit one with: schema tables-baseline --update --reason "first baseline" tables/messages
$ echo $?
0
```

`make check` now prints this for the eight table corpora and the six
`test/tables/*.schema` units that carry no baseline. That is the feature
working — those units are unguarded — and `make check` still exits 0.
Committing baselines for the corpora that can hold one is a follow-on;
`test/tables/` cannot, because it holds several units in one directory.

## Negative controls, run red

Each mechanism removed from the source, its test run, then restored. Full
outputs are below; every one restores green.

<details>
<summary>#443 — the <code>min</code>/<code>max</code> rendering deleted from <code>renderField</code></summary>

```
--- FAIL: TestRangeFacts (0.00s)
    --- FAIL: TestRangeFacts/a_maximum_lowered (0.00s)
        baseline_test.go:1275: a tightened range must warn; wanted Ship.hull: declared maximum 1000 -> 100 (a stored value above the new maximum reads back AS the maximum and counts clamped), got:(no findings)
    --- FAIL: TestRangeFacts/a_minimum_raised (0.00s)
        baseline_test.go:1275: a tightened range must warn; wanted Ship.hull: declared minimum 0 -> 10 (a stored value below the new minimum reads back AS the minimum and counts clamped), got:(no findings)
    --- FAIL: TestRangeFacts/a_fixed_field's_whole-unit_bounds_narrowed (0.00s)
        baseline_test.go:1275: a tightened range must warn; wanted Ship.angle: declared minimum -180 -> -90, got:(no findings)
    --- FAIL: TestRangeFacts/a_compressed_float's_maximum_lowered (0.00s)
        baseline_test.go:1275: a tightened range must warn; wanted Ship.speed: declared maximum 100.0 -> 10.5, got:(no findings)
    --- FAIL: TestRangeFacts/a_range_added_where_the_field_had_none (0.00s)
        baseline_test.go:1275: a tightened range must warn; wanted Ship.tally: declared maximum 10 added (a stored value above the new maximum reads back AS the maximum and counts clamped), got:(no findings)
FAIL
```
</details>

<details>
<summary>#444(a) — the <code>d.wasChain</code> call removed from <code>diffTables</code></summary>

```
--- FAIL: TestWasChainIsRefused (0.00s)
    baseline_test.go:1356: a second `was` naming the field's own current spelling must be refused, got:(no findings)
FAIL
```
</details>

<details>
<summary>#444(b) — the rename-hint block removed from <code>diffTokens</code></summary>

```
--- FAIL: TestRenameHintsTheJsonPairing (0.00s)
    baseline_test.go:1383: a bare rename must hint the text-key pairing, got:(no findings)
FAIL
```
</details>

<details>
<summary>#444(c) — the <code>d.renamePair</code> call removed from <code>diffTables</code></summary>

```
--- FAIL: TestRemovalAndAdditionWarnAsAPossibleRename (0.00s)
    baseline_test.go:1414: a removal and an addition in one table must warn, got:(no findings)
FAIL
```
</details>

<details>
<summary>#445 — <code>Nudge</code> made to return "" unconditionally</summary>

```
--- FAIL: TestNudge (0.00s)
    baseline_test.go:1463: the notice must carry "fixture declares 1 table and", got: 
    baseline_test.go:1463: the notice must carry "holds no tables.baseline", got: 
    baseline_test.go:1463: the notice must carry "save-game evolution is unguarded (docs/SPEC-TABLES.md §18)", got: 
    baseline_test.go:1463: the notice must carry "commit one with: schema tables-baseline --update --reason \"first baseline\"", got: 
    baseline_test.go:1463: the notice must carry "/var/folders/.../TestNudge1973654536/001", got: 
FAIL
```
</details>

Beside those, every case carries the package's two standing controls: a
DISCRIMINATION control (the same edit in the direction the wire absorbs — a
range loosened, the second rename done right, the pairing declared, each half
of the pair alone) and an ATTRIBUTION control (the same edit re-judged with
that one policy row dropped), so each finding is proven to come from its own
check and not from something else in the walk.

## The pages

- **SPEC-TABLES.md §4.1** — the three-frames table: the tightened-range row now
  reads **warns**; the field add/remove row names the pair; the `was` row names
  the `json =` hint; a new row for the second `was`.
- **SPEC-TABLES.md §18.1** — the range in the fact list and its own paragraph;
  the absence-notice paragraph; the sample file at version 4 with a ranged
  field (real ids).
- **SPEC-TABLES.md §18.2** — the `was` chain under REFUSES; the range and the
  pair under WARNS; a new HINTS verdict; ranges added to what a growth passes.
- **SPEC-TABLES.md §18.6** — the new gates named.
- **VERSIONING.md** — the two `was` bullets, four three-frames rows, the
  baseline section, the tightened-range sharp edge; **the "Owed before 3.0.0"
  list drops #443, #444 and #445**, and the baseline section's own "before
  3.0.0" line is now just #441.
- **USAGE.md** — the `was`-forever paragraph, the verdict paragraph, and a
  transcript of the notice.
- **COMPARISON-TABLES.md** — one row said "bare rename refused", which was
  never true; it now says what the baseline does.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, `go mod tidy -diff`,
`golangci-lint run` (v2.12.2, the CI pin), `modernize` — all clean.
`go test ./...` green. `make check` exits 0. `make conformance-generate` moves
no file. The committed `generated/` tree regenerates unchanged.

The only goldens that moved are the two committed corpus baselines, re-pinned
deliberately for the rendering version bump: `tables/examples/tables.baseline`
and `tables/pointers/tables.baseline`, each gaining `min=`/`max=` on its ranged
fields and a history entry recording the regeneration.

Closes #443
Closes #444
Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
