### PR TITLE
ci: the serialize runtimes pinned at format version 1.1

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -51,12 +51,12 @@ concurrency:
 # changes. Find the newest tag with:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
-  SERIALIZE_TAG: v1.12.0
-  SERIALIZE_C_TAG: v1.5.0
-  SERIALIZE_GO_TAG: v1.14.0
-  SERIALIZE_RS_TAG: v2.2.2
-  SERIALIZE_CS_TAG: v1.5.0
-  SERIALIZE_JS_TAG: v1.3.0
+  SERIALIZE_TAG: v1.16.0
+  SERIALIZE_C_TAG: v1.9.0
+  SERIALIZE_GO_TAG: v1.15.0
+  SERIALIZE_RS_TAG: v2.3.0
+  SERIALIZE_CS_TAG: v1.9.0
+  SERIALIZE_JS_TAG: v1.4.0
 
 jobs:
   # THE FULL CHAIN. `make test` builds the corpus in every language and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,12 @@ concurrency:
 # changes. Find the newest tag with:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
-  SERIALIZE_TAG: v1.12.0
-  SERIALIZE_C_TAG: v1.5.0
-  SERIALIZE_GO_TAG: v1.14.0
-  SERIALIZE_RS_TAG: v2.2.2
-  SERIALIZE_CS_TAG: v1.5.0
-  SERIALIZE_JS_TAG: v1.3.0
+  SERIALIZE_TAG: v1.16.0
+  SERIALIZE_C_TAG: v1.9.0
+  SERIALIZE_GO_TAG: v1.15.0
+  SERIALIZE_RS_TAG: v2.3.0
+  SERIALIZE_CS_TAG: v1.9.0
+  SERIALIZE_JS_TAG: v1.4.0
 
 jobs:
   # The compiler's own test suite, and the only job in this file that reads a


### PR DESCRIPTION
The six serialize runtimes schema pins released today against format version 1.1 of the wire standard (int_relative domain and checked reconstruction, non-mutation, the failure latch, min <= max on int128, the conformance corpus). The wire is unchanged, so the nine conformance legs here are the proof that schema's generated code and the new runtimes agree byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)