### PR TITLE
conformance: the REFERENCE leg's absence is red at every grain (#467)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1300,6 +1300,49 @@ conformance-negative-control-absent: build/conformance-harness build/tables-gene
 	./build/conformance-harness run --drivers build/conformance-solo-drivers.txt --work build/conformance-solo-work
 	@echo "negative control: the same absences under a SUBSTITUTED registry are ordinary, and the leg passes"
 
+# THE SAME RULE AT THE COARSER GRAIN (schema#467): a WHOLE SURFACE the reference
+# leg never registers.
+#
+# A reference leg that drops a surface from `list` — or exits 2 on it — leaves
+# every other leg comparing against a surface nothing pins, which is the same
+# hole a per-case absence there would leave and is red for the same reason. The
+# success footer may not print beside it, and this is the control that says so.
+#
+# The sabotage is on the DRIVER rather than on an emitter (docs/PORTING.md I2)
+# because `list` is the driver's own answer and nothing generates it: a WRAPPER
+# around the committed reference driver, filtering one surface out of its list,
+# planted as the reference of a scratch DISCOVERED registry — the rule belongs
+# to that registry alone, so a substituted one would not exercise it. The
+# wrapper refuses rather than filtering nothing, so a control that removed no
+# surface says so instead of reading as a pass. No tracked file is written.
+CONFORMANCE_REFERENCE_MISSING := build/conformance-reference-missing
+CONFORMANCE_REFERENCE_SURFACE := block-dump
+.PHONY: conformance-negative-control-reference-surface
+conformance-negative-control-reference-surface: build/conformance-harness build/conformance-cpp build/schema_test_cook
+	@rm -rf $(CONFORMANCE_REFERENCE_MISSING)
+	@mkdir -p $(CONFORMANCE_REFERENCE_MISSING)/registry/cpp
+	@printf '#!/bin/sh\nif [ "$$2" != list ]; then exec test/conformance/cpp/driver "$$@"; fi\ntest/conformance/cpp/driver "$$1" list > %s/listed.txt\ngrep -q "^$(CONFORMANCE_REFERENCE_SURFACE)$$" %s/listed.txt || { echo "the reference leg registers no $(CONFORMANCE_REFERENCE_SURFACE) surface: this control removes nothing" >&2; exit 1; }\ngrep -v "^$(CONFORMANCE_REFERENCE_SURFACE)$$" %s/listed.txt\n' \
+		"$(CONFORMANCE_REFERENCE_MISSING)" "$(CONFORMANCE_REFERENCE_MISSING)" "$(CONFORMANCE_REFERENCE_MISSING)" \
+		> $(CONFORMANCE_REFERENCE_MISSING)/registry/cpp/driver
+	@chmod +x $(CONFORMANCE_REFERENCE_MISSING)/registry/cpp/driver
+	@if ./build/conformance-harness run --drivers $(CONFORMANCE_REFERENCE_MISSING)/registry \
+			--work $(CONFORMANCE_REFERENCE_MISSING)/work > $(CONFORMANCE_REFERENCE_MISSING)/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: the REFERENCE leg registered no $(CONFORMANCE_REFERENCE_SURFACE) surface and the harness stayed green"; \
+		cat $(CONFORMANCE_REFERENCE_MISSING)/log; exit 1; \
+	fi
+	@grep -q "REFERENCE leg is ABSENT on the whole $(CONFORMANCE_REFERENCE_SURFACE) surface" $(CONFORMANCE_REFERENCE_MISSING)/log || \
+		{ echo "NEGATIVE CONTROL FAILED: it went red, but not on the reference rule"; \
+		  cat $(CONFORMANCE_REFERENCE_MISSING)/log; exit 1; }
+	@if grep -q "every registered surface passes" $(CONFORMANCE_REFERENCE_MISSING)/log; then \
+		echo "NEGATIVE CONTROL FAILED: the success footer printed beside a reference ABSENT"; \
+		cat $(CONFORMANCE_REFERENCE_MISSING)/log; exit 1; \
+	fi
+	@grep -q "wire          pass" $(CONFORMANCE_REFERENCE_MISSING)/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the whole matrix went red, so it localises nothing"; \
+		  cat $(CONFORMANCE_REFERENCE_MISSING)/log; exit 1; }
+	@grep -m1 "cpp / $(CONFORMANCE_REFERENCE_SURFACE)" $(CONFORMANCE_REFERENCE_MISSING)/log
+	@echo "negative control: a SURFACE the reference leg never registers turns the harness red"
+
 # THE CROSS-IMPLEMENTATION LOCK for the FLAT NODE TABLE (docs/SPEC-TABLES.md
 # §3.1), and it is what makes TWO implementations of one wire mean something.
 #
