### PR TITLE
ir: checked size arithmetic, and width helpers that stop at pointer edges (#468, #469)

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -5627,6 +5627,13 @@ in build version (§20.5).
 - `table` bodies containing `const`/`reserved`/`align` (§2 — no bit
   positions). Extents have no wire ceiling (§3); an extent past the
   language's own int32 storage cap is refused there, not here.
+- **A DERIVED SIZE past the cap** (SPEC §4.6): extents are capped one at a
+  time, and a record's storage, an array's whole storage, a block form's
+  extent (§19.3) and a wire width are each refused past 2^40 bytes, naming
+  the field and the product, so a schema of individually legal bounds cannot
+  hand a backend a number the arithmetic no longer represents. The cap is
+  above every node body the wire can frame (a node's length is a `u32`,
+  §3.1) and far below where an int64 size stops being exact.
 - Recursive nesting (§2 — the cycle is named).
 - A bare rename hazard: `was` naming the field's own name (§5).
 - Id collisions, hash or `was`-induced (§5).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -929,6 +929,12 @@ All compile errors with positions:
   `None = 0`, so its wire range is the degenerate `[0, 0]` and it costs zero
   bits — the value is recovered from the range alone, under the same rule as
   any degenerate range.
+- **A derived size past the cap:** an array bound, a `string(N)` and a
+  `bytes(N)` are capped at int32 one at a time (§4.3), and what they multiply
+  to is capped too. A field's wire width, an array's whole storage, a record's
+  storage and a `MaxBytes` buffer bound are each refused past 2^40 bytes
+  (2^43 bits), with a diagnostic naming the field and the product, so no
+  generated file can carry a size the arithmetic does not represent.
 - **One flat namespace, and the compiler's claimed names:** all declaration
   kinds share one unit-level namespace (`const Foo` and `type Foo` collide),
   and no unit declares `ProtocolId`. The checker likewise refuses user names

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -123,6 +123,7 @@ func Unit(files []SourceFile) (*ir.Unit, []error) {
 	c.checkClaimedNames()
 	c.checkTargetNames()
 	c.assemble()
+	c.checkSizes()
 	if len(c.errs) > 0 {
 		return nil, c.errs
 	}
@@ -3210,6 +3211,29 @@ func (c *checker) assemble() {
 		u.Files = append(u.Files, irf)
 	}
 	maps.Copy(u.DeclFile, c.declFile)
+}
+
+// checkSizes refuses a unit whose derived sizes pass the caps [ir.CheckSizes]
+// holds: a wire width, a record's storage, an array's whole storage, a block
+// form's extent. Individual bounds are capped at int32 (SPEC §4.3) and their
+// PRODUCT was not, so a schema of legal bounds could reach a backend carrying
+// arithmetic that no longer fit, and a generated file could carry a negative
+// stride or a wrapped buffer bound (SPEC §4.6, docs/SPEC-TABLES.md §11).
+//
+// It runs over the ASSEMBLED unit, because the sizes are derived from resolved
+// bounds, and only when the unit is otherwise clean: a size computed from a
+// field the checker already refused describes nothing.
+func (c *checker) checkSizes() {
+	if len(c.errs) > 0 {
+		return
+	}
+	for _, e := range ir.CheckSizes(c.unit) {
+		pos := ast.Pos{}
+		if d, ok := c.astDecls[e.Owner]; ok {
+			pos = d.DeclPos()
+		}
+		c.errf(pos, "%s", e.Error())
+	}
 }
 
 // ---- the protocol id (SPEC §3.1) ----

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -142,6 +142,11 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\ntype T { a [0]uint8 }\n"},
 		{name: "count range backwards", want: "0 <= Min < N",
 			src: "package t\ntype T { a [5..3]uint8 }\n"},
+		// bounds are capped one at a time (SPEC §4.3) and their PRODUCT is
+		// capped too (SPEC §4.6, docs/SPEC-TABLES.md §11): three nested arrays
+		// of legal bounds are a wire width no arithmetic represents
+		{name: "nested array bounds whose product passes the cap", want: "past the cap of 8796093022208 bits",
+			src: "package t\ntype L { v uint64 }\ntype I { a [2147483647]L }\ntype M { a [2147483647]I }\n"},
 		// ---- the qualification section (SPEC §4.2) ----
 		{name: "the retired field attribute block names its replacement", want: "qualifiers follow | to the end of the line",
 			src: "package t\ntype T { h int16 " + "[min = 0, max = 5] }\n"},

--- a/ir/blocklayout.go
+++ b/ir/blocklayout.go
@@ -455,7 +455,7 @@ func UnionLayout(u *Unit, un *Union) (size, align, tag, armOffset int64) {
 		align = armAlign
 	}
 	armOffset = alignUp(tag, armAlign)
-	size = alignUp(armOffset+armSize, align)
+	size = alignUp(addSize(armOffset, armSize), align)
 	return size, align, tag, armOffset
 }
 
