### PR TITLE
ci: serialize.c pinned at v1.9.1

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -52,7 +52,7 @@ concurrency:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
   SERIALIZE_TAG: v1.16.0
-  SERIALIZE_C_TAG: v1.9.0
+  SERIALIZE_C_TAG: v1.9.1
   SERIALIZE_GO_TAG: v1.15.0
   SERIALIZE_RS_TAG: v2.3.0
   SERIALIZE_CS_TAG: v1.9.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ concurrency:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
   SERIALIZE_TAG: v1.16.0
-  SERIALIZE_C_TAG: v1.9.0
+  SERIALIZE_C_TAG: v1.9.1
   SERIALIZE_GO_TAG: v1.15.0
   SERIALIZE_RS_TAG: v2.3.0
   SERIALIZE_CS_TAG: v1.9.0


### PR DESCRIPTION
serialize.c 1.9.1 makes the padded wrapper check its destination in every build; at 1.9.0 the size parameter lived only in an assert, and the C inline gate's -Werror build of the header refused it on macOS (certify runs 33848620595 and 33853653508). The wire is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)