### PR TITLE
Re-pin the four C++ Table goldens #429 moved, and run the block zero-cost gate's byte-identity half on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,9 @@ jobs:
             exit 1
           fi
 
+      - name: the tables goldens match a fresh generation (the block zero-cost gate, byte-identity half)
+        run: make tables-block-zero-cost
+
   # THE CONFORMANCE MATRIX (test/conformance/README.md), one job per registered
   # driver. The same corpus as data, one driver per language, and the matrix
   # that says which surfaces a backend has: cross-language bit identity is the
@@ -183,9 +186,6 @@ jobs:
   # Registering a port is its driver and its ci.json, and no edit here — unless
   # its toolchain has no step yet, in which case it adds one step keyed on a
   # new field, which is the one edit this file still takes.
-      - name: the tables goldens match a fresh generation (the block zero-cost gate, byte-identity half)
-        run: make tables-block-zero-cost
-
   conformance-matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
   # Registering a port is its driver and its ci.json, and no edit here — unless
   # its toolchain has no step yet, in which case it adds one step keyed on a
   # new field, which is the one edit this file still takes.
+      - name: the tables goldens match a fresh generation (the block zero-cost gate, byte-identity half)
+        run: make tables-block-zero-cost
+
   conformance-matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/testdata/golden/tables/blobs/AssetsTable.h