@@ -2078,6 +2121,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) conformance
 	$(MAKE) conformance-negative-control
 	$(MAKE) conformance-negative-control-absent
+	$(MAKE) conformance-negative-control-reference-surface
 	$(MAKE) conformance-negative-control-block-dump
 	$(MAKE) tables-json-keyed-dup-negative-control
 	$(MAKE) tables-flat-wire

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -741,16 +741,19 @@ implements writes `<case>.absent` — an empty file beside where the answer
 would go — and the harness counts it: `pass 16/16 +4a`. A missing FEATURE per
 case, not a failing test, so a backend with no variable class still answers
 the wire surface over every fixed instance. The reference leg may not answer
-absent: an absence from the first driver in the registry is the corpus losing
-its own expectation.
+absent AT EITHER GRAIN — a whole surface left out of `list` or exited 2 on, or
+one case — because an absence from the first driver in the registry is the
+corpus losing its own expectation.
 
-**Reference.** `test/conformance/README.md`; `test/conformance/harness/run.go:35-42`.
+**Reference.** `test/conformance/README.md`; `test/conformance/harness/run.go:36-43`.
 
 **Proven in.** C# (the first port with a text surface absent).
 
 **Measured effect.** Structural; the matrix is the completion tracker.
 
-**Negative control.** `conformance-negative-control-absent`.
+**Negative control.** `conformance-negative-control-absent` for a case, and
+`conformance-negative-control-reference-surface` for a whole surface the
+reference leg never registers.
 
 **Targets:** none
 

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -95,15 +95,18 @@ instances: a backend with no variable class still answers the wire surface over
 every FIXED instance, and a leg that failed the whole surface for them would say
 nothing about what it does carry.
 
-**THE REFERENCE LEG MAY NOT ANSWER ABSENT**, and that rule is what makes
-per-case absence safe rather than a place to hide: an absence from the
+**THE REFERENCE LEG MAY NOT ANSWER ABSENT, AT EITHER GRAIN**, and that rule is
+what makes absence safe rather than a place to hide: an absence from the
 reference leg — `cpp`, first in the discovered registry, and the one
 `conformance-pin` takes its pins from — is the corpus losing its own
-expectation, not a port's missing feature. It belongs to that registry alone:
-a run handed a SUBSTITUTED one with
-`--drivers`, as the big-endian leg does for its single Go driver, is one leg of
-a port and not the matrix, so its first line is not the reference and its
-absences are ordinary.
+expectation, not a port's missing feature. All three ways of saying it are a
+FAILURE there, named in the matrix and in the failure list: a surface left out
+of `list`, exit code 2 on a surface, and `<case>.absent` for a single case. The
+harness prints `FAIL absent` for the two coarse ones, and the success footer
+cannot print beside any of them. The rule belongs to that registry alone: a run
+handed a SUBSTITUTED one with `--drivers`, as the big-endian leg does for its
+single Go driver, is one leg of a port and not the matrix, so its first line is
+not the reference and its absences are ordinary.
 
 **THE MATRIX IS THE COMPLETION TRACKER.** Green cells over total cells is what
 "done" means for the tables layer, and an absence — per surface or per case — is