@@ -475,13 +475,6 @@ func memberStruct(u *Unit, name string) *Struct {
 type storagePiece struct {
 	size  int64
 	align int64
-}
-
-func alignUp(v, a int64) int64 {
-	if a <= 1 {
-		return v
-	}
-	return (v + a - 1) / a * a
 }
 
 // layoutRecord walks one generated record's storage the way a C compiler does.
@@ -504,7 +497,7 @@ func layoutRecord(u *Unit, st *Struct) *MemberLayout {
 			if start < 0 {
 				start = offset
 			}
-			offset += p.size
+			offset = addSize(offset, p.size)
 		}
 		if start < 0 {
 			continue
@@ -544,7 +537,7 @@ func layoutProjection(u *Unit, st *Struct) MemberLayout {
 			if start < 0 {
 				start = offset
 			}
-			offset += p.size
+			offset = addSize(offset, p.size)
 		}
 		if start < 0 {
 			continue
@@ -575,7 +568,7 @@ func BlockFieldPieceOffsets(u *Unit, f *Field, fieldOffset int64, projection boo
 	for _, p := range pieces {
 		at = alignUp(at, p.align)
 		out = append(out, BlockFieldPiece{Offset: at, Size: p.size})
-		at += p.size
+		at = addSize(at, p.size)
 	}
 	return out
 }
@@ -619,20 +612,20 @@ func fieldPieces(u *Unit, f *Field, projection bool) []storagePiece {
 		// region reaches everything, which is the scale §7 is built for.
 		pieces = append(pieces, storagePiece{size: 8, align: 8})
 	case f.Type.Kind == TString:
-		pieces = append(pieces, storagePiece{size: f.Type.Size + 1, align: 1}) // char[N+1]
-		pieces = append(pieces, storagePiece{size: 4, align: 4})               // int32 length
+		pieces = append(pieces, storagePiece{size: addSize(f.Type.Size, 1), align: 1}) // char[N+1]
+		pieces = append(pieces, storagePiece{size: 4, align: 4})                       // int32 length
 	case f.Type.Kind == TBytes:
 		pieces = append(pieces, storagePiece{size: f.Type.Size, align: 1}) // uint8[N]
 		pieces = append(pieces, storagePiece{size: 4, align: 4})           // int32 length
 	case f.KeyEnum != "":
 		e := elementPiece(u, f)
-		pieces = append(pieces, storagePiece{size: e.size * f.ArrayBound, align: e.align})
+		pieces = append(pieces, storagePiece{size: mulSize(e.size, f.ArrayBound), align: e.align})
 	case f.Array == ArrayFixed:
 		e := elementPiece(u, f)
-		pieces = append(pieces, storagePiece{size: e.size * f.ArrayBound, align: e.align})
+		pieces = append(pieces, storagePiece{size: mulSize(e.size, f.ArrayBound), align: e.align})
 	case f.Array == ArrayCounted:
 		e := elementPiece(u, f)
-		pieces = append(pieces, storagePiece{size: e.size * f.ArrayBound, align: e.align})
+		pieces = append(pieces, storagePiece{size: mulSize(e.size, f.ArrayBound), align: e.align})
 		pieces = append(pieces, storagePiece{size: 4, align: 4}) // int32 count
 	default:
 		pieces = append(pieces, elementPiece(u, f))
@@ -709,7 +702,7 @@ func elementPiece(u *Unit, f *Field) storagePiece {
 			if armAlign > align {
 				align = armAlign
 			}
-			size = alignUp(size, armAlign) + armSize
+			size = addSize(alignUp(size, armAlign), armSize)
 			return storagePiece{size: alignUp(size, align), align: align}
 		}
 	}
@@ -733,7 +726,7 @@ func BlockExtent(bl *BlockLayout, elemAligns []int64, counts []int64) (starts []
 	starts = make([]int64, len(bl.Arrays))
 	for i, a := range bl.Arrays {
 		starts[i] = BlockArrayStart(offset, elemAligns[i])
-		offset = starts[i] + counts[i]*a.Stride
+		offset = addSize(starts[i], mulSize(counts[i], a.Stride))
 	}
 	used = alignUp(offset, BlockAlign)
 	if used < bl.Projection.Size {
@@ -749,7 +742,7 @@ func blockMaxBytes(bl *BlockLayout) int64 {
 	offset := bl.Projection.Size
 	for _, a := range bl.Arrays {
 		offset = BlockArrayStart(offset, elemAlignOf(a))
-		offset += a.Max * a.Stride
+		offset = addSize(offset, mulSize(a.Max, a.Stride))
 	}
 	return alignUp(offset, BlockAlign)
 }

--- a/ir/pointerwidth_test.go
+++ b/ir/pointerwidth_test.go
@@ -1,0 +1,134 @@
+// The width helpers stop at pointer edges (docs/SPEC-TABLES.md §3.1): a
+// pointer rides as a u32 node index and no pointer edge is a nesting level, so
+// a width is the REFERENCE's, never the referent's. Following one by value
+// read a legal `table Node { next *Node }` as an infinite nesting and killed
+// the process with a stack overflow, which no caller could recover.
+//
+// The corpus below carries every pointer spelling the language has beside a
+// by-value nesting, because the fix must stop at pointer edges WITHOUT
+// stopping at the by-value edges the same helpers exist to follow.
+package ir_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+const pointerCorpus = `package ptrtest
+
+type Vec {
+    x float32
+    y float32
+}
+
+table Node {
+    value    int32 | min = 0, max = 100
+    next     *Node
+    children [..4]*Node
+    blob     *bytes
+    position Vec
+}
+
+table ByValue {
+    position Vec
+}
+`
+
+func loadPointerCorpus(t *testing.T) *ir.Unit {
+	t.Helper()
+	f, perrs := parser.Parse("Ptr.schema", []byte(pointerCorpus))
+	if len(perrs) > 0 {
+		t.Fatalf("test corpus does not parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path:  "Ptr.schema",
+		Name:  "Ptr.schema",
+		Base:  "Ptr",
+		Bytes: []byte(pointerCorpus),
+		AST:   f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("test corpus does not check: %v", cerrs[0])
+	}
+	return u
+}
+
+// withinBounds runs f and fails if it has not finished in time. A descent
+// through pointer edges either overflows the stack (which takes the process
+// down, red on its own) or runs long; the bound turns the second into a
+// failure rather than a hang.
+func withinBounds(t *testing.T, what string, f func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("%s did not finish in 30s: the walk is following pointer edges", what)
+	}
+}
+
+func TestPointerRecursiveTableHasAFiniteWidth(t *testing.T) {
+	u := loadPointerCorpus(t)
+	node := u.Tables["Node"]
+	if node == nil {
+		t.Fatal("the corpus declares table Node")
+	}
+
+	var bits int64
+	withinBounds(t, "ir.MaxBitsStruct", func() { bits = ir.MaxBitsStruct(node) })
+
+	// value 7 bits (the range [0, 100]), next 32, children 3 count bits plus
+	// 4 x 32, blob 32, position 64 (docs/SPEC-TABLES.md §3.1)
+	if want := int64(7 + 32 + (3 + 4*32) + 32 + 64); bits != want {
+		t.Errorf("MaxBitsStruct(Node) = %d, want %d", bits, want)
+	}
+	if got, want := ir.MaxBytes(bits), int64(40); got != want {
+		t.Errorf("MaxBytes = %d, want %d", got, want)
+	}
+
+	// the alignment analysis walks the same edges and must stop at the same
+	// places
+	withinBounds(t, "ir.AlignedFixedByteArrays", func() { ir.AlignedFixedByteArrays(node) })
+
+	// so does the storage layout, which already stopped: a pointer slot is
+	// eight bytes (§6.3), not its referent's record
+	var size int64
+	withinBounds(t, "ir.RecordLayout", func() { size = ir.RecordLayout(u, node).Size })
+	if want := int64(72); size != want {
+		t.Errorf("sizeof(Node) = %d, want %d", size, want)
+	}
+}
+
+// A BY-VALUE edge is still followed: the stop is at pointer edges only, and a
+// helper that stopped at both would report a nested type as costing nothing.
+func TestByValueNestingStillDescends(t *testing.T) {
+	u := loadPointerCorpus(t)
+	byValue := u.Tables["ByValue"]
+	if byValue == nil {
+		t.Fatal("the corpus declares table ByValue")
+	}
+	if got, want := ir.MaxBitsStruct(byValue), int64(64); got != want {
+		t.Errorf("MaxBitsStruct(ByValue) = %d, want %d — a by-value nesting must still be counted", got, want)
+	}
+}
+
+func TestPointerFieldWidthIsTheReference(t *testing.T) {
+	u := loadPointerCorpus(t)
+	node := u.Tables["Node"]
+	for _, f := range node.Fields {
+		if !f.Type.Pointer || f.Array != ir.ArrayNone {
+			continue
+		}
+		if got := ir.MaxBitsField(f); got != ir.PointerWireBits {
+			t.Errorf("MaxBitsField(%s) = %d, want %d", f.Name, got, ir.PointerWireBits)
+		}
+	}
+}

--- a/ir/sizes.go
+++ b/ir/sizes.go
@@ -1,0 +1,240 @@
+// Checked size arithmetic: the ONE place every size, stride, offset and
+// MaxBytes this package derives is added, multiplied and rounded up.
+//
+// Individual bounds are legal in isolation and their PRODUCT is not: three
+// nested [2147483647] arrays are three legal bounds (SPEC §4.3 caps a bound at
+// int32, and nothing caps what they multiply to) whose widths pass int64.
+// Unguarded arithmetic wrapped there, and a wrapped number reaches a generated
+// file as a negative stride, a negative static_assert size, or a
+// plausible-looking positive buffer bound that under-states the truth by
+// orders of magnitude.
+//
+// Two properties close that class. The helpers below SATURATE rather than
+// wrap, so no derived size is ever negative or smaller than the number it
+// stands for; and [CheckSizes] refuses a unit whose numbers pass the cap,
+// naming the field and the product, before any backend is handed the IR
+// (SPEC §4.6, docs/SPEC-TABLES.md §11).
+package ir
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+)
+
+// MaxSizeBytes is the cap on every size the compiler derives: a record's
+// storage, an array's whole storage, a block form's extent, a MaxBytes buffer
+// bound. A terabyte is past anything a target can hold and past the largest
+// node body the wire can frame (a node's length is a u32, docs/SPEC-TABLES.md
+// §3.1), so no legal schema meets it; what it buys is that every number the
+// compiler emits is small enough that the arithmetic reaching it cannot wrap.
+const MaxSizeBytes = int64(1) << 40
+
+// MaxWireBits is the same cap in the wire's unit: the bits that fit
+// MaxSizeBytes bytes. A width past it could not be advertised as a buffer
+// bound anyway, because [MaxBytes] of it would pass the byte cap.
+const MaxWireBits = MaxSizeBytes * 8
+
+// sizeCeiling is where the checked helpers saturate. It is a power of two far
+// above [MaxSizeBytes] and far below math.MaxInt64, which gives three
+// properties the arithmetic below depends on: a saturated value can be added
+// and multiplied again without wrapping, rounding one up to any alignment this
+// package uses returns it unchanged (it is a multiple of every power of two up
+// to itself), and it is unmistakably past the cap, so a saturated number is
+// always refused rather than emitted.
+const sizeCeiling = int64(1) << 62
+
+// addSize is a + b for two non-negative sizes, saturating at [sizeCeiling].
+func addSize(a, b int64) int64 {
+	if a > sizeCeiling-b {
+		return sizeCeiling
+	}
+	return a + b
+}
+
+// mulSize is a * b for two non-negative sizes, saturating at [sizeCeiling].
+func mulSize(a, b int64) int64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	if a > sizeCeiling/b {
+		return sizeCeiling
+	}
+	return a * b
+}
+
+// alignUp rounds v up to a multiple of a, saturating at [sizeCeiling]. It is
+// the one rounding step in the layout model: every record size, every field
+// offset and every block array start goes through it.
+func alignUp(v, a int64) int64 {
+	if a <= 1 {
+		return v
+	}
+	if r := v % a; r != 0 {
+		return addSize(v, a-r)
+	}
+	return v
+}
+
+// SizeError is one derived size the compiler refuses: which declaration and
+// field it belongs to, and the arithmetic that passed the cap.
+type SizeError struct {
+	Owner     string // the declaration the number belongs to
+	OwnerKind string // "type" or "table"
+	Field     string // the field at fault, or "" when the record total is
+	Detail    string // the arithmetic, spelled out against its cap
+}
+
+func (e SizeError) Error() string {
+	where := e.OwnerKind + " " + e.Owner
+	if e.Field != "" {
+		where += ": field " + e.Field
+	}
+	return where + " " + e.Detail
+}
+
+// productDetail spells one product out exactly. The operands are int64 and
+// their product is not, so the number is formed in big.Int: this is the
+// message for an already-refused computation, and a diagnostic that says
+// "past the cap" without saying by how much sends its reader guessing.
+func productDetail(what string, count, each int64, unit string, limit int64) string {
+	exact := new(big.Int).Mul(big.NewInt(count), big.NewInt(each))
+	return fmt.Sprintf("is %d %s x %d %s each = %s %s, past the cap of %d %s on a derived size: every bound here is legal on its own and their product is not (SPEC §4.6, docs/SPEC-TABLES.md §11)",
+		count, what, each, unit, exact, unit, limit, unit)
+}
+
+// totalDetail spells a record total out. Every term of it is inside the cap
+// (a record whose parts are not is reported by those parts), so the sum is
+// exact in int64.
+func totalDetail(what string, total int64, unit string, limit int64) string {
+	return fmt.Sprintf("%s is %d %s, past the cap of %d %s on a derived size (SPEC §4.6, docs/SPEC-TABLES.md §11)",
+		what, total, unit, limit, unit)
+}
+
+// CheckSizes recomputes every size this package derives for a unit, through
+// the same helpers the backends call, and returns one error per number that
+// passes a cap. The checker runs it and refuses the unit, so no generated file
+// can carry a size the arithmetic could not represent.
+//
+// A number is reported ONCE, at the declaration it belongs to: a field whose
+// element type is itself past the cap is skipped, because that element's own
+// declaration carries the diagnostic and reporting a product of an already
+// saturated operand would name a number that stands for nothing.
+func CheckSizes(u *Unit) []SizeError {
+	var out []SizeError
+	for _, name := range sizeCheckOrder(u) {
+		st := memberStruct(u, name)
+		if st == nil {
+			continue
+		}
+		out = append(out, checkRecordSizes(u, st)...)
+	}
+	if b := Blocks(u); b != nil {
+		for _, bl := range b.Tables {
+			out = append(out, checkBlockSizes(bl)...)
+		}
+	}
+	return out
+}
+
+// sizeCheckOrder is every record of a unit, tables and types alike, in one
+// sorted order so the diagnostics do not shuffle run to run.
+func sizeCheckOrder(u *Unit) []string {
+	names := make([]string, 0, len(u.Structs)+len(u.Tables))
+	for name := range u.Structs {
+		names = append(names, name)
+	}
+	for name := range u.Tables {
+		if _, dup := u.Structs[name]; !dup {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// checkRecordSizes covers one record: each field's wire width and storage, then
+// the record's own totals when no field of it was already refused.
+func checkRecordSizes(u *Unit, st *Struct) []SizeError {
+	kind := "type"
+	if st.IsTable {
+		kind = "table"
+	}
+	var out []SizeError
+	poisoned := false
+	for _, f := range st.Fields {
+		elemBits := maxBitsScalar(f)
+		elemBytes := fieldElemBytes(u, f)
+		if elemBits > MaxWireBits || elemBytes > MaxSizeBytes {
+			// the element's own declaration carries the diagnostic
+			poisoned = true
+			continue
+		}
+		if f.Array == ArrayNone {
+			continue
+		}
+		if MaxBitsField(f) > MaxWireBits {
+			out = append(out, SizeError{Owner: st.Name, OwnerKind: kind, Field: f.Name,
+				Detail: productDetail("elements", f.ArrayBound, elemBits, "bits", MaxWireBits)})
+			poisoned = true
+			continue
+		}
+		if mulSize(f.ArrayBound, elemBytes) > MaxSizeBytes {
+			out = append(out, SizeError{Owner: st.Name, OwnerKind: kind, Field: f.Name,
+				Detail: productDetail("elements", f.ArrayBound, elemBytes, "bytes", MaxSizeBytes)})
+			poisoned = true
+		}
+	}
+	if poisoned {
+		return out
+	}
+	if bits := MaxBitsStruct(st); bits > MaxWireBits {
+		out = append(out, SizeError{Owner: st.Name, OwnerKind: kind,
+			Detail: totalDetail("its wire width", bits, "bits", MaxWireBits)})
+	}
+	if size := layoutRecord(u, st).Size; size > MaxSizeBytes {
+		out = append(out, SizeError{Owner: st.Name, OwnerKind: kind,
+			Detail: totalDetail("its storage", size, "bytes", MaxSizeBytes)})
+	}
+	return out
+}
+
+// fieldElemBytes is ONE value of a field's declared type in storage: the array
+// element, or the scalar itself. A string, a bytes and a map carry companions
+// rather than elements, so their whole storage is the value.
+func fieldElemBytes(u *Unit, f *Field) int64 {
+	var total int64
+	for _, p := range fieldPieces(u, f, false) {
+		total = addSize(total, p.size)
+	}
+	if f.Array == ArrayNone {
+		return total
+	}
+	return elementPiece(u, f).size
+}
+
+// checkBlockSizes covers one block form: each out-of-line array at its declared
+// maximum, then the extent those maxima sum to (docs/SPEC-TABLES.md §19.1).
+func checkBlockSizes(bl *BlockLayout) []SizeError {
+	var out []SizeError
+	poisoned := false
+	for _, a := range bl.Arrays {
+		if a.Stride > MaxSizeBytes {
+			poisoned = true
+			continue
+		}
+		if mulSize(a.Max, a.Stride) > MaxSizeBytes {
+			out = append(out, SizeError{Owner: bl.Table.Name, OwnerKind: "table", Field: a.Field.Name,
+				Detail: productDetail("rows", a.Max, a.Stride, "bytes", MaxSizeBytes)})
+			poisoned = true
+		}
+	}
+	if poisoned {
+		return out
+	}
+	if bl.MaxBytes > MaxSizeBytes {
+		out = append(out, SizeError{Owner: bl.Table.Name, OwnerKind: "table",
+			Detail: totalDetail("its block form's extent", bl.MaxBytes, "bytes", MaxSizeBytes)})
+	}
+	return out
+}

--- a/ir/sizes_test.go
+++ b/ir/sizes_test.go
@@ -1,0 +1,129 @@
+// The cap on a derived size (SPEC §4.6, docs/SPEC-TABLES.md §11): array bounds
+// are capped one at a time and their PRODUCT was not, so a schema of legal
+// bounds could carry a wire width or a storage size that no longer fit the
+// arithmetic. What is pinned here is the pair of properties that closes the
+// class: a unit one step under the cap compiles and its numbers are EXACT, and
+// a unit past it is refused before a backend sees it.
+package ir_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// atCapCorpus sits one step under both caps. Wide is the largest array a
+// legal bound can spell (SPEC §4.3 caps a bound at int32) over the widest bare
+// scalar; AtCap holds 64 of them, which is 512 bytes under MaxSizeBytes and
+// 4096 bits under MaxWireBits. One more element passes both.
+const atCapCorpus = `package sizetest
+
+type Wide {
+    x [2147483647]uint64
+}
+
+type AtCap {
+    rows [64]Wide
+}
+`
+
+func loadSizeCorpus(t *testing.T, src string) (*ir.Unit, []error) {
+	t.Helper()
+	f, perrs := parser.Parse("Size.schema", []byte(src))
+	if len(perrs) > 0 {
+		t.Fatalf("test corpus does not parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path:  "Size.schema",
+		Name:  "Size.schema",
+		Base:  "Size",
+		Bytes: []byte(src),
+		AST:   f,
+	}})
+	return u, cerrs
+}
+
+func TestSizesOneStepUnderTheCapAreExact(t *testing.T) {
+	u, errs := loadSizeCorpus(t, atCapCorpus)
+	if len(errs) > 0 {
+		t.Fatalf("the at-cap corpus must compile: %v", errs[0])
+	}
+
+	// Wide: 2147483647 elements of 64 bits, and the same in storage
+	wide := u.Structs["Wide"]
+	if got, want := ir.MaxBitsStruct(wide), int64(137438953408); got != want {
+		t.Errorf("WideMaxBits = %d, want %d", got, want)
+	}
+	if got, want := ir.MaxBytes(ir.MaxBitsStruct(wide)), int64(17179869176); got != want {
+		t.Errorf("WideMaxBytes = %d, want %d", got, want)
+	}
+	if got, want := ir.RecordLayout(u, wide).Size, int64(17179869176); got != want {
+		t.Errorf("sizeof(Wide) = %d, want %d", got, want)
+	}
+
+	// AtCap: 64 of those, one step under each cap
+	atCap := u.Structs["AtCap"]
+	bits := ir.MaxBitsStruct(atCap)
+	if want := int64(8796093018112); bits != want {
+		t.Errorf("AtCapMaxBits = %d, want %d", bits, want)
+	}
+	if got, want := ir.MaxBytes(bits), int64(1099511627264); got != want {
+		t.Errorf("AtCapMaxBytes = %d, want %d", got, want)
+	}
+	size := ir.RecordLayout(u, atCap).Size
+	if want := int64(1099511627264); size != want {
+		t.Errorf("sizeof(AtCap) = %d, want %d", size, want)
+	}
+	// the numbers above are exact BECAUSE they are inside the caps: state the
+	// distance, so a change to either cap lands here rather than in a
+	// generated file
+	if slack := ir.MaxWireBits - bits; slack != 4096 {
+		t.Errorf("AtCap is %d bits under MaxWireBits, want 4096", slack)
+	}
+	if slack := ir.MaxSizeBytes - size; slack != 512 {
+		t.Errorf("AtCap is %d bytes under MaxSizeBytes, want 512", slack)
+	}
+}
+
+func TestSizesPastTheCapAreRefused(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			// the issue's reproducer: three nested arrays, every bound legal
+			name: "nested arrays whose product wraps",
+			src:  "package sizetest\ntype Leaf { v uint64 }\ntype Inner { leaves [2147483647]Leaf }\ntype Mid { inners [2147483647]Inner }\ntype Top { mids [2147483647]Mid }\n",
+			want: "type Mid: field inners is 2147483647 elements x 137438953408 bits each = 295147904904474918976 bits, past the cap of 8796093022208 bits",
+		},
+		{
+			// one element past the corpus above
+			name: "one element past the cap",
+			src:  "package sizetest\ntype Wide { x [2147483647]uint64 }\ntype OverCap { rows [65]Wide }\n",
+			want: "type OverCap: field rows is 65 elements x 137438953408 bits each = 8933531971520 bits, past the cap of 8796093022208 bits",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, errs := loadSizeCorpus(t, tc.src)
+			if len(errs) == 0 {
+				t.Fatal("the unit must be refused, and it compiled")
+			}
+			if u != nil {
+				t.Error("a refused unit must not be handed to a backend")
+			}
+			var joined []string
+			for _, e := range errs {
+				joined = append(joined, e.Error())
+			}
+			all := strings.Join(joined, "\n")
+			if !strings.Contains(all, tc.want) {
+				t.Errorf("diagnostic missing %q; got:\n%s", tc.want, all)
+			}
+		})
+	}
+}

--- a/ir/wire.go
+++ b/ir/wire.go
@@ -23,8 +23,7 @@ func BitsRequired(min, max *big.Int) int64 {
 // directly usable as one, and conservative is correct for a buffer bound
 // (SPEC §6.1 item 4).
 func MaxBytes(bits int64) int64 {
-	bytes := (bits + 7) / 8
-	return (bytes + 7) / 8 * 8
+	return alignUp(alignUp(bits, 8)/8, 8)
 }
 
 // CompressedFloatParams replicates serialize_compressed_float's parameter
@@ -51,21 +50,37 @@ func CompressedFloatBits(fmin, fmax, res float64) int64 {
 	return wireBits
 }
 
+// PointerWireBits is what a pointer field costs on the wire: a `u32` index
+// into the flat node table under kind 17 (docs/SPEC-TABLES.md §3.1). It is the
+// width of the REFERENCE; the referent is a node of its own, counted once
+// wherever it is reached from.
+const PointerWireBits = 32
+
 // MaxBitsField is one field's worst-case wire bits, alignment points counted
 // at the worst 7.
 func MaxBitsField(f *Field) int64 {
 	elem := maxBitsScalar(f)
 	switch f.Array {
 	case ArrayFixed:
-		return f.ArrayBound * elem
+		return mulSize(f.ArrayBound, elem)
 	case ArrayCounted:
-		return BitsRequired(big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound)) + f.ArrayBound*elem
+		return addSize(BitsRequired(big.NewInt(f.ArrayMin), big.NewInt(f.ArrayBound)), mulSize(f.ArrayBound, elem))
 	default:
 		return elem
 	}
 }
 
 func maxBitsScalar(f *Field) int64 {
+	if f.Type.Pointer {
+		// A POINTER IS ITS REFERENCE, NEVER ITS REFERENT
+		// (docs/SPEC-TABLES.md §3.1): a `*T` and a `*bytes`/`*string` ride as
+		// a u32 node index into the flat node table, and no pointer edge is a
+		// nesting level, so a width computation stops here exactly as the
+		// numbering walk and the storage layout do. Descending instead read a
+		// legal `table Node { next *Node }` as an infinite by-value nesting
+		// and overflowed the stack.
+		return PointerWireBits
+	}
 	switch f.Type.Kind {
 	case TInt:
 		if f.HasIntRange {
@@ -96,7 +111,7 @@ func maxBitsScalar(f *Field) int64 {
 		return 64
 	case TString, TBytes:
 		// length prefix + worst-case align pad + the bytes
-		return BitsRequired(big.NewInt(0), big.NewInt(f.Type.Size)) + 7 + f.Type.Size*8
+		return addSize(addSize(BitsRequired(big.NewInt(0), big.NewInt(f.Type.Size)), 7), mulSize(f.Type.Size, 8))
 	case TNamed:
 		switch ref := f.Type.Ref.(type) {
 		case *Enum:
@@ -122,11 +137,14 @@ func MaxBitsUnion(u *Union) int64 {
 			largest = b
 		}
 	}
-	return bits + largest
+	return addSize(bits, largest)
 }
 
 // MaxBitsStruct is the longest wire path through a struct: branches take the
-// larger side (composition cycles are compile errors, so recursion ends).
+// larger side. The walk descends BY-VALUE EDGES ONLY, so it terminates on
+// every legal declaration: a by-value composition cycle is a compile error,
+// and a pointer edge is a reference whose width is [PointerWireBits]
+// (docs/SPEC-TABLES.md §3.1), so a pointer-recursive table is finite here.
 func MaxBitsStruct(st *Struct) int64 {
 	var walk func(items []Item) int64
 	walk = func(items []Item) int64 {
@@ -134,20 +152,20 @@ func MaxBitsStruct(st *Struct) int64 {
 		for _, item := range items {
 			switch item := item.(type) {
 			case *FieldItem:
-				total += MaxBitsField(item.F)
+				total = addSize(total, MaxBitsField(item.F))
 			case *Branch:
 				then, els := walk(item.Then), walk(item.Else)
 				if then > els {
-					total += then
+					total = addSize(total, then)
 				} else {
-					total += els
+					total = addSize(total, els)
 				}
 			case *ConstItem:
-				total += item.Bits
+				total = addSize(total, item.Bits)
 			case *ReservedItem:
-				total += item.Bits
+				total = addSize(total, item.Bits)
 			case *AlignItem:
-				total += 7
+				total = addSize(total, 7)
 			}
 		}
 		return total
@@ -245,8 +263,11 @@ func isFixedByteArray(f *Field) bool {
 
 // afterField advances the position across one field's wire.
 func afterField(f *Field, pos wirePos) wirePos {
+	// a POINTER is never a nesting: it rides as its reference's fixed width
+	// (docs/SPEC-TABLES.md §3.1), so the position advances by that and the
+	// walk does not descend into the referent
 	isStruct := false
-	if f.Type.Kind == TNamed {
+	if f.Type.Kind == TNamed && !f.Type.Pointer {
 		_, isStruct = f.Type.Ref.(*Struct)
 	}
 	switch f.Array {
@@ -263,7 +284,7 @@ func afterField(f *Field, pos wirePos) wirePos {
 			}
 			return wireUnknown
 		}
-		return pos.add(f.ArrayBound * maxBitsScalar(f))
+		return pos.add(mulSize(f.ArrayBound, maxBitsScalar(f)))
 	case ArrayCounted:
 		// count prefix, then count elements: the exit is static only when
 		// each element is a whole number of bytes


### PR DESCRIPTION
Two defects in the IR's size and width arithmetic, both confirmed against main by running the compiler.

## #468: aggregate size arithmetic wraps

SPEC §4.3 caps an array bound, a `string(N)` and a `bytes(N)` at int32 one at a time, and nothing capped what they multiply to. Three nested `[2147483647]` arrays of individually legal bounds compiled clean and generated `MidMaxBits = -274877906880`, `MidMaxBytes = -34359738352` and `TopMaxBytes = 51539607544`, a plausible positive bound that under-states the true worst case by eighteen orders of magnitude. The block path emitted a negative stride and a negative `static_assert` size over the same nesting.

`ir/sizes.go` is now the one place this package adds, multiplies and rounds up a size. `addSize`, `mulSize` and `alignUp` saturate rather than wrap, so no derived number is ever negative or smaller than the number it stands for, and every size, stride, offset and `MaxBytes` computation in `ir/wire.go` and `ir/blocklayout.go` goes through them. `ir.CheckSizes` recomputes each of those numbers through the same helpers and returns one error per number past the cap; the checker runs it over the assembled unit, so a refused schema reaches no backend and no generated file can carry a size the arithmetic does not represent.

The diagnostic names the field and the product:

```
Nested.schema:13:1: type Mid: field inners is 2147483647 elements x 137438953408 bits each = 295147904904474918976 bits, past the cap of 8796093022208 bits on a derived size: every bound here is legal on its own and their product is not (SPEC §4.6, docs/SPEC-TABLES.md §11)
```

The cap is 2^40 bytes, and the same number of bits. It sits above every node body the wire can frame (a node's length is a `u32`, docs/SPEC-TABLES.md §3.1), so no documented case becomes unreachable, and far below where int64 size arithmetic stops being exact. A number is reported once, at the declaration it belongs to: a field whose element type is itself past the cap is skipped, because that element's own declaration carries the diagnostic.

## #469: the width helpers followed pointer edges as if by value

`ir.MaxBitsStruct` read `table Node { value int32 | min = 0, max = 100; next *Node }` as an infinite by-value nesting and took the process down with an unrecoverable stack overflow; `ir.AlignedFixedByteArrays` walked the same edge. A pointer rides as a `u32` node index under kind 17 and no pointer edge is a nesting level (docs/SPEC-TABLES.md §3.1), so the width helpers stop there now, exactly as the storage layout (§6.3) and the numbering walk already do. `ir.PointerWireBits` names the width. By-value edges are still followed, which is what the helpers exist for, and a test pins that separately.

## The spec

The pointer width was already stated (§3.1: a pointer field rides as a `u32` index, and no pointer edge is a nesting level), so nothing was added for it. The size cap was not stated anywhere, and one sentence goes in each law-home: SPEC §4.6 for the packet wire and its buffer bounds, docs/SPEC-TABLES.md §11 for the record, block and table side. Both are cited from the tests.

## Tests

- `ir.TestSizesPastTheCapAreRefused` - the issue's three-nested-array reproducer, and a unit one element past the cap, each refused with the diagnostic above.
- `ir.TestSizesOneStepUnderTheCapAreExact` - a unit 512 bytes and 4096 bits under the caps compiles, and its `MaxBits`, `MaxBytes` and record size are exact.
- `check.TestDiagnostics/nested_array_bounds_whose_product_passes_the_cap` - the same refusal in the break-the-language suite.
- `ir.TestPointerRecursiveTableHasAFiniteWidth` - the recursive table's width, `MaxBytes`, alignment analysis and record layout all compute, each under a 30 second bound so a following walk fails rather than hangs.
- `ir.TestByValueNestingStillDescends`, `ir.TestPointerFieldWidthIsTheReference`.

## Negative controls

**#468, the check removed** (the checker call, and the saturation in `addSize`, `mulSize` and `alignUp`):

```
--- FAIL: TestSizesPastTheCapAreRefused (0.00s)
    --- FAIL: TestSizesPastTheCapAreRefused/nested_arrays_whose_product_wraps (0.00s)
        sizes_test.go:114: the unit must be refused, and it compiled
    --- FAIL: TestSizesPastTheCapAreRefused/one_element_past_the_cap (0.00s)
        sizes_test.go:114: the unit must be refused, and it compiled
FAIL
FAIL	github.com/mas-bandwidth/schema/v2/ir	0.420s
FAIL
```

and the reproducer's generated header carries a negative number again:

```
inline constexpr int64_t MidMaxBits = -274877906880; // longest wire path; align pads at worst case (SPEC §6.1)
inline constexpr int64_t MidMaxBytes = -34359738352; // 8-byte write granularity; read slack per the contract above

// type Top
struct Top {
    Mid mids[2147483647] = {};
};

inline constexpr int64_t TopMaxBits = 412316860352; // longest wire path; align pads at worst case (SPEC §6.1)
inline constexpr int64_t TopMaxBytes = 51539607544; // 8-byte write granularity; read slack per the contract above
```

**#469, the by-value descent restored** (`go test ./ir/ -run TestPointerRecursiveTableHasAFiniteWidth -timeout 60s`), trimmed at the head and the tail of a 100 MB dump:

```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x6f77ddb78370 stack=[0x6f77ddb78000, 0x6f77fdb78000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x104319ca3?, 0x1041b2e64?})
	/opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/panic.go:1243 +0x38 fp=0x16beaeda0 sp=0x16beaed70 pc=0x1041fa5c8
runtime.newstack()
	/opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/stack.go:1207 +0x480 fp=0x16beaeed0 sp=0x16beaeda0 pc=0x1041dd010
runtime.morestack()
	/opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/asm_arm64.s:487 +0x70 fp=0x16beaeed0 sp=0x16beaeed0 pc=0x1041ff140

goroutine 35 gp=0x6f77bda803c0 m=4 mp=0x6f77bda00008 [running]:
math/big.(*Int).Sub(0x6f77ddb78398, 0x6f77bdaac840?, 0x6f77bdaac820?)
	/opt/homebrew/Cellar/go/1.27.0/libexec/src/math/big/int.go:162 +0x188 fp=0x6f77ddb783c0 sp=0x6f77ddb78370 pc=0x1042acfc8
github.com/mas-bandwidth/schema/v2/ir.BitsRequired(0x6f77be176a60?, 0x6f77bda00008?)
	/private/tmp/.../ir/wire.go:16 +0x30 fp=0x6f77ddb783c0 sp=0x6f77ddb78370 pc=0x1042c6770
github.com/mas-bandwidth/schema/v2/ir.maxBitsScalar(0x6f77bdaae9c0)
...
FAIL	github.com/mas-bandwidth/schema/v2/ir	1.243s
FAIL
```

## Gates

`go build ./...`, `go test ./...`, `make check`, `gofmt -l`, `go vet ./...` and golangci-lint v2.12.2 are all clean, and `make conformance-generate` leaves `git status --porcelain` empty: no generated file moves. Nothing generated could move from the pointer fix either, because a pointer is only legal in a table body and the packet backends that emit `MaxBits`/`MaxBytes` walk `Structs`/`Unions` only.

Closes #468
Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