+++ b/testdata/golden/tables/blobs/AssetsTable.h
@@ -2947,6 +2947,7 @@ inline const Asset * AssetLoad( uint8_t * region, int64_t region_bytes, const ui
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Asset ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = AssetNodeStorage( type_id, length );
@@ -2955,7 +2956,7 @@ inline const Asset * AssetLoad( uint8_t * region, int64_t region_bytes, const ui
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -2969,7 +2970,10 @@ inline const Asset * AssetLoad( uint8_t * region, int64_t region_bytes, const ui
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -3031,12 +3035,13 @@ inline bool AssetLoadBuilder( AssetBuilder & builder, const uint8_t * wire, int6
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = AssetNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -3047,7 +3052,7 @@ inline bool AssetLoadBuilder( AssetBuilder & builder, const uint8_t * wire, int6
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {
@@ -3400,6 +3405,7 @@ inline const Catalog * CatalogLoad( uint8_t * region, int64_t region_bytes, cons
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Catalog ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = CatalogNodeStorage( type_id, length );
@@ -3408,7 +3414,7 @@ inline const Catalog * CatalogLoad( uint8_t * region, int64_t region_bytes, cons
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -3422,7 +3428,10 @@ inline const Catalog * CatalogLoad( uint8_t * region, int64_t region_bytes, cons
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -3484,12 +3493,13 @@ inline bool CatalogLoadBuilder( CatalogBuilder & builder, const uint8_t * wire, 
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = CatalogNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -3500,7 +3510,7 @@ inline bool CatalogLoadBuilder( CatalogBuilder & builder, const uint8_t * wire, 
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {

--- a/testdata/golden/tables/pointers/GraphTable.h
+++ b/testdata/golden/tables/pointers/GraphTable.h
@@ -4939,6 +4939,7 @@ inline const ListNode * ListNodeLoad( uint8_t * region, int64_t region_bytes, co
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( ListNode ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = ListNodeNodeStorage( type_id, length );
@@ -4947,7 +4948,7 @@ inline const ListNode * ListNodeLoad( uint8_t * region, int64_t region_bytes, co
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -4961,7 +4962,10 @@ inline const ListNode * ListNodeLoad( uint8_t * region, int64_t region_bytes, co
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -5023,12 +5027,13 @@ inline bool ListNodeLoadBuilder( ListNodeBuilder & builder, const uint8_t * wire
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = ListNodeNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -5039,7 +5044,7 @@ inline bool ListNodeLoadBuilder( ListNodeBuilder & builder, const uint8_t * wire
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {
@@ -5387,6 +5392,7 @@ inline const TreeNode * TreeNodeLoad( uint8_t * region, int64_t region_bytes, co
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( TreeNode ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = TreeNodeNodeStorage( type_id, length );
@@ -5395,7 +5401,7 @@ inline const TreeNode * TreeNodeLoad( uint8_t * region, int64_t region_bytes, co
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -5409,7 +5415,10 @@ inline const TreeNode * TreeNodeLoad( uint8_t * region, int64_t region_bytes, co
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -5471,12 +5480,13 @@ inline bool TreeNodeLoadBuilder( TreeNodeBuilder & builder, const uint8_t * wire
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = TreeNodeNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -5487,7 +5497,7 @@ inline bool TreeNodeLoadBuilder( TreeNodeBuilder & builder, const uint8_t * wire
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {
@@ -5835,6 +5845,7 @@ inline const Layer * LayerLoad( uint8_t * region, int64_t region_bytes, const ui
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Layer ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = LayerNodeStorage( type_id, length );
@@ -5843,7 +5854,7 @@ inline const Layer * LayerLoad( uint8_t * region, int64_t region_bytes, const ui
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -5857,7 +5868,10 @@ inline const Layer * LayerLoad( uint8_t * region, int64_t region_bytes, const ui
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -5919,12 +5933,13 @@ inline bool LayerLoadBuilder( LayerBuilder & builder, const uint8_t * wire, int6
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = LayerNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -5935,7 +5950,7 @@ inline bool LayerLoadBuilder( LayerBuilder & builder, const uint8_t * wire, int6
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {
@@ -6291,6 +6306,7 @@ inline const Scene * SceneLoad( uint8_t * region, int64_t region_bytes, const ui
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Scene ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = SceneNodeStorage( type_id, length );
@@ -6299,7 +6315,7 @@ inline const Scene * SceneLoad( uint8_t * region, int64_t region_bytes, const ui
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -6313,7 +6329,10 @@ inline const Scene * SceneLoad( uint8_t * region, int64_t region_bytes, const ui
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -6375,12 +6394,13 @@ inline bool SceneLoadBuilder( SceneBuilder & builder, const uint8_t * wire, int6
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = SceneNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -6391,7 +6411,7 @@ inline bool SceneLoadBuilder( SceneBuilder & builder, const uint8_t * wire, int6
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {
@@ -6739,6 +6759,7 @@ inline const Depot * DepotLoad( uint8_t * region, int64_t region_bytes, const ui
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Depot ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = DepotNodeStorage( type_id, length );
@@ -6747,7 +6768,7 @@ inline const Depot * DepotLoad( uint8_t * region, int64_t region_bytes, const ui
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -6761,7 +6782,10 @@ inline const Depot * DepotLoad( uint8_t * region, int64_t region_bytes, const ui
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -6823,12 +6847,13 @@ inline bool DepotLoadBuilder( DepotBuilder & builder, const uint8_t * wire, int6
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = DepotNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -6839,7 +6864,7 @@ inline bool DepotLoadBuilder( DepotBuilder & builder, const uint8_t * wire, int6
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {
@@ -7195,6 +7220,7 @@ inline const Album * AlbumLoad( uint8_t * region, int64_t region_bytes, const ui
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Album ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = AlbumNodeStorage( type_id, length );
@@ -7203,7 +7229,7 @@ inline const Album * AlbumLoad( uint8_t * region, int64_t region_bytes, const ui
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -7217,7 +7243,10 @@ inline const Album * AlbumLoad( uint8_t * region, int64_t region_bytes, const ui
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -7279,12 +7308,13 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire, int6
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = AlbumNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -7295,7 +7325,7 @@ inline bool AlbumLoadBuilder( AlbumBuilder & builder, const uint8_t * wire, int6
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {

--- a/testdata/golden/tables/pointers/MarksTable.h
+++ b/testdata/golden/tables/pointers/MarksTable.h
@@ -2479,6 +2479,7 @@ inline const Marker * MarkerLoad( uint8_t * region, int64_t region_bytes, const 
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Marker ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = MarkerNodeStorage( type_id, length );
@@ -2487,7 +2488,7 @@ inline const Marker * MarkerLoad( uint8_t * region, int64_t region_bytes, const 
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -2501,7 +2502,10 @@ inline const Marker * MarkerLoad( uint8_t * region, int64_t region_bytes, const 
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -2563,12 +2567,13 @@ inline bool MarkerLoadBuilder( MarkerBuilder & builder, const uint8_t * wire, in
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = MarkerNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -2579,7 +2584,7 @@ inline bool MarkerLoadBuilder( MarkerBuilder & builder, const uint8_t * wire, in
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -2992,6 +2992,7 @@ inline const Chunk * ChunkLoad( uint8_t * region, int64_t region_bytes, const ui
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Chunk ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = ChunkNodeStorage( type_id, length );
@@ -3000,7 +3001,7 @@ inline const Chunk * ChunkLoad( uint8_t * region, int64_t region_bytes, const ui
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -3014,7 +3015,10 @@ inline const Chunk * ChunkLoad( uint8_t * region, int64_t region_bytes, const ui
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -3076,12 +3080,13 @@ inline bool ChunkLoadBuilder( ChunkBuilder & builder, const uint8_t * wire, int6
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = ChunkNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -3092,7 +3097,7 @@ inline bool ChunkLoadBuilder( ChunkBuilder & builder, const uint8_t * wire, int6
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {
@@ -3440,6 +3445,7 @@ inline const Feed * FeedLoad( uint8_t * region, int64_t region_bytes, const uint
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t used = TableAlignUp64( (int64_t) sizeof( Feed ) );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             int64_t storage = FeedNodeStorage( type_id, length );
@@ -3448,7 +3454,7 @@ inline const Feed * FeedLoad( uint8_t * region, int64_t region_bytes, const uint
                 // a record whose type id this build cannot name KEEPS ITS
                 // INDEX, is counted once here and not once per pointer, and
                 // every reference to it reads null (§3.1)
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
                 directory[k + 1].type_id = type_id;
             }
@@ -3462,7 +3468,10 @@ inline const Feed * FeedLoad( uint8_t * region, int64_t region_bytes, const uint
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; } // the table is whole or it is nothing
+        // the table is whole or it is nothing: a scan that failed counts
+        // malformed and NOT the unknowns it met on the way, because the
+        // numbering they belonged to does not exist (§3.1)
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
 
     // PASS TWO: decode each body into its own storage. A forward index
@@ -3524,12 +3533,13 @@ inline bool FeedLoadBuilder( FeedBuilder & builder, const uint8_t * wire, int64_
     {
         TableNodeScan scan = TableNodeScanBegin( wire, wire_bytes, out );
         int64_t k = 0;
+        int32_t unknown_records = 0; // counted once the scan is known whole
         while ( TableNodeScanNext( scan, type_id, body, length ) )
         {
             uint32_t at = FeedNodeAlloc( type_id, builder.main, length );
             if ( at == 0 )
             {
-                out->unknown++;
+                unknown_records++;
                 directory[k + 1].offset = kTableNodeAbsent;
             }
             else
@@ -3540,7 +3550,7 @@ inline bool FeedLoadBuilder( FeedBuilder & builder, const uint8_t * wire, int64_
             k++;
         }
         nodes.good = TableNodeScanWhole( scan );
-        if ( !nodes.good ) { out->malformed = true; }
+        if ( nodes.good ) { out->unknown += unknown_records; } else { out->malformed = true; }
     }
     if ( nodes.good )
     {


### PR DESCRIPTION
Main's certification has been red since #429 merged: `tables-block-zero-cost`'s byte-identity half compares the committed C++ Table goldens under testdata/golden/tables/ against a fresh generation, and four of them (pointers/GraphTable.h, pointers/MarksTable.h, stream/StreamTable.h, blobs/AssetsTable.h — the variable-class units) no longer matched: #429 deferred `unknown_records` in the pointer walk (§3.1's rule that a failed scan counts nothing but malformed) and re-pinned generated/ but not these goldens. The diff is exactly that change and nothing else. That gate ran only in certification, so every PR gate stayed green while main was red — the #461 gap. This PR re-pins the four files and runs the gate on every pull request, in the `generated` job, so a golden that moves without its pin is red before merge.