### PR TITLE
spec: reachability-scoped protocol id, and retain-unknown (#524, #525)

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -1097,14 +1097,34 @@ enum is keyed.
   id, and that is held by test.
 - **Fixed-size when `T` is**, so the zero-cost gate holds.
 
-**The two spellings are ONE FIELD on the type wire and TWO DIFFERENT
-ENCODINGS on the table wire.** `[E]T` is kind `16` and `[E.Max]T` is
-kind `14` (§3), so changing a TABLE field from one spelling to the other
-is a wire break, not a refactor: an old file read under the new spelling
-is a kind mismatch — skipped, counted, never misdecoded (§4) — and the
-committed baseline refuses the edit at compile time (§18.2). Giving the
-keyed body its own kind is what buys that; the two encodings are not
-mutually decodable and nothing should let them be tried.
+**`[E.Max]T` IS REFUSED IN A TABLE BODY, and `[E]T` is the table form.** The
+two spellings were once both legal on this wire, `[E]T` as kind `16` and
+`[E.Max]T` as kind `14` (§3), and the second is now a compile error naming
+the field and the enum, with the one-word fix in the diagnostic. **The reason
+is that an ordinal-indexed array is a POSITIONAL vocabulary and a table may
+have only one.** A `[E.Max]T` field carries its elements by position, so
+inserting a variant in the middle of `E` lands every later element one slot
+off, in every file already written, with nothing on the wire that could say
+so. That is the shape §4.1's second member has, and it is the shape §4.1's
+first REPORTABLE-by-construction bullet was built to remove: keyed slots ride
+by name, so a middle insert moves no slot. Leaving the positional spelling
+legal beside the keyed one left the class open for anyone who spelled it the
+old way and never changed it, which no kind number can catch, because nothing
+about the FIELD moved.
+
+**It is also what makes `flags` the only exception to the reachability rule**
+(SPEC.md §3.1). Under a projection scoped to what a `type` reaches, an enum
+only tables reach leaves the protocol id, so the connect gate stops refusing
+two peers whose variant orders disagree. That is correct for a vocabulary
+read by NAME and wrong for one read by POSITION, and refusing `[E.Max]T` here
+is what leaves `flags` as the only positional vocabulary a table has, and
+therefore the only exception the projection needs.
+
+**On the TYPE wire the spelling stays legal and positional**, unchanged: a
+`type` body's `[E.Max]T` is a plain array whose extent is the variant count,
+its bytes are the packet wire's, and every fact of it projects (SPEC.md
+§3.1). The refusal is the TABLE body's alone, and it is what §2.2's mode
+derivation already made a per-body question.
 
 **A KEY ENUM IS IN THE TABLE CLOSURE'S VOCABULARY**, and the closure's
 rules reach it through the keying field. An enum that a table closure
@@ -1117,11 +1137,11 @@ KEYING FIELD as the edge that pulled the enum in, because that edge is the
 only reason the rule applies and a person looking at the enum alone would
 not otherwise see it.
 
-Refused by name: a bound naming a `flags` declaration (a mask holds any
-set of bits at once, so it names no single slot); a bounded keyed array,
-`[..E]` or `[A..E]` (a keyed array is COMPLETE by construction); an
-element that is a pointer, as for any array (§15); and an index of
-`E::None`, which names no slot.
+Refused by name: **`[E.Max]T` in a table body**, above; a bound naming a
+`flags` declaration (a mask holds any set of bits at once, so it names no
+single slot); a bounded keyed array, `[..E]` or `[A..E]` (a keyed array is
+COMPLETE by construction); an element that is a pointer, as for any array
+(§15); and an index of `E::None`, which names no slot.
 
 ### 2.5 Byte buffers: `data *bytes`
 
@@ -3358,11 +3378,18 @@ on it.**
 - **An enum-ordinal-indexed array** was the last positional vocabulary
   besides flags: insert a variant in the middle and every later slot lands
   one place off. `[E]T` (§2.4) closes it — keyed slots ride by name, so a
-  middle insert moves no slot.
+  middle insert moves no slot. **And `[E.Max]T` is now REFUSED in a table
+  body by name** (§2.4, §11), so the closed class cannot be reopened by
+  spelling it the old way and never touching the field again. That refusal
+  is what leaves `flags` the ONE positional vocabulary a table has, which
+  is in turn what makes `flags` the one exception to the reachability rule
+  the protocol id is scoped by (SPEC.md §3.1).
 - **Changing a table field between `[E]T` and `[E.Max]T`** would then
   have replaced it: two encodings under one kind would have let a reader
   decode keys as values and report nothing. The keyed body's own kind `16`
-  (§3.2) turns that edit into a kind mismatch, counted like any other.
+  (§3.2) turns that edit into a kind mismatch, counted like any other, and
+  the refusal above means one END of that edit no longer compiles. The kind
+  is what covers the wire an old build already wrote.
 - **Changing a table field between `*T` and a plain `uint32`** is the
   same shape one more time: a node index and a number are the same four
   bytes, and under a shared kind an index would read back as a plausible
@@ -3526,7 +3553,11 @@ that replays it:
 3. **The decoded value matches.** The leg saves what it loaded; the oracle
    encodes what it decoded; the bytes must be identical, or both must refuse
    to write. A reader that reports correctly and fabricates a value from a
-   neighbor's bytes fails here.
+   neighbor's bytes fails here. **This runs with RETENTION OFF** (§6.6), which
+   is what leaves the requirement the one stated. A retention leg is owed
+   beside it, and its cost lands on the ORACLE first: `internal/tablewire`
+   carries no retention, so there is nothing to compare a retaining leg
+   against until it does.
 4. **`LoadMeasure` never asks past a stated bound.** For a variable root the
    region it asks for is held to the framing. When the node table read whole
    AND the read reports nothing, the answer is EXACT: the root's storage, each
@@ -4101,11 +4132,26 @@ build added is gone from that file forever.
 **The wire already carries what it takes, so nothing about it moves.** Every
 field is `id reference, kind, payload` and every kind is skippable by its kind
 byte alone (§3), so the bytes a reader skips are a self-framed unit it can copy
-out and copy back without knowing what they mean. **No byte of §3 moves, no
-kind is spent, no form byte changes, and a file written with retention on is a
-file every reader of this form reads**, because it is a file of ordinary
-fields. Retention is a runtime feature of the READER and the WRITER, and that
-is the whole of the change.
+out and copy back. **No byte of §3 moves, no kind is spent, no form byte
+changes, and a file written with retention on is a file every reader of this
+form reads**, because it is a file of ordinary fields. Retention is a runtime
+feature of the READER and the WRITER, and that is the whole of the change.
+
+**IT IS A REGION ROUND TRIP, AND ONLY THAT.** `LoadRetain` is `Load`'s path
+into a REGION (§6.5), and `SaveRetain` saves from that same region.
+**The BUILDER path does not carry retention**, by name and not by omission,
+and there are two reasons. A builder has no NODE DIRECTORY, because `Lock`
+does not fill one yet and a builder's slots hold arena offsets rather than the
+wire's numbering (§6.3), so there is no stable index for a record to name.
+And a save from a builder re-derives the numbering by walking the graph in the
+READER's declaration order (§3.1), which is not the order the writer numbered
+in, so a field reordered between two builds, which is a free edit on this wire
+(§4), would land a retained field in the wrong body in silence. A region
+round trip has neither problem: `Load` fills the directory from the wire's own
+framing and nothing afterwards renumbers a region, so an index means one node
+for the life of that region. **Land and expand**: a builder-path form is a
+later page if a case for it appears, and it needs an anchor a builder can hold
+rather than this one.
 
 **THE SURFACE: the caller's buffer, threaded through three calls.**
 
@@ -4116,7 +4162,9 @@ TableRetain retain;
 retain.bytes = storage;
 retain.capacity = sizeof( storage );
 
-SceneLoadRetain( scene, wire, wire_size, &retain, &report );
+TableReport report;                        // zeroed once, read at the end
+SceneLoadRetain( scene, region, region_size, wire, wire_size,
+                 &retain, &report );
 // ... the game edits values ...
 int64_t size = SceneMeasureRetain( scene, &retain );
 SceneSaveRetain( scene, &retain, buffer, size, &report );
@@ -4124,33 +4172,51 @@ SceneSaveRetain( scene, &retain, buffer, size, &report );
 
 - **`TableRetain` is a byte buffer, a capacity, and what has been used.** It
   allocates nothing, it never grows, and it is the whole of the memory this
-  feature can command. A retention buffer belongs to one loaded value, and the
-  next `LoadRetain` into it resets it.
+  feature can command. A retention buffer belongs to one loaded region, and
+  the next `LoadRetain` into it resets it.
 - **The three names are ADDITIVE.** `Load`, `Measure` and `Save` are unchanged
   and retain nothing, so every existing caller, every conformance leg and every
   generated golden stands byte for byte. Retention is a thing a caller asks
-  for, in both directions: a value loaded with retention may be saved without
-  it, which drops the retained fields and counts them.
-- **Both load paths take it** (§6.5), a region root and a builder alike, since
-  a retained record names a body and not a storage form.
+  for, in both directions: a region loaded with retention may be saved without
+  it, which drops the retained fields and reports nothing at all, because the
+  plain `Save` has no retention buffer to read.
 - **`LoadMeasure` is untouched.** It sizes the region from the framing and says
   nothing about retention, and a caller sizes the retention buffer from its own
   policy rather than from the wire.
-- **The three spellings are OWED to §11's claimed suffix set.**
-  `LoadRetain`, `MeasureRetain` and `SaveRetain` join that list and
-  `tableGeneratedVerbs` in the change that lands them, and not before, because
-  a claim this page makes and the checker does not is a name a user may still
-  take (§11).
+- **`SaveRetain` REFUSES A NULL REPORT and returns `-1`.** `MeasureRetain` and
+  `SaveRetain` drop the same records under the same walk, so `Measure`'s answer
+  always suffices, and the save is the only place a caller learns that a record
+  was dropped. A surface that let a caller retain, save, and never find out
+  would be a promise it could not check, so the report is required here where
+  it is optional everywhere else (USAGE.md).
+- **THE REPORT ACCUMULATES ACROSS THE PAIR.** The caller zeroes one report
+  before `LoadRetain` and reads it after `SaveRetain`, and `retain_lost` at the
+  end is the sum of what the load could not keep and what the save could not
+  place. That is the number the safety check wants, and it is why the check is
+  read after the save.
+- **`TableRetain` and the three verbs are OWED to §11's claimed set**, and the
+  claim is deliberately not made in this page's own change: a claim the page
+  states and the checker does not make is a name a user may still take (§11).
+  What lands with the feature is `TableRetain` in the unit-scope registry
+  beside `TableReport`, the three suffixes `LoadRetain`, `MeasureRetain` and
+  `SaveRetain` in `tableGeneratedVerbs`, and **Dart's three member spellings**
+  `loadRetain`, `measureRetain` and `saveRetain`, which take that backend's
+  nine claimed field-name verbs to twelve (§11), plus `TableRetain` in the
+  Dart library-scope registry the names negative control holds.
 
 **WHAT IS RETAINED: a FIELD whose id this reader cannot name**, at any depth,
-in the root body and in every node record (§3.1). That is the whole of the
-class, and the four exclusions share one reason. They are not fields, so
-putting one back is a splice into a body the reader rewrites whole rather than
-a field appended to one.
+in the root body and in every node record (§3.1), **except the five kinds
+below**. The exclusions each have one reason: the thing excluded is not a
+self-contained field, so putting it back is a splice into something the reader
+rebuilds rather than a field appended to a body. **Every exclusion counts
+`retain_lost`**, so a caller that needs to know retention held reads one
+number and never has to reason about the list.
 
 | the unknown | retained | why not |
 |---|---|---|
-| a FIELD id this reader cannot name | **yes** | a self-framed unit, and no id this reader writes can collide with it |
+| a FIELD id this reader cannot name, of any kind but those below | **yes** | a self-framed unit, and no id this reader writes can collide with it |
+| a field of kind `17`, or an ARRAY whose element kind is `17` (§3.1) | no | the payload is a NODE INDEX into the writer's numbering, and this reader neither keeps that numbering nor retains the record it names, so a re-emitted index would point at another node or at nothing |
+| the RESERVED node-table field, id `0xFFFFFFFFFFFFFFFF` under kind `12` (§3.1) | no | it is the writer's whole numbering. A build with no kind `17` counts it one `unknown`, and re-emitting it would put a second numbering in a file whose own numbering the writer re-derives |
 | an unknown ENUM variant reference (§3) | no | the FIELD is the reader's, and the reader writes its own value under that id, so a retained copy would be a second occurrence of an id the reader already wrote |
 | an unknown UNION arm id (§3) | no | the same, one level in: the union field is the reader's |
 | an unknown KEYED-ARRAY slot (§3.2) | no | a slot is not a field, the reader rewrites the array body whole, and a slot has nowhere to append to |
@@ -4162,45 +4228,66 @@ from, and a writer writes only ids it CAN name, so no retained field can land
 in a body under an id the reader also wrote. A body carrying one id twice is
 legal input whose last occurrence wins (§3), which is exactly the shape a
 retained field must never take, and the definition of the class is what rules
-it out. The four rows above are excluded so that it stays ruled out.
+it out.
 