--- a/test/conformance/harness/absence_test.go
+++ b/test/conformance/harness/absence_test.go
@@ -1,0 +1,264 @@
+// THE REFERENCE LEG MAY NOT ANSWER ABSENT, at every grain the harness can meet
+// an absence (test/conformance/README.md).
+//
+// A whole SURFACE goes absent two ways — left out of `list`, or exit code 2 —
+// and a single CASE a third, `<case>.absent`. All three are the corpus losing
+// its own expectation when they come from the reference leg, and an ordinary
+// missing feature when they come from a port. These tests drive `run` with
+// fake drivers over a one-instance corpus, so every path is gated without a
+// language leg: the reference goes red on each grain and the matrix cannot
+// print the success footer, and the same three answers from a port stay green
+// and stay visible.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// footer is what `report` prints when nothing failed, and the thing that must
+// never appear beside a reference absence.
+const footer = "tables conformance: every registered surface passes"
+
+// fakeLeg is how one fake driver goes absent. The zero value answers every
+// surface the corpus asks about and registers all thirteen.
+type fakeLeg struct {
+	unlisted string // a surface left out of `list` altogether
+	exitTwo  string // a surface the driver exits 2 on
+	caseGone bool   // the wire surface answers `<case>.absent` for its one case
+}
+
+// fakeCorpus is a one-instance conformance corpus: enough for the wire, json-read
+// and json-write surfaces to carry an expectation, and nothing else, so a test
+// never builds a fixture generator or a language leg.
+type fakeCorpus struct {
+	manifest string
+	jsonDir  string
+	reports  string
+	wire     string
+	json     string
+	m        *Manifest
+}
+
+func newFakeCorpus(t *testing.T) fakeCorpus {
+	t.Helper()
+	dir := t.TempDir()
+	c := fakeCorpus{
+		manifest: filepath.Join(dir, "MANIFEST.txt"),
+		jsonDir:  filepath.Join(dir, "json"),
+		reports:  filepath.Join(dir, "reports.txt"),
+		wire:     filepath.Join(dir, "alpha.bin"),
+	}
+	c.json = filepath.Join(c.jsonDir, "alpha.json")
+	writeFile(t, c.wire, "\x01\x02\x03\x04")
+	writeFile(t, c.json, "{\"alpha\":1}\n")
+	writeFile(t, c.manifest, "unit u tables/examples\ninstance alpha u Root "+c.wire+"\n")
+	writeFile(t, c.reports, "")
+	m, err := ReadManifest(c.manifest, c.jsonDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.m = m
+	return c
+}
+
+// driverScript writes one fake driver: a command that answers this corpus and
+// goes absent exactly where the case under test says it does.
+func (c fakeCorpus) driverScript(t *testing.T, path string, leg fakeLeg) {
+	t.Helper()
+	var list strings.Builder
+	for _, s := range surfaces {
+		if s == leg.unlisted {
+			continue
+		}
+		fmt.Fprintf(&list, "\techo %s\n", s)
+	}
+	answer := fmt.Sprintf("cp %q \"$out/alpha\"", c.wire)
+	if leg.caseGone {
+		answer = `: > "$out/alpha.absent"`
+	}
+	exitTwo := leg.exitTwo
+	if exitTwo == "" {
+		exitTwo = "\x00" // a name no surface has, so the arm never fires
+	}
+	writeExec(t, path, fmt.Sprintf(`#!/bin/sh
+surface="$2"
+out="$3"
+if [ "$surface" = list ]; then
+%s	exit 0
+fi
+if [ "$surface" = %q ]; then
+	exit 2
+fi
+case "$surface" in
+wire|json-read) %s ;;
+json-write) cp %q "$out/alpha.json" ;;
+esac
+exit 0
+`, list.String(), exitTwo, answer, c.json))
+}
+
+// committed plants a DISCOVERED registry — one <lang>/driver per leg, which is
+// the committed registry's own shape and the only one the reference rule
+// reaches.
+func (c fakeCorpus) committed(t *testing.T, legs map[string]fakeLeg) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "registry")
+	for lang, leg := range legs {
+		c.driverScript(t, filepath.Join(dir, lang, "driver"), leg)
+	}
+	return dir
+}
+
+// substituted plants a SUBSTITUTED registry — a file of "<lang> <command>"
+// lines, which is one leg of a port rather than the matrix, so its first line
+// is not the reference.
+func (c fakeCorpus) substituted(t *testing.T, lang string, leg fakeLeg) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "driver")
+	c.driverScript(t, script, leg)
+	path := filepath.Join(dir, "drivers.txt")
+	writeFile(t, path, lang+" "+script+"\n")
+	return path
+}
+
+// runHarness runs the gate over this corpus and hands back what it printed.
+func (c fakeCorpus) runHarness(t *testing.T, drivers string) (string, bool) {
+	t.Helper()
+	var out bytes.Buffer
+	ok, err := run(&out, c.m, c.manifest, c.jsonDir, c.reports, drivers,
+		filepath.Join(t.TempDir(), "work"), "")
+	if err != nil {
+		t.Fatalf("harness run: %v\n%s", err, out.String())
+	}
+	return out.String(), ok
+}
+
+func needShell(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no sh on PATH")
+	}
+}
+
+// want holds the printed matrix to what it must and must not say.
+func mustSay(t *testing.T, out string, has []string, hasNot []string) {
+	t.Helper()
+	for _, s := range has {
+		if !strings.Contains(out, s) {
+			t.Errorf("the matrix does not say %q:\n%s", s, out)
+		}
+	}
+	for _, s := range hasNot {
+		if strings.Contains(out, s) {
+			t.Errorf("the matrix says %q and must not:\n%s", s, out)
+		}
+	}
+}
+
+// TestReferenceSurfaceMissingFromList is one half of the coarse grain: a
+// reference leg that never registers a surface leaves the corpus's
+// expectations for it comparing against nothing, so the surface is red and the
+// success footer may not print beside its cell.
+func TestReferenceSurfaceMissingFromList(t *testing.T) {
+	needShell(t)
+	c := newFakeCorpus(t)
+	out, ok := c.runHarness(t, c.committed(t, map[string]fakeLeg{
+		referenceLang: {unlisted: "json-write"},
+	}))
+	if ok {
+		t.Errorf("the reference leg left json-write out of `list` and the harness stayed green:\n%s", out)
+	}
+	mustSay(t, out,
+		[]string{
+			"the REFERENCE leg is ABSENT on the whole json-write surface (`list` does not name it)",
+			"FAIL absent",
+			"pass 1/1", // the surfaces it did register still pass, so this localises
+		},
+		[]string{footer})
+	if n := strings.Count(out, "  cpp / "); n != 1 {
+		t.Errorf("one surface went absent and the harness reported %d failures:\n%s", n, out)
+	}
+}
+
+// TestReferenceSurfaceExitsTwo is the other half: the same absence said the
+// other way the contract allows it to be said.
+func TestReferenceSurfaceExitsTwo(t *testing.T) {
+	needShell(t)
+	c := newFakeCorpus(t)
+	out, ok := c.runHarness(t, c.committed(t, map[string]fakeLeg{
+		referenceLang: {exitTwo: "json-read"},
+	}))
+	if ok {
+		t.Errorf("the reference leg exited 2 on json-read and the harness stayed green:\n%s", out)
+	}
+	mustSay(t, out,
+		[]string{
+			"the REFERENCE leg is ABSENT on the whole json-read surface (the driver exited 2)",
+			"FAIL absent",
+			"pass 1/1",
+		},
+		[]string{footer})
+	if n := strings.Count(out, "  cpp / "); n != 1 {
+		t.Errorf("one surface went absent and the harness reported %d failures:\n%s", n, out)
+	}
+}
+
+// TestReferenceCaseAbsent is the fine grain, gated beside the two coarse ones
+// so that no grain of the rule can regress on its own.
+func TestReferenceCaseAbsent(t *testing.T) {
+	needShell(t)
+	c := newFakeCorpus(t)
+	out, ok := c.runHarness(t, c.committed(t, map[string]fakeLeg{
+		referenceLang: {caseGone: true},
+	}))
+	if ok {
+		t.Errorf("the reference leg answered a case ABSENT and the harness stayed green:\n%s", out)
+	}
+	mustSay(t, out,
+		[]string{"the REFERENCE leg answered ABSENT for 1 case(s)"},
+		[]string{footer})
+}
+
+// TestPortAbsenceStaysAllowed is the other direction, and the half a one-sided
+// rule would break: absent is not failure for a port. The same three answers
+// from a leg that is not the reference stay green and stay PRINTED, because
+// the matrix is the completion tracker.
+func TestPortAbsenceStaysAllowed(t *testing.T) {
+	needShell(t)
+	absences := fakeLeg{unlisted: "json-write", exitTwo: "json-read", caseGone: true}
+
+	t.Run("a second leg of the committed registry", func(t *testing.T) {
+		c := newFakeCorpus(t)
+		out, ok := c.runHarness(t, c.committed(t, map[string]fakeLeg{
+			referenceLang: {},
+			"zz":          absences,
+		}))
+		if !ok {
+			t.Errorf("a PORT's absences turned the harness red:\n%s", out)
+		}
+		mustSay(t, out,
+			[]string{
+				footer,
+				"absent",       // the surfaces zz does not implement, named where they can be seen
+				"pass 0/0 +1a", // and the case it said it cannot answer
+			},
+			[]string{"REFERENCE leg", "FAIL"})
+	})
+
+	// A run handed a SUBSTITUTED registry is one leg of a port and not the
+	// matrix, so its first line is not the reference however it goes absent.
+	t.Run("the first leg of a substituted registry", func(t *testing.T) {
+		c := newFakeCorpus(t)
+		out, ok := c.runHarness(t, c.substituted(t, referenceLang, absences))
+		if !ok {
+			t.Errorf("absences under a SUBSTITUTED registry turned the harness red:\n%s", out)
+		}
+		mustSay(t, out, []string{footer, "absent"}, []string{"REFERENCE leg", "FAIL"})
+	})
+}

