### PR TITLE
bench/LOCK: the carve is spent, the prefixes are back

### DIFF
--- a/bench/LOCK
+++ b/bench/LOCK
@@ -66,7 +66,7 @@
 #
 # THE EMITTERS ARE BYTE-IDENTICAL, which is control 1 and the protection this
 # lock is for: `git diff main...check-zero-range-346 -- internal/codegen/c
-internal/codegen/cpp ':!**/*_test.go'` is EMPTY. The two locked
+# internal/codegen/cpp ':!**/*_test.go'` is EMPTY. The two locked
 # internal/codegen paths PR #348 touches are expr_test.go fixtures, whose
 # inline schemas carry the shape the new gate refuses and now declare the same
 # in-range defaults the corpus does.

--- a/bench/LOCK
+++ b/bench/LOCK
@@ -66,7 +66,7 @@
 #
 # THE EMITTERS ARE BYTE-IDENTICAL, which is control 1 and the protection this
 # lock is for: `git diff main...check-zero-range-346 -- internal/codegen/c
-# internal/codegen/cpp ':!**/*_test.go'` is EMPTY. The two locked
+internal/codegen/cpp ':!**/*_test.go'` is EMPTY. The two locked
 # internal/codegen paths PR #348 touches are expr_test.go fixtures, whose
 # inline schemas carry the shape the new gate refuses and now declare the same
 # in-range defaults the corpus does.
@@ -81,27 +81,16 @@
 # protocol's PR C, whose diff is this file alone. The full lift condition is
 # unchanged: the round closing, on the owner's word (issue #170).
 #
-# ONE-SHOT CARVE, 2026-09-04, on the owner's word ("Please land", given after
-# PR #488 and PR #489 were reported green except this lock):
-#
-# WHAT THE CARVE ADMITS, exactly and nothing else:
-#
-#   1. PR #488: the protocol id projection sees enum, flags and union arm
-#      order and names (issues #462, #491; ProjectionVersion 2). Under the
-#      locked prefixes it moves re-pinned protocol ids and build-version
-#      words only; the emitters under internal/codegen/c and
-#      internal/codegen/cpp are byte-identical.
-#   2. PR #489: every enum exports Count (issue #456). One emitter line each
-#      in internal/codegen/c/c.go and internal/codegen/cpp/cpp.go, and the
-#      generated Enums.h, Wire.h and Ludicrous.h lines they emit.
-#
-# THE PREFIXES ARE SUSPENDED BELOW for these two merges. The restoring PR,
-# whose diff is this file alone, re-freezes at the new reference. The full
+# ONE-SHOT CARVE, 2026-09-04, SPENT: PR #488 (the protocol id projection sees
+# enum, flags and union arm order and names, ProjectionVersion 2) and PR #489
+# (every enum exports Count) merged under the suspended prefixes, each with
+# the emitter diffs its PR body records. The lock re-froze at the new
+# reference when this restoring PR landed, its diff this file alone. The full
 # lift condition is unchanged: the round closing, on the owner's word (#170).
 #
-# Locked prefixes, one per line (matched against changed paths), SUSPENDED:
-# internal/codegen/c/
-# internal/codegen/cpp/
-# generated/c/
-# generated/cpp/
-# generated/c-ludicrous/
+# Locked prefixes, one per line (matched against changed paths):
+internal/codegen/c/
+internal/codegen/cpp/
+generated/c/
+generated/cpp/
+generated/c-ludicrous/


### PR DESCRIPTION
The restoring half of the #495 carve: #488 and #489 are merged, the five prefixes return, and the lock re-freezes at the new reference. Diff: this file alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)