-**RETENTION FORM: the wire's own bytes with the references resolved.** A
-reference names a slot of the FILE's id table (§3), so a verbatim copy
-re-emitted into a file whose table is ordered differently would point at other
-names in silence. A retained record therefore holds the field in **retention
-form: the wire form with every reference replaced by the eight-byte id it
-names, little-endian, and every `L` that frames a rewritten reference
-recomputed for the new width.** It is one generic rewrite driven by §3's skip
-rules and nothing else, the same walk a skipper already performs, and it runs
-in the other direction at save. **A record is then SELF-CONTAINED**: it carries
-its own identity and every identity inside it, survives without the file it
-came from, and can be written beside a file, diffed against another, or handed
-to a different build.
+**RETENTION FORM: the field with every reference resolved.** A reference names
+a slot of the FILE's id table (§3), so a verbatim copy re-emitted into a file
+whose table is ordered differently would point at other names in silence. A
+retained record therefore holds the field with **every reference replaced by
+the sixty-four-bit id it names**, and every length that frames a rewritten
+reference recomputed. It is one walk driven by §3's skip rules and nothing
+else, and it runs in the other direction at save.
 
-The rewrite touches only the kinds that carry a reference: the field header's
-own id, and inside the payload kinds `13` (a body's fields), `14` and `16`
-(where the element kind is `13`, `15` or `30`), `15` (an arm id, and the arm's
-payload under the same rule) and `30` (a variant id). **Every other payload is
-copied verbatim**, which is every scalar, every fixed-point and 128-bit kind,
-and kinds `12`, `17`, `31` and `32`, so the ordinary unknown field costs a
-copy, an eight-byte id and nothing else.
+**A retained record is READER-PRIVATE.** It is not a wire form: it has no form
+byte, no version, no declared byte order, and nothing ever writes one to disk
+or hands one to another process or another build. What this page specifies is
+what a record must CARRY and what it may COST, and the byte layout inside the
+buffer is the port's own:
 
-**A RECORD, in full.** Records sit back to back in the buffer, in the order
-they were retained:
+- **It carries the BODY it belongs to**, as the path below.
+- **It carries the field's identity and bytes with every reference resolved**,
+  so that re-emitting it into any id table is correct.
+- **Its cost is bounded** by the accounting in the security bound below, which
+  is what a caller sizes the buffer against.
 
-```
-path length     one byte: the number of steps, at least 1
-path steps      that many unsigned LEB128 values (§3)
-byte length     one unsigned LEB128: the retention-form bytes that follow
-bytes           the field in retention form: id (8 bytes), kind (u8), payload
-```
+A port may lay a record out however it likes inside those three, and one
+sound layout is a path length, the path steps, a byte length and the resolved
+bytes. Nothing compares two ports' buffers, because nothing ever sees one but
+the reader that filled it.
 
-**THE PATH NAMES THE BODY, and it is the READER's own address, never the
-writer's.**
+**WHICH KINDS THE RESOLVING WALK TOUCHES.** The field header's own id always.
+Inside the payload: kind `13`, a body's fields. Kind `15`, an arm id and then
+the arm's payload under this same rule. Kind `30`, a variant id. Kind `14`,
+where the element kind is `13`, `15` or `30`. And **kind `16` at EVERY element
+kind**, because an enum-keyed array's body carries a KEY REFERENCE per slot
+whatever the elements are (§3.2), so its keys resolve even when the elements
+carry no reference of their own. Every other payload is copied verbatim, which
+is every scalar, every fixed-point and 128-bit kind, and kinds `12` and `31`.
+Kinds `17` and `32` never reach this walk: `17` is excluded above, and `32`
+has no payload.
 
-- **Step one is the NODE INDEX of §3.1's numbering**, `1` for the root body
-  and `k` for the node a pointer resolves to. Index `0` names no node, so no
-  path carries it and a zero first step is a record no walk can place.
+**THE WALK IS AN INTERPRETATION, AND ITS VERDICT IS STATED.** Resolving
+references means reading the field's inner structure, which the plain read did
+not do: the plain read skipped the whole field by its outer framing and was
+right to. So the walk can meet damage the read never looked at: a reference
+above the id table's entry count, a non-canonical length, an inner body whose
+terminator falls short, a nested `L` that runs past its parent. **Any of those
+DROPS THE RECORD, counts one `retain_lost`, and changes nothing else.** In
+particular it **never raises `malformed` on the plain read**: the outer
+framing was sound, the enclosing body walked past the field correctly, every
+sibling decoded, and the reader's own data is exactly what it would have been
+with retention off. Retention can lose a field. It can never turn a good read
+into a bad one, and that is the property that lets a caller switch it on
+without re-reading its own error handling.
+
+**THE PATH NAMES THE BODY, and it is the REGION's own address.**
+
+- **Step one is the node's index in the REGION's NODE DIRECTORY** (§6.3):
+  `1` for the root body, and `k` for the node at directory position `k − 1`.
+  `Load` fills that directory from the wire's framing and nothing afterwards
+  renumbers a region, so an index means one node for the life of the region.
+  This is the step a builder cannot hold, and the reason retention is a region
+  round trip.
 - **Every further step names a CHILD BODY of the body before it, in the
   reader's own declaration order**: fields in declaration order, and within a
   field, elements in index order, which is a present `?T`, a nested `T`, an
@@ -4223,12 +4310,27 @@ terminated by a zero reference and a field is found by its id, so an "original
 position" is not a fact the wire holds and reproducing one would buy nothing.
 Appending is chosen for three properties: it is a write with no splice, the
 retained order among the retained fields is preserved, and the result is
-IDEMPOTENT after the first save. A file loaded and saved once has its unknown
-fields moved to the end of each body. Loaded and saved again they are unknown
-again, retained in that same order and written back in it, so
-`save(load(save(load(W))))` equals `save(load(W))` byte for byte. The first
-round trip is the only one that moves a byte, and that is a property a test can
-pin.
+IDEMPOTENT after the first save.
+
+**In the ROOT body the tail is pinned BEFORE the node-table field** (§3.1).
+That field rides last by this implementation's own rule, so that a reader
+which gives up inside the node table already holds the root's own values, and
+a retained field is one of those values: the order is the root's declared
+fields, then the retained tail, then the node table. A retained tail written
+after the node table would put the cheap part behind the large and
+damage-prone one and take that property away for no gain.
+
+**IDEMPOTENCE, and what the first save actually does.** A file loaded and
+saved once has its unknown fields moved to the end of each body. Loaded and
+saved again they are unknown again, retained in that same order and written
+back in it, so the second save equals the first byte for byte. **The first
+save does NOT equal the original**, and it is worth saying why rather than
+waving at it: moving a field changes the order ids are first used in, and the
+id table is in FIRST-USE ORDER over the whole wire (§3), so the trailer's
+entries are permuted and every reference in the body is renumbered with them.
+The first save is a different byte string carrying the same fields, and the
+golden for it is a pinned byte string like every other golden, not a
+comparison "modulo the move".
 
 Two consequences follow, and each is a rule:
 
@@ -4241,22 +4343,30 @@ Two consequences follow, and each is a rule:
   already in the table takes that entry and is never appended twice, exactly as
   any repeat is.
 
-**THE REPORT: two counters, and one of them is the whole check** (§4).
+**THE REPORT: two counters, and one of them is most of the check** (§4).
 
 - **`retained`** counts the fields whose bytes were kept.
 - **`retain_lost`** counts every unknown this load or save could not keep: a
-  record the remaining capacity had no room for, an unknown of one of the four
-  excluded classes above, and, at save, a retained record whose path no longer
-  names a body.
+  record the remaining capacity had no room for, an unknown of one of the
+  excluded classes above, a record the resolving walk found damaged, and, at
+  save, a retained record whose path no longer names a body.
 
 Both are zero in every read that did not opt in, and they ride the same report
 struct for the reason `duplicate` does, which is that a caller has one report
 type and not two (§4). Retention moves no existing counter: a retained field
 still counts `unknown`, because `unknown` says what a READER could not name and
-that stays true. **`retain_lost == 0` is the whole of the safety check**, and
-it is what the never-clobber rule becomes for a caller that opted in. A rewrite
-is safe when the last load's report was silent, OR when retention was on and
-`retain_lost` is zero after the save.
+that stays true.
+
+**`retain_lost` IS NOT THE WHOLE OF THE SAFETY CHECK, and the other three
+counters are still in it.** Retention covers the `unknown` class and nothing
+else, so a load that counted `kind_mismatch` skipped a field and read its
+declared default, a load that counted `clamped` changed a value, and a
+`malformed` load kept a partial decode. Each of those still loses data on
+rewrite exactly as it did before. **A rewrite is safe when the last load's
+report was silent, OR when retention was on and `retain_lost`,
+`kind_mismatch`, `clamped` and `malformed` are all zero after the save.** The
+second is the first with `unknown` struck out, and that is precisely what
+retention buys.
 
 **REFUSAL IS PER RECORD AND NEVER PARTIAL.** A record the remaining capacity
 cannot hold whole is not written at all: `retain_lost` counts one, the read
@@ -4270,65 +4380,78 @@ its own rewrite is back at the never-clobber rule with no code path of its own.
 copies attacker-chosen bytes, so the bound is stated rather than assumed:
 
 - **The caller's capacity is the only ceiling, and the wire cannot raise it.**
-  Retention allocates nothing, in any port, on either path. A caller that will
-  accept 64 KiB of fields it cannot name declares 64 KiB, and a file asking for
-  more loses the surplus and says so.
-- **The retained bytes are never INTERPRETED.** The reader reads exactly what
-  it read in order to SKIP the field, which is the kind bytes and the lengths
-  §3's skip rules need, and the references it rewrites. No value is decoded, no
-  bound is checked, no branch is taken on a payload byte, and nothing inside a
-  retained record can reach a decision the reader makes about its own data.
+  Retention allocates nothing, in any port. A caller that will accept 64 KiB
+  of fields it cannot name declares 64 KiB, and a file asking for more loses
+  the surplus and says so.
+- **The interpretation is bounded to §3's own framing rules, and its failures
+  are contained.** The resolving walk reads kind bytes, lengths and references
+  and nothing else: no value is decoded, no bound is checked, no branch is
+  taken on a payload byte, no allocation is sized from one, and a walk that
+  meets anything it cannot frame drops the record and counts it, as above.
+  Nothing inside a retained record reaches a decision the reader makes about
+  its own data.
 - **The expansion is bounded, and a port states the constant.** A record costs
-  its wire bytes, plus seven for each reference widened to eight, plus the path
-  and the two lengths that frame it. The path is at most `1 + D` steps where
+  its wire bytes, plus seven for each reference widened to eight, plus the
+  path and the lengths that frame it. The path is at most `1 + D` steps where
   `D` is the schema's own by-value nesting depth, a compile-time constant of
-  the unit. The smallest unknown field on the wire is three bytes, so a file of
-  nothing but tiny unknown fields is the worst ratio, and the caller's capacity
-  is what answers it rather than any rule of the wire's.
+  the unit. The smallest unknown field on the wire is three bytes, so a file
+  of nothing but tiny unknown fields is the worst ratio, and the caller's
+  capacity is what answers it rather than any rule of the wire's.
 - **`retain_lost` is the whole of the denial-of-service surface, and it is a
   counter rather than a failure.** A file engineered to fill the buffer
-  degrades one field at a time. It cannot make a read fail, allocate, or take a
-  path it would not otherwise take.
+  degrades one field at a time. It cannot make a read fail, allocate, or take
+  a path it would not otherwise take.
 - **A path is the READER's own**, computed from the reader's declaration and
-  the reader's own numbering, and never read from the wire. A hostile file
+  the region's own directory, and never read from the wire. A hostile file
   cannot write a path, name a body or reach a node.
 
-**WHAT INVALIDATES A PATH, said once.** A retained record addresses the value
+**WHAT INVALIDATES A PATH, said once.** A retained record addresses the region
 as `Load` left it. A caller that changes the SHAPE between load and save, by
 removing an array element, a map entry or a node, or by clearing an optional,
 may leave a record naming a body that is gone. That record is dropped at save
 and counted `retain_lost`. Changing a VALUE invalidates nothing. It is the rule
 a caller already lives under for anything else it holds beside a loaded
-instance, and it is why the safety check is read after `Save` and not only
-after `Load`.
+instance, and it is why the safety check is read after `Save`.
 
 **HELD BY TEST, when it lands.** The rows the conformance manifest owes, each
 red for one reason:
 
 - a wire whose unknown fields sit at three depths, retained and re-emitted,
-  byte-compared against the original modulo the move to each body's end. Red if
-  a field is lost, duplicated, or placed in another body.
-- the same wire loaded and saved TWICE, the two saves byte-identical. Red on
-  any drift, which is the idempotence claim.
+  the save pinned as a byte string of its own. Red if a field is lost,
+  duplicated, or placed in another body, and red if the id table's entries are
+  not the first-use order the moved fields produce.
+- the same region saved TWICE, the two saves byte-identical. Red on any drift,
+  which is the idempotence claim.
 - a buffer sized one byte short of the last record, pinning `retained` and
   `retain_lost` and the read's own five counters unmoved. Red if a counter
   above moves, or if the truncated record is written.
 - a retained field of kind `13` whose inner body names four ids, re-emitted
-  into a file whose id table is in a different order. Red if a reference points
-  at the wrong name, which is exactly what a verbatim copy does and what the
-  retention form exists to prevent.
-- each of the four excluded classes, pinning `retain_lost` at one and
-  `retained` unmoved. Red if any of them is retained.
+  into a file whose id table is in a different order, and a retained kind `16`
+  field of a SCALAR element kind whose slot keys must resolve all the same.
+  Red if a reference points at the wrong name, which is what a verbatim copy
+  does and what the resolved form exists to prevent.
+- a retained field whose inner structure is damaged inside sound outer
+  framing, pinning `retain_lost` at one, `malformed` at zero, and every
+  sibling field's value intact. Red if the read reports damage it did not see.
+- each excluded class, pinning `retain_lost` at one and `retained` unmoved,
+  with the kind `17`, element-kind `17` and reserved-node-table rows each
+  their own case. Red if any of them is retained.
+- a pointered save whose retained tail sits before the node-table field in the
+  root body. Red on any other order.
 
 **The wire fuzzer runs with retention OFF** (§4.2), which leaves its round-trip
 requirement the requirement it is today, and it gains one leg that runs with it
-ON: the same five counters, and a save that differs from the oracle's only by
-the retained tails.
+ON: the same five counters, and a save the oracle reproduces. **That leg needs
+the ORACLE to retain too.** `internal/tablewire` is the compiler-side engine
+the fuzzer compares against, a third reading of §3 written from the page rather
+than from a backend, and it carries no retention today. The leg is not
+buildable until it does, and that is part of what the feature costs rather than
+a detail of it.
 
 **Backend status: NOT BUILT, in any language.** No port carries `TableRetain`
-or the three calls, no generated file mentions them, and this subsection is the
-specification a port is written from rather than a description of the tree.
-Owed as schema#525.
+or the three calls, no generated file mentions them, `internal/tablewire` has
+no retention, and this subsection is the specification a port is written from
+rather than a description of the tree. Owed as schema#525.
 
 ## 7. The cooked form
 
@@ -6288,9 +6411,13 @@ in build version (§20.5).
   `?[N]T` of everything else are legal (§2.3). Also refused: a specified
   default on an optional; and a field whose name collides with an
   optional's `<field>_present` companion.
-- **Enum-keyed arrays** (§2.4): a bound naming a `flags` declaration (a mask
-  names no single slot); a bounded keyed array, `[..E]` or `[A..E]` (a keyed
-  array is complete by construction); an element that is a pointer — `[E]*T`,
+- **Enum-keyed arrays** (§2.4): **the POSITIONAL spelling `[E.Max]T` in a
+  TABLE body**, a compile error naming the field and the enum with `[E]T` as
+  the fix, because an ordinal-indexed array is a positional vocabulary and a
+  table has one, `flags` (§2.4, §4.1, SPEC.md §3.1); the spelling stays legal
+  in a `type` body, where it is a plain array; a bound naming a `flags`
+  declaration (a mask names no single slot); a bounded keyed array, `[..E]`
+  or `[A..E]` (a keyed array is complete by construction); an element that is a pointer — `[E]*T`,
   a named follow-on (§15) where the bounded arrays of pointers are not (§2.1); an index of `E::None`, which names no slot — asserted
   through `operator[]( E )` in a debug build, and not reachable at all
   through the iteration surface, which offers the valid slots only (§2.4);
@@ -6907,8 +7034,15 @@ are these rulings, in the owner's words:
   holds the gate to.
 - **Enum-keyed arrays** (§2.4): "I like the enum keyed arrays. That is
   cool… It's a really good, unique language feature, that is optional."
-  Optional is part of the design: `[E.Max]T` stays legal and positional;
-  `[E]T` is the keyed form a user chooses.
+  **The optional half is the TYPE wire's, and the table wire's answer
+  narrowed on 2026-09-05** with the reachability ruling (SPEC.md §3.1):
+  `[E.Max]T` stays legal and positional in a `type` body, where the whole
+  spelling projects and the connect gate covers a variant insert, and it is
+  REFUSED in a table body, where nothing on the wire could report the same
+  insert. `[E]T` is the table form. What the user chooses is still a choice
+  in the place the choice is safe, and the table body has one spelling
+  because a table has one positional vocabulary, `flags`, and that is what
+  makes `flags` the only exception the scoped projection needs.
 - **Enum arrays shift left** (§2.4, 2026-09-03): "I think there is really
   just a rule here for enum arrays" / "enum arrays should not pack index 0"
   / "and shift left." The basis was given the day before: "the 0th entry in
@@ -9947,6 +10081,12 @@ the type wire, on what the region looks like, and on what a load puts in it.
 1. **THE TYPE WIRE: the unit's protocol id** (SPEC.md §3.1). Types nest in
    tables BY VALUE and their bytes are written into the region verbatim, so
    the wire-shape projection rides in whole, already reviewed, as one id.
+   **That id is SCOPED to what a `type` reaches** (SPEC.md §3.1), plus every
+   `flags` declaration, so a vocabulary only a table closure reaches is not
+   inside it and group 3 below is what carries such a vocabulary here. The
+   two groups together are what leave this digest covering every fact a
+   cook's bytes depend on whichever way a declaration is reached, and §20.8's
+   controls are built on the difference.
 2. **THE LAYOUT of every record in the unit's table closure** — each record's
    `sizeof` and `alignof`, and per field its WIRE ID, kind, offset, size, the
    DECLARATION it names, its array class, bound and key, an out-of-line
@@ -10488,9 +10628,14 @@ a second digest.
 - **The independence pair, both directions** (§10's test, extended): a table
   edit moves the build version and does not move the protocol id; a type edit
   moves both. The second is the one that must never regress.
-- **The ARM's own id control** (SPEC.md §3.1): a union a table closure holds
-  gains a SCALAR arm, and the PROTOCOL id moves, because an arm is a field
-  line in the wire-shape projection. It is red if that id stands still.
+- **The ARM's own id control** (SPEC.md §3.1), **restated under the scoped
+  projection**: the union has to be one a `type` REACHES, and then a scalar
+  arm added to it moves the PROTOCOL id, because an arm is a field line in
+  the wire-shape projection. It is red if that id stands still. **Its twin is
+  the control the scoping added**: the same edit to a union only a TABLE
+  closure reaches moves the BUILD VERSION and leaves the protocol id where it
+  was, and it is red if that id moves. The pair is what says the closure is
+  being walked rather than the unit listed.
 - **The unchanged-unit twin**, which is what makes the two arm spellings
   worth having: a unit whose arms all name declared `type`s regenerates both
   projections byte-identically, this one's `--facts` text and §18.1's
@@ -10501,13 +10646,17 @@ a second digest.
   `bits(N)` narrowed within one storage width** — the case where the implied
   range moves and the storage kind, the size and the wire id do not; an `enum`
   variant renamed; two `enum` variants swapped; **a `union` arm RENAMED**;
-  **a `flags` variant REORDERED, and one RENAMED**. Those four rows now ride
-  group 1 as well, because SPEC.md §3.1 projects every vocabulary's ordered
-  names and the protocol id rides here in whole (§20.1) — so each proves the
-  build version moves, and none of them isolates group 3's own vocabulary
-  tokens any more. **What isolates them is a TABLE-ARMED union's arm renamed**
-  (§2.6): such a union has no packet wire, so the protocol id cannot cover it
-  and only the cook projection's `union=`/`payload=` tokens can see the edit.
+  **a `flags` variant REORDERED, and one RENAMED**. **Whether a row also
+  rides group 1 now depends on REACHABILITY, and that is the point of the
+  scoping** (SPEC.md §3.1): a vocabulary a `type` reaches rides group 1 as
+  well, so the row proves the build version moves and isolates nothing. A
+  vocabulary only a TABLE closure reaches isolates group 3 cleanly, which is
+  what the enum and union rows should be built on, and it is the shape the
+  TABLE-ARMED union's arm renamed always had (§2.6). **`flags` is the
+  exception in this list too**: it projects whether a `type` reaches it or
+  not, so a flags variant reordered or renamed in place rides group 1 in
+  every unit and isolates nothing here, and its group-3 fact is held by the
+  bit positions the cook projection carries, which #435 owes.
 - **The layout group's own controls**: a field's KIND changed with its width
   unmoved; a field's offset moved with the record's `sizeof` unmoved; **a
   declared maximum raised** — which moves it, and whose §19.4 consequence is

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -3235,6 +3235,14 @@ games decide their own policy over it. Nothing crashes on data from a
 different schema version, in either direction, and that property is held by
 a both-directions evolution test in the corpus.
 
+**TWO MORE COUNTERS RIDE ON THE SAME STRUCT AND STAY ZERO UNTIL A CALLER ASKS
+FOR THEM**: `retained` and `retain_lost`, the retain-unknown pair (§6.6). They
+report on RETENTION rather than on the read, and they change no counter above.
+A retained field still counts `unknown`, because `unknown` says what a reader
+could not name and that stays true whether or not its bytes were kept. Every
+existing caller sees the same five values it saw before, and every `report` row
+of the conformance manifest pins the same five.
+
 **THE ARM EVOLUTION ROWS, each red for one reason** (§2.6, §3). Each is a
 `report` row of the conformance manifest, one wire written under one
 declaration and read under another, pinning the five counters and the value:
@@ -3412,7 +3420,7 @@ only.
 | a union ARM's declared TYPE changed | `kind_mismatch` where the arm's kind moved, `malformed` where its `L` no longer frames its kind | **refuses** | **moves** |
 | a declared RANGE tightened — a maximum lowered, a minimum raised, or a range declared where the field had none | `clamped` | **warns** — the `min=`/`max=` tokens are extents like a capacity (§18.1) | **moves** |
 | a fixed field's `F` moved under the same storage width | silent — the kind carries the width and the signedness, and `F` is a declaration-side fact like a resolution (§3) | **refuses** — the `frac=` token is a fixed fact (§18.1) | **moves** |
-| an `enum`'s or a `union`'s variant order or names moved | `unknown` for a name this reader lacks; a reorder is silent and safe | warns on a removal or a vanished name | **moves**, and so does the protocol id: both vocabularies project their ordered names (SPEC.md §3.1) |
+| an `enum`'s or a `union`'s variant order or names moved | `unknown` for a name this reader lacks; a reorder is silent and safe | warns on a removal or a vanished name | **moves**, and the protocol id with it where a `type` reaches the declaration: both vocabularies project their ordered names, and only within the closure over the unit's types (SPEC.md §3.1) |
 | a field added, removed or reordered | `unknown` for an id this reader lacks; an absent field defaults | passes; a removal AND an addition in one table in one edit **warn** as the pair a bare rename leaves (§18.2) | **moves** |
 | a field renamed under `was` | silent, and nothing is lost | passes; the edit that ADDS the `was` hints the `json =` pairing, because the wire id survives the rename and the text key does not (§16.4) | no — `was` holds the wire id fixed |
 | a field renamed a SECOND time, the new `was` naming the INTERMEDIATE spelling instead of the first | `unknown` on every old file; the new id was never written to | **refuses** — `was` names the first wire name, forever (§5) | **moves** |
@@ -4080,6 +4088,247 @@ stated here once and inherited by every port rather than rediscovered as a
 per-backend accident, and it does not widen: the type wire allocates
 nowhere, in any language, and a fixed-size table with no union allocates
 nowhere either.
+
+### 6.6 Retain-unknown: an opt-in that keeps what this build cannot name
+
+**By default a rewrite drops what the reader could not name**, and the
+never-clobber rule (VERSIONING.md) is the consequence a studio writes into its
+own code. This subsection is the opt-in that answers the case the rule exists
+for: a player on a newer build rolls back, through a beta opt-out, a
+certification lag or a store rollout paused, saves, and every field the newer
+build added is gone from that file forever.
+
+**The wire already carries what it takes, so nothing about it moves.** Every
+field is `id reference, kind, payload` and every kind is skippable by its kind
+byte alone (§3), so the bytes a reader skips are a self-framed unit it can copy
+out and copy back without knowing what they mean. **No byte of §3 moves, no
+kind is spent, no form byte changes, and a file written with retention on is a
+file every reader of this form reads**, because it is a file of ordinary
+fields. Retention is a runtime feature of the READER and the WRITER, and that
+is the whole of the change.
+
+**THE SURFACE: the caller's buffer, threaded through three calls.**
+
+```cpp
+uint8_t storage[ 64 * 1024 ];              // the caller owns it and sizes it
+
+TableRetain retain;
+retain.bytes = storage;
+retain.capacity = sizeof( storage );
+
+SceneLoadRetain( scene, wire, wire_size, &retain, &report );
+// ... the game edits values ...
+int64_t size = SceneMeasureRetain( scene, &retain );
+SceneSaveRetain( scene, &retain, buffer, size, &report );
+```
+
+- **`TableRetain` is a byte buffer, a capacity, and what has been used.** It
+  allocates nothing, it never grows, and it is the whole of the memory this
+  feature can command. A retention buffer belongs to one loaded value, and the
+  next `LoadRetain` into it resets it.
+- **The three names are ADDITIVE.** `Load`, `Measure` and `Save` are unchanged
+  and retain nothing, so every existing caller, every conformance leg and every
+  generated golden stands byte for byte. Retention is a thing a caller asks
+  for, in both directions: a value loaded with retention may be saved without
+  it, which drops the retained fields and counts them.
+- **Both load paths take it** (§6.5), a region root and a builder alike, since
+  a retained record names a body and not a storage form.
+- **`LoadMeasure` is untouched.** It sizes the region from the framing and says
+  nothing about retention, and a caller sizes the retention buffer from its own
+  policy rather than from the wire.
+- **The three spellings are OWED to §11's claimed suffix set.**
+  `LoadRetain`, `MeasureRetain` and `SaveRetain` join that list and
+  `tableGeneratedVerbs` in the change that lands them, and not before, because
+  a claim this page makes and the checker does not is a name a user may still
+  take (§11).
+
+**WHAT IS RETAINED: a FIELD whose id this reader cannot name**, at any depth,
+in the root body and in every node record (§3.1). That is the whole of the
+class, and the four exclusions share one reason. They are not fields, so
+putting one back is a splice into a body the reader rewrites whole rather than
+a field appended to one.
+
+| the unknown | retained | why not |
+|---|---|---|
+| a FIELD id this reader cannot name | **yes** | a self-framed unit, and no id this reader writes can collide with it |
+| an unknown ENUM variant reference (§3) | no | the FIELD is the reader's, and the reader writes its own value under that id, so a retained copy would be a second occurrence of an id the reader already wrote |
+| an unknown UNION arm id (§3) | no | the same, one level in: the union field is the reader's |
+| an unknown KEYED-ARRAY slot (§3.2) | no | a slot is not a field, the reader rewrites the array body whole, and a slot has nowhere to append to |
+| a NODE RECORD whose type id this reader cannot name (§3.1) | no | a whole node, and putting one back means renumbering a graph the writer numbers from its own edges (§3.1) |
+
+**The collision argument, stated because retention rests on it.** A retained
+field's id is by definition one this reader cannot name in the body it came
+from, and a writer writes only ids it CAN name, so no retained field can land
+in a body under an id the reader also wrote. A body carrying one id twice is
+legal input whose last occurrence wins (§3), which is exactly the shape a
+retained field must never take, and the definition of the class is what rules
+it out. The four rows above are excluded so that it stays ruled out.
+
+**RETENTION FORM: the wire's own bytes with the references resolved.** A
+reference names a slot of the FILE's id table (§3), so a verbatim copy
+re-emitted into a file whose table is ordered differently would point at other
+names in silence. A retained record therefore holds the field in **retention
+form: the wire form with every reference replaced by the eight-byte id it
+names, little-endian, and every `L` that frames a rewritten reference
+recomputed for the new width.** It is one generic rewrite driven by §3's skip
+rules and nothing else, the same walk a skipper already performs, and it runs
+in the other direction at save. **A record is then SELF-CONTAINED**: it carries
+its own identity and every identity inside it, survives without the file it
+came from, and can be written beside a file, diffed against another, or handed
+to a different build.
+
+The rewrite touches only the kinds that carry a reference: the field header's
+own id, and inside the payload kinds `13` (a body's fields), `14` and `16`
+(where the element kind is `13`, `15` or `30`), `15` (an arm id, and the arm's
+payload under the same rule) and `30` (a variant id). **Every other payload is
+copied verbatim**, which is every scalar, every fixed-point and 128-bit kind,
+and kinds `12`, `17`, `31` and `32`, so the ordinary unknown field costs a
+copy, an eight-byte id and nothing else.
+
+**A RECORD, in full.** Records sit back to back in the buffer, in the order
+they were retained:
+
+```
+path length     one byte: the number of steps, at least 1
+path steps      that many unsigned LEB128 values (§3)
+byte length     one unsigned LEB128: the retention-form bytes that follow
+bytes           the field in retention form: id (8 bytes), kind (u8), payload
+```
+
+**THE PATH NAMES THE BODY, and it is the READER's own address, never the
+writer's.**
+
+- **Step one is the NODE INDEX of §3.1's numbering**, `1` for the root body
+  and `k` for the node a pointer resolves to. Index `0` names no node, so no
+  path carries it and a zero first step is a record no walk can place.
+- **Every further step names a CHILD BODY of the body before it, in the
+  reader's own declaration order**: fields in declaration order, and within a
+  field, elements in index order, which is a present `?T`, a nested `T`, an
+  element of a fixed, bounded or enum-keyed array, a map entry's value in
+  ascending key order, and a union's set arm. **A pointer field is not a
+  step**, because its target is a node and takes a first step of its own.
+- **The path has no data-driven depth.** By-value nesting is refused a cycle
+  (§2), so the number of steps is bounded by the schema's own nesting depth, a
+  compile-time constant, and a pointer chain is flat on this wire (§3.1). A
+  hostile file cannot make a path long.
+- **A step is computed LOCALLY, at the moment the walk descends**, which is
+  what makes one address available on both sides. `Load` knows the
+  declaration-side field and the element index it is descending through,
+  because it descends only through fields it can name, and `Save` walks that
+  same order by construction. Neither side numbers a whole tree.
+
+**WHERE THEY GO BACK: at the END of their own body, in the order retained.**
+Position carries nothing on this wire (§3), since a body is a set of fields
+terminated by a zero reference and a field is found by its id, so an "original
+position" is not a fact the wire holds and reproducing one would buy nothing.
+Appending is chosen for three properties: it is a write with no splice, the
+retained order among the retained fields is preserved, and the result is
+IDEMPOTENT after the first save. A file loaded and saved once has its unknown
+fields moved to the end of each body. Loaded and saved again they are unknown
+again, retained in that same order and written back in it, so
+`save(load(save(load(W))))` equals `save(load(W))` byte for byte. The first
+round trip is the only one that moves a byte, and that is a property a test can
+pin.
+
+Two consequences follow, and each is a rule:
+
+- **A body that carries a retained field does not ELIDE.** A by-value `T` at
+  its defaults writes nothing (§3). One whose body holds a retained field
+  writes its body, that field and its terminator. Elision is about what a body
+  CONTAINS, and a retained field is content.
+- **A retained id enters the file's ID TABLE in first-use order** (§3), at the
+  point the walk reaches it, which is after its body's own fields. An id
+  already in the table takes that entry and is never appended twice, exactly as
+  any repeat is.
+
+**THE REPORT: two counters, and one of them is the whole check** (§4).
+
+- **`retained`** counts the fields whose bytes were kept.
+- **`retain_lost`** counts every unknown this load or save could not keep: a
+  record the remaining capacity had no room for, an unknown of one of the four
+  excluded classes above, and, at save, a retained record whose path no longer
+  names a body.
+
+Both are zero in every read that did not opt in, and they ride the same report
+struct for the reason `duplicate` does, which is that a caller has one report
+type and not two (§4). Retention moves no existing counter: a retained field
+still counts `unknown`, because `unknown` says what a READER could not name and
+that stays true. **`retain_lost == 0` is the whole of the safety check**, and
+it is what the never-clobber rule becomes for a caller that opted in. A rewrite
+is safe when the last load's report was silent, OR when retention was on and
+`retain_lost` is zero after the save.
+
+**REFUSAL IS PER RECORD AND NEVER PARTIAL.** A record the remaining capacity
+cannot hold whole is not written at all: `retain_lost` counts one, the read
+continues, and the buffer never holds a truncated field. Nothing else about the
+read changes, because the field is skipped by its framing and counted `unknown`
+exactly as it always was, so a full buffer degrades to the default behavior one
+field at a time, and a caller that treats `retain_lost` as fatal and refuses
+its own rewrite is back at the never-clobber rule with no code path of its own.
+
+**THE SECURITY BOUND.** A table read is untrusted input (§4.2) and retention
+copies attacker-chosen bytes, so the bound is stated rather than assumed:
+
+- **The caller's capacity is the only ceiling, and the wire cannot raise it.**
+  Retention allocates nothing, in any port, on either path. A caller that will
+  accept 64 KiB of fields it cannot name declares 64 KiB, and a file asking for
+  more loses the surplus and says so.
+- **The retained bytes are never INTERPRETED.** The reader reads exactly what
+  it read in order to SKIP the field, which is the kind bytes and the lengths
+  §3's skip rules need, and the references it rewrites. No value is decoded, no
+  bound is checked, no branch is taken on a payload byte, and nothing inside a
+  retained record can reach a decision the reader makes about its own data.
+- **The expansion is bounded, and a port states the constant.** A record costs
+  its wire bytes, plus seven for each reference widened to eight, plus the path
+  and the two lengths that frame it. The path is at most `1 + D` steps where
+  `D` is the schema's own by-value nesting depth, a compile-time constant of
+  the unit. The smallest unknown field on the wire is three bytes, so a file of
+  nothing but tiny unknown fields is the worst ratio, and the caller's capacity
+  is what answers it rather than any rule of the wire's.
+- **`retain_lost` is the whole of the denial-of-service surface, and it is a
+  counter rather than a failure.** A file engineered to fill the buffer
+  degrades one field at a time. It cannot make a read fail, allocate, or take a
+  path it would not otherwise take.
+- **A path is the READER's own**, computed from the reader's declaration and
+  the reader's own numbering, and never read from the wire. A hostile file
+  cannot write a path, name a body or reach a node.
+
+**WHAT INVALIDATES A PATH, said once.** A retained record addresses the value
+as `Load` left it. A caller that changes the SHAPE between load and save, by
+removing an array element, a map entry or a node, or by clearing an optional,
+may leave a record naming a body that is gone. That record is dropped at save
+and counted `retain_lost`. Changing a VALUE invalidates nothing. It is the rule
+a caller already lives under for anything else it holds beside a loaded
+instance, and it is why the safety check is read after `Save` and not only
+after `Load`.
+
+**HELD BY TEST, when it lands.** The rows the conformance manifest owes, each
+red for one reason:
+
+- a wire whose unknown fields sit at three depths, retained and re-emitted,
+  byte-compared against the original modulo the move to each body's end. Red if
+  a field is lost, duplicated, or placed in another body.
+- the same wire loaded and saved TWICE, the two saves byte-identical. Red on
+  any drift, which is the idempotence claim.
+- a buffer sized one byte short of the last record, pinning `retained` and
+  `retain_lost` and the read's own five counters unmoved. Red if a counter
+  above moves, or if the truncated record is written.
+- a retained field of kind `13` whose inner body names four ids, re-emitted
+  into a file whose id table is in a different order. Red if a reference points
+  at the wrong name, which is exactly what a verbatim copy does and what the
+  retention form exists to prevent.
+- each of the four excluded classes, pinning `retain_lost` at one and
+  `retained` unmoved. Red if any of them is retained.
+
+**The wire fuzzer runs with retention OFF** (§4.2), which leaves its round-trip
+requirement the requirement it is today, and it gains one leg that runs with it
+ON: the same five counters, and a save that differs from the oracle's only by
+the retained tails.
+
+**Backend status: NOT BUILT, in any language.** No port carries `TableRetain`
+or the three calls, no generated file mentions them, and this subsection is the
+specification a port is written from rather than a description of the tree.
+Owed as schema#525.
 
 ## 7. The cooked form
 

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -4294,6 +4294,12 @@ without re-reading its own error handling.
   element of a fixed, bounded or enum-keyed array, a map entry's value in
   ascending key order, and a union's set arm. **A pointer field is not a
   step**, because its target is a node and takes a first step of its own.
+- **A UNION's step is the ARM's OWN ORDINAL**, and not "whichever arm is
+  set". A caller that switches the arm between load and save therefore leaves
+  a step no child body answers, so the record is DROPPED and counted
+  `retain_lost`. It is never placed in the other arm's body, which is the one
+  outcome an arm-agnostic step would have produced and the reason the step
+  names the arm.
 - **The path has no data-driven depth.** By-value nesting is refused a cycle
   (§2), so the number of steps is bounded by the schema's own nesting depth, a
   compile-time constant, and a pointer chain is flat on this wire (§3.1). A
@@ -4405,13 +4411,26 @@ copies attacker-chosen bytes, so the bound is stated rather than assumed:
   the region's own directory, and never read from the wire. A hostile file
   cannot write a path, name a body or reach a node.
 
-**WHAT INVALIDATES A PATH, said once.** A retained record addresses the region
-as `Load` left it. A caller that changes the SHAPE between load and save, by
-removing an array element, a map entry or a node, or by clearing an optional,
-may leave a record naming a body that is gone. That record is dropped at save
-and counted `retain_lost`. Changing a VALUE invalidates nothing. It is the rule
-a caller already lives under for anything else it holds beside a loaded
-instance, and it is why the safety check is read after `Save`.
+**WHAT INVALIDATES A PATH, said once, and it is the CALLER's own hazard.** A
+retained record addresses the region as `Load` left it, and every step after
+the first is an ORDINAL. So a caller that changes the SHAPE between load and
+save can do worse than lose a record. **Removing an array element or a map
+entry from the MIDDLE renumbers every sibling after it**, so the record held
+for old entry 2 lands in old entry 3's body, and only the record held for the
+LAST entry is dropped for want of a body to name. Clearing an optional or
+switching a union arm drops the records beneath it, because the step then
+names a child body that does not exist. A node is not on this list, because a
+node cannot be removed from a region. Changing a VALUE invalidates nothing,
+and neither does editing an element in place.
+
+**And `retain_lost` cannot see a misplacement.** It counts the record that
+lost its body, never the ones that moved into a sibling's, because the counter
+answers what retention could not keep and not what a caller's own edit
+re-addressed. That is why this is framed as the caller's hazard: it is the
+rule a caller already lives under for anything else it holds beside a loaded
+instance, and the discipline is to retain, edit values, and save, or to reload
+after a shape edit. The safety check is still read after `Save`, and it
+catches the drop.
 
 **HELD BY TEST, when it lands.** The rows the conformance manifest owes, each
 red for one reason:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -130,11 +130,12 @@ walk forgot becomes two incompatible builds shaking hands. The projection is
 TEXT: what the id depends on can be printed, read and diffed, and a fact
 missing from it is a review question rather than an implementation detail.
 
-**Included — each fact moves the wire:** the package; every type's field
-order; field NAMES; type kind, width and signedness; declared bounds; array
-kind and bounds; string/wstring/bytes capacity; float range, resolution and
-step count; fixed `I` and `F`; specified defaults (both ends must agree on the
-value a constructor materializes — untaken branches read as ZEROS, never
+**Included — each fact moves the wire, for every declaration the closure
+below carries:** the package; every type's field order; field NAMES; type
+kind, width and signedness; declared bounds; array kind and bounds;
+string/wstring/bytes capacity; float range, resolution and step count; fixed
+`I` and `F`; specified defaults (both ends must agree on the value a
+constructor materializes — untaken branches read as ZEROS, never
 defaults, per §5);
 branch structure; `const`/`reserved`/`align` items; enum max and storage
 bits; **every enum's variant names in declaration order**; flags wire bits
@@ -173,6 +174,45 @@ tags and native-type attributes.
 table has no packet wire, so an arm that names one has no packet encoding to
 project (SPEC-TABLES.md §2.6).
 
+**Also excluded: a declaration no `type` REACHES.** The projection is the
+CLOSURE over the unit's `type` declarations, not a listing of the unit.
+**Every `type` is a root**, because the language has no way to say which types
+go on a wire. A `type` is a struct and its codec, every one of them is
+emitted, and any of them may be handed to a writer, so scoping the ROOTS by
+use would be the dangerous direction, and an unused helper type projects like
+a used one. From those roots the walk descends through every named referent a
+packet byte can reach: a field's named `type`, `enum` or `union`, an array's
+element type, the members of both sides of a branch, and a union arm's payload
+and the arm's own field facts. **An `enum` or a `union` the walk never reaches
+is not in the projection**, so a declaration only `table` bodies reach
+contributes nothing to this id. `flags` is the one vocabulary held out of the
+rule, and it projects whether a `type` reaches it or not.
+
+**Why `flags` projects unconditionally.** A flags mask is the table wire's one
+POSITIONAL vocabulary (SPEC-TABLES.md §3). A variant's identity is its bit, an
+insert or a reorder remaps every stored file, and no read report can see it,
+which makes it the second member of the silent class (SPEC-TABLES.md §4.1).
+The protocol id is the only frame that refuses two peers holding different bit
+assignments before they exchange table data over one connection. Content never
+rides in a flags declaration, because sixty-four bits is the ceiling and the
+law is append at the end, so the case this scoping exists for, a content enum
+of item kinds, quests or achievements growing weekly, cannot arise in one.
+Holding `flags` in keeps the fail-safe direction exactly where the report
+cannot help, and it costs a redeploy only for an edit that was a redeploy
+before. It is one line of the walk rather than a case anyone has to remember.
+
+**What reachability does not change is what the projection MEANS.** The
+contract is that two units rendering one projection produce the same packet
+bytes, and an unreachable declaration produces no packet byte by construction,
+so the closure preserves it exactly. What moves is the other direction, the
+spurious MISMATCH: two units whose packet halves are identical and whose table
+halves differ now hold one id, which is correct. **So the walk is the whole of
+what this rests on.** A missed edge is the dangerous direction, a declaration
+a packet byte reaches that the walk does not, which is two incompatible builds
+shaking hands. The obligation is a negative control: remove one edge from the
+walk and `internal/check/projection_test.go`'s "an edit that moves bytes must
+move the id" leg goes red.
+
 **The projection carries two version lines.** `ProjectionVersion` rides the
 first, so a change to the RENDERING moves every id deliberately and visibly
 rather than silently. `WireLaw` rides the second, and it is the CODEC LAW's
@@ -191,6 +231,15 @@ alone, so a bump costs no per-release churn in the tree.
 move the id, and an edit that moves bytes must. The second is the one that
 must never regress.
 
+**Scoping the projection by reachability is a `ProjectionVersion` bump**,
+`2` to `3`. Every id in existence moves once, deliberately and visibly, and
+the release carrying it announces that first.
+
+**Compiler status: NOT SCOPED YET.** `ir.WireProjection` renders the unit and
+`ProjectionVersion` is `2`, so the reachability rule above is the
+specification the change is written from rather than a description of the
+tree. Owed as schema#524, with the negative control it names.
+
 ### 3.2 The unit
 
 A compilation unit is a set of `*.schema` files compiled together (one
@@ -203,11 +252,46 @@ any order, with no semantic effect. One id per unit, exposed as a constant
 The id depends on the projection's facts (§3.1) and nothing else.
 Consequences, in both directions:
 
-- **Every declaration contributes.** The projection lists all of the unit's
-  declarations, not a reachable subset, so an unused helper type moves the id
-  like a used one. Accepted: it fails safe (sides refuse to talk when they
-  actually could), and under the ship-together model the redeploy was
-  happening anyway.
+- **Every declaration a `type` REACHES contributes, and every `flags`
+  declaration contributes whether reached or not** (§3.1). An unused helper
+  TYPE still moves the id, because every `type` is a root. An `enum` or a
+  `union` only `table` bodies reach does not. **The content enum is the case
+  the rule exists for.** The README's promise is that one system does packets,
+  saves, config and assets, so a game takes that promise up by keeping all
+  four in one unit, and under a projection that listed the unit every item
+  kind, quest or achievement added to an enum only tables read bought a
+  coordinated redeploy of both ends for a byte no packet carries. It fails
+  safe still: an unreachable declaration produces no packet byte, so two units
+  holding one id under this rule write the same packet bytes exactly as they
+  did under the old one.
+- **What still moves it, in one list.** Any edit to a `type`, which is a field
+  added, removed, reordered, renamed or retyped, a bound, a capacity, a
+  default, a branch, or a `const`, `reserved` or `align` item. A `type` added
+  or removed. Any edit to an `enum` or `union` declaration the closure
+  carries, a variant or arm reordered or RENAMED included, because that order
+  is spelled in names and nothing else (§3.1). Any edit to any `flags`
+  declaration. And an edit that moves REACHABILITY itself, since removing the
+  last type-side use of an enum takes its lines out of the projection and
+  adding the first puts them back. A reachability move never arrives alone,
+  because the use that moved is a `type` edit in the same commit, so it costs
+  no id move that was not owed already.
+- **What scoping OPENED, read against the silent class.** The four edits the
+  table wire cannot report (SPEC-TABLES.md §4.1) gain no fifth member here,
+  because reachability moves no byte, no kind and no counter. What it removes
+  is an INCIDENTAL guard. A declaration both wires shared was covered by the
+  connect gate as a side effect, so two peers whose vocabularies disagreed
+  refused each other before they exchanged a byte, table data included. Each
+  of the four was re-read against losing that. A changed DEFAULT and a moved
+  fixed `F` are facts of a `table` body, which never entered this projection
+  at all. A REFERENT swapped for a twin is the tables baseline's
+  (SPEC-TABLES.md §18), and the build version moves on it either way
+  (SPEC-TABLES.md §20.4). FLAGS is the one member the connect gate was really
+  covering, and it is held in the projection for exactly that reason (§3.1).
+  **And nothing that left this id left the BUILD VERSION.** §20.4 lists an
+  enum, flags or union variant edit as its own mover, and the cook projection
+  carries every such declaration's variant names and bit positions in a block
+  of its own (SPEC-TABLES.md §20.2), so a cook written before the edit still
+  refuses to open after it.
 - **File layout, declaration order across files, comments and whitespace move
   nothing.** Variant order inside an enum or a flags declaration is not
   declaration order in this sense: it is the wire, and it moves the id (§3.1).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -180,38 +180,78 @@ CLOSURE over the unit's `type` declarations, not a listing of the unit.
 go on a wire. A `type` is a struct and its codec, every one of them is
 emitted, and any of them may be handed to a writer, so scoping the ROOTS by
 use would be the dangerous direction, and an unused helper type projects like
-a used one. From those roots the walk descends through every named referent a
-packet byte can reach: a field's named `type`, `enum` or `union`, an array's
-element type, the members of both sides of a branch, and a union arm's payload
-and the arm's own field facts. **An `enum` or a `union` the walk never reaches
-is not in the projection**, so a declaration only `table` bodies reach
-contributes nothing to this id. `flags` is the one vocabulary held out of the
-rule, and it projects whether a `type` reaches it or not.
+a used one. **An `enum` or a `union` the walk never reaches is not in the
+projection**, so a declaration only `table` bodies reach contributes nothing to
+this id. `flags` is the one vocabulary held out of the rule, and it projects
+whether a `type` reaches it or not.
 
-**Why `flags` projects unconditionally.** A flags mask is the table wire's one
-POSITIONAL vocabulary (SPEC-TABLES.md §3). A variant's identity is its bit, an
-insert or a reorder remaps every stored file, and no read report can see it,
-which makes it the second member of the silent class (SPEC-TABLES.md §4.1).
-The protocol id is the only frame that refuses two peers holding different bit
-assignments before they exchange table data over one connection. Content never
-rides in a flags declaration, because sixty-four bits is the ceiling and the
-law is append at the end, so the case this scoping exists for, a content enum
-of item kinds, quests or achievements growing weekly, cannot arise in one.
-Holding `flags` in keeps the fail-safe direction exactly where the report
-cannot help, and it costs a redeploy only for an edit that was a redeploy
-before. It is one line of the walk rather than a case anyone has to remember.
+**THE EDGES, ENUMERATED, because the walk is the whole of what this rests
+on.** A declaration is reached when a `type`'s own facts reach it by any of
+these, and the list is exhaustive rather than illustrative:
+
+1. **A field's named TYPE**: a `type`, an `enum`, a `union` or a `flags`
+   declaration a field line names, in any spelling, `T`, `?T` or `*T`.
+2. **An array's ELEMENT type**, which is the same set one level in.
+3. **An array's BOUND, where the bound names an enum**. `[E.Max]T` puts
+   `E`'s VARIANT COUNT in the extent, so an enum reached by nothing but a
+   bound still sets how many elements ride, and a variant added to it moves
+   packet bytes. This is the edge a walk that followed only types would
+   miss, and missing it is the spurious MATCH.
+4. **A keyed array's KEY enum**, `[E]T`. In a `type` body the spelling
+   lowers to the positional `[E.Max]T` (SPEC-TABLES.md §2.4), so the key
+   enum is an extent by another name and the third edge's reason is its
+   reason.
+5. **A CONSTANT's value expression**, followed through to what it names. A
+   `const` declaration does not project, because its value is already
+   resolved into the bound or the default that does, so the walk has to
+   reach the enum BEHIND a `const N = E.Max` exactly as it reaches one
+   spelled at the bound.
+6. **A UNION ARM's payload type, and the arm's own field facts**, which
+   re-enter the list at 1.
+7. **The members of BOTH SIDES of a branch**, which re-enter the list at 1.
+   An untaken branch's members are wire facts (§4.4), so an `else` body
+   reaches what a `then` body does.
+8. **Every item of a `type` the walk has reached**, transitively, which is
+   what makes it a closure rather than one step.
+
+**Why `flags` projects unconditionally, and it is the ONE exception.** A
+flags mask is the table wire's one POSITIONAL vocabulary (SPEC-TABLES.md §3):
+a variant's identity is its bit, an insert or a reorder remaps every stored
+file, and no read report can see it, which makes it the second member of the
+silent class (SPEC-TABLES.md §4.1). **Stated as the narrowing it is: this one
+line narrows the reachability rule, because `flags` is the only vocabulary a
+table cannot report a move in, the committed baseline is only a COMPILE-TIME
+guard and a studio may not have one, and the protocol id is the only RUNTIME
+frame that refuses two peers holding different bit assignments before they
+exchange table data over one connection.** Content never rides in a flags
+declaration, because sixty-four bits is the ceiling and the law is append at
+the end, so the case this scoping exists for, a content enum of item kinds,
+quests or achievements growing weekly, cannot arise in one. The other
+positional vocabulary a table could have had is gone rather than excepted:
+`[E.Max]T` is REFUSED in a table body by name (SPEC-TABLES.md §2.4, §11), so
+`[E]T` is the table form and an enum a table reaches moves no slot when it
+changes. Flags is therefore the whole of the exception, and there is no
+second.
 
 **What reachability does not change is what the projection MEANS.** The
 contract is that two units rendering one projection produce the same packet
 bytes, and an unreachable declaration produces no packet byte by construction,
 so the closure preserves it exactly. What moves is the other direction, the
 spurious MISMATCH: two units whose packet halves are identical and whose table
-halves differ now hold one id, which is correct. **So the walk is the whole of
-what this rests on.** A missed edge is the dangerous direction, a declaration
-a packet byte reaches that the walk does not, which is two incompatible builds
-shaking hands. The obligation is a negative control: remove one edge from the
-walk and `internal/check/projection_test.go`'s "an edit that moves bytes must
-move the id" leg goes red.
+halves differ now hold one id, which is correct.
+
+**THE NEGATIVE CONTROL IS ONE CASE PER EDGE KIND**, and that is what the
+obligation costs. A missed edge is the dangerous direction, a declaration a
+packet byte reaches that the walk does not, which is two incompatible builds
+shaking hands, so a single control over a single edge proves nothing about the
+other seven. Each case is a unit in which one declaration is reachable ONLY
+through that edge kind, edited so that packet bytes move, with
+`internal/check/projection_test.go`'s "an edit that moves bytes must move the
+id" leg required to go red when that edge is removed from the walk: an enum
+named only as a field type, one named only as an array element, one named only
+by an `[E.Max]` bound, one named only as an `[E]T` key, one named only through
+a `const`, a union named only as an arm payload, a declaration named only
+inside an `else` body, and one named only through a `type` two steps away.
 
 **The projection carries two version lines.** `ProjectionVersion` rides the
 first, so a change to the RENDERING moves every id deliberately and visibly
@@ -276,22 +316,34 @@ Consequences, in both directions:
   because the use that moved is a `type` edit in the same commit, so it costs
   no id move that was not owed already.
 - **What scoping OPENED, read against the silent class.** The four edits the
-  table wire cannot report (SPEC-TABLES.md §4.1) gain no fifth member here,
-  because reachability moves no byte, no kind and no counter. What it removes
-  is an INCIDENTAL guard. A declaration both wires shared was covered by the
-  connect gate as a side effect, so two peers whose vocabularies disagreed
-  refused each other before they exchanged a byte, table data included. Each
-  of the four was re-read against losing that. A changed DEFAULT and a moved
-  fixed `F` are facts of a `table` body, which never entered this projection
-  at all. A REFERENT swapped for a twin is the tables baseline's
-  (SPEC-TABLES.md §18), and the build version moves on it either way
-  (SPEC-TABLES.md §20.4). FLAGS is the one member the connect gate was really
-  covering, and it is held in the projection for exactly that reason (§3.1).
-  **And nothing that left this id left the BUILD VERSION.** §20.4 lists an
-  enum, flags or union variant edit as its own mover, and the cook projection
-  carries every such declaration's variant names and bit positions in a block
-  of its own (SPEC-TABLES.md §20.2), so a cook written before the edit still
-  refuses to open after it.
+  table wire cannot report (SPEC-TABLES.md §4.1) gain no fifth member, and the
+  claim rests on two facts rather than on inspection. **One: a table has
+  exactly one positional vocabulary, and it is `flags`.** `[E.Max]T` is
+  refused in a table body by name (SPEC-TABLES.md §2.4, §11), so an enum a
+  table reaches is read by variant name at every site and a variant inserted,
+  removed or reordered moves no stored slot. **Two: `flags` is held in this
+  projection** (§3.1), so the one vocabulary whose move a table cannot report
+  is the one the connect gate still refuses. Reachability itself moves no
+  byte, no kind and no counter, so it cannot author a silent edit of its own.
+- **NOTHING IS MISDECODED, and the reason is the table wire and not this id.**
+  A field, an enum variant, a union arm and a table are identified on the
+  table wire by the hash of their name (SPEC-TABLES.md §5), so a variant
+  reordered reads back as itself, a variant renamed or removed reads `None`
+  and counts `unknown`, and a retyped field is a counted kind mismatch. That
+  promise was never the protocol id's to keep, and scoping makes the division
+  explicit: the connect gate holds the PACKET wire, whose bytes say nothing
+  about themselves, and the table wire holds itself. `flags` is the single
+  place where the table wire cannot, which is why it did not move.
+- **What scoping does REMOVE is an incidental guard, and the page says so.** A
+  declaration both wires shared was covered by the connect gate as a side
+  effect, so two peers whose table-only vocabularies disagreed refused each
+  other before they exchanged a byte. They now connect, correctly, and a
+  table-only vocabulary is guarded by the tables baseline and the build
+  version instead. **Nothing that left this id left the BUILD VERSION**:
+  §20.4 lists an enum, flags or union variant edit as its own mover, and the
+  cook projection carries every such declaration's variant names and bit
+  positions in a block of its own (SPEC-TABLES.md §20.2), so a cook written
+  before the edit still refuses to open after it.
 - **File layout, declaration order across files, comments and whitespace move
   nothing.** Variant order inside an enum or a flags declaration is not
   declaration order in this sense: it is the wire, and it moves the id (§3.1).

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -73,10 +73,15 @@ what proves them across releases, #463, named in its section below.
     fields are dropped on rewrite by default, and the never-clobber rule below
     is the consequence. A caller that opts in at `Load`, with a bounded side
     buffer it declares and owns, keeps every unknown FIELD's bytes, and `Save`
-    writes them back. A player who rolls back to an older build, saves, and
-    rolls forward again then loses nothing the older build could not name. It
-    is opt-in, it allocates nothing, and the report says whether it held:
-    `retain_lost` at zero is the whole of the check. Specified in
+    writes them back into the body they came from, so a player who rolls back
+    to an older build, saves, and rolls forward again keeps the newer build's
+    fields. **The promise is exactly as wide as the sharp edge below says.**
+    It is a REGION round trip and not a builder one. It covers unknown FIELDS
+    and not unknown enum variants, union arms, keyed-array slots, node
+    records, node indices or the node table itself. And it covers the
+    `unknown` class alone, so a load that reported `kind_mismatch`, `clamped`
+    or `malformed` still loses what those counters name. It is opt-in, it
+    allocates nothing, and every gap counts `retain_lost`. Specified in
     SPEC-TABLES.md §6.6, owed as #525.
 11. **This page moves with the facts.** No mechanical gate reads this page
     today; #446 adds one, the evolution table's fixtures, and the rest is
@@ -287,7 +292,7 @@ does today.
 | a flags variant inserted or removed | silent | refuses | moves, and so does the protocol id |
 | a flags variant reordered or renamed in place | **silent** | **refuses** | moves: the cook projection digests each variant's bit position, and the protocol id moves too |
 | a union arm reordered or renamed | `unknown` for an arm this reader lacks; a reorder is silent and safe | warns on a vanished name | moves, and the protocol id with it where a `type` reaches the union: the arm names are what a same-typed reorder moves |
-| a keyed array made positional | `kind_mismatch` | refuses | moves |
+| a keyed array made positional | `kind_mismatch` | refuses; and in a TABLE body the positional spelling no longer compiles at all (SPEC-TABLES.md §2.4) | moves |
 | a keyed array's key enum swapped for another | `unknown`, one per slot; the kind stays | refuses | moves |
 | a map's KEY kind changed, or its KEY bound tightened (SPEC-TABLES.md §2.8) | a changed kind is one `kind_mismatch` for the map, which reads empty. A tightened bound drops the entries that no longer fit and counts `clamped`, one per entry | **refuses** a changed kind, warns on a tightened bound | moves |
 | a guard added or removed | nothing | passes | nothing |
@@ -334,16 +339,23 @@ the runtime enforces this: no generated `Save` refuses when the last load's
 report was not silent, so the game keeps the report beside the instance and
 checks it before it writes.
 
-**RETAIN-UNKNOWN is the opt-in that answers the case the rule exists for**
-(SPEC-TABLES.md §6.6, owed as #525). A caller that hands `Load` a bounded side
-buffer it declares and owns keeps every unknown FIELD's bytes, and `Save`
-writes them back into the body they came from. The rule then reads: **a save
-cycle or a rewriting tool never overwrites a file whose read report is not
-silent, UNLESS retention was on and `retain_lost` is zero.** One counter, read
-after the save and not only after the load, is the whole of the check. The
-default is unchanged, every existing caller keeps the behavior it has, and a
-caller that treats `retain_lost` as fatal and refuses its own rewrite is back
-at the rule above with no code path of its own.
+**RETAIN-UNKNOWN is the opt-in that answers the case the rule exists for, and
+it strikes out ONE of the four counters** (SPEC-TABLES.md §6.6, owed as #525).
+A caller that hands `LoadRetain` a bounded side buffer it declares and owns
+keeps every unknown FIELD's bytes, and `SaveRetain` writes them back into the
+body they came from. Retention covers the `unknown` class and nothing else, so
+the rule reads: **a save cycle or a rewriting tool never overwrites a file
+whose read report is not silent, UNLESS retention was on and `retain_lost`,
+`kind_mismatch`, `clamped` and `malformed` are all zero after the save.** That
+is the original condition with `unknown` struck out and nothing else moved,
+and it is precisely what retention buys. The other three still name real loss:
+a `kind_mismatch` field was skipped and read its declared default, a `clamped`
+value was changed on the way in, and a `malformed` load kept a partial decode.
+The condition is read after the SAVE and not only after the load, because a
+retained record can also fail to be placed. The default is unchanged, every
+existing caller keeps the behavior it has, and a caller that treats
+`retain_lost` as fatal and refuses its own rewrite is back at the rule above
+with no code path of its own.
 
 ## The baseline
 
@@ -656,7 +668,8 @@ years, and several of the answers are patterns rather than syntax.
   an enum or union edit a `type` reaches. Write the never-clobber rule before
   the first staged rollout, or turn retain-unknown on and check `retain_lost`.
   Roll back freely: the old build reads the new files and counts what it
-  cannot use, and under retention it writes them back out unharmed.
+  cannot use, and under retention it writes the unknown fields back out
+  unharmed.
 - **Debug an old file.** `unpack --tolerate` renders a wire file of any
   version to text and reports what it did not understand; without
   `--tolerate` it refuses a file whose report is not silent, and a file
@@ -672,13 +685,26 @@ A versioning page that hides its edges is how the failure this page exists to
 prevent happens. These are the places the design chose a cost, or has one
 still open.
 
-- **Unknown fields do not survive a rewrite unless the caller asks.** The
-  default is a drop, with the never-clobber rule as the required consequence
-  and no runtime enforcement. Retain-unknown (SPEC-TABLES.md §6.6, #525) is
-  opt-in, is bounded by a buffer the caller sizes, and covers unknown FIELDS
-  only. An unknown enum variant, an unknown union arm, an unknown keyed-array
-  slot and a node record whose type id is unnameable are still dropped, and
-  each of those counts `retain_lost` so the caller knows.
+- **Unknown fields do not survive a rewrite unless the caller asks, and even
+  then not all of them.** The default is a drop, with the never-clobber rule
+  as the required consequence and no runtime enforcement. Retain-unknown
+  (SPEC-TABLES.md §6.6, #525) is opt-in, is bounded by a buffer the caller
+  sizes, and is a REGION round trip only: `LoadRetain` loads into a region and
+  `SaveRetain` saves from that region, and the BUILDER path carries no
+  retention, because a builder has no node directory to anchor a record on and
+  re-derives its numbering from the reader's own declaration order. Seven
+  things are still dropped and each counts `retain_lost`. A field of kind
+  `17`, an array whose element kind is `17`, and the reserved node-table field
+  itself, all three because a node index means nothing in a numbering this
+  reader re-derives. An unknown enum variant, an unknown union arm and an
+  unknown keyed-array slot, none of which is a field the reader can append.
+  And a node record whose type id is unnameable, which is a whole node. A
+  record whose inner structure the resolving walk finds damaged is dropped
+  too, and that never turns the plain read `malformed`.
+- **Retention covers `unknown` and no other counter.** A load that counted
+  `kind_mismatch`, `clamped` or `malformed` still loses what those name on a
+  rewrite, so the never-clobber condition keeps all three beside
+  `retain_lost`.
 - **There is no widening path**, by choice: a whitelist of compatible pairs
   silently misdecodes everything outside the list.
 - **A variant or union arm reordered or renamed is a lockstep redeploy**
@@ -690,13 +716,16 @@ still open.
   was real while it lasted.** Scoping the projection by reachability (SPEC.md
   §3.1) ends an INCIDENTAL protection: two peers whose enum or union
   declarations disagreed used to refuse each other before they exchanged a
-  byte, table data included, and they now connect. Nothing is misdecoded,
-  because a variant and an arm ride as name hashes on the table wire, so a
-  reorder is invisible and safe and a rename is `unknown`, counted. `flags`,
-  the one vocabulary where a reorder IS silent, is held in the projection for
-  exactly this reason. The residue is that a table-only vocabulary is guarded
-  by the tables baseline and the build version and no longer by the connect
-  gate.
+  byte, table data included, and they now connect. Nothing is misdecoded, and
+  the reason is the table wire rather than this id. A variant and an arm ride
+  as name hashes, so a reorder is invisible and safe and a rename is
+  `unknown`, counted. **Two things had to be true for that to hold, and both
+  were made true rather than found true.** `flags`, the one vocabulary where a
+  reorder IS silent, is held in the projection. And `[E.Max]T` is refused in a
+  table body (SPEC-TABLES.md §2.4, §11), so the other positional vocabulary a
+  table could have had is gone rather than excepted. The residue is that a
+  table-only enum or union is guarded by the tables baseline and the build
+  version and no longer by the connect gate.
 - **A field of a `type` that a table reaches cannot be renamed safely
   today** (#478): `was` is refused there, and a bare rename orphans every
   stored value.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -40,9 +40,11 @@ what proves them across releases, #463, named in its section below.
    is the only thing two peers compare before they talk. The *build version*
    versions the cooked and blocked forms and addresses every cooked asset. An
    edit inside a `table` body moves the build version and never the protocol
-   id. An edit to a `type`, or to an enum, flags or union declaration, which
-   both wires share, moves both — a variant or arm reordered or renamed
-   included, because that order is the wire. A `was` rename moves neither.
+   id. An edit to a `type`, to an enum or union declaration a `type` REACHES,
+   or to any `flags` declaration, moves both, a variant or arm reordered or
+   renamed included, because that order is the wire. An enum or a union only
+   tables reach moves the build version alone, which is what makes a content
+   addition a table edit (SPEC.md §3.1). A `was` rename moves neither.
 5. **Same-build forms match or refuse.** A cook or a block opens under
    exactly the build version that wrote it, by a header match, and otherwise
    refuses: `Open` returns null, and the tool's `uncook` names the mismatch.
@@ -67,7 +69,16 @@ what proves them across releases, #463, named in its section below.
    and never changes a byte under an unchanged id.** A minor may move either
    only together with the wire, announced first. A major is when your world
    breaks. The cross-release gate that proves this is #463.
-10. **This page moves with the facts.** No mechanical gate reads this page
+10. **A build can keep what it cannot name, when the caller asks.** Unknown
+    fields are dropped on rewrite by default, and the never-clobber rule below
+    is the consequence. A caller that opts in at `Load`, with a bounded side
+    buffer it declares and owns, keeps every unknown FIELD's bytes, and `Save`
+    writes them back. A player who rolls back to an older build, saves, and
+    rolls forward again then loses nothing the older build could not name. It
+    is opt-in, it allocates nothing, and the report says whether it held:
+    `retain_lost` at zero is the whole of the check. Specified in
+    SPEC-TABLES.md §6.6, owed as #525.
+11. **This page moves with the facts.** No mechanical gate reads this page
     today; #446 adds one, the evolution table's fixtures, and the rest is
     review.
 
@@ -105,11 +116,12 @@ The projection is a text rendering of every fact that determines packet bytes:
 field order and names, kinds, widths, bounds, capacities, defaults, branch
 structure, enum storage, flags bits, enum and flags variant names in
 declaration order, union arm order and arm names. It excludes what the bytes
-cannot see: comments, layout, declaration order across records. A
-source-text hash would produce spurious mismatches; hashing the compiler's
-internal structures could produce a spurious *match*, which is the dangerous
-direction. The projection is the thing in between. `schema id` prints the id
-and `schema projection` prints the text it is taken over.
+cannot see: comments, layout, declaration order across records, and every
+declaration no `type` reaches, `flags` excepted. A source-text hash would
+produce spurious mismatches, and hashing the compiler's internal structures
+could produce a spurious *match*, which is the dangerous direction. The
+projection is the thing in between. `schema id` prints the id and
+`schema projection` prints the text it is taken over.
 
 Two version lines ride the top of that text, and bumping either moves every
 protocol id in existence:
@@ -144,17 +156,31 @@ Whether the id travels on the wire, in a connect token, in a `const` field,
 or out of band, is the application's choice. There is no negotiation and no
 fallback, and everything downstream of the connection is simpler for it.
 
-**What the same-or-refuse rule costs, and who pays.** Every declaration in the
-unit contributes to the id, because a projection that guessed at reachability
-would fail in the dangerous direction. So any `type` edit moves the id, an
-unused helper type moves it, and so does any edit to an enum, flags or union
-declaration, even one that only tables reach: adding an item kind or a quest
-to an enum is a protocol id move. The price of every id move is a coordinated
-redeploy of both ends. This project's own games redeploy both sides of every
-connection together, always; cross-platform studios with certification lag
-ship both store builds dark behind a gate and flip the server when both have
-cleared. A studio that cannot force-update its clients is outside this model,
-and should know it before choosing the packet wire for anything long-lived.
+**What the same-or-refuse rule costs, and who pays.** The projection is the
+CLOSURE over the unit's `type` declarations, plus every `flags` declaration
+(SPEC.md §3.1). So any `type` edit moves the id, an unused helper type moves
+it, since every `type` is a root because nothing in the language says which
+types go on a wire, and so does any edit to an `enum` or `union` a `type`
+reaches, or to any `flags` declaration at all. **What does NOT move it is a
+declaration only tables reach.** Adding an item kind, a quest or an
+achievement to a content enum no packet carries is a table edit, and it costs
+no redeploy. That is the one concession, and it is aimed at the game that
+takes the README at its word and keeps packets, saves, config and assets in
+one unit. The price of every id move that remains is a coordinated redeploy of
+both ends. This project's own games redeploy both sides of every connection
+together, always. Cross-platform studios with certification lag ship both
+store builds dark behind a gate and flip the server when both have cleared. A
+studio that cannot force-update its clients is outside this model, and should
+know it before choosing the packet wire for anything long-lived.
+
+**`flags` is held in the projection deliberately, and it is the exception to
+the closure.** A mask is the table wire's one positional vocabulary, so an
+insert, a reorder or a rename in place is the silent class's second member and
+no read report can see it. The protocol id is the only frame that refuses two
+peers holding different bit assignments while they exchange table data over
+one connection. Content never rides in a flags declaration, because
+sixty-four bits is the ceiling and the law is append at the end, so holding it
+in costs nothing the closure was meant to buy.
 
 **Table bodies never enter the projection.** No edit inside a `table` body
 can move the protocol id. That independence is held by test, and it is the
@@ -223,7 +249,9 @@ Three mechanisms judge an edit, and each sees what the others cannot:
 
 - **The read report** says what a *reader* can tell happened: four counters,
   `unknown`, `kind_mismatch`, `clamped` and `duplicate`, and a `malformed`
-  flag, filled on every load and never fatal on data from another build.
+  flag, filled on every load and never fatal on data from another build. A
+  caller that opts into retain-unknown reads two more on the same struct
+  (SPEC-TABLES.md §6.6), and they report on retention rather than on the read.
 - **The baseline** says what the *compiler* refuses to let you do to data
   already written: the edits the wire cannot report, caught before they ship.
 - **The build version** says whether a cooked or blocked file this build
@@ -249,16 +277,16 @@ does today.
 | a range tightened | `clamped` | warns | moves |
 | a field's kind changed (`int32`→`int64`, `T`→`*T`, `string`→`bytes`, `bits(8)`→`bits(9)`) | `kind_mismatch`; the value reads as the default | **refuses** | moves |
 | `T`→`?T`, `?T`→`T` | nothing: one framing. An old file's elided default reads as *absent* under `?T` | passes | moves (the presence flag is storage) |
-| an enum variant added or removed | `unknown` where a stored name is gone | passes; warns on a removal | moves, and so does the protocol id |
-| an enum variant reordered | nothing | passes | moves, and so does the protocol id |
-| an enum variant renamed | the old name reads `None`, counted | warns | moves, and so does the protocol id: order is spelled in names |
+| an enum variant added or removed | `unknown` where a stored name is gone | passes; warns on a removal | moves, and the protocol id with it where a `type` reaches the enum |
+| an enum variant reordered | nothing | passes | moves, and the protocol id with it where a `type` reaches the enum |
+| an enum variant renamed | the old name reads `None`, counted | warns | moves, and the protocol id with it where a `type` reaches the enum: order is spelled in names |
 | a `fixed` field's `F` moved | **silent**: the raw integer reads at the new scale | **refuses** | moves |
 | a field's referent replaced by one that cannot stand in (a nested table swapped for a same-shaped twin) | **silent** | **refuses** | moves |
 | a field or a union arm changed between an enum and its raw integer | `kind_mismatch`: an enum has a kind of its own | **refuses** | moves |
 | a union arm's declared type changed | `kind_mismatch` where the kind moved, `malformed` where the length no longer frames it | **refuses** | moves |
 | a flags variant inserted or removed | silent | refuses | moves, and so does the protocol id |
 | a flags variant reordered or renamed in place | **silent** | **refuses** | moves: the cook projection digests each variant's bit position, and the protocol id moves too |
-| a union arm reordered or renamed | `unknown` for an arm this reader lacks; a reorder is silent and safe | warns on a vanished name | moves, and so does the protocol id: the arm names are what a same-typed reorder moves |
+| a union arm reordered or renamed | `unknown` for an arm this reader lacks; a reorder is silent and safe | warns on a vanished name | moves, and the protocol id with it where a `type` reaches the union: the arm names are what a same-typed reorder moves |
 | a keyed array made positional | `kind_mismatch` | refuses | moves |
 | a keyed array's key enum swapped for another | `unknown`, one per slot; the kind stays | refuses | moves |
 | a map's KEY kind changed, or its KEY bound tightened (SPEC-TABLES.md §2.8) | a changed kind is one `kind_mismatch` for the map, which reads empty. A tightened bound drops the entries that no longer fit and counts `clamped`, one per entry | **refuses** a changed kind, warns on a tightened bound | moves |
@@ -268,8 +296,10 @@ does today.
 | a retired name re-added with a new meaning | **silent** | **passes today**; the ledger is #441 | moves |
 | a language added to the build | nothing | nothing | nothing |
 
-Enum, flags and union declarations are shared by both wires, which is why
-some rows move the protocol id as well: see the packet wire section.
+Enum, flags and union declarations are shared by both wires, which is why some
+rows move the protocol id as well. An enum or a union does so only where a
+`type` reaches it, and a `flags` declaration always does: see the packet wire
+section.
 
 ## The read report
 
@@ -285,17 +315,35 @@ the file with the descriptors, the per-field facts every table's generated
 header carries; per-event attribution on the generated read path is additive
 and safe to add after 3.0.0.
 
-**The never-clobber rule.** Unknown fields are dropped on rewrite, by
-decision: everything in schema has a schema, and a tool built from an older
-schema that rewrites a newer file drops what it does not know and counts it.
-That decision has one consequence every studio with a mixed fleet must write
-into its own code before the first staged rollout: **a save cycle or a
-rewriting tool never overwrites a file whose read report is not silent.** The
-`unknown` counter fires on the exact load that precedes the destructive
-rewrite. Write beside the file, or refuse the rewrite. Nothing in the runtime
-enforces this: no generated `Save` refuses when the last load's report was
-not silent, so the game keeps the report beside the instance and checks it
-before it writes.
+**Two more counters ride on the same struct and stay zero unless a caller asks
+for them**: `retained` and `retain_lost`, the retain-unknown pair
+(SPEC-TABLES.md §6.6). They report on RETENTION and not on the read. A
+retained field still counts `unknown`, because `unknown` says what a reader
+could not name and that stays true, so no existing counter changes meaning and
+no existing caller sees a number move.
+
+**The never-clobber rule, and the opt-in that lifts it.** Unknown fields are
+dropped on rewrite BY DEFAULT: everything in schema has a schema, and a tool
+built from an older schema that rewrites a newer file drops what it does not
+know and counts it. That default has one consequence every studio with a mixed
+fleet must write into its own code before the first staged rollout: **a save
+cycle or a rewriting tool never overwrites a file whose read report is not
+silent.** The `unknown` counter fires on the exact load that precedes the
+destructive rewrite. Write beside the file, or refuse the rewrite. Nothing in
+the runtime enforces this: no generated `Save` refuses when the last load's
+report was not silent, so the game keeps the report beside the instance and
+checks it before it writes.
+
+**RETAIN-UNKNOWN is the opt-in that answers the case the rule exists for**
+(SPEC-TABLES.md §6.6, owed as #525). A caller that hands `Load` a bounded side
+buffer it declares and owns keeps every unknown FIELD's bytes, and `Save`
+writes them back into the body they came from. The rule then reads: **a save
+cycle or a rewriting tool never overwrites a file whose read report is not
+silent, UNLESS retention was on and `retain_lost` is zero.** One counter, read
+after the save and not only after the load, is the whole of the check. The
+default is unchanged, every existing caller keeps the behavior it has, and a
+caller that treats `retain_lost` as fatal and refuses its own rewrite is back
+at the rule above with no code path of its own.
 
 ## The baseline
 
@@ -603,9 +651,12 @@ years, and several of the answers are patterns rather than syntax.
   re-add the name with a new meaning; until the ledger (#441) refuses it,
   nothing records that the name is haunted, so keep your own list.
 - **Ship a schema change to a mixed fleet.** A table-body edit never forces a
-  redeploy; a type, enum, flags or union edit always does. Write the
-  never-clobber rule before the first staged rollout. Roll back freely: the
-  old build reads the new files and counts what it cannot use.
+  redeploy, and neither does an edit to an enum or a union no `type` reaches,
+  which is where content lives. A type or flags edit always does, and so does
+  an enum or union edit a `type` reaches. Write the never-clobber rule before
+  the first staged rollout, or turn retain-unknown on and check `retain_lost`.
+  Roll back freely: the old build reads the new files and counts what it
+  cannot use, and under retention it writes them back out unharmed.
 - **Debug an old file.** `unpack --tolerate` renders a wire file of any
   version to text and reports what it did not understand; without
   `--tolerate` it refuses a file whose report is not silent, and a file
@@ -621,17 +672,31 @@ A versioning page that hides its edges is how the failure this page exists to
 prevent happens. These are the places the design chose a cost, or has one
 still open.
 
-- **Unknown fields do not survive a rewrite.** By decision, with the
-  never-clobber rule as the required consequence, and no runtime enforcement.
+- **Unknown fields do not survive a rewrite unless the caller asks.** The
+  default is a drop, with the never-clobber rule as the required consequence
+  and no runtime enforcement. Retain-unknown (SPEC-TABLES.md §6.6, #525) is
+  opt-in, is bounded by a buffer the caller sizes, and covers unknown FIELDS
+  only. An unknown enum variant, an unknown union arm, an unknown keyed-array
+  slot and a node record whose type id is unnameable are still dropped, and
+  each of those counts `retain_lost` so the caller knows.
 - **There is no widening path**, by choice: a whitelist of compatible pairs
   silently misdecodes everything outside the list.
-- **A content addition that is an enum variant is a lockstep redeploy**, even
-  when only tables reach the enum, because the declaration is shared by both
-  wires.
-- **A variant or union arm reordered or renamed is a lockstep redeploy**, a
-  spelling fix included: those names ride in the projection in declaration
-  order, because a reorder changes what every ordinal means and nothing else
-  can see it, so a rename moves the protocol id with it.
+- **A variant or union arm reordered or renamed is a lockstep redeploy**
+  wherever a `type` reaches the declaration, a spelling fix included: those
+  names ride in the projection in declaration order, because a reorder changes
+  what every ordinal means and nothing else can see it, so a rename moves the
+  protocol id with it.
+- **The protocol id no longer guards a table-only vocabulary, and that guard
+  was real while it lasted.** Scoping the projection by reachability (SPEC.md
+  §3.1) ends an INCIDENTAL protection: two peers whose enum or union
+  declarations disagreed used to refuse each other before they exchanged a
+  byte, table data included, and they now connect. Nothing is misdecoded,
+  because a variant and an arm ride as name hashes on the table wire, so a
+  reorder is invisible and safe and a rename is `unknown`, counted. `flags`,
+  the one vocabulary where a reorder IS silent, is held in the projection for
+  exactly this reason. The residue is that a table-only vocabulary is guarded
+  by the tables baseline and the build version and no longer by the connect
+  gate.
 - **A field of a `type` that a table reaches cannot be renamed safely
   today** (#478): `was` is refused there, and a bare rename orphans every
   stored value.
@@ -708,6 +773,9 @@ repository not yet behind it. The 3.0.0 release holds the list at zero.
 - #442: `was` for variants and arms; #478: `was` for the fields of a `type`
   that a table reaches.
 - #446: the evolution table's fixtures.
+- #524: the reachability-scoped wire-shape projection, and the negative
+  control on the walk that a missed edge must turn red.
+- #525: retain-unknown, the two report counters, and the conformance rows.
 - #439 and #460: the standard's own contradictions on `T`→`*T`, the flags
   row, writer misuse, the declaration-rename row, the count of silent edits,
   and the pages that still say schema is not an evolution system.


### PR DESCRIPTION
Rulings 11 and 12 on #523, the two items filed **before 3.0.0 and not blocking the sweep**. Specification only. No compiler change, no runtime change, and no wire change: the two issues this PR opens, #524 and #525, carry the implementations.

Draft until #507 merges and this rebases onto it.

---

## 1. A reachability-scoped protocol id (#524)

**docs/SPEC.md §3.1, §3.2 and docs/VERSIONING.md.**

The wire-shape projection becomes the **closure over the unit's `type` declarations** rather than a listing of the unit, so an `enum` or a `union` only `table` bodies reach contributes nothing to the protocol id.

**The content enum is the reason, and the page says so.** The README's promise is that one system does packets, saves, config and assets, so a game takes that promise up by keeping all four in one unit. Under a projection that listed the unit, every item kind, quest or achievement added to an enum only tables read bought a coordinated redeploy of both ends for a byte no packet carries.

**What still moves the id**, listed on the page: any `type` edit, a `type` added or removed, any edit to an `enum` or `union` the closure carries (a variant or arm reordered or renamed included), any edit to any `flags` declaration, and an edit that moves reachability itself, which never arrives alone because the use that moved is a `type` edit in the same commit.

`ProjectionVersion` `2` to `3`. Every id moves once.

### Decisions beyond the ruling

- **Every `type` is a root, including an unused one.** The language has no way to say which types go on a wire, so scoping the roots by use would be the dangerous direction. The "an unused type moves the protocol id" sharp edge stands unchanged.
- **`flags` projects unconditionally, and it is the whole of the exception.** A mask is the table wire's one positional vocabulary, so an insert, a reorder or a rename in place is the silent class's second member and no read report can see it. The protocol id is the only frame that refuses two peers holding different bit assignments while they exchange table data over one connection. Content never rides in a flags declaration, because sixty-four bits is the ceiling and the law is append at the end, so holding it in costs nothing the closure was meant to buy. **This narrows ruling 11 by one vocabulary**, and it is the one place to reverse if the owner would rather have the rule with no exception.

### The silent class, re-examined

The four members of SPEC-TABLES.md §4.1 gain **no fifth member**: reachability moves no byte, no kind and no counter. What it removes is an **incidental guard**, and the page now says so as a sharp edge. Until this change a declaration both wires shared was covered by the connect gate as a side effect, so two peers whose vocabularies disagreed refused each other before they exchanged a byte, table data included.

Each member was read against losing that:

| member | what it costs |
|---|---|
| a changed DEFAULT | a fact of a `table` body, which never entered this projection |
| a moved fixed `F` | the same |
| a REFERENT swapped for a twin | the tables baseline's, and the build version moves on it either way (§20.4) |
| a FLAGS variant moved | the one the connect gate was really covering, so `flags` stays in |

And **nothing that left the protocol id left the build version**: §20.4 lists an enum, flags or union variant edit as its own mover, and the cook projection carries every such declaration's variant names and bit positions in a block of its own (§20.2). A cook written before the edit still refuses to open after it.

### What #524 owes

The walk is the whole of what the change rests on, and a missed edge is the spurious MATCH the projection exists to refuse. The page states the obligation: **a negative control that removes one edge from the walk and requires `internal/check/projection_test.go`'s "an edit that moves bytes must move the id" leg to go red.**

---

## 2. Retain-unknown (#525)

**A new docs/SPEC-TABLES.md §6.6, one paragraph in §4, one cell in §4.1, and docs/VERSIONING.md.**

An opt-in on `Load` that keeps every unknown field's bytes in a bounded side buffer the caller declares and owns, re-emitted by `Save`, so a player who rolls back to an older build, saves, and rolls forward again loses nothing the older build could not name.

**No wire change.** Every field is `id reference, kind, payload` and every kind is skippable by its kind byte alone, so the bytes a reader skips are a self-framed unit it copies out and copies back. No byte of §3 moves, no kind is spent, no form byte changes.

### Decisions beyond the ruling

- **Scope: field-position unknowns only.** An unknown enum variant, an unknown union arm, an unknown keyed-array slot and a node record whose type id is unnameable are declined, each with its reason on the page. The first two would be a second occurrence of an id the reader already wrote; the last two are not fields, so putting one back is a splice into a body the reader rewrites whole. The collision argument the whole feature rests on falls out of the scope: a retained id is one the reader cannot name, and a writer writes only ids it can name.
- **Re-emitted at the END of the body, not in the original position.** Position carries nothing on this wire, so an original position is not a fact the wire holds. Appending has no splice, preserves the retained order, and makes the round trip **idempotent after the first save**, which is a property a test pins.
- **A retention FORM, not a byte copy.** A reference names a slot of the file's own id table, so a verbatim copy re-emitted into a file whose table is ordered differently would silently point at other names. A record holds the field with every reference resolved to the eight-byte id it names, so it is self-contained. Only kinds `13`, `14`, `16`, `15` and `30` carry an inner reference; every other payload is copied verbatim.
- **A record is addressed by a PATH, not by an ordinal.** Step one is the node index of §3.1's numbering, and every further step names a child body in the reader's own declaration order. A path step is computable locally at the moment either walk descends, which is what makes one address available to a `Load` walking wire order and a `Save` walking declaration order. Depth is bounded by the schema, never by data.
- **Two counters, `retained` and `retain_lost`, and `retain_lost == 0` is the whole of the safety check.** One number covers a full buffer, an excluded class, and a path a caller invalidated by editing the shape between load and save. The never-clobber rule on the promise page now reads "unless retention was on and `retain_lost` is zero".
- **Three additive entry points**, `LoadRetain`, `MeasureRetain` and `SaveRetain`. `Load`, `Measure` and `Save` are unchanged, so every existing caller, conformance leg and generated golden stands byte for byte. The three suffixes are **owed to §11's claimed set and to `tableGeneratedVerbs` in the change that lands them, and §11 is deliberately not touched here**, because a claim the page makes and the checker does not is a name a user may still take.

### The security bound, stated

The caller's capacity is the only ceiling and the wire cannot raise it. The retained bytes are never interpreted beyond what a skipper already reads. The expansion is bounded and a port states the constant. `retain_lost` is the whole of the denial-of-service surface and it is a counter rather than a failure. A path is the reader's own and is never read from the wire.

### What #525 owes

Five conformance rows, including the id-table-reorder case a verbatim copy fails and the twice-saved byte-identity case, and one wire-fuzzer leg. The existing fuzzer runs with retention off, so its round-trip requirement does not move.

---

## Not touched

- SPEC-TABLES.md §2.8, §3 and §20.2, which #507 edits.
- USAGE.md, which teaches what exists.
- §11's claimed suffix set, and SPEC-TABLES.md §10, which would gain a sentence in the implementation PRs.

---

# Second pass: rulings A and B, and the cold read's named changes

Commit `39cc126`. The cold read ruled "merge after named changes and two owner rulings"; both rulings are made and everything below is landed on this branch.

## Ruling A: the positional array against the flags exception

**`[E.Max]T` is refused in a table body by name** (SPEC-TABLES.md §2.4, §11, §4.1). The keyed spelling `[E]T` is the table form and exists to close exactly this class. The refusal is what makes the flags exception *sound* rather than merely convenient: with the positional array gone, `flags` is the one positional vocabulary a table has, and therefore the one exception the scoped projection needs. `[E.Max]T` stays legal and positional in a `type` body, where the whole spelling projects and the connect gate covers a variant insert.

The flags paragraph now states in one sentence that it **narrows the ruling**, and why: the one vocabulary a table cannot report a move in, a committed baseline that is only a compile-time guard a studio may not have, and the protocol id as the only runtime frame.

**SPEC.md §3.1 enumerates all eight walk edges** rather than illustrating them — a field's named type, an array's element type, an array's bound naming `E.Max`, a keyed array's key enum, a constant's value expression, a union arm's payload and its own field facts, both sides of a branch, and transitivity. The `E.Max` bound and the key enum are the two the earlier draft would have missed, and missing either is the spurious MATCH. **The negative control is now one case per edge kind**, each a declaration reachable only through that edge.

**Restated claims.** "No fifth member" now rests on two stated facts rather than inspection: a table has exactly one positional vocabulary, and that one is held in the projection. "Nothing is misdecoded" is restated as the **table wire's** property, not the protocol id's — the connect gate holds the packet wire, the table wire holds itself, and `flags` is the single place it cannot, which is why it did not move.

**Refreshed:** §13.3 records the narrowing against the owner's original "that is optional" ruling; §20.1 states the scope of group 1 and that group 3 carries what left it; §20.8's arm control gains its **table-only twin** (the same edit to a table-only union must move the build version and leave the protocol id still), and the meaning group's rows are re-sorted by reachability, with `flags` called out as the exception there too.

## Ruling B: retention is a region round trip only

`LoadRetain` loads into a **region**; `SaveRetain` saves from that same region. **The builder path is declined by name**, with two reasons: a builder has no node directory (`Lock` does not fill one, and its slots hold arena offsets), and a builder-side save re-derives the numbering by walking in the reader's own declaration order, so a field reordered between builds — a free edit on this wire — would misplace a path in silence. A region has neither problem: `Load` fills the directory from the wire's framing and nothing afterwards renumbers a region.

A path's first step is therefore the **region's node-directory index**, not a wire index re-derived at save. Land and expand: a builder-path form is a later page if a case appears, and it needs an anchor a builder can hold.

## Named changes from the log

| change | where |
|---|---|
| kind `17`, arrays of element kind `17`, and the reserved node-table field (`0xFFFF…FFFF` under kind `12`) declined from retention, counted `retain_lost` | §6.6 exclusion table, three rows with their own reasons |
| kind-`16` keys resolved at **every** element kind, since the slot key references ride whatever the elements are | §6.6 resolving-walk list |
| "never interpreted" dropped; the inner-walk verdict stated: damage inside sound outer framing **drops the record and counts `retain_lost`**, and **never raises `malformed` on the plain read** | §6.6, its own paragraph |
| `kind_mismatch`, `clamped` and `malformed` restored to the never-clobber condition beside `retain_lost` | §6.6, VERSIONING never-clobber, new sharp edge |
| promise 10 cut to the width of the sharp edge (region-only, seven exclusions, `unknown` class alone) | VERSIONING promise 10 |
| `SaveRetain` **refuses a null report** and returns `-1`, because the save is the only place a caller learns a record was dropped | §6.6 surface |
| the record is **reader-private**, not a wire: no form byte, no version, no byte order, never written or handed anywhere. The page specifies what it must carry and what it may cost, and leaves the layout to the port | §6.6 |
| the retained tail sits **before the node-table field** in the root body, keeping the property that a reader dying inside the node table already holds the root's values | §6.6 |
| the id-table effect stated: moving fields to the end changes first-use order, so the trailer permutes and every reference renumbers. The first save is a **pinned byte string**, not a comparison "modulo the move" | §6.6 idempotence |
| the report **accumulates** across `LoadRetain` and `SaveRetain`, zeroed once and read at the end | §6.6 surface |
| `TableRetain` and **Dart's three member verbs** (`loadRetain`, `measureRetain`, `saveRetain`, taking that backend's nine claimed field-name verbs to twelve) owed to §11, with the reason the claim is not made in this page's own change | §6.6 |
| `internal/tablewire` carries no retention, so the fuzzer's retention leg is not buildable until the **oracle** retains too | §4.2 requirement 3, and §6.6 |

## Still open

Nothing from the log is unresolved.

**Rebased onto main after #507 merged** (`b74a7d4c`), with no conflicts. Every fact §6.6 rests on was re-checked against the merged §3: the field framing, the skip rules, first-use order in the id table, the reserved node-table field under kind `12`, kind `16`'s per-slot key references, kinds `17`, `31` and `32`, the node-table field written last in the root body, and node index `1` as the root. #507's own edits land in §2.8, §3's trailer and §20.2, none of which this PR restates. Its rewrite of the trailer paragraph reinforces the retention form rather than colliding with it: "the reference and the compiler's engine both resolve a reference to its id through one array index", which is exactly the resolution a retained record carries.