--- a/test/conformance/harness/main.go
+++ b/test/conformance/harness/main.go
@@ -133,7 +133,7 @@ func main() {
 			fatalf("%v", err)
 		}
 	case "run":
-		ok, err := run(m, *manifest, *jsonDir, *reports, *drivers, *work, *only)
+		ok, err := run(os.Stdout, m, *manifest, *jsonDir, *reports, *drivers, *work, *only)
 		if err != nil {
 			fatalf("%v", err)
 		}

--- a/test/conformance/harness/run.go
+++ b/test/conformance/harness/run.go
@@ -12,6 +12,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -300,7 +301,7 @@ func expectations(m *Manifest, surface string, reports map[string]Counts, jsonDi
 	return out, nil
 }
 
-func run(m *Manifest, manifestPath, jsonDir, reportsPath, driversPath, work, only string) (bool, error) {
+func run(w io.Writer, m *Manifest, manifestPath, jsonDir, reportsPath, driversPath, work, only string) (bool, error) {
 	drivers, discovered, err := loadDrivers(driversPath)
 	if err != nil {
 		return false, err
@@ -329,14 +330,16 @@ func run(m *Manifest, manifestPath, jsonDir, reportsPath, driversPath, work, onl
 	results := map[string]map[string]*result{}
 	var langs []string
 	for i, d := range drivers {
-		// THE REFERENCE LEG MAY NOT ANSWER ABSENT. It is the first driver in
-		// the COMMITTED registry — the discovered one, where the reference
-		// sorts first — and the one `conformance-pin` takes its pins from, so
-		// an absence there is not a port's missing feature: it is the corpus
-		// losing its own expectation, quietly, while every other leg keeps
-		// comparing against nothing. Per-case absence is safe exactly because
-		// this rule stands beside it, and a SUBSTITUTED registry is one leg of
-		// a port rather than the matrix, so the rule does not reach it.
+		// THE REFERENCE LEG MAY NOT ANSWER ABSENT, AT EITHER GRAIN. It is the
+		// first driver in the COMMITTED registry — the discovered one, where
+		// the reference sorts first — and the one `conformance-pin` takes its
+		// pins from, so an absence there is not a port's missing feature: it is
+		// the corpus losing its own expectation, quietly, while every other leg
+		// keeps comparing against nothing. That holds whether the absence is a
+		// whole SURFACE (left out of `list`, or exit code 2) or a single CASE
+		// (`<case>.absent`); per-case absence is safe exactly because this rule
+		// stands beside it. A SUBSTITUTED registry is one leg of a port rather
+		// than the matrix, so the rule does not reach it.
 		reference := i == 0 && discovered
 		if only != "" && d.lang != only {
 			continue
@@ -353,6 +356,9 @@ func run(m *Manifest, manifestPath, jsonDir, reportsPath, driversPath, work, onl
 			results[d.lang][s] = r
 			if !listed[s] {
 				r.absent = true
+				if reference {
+					r.failures = append(r.failures, absentReference(s, "`list` does not name it"))
+				}
 				continue
 			}
 			out := filepath.Join(work, "out", d.lang, s)
@@ -368,6 +374,9 @@ func run(m *Manifest, manifestPath, jsonDir, reportsPath, driversPath, work, onl
 			}
 			if code == 2 {
 				r.absent = true
+				if reference {
+					r.failures = append(r.failures, absentReference(s, "the driver exited 2"))
+				}
 				continue
 			}
 			if code != 0 {
@@ -401,7 +410,17 @@ func run(m *Manifest, manifestPath, jsonDir, reportsPath, driversPath, work, onl
 		}
 	}
 
-	return report(langs, results), nil
+	return report(w, langs, results), nil
+}
+
+// absentReference is what the REFERENCE leg's absence reads as in the failure
+// list: the surface, how it went absent, and why that is red where the same
+// answer from a port is an ordinary missing feature.
+func absentReference(surface, how string) string {
+	return fmt.Sprintf(
+		"the REFERENCE leg is ABSENT on the whole %s surface (%s) — an absence here is the corpus "+
+			"losing its own expectation, not a missing feature; every other leg would keep comparing "+
+			"against a surface nothing pins", surface, how)
 }
 
 func listSurfaces(d driver, manifest string) (map[string]bool, error) {
@@ -452,8 +471,11 @@ func describeDiff(name string, want, got []byte) string {
 	return name + ": differs"
 }
 
-func report(langs []string, results map[string]map[string]*result) bool {
-	ok := true
+// report prints the matrix and returns the verdict. THE VERDICT IS THE FAILURE
+// LIST and nothing else, so that a cell printing something other than FAIL — an
+// ABSENT one — cannot lose a failure recorded against it and the success footer
+// cannot print beside one.
+func report(w io.Writer, langs []string, results map[string]map[string]*result) bool {
 	// wide enough for "pass 111/111 +4a", the widest cell the matrix can print
 	width := 18
 	for _, s := range surfaces {
@@ -461,35 +483,39 @@ func report(langs []string, results map[string]map[string]*result) bool {
 			width = len(s) + 2
 		}
 	}
-	fmt.Printf("\nTABLES CONFORMANCE — surface x language\n\n")
-	fmt.Printf("%-14s", "surface")
+	fmt.Fprintf(w, "\nTABLES CONFORMANCE — surface x language\n\n")
+	fmt.Fprintf(w, "%-14s", "surface")
 	for _, l := range langs {
-		fmt.Printf("%-*s", width, l)
+		fmt.Fprintf(w, "%-*s", width, l)
 	}
-	fmt.Println()
-	fmt.Printf("%s\n", strings.Repeat("-", 14+width*len(langs)))
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "%s\n", strings.Repeat("-", 14+width*len(langs)))
 	for _, s := range surfaces {
-		fmt.Printf("%-14s", s)
+		fmt.Fprintf(w, "%-14s", s)
 		for _, l := range langs {
 			r := results[l][s]
 			switch {
-			case r.absent:
-				fmt.Printf("%-*s", width, "absent")
+			case len(r.failures) > 0 && r.absent:
+				// the REFERENCE leg's absence: what it did, and what that is.
+				// "FAIL 0/13" would claim it ran the surface and answered
+				// nothing, and it never ran the surface at all.
+				fmt.Fprintf(w, "%-*s", width, "FAIL absent")
 			case len(r.failures) > 0:
-				fmt.Printf("%-*s", width, fmt.Sprintf("FAIL %d/%d", r.pass, r.total))
-				ok = false
+				fmt.Fprintf(w, "%-*s", width, fmt.Sprintf("FAIL %d/%d", r.pass, r.total))
+			case r.absent:
+				fmt.Fprintf(w, "%-*s", width, "absent")
 			case r.missing > 0:
 				// what it answered, and what it said it cannot: the cell is the
 				// completion tracker, so an absence stays visible rather than
 				// being rounded away into a smaller total
-				fmt.Printf("%-*s", width, fmt.Sprintf("pass %d/%d +%da", r.pass, r.total-r.missing, r.missing))
+				fmt.Fprintf(w, "%-*s", width, fmt.Sprintf("pass %d/%d +%da", r.pass, r.total-r.missing, r.missing))
 			default:
-				fmt.Printf("%-*s", width, fmt.Sprintf("pass %d/%d", r.pass, r.total))
+				fmt.Fprintf(w, "%-*s", width, fmt.Sprintf("pass %d/%d", r.pass, r.total))
 			}
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
-	fmt.Println()
+	fmt.Fprintln(w)
 
 	var lines []string
 	for _, l := range langs {
@@ -501,10 +527,9 @@ func report(langs []string, results map[string]map[string]*result) bool {
 	}
 	sort.Strings(lines)
 	if len(lines) > 0 {
-		fmt.Printf("FAILURES\n%s\n\n", strings.Join(lines, "\n"))
+		fmt.Fprintf(w, "FAILURES\n%s\n\n", strings.Join(lines, "\n"))
+		return false
 	}
-	if ok {
-		fmt.Printf("tables conformance: every registered surface passes\n")
-	}
-	return ok
+	fmt.Fprintf(w, "tables conformance: every registered surface passes\n")
+	return true
 }

--- a/test/conformance/harness/run.go
+++ b/test/conformance/harness/run.go
@@ -476,6 +476,7 @@ func describeDiff(name string, want, got []byte) string {
 // ABSENT one — cannot lose a failure recorded against it and the success footer
 // cannot print beside one.
 func report(w io.Writer, langs []string, results map[string]map[string]*result) bool {
+	var b strings.Builder
 	// wide enough for "pass 111/111 +4a", the widest cell the matrix can print
 	width := 18
 	for _, s := range surfaces {
@@ -483,39 +484,40 @@ func report(w io.Writer, langs []string, results map[string]map[string]*result) 
 			width = len(s) + 2
 		}
 	}
-	fmt.Fprintf(w, "\nTABLES CONFORMANCE — surface x language\n\n")
-	fmt.Fprintf(w, "%-14s", "surface")
+	b.WriteString("\nTABLES CONFORMANCE — surface x language\n\n")
+	fmt.Fprintf(&b, "%-14s", "surface")
 	for _, l := range langs {
-		fmt.Fprintf(w, "%-*s", width, l)
+		fmt.Fprintf(&b, "%-*s", width, l)
 	}
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "%s\n", strings.Repeat("-", 14+width*len(langs)))
+	fmt.Fprintf(&b, "\n%s\n", strings.Repeat("-", 14+width*len(langs)))
 	for _, s := range surfaces {
-		fmt.Fprintf(w, "%-14s", s)
+		fmt.Fprintf(&b, "%-14s", s)
 		for _, l := range langs {
 			r := results[l][s]
+			var cell string
 			switch {
 			case len(r.failures) > 0 && r.absent:
 				// the REFERENCE leg's absence: what it did, and what that is.
 				// "FAIL 0/13" would claim it ran the surface and answered
 				// nothing, and it never ran the surface at all.
-				fmt.Fprintf(w, "%-*s", width, "FAIL absent")
+				cell = "FAIL absent"
 			case len(r.failures) > 0:
-				fmt.Fprintf(w, "%-*s", width, fmt.Sprintf("FAIL %d/%d", r.pass, r.total))
+				cell = fmt.Sprintf("FAIL %d/%d", r.pass, r.total)
 			case r.absent:
-				fmt.Fprintf(w, "%-*s", width, "absent")
+				cell = "absent"
 			case r.missing > 0:
 				// what it answered, and what it said it cannot: the cell is the
 				// completion tracker, so an absence stays visible rather than
 				// being rounded away into a smaller total
-				fmt.Fprintf(w, "%-*s", width, fmt.Sprintf("pass %d/%d +%da", r.pass, r.total-r.missing, r.missing))
+				cell = fmt.Sprintf("pass %d/%d +%da", r.pass, r.total-r.missing, r.missing)
 			default:
-				fmt.Fprintf(w, "%-*s", width, fmt.Sprintf("pass %d/%d", r.pass, r.total))
+				cell = fmt.Sprintf("pass %d/%d", r.pass, r.total)
 			}
+			fmt.Fprintf(&b, "%-*s", width, cell)
 		}
-		fmt.Fprintln(w)
+		b.WriteString("\n")
 	}
-	fmt.Fprintln(w)
+	b.WriteString("\n")
 
 	var lines []string
 	for _, l := range langs {
@@ -527,9 +529,12 @@ func report(w io.Writer, langs []string, results map[string]map[string]*result) 
 	}
 	sort.Strings(lines)
 	if len(lines) > 0 {
-		fmt.Fprintf(w, "FAILURES\n%s\n\n", strings.Join(lines, "\n"))
-		return false
+		fmt.Fprintf(&b, "FAILURES\n%s\n\n", strings.Join(lines, "\n"))
+	} else {
+		b.WriteString("tables conformance: every registered surface passes\n")
 	}
-	fmt.Fprintf(w, "tables conformance: every registered surface passes\n")
-	return true
+	// the matrix goes out in one write; a stdout that cannot be written to is
+	// not a verdict this gate can improve on
+	_, _ = io.WriteString(w, b.String())
+	return len(lines) == 0
 }


### PR DESCRIPTION
Closes #467.

`harness run` made a reference leg's per-case `.absent` markers fatal and let a
WHOLE surface go absent for free. A reference driver that left a surface out of
`list` (`run.go:354-357`) or exited 2 on it (`:369-372`) set `r.absent` with no
`reference` check; the matrix printed `absent` without touching the verdict
(`:476-477`) and the success footer printed beside it (`:506-508`), exit 0 —
while every other leg went on comparing against a surface nothing pinned.

## The bug, on the harness at main

A single-driver discovered registry whose `cpp` leg lists twelve of the
thirteen surfaces:

```
surface       cpp
--------------------------------
wire          pass 1/1
report        pass 0/0
json-read     pass 1/1
json-write    pass 1/1
json-hostile  pass 0/0
cook          pass 0/0
cook-write    pass 0/0
cook-foreign  pass 0/0
block         pass 0/0
block-foreign pass 0/0
block-dump    absent
forgery       pass 0/0
cook-forgery  pass 0/0

tables conformance: every registered surface passes
harness exit: 0
```

## The same registry, with the fix

```
surface       cpp
--------------------------------
wire          pass 1/1
report        pass 0/0
json-read     pass 1/1
json-write    pass 1/1
json-hostile  pass 0/0
cook          pass 0/0
cook-write    pass 0/0
cook-foreign  pass 0/0
block         pass 0/0
block-foreign pass 0/0
block-dump    FAIL absent
forgery       pass 0/0
cook-forgery  pass 0/0

FAILURES
  cpp / block-dump: the REFERENCE leg is ABSENT on the whole block-dump surface (`list` does not name it) — an absence here is the corpus losing its own expectation, not a missing feature; every other leg would keep comparing against a surface nothing pins

harness exit: 1
```

and the exit-2 branch, same shape:

```
FAILURES
  cpp / block-dump: the REFERENCE leg is ABSENT on the whole block-dump surface (the driver exited 2) — an absence here is the corpus losing its own expectation, not a missing feature; every other leg would keep comparing against a surface nothing pins
```

## What changed

- Both absence branches record a failure naming the surface and how it went
  absent, under the same `reference` test the per-case rule already used.
- The verdict now comes from the failure list rather than from a print branch,
  so no cell that prints something other than `FAIL` can swallow a failure
  recorded against it. That is the class of the bug, not just the instance.
- The reference's absent cell reads `FAIL absent`: it never ran the surface, so
  `FAIL 0/N` would claim more than happened.
- A port's absence is untouched — allowed, and still printed where the
  completion tracker can show it.
- `report` takes an `io.Writer` so the printed matrix is testable.

## Gates

Four harness unit tests over fake drivers
(`test/conformance/harness/absence_test.go`), each over a one-instance corpus
so no language leg or fixture generator is needed:

1. a surface missing from the REFERENCE's `list` — red, named, no footer, the
   other surfaces still `pass 1/1`, exactly one failure;
2. exit code 2 on the REFERENCE — same;
3. per-case absence on the REFERENCE — already fatal, now pinned;
4. all three from a leg that is NOT the reference — a second leg of the
   committed registry, and the first line of a substituted one — green, and
   still printed as `absent` / `pass 0/0 +1a`.

Negative control on the tests themselves: removing both `if reference` blocks
turns exactly tests 1 and 2 red and leaves 3 and 4 green.

```
--- FAIL: TestReferenceSurfaceMissingFromList (0.44s)
--- FAIL: TestReferenceSurfaceExitsTwo (0.43s)
```

`conformance-negative-control-reference-surface` puts the rule in the control
chain on the real reference leg, beside `conformance-negative-control-absent`:
a wrapper around the committed cpp driver filters `block-dump` out of its
`list`, planted as the reference of a scratch DISCOVERED registry (the rule
belongs to that registry alone), and the harness must exit nonzero naming that
surface, print no success footer, and leave every other surface passing. The
wrapper refuses rather than filtering nothing, so a control that removed no
surface says so instead of reading as a pass. No tracked file is written.

## Docs

`test/conformance/README.md` states the rule at both grains and says what the
matrix prints. `docs/PORTING.md` I4 names the new control beside the per-case
one and its `run.go` citation is re-anchored.

## Run

`go test ./...` green (the harness package included); `make check` green. The
C++ half of the chain — `conformance-negative-control-reference-surface` and
the rest of `make test` — was not built locally; it runs in CI.
