### PR TITLE
docs: CONTRIBUTING describes the CAA instead of denying a CLA

### DIFF
--- a/README-NEW.md
+++ b/README-NEW.md
@@ -330,6 +330,10 @@ whatever terms you choose, including in closed-source projects. That grant is
 intentional and permanent. If you modify the compiler and run it as a service
 or distribute it, the AGPL's terms apply to those modifications.
 
+Contributing is a separate matter. Contributions are made under a Contributor
+Assignment Agreement, described in
+[CONTRIBUTING.md](docs/CONTRIBUTING.md#the-contributor-assignment-agreement).
+
 ## Author
 
 Glenn Fiedler and Rowan Claude, Más Bandwidth LLC.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ whatever terms you choose, including in closed-source projects. That grant is
 intentional and permanent. If you modify the compiler and run it as a service
 or distribute it, the AGPL's terms apply to those modifications.
 
+Contributing is a separate matter. Contributions are made under a Contributor
+Assignment Agreement, described in
+[CONTRIBUTING.md](docs/CONTRIBUTING.md#the-contributor-assignment-agreement).
+
 ## Author
 
 Glenn Fiedler and Rowan Claude, Más Bandwidth LLC.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,6 +79,9 @@ cost most of the wall clock.
 So a change to the C++ emitters wants a dispatch run on its branch before
 merging, not just a green pull request.
 
+One more gate is not CI at all. A pull request is not merged until its authors
+have signed the [Contributor Assignment Agreement](#the-contributor-assignment-agreement).
+
 ## Changing generated output
 
 Any change to a backend's emitted code will move the goldens, and that is
@@ -165,8 +168,45 @@ one that restates the code.
 If a change and the SPEC disagree, one of them is wrong and the pull request
 should say which.
 
-## Licence
+## The Contributor Assignment Agreement
 
-The compiler is AGPL-3.0, with an explicit exception for the code it generates
-(see [LICENSE](../LICENSE)). Contributions are accepted under those terms. There
-is no CLA.
+Contributions require signing the Contributor Assignment Agreement, the CAA. A
+workflow checks every human commit author on a pull request against a signature
+ledger. The pull request stays red until each of them has signed, and it is not
+merged before it is green. Maintainer accounts and bots are allowlisted and
+never sign.
+
+You sign once, on your first pull request to any Más Bandwidth repository, by
+posting this exact sentence as a comment on that pull request:
+
+> I have read the CAA and I hereby sign it, assigning copyright in my contributions to Más Bandwidth LLC.
+
+Read [the agreement](https://github.com/mas-bandwidth/.github/blob/main/CAA.md)
+before you sign it. It is the authority, and what follows is only a summary of
+it. You assign the copyright in your contribution to Más Bandwidth LLC. You
+keep a perpetual license to use your own work for any purpose. You grant a
+patent license covering your contribution. You state that the contribution is
+yours to submit, and that any employer with a claim on your work has cleared
+it. Third-party material you include is not assigned, so identify it and its
+license when you submit it. Section 3 of the agreement governs how Más
+Bandwidth licenses what you assign.
+
+Signatures are recorded in
+[`signatures/caa.json`](https://github.com/mas-bandwidth/.github/blob/cla-signatures/signatures/caa.json)
+on the `cla-signatures` branch of `mas-bandwidth/.github`, one entry per GitHub
+user. The ledger covers every Más Bandwidth repository, so one signature is
+enough for all of them.
+
+The check is an exact string match. A signature that carries extra text, or one
+posted on an issue rather than on a pull request, is still a valid signature,
+but a maintainer has to enter it in the ledger by hand. Comment `recheck` on a
+pull request to re-run the check once that is done. Any other open pull request
+of yours stays red until it is rechecked too.
+
+## License
+
+The compiler ships under the license in [LICENSE](../LICENSE), and the
+[README](../README.md#license) says what that means for you and for the code
+the compiler generates. Contributions are assigned under the CAA above, and Más
+Bandwidth licenses them under the project's license and any other license it
+chooses (CAA section 3).


### PR DESCRIPTION
Fixes the docs half of #474. Docs only. No code, no legal text, no workflow changed.

## What was wrong

`docs/CONTRIBUTING.md` ended with "Contributions are accepted under those terms. There is no CLA." while `.github/workflows/cla.yml` holds every pull request red until each human commit author posts a copyright assignment. A contributor read the guide, opened a pull request, and met a gate the guide denied existed. An assignment is stronger than the CLA the guide denied.

## What this does

`docs/CONTRIBUTING.md` gets a `## The Contributor Assignment Agreement` section that states, in order: the check exists and gates the merge, maintainers and bots are allowlisted, you sign once on your first pull request to any Más Bandwidth repository, the exact sentence to post, what the agreement assigns, where the signature ledger lives, and what happens to a signature the automation cannot record (extra text, or posted on an issue) plus the `recheck` escape hatch. Every fact is read off `cla.yml` and off [CAA.md](https://github.com/mas-bandwidth/.github/blob/main/CAA.md); the section says the agreement is the authority and the prose is a summary.

Each fact sits in the file that owns it. `docs/CONTRIBUTING.md` owns contributing and its short `## License` section now points at `LICENSE` and the README instead of restating them. `README.md` keeps the user-facing license paragraph and gains one cross-reference line to the new section. The `## Licence` heading is now `## License`.

`README-NEW.md` gets the same one-line cross-reference so the in-progress 3.0.0 page does not land without it.

## Sentences changed

- `docs/CONTRIBUTING.md:168-172`, the whole `## Licence` section, replaced by `## The Contributor Assignment Agreement` and a three-line `## License`.
- `docs/CONTRIBUTING.md`, "The gates a change has to pass": one sentence added, "One more gate is not CI at all. A pull request is not merged until its authors have signed the Contributor Assignment Agreement."
- `README.md:135`, `README-NEW.md:332`: one sentence added, "Contributing is a separate matter. Contributions are made under a Contributor Assignment Agreement, described in CONTRIBUTING.md."

## For the owner's eye

Legal text was left verbatim. These are the sentences the issue puts on you, quoted, with what I would write beside them.

**1. The SPDX expression. `LICENSE:4-7` grants more than the badge and the prose claim.**

- `LICENSE:4-7`: "either version 3 of the License, or (at your option) any later version" — this is `AGPL-3.0-or-later`.
- `README.md:4`: `[![License: AGPL v3](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)`
- `README.md:125`: "**The compiler is AGPL-3.0, and will stay that way.**"
- `README.md:128`: "The compiler is licensed under the GNU Affero General Public License v3.0"
- `docs/FAQ.md:194`: "The **compiler** is AGPL-3.0."
- `docs/SPEC.md:1927`: "License: AGPL-3.0, with an explicit additional permission for generated output"

Proposed, if the grant is what you want: `AGPL-3.0-or-later` in all five places and `license-AGPL--3.0--or--later` in the badge. Proposed, if the badge is what you want: strike "or (at your option) any later version" from `LICENSE`. One or the other, not both. I changed none of them, since which one is the grant is your call and `LICENSE` is legal text.

**2. The CAA names a license this project does not use.**

- `CAA.md` section 3: "the license the project uses at the time (currently the Más Bandwidth Source License, the MBSL, for most Más Bandwidth libraries)"
- `CAA.md`, closing line: "By signing, You agree to assign the copyright in Your Contributions to Más Bandwidth LLC and to have them distributed under the MBSL, on the terms above."

A contributor to schema reads the agreement and is told their work goes out under the MBSL, while schema is AGPL. Proposed for the closing line: "...and to have them distributed under the license that project uses, on the terms above." That file is in `mas-bandwidth/.github`, not this repo, so nothing here can fix it.

**3. The relicensing reservation against the permanence promise.**

- `CAA.md` section 3: "You acknowledge that the Company may relicense the project, including Your Contribution, at its sole discretion."
- `README.md:125`: "The compiler is AGPL-3.0, and will stay that way."
- `README.md:132-133`: "That grant is intentional and permanent."

Both can be true, a promise you make and a right you keep, but a contributor may read the pair as a contradiction. My new sentence in `docs/CONTRIBUTING.md` reports the agreement rather than the promise: "Contributions are assigned under the CAA above, and Más Bandwidth licenses them under the project's license and any other license it chooses (CAA section 3)." Say the word and I will replace it with whatever you want a contributor to be told, or drop the clause.

**4. My summary of the agreement.** The paragraph beginning "Read the agreement before you sign it." compresses CAA sections 2, 4, 5, 6, 7 into six sentences. It is descriptive, and it says the agreement governs, but it is prose about a legal document and you may want to read it as such.

## Not in this pull request, deliberately

The issue's third item: the generated-file header carries `SPDX-License-Identifier: NONE`, which is not a valid SPDX expression (`NOASSERTION` is the idiom). The issue rules that it rides a release that moves the goldens anyway. Same for the compiler sources carrying no SPDX header. The remaining British "licence" spellings in `docs/FAQ.md:206`, `docs/FAQ.md:209`, `docs/SPEC-TABLES.md:9223` and three `internal/codegen/jstable/` comments belong to #402's sweep; only the one in the section rewritten here was fixed.

## Gates

- `go test ./compiler/...` green, including `compiler/docs_test.go`, the docs-examples gate.
- `make check` green.

Go untouched, so no other leg applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
