### PR TITLE
spec: wstring(N), the wide string type (#188)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -47,11 +47,12 @@ the buffer. Specifically:
 - An array count, string length or bytes length past its declared bound that is
   not refused before it drives a copy or an allocation.
 - An enum value that is not a declared variant being accepted.
-- A `wstring(N)` payload that is not well-formed UTF-16 being accepted: a code
-  unit group above `0xFFFF`, an unpaired surrogate, or a zero group among the
-  transmitted units. The rules are stated once in SPEC §4.12 and every target
-  owes the same verdict, so a target that skips one is a divergence bug as
-  well as an acceptance bug.
+- A text payload that is not well formed being accepted: malformed UTF-8 in a
+  `string(N)`, or in a `wstring(N)` a code unit group above `0xFFFF`, an
+  unpaired surrogate, or a zero group among the transmitted units. The rules
+  are stated once in SPEC §4.7 and §4.12 and every target owes the same
+  verdict, so a target that skips one is a divergence bug as well as an
+  acceptance bug.
 - Any read that continues past the end of the stream instead of failing.
 - Integer overflow in a bit or byte count computed from wire data.
 - **Any divergence between the nine languages on the above** — if C++ refuses

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -47,6 +47,11 @@ the buffer. Specifically:
 - An array count, string length or bytes length past its declared bound that is
   not refused before it drives a copy or an allocation.
 - An enum value that is not a declared variant being accepted.
+- A `wstring(N)` payload that is not well-formed UTF-16 being accepted: a code
+  unit group above `0xFFFF`, an unpaired surrogate, or a zero group among the
+  transmitted units. The rules are stated once in SPEC §4.12 and every target
+  owes the same verdict, so a target that skips one is a divergence bug as
+  well as an acceptance bug.
 - Any read that continues past the end of the stream instead of failing.
 - Integer overflow in a bit or byte count computed from wire data.
 - **Any divergence between the nine languages on the above** — if C++ refuses

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -1459,7 +1459,7 @@ nowhere else in the grammar and buy nothing over the bracket.
 
 **Keys are BOUNDED STRINGS and INTEGERS, and nothing else.** `K` is
 `string(N)` or one of `int8` through `int64`, `uint8` through `uint64`,
-bare. No `| min`, no `| max`, no default, because a key is an identity and
+bare, and `wstring(N)` is not a key. No `| min`, no `| max`, no default, because a key is an identity and
 clamping an identity merges two entries. Every other key is refused by name,
 each with its reason in the diagnostic:
 
@@ -5944,6 +5944,13 @@ in build version (§20.5).
   itself frames a body of any size (§3), so this cap is the STORAGE side's,
   and a wire body past it is refused at LOAD rather than at compile time
   (§3.1). It sits far below where an int64 size stops being exact.
+- **A type holding a `wstring(N)` field, reaching a table closure** — the
+  id-table wire assigns wide text no kind. §2.6's value list, the closed kind
+  set of §3, the arm-kind table, §16.2's text form and §7.2's cooked storage
+  all stop at `string(N)`. The packet wire carries `wstring(N)` in full (SPEC
+  §4.12) and the TABLE wire is the deferred half, so the refusal names the
+  field and its follow-on rather than letting a kind be invented per backend.
+  Map keys stay `string(N)` and the integer kinds on the same grounds (§2.8).
 - Recursive nesting (§2 — the cycle is named).
 - A bare rename hazard: `was` naming the field's own name (§5).
 - Id collisions, hash or `was`-induced (§5).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1037,6 +1037,13 @@ The byte-string tightening is what lets the targets agree:
   validation pass over those bytes rather than a conversion into a native
   string.
 
+**A successful read terminates the C string.** In C and C++, a successful
+read writes the **zero byte at index `length`**, always, so the buffer is a
+valid C string after every accepted read. That is what the `+ 1` in those
+two storage rows is for (§6.1). In the other seven targets the used length
+is the truth, and a successful read writes nothing past it, under §5's tail
+rule.
+
 For every legal write the wire bits are identical to `serialize_string` over
 a buffer of N + 1.
 
@@ -1450,6 +1457,13 @@ native text is UTF-8, the transcode is real and is paid in application code
 in both directions. No target transcodes inside the generated read or write
 path, and no target allocates per value.
 
+**A successful read terminates the C string.** In C and C++, a successful
+read writes the **zero unit at index `length`**, always, so the buffer is a
+valid `char16_t` or `uint16_t` string after every accepted read. That is
+what the `+ 1` in those two storage rows is for. In the other seven targets
+the used length is the truth, and a successful read writes nothing past it,
+under §5's tail rule.
+
 **Goldens.** The wire is pinned to serialize's shared corpus
 (`conformance/wstring.txt`), which a `wstring(7)` field reproduces exactly,
 its 3-bit length field being the corpus's `buffer_size` 8. **The row's own
@@ -1534,7 +1548,13 @@ construction; the wire contract stays a pure function of the encodings.
 elements past a used count and bytes past a used length are not rewritten by
 a successful read, and a union's UNSELECTED arms are not rewritten either
 (the selected arm is zero-established, §4.8), so a REUSED output object
-keeps stale tail data there (the classic runtime's own prefix convention). Whole-object comparison in the conformance matrix is
+keeps stale tail data there (the classic runtime's own prefix convention).
+**The tail rule has exactly one stated exception**, and it is the C string
+terminator: in C and C++, a successful read of a `string(N)` writes the zero
+byte at index `length` and a successful read of a `wstring(N)` writes the
+zero unit at index `length`, so those buffers are valid C strings after
+every accepted read (§4.7, §4.12). Nothing else past a used length or a used
+count is written, in any target. Whole-object comparison in the conformance matrix is
 defined over a fresh output or the used prefix. Write reads only taken
 fields.
 
@@ -1560,8 +1580,8 @@ Per `type`, per target:
    | `float32` / `float64` (attributed or bare) | `float` / `double` | `float` / `double` | `float32` / `float64` | `f32` / `f64` |
    | enum `E` | `enum class E : uintN_t` (N = smallest fitting max) | `enum E : uintN` | `type E uintN` + consts | `#[repr(transparent)] struct E(pub uN)` + consts |
    | `flags E` | `uint64_t` + one mask const per variant | `ulong` + consts | `uint64` + consts | `u64` + consts |
-   | `string(N)` | `char[N + 1]` + `int32_t` length | `byte[]` (capacity N, pre-allocated) + `int` length | `[N]byte` + `int32` length | `[u8; N]` + length |
-   | `wstring(N)` | `char16_t[N + 1]` + `int32_t` length | `char[]` (capacity N, pre-allocated) + `int` length | `[N]uint16` + `int32` length | `[u16; N]` + length |
+   | `string(N)` | `char[N + 1]` + `int32_t` length (the `+ 1` holds the zero byte a successful read writes at index `length`, §4.7) | `byte[]` (capacity N, pre-allocated) + `int` length | `[N]byte` + `int32` length | `[u8; N]` + length |
+   | `wstring(N)` | `char16_t[N + 1]` + `int32_t` length (the `+ 1` holds the zero unit a successful read writes at index `length`, §4.12) | `char[]` (capacity N, pre-allocated) + `int` length | `[N]uint16` + `int32` length | `[u16; N]` + length |
    | `bytes(N)` | `uint8_t[N]` + `int32_t` length | `byte[]` (capacity N, pre-allocated) + `int` length | `[N]byte` + `int32` length | `[u8; N]` + length |
    | `[N]T` | `T[N]` | `T[N]` (pre-allocated) | `[N]T` | `[T; N]` |
    | `[..N]T` | `T[N]` + `int32_t` count | `T[N]` (pre-allocated) + `int` count | `[N]T` + `int32` count | `[T; N]` + count |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -81,8 +81,8 @@ conventions. Delta serialization is out of scope for v1.
   compiled together (§3.2).
 - **No self-describing wire data.** The wire stays an unattributed bit
   stream; all knowledge lives in the generated code on both ends.
-- **Deferred constructs:** wide strings (`serialize_wstring`) and relative
-  integers (`serialize_int_relative`) are not in v1 — see §4.10.
+- **Deferred constructs:** relative integers (`serialize_int_relative`) are
+  not in v1 — see §4.10.
 
 The grammar must not claim syntax reserved for planned language passes:
 `packet`, `delta`, `baseline` and `index` are usable as ordinary names today
@@ -131,8 +131,8 @@ missing from it is a review question rather than an implementation detail.
 
 **Included — each fact moves the wire:** the package; every type's field
 order; field NAMES; type kind, width and signedness; declared bounds; array
-kind and bounds; string/bytes capacity; float range, resolution and step
-count; fixed `I` and `F`; specified defaults (both ends must agree on the
+kind and bounds; string/wstring/bytes capacity; float range, resolution and
+step count; fixed `I` and `F`; specified defaults (both ends must agree on the
 value a constructor materializes — untaken branches read as ZEROS, never
 defaults, per §5);
 branch structure; `const`/`reserved`/`align` items; enum max and storage
@@ -275,8 +275,8 @@ from this projection rather than carried in it.
   replacement named.
 - **Reserved words:** `package const enum type table map message object if else
   switch case align reserved`, the wire-type keywords `bits bool float32
-  float64 string bytes fixed ufixed`, and the integer family `int8 int16
-  int32 int64 uint8 uint16 uint32 uint64 int128 uint128` — plus `int` and
+  float64 string wstring bytes fixed ufixed`, and the integer family `int8
+  int16 int32 int64 uint8 uint16 uint32 uint64 int128 uint128` — plus `int` and
   `uint`, reserved so `int` gets a "did you mean int32?" diagnostic instead
   of a parse error. Reserved words cannot be used as names. Attribute keys
   (`min`, `max`, `resolution`, ...) are contextual — they live only right of
@@ -380,6 +380,8 @@ Scalar      = IntType
             | "bits" "(" IntExpr ")"
             | "bool" | "float32" | "float64"
             | "string" "(" IntExpr ")"
+            | "wstring" "(" IntExpr ")"                          // wstring(N) — N in UTF-16 CODE
+                                                                 // UNITS (§4.12)
             | "bytes" "(" IntExpr ")"
             | "fixed" "(" IntExpr "," IntExpr ")"                // fixed(I, F) — signed Q I.F (§4.3);
                                                                  // the Q format is the type's SHAPE,
@@ -605,9 +607,9 @@ sequence    uint16
   side in one flat list — `| vec3, cpp_native = VecMath` — valueless
   markers first, then valued keys; there is no nested argument syntax.
 - **The line between positional and attribute:** a *size* that defines the
-  type's shape stays positional — `bits(64)`, `string(64)`, `bytes(N)`,
-  `fixed(I, F)`, array bounds. A *constraint or refinement* of a named type
-  is a qualifier. The enum's `| max = 15` is the same syntax; it is one
+  type's shape stays positional — `bits(64)`, `string(64)`, `wstring(64)`,
+  `bytes(N)`, `fixed(I, F)`, array bounds. A *constraint or refinement* of a
+  named type is a qualifier. The enum's `| max = 15` is the same syntax; it is one
   general mechanism. The glyph is deliberately the language's own — a DSL
   owns its spelling, and familiarity to other languages' readers is not a
   design constraint where clarity is better served ("let's be bold and do
@@ -791,8 +793,9 @@ takes no headroom, so its count and its extent are one number.
   zigzag on the wire, ever.
 - **`align` emits zero bits up to the next byte boundary — zero bits when
   already aligned**; readers verify the padding is zero.
-- **Length prefixes** (`string(N)`, `bytes(N)`, `[..N]T`, `[Min..N]T`) are
-  ranged integers over their declared count range, per the rows below.
+- **Length prefixes** (`string(N)`, `wstring(N)`, `bytes(N)`, `[..N]T`,
+  `[Min..N]T`) are ranged integers over their declared count range, per the
+  rows below.
 
 The wire encodings are exactly classic serialize's — each row names its
 classic twin, which is the wire oracle for the stated model.
@@ -818,6 +821,7 @@ classic twin, which is the wire oracle for the stated model.
 | `reserved(Bits)` | zeros; read rejects nonzero | `serialize_bits` + compare |
 | `align` | zero-pad to the next byte boundary; read rejects nonzero padding | `serialize_align` |
 | `f string(N)` | length in [0, N], align, then the used bytes — N = max length; the bound sizes the length prefix's bits | `serialize_string` with buffer N + 1 |
+| `f wstring(N)` | length in [0, N], **no alignment**, then one 32-bit group per UTF-16 code unit. N is the max length in CODE UNITS, and the bound sizes the length prefix's bits (§4.12) | `serialize_wstring` with buffer N + 1 |
 | `f bytes(N)` | identical shape: length in [0, N], align, then the used bytes | `serialize_int` + `serialize_bytes` |
 | `f [N]T` | N elements, back to back | element per element |
 | `f [..N]T` / `f [Min..N]T` | count in [Min, N] encoded relative to Min, then that many elements | `serialize_int` + the element loop |
@@ -827,13 +831,14 @@ in v1 (wrap the inner array in a type). Runtime-count arrays carry their own
 count on the wire — there is no separately-declared count field in v1.
 
 **Wire fidelity.** For every legal write, the bits are identical to the named
-classic twins — serialize.modern's one documented deviation (`wstring_`
-alignment) does not arise because schema emits sequential stream operations,
-and wide strings are deferred anyway. On the *read* side, schema's generated
-readers enforce the language's validation rules uniformly (e.g. the
-interior-null rule of §4.7), which can be stricter than a hand-written
-classic reader; acceptance is uniform across the targets, which is what the
-conformance gates check.
+classic twins. **Classic `serialize_wstring` is the normative twin for
+`wstring(N)`**: serialize.modern's `wstring_` inserts an `align` between the
+length and the code units, and that alignment is the one thing schema does
+not do (§4.12). On the *read* side, schema's generated readers enforce the
+language's validation rules uniformly (e.g. the interior-null rule of §4.7
+and the UTF-16 well-formedness rules of §4.12), which can be stricter than a
+hand-written classic reader; acceptance is uniform across the targets, which
+is what the conformance gates check.
 
 **The count-range cap is lifted.** serialize.modern caps `array_n`'s count
 range at 16 because each possible count is a separately spliced compile-time
@@ -947,8 +952,8 @@ All compile errors with positions:
   requires at least one bit — which also means generated code needs no
   degenerate support from any runtime. What stays an error: an INVERTED range
   (min > max) anywhere; `[Min..N]T` with Min ≥ N (`[N]T` is the degenerate
-  spelling); `string(N)` with N < 2; `bytes(N)` with N < 1; `[N]T` with
-  N < 1; `[..N]T` with N < 1; `resolution` ≤ 0. An empty `type`
+  spelling); `string(N)` and `wstring(N)` with N < 2; `bytes(N)` with N < 1;
+  `[N]T` with N < 1; `[..N]T` with N < 1; `resolution` ≤ 0. An empty `type`
   body is legal — zero wire bits, presence as the payload; a unit with
   no `.schema` files is an error.
 
@@ -956,8 +961,9 @@ All compile errors with positions:
   `None = 0`, so its wire range is the degenerate `[0, 0]` and it costs zero
   bits — the value is recovered from the range alone, under the same rule as
   any degenerate range.
-- **A derived size past the cap:** an array bound, a `string(N)` and a
-  `bytes(N)` are capped at int32 one at a time (§4.3), and what they multiply
+- **A derived size past the cap:** an array bound, a `string(N)`, a
+  `wstring(N)` and a `bytes(N)` are capped at int32 one at a time (§4.3),
+  and what they multiply
   to is capped too. A field's wire width, an array's whole storage, a record's
   storage and a `MaxBytes` buffer bound are each refused past 2^40 bytes
   (2^43 bits), with a diagnostic naming the field and the product, so no
@@ -1047,6 +1053,10 @@ and do not. **The interior-null check is
 generated-code validation in every target** — no runtime primitive performs
 it (classic C++ read appends `'\0'` and would silently truncate).
 
+**Wide text is a separate construct**, not a spelling of this one: `wstring(N)`
+carries UTF-16 code units, counts its bound in code units, and performs no
+alignment (§4.12).
+
 ### 4.8 Unions — `union`, first-class one-of fields
 
 A `union` declares a type that holds **at most one** of a named set of
@@ -1089,12 +1099,13 @@ union Value
   no payload** (below). **What a row may not take is SPEC-TABLES.md §2.6's
   list**, each refused by name. A union FIELD likewise takes no
   attributes and no `= default` (it zero-initializes to None, joining
-  arrays, strings, bytes and composites in §4.2's no-override list).
+  arrays, strings, wide strings, bytes and composites in §4.2's no-override
+  list).
 - **An arm is any field type, or none.** A variant's payload is what a
   field's type can be: a scalar with its bounds, a compressed float, a
   `fixed(I, F)`, a 128-bit integer, an `enum`, a `flags` mask, `string(N)`,
-  `bytes(N)`, a bounded array `[N]T` or `[..N]T`, a declared `type`,
-  another union, and, inside a table closure, a `table` and a pointer `*T`
+  `wstring(N)`, `bytes(N)`, a bounded array `[N]T` or `[..N]T`, a declared
+  `type`, another union, and, inside a table closure, a `table` and a pointer `*T`
   (SPEC-TABLES.md §2.6). **An arm may also have NO PAYLOAD**, written as
   its name alone: the arm selects and carries nothing, which is what a
   one-of wants for a case that is a fact rather than a value. It is not
@@ -1275,16 +1286,6 @@ Pong may both name a field `sequence` because they are separate types;
   is an opt-in `[packed]` attribute on a type generating accessor-based
   storage — a generator-kind decision for a later pass, not a v1 wire
   construct.
-- **Wide strings** (`serialize_wstring`): deferred — no near-term need — but
-  the WIRE is decided so the deferral cannot foreclose it: length, then one
-  unaligned 32-bit group per **UTF-16 CODE UNIT** — not per code point — and
-  the payload is **well-formed UTF-16 by contract**, writer-trusted per §5's
-  doctrine. Surrogate PAIRS are valid (full Unicode: an astral character is
-  two groups); an UNPAIRED surrogate is a writer contract violation,
-  debug-asserted where the language supports it. 2-byte and 4-byte `wchar_t`
-  platforms must produce IDENTICAL bytes: the 4-byte platform converts at the
-  boundary — splits astral code points into surrogate pairs on write,
-  recombines on read. Basic-plane text is unaffected on every platform.
 - **Relative integers** (`serialize_int_relative`): deferred. The classic use
   is a strictly-increasing sequence across *array elements* (the previous
   element's field feeding the next), which the back-reference rule cannot
@@ -1318,11 +1319,138 @@ deliberately or not at all. `table` declarations (SPEC-TABLES.md) never
 enter the projection at all — a `type` line's token is `table=false`
 forever, and packets and tables version independently.
 
+### 4.12 Wide strings: `wstring(N)`
+
+**Declaration.** `f wstring(N)`. **N is the capacity in UTF-16 CODE UNITS**,
+not in code points and not in bytes, so a character outside the basic plane
+occupies two of them. The bound is positional, part of the type's shape,
+exactly as `string(N)`'s is, and it does two jobs: it sizes the length
+prefix's bits and it sizes the storage. A `wstring` field takes no
+attributes and no `= default` (§4.2), and `wstring(N)` with N below 2 is a
+compile error, the same floor `string(N)` carries (§4.6).
+
+**Why the language carries a wide type at all:** on a host whose native text
+is already UTF-16, the wire and the string hold the same units, so text
+crosses the boundary as a copy of code units rather than as a transcode.
+
+**The wire.** Two steps, and no alignment in either of them:
+
+1. **the length**, a ranged integer over [0, N] in `bits_required(0, N)`
+   bits, encoded like any other ranged integer (§4.3),
+2. **each code unit as a 32-BIT GROUP**, in order, packed LSB-first like
+   every other value.
+
+`MaxBits` for the field is therefore `bits_required(0, N) + 32 * N`, with no
+padding term. A `wstring(N)` field introduces no alignment point, so unlike
+`string` and `bytes` it does not make its type's layout depend on the entry
+bit offset (§6.1).
+
+**Classic `serialize_wstring` is normative.** serialize.modern's `wstring_`
+inserts an `align` between the length and the code units, and that align is
+the one thing schema does not do. The classic twin for the row is
+`serialize_wstring` over a buffer of N + 1, whose length field is
+`serialize_int( length, 0, buffer_size - 1 )` and whose first group begins
+at the bit immediately after it.
+
+**Validation: what every generated reader enforces, uniformly.** The rules
+are stated once here and hold in all nine targets, in every build mode, in
+this order:
+
+- **The length.** A decoded length outside [0, N] fails the read. The check
+  runs before the group loop, so the length never drives a copy it has not
+  been bounded for.
+- **The group value.** A group above `0xFFFF` is not a UTF-16 code unit and
+  fails the read, on every target and every platform, whatever local wide
+  character type the host happens to have.
+- **The interior null.** A zero group among the transmitted groups fails the
+  read. This is §4.7's interior-null rule in code-unit terms, and it exists
+  for the same reason: a payload whose wire length disagrees with the length
+  a downstream consumer computes from a terminator carries two lengths, and
+  everything between them rides past whichever side uses the other.
+- **Surrogate pairing.** A high surrogate (`0xD800`-`0xDBFF`) not
+  immediately followed by a low surrogate (`0xDC00`-`0xDFFF`) fails, a low
+  surrogate not immediately preceded by a high surrogate fails, and a high
+  surrogate as the final transmitted group fails. Well-formed **pairs** are
+  valid, and they are how astral text travels.
+- **Exhaustion.** Running out of input mid-read fails, like any other read
+  (§5).
+
+**What no reader enforces**, stated so that no target can be stricter than
+another: nothing else about the text is examined. Noncharacters are
+accepted, `0xFFFF` included. There is no normalization, no case folding, no
+code-point count, and no check that the code units spell anything in
+particular. A reader that adds a check here is as wrong as one that drops a
+check above, because what the nine targets owe each other is an identical
+accept or reject verdict on identical bytes.
+
+**A refusal is terminal.** Nothing after a failing read has a defined
+position, so the read fails in the target's own error idiom (§6.1) and
+leaves the output object unspecified (§5). Refusal is the only conforming
+answer: no target traps, panics or aborts on a malformed payload.
+
+**The write side** follows §5's doctrine and §4.7's precedent exactly. The
+length bound is checked on every write in every target, because it guards
+the copy. UTF-16 well-formedness is a writer OBLIGATION, asserted only where
+§4.7's UTF-8 contract is asserted, which is C, C++ and Rust, and absent from
+the other six. A code unit above `0xFFFF` cannot be written at all, because
+the storage holds 16 bits per unit in every target.
+
+**Storage, and the conversion rule at the boundary.** Storage is a
+pre-allocated buffer of UTF-16 code units with a used length beside it,
+under §6.1's rule that nothing is dynamically sized, and the generated read
+and write paths transcode in no target:
+
+| target | storage | boundary conversion |
+|---|---|---|
+| C++ | `char16_t[N + 1]` + `int32_t` length | none. A caller holding `std::u16string`, or `wchar_t[]` on Windows, copies code units. The field is code units and never `wchar_t`, so a 4-byte `wchar_t` caller splits astral code points into pairs in its own code |
+| C | `uint16_t[N + 1]` + `int32_t` length | none, the C++ rule in C's own types |
+| C# | `char[]` (capacity N, pre-allocated) + `int` length | none. `char` IS a UTF-16 code unit: `new string(buf, 0, len)` and `String.CopyTo` copy |
+| Java | `char[N]` + `int` length | none. `char` IS a UTF-16 code unit: `new String(buf, 0, len)` and `String.getChars` copy |
+| JavaScript | `Uint16Array(N)` + length | none. A JS string is UTF-16 code units: `String.fromCharCode` and `charCodeAt` copy |
+| Dart | `Uint16List(N)` + `int` length | none. A Dart `String` is UTF-16 code units: `String.fromCharCodes` and `String.codeUnits` copy |
+| Go | `[N]uint16` + `int32` length | a transcode, in application code, in both directions: `utf16.Encode` from the runes of a Go string on the way in, `utf16.Decode` on the way out |
+| Rust | `[u16; N]` + length | a transcode, in application code, in both directions: `str::encode_utf16` on the way in, `String::from_utf16` on the way out |
+| Elixir | a binary of 16-bit little-endian code units, `byte_size(v) >>> 1` being the used length | a transcode, in application code, in both directions: `:unicode.characters_to_binary(s, :utf8, {:utf16, :little})` on the way in and the inverse on the way out. The little-endian convention is in-memory only and never reaches the wire, which carries each code unit as the 32-bit group above |
+
+**The honest cost, per target.** On C#, Java, JavaScript, Dart, and C++ or C
+on a UTF-16 host, the boundary is a copy of code units with no transcoding
+step, which is the reason the type exists. On Go, Rust and Elixir, whose
+native text is UTF-8, the transcode is real and is paid in application code
+in both directions. No target transcodes inside the generated read or write
+path, and no target allocates per value.
+
+**Goldens.** The wire is pinned to serialize's shared corpus
+(`conformance/wstring.txt`), which a `wstring(7)` field reproduces exactly,
+its 3-bit length field being the corpus's `buffer_size` 8. **The row's own
+golden is `wstring-worked-example`**, three basic-plane code units in 13
+bytes. The accepted set at `wstring(7)` adds `wstring-empty`,
+`wstring-single-basic-plane-character`, `wstring-accept-group-ffff`,
+`wstring-accept-just-below-the-surrogate-block`,
+`wstring-accept-just-above-the-surrogate-block`,
+`wstring-accept-surrogate-pair` and
+`wstring-accept-two-basic-plane-groups`, and at `wstring(4)` it adds
+`wstring-accept-length-inside-a-five-character-buffer`. The refused set,
+which gate 5 holds every target to together, is the corpus's seventeen
+refusals: the two group-above-`0xFFFF` vectors, the seven unpaired-surrogate
+vectors, the three interior-null vectors, the two out-of-range length
+vectors, and the three past-end vectors. Two corpus vectors have no schema
+declaration that reproduces them, `wstring-buffer-size-1-zero-bit-length-field`
+and `wstring-no-alignment-before-the-characters`, because their
+`buffer_size` of 1 and 2 sits below the N floor of 2. The no-alignment
+property loses nothing by it: the worked example's first group begins at bit
+3, so an align before the groups moves every byte after it.
+
+Beside the corpus, the cross-language matrix carries a `wstring(7)` field
+holding serialize.js's interop cases: empty, three basic-plane code units,
+`0xE000`, `0xFFFF`, an astral pair between two basic-plane units, and seven
+code units, the most the bound carries.
+
 ## 5. Trust model — inherited
 
 **Reads validate everything** — integer ranges, enum bounds, alignment
 padding, constants, reserved bits, count bounds, string lengths, the
-interior-null rule, and buffer exhaustion (running out of input mid-read is a
+interior-null rule, the UTF-16 well-formedness rules of §4.12, and buffer
+exhaustion (running out of input mid-read is a
 read failure like any other) — and fail on any violation, because network
 input is the trust boundary. Generated read code never lets a value that
 controls iteration go unchecked before use.
@@ -1401,6 +1529,7 @@ Per `type`, per target:
    | enum `E` | `enum class E : uintN_t` (N = smallest fitting max) | `enum E : uintN` | `type E uintN` + consts | `#[repr(transparent)] struct E(pub uN)` + consts |
    | `flags E` | `uint64_t` + one mask const per variant | `ulong` + consts | `uint64` + consts | `u64` + consts |
    | `string(N)` | `char[N + 1]` + `int32_t` length | `byte[]` (capacity N, pre-allocated) + `int` length | `[N]byte` + `int32` length | `[u8; N]` + length |
+   | `wstring(N)` | `char16_t[N + 1]` + `int32_t` length | `char[]` (capacity N, pre-allocated) + `int` length | `[N]uint16` + `int32` length | `[u16; N]` + length |
    | `bytes(N)` | `uint8_t[N]` + `int32_t` length | `byte[]` (capacity N, pre-allocated) + `int` length | `[N]byte` + `int32` length | `[u8; N]` + length |
    | `[N]T` | `T[N]` | `T[N]` (pre-allocated) | `[N]T` | `[T; N]` |
    | `[..N]T` | `T[N]` + `int32_t` count | `T[N]` (pre-allocated) + `int` count | `[N]T` + `int32` count | `[T; N]` + count |
@@ -1409,7 +1538,9 @@ Per `type`, per target:
 
    The C target mirrors the C++ storage rules in C's own types; JavaScript
    storage is `Number` for wire widths of 32 bits or fewer and `BigInt` for
-   64 and 128 (the serialize.js value-domain seam).
+   64 and 128 (the serialize.js value-domain seam). `wstring(N)` storage in
+   all nine targets, and the conversion rule each one carries at the
+   boundary, is §4.12's own table.
 
    **The storage principle behind every row: nothing is dynamically sized.**
    Generated storage never heap-allocates per value in any target: every
@@ -1997,9 +2128,11 @@ Every row to date is settled, deferred with its design banked, or discarded.
 2. ~~Storage-type overrides~~ — settled by the integer family: storage is
    declared by the type name (`thrust int8 | min = 0, max = 100`); no
    override mechanism exists.
-3. ~~Wide strings and relative integers~~ — deferred: §4.10. Wide strings
-   have no usage anywhere in the surveyed tree; every `int_relative` use site
-   lives inside the packet shapes the delta pass owns.
+3. ~~Wide strings and relative integers~~ — wide strings are settled:
+   `wstring(N)` is §4.12, its wire the classic `serialize_wstring` and its
+   reader rules uniform across the nine targets. Relative integers stay
+   deferred at §4.10: every `int_relative` use site lives inside the packet
+   shapes the delta pass owns.
 4. ~~`schemafmt` timing~~ — settled: built early, as the parser's first
    consumer; rules in §7.4.
 5. ~~Doc comments~~ — deferred; the design is kept at §4.1.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1406,8 +1406,9 @@ this order:
   surrogate not immediately preceded by a high surrogate fails, and a high
   surrogate as the final transmitted group fails. Well-formed **pairs** are
   valid, and they are how astral text travels.
-- **Exhaustion.** Running out of input mid-read fails, like any other read
-  (§5).
+- **Exhaustion at any group.** Running out of input mid-read fails, like any
+  other read (§5), whether the length field or any group is the part that
+  runs past the end.
 
 **What no reader enforces**, stated so that no target can be stricter than
 another: nothing else about the text is examined. Noncharacters are
@@ -1426,17 +1427,38 @@ answer: no target traps, panics or aborts on a malformed payload.
 UTF-8 (§4.7) and `wstring(N)` refuses unpaired surrogates, both on the read
 path, both in all nine targets, and both terminal.
 
-**The write side** follows §5's doctrine and §4.7's precedent exactly. The
-length bound is checked on every write in every target, because it guards
-the copy. UTF-16 well-formedness is a writer obligation whose enforcement is
-the read-side refusal above, so no write-side check is load-bearing anywhere
-and none is required of a target. A code unit above `0xFFFF` cannot be
-written at all, because the storage holds 16 bits per unit in every target.
+**The packet wire carries `wstring(N)`, and the TABLE wire is the deferred
+half.** The id-table wire assigns wide text no kind, so a type holding a
+`wstring(N)` field is refused BY NAME inside a table closure until it does,
+and a map key stays `string(N)` or an integer kind
+(SPEC-TABLES.md §11 and §2.8). The protocol id needs no
+`ProjectionVersion` bump for any of this: a wstring field projects its
+capacity beside its kind (§3.1), and no unit could declare the construct
+before.
+
+**The write side** follows §5's doctrine and §4.7's precedent exactly. Two
+things are checked on every write, in every target, in that target's own
+idiom (§5): **the used length is within [0, N]**, because it guards the
+copy, and **a zero code unit among the used units is refused**, exactly as
+§4.7 refuses the interior null and symmetric with the reader's zero-group
+refusal. Surrogate pairing is NOT checked on write. It is a writer
+obligation whose enforcement is the reader on the other end, which refuses
+an unpaired surrogate under the rules above. A code unit above `0xFFFF`
+cannot be written at all, because the storage holds 16 bits per unit in
+every target. In Elixir, where the storage is a binary rather than a counted
+buffer, the write additionally requires an EVEN `byte_size` and raises
+`ArgumentError` otherwise, which is that target's write-refusal idiom under
+§5: an odd binary has no last code unit.
 
 **Storage, and the conversion rule at the boundary.** Storage is a
 pre-allocated buffer of UTF-16 code units with a used length beside it,
 under §6.1's rule that nothing is dynamically sized, and the generated read
-and write paths transcode in no target:
+and write paths transcode in no target. **This is a stated departure from
+the reference's destination rule**, which decodes into the language's own
+string type and recombines surrogate pairs on a runtime whose strings are
+not UTF-16. schema stores code units in every target instead, because that
+destination would allocate per value and §6.1 forbids it, and the wire is
+unchanged either way:
 
 | target | storage | boundary conversion |
 |---|---|---|
@@ -1455,7 +1477,9 @@ on a UTF-16 host, the boundary is a copy of code units with no transcoding
 step, which is the reason the type exists. On Go, Rust and Elixir, whose
 native text is UTF-8, the transcode is real and is paid in application code
 in both directions. No target transcodes inside the generated read or write
-path, and no target allocates per value.
+path, and no target allocates per value, under the estate's standing Elixir
+exception: a decoded BEAM binary IS an allocation, so the Elixir leg pins
+the per-read allocation COUNT rather than claiming zero (PORTING.md M1).
 
 **A successful read terminates the C string.** In C and C++, a successful
 read writes the **zero unit at index `length`**, always, so the buffer is a
@@ -1474,21 +1498,27 @@ bytes. The accepted set at `wstring(7)` adds `wstring-empty`,
 `wstring-accept-just-above-the-surrogate-block`,
 `wstring-accept-surrogate-pair` and
 `wstring-accept-two-basic-plane-groups`, and at `wstring(4)` it adds
-`wstring-accept-length-inside-a-five-character-buffer`. The refused set,
-which gate 5 holds every target to together, is the corpus's seventeen
-refusals: the two group-above-`0xFFFF` vectors, the seven unpaired-surrogate
-vectors, the three interior-null vectors, the two out-of-range length
-vectors, and the three past-end vectors. Two corpus vectors have no schema
+`wstring-accept-length-inside-a-five-character-buffer`. The refused set is
+the corpus's seventeen refusals, hand-authored bytes with a checked-in
+verdict, so they ride **gate 7** (§7.2) in every target rather than gate 5's
+generated sweeps: the two group-above-`0xFFFF` vectors, the seven
+unpaired-surrogate vectors, the three interior-null vectors and the three
+past-end vectors at `wstring(7)`, and the two out-of-range length vectors at
+`wstring(4)`, whose 3-bit length field over [0, 4] is what makes lengths 5,
+6 and 7 expressible and refusable. Two corpus vectors have no schema
 declaration that reproduces them, `wstring-buffer-size-1-zero-bit-length-field`
 and `wstring-no-alignment-before-the-characters`, because their
 `buffer_size` of 1 and 2 sits below the N floor of 2. The no-alignment
 property loses nothing by it: the worked example's first group begins at bit
 3, so an align before the groups moves every byte after it.
 
-Beside the corpus, the cross-language matrix carries a `wstring(7)` field
-holding serialize.js's interop cases: empty, three basic-plane code units,
-`0xE000`, `0xFFFF`, an astral pair between two basic-plane units, and seven
-code units, the most the bound carries.
+Beside the corpus, the cross-language matrix is **owed** a `wstring(7)`
+field holding serialize.js's interop cases: empty, three basic-plane code
+units, `0xE000`, `0xFFFF`, an astral pair between two basic-plane units, and
+seven code units, the most the bound carries. That field, schema's own
+golden source and golden-id pins for a wstring-bearing unit (gates 1, 2 and
+7), and the `examples/` declaration §7.3 requires are owed by the first
+implementation PR, which is the one that teaches a backend to emit the type.
 
 ## 5. Trust model — inherited
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -81,8 +81,9 @@ conventions. Delta serialization is out of scope for v1.
   compiled together (§3.2).
 - **No self-describing wire data.** The wire stays an unattributed bit
   stream; all knowledge lives in the generated code on both ends.
-- **Deferred constructs:** relative integers (`serialize_int_relative`) are
-  not in v1 — see §4.10.
+- **Relative integers are out of scope by decision:** `serialize_int_relative`
+  belongs to the delta layer, which is replicant's and serialize.pro's, not
+  schema's (§4.10).
 
 The grammar must not claim syntax reserved for planned language passes:
 `packet`, `delta`, `baseline` and `index` are usable as ordinary names today
@@ -1010,31 +1011,31 @@ the max length; the wire is length in [0, N], align, then the used bytes;
 storage is a pre-allocated fixed buffer plus a used count. The declared bound
 exists for exactly one reason — it sizes the length prefix's bits.
 
-**`string(N)` payloads are well-formed UTF-8 by contract.** The wire shape is
-unchanged and identical to `bytes(N)`; what the `string` spelling adds is a
-CONTRACT: the payload is well-formed UTF-8 — the writer's obligation, never
-the reader's check. Writing malformed UTF-8 is a writer contract violation,
-surfaced by debug-only asserts where the language supports them. The list is
-exhaustive: C, C++ and Rust assert — C and C++ through a generated validator,
-Rust through `debug_assert!` — and the other six (C#, Dart, Elixir, Go, Java,
-JavaScript) assert nothing. There is no mandatory read-path validation and no
-release-path cost anywhere, and the conformance vectors carry only valid
-UTF-8. An application with genuinely arbitrary payloads uses `bytes(N)`,
-which remains exactly that.
+**`string(N)` payloads are well-formed UTF-8, and the reader enforces it.**
+The wire shape is unchanged and identical to `bytes(N)`. What the `string`
+spelling adds is a read-side rule, stated once here and holding in all nine
+targets, in every build mode: **a payload that is not well-formed UTF-8
+fails the read.** Not well formed means not well formed under Unicode Table
+3-7, so overlong forms, surrogates encoded in UTF-8, code points above
+`10FFFF`, truncated sequences and the bytes `0xFE` and `0xFF` all fail. This
+is classic `serialize_string`'s own rule, mirrored exactly. **A refusal is
+terminal** (§5), and refusal is the only conforming answer: no target traps,
+panics or aborts on a malformed payload. An application with genuinely
+arbitrary payloads uses `bytes(N)`, which remains exactly that.
 
-Beneath the contract, `string(N)` carries **bytes excluding 0x00** — all
-generated readers reject interior nulls; writes assert per §5 (NUL is valid
-UTF-8, so the interior-null rule is its own, stricter check). `bytes(N)` is
-the same wire with no interior-null rule and no encoding contract. The
-byte-string tightening is what lets the targets agree:
+Beneath the encoding rule, `string(N)` carries **bytes excluding 0x00** —
+all generated readers reject interior nulls, and writes assert per §5 (NUL
+is valid UTF-8, so the interior-null rule is its own, stricter check).
+`bytes(N)` is the same wire with no interior-null rule and no encoding rule.
+The byte-string tightening is what lets the targets agree:
 
 - Classic C++ `serialize_string` is strlen-based — it cannot represent
   interior nulls; a writer in another language must not be able to produce a
   payload the C++ reader silently truncates.
-- Rust `String` storage would impose UTF-8 validation ON READ that no target
-  performs (the contract is writer-trusted — a reader must accept what a
-  non-conforming writer produced rather than fail on text), so Rust storage
-  stays a fixed byte buffer (§6.1).
+- Rust `String` storage would heap-allocate per value, which §6.1 forbids,
+  so Rust storage stays a fixed byte buffer and the encoding rule is a
+  validation pass over those bytes rather than a conversion into a native
+  string.
 
 For every legal write the wire bits are identical to `serialize_string` over
 a buffer of N + 1.
@@ -1046,12 +1047,37 @@ primitives** — length over [0, N], then align, then raw bytes — and none
 emits a runtime string call. C# and Rust have no alternative: the §6.1
 storage rules make the runtime string method unusable there — C# stores a
 byte buffer but `SerializeString` takes `ref string`; Rust stores a byte
-buffer but `serialize_string` takes `&mut String` and rejects non-UTF-8
-bytes, which are legal here. Dart, Java and Elixir have no runtime to call.
+buffer but `serialize_string` takes `&mut String`, which allocates.
+Dart, Java and Elixir have no runtime to call.
 C++, C, Go and JavaScript may use their runtime string call for the framing
-and do not. **The interior-null check is
+and do not. **The encoding check and the interior-null check are
 generated-code validation in every target** — no runtime primitive performs
-it (classic C++ read appends `'\0'` and would silently truncate).
+the second, and the first has to hold identically in the three targets that
+have no runtime at all (classic C++ read appends `'\0'` and would silently
+truncate).
+
+**Goldens.** The read-side rule is pinned to serialize's shared corpus
+(`conformance/string.txt`), which a `string(15)` field reproduces exactly,
+its 4-bit length field being the corpus's `buffer_size` 16. The thirteen
+refused vectors are `string-refuse-overlong-two-byte-nul`,
+`string-refuse-overlong-two-byte-slash`,
+`string-refuse-overlong-three-byte-slash`,
+`string-refuse-surrogate-encoded-in-utf8`,
+`string-refuse-low-surrogate-encoded-in-utf8`,
+`string-refuse-code-point-above-10FFFF`, `string-refuse-five-byte-sequence`,
+`string-refuse-lone-continuation-byte`,
+`string-refuse-continuation-byte-after-ascii`,
+`string-refuse-truncated-two-byte-sequence`,
+`string-refuse-truncated-three-byte-sequence`, `string-refuse-byte-fe` and
+`string-refuse-byte-ff`. Each is pinned beside the accepted vector the
+corpus pairs it with, so a reader that refuses a byte class wholesale fails
+an accept: `string-accept-shortest-two-byte-sequence`,
+`string-accept-shortest-three-byte-sequence`,
+`string-accept-just-below-the-surrogate-block`,
+`string-accept-just-above-the-surrogate-block`,
+`string-accept-astral-code-point`, `string-accept-the-largest-code-point`,
+`string-accept-the-same-two-byte-sequence-completed` and
+`string-accept-the-same-three-byte-sequence-completed`.
 
 **Wide text is a separate construct**, not a spelling of this one: `wstring(N)`
 carries UTF-16 code units, counts its bound in code units, and performs no
@@ -1271,7 +1297,7 @@ of `Payload`, or a hand-written loop ending on the in-band `None`. (Ping and
 Pong may both name a field `sequence` because they are separate types;
 §4.6's unique-names rule is per type.)
 
-### 4.10 Deferred constructs
+### 4.10 Declined constructs
 
 - **C++-style bitfields (`uint64 blah : 8`) — declined across the targets**,
   for three reasons. (1) The wire half already exists: `bits(N)` is exactly
@@ -1286,14 +1312,15 @@ Pong may both name a field `sequence` because they are separate types;
   is an opt-in `[packed]` attribute on a type generating accessor-based
   storage — a generator-kind decision for a later pass, not a v1 wire
   construct.
-- **Relative integers** (`serialize_int_relative`): deferred. The classic use
-  is a strictly-increasing sequence across *array elements* (the previous
-  element's field feeding the next), which the back-reference rule cannot
-  express; a scalar-to-scalar form inside one type earns too little to carry
-  the construct. It is designed with the delta pass, never standalone. **The
-  semantics are pinned ahead of it:** strictly increasing, positive only —
-  `current > previous`, the reader fails otherwise; no wrap semantics exist,
-  and a caller with a wrapping counter unwraps before serializing.
+- **Relative integers (`serialize_int_relative`) are out of scope for
+  schema.** The construct belongs to the delta layer, and the delta layer is
+  replicant's and serialize.pro's, where it sits beside the entropy coding
+  (rANS) that the same traffic wants. schema declares types and bitpacks
+  them, so the primitive is not a v1 omission waiting to be filled. The
+  classic use is a strictly-increasing sequence across array elements, with
+  the previous element's field feeding the next, which the back-reference
+  rule of §4.5 does not express, and a scalar-to-scalar form inside one type
+  earns too little to carry the construct on its own.
 
 ### 4.11 Reserved and refused by name
 
@@ -1388,12 +1415,16 @@ position, so the read fails in the target's own error idiom (§6.1) and
 leaves the output object unspecified (§5). Refusal is the only conforming
 answer: no target traps, panics or aborts on a malformed payload.
 
+**The two text types are symmetric on read:** `string(N)` refuses malformed
+UTF-8 (§4.7) and `wstring(N)` refuses unpaired surrogates, both on the read
+path, both in all nine targets, and both terminal.
+
 **The write side** follows §5's doctrine and §4.7's precedent exactly. The
 length bound is checked on every write in every target, because it guards
-the copy. UTF-16 well-formedness is a writer OBLIGATION, asserted only where
-§4.7's UTF-8 contract is asserted, which is C, C++ and Rust, and absent from
-the other six. A code unit above `0xFFFF` cannot be written at all, because
-the storage holds 16 bits per unit in every target.
+the copy. UTF-16 well-formedness is a writer obligation whose enforcement is
+the read-side refusal above, so no write-side check is load-bearing anywhere
+and none is required of a target. A code unit above `0xFFFF` cannot be
+written at all, because the storage holds 16 bits per unit in every target.
 
 **Storage, and the conversion rule at the boundary.** Storage is a
 pre-allocated buffer of UTF-16 code units with a used length beside it,
@@ -1449,8 +1480,8 @@ code units, the most the bound carries.
 
 **Reads validate everything** — integer ranges, enum bounds, alignment
 padding, constants, reserved bits, count bounds, string lengths, the
-interior-null rule, the UTF-16 well-formedness rules of §4.12, and buffer
-exhaustion (running out of input mid-read is a
+interior-null rule, the UTF-8 and UTF-16 well-formedness rules of §4.7 and
+§4.12, and buffer exhaustion (running out of input mid-read is a
 read failure like any other) — and fail on any violation, because network
 input is the trust boundary. Generated read code never lets a value that
 controls iteration go unchecked before use.
@@ -1484,10 +1515,11 @@ production one. **No target panics and none throws**: Elixir's raise is the
 only unwinding path in the nine, and it is the BEAM's own. The generated
 write code's job is to
 make misuse impossible by construction — bounds come from the schema. Costlier contracts
-assert in DEBUG ONLY, and only where a target carries one at all (§4.7's
-UTF-8 well-formedness contract is the type case: an O(n) check no release
-path should carry, asserted by C, C++ and Rust and absent from the other
-six). Ranges are trusted
+assert in DEBUG ONLY, and only where a target carries one at all. Text
+well-formedness is not one of them. UTF-8 in `string(N)` and UTF-16 in
+`wstring(N)` are READ-side refusals in every target (§4.7, §4.12), so the
+guarantee rests on the reader rather than on a write-side check some
+targets carry and others do not. Ranges are trusted
 inputs everywhere: generated code never feeds attacker-influenced values as
 min/max.
 
@@ -2124,15 +2156,16 @@ Every row to date is settled, deferred with its design banked, or discarded.
 
 1. ~~Strings as byte strings~~ — settled: §4.7. One shape for
    `string`/`bytes`; every backend composes the wire from primitives; the
-   interior-null check is generated-code validation in every target.
+   UTF-8 encoding check and the interior-null check are generated-code
+   validation in every target.
 2. ~~Storage-type overrides~~ — settled by the integer family: storage is
    declared by the type name (`thrust int8 | min = 0, max = 100`); no
    override mechanism exists.
 3. ~~Wide strings and relative integers~~ — wide strings are settled:
    `wstring(N)` is §4.12, its wire the classic `serialize_wstring` and its
-   reader rules uniform across the nine targets. Relative integers stay
-   deferred at §4.10: every `int_relative` use site lives inside the packet
-   shapes the delta pass owns.
+   reader rules uniform across the nine targets. Relative integers are out
+   of scope by decision (§4.10): the construct belongs to the delta layer,
+   which is replicant's and serialize.pro's.
 4. ~~`schemafmt` timing~~ — settled: built early, as the parser's first
    consumer; rules in §7.4.
 5. ~~Doc comments~~ — deferred; the design is kept at §4.1.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -407,17 +407,13 @@ int32_t name_length = 0;
 The write refuses embedded NULs and any length past the maximum; the read
 validates both.
 
-**`string(N)` also carries a UTF-8 contract, and it is the WRITER's.** The
-wire is byte-identical to `bytes(N)`; what the `string` spelling adds is the
-obligation that the payload is well-formed UTF-8 — never a reader's check,
-so a reader must accept whatever a conforming writer produced. Because the
-check is O(n), it is a DEBUG-only assert and only in the targets that carry
-one: C and C++ assert through a generated validator, Rust through
-`debug_assert!`, and C#, Dart, Elixir, Go, Java and JavaScript assert
-nothing. So Latin-1 bytes in a `string(32)` fire an assert in a C++ debug
-build and pass in a release one — if your payload is genuinely arbitrary
-bytes, declare `bytes(N)`, which is the same wire with no encoding contract
-(SPEC.md §4.7).
+**`string(N)` also carries a UTF-8 rule, and the READER enforces it.** The
+wire is byte-identical to `bytes(N)`. What the `string` spelling adds is
+that a payload which is not well-formed UTF-8 fails the read, in every
+target and in every build, and the failure is terminal like any other read
+failure. So Latin-1 bytes in a `string(32)` are refused by every reader that
+sees them. If your payload is genuinely arbitrary bytes, declare `bytes(N)`,
+which is the same wire with no encoding rule (SPEC.md §4.7).
 
 ### Arrays
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -404,8 +404,11 @@ char name[MaxName + 1] = {};
 int32_t name_length = 0;
 ```
 
-The write refuses embedded NULs and any length past the maximum; the read
-validates both.
+The write refuses embedded NULs and any length past the maximum, and the
+read validates both. In C and C++ a successful read also writes the zero
+byte at `name[name_length]`, so `name` is a valid C string every time the
+read succeeds, which is what the `+ 1` in the array is for. The other seven
+targets carry the buffer and the used length with nothing written past it.
 
 **`string(N)` also carries a UTF-8 rule, and the READER enforces it.** The
 wire is byte-identical to `bytes(N)`. What the `string` spelling adds is


### PR DESCRIPTION
Spec only. No compiler, emitter or corpus code, and nothing built or run here.

Adds SPEC §4.12, the wide string type, as a new subsection at the end of §4 so every existing subsection number is unmoved. Carries three further owner rulings of 2026-09-04: the text asymmetry resolves toward the reference (§4.7 gains a read-side UTF-8 refusal), relative integers are out of scope by decision rather than deferred, and a successful read terminates the C string where the storage is one. Cold-read changes are in the final commit.

Implementation follow-ons: **#519** (the string half of the UTF-8 ruling) and **#522** (the wstring kind on the id-table wire).

## What the page decides

**`wstring(N)`, the new type (§4.12)**

- **N counts UTF-16 code units**, not code points and not bytes. It maps to classic `buffer_size` N + 1, the same convention `string(N)` already carries. `wstring(N)` with N below 2 is a compile error, the `string(N)` floor.
- **The wire is classic `serialize_wstring`, exactly**: the length as a ranged integer over [0, N], then one 32-bit group per code unit, and no alignment anywhere. `MaxBits` is `bits_required(0, N) + 32 * N` with no padding term, so a `wstring` field adds no alignment point and does not make its type stream-relative.
- **Classic is normative, in one sentence.** serialize.modern's `wstring_` inserts an `align` between the length and the code units. That align is named on the page as the thing schema does not do.
- **The validation paragraph mirrors the reference.** Every generated reader, in all nine targets and in every build mode, refuses: a length outside [0, N], a group above `0xFFFF`, a zero group among the transmitted units, an unpaired surrogate at either end of either surrogate block or as the final group, and exhaustion at any group. Refusal is terminal. Well-formed surrogate pairs are valid.
- **What no reader enforces is stated too**, so no target can be stricter or looser: noncharacters are accepted, `0xFFFF` included, and there is no normalization, case folding or code-point count.
- **The write side is precise about its two checks**: the used length within [0, N], and a zero code unit among the used units, both refused in every target's own idiom, symmetric with the reader's zero-group refusal and with §4.7's interior null. Surrogate pairing is not checked on write, and the page says whose job it is. Elixir, whose storage is a binary rather than a counted buffer, additionally requires an even `byte_size`.
- **Storage is a buffer of UTF-16 code units plus a used length in every target**, under §6.1's no-dynamic-allocation rule: C++ `char16_t[N + 1]`, C `uint16_t[N + 1]`, C# and Java `char[]`, Dart `Uint16List`, JavaScript `Uint16Array`, Go `[N]uint16`, Rust `[u16; N]`, Elixir a `{:utf16, :little}` binary. The page names this as a **stated departure from the reference's destination rule**, which decodes into the language's own string type and recombines pairs on non-UTF-16 runtimes, and gives the reason: that destination allocates per value.
- **The per-target cost claim is only what is true.** On C#, Java, JavaScript, Dart and a UTF-16 C++ or C host, the boundary is a copy of code units with no transcode, which is the stated reason the type exists. On Go, Rust and Elixir the transcode is real and paid in application code in both directions. No target transcodes inside the generated read or write path, and the "no target allocates per value" claim carries the estate's standing Elixir exception (a decoded BEAM binary is an allocation, PORTING.md M1).
- **Goldens are named**, pinned to serialize's `conformance/wstring.txt`, which a `wstring(7)` field reproduces exactly. The row's own golden is `wstring-worked-example`. The seventeen refusals are hand-authored bytes with a checked-in verdict, so they ride gate 7 rather than gate 5's generated sweeps, the two length refusals at `wstring(4)`. Two corpus vectors have no schema declaration that reproduces them, because `buffer_size` 1 and 2 sit below the N floor of 2.
- **What the implementation PR owes is named on the page**: the interop matrix field, schema's own golden source and id pins (gates 1, 2 and 7), and the `examples/` declaration §7.3 requires.

**Tables: land-and-expand (SPEC-TABLES.md §11 and §2.8)**

The packet wire carries `wstring(N)` in full. The id-table wire assigns wide text no kind, so a type holding a `wstring(N)` field is **refused by name inside a table closure**, and map keys stay `string(N)` and the integer kinds. §4.12 carries the cross-reference and says the packet wire is done while the table wire is the deferred half. No `ProjectionVersion` bump is needed: a wstring field projects its capacity beside its kind, and no unit could declare the construct before. The expand half is **#522**, sequenced after #507 stops re-pinning every table golden.

**The text symmetry (§4.7, ruling of 2026-09-04)**

- **`string(N)` payloads are refused on read when they are not well-formed UTF-8**, mirroring classic `serialize_string` exactly: overlong forms, surrogates encoded in UTF-8, code points above `10FFFF`, truncated sequences, and the bytes `0xFE` and `0xFF`. Stated once, uniform across nine targets, every build mode, terminal.
- **The per-target assert list is gone.** It described the state this ruling ends. The interior-null rule stays exactly where it was, as the stricter check beneath the encoding rule, and `bytes(N)` remains the escape hatch for genuinely arbitrary payloads.
- **§4.12 states the symmetry in one sentence**: `string(N)` refuses malformed UTF-8, `wstring(N)` refuses unpaired surrogates, both on read, both terminal.
- **§4.7 pins its own goldens** the way §4.12 does: the thirteen refused UTF-8 vectors of `conformance/string.txt` by name, each beside the accepted vector the corpus pairs it with, eight of those.
- Consequences carried: §5's write-side doctrine no longer names text well-formedness as its debug-assert type case, the Rust storage rationale is now the allocation rule rather than a read-validation claim that is no longer true, §9 q1 follows, and USAGE.md's writer-contract paragraph is replaced by the read rule.

**The C string terminator (§4.7, §4.12, §5, §6.1, ruling of 2026-09-04)**

- **Where the storage is a C string, a successful read terminates it.** In C and C++, a successful read of a `string(N)` writes the zero byte at index `length` and a successful read of a `wstring(N)` writes the zero unit at index `length`, always, so the buffer is a valid C string or `char16_t` string after every accepted read. That is the reason for the `+ 1` in both storage rows, and §6.1 now says so on the rows themselves.
- **In the other seven targets the used length is the truth** and a successful read writes nothing past it, which is §5's tail rule unchanged.
- **§5's tail rule names the terminator as its one stated exception**, so the two statements cannot drift apart. USAGE.md teaches the same fact at the `char name[MaxName + 1]` example.

**Relative integers (§1, §4.10, ruling of 2026-09-04)**

- **Out of scope by decision, not deferred.** The construct belongs to the delta layer, which is replicant's and serialize.pro's, beside the entropy coding (rANS) the same traffic wants. One sentence in §1, one paragraph in §4.10, and §9 q3 follows.
- **§4.10 is retitled "Declined constructs".** With wstring landing and this ruling, it holds no deferred serialize primitive at all.

## Held, with the evidence

**The N floor stays at 2**, mirroring `string(N)`. It costs `wstring-buffer-size-1-zero-bit-length-field` and `wstring-no-alignment-before-the-characters` their schema expression. The estate's only `serialize_wstring` call sites outside tests are the reference's own test messages and its fuzz harness, and no production message uses a buffer below 3, so the two lost expressions cost nothing shipping. The no-alignment property is pinned by the worked example instead, whose first group begins at bit 3.

## Follow-ons, not on the page

- **#519**, the implementation half of the string ruling: the C++ reference validator moved to the read path, the eight ports, the conformance rows and the fuzzer expectation with its negative control.
- **#522**, the wstring kind on the id-table wire: §2.6's value list, the closed kind set, the arm-kind table, §16.2's text form and §7.2's cooked storage. After #507.
- **`bench_mixed` gains a short `wstring` field**, the row deleted from BENCH-STANDARD.md on 2026-08-31 and bound to #188, under #184's standing weighting law: integers stay at or above 90% of bytes, so the field is deliberately short.
- The first implementation PR owes the `examples/` declaration, the schema-side golden pins and the interop matrix field, as §4.12 says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
