### PR TITLE
certify.yml: the test legs get the hour

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -74,7 +74,7 @@ jobs:
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The ubuntu `make test` leg ran to its 30-minute cap and was cancelled on run 33842127266 after today's gates joined the chain (the four wire-fuzz controls, the maps gates with their ASan twin); macOS finished the same chain in 24 minutes. The cap becomes the hour the release legs already have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)