### PR TITLE
Pin the serialize family at the 1.16.2 release set

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -51,12 +51,12 @@ concurrency:
 # changes. Find the newest tag with:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
-  SERIALIZE_TAG: v1.16.0
-  SERIALIZE_C_TAG: v1.9.1
-  SERIALIZE_GO_TAG: v1.15.0
-  SERIALIZE_RS_TAG: v2.3.0
-  SERIALIZE_CS_TAG: v1.9.0
-  SERIALIZE_JS_TAG: v1.4.0
+  SERIALIZE_TAG: v1.16.2
+  SERIALIZE_C_TAG: v1.9.2
+  SERIALIZE_GO_TAG: v1.15.1
+  SERIALIZE_RS_TAG: v2.4.0
+  SERIALIZE_CS_TAG: v1.9.1
+  SERIALIZE_JS_TAG: v1.4.2
 
 jobs:
   # THE FULL CHAIN. `make test` builds the corpus in every language and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,12 @@ concurrency:
 # changes. Find the newest tag with:
 #   gh release list --repo mas-bandwidth/<repo> --limit 1
 env:
-  SERIALIZE_TAG: v1.16.0
-  SERIALIZE_C_TAG: v1.9.1
-  SERIALIZE_GO_TAG: v1.15.0
-  SERIALIZE_RS_TAG: v2.3.0
-  SERIALIZE_CS_TAG: v1.9.0
-  SERIALIZE_JS_TAG: v1.4.0
+  SERIALIZE_TAG: v1.16.2
+  SERIALIZE_C_TAG: v1.9.2
+  SERIALIZE_GO_TAG: v1.15.1
+  SERIALIZE_RS_TAG: v2.4.0
+  SERIALIZE_CS_TAG: v1.9.1
+  SERIALIZE_JS_TAG: v1.4.2
 
 jobs:
   # The compiler's own test suite, and the only job in this file that reads a


### PR DESCRIPTION
The serialize family cut a release set carrying format version 1.1, the amended STANDARD.md and the 351 vector conformance corpus. These are the six siblings this repository clones, moved to it:

| pin | was | now |
|---|---|---|
| `SERIALIZE_TAG` | v1.16.0 | v1.16.2 |
| `SERIALIZE_C_TAG` | v1.9.1 | v1.9.2 |
| `SERIALIZE_GO_TAG` | v1.15.0 | v1.15.1 |
| `SERIALIZE_RS_TAG` | v2.3.0 | v2.4.0 |
| `SERIALIZE_CS_TAG` | v1.9.0 | v1.9.1 |
| `SERIALIZE_JS_TAG` | v1.4.0 | v1.4.2 |

The two env blocks move together, as their comment requires. Nothing else changes.

The Rust pin is a minor rather than a patch because `Stream::refuse_if_failed` is new public API in that release, a defaulted trait method an outside implementor of `Stream` inherits. No wire change anywhere in the set: mas-bandwidth/serialize's family matrix proves all nine runtimes carry format version 1.1 and vendor the same standard and corpus commit.