### PR TITLE
spec: doc and tags columns, field-level tags (#523)

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -7655,10 +7655,6 @@ inspects everything in the schema built:
   same pin (§8.7). Nothing is refused meanwhile, because nothing in a schema
   asks for one (§8.4): a backend without the emitter is a backend whose
   users have no registry, and the status paragraph says so.
-- **DOC STRINGS in the view.** Doc comments are deferred with their design
-  pinned (SPEC §4.1, §9 q5); when they land they become one more descriptor
-  column and one more registry column, and nothing else about §8 moves. No
-  competing `| doc = "..."` attribute is introduced ahead of them.
 - **A view over the PACKET wire's own layout** — bit offsets, field widths
   and the compressed-float parameters a `type` rides under (SPEC §6.1),
   beside the declaration facts §8 carries. It is what a packet inspector

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -5318,6 +5318,16 @@ decided by whether it COMPILES that file (§8.4). An editor does; a game
 build never includes it. Nothing here rides a wire either: the view moves no
 protocol id, no generated wire byte and no baseline row (§10, §18).
 
+**This is also where what a PERSON wrote about a declaration comes out.** A
+doc comment (SPEC §4.1) and a tag (SPEC §4.2) are the language's two open
+channels — one prose, one an identifier in a namespace the compiler assigns
+no meaning — and they reach a tool through two descriptor columns, `doc` and
+`tags`, and through nothing else. They are id-neutral and byte-neutral in
+every direction the rest of this page measures, which is what lets the
+namespace stay open: annotating a shipped schema costs no redeploy, no
+re-cook and no baseline row. The columns are specified with the rest of the
+descriptors in §8.1 and appear on the registry's records in §8.3.
+
 ### 8.1 The descriptors
 
 For every table in the unit's closure the generated header carries static
@@ -5347,6 +5357,67 @@ what an element starts as.
 **A field carries its TEXT KEY** beside its name — the `json = "..."`
 attribute's value, else the field's own name (§16.4) — so a walker over the
 text form spells keys without a second table.
+
+**A field carries its DOC COMMENT and its TAGS.** These are the two columns
+that carry what a PERSON wrote about a declaration rather than what the
+compiler derived from it: `doc` is the comment block above the field,
+verbatim as SPEC §4.1 defines it, and `num_tags` with `tags` are the
+valueless identifiers right of the field's pipe (SPEC §4.2), in declared
+order. The same three members sit on the TYPE descriptor, `TableTypeInfo`,
+beside a table's name and its `reset` hook, so a walker that entered a
+nested table through the `table` column reads that declaration's own doc and
+tags there, with no registry (§8.3) compiled and no second lookup.
+
+**Absence has a spelling, and it is not NULL.** A declaration with no doc
+comment carries `doc` pointing at one shared static empty string; a
+declaration with no tags carries `num_tags` of 0 beside a NULL `tags`. A
+printer concatenates `doc` with no test — there is nothing an empty doc
+comment could mean that "no doc comment" does not — while a LIST has its
+count checked before it is walked whatever it holds, so each column takes
+the spelling its own walk already wanted. A unit that documents and tags
+nothing pays one pointer per row and not one byte of string data.
+
+**Both are STATIC, and they allocate nothing.** `doc` is a string literal in
+the generated file and `tags` an array of them, constant-initialized with the
+descriptor and cached with it exactly as the accessor columns are (above), so
+a walk that prints every doc and every tag in a unit allocates what a walk
+that prints none allocates, which is nothing. All nine targets carry the
+three members, each spelling them in its own immutable string and immutable
+ordered sequence; the COLUMNS are one vocabulary doing one job, as
+everywhere else in this section.
+
+**A descriptor carries its OWN doc and tags and nobody else's.** A field
+descriptor's vocabulary columns name an enum's values or a union's arms
+(above), and a VARIANT's doc and tags belong to the enum, flags or union
+DECLARATION rather than to a field that happens to reference it — so they
+ride that declaration's registry rows (§8.3), one lookup away by
+`type_name`, and no `variant_doc( value )` or `variant_tags( value )` joins
+the descriptor in nine ports to spell what the registry already spells.
+**The one place two records describe one item is a GENERAL ARM** (§2.6): an
+arm that names no record is a field line and carries a `TableFieldInfo`, so
+that descriptor holds the arm's own doc and tags and the arm's `ViewVariant`
+row holds the same two values. They agree by construction, and §8.7 is where
+that is checked rather than assumed.
+
+**The BLOCK field descriptor carries neither** (`TableBlockFieldInfo`,
+below). It says where a field sits in the block's projection, and that
+field's doc and tags are one record away on the table field descriptor for
+the same field. A second copy would be a second thing to keep in step, for
+the one form whose whole reason is layout.
+
+**Neither column is in reach of a byte, in any direction this page
+measures.** Both are excluded from the wire shape projection (SPEC §3.1) and
+from the cook projection (§20.2), so neither moves the protocol id and
+neither moves the build version; neither enters a baseline row (§18), so
+`schema check` never sees one and no doc or tag edit can be a warn or a
+refusal; and neither is a member of the silent class (§4.1), because there
+is no stored byte whose meaning a comment or an inert identifier could
+change. **The text form does not read them and never writes them** (§16):
+its keys are the `json` column and its values are the storage columns, and a
+doc comment is not a value. **The pack tree does not see them either**
+(§17): a directory and a file name a field by its text key, so nothing in a
+tree is ever spelled by a doc or a tag. Documenting and tagging a shipped
+schema is a free edit, and that is the property the open namespace rests on.
 
 **A field carries WHERE IT LIVES, and the spelling is the language's.** C++
 carries an offset and a width, because its storage is one flat struct; a
@@ -5618,6 +5689,10 @@ struct ViewConstant
     bool is_float;
     int64_t int_value;       // the folded value; float_value when is_float
     double float_value;
+    const char * doc;        // the doc comment above it, verbatim (SPEC §4.1);
+                             // "" when there is none, never NULL (§8.1)
+    int32_t num_tags;             // the declaration's tags (SPEC §4.2), in
+    const char * const * tags;    // DECLARED order; 0 and NULL when there are none
 };
 
 struct ViewVariant          // one enum variant, one flags bit, one union arm
@@ -5641,6 +5716,12 @@ struct ViewVariant          // one enum variant, one flags bit, one union arm
                                     // storage. NULL on an arm naming a `type` or
                                     // a `table`, on a payload-free arm, on tag 0,
                                     // and on an enum or flags row
+    const char * doc;               // the doc comment above this variant, bit or
+                                    // arm, verbatim; "" when there is none (§8.1)
+    int32_t num_tags;               // this row's own tags, in DECLARED order;
+    const char * const * tags;      // 0 and NULL when there are none. On a general
+                                    // arm the `field` descriptor above carries the
+                                    // same two values (§8.1)
 };
 
 struct ViewVocabulary       // an enum, a flags or a union declaration
@@ -5651,6 +5732,9 @@ struct ViewVocabulary       // an enum, a flags or a union declaration
     int32_t storage_bits;
     int32_t num_variants;
     const ViewVariant * variants;
+    const char * doc;             // the declaration's own doc comment; "" when none
+    int32_t num_tags;             // the declaration's own tags, in DECLARED order;
+    const char * const * tags;    // 0 and NULL when there are none
 };
 
 struct ViewType             // one declaration: a type, or a table
@@ -5658,9 +5742,12 @@ struct ViewType             // one declaration: a type, or a table
     const char * name;
     const char * file;
     bool table;                     // declared `table`
-    const TableTypeInfo * type;     // §8.1's descriptor: the properties
-    int32_t num_tags;               // the declaration's type tags (SPEC §4.2)
-    const char * const * tags;
+    const TableTypeInfo * type;     // §8.1's descriptor: the properties, and this
+                                    // declaration's own doc and tags beside them
+    const char * doc;               // the doc comment above it; "" when none. The
+                                    // same text `type->doc` carries (§8.1)
+    int32_t num_tags;               // the declaration's tags (SPEC §4.2), in
+    const char * const * tags;      // DECLARED order; the same list `type` carries
 };
 
 struct UnitViewInfo
@@ -5719,6 +5806,23 @@ const UnitViewInfo * UnitView();
   every generated file already names its source (SPEC §6.1) — a tool
   grouping a build's declarations the way a person navigates them needs no
   second table to do it.
+- **Every record carries `doc` and its two `tags` columns**, and they mean
+  one thing on all of them: the comment a person wrote above the item, and
+  the identifiers that person hung on it (§8.1). Every DECLARATION has them —
+  a type, a table, an enum, a flags, a union, a constant — and so does every
+  declared ITEM, which is what `ViewVariant` carries them for: an enum
+  variant, a flags bit and a union arm each has its own. A field's are on its
+  `TableFieldInfo` (§8.1), reached through the entry's `type`, so the
+  registry does not restate them. **Tag 0 of a union is the one row that has
+  neither**, along with everything else it has: it is not a declared arm, and
+  there was nothing above it to write.
+- **A REGISTRY LISTING IS THE WHOLE ANNOTATION SURFACE.** A tool that wants
+  every doc and every tag in a build walks `UnitView()` and reaches all of
+  them — declarations from the six sets, fields through each entry's
+  descriptor, variants and arms through each vocabulary's rows — with no
+  schema files on hand and no second pass. That is what makes an editor's
+  property grid, a documentation generator and a project's own claiming pass
+  (SPEC §4.2) consumers of one surface rather than three.
 - **Each set is ordered by DECLARATION NAME**, and deliberately not by where
   the declaration lives. File layout and declaration order move nothing in
   this language — not an id, not a wire byte (SPEC §3.2) — so a listing that
@@ -5801,18 +5905,29 @@ per-schema-file name does not.
 
 ### 8.6 What the view does not carry
 
-- **No semantics.** A type tag is an identifier the language assigns no
-  meaning (SPEC §4.2); the registry lists a declaration's tags because they
-  are part of what was declared, and claims nothing about them. A claiming
-  pass that gives a tag meaning changes what a consumer does with the
-  listing, never the listing.
-- **No UI hints.** Names, kinds, ids, bounds, extents, offsets, presence
-  companions and key vocabularies — the facts the declaration states, and
-  those alone. No widget, no grouping, no ordering hint, no unit of measure.
-- **No description strings, and no `| doc` attribute.** Doc comments are
-  deferred with their design pinned (SPEC §4.1, §9 q5); when they land the
-  view carries them as one more column. A second spelling for the same text
-  is not introduced ahead of them.
+- **No semantics.** A tag is an identifier the language assigns no meaning
+  (SPEC §4.2); the view lists what a declaration or an item was tagged with
+  because that is part of what was declared, and claims nothing about it. A
+  claiming pass that gives a tag meaning changes what a consumer does with
+  the listing, never the listing. **This is the line the open namespace buys
+  its safety with**: the view will report `ui_slider` and `asset_ref` and
+  `localized` exactly as written and will never act on one, so no tag can
+  ever become a fact a codec reads.
+- **No UI hints of its own.** Names, kinds, ids, bounds, extents, offsets,
+  presence companions and key vocabularies — the facts the declaration
+  states, and those alone. No widget column, no grouping column, no ordering
+  hint, no unit of measure. What a project wants there it writes as a tag and
+  reads back out of the `tags` column, which is the same answer one level
+  up: the language holds the channel and the project holds the meaning.
+- **No `| doc` attribute.** Documentation has one spelling, the doc comment
+  above the item (SPEC §4.1), and the view carries it in the `doc` column
+  (§8.1, §8.3). A valued `doc` key is refused by name (SPEC §4.11) so that
+  one text can never have two homes and a tool never has to decide which of
+  them won.
+- **No rendering of either.** `doc` is the block a person wrote, verbatim,
+  and `tags` are identifiers; the view does not reflow, wrap, escape, parse
+  or sort them, because every one of those would make the listing a function
+  of the walker rather than of the source.
 - **No per-field default VALUE.** A walker that fills a value establishes
   defaults through the descriptor's `reset` hook (§8.1) — one instance put
   back at its declared defaults, which is what a filler actually needs and
@@ -5864,6 +5979,37 @@ goes red for one reason: an arm whose `field` is NULL, or whose offset does
 not reach the value the compiler's own listing carries, prints a line the
 pin does not have.
 
+**DOC AND TAGS ARE IN THAT LISTING, on every row that has them** (§8.1,
+§8.3). The program prints each declaration's `doc` and its tags in declared
+order, each field's, and each variant's, bit's and arm's, and the compiler's
+listing carries the same text off the IR — so a target that drops a doc
+comment, reorders a tag list, reflows a block or fills `doc` with NULL where
+the pin has `""` prints a line the pin does not have. **The general arm's
+two records are checked against each other in the same pass**: an arm whose
+`field` descriptor and whose `ViewVariant` row disagree about either column
+is a red line, which is what makes "they agree by construction" a tested
+claim rather than a stated one.
+
+**ONE CORPUS DECLARATION SHOWS BOTH COLUMNS FILLED, and it is the golden
+this section is read against.** The `tabledemo` unit carries a declaration
+documented and tagged at every level the language admits — the declaration
+itself, a field, an enum variant, a union arm and a constant beside it — so
+the C++ reference's generated descriptors and its view listing exhibit `doc`
+and `tags` on a `TableFieldInfo`, a `TableTypeInfo`, a `ViewVariant`, a
+`ViewVocabulary`, a `ViewType` and a `ViewConstant`, with the rest of the
+corpus exhibiting the empty spelling beside it. The pinned source goldens
+carry that declaration's descriptor initializers verbatim, so both halves
+are held: what a filled column looks like, and that an undocumented,
+untagged unit still emits `""` and 0 and NULL rather than omitting the
+columns.
+
+**The COST claim is held too, and it is the one a game build cares about.**
+For a unit that documents and tags nothing, every `doc` in every descriptor
+is the SAME pointer — one shared empty string — and every `tags` is NULL, so
+the columns add three members per row to the descriptor tables and no string
+data at all to the binary. A backend that emits a distinct `""` per row, or
+an empty array per row, fails it.
+
 **A gate that cannot go red proves nothing.** Dropping one declaration, one
 property, one variant or one constant from an emitter's registry turns the
 corpus gate red, and that is established by doing it rather than assumed.
@@ -5874,6 +6020,16 @@ view adds a file and moves nothing else: every generated file other than
 view existed, and `schema id` reports the same protocol id. That is what
 proves reflection costs the type wire's generated code not one byte — §10's
 independence, claimed for a table edit, holding for a view.
+
+**Landing the doc and tags columns is the one edit that moves that gate's
+left-hand side, and it moves it once.** The columns sit on `TableFieldInfo`
+and `TableTypeInfo`, which live in the table headers (§8.5), so every
+descriptor initializer in the corpus gains three members and the source
+goldens are re-pinned in the same commit. What must NOT move with them is
+anything the wire touches — no protocol id, no build version, no wire
+golden, no baseline row — and that half stays red-capable afterwards, which
+is the half worth having: the columns are metadata, and a metadata edit that
+moved a wire byte would be the bug this page exists to make impossible.
 
 **Its left-hand side is the RECORDED SOURCE GOLDENS**, because with nothing
 selecting the view there is no second generate to compare against: "before

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -5319,14 +5319,17 @@ build never includes it. Nothing here rides a wire either: the view moves no
 protocol id, no generated wire byte and no baseline row (§10, §18).
 
 **This is also where what a PERSON wrote about a declaration comes out.** A
-doc comment (SPEC §4.1) and a tag (SPEC §4.2) are the language's two open
-channels — one prose, one an identifier in a namespace the compiler assigns
-no meaning — and they reach a tool through two descriptor columns, `doc` and
-`tags`, and through nothing else. They are id-neutral and byte-neutral in
-every direction the rest of this page measures, which is what lets the
-namespace stay open: annotating a shipped schema costs no redeploy, no
-re-cook and no baseline row. The columns are specified with the rest of the
-descriptors in §8.1 and appear on the registry's records in §8.3.
+`///` doc comment (SPEC §4.1) and a tag (SPEC §4.2) are the language's two
+open channels — one prose, one an identifier in a namespace the compiler
+assigns no meaning — and they reach a tool through two descriptor columns,
+`doc` and `tags`, and through nothing else. **Both are OPT-IN**: an ordinary
+`//` comment above a declaration reaches no column, so an unannotated unit's
+columns are empty and a build carries what its author asked it to carry.
+They are id-neutral and byte-neutral in every direction the rest of this
+page measures, which is what lets the namespace stay open: annotating a
+shipped schema costs no redeploy, no re-cook and no baseline row. The
+columns are specified with the rest of the descriptors in §8.1 and appear on
+the registry's records in §8.3.
 
 ### 8.1 The descriptors
 
@@ -5360,13 +5363,25 @@ text form spells keys without a second table.
 
 **A field carries its DOC COMMENT and its TAGS.** These are the two columns
 that carry what a PERSON wrote about a declaration rather than what the
-compiler derived from it: `doc` is the comment block above the field,
-verbatim as SPEC §4.1 defines it, and `num_tags` with `tags` are the
-valueless identifiers right of the field's pipe (SPEC §4.2), in declared
-order. The same three members sit on the TYPE descriptor, `TableTypeInfo`,
-beside a table's name and its `reset` hook, so a walker that entered a
-nested table through the `table` column reads that declaration's own doc and
-tags there, with no registry (§8.3) compiled and no second lookup.
+compiler derived from it: `doc` is the `///` block above the field, verbatim
+as SPEC §4.1 defines it, and `num_tags` with `tags` are the valueless
+identifiers right of the field's pipe (SPEC §4.2), in declared order. The
+same three members sit on the TYPE descriptor, `TableTypeInfo`, beside a
+table's name and its `reset` hook, so a walker that entered a nested table
+through the `table` column reads that declaration's own doc and tags there,
+with no registry (§8.3) compiled and no second lookup.
+
+**WHICH ANNOTATIONS A BUILD CAN REACH FOLLOWS THE PLACEMENT RULE, and it is
+worth stating beside the walk it constrains** (§8.4, §8.5). A FIELD's and a
+TYPE's doc and tags ride the table headers, so any build that links a table
+reaches them, view file or no view file — a GENERAL ARM's with them, since
+that arm's annotation is on the `field` descriptor a union field already
+carries (below). An enum VARIANT's, a flags BIT's and a record-naming ARM's
+ride the registry rows, so reaching those means compiling `<Package>View.*`.
+A tool wanting the whole annotation surface compiles the view file; a game
+that wanted an enum variant's doc at runtime and did not would find the
+column it needs is not in its binary, which is the same trade §8.4 makes
+everywhere and is stated here so a walker's author meets it once.
 
 **Absence has a spelling, and it is not NULL.** A declaration with no doc
 comment carries `doc` pointing at one shared static empty string; a
@@ -5384,7 +5399,24 @@ a walk that prints every doc and every tag in a unit allocates what a walk
 that prints none allocates, which is nothing. All nine targets carry the
 three members, each spelling them in its own immutable string and immutable
 ordered sequence; the COLUMNS are one vocabulary doing one job, as
-everywhere else in this section.
+everywhere else in this section. **The text is escaped by exactly one rule,
+the target's own string-literal escape** (SPEC §4.1), because a descriptor
+column is a string literal and nothing else in this page's surface parses
+what an author wrote.
+
+**WHAT A GAME BINARY PAYS, stated as a rule.** A field's and a type's doc
+text is a string literal in the TABLE HEADER's translation unit, so it ships
+in every build that links that unit — a game that loads tables carries its
+own schema's prose whether or not anything reads it, exactly as it already
+carries the field names beside it. §8.4's answer ("what a build pays is what
+it compiles") does not reach this one, because a game compiles the table
+headers by definition. **The opt-in marker is what bounds it, and that is
+why the marker exists** (SPEC §4.1): this repo's own corpus carries 166
+comment lines sitting directly above a declaration, a field, a variant or an
+arm, across 40 of its 47 files, working notes to the last one, and under an
+implicit binding rule every one of them would be in that binary and in nine
+languages' generated comments. Under `///` a build pays for the lines an
+author chose to publish and for no others.
 
 **A descriptor carries its OWN doc and tags and nobody else's.** A field
 descriptor's vocabulary columns name an enum's values or a union's arms
@@ -5689,7 +5721,7 @@ struct ViewConstant
     bool is_float;
     int64_t int_value;       // the folded value; float_value when is_float
     double float_value;
-    const char * doc;        // the doc comment above it, verbatim (SPEC §4.1);
+    const char * doc;        // the `///` block above it, verbatim (SPEC §4.1);
                              // "" when there is none, never NULL (§8.1)
     int32_t num_tags;             // the declaration's tags (SPEC §4.2), in
     const char * const * tags;    // DECLARED order; 0 and NULL when there are none
@@ -5716,7 +5748,7 @@ struct ViewVariant          // one enum variant, one flags bit, one union arm
                                     // storage. NULL on an arm naming a `type` or
                                     // a `table`, on a payload-free arm, on tag 0,
                                     // and on an enum or flags row
-    const char * doc;               // the doc comment above this variant, bit or
+    const char * doc;               // the `///` block above this variant, bit or
                                     // arm, verbatim; "" when there is none (§8.1)
     int32_t num_tags;               // this row's own tags, in DECLARED order;
     const char * const * tags;      // 0 and NULL when there are none. On a general
@@ -5732,7 +5764,7 @@ struct ViewVocabulary       // an enum, a flags or a union declaration
     int32_t storage_bits;
     int32_t num_variants;
     const ViewVariant * variants;
-    const char * doc;             // the declaration's own doc comment; "" when none
+    const char * doc;             // the declaration's own `///` block; "" when none
     int32_t num_tags;             // the declaration's own tags, in DECLARED order;
     const char * const * tags;    // 0 and NULL when there are none
 };
@@ -5744,7 +5776,7 @@ struct ViewType             // one declaration: a type, or a table
     bool table;                     // declared `table`
     const TableTypeInfo * type;     // §8.1's descriptor: the properties, and this
                                     // declaration's own doc and tags beside them
-    const char * doc;               // the doc comment above it; "" when none. The
+    const char * doc;               // the `///` block above it; "" when none. The
                                     // same text `type->doc` carries (§8.1)
     int32_t num_tags;               // the declaration's tags (SPEC §4.2), in
     const char * const * tags;      // DECLARED order; the same list `type` carries
@@ -5919,7 +5951,7 @@ per-schema-file name does not.
   hint, no unit of measure. What a project wants there it writes as a tag and
   reads back out of the `tags` column, which is the same answer one level
   up: the language holds the channel and the project holds the meaning.
-- **No `| doc` attribute.** Documentation has one spelling, the doc comment
+- **No `| doc` attribute.** Documentation has one spelling, the `///` block
   above the item (SPEC §4.1), and the view carries it in the `doc` column
   (§8.1, §8.3). A valued `doc` key is refused by name (SPEC §4.11) so that
   one text can never have two homes and a tool never has to decide which of
@@ -5983,32 +6015,76 @@ pin does not have.
 §8.3). The program prints each declaration's `doc` and its tags in declared
 order, each field's, and each variant's, bit's and arm's, and the compiler's
 listing carries the same text off the IR — so a target that drops a doc
-comment, reorders a tag list, reflows a block or fills `doc` with NULL where
-the pin has `""` prints a line the pin does not have. **The general arm's
-two records are checked against each other in the same pass**: an arm whose
-`field` descriptor and whose `ViewVariant` row disagree about either column
-is a red line, which is what makes "they agree by construction" a tested
-claim rather than a stated one.
+comment, reorders a tag list or reflows a block prints a line the pin does
+not have.
 
-**ONE CORPUS DECLARATION SHOWS BOTH COLUMNS FILLED, and it is the golden
-this section is read against.** The `tabledemo` unit carries a declaration
-documented and tagged at every level the language admits — the declaration
-itself, a field, an enum variant, a union arm and a constant beside it — so
-the C++ reference's generated descriptors and its view listing exhibit `doc`
-and `tags` on a `TableFieldInfo`, a `TableTypeInfo`, a `ViewVariant`, a
-`ViewVocabulary`, a `ViewType` and a `ViewConstant`, with the rest of the
-corpus exhibiting the empty spelling beside it. The pinned source goldens
-carry that declaration's descriptor initializers verbatim, so both halves
-are held: what a filled column looks like, and that an undocumented,
-untagged unit still emits `""` and 0 and NULL rather than omitting the
-columns.
+**A MULTI-LINE doc prints as ONE LINE**, each newline written `\n` and the
+escape's own backslash written `\\`. The listing is a line-oriented byte
+comparison, so a column whose text carries newlines has to be flattened
+before it is compared, and both halves flattening it by the same rule is
+what keeps the comparison a comparison rather than a formatting argument.
 
-**The COST claim is held too, and it is the one a game build cares about.**
-For a unit that documents and tags nothing, every `doc` in every descriptor
-is the SAME pointer — one shared empty string — and every `tags` is NULL, so
-the columns add three members per row to the descriptor tables and no string
-data at all to the binary. A backend that emits a distinct `""` per row, or
-an empty array per row, fails it.
+**THE TWO PLACES ONE DECLARATION'S ANNOTATION IS SPELLED TWICE ARE BOTH
+CHECKED HERE, and they are the only two** (§8.1). The general ARM pair: an
+arm whose `field` descriptor and whose `ViewVariant` row disagree about
+either column is a red line. The TYPE pair: every `ViewType`'s `doc` and
+`tags` must equal the `doc` and `tags` on the `TableTypeInfo` its `type`
+points at, string for string and entry for entry. "They agree by
+construction" is a claim a test makes, not one this page makes.
+
+**ONE CORPUS DECLARATION SHOWS BOTH COLUMNS FILLED, and it is the exhibit
+this section is read against.** The `tabledemo` unit carries an annotation
+at every level the language admits — a declaration, a field, an enum
+variant, a union arm, and a constant beside them — so the C++ reference's
+generated descriptors and its view listing exhibit `doc` and `tags` on a
+`TableFieldInfo`, a `TableTypeInfo`, a `ViewVariant`, a `ViewVocabulary`, a
+`ViewType` and a `ViewConstant`, with the rest of the corpus exhibiting the
+empty spelling beside it — which under opt-in (SPEC §4.1) is what the rest
+of the corpus exhibits without being edited at all.
+
+**The exhibit ANNOTATES EXISTING DECLARATIONS and adds none.** A doc comment
+and a tag move no id (§8.1), and a new declaration in `tabledemo` would move
+that unit's build version and every golden keyed to it — so the exhibit
+would be the one edit on this page that contradicted the page while
+demonstrating it. Annotating declarations already there keeps the protocol
+id, the build version and every wire golden exactly where they are, which is
+also the sharpest form of the independence claim below.
+
+**The exhibit's doc text carries the edge cases the extraction rule needs
+pinned** (SPEC §4.1), because a rule stated in prose and exercised only on
+`/// Hello` is a rule nothing holds: two leading spaces after the marker
+(one is dropped, one survives), a marker line with nothing after it (an
+empty line inside the text), trailing whitespace on a line (dropped), a
+double quote and a backslash (the target's own string-literal escape, and
+the one escaping rule there is). Its tags exercise the list: a declaration
+with one, an item with several in an order the listing must keep.
+
+**Its GOLDEN lands in the same commit as the columns.** `tabledemo` has no
+recorded source golden today — extending the source goldens to the two table
+corpora is the named follow-on §15 carries — so the commit that adds the
+columns records `tabledemo`'s first, and the exhibit is pinned from the
+moment it exists rather than described until the follow-on catches up. Until
+that commit there is no left-hand side for this gate and the section says so
+plainly instead of implying a pin that is not there.
+
+**The COST claims are held by observables, not by inspection.** Two of them,
+and each has a failure a test can see:
+
+- **`doc` IS NEVER NULL.** A printer walks every descriptor and every
+  registry record in the corpus and CONCATENATES every `doc` into one buffer
+  with no null test. A NULL column faults or throws there rather than
+  printing a line that happens to look right, so the rule has a red state;
+  the negative control is an emitter patched to write NULL for one absent
+  doc, and it must take the gate down.
+- **ABSENCE IS ONE SHARED EMPTY STRING.** Where the language has address
+  identity — C, C++, Rust — the gate asserts every absent `doc` in a unit
+  compares equal BY ADDRESS, one static for the whole unit. Where it does
+  not — C#, Go, Java, JS, Dart, Elixir — the observable is the emitted TEXT:
+  the generated file defines the empty doc ONCE and every absent row names
+  that definition, so the source golden shows one definition against many
+  references and an emitter that inlines an empty literal per row goes red.
+  `tags` takes the same shape one column over: absent is NULL, never a
+  per-row empty array.
 
 **A gate that cannot go red proves nothing.** Dropping one declaration, one
 property, one variant or one constant from an emitter's registry turns the
@@ -6022,14 +6098,29 @@ proves reflection costs the type wire's generated code not one byte — §10's
 independence, claimed for a table edit, holding for a view.
 
 **Landing the doc and tags columns is the one edit that moves that gate's
-left-hand side, and it moves it once.** The columns sit on `TableFieldInfo`
-and `TableTypeInfo`, which live in the table headers (§8.5), so every
-descriptor initializer in the corpus gains three members and the source
-goldens are re-pinned in the same commit. What must NOT move with them is
-anything the wire touches — no protocol id, no build version, no wire
-golden, no baseline row — and that half stays red-capable afterwards, which
-is the half worth having: the columns are metadata, and a metadata edit that
-moved a wire byte would be the bug this page exists to make impossible.
+left-hand side, and it moves it once. THREE things move, and naming all
+three is what makes the re-pin reviewable rather than a wave-through:**
+
+1. **Every descriptor initializer gains three members.** The columns sit on
+   `TableFieldInfo` and `TableTypeInfo`, which live in the table headers
+   (§8.5), so every row in every backend's generated text grows by `doc`,
+   `num_tags` and `tags`, filled with the empty spelling everywhere the
+   exhibit does not reach.
+2. **The generated DATA files gain doc idioms**, where the exhibit is
+   annotated: the line comments SPEC §4.1 emits above a declaration, a field
+   and a variant, in each target's own spelling. Nothing else in those files
+   moves, and no unannotated declaration gains a line.
+3. **The FORMATTER's output moves where a doc comment sits in a field run**,
+   because a `///` block no longer breaks an alignment group (SPEC §7.4
+   rule 2) — so a run that gains one keeps its columns instead of splitting
+   into one-field groups. Under opt-in that is the exhibit's file and nothing
+   else in the corpus.
+
+What must NOT move with any of the three is anything the wire touches — no
+protocol id, no build version, no wire golden, no baseline row — and that
+half stays red-capable afterwards, which is the half worth having: the
+columns are metadata, and a metadata edit that moved a wire byte would be
+the bug this page exists to make impossible.
 
 **Its left-hand side is the RECORDED SOURCE GOLDENS**, because with nothing
 selecting the view there is no second generate to compare against: "before
@@ -9943,8 +10034,8 @@ keep, so it belongs in `none` with its reason or the token belongs on the line.
 | an `if` GUARD added or removed | none | a load finds a field by its id whatever branch encloses it, with every counter zero (§4.1). The cost is on the next WRITE, which is §18's case and not a cook's |
 | the `json` key (§16.4) | none | a cook is produced from the WIRE file, whose hash is the tuple's other half (§7) |
 | a `const` declaration | none of its own | its value flows into a bound (layout) or a default or range (meaning) and is EVALUATED into that token |
-| a type tag | none | it claims meaning no generated byte depends on (SPEC.md §3.1) |
-| comments, whitespace, file names, file layout, declaration ORDER ACROSS records | none | none of it reaches the projection |
+| a TAG, on any line that takes one — a declaration, a field, a variant, an arm (SPEC.md §4.2) | none | it claims meaning no generated byte depends on (SPEC.md §3.1) |
+| comments, whitespace, file names, file layout, declaration ORDER ACROSS records | none | none of it reaches the projection, the `///` doc comment (SPEC.md §4.1) included — the compiler reads that one, and it still reaches a descriptor column and never a fact a byte depends on |
 | a `tables.baseline`, its history, a `--reason` | none | a record of what an edit may do, not a fact a byte depends on |
 
 **The closure is TRANSITIVE** — every table, `type`, `enum` and `union` the

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -129,6 +129,11 @@ the churn and introduce the dangerous direction: any wire-affecting fact the
 walk forgot becomes two incompatible builds shaking hands. The projection is
 TEXT: what the id depends on can be printed, read and diffed, and a fact
 missing from it is a review question rather than an implementation detail.
+**The compiler now reads one comment kind** — §4.1's `///` doc block — and
+the projection is exactly why that is safe: a source-text hash would have
+turned every edit to an author's prose into a coordinated redeploy, while a
+projection carries the facts the bytes depend on and a doc comment is not
+one of them (Excluded, below).
 
 **Included — each fact moves the wire:** the package; every type's field
 order; field NAMES; type kind, width and signedness; declared bounds; array
@@ -249,26 +254,55 @@ from this projection rather than carried in it.
 - **Encoding:** UTF-8 source; a UTF-8 BOM is rejected at parse. `//` line
   comments and `/* */` block comments (non-nesting). Comments are invisible
   to code generation and preserved by `schemafmt` — with the one exception
-  below, the DOC comment, which is the only comment the compiler reads.
-- **Doc comments bind upward, to the item below them.** A `//` comment block
-  whose last line immediately precedes a declaration, a field, an enum or
-  flags variant, or a union arm — no blank line between, and nothing but the
-  comment on each of its lines — is that item's DOC COMMENT. A `/* */` block
-  is never one, and neither is a comment that trails an item on the item's
-  own line (`health int16 // hp`), so the comment that terminates a
-  qualification section (§4.2) can never become one either. Above `package`,
-  above a `const( )`, `reserved( )` or `align` item, or above a closing
-  brace, a comment block stays an ordinary comment: those have no descriptor
-  row to carry one (SPEC-TABLES.md §8).
+  below, the `///` DOC comment, which is the only comment the compiler reads
+  and the only one an author opts into.
+- **Doc comments are OPT-IN, and the marker is `///`.** A DOC COMMENT is a
+  contiguous run of `///` lines, each carrying nothing but the comment, whose
+  last line immediately precedes a declaration, a field, an enum or flags
+  variant, or a union arm. **A `//` block above the same item stays an
+  ordinary comment and never reaches a descriptor**, and that is the whole
+  reason the marker exists: a schema tree is full of working notes written
+  directly above things — 166 such lines, above a declaration, a field, a
+  variant or an arm, in 40 of this repo's 47 corpus files — and under an
+  implicit rule every one of them would become a descriptor string, a comment
+  in nine generated languages, and read-only data in the binary of every game
+  that links the table headers (SPEC-TABLES.md §8.1). What a build carries is
+  what an author asked it to carry. The marker costs the language nothing:
+  `///` is a `//` line by ordinary lexing, so a reader that does not know the
+  rule sees a comment, and `schemafmt` and every editor already treat it as
+  one. A `/* */` block is never a doc comment in any spelling.
+- **Every `///` line is part of a doc comment or is REFUSED BY NAME**, and
+  that one rule closes every trap at once, because silently dropping an
+  author's opt-in is the outcome opt-in exists to prevent. Refused: a `///`
+  block above `package`, above a `const( )`, `reserved( )` or `align` item,
+  or above a closing brace, none of which has a descriptor row to carry one
+  (SPEC-TABLES.md §8) — "nothing here carries a doc comment; write `//`"; a
+  `///` block separated from its item by a blank line or by an ordinary `//`
+  line — "a doc comment touches the item it documents"; and a `///` that
+  TRAILS code on the item's own line, `health int16 /// hp` or one sitting
+  past a qualification section (§4.2) — "a doc comment stands on its own line
+  above the item". Each is a diagnostic naming the spelling that works, and
+  `//` is always that spelling.
 - **The doc TEXT is the block verbatim, with the marker removed.** Each line
-  contributes what follows its `//`, with at most one leading space dropped
+  contributes what follows its `///`, with at most one leading space dropped
   and trailing whitespace dropped; the lines join with a single newline and
   the text ends without one. Nothing else is interpreted — no markup, no
-  keywords, no reflow — so what the author wrote is what a tool prints. The
-  text rides the IR into the `doc` descriptor column (SPEC-TABLES.md §8.1,
-  §8.3) and is emitted in each target's own doc idiom: `//` in C++ and C,
-  `///` in Rust and Dart, `/// <summary>` in C#, a preceding-line `//` in Go,
-  `/** */` in JS and Java, and `@doc` / `@typedoc` in Elixir.
+  keywords, no reflow, no escape sequences — so what the author wrote is what
+  a tool prints, two leading spaces and an empty line in the middle included.
+  The text rides the IR into the `doc` descriptor column (SPEC-TABLES.md
+  §8.1, §8.3).
+- **There is ONE escaping rule, and it is the string literal's.** The text
+  reaches a descriptor column as a string literal, so each target escapes it
+  by its own language's rule and by nothing else — a quote, a backslash, and
+  the newline that joins the lines are what that rule covers. It reaches
+  GENERATED CODE as ordinary LINE comments above the declaration: `//` in
+  C++, C, C#, Go, JS and Java, `///` in Rust and Dart. A line comment ends
+  where the line does, so a `*/` or a `<` in an author's text needs no rule
+  at all — which is why no target emits `/** */` or a `/// <summary>`
+  element, and why a C# reader gets the text as comments rather than as XML
+  documentation. **Elixir carries the descriptor column alone for a field and
+  for a variant** — a struct field and an enum variant have no attribute to
+  hang a doc on — and emits `@moduledoc` / `@typedoc` for a declaration.
 - **A doc comment moves nothing.** It is excluded from the wire shape
   projection (§3.1) and from the cook projection (SPEC-TABLES.md §20.2), so
   it moves neither the protocol id nor the build version; it enters no
@@ -327,12 +361,19 @@ from this projection rather than carried in it.
   below, a trailing `NL` is satisfied by an actual newline or by the
   immediately following `}` — and **end-of-file synthesizes a terminator**,
   so a file without a trailing newline still parses. Within an enum or flags
-  body a variant is separated from the next by a COMMA or by a NEWLINE, and
-  newlines around commas stay ordinary whitespace (suppression after `,`), so
-  every comma list written to date parses exactly as it did. The newline
-  earns its place at one line kind: a variant carrying a qualification
-  section is terminated by the newline like every other pipe, so it is the
-  last variant on its line and no comma can follow it (§4.2).
+  body a variant is separated from the next by a COMMA or by a NEWLINE. The
+  newline earns its place at one line kind: a variant carrying a
+  qualification section is terminated by the newline like every other pipe,
+  so it is the last variant on its line and no comma can follow it (§4.2).
+  **Two lexer rules keep every comma list ever written parsing exactly as it
+  did.** A newline immediately AFTER a `,` is suppressed, as it always was;
+  and inside a variant list a newline immediately BEFORE a `,` is suppressed
+  too, so a list that puts its separators at the head of the line still sees
+  one separator rather than two. **A `}` on the same line as a QUALIFIED
+  variant is refused by name** — `{ Laser | beam }` draws "a qualified
+  variant ends its own line: write the list one variant per line" — because
+  the pipe claims the rest of the line and the brace would be arguing with
+  it. Both rules have a named negative control (§7.2).
 
 ### 4.2 Grammar
 
@@ -649,10 +690,13 @@ sequence    uint16
   spelling named. Scalar
   constraints like `min`/`max` apply per element.
 - **Valueless qualifiers** (a tag, §4.2) and valued keys sit side by
-  side in one flat list — `| vec3, cpp_native = VecMath` — valueless
-  markers first, then valued keys; there is no nested argument syntax. The
-  order is one rule at every line kind, so a field reads
-  `health int16 | ui_tuned, min = 0, max = MaxHealth` with the open
+  side in one flat list — `| vec3, cpp_native = VecMath` — valueless markers
+  first, then valued keys; there is no nested argument syntax. **That order
+  is a FORMATTER NORMALIZATION, not a refusal** (§7.4): the parser takes the
+  entries in any order and `schema fmt` writes them in this one, because a
+  qualification is a set and an ordering rule the compiler enforced would be
+  a diagnostic that teaches nothing. Canonical output reads
+  `health int16 | ui_tuned, min = 0, max = MaxHealth`, with the open
   namespace ahead of the closed one.
 - **The line between positional and attribute:** a *size* that defines the
   type's shape stays positional — `bits(64)`, `string(64)`, `wstring(64)`,
@@ -675,10 +719,18 @@ sequence    uint16
   VALUELESS half is open at every one of them** — that is the tag, below.
 - **A bare identifier that spells a known valued key is refused by name**,
   never taken as a tag: `| min` draws "min takes a value: write min = 0". The
-  open namespace must not be able to swallow a typo in the closed one, and
-  the check is one lookup against the same table the valued vocabulary
-  already is. **A repeated tag on one line is refused by name** too, and so
-  is a tag that repeats a valued key already on the line.
+  open namespace must not be able to swallow a typo in the closed one.
+  **The lookup is against the UNION of every valued key the language has, on
+  every line kind** — `min`, `max`, `resolution`, `was`, `json`,
+  `cpp_native`, `cpp_include` — **plus the keys refused by name**
+  (`doc`, `round`; §4.11). It is deliberately not the line's own vocabulary:
+  `| min` on a `string(N)` field, where `min` was never legal, is the exact
+  case a per-line check would wave through as a tag, and one union table
+  spares a reader the question of which line kind forgives which typo.
+  **Reserved words are not identifiers here** (§4.1) and are refused with the
+  word named, so `| table` draws "table is a reserved word" rather than
+  becoming a tag. **A repeated tag on one line is refused by name** too, and
+  so is a tag that repeats a valued key already on the line.
 - **`was = "old_name"` — the rename attribute, table bodies only**
   (SPEC-TABLES.md §5). A table field's wire id is the hash of its name, so a
   bare rename would orphan every byte ever written under the old one; `was`
@@ -740,7 +792,7 @@ type Quat | quat4
 
   table ShipConfig | designer_facing
   {
-      // The hull's structural health. A hull at zero is destroyed.
+      /// The hull's structural health. A hull at zero is destroyed.
       health   float32 = 100.0 | ui_slider, min = 0.0, max = 1000.0
       texture  uint64          | asset_ref
       nickname string(32)      | localized
@@ -1444,8 +1496,8 @@ NAME rather than falling into a generic parse error:
 - **`round`** (the attribute) — rounding is not an attribute: it is the one
   fixed-point rule, half away from zero, everywhere (§4.3).
 - **`doc`** (the attribute) — documentation is not an attribute: it is the
-  doc comment above the item (§4.1), and one text has one spelling. `| doc =
-  "..."` is refused with the comment form named.
+  `///` doc comment above the item (§4.1), and one text has one spelling.
+  `| doc = "..."` is refused with the comment form named.
 
 The projection (§3.1) keeps FROZEN tokens — `table=false message=false` on
 every type line, `round=nearest` on every compressed-float field line — so
@@ -2186,7 +2238,20 @@ The conformance program is seven gates. `make test` runs all of it;
    every diagnostic in the suite asserted by exact message and position. The
    diagnostics suite covers generated-name collisions: companion length/count
    names, the dispatch surface, and the per-declaration generated symbols are
-   claimed names the checker refuses (§4.6).
+   claimed names the checker refuses (§4.6). **Each refusal the annotation
+   rules add carries its accepting twin**, so no case can go green by the
+   checker forgetting it: a `///` block above `package`, above a `const( )`,
+   `reserved( )` or `align` item, and above a closing brace; a `///` block
+   held off its item by a blank line and by a `//` line; and a `///`
+   trailing code on an item's own line — each beside the same text written
+   `//` and accepted as an ordinary comment (§4.1); a `}`
+   on the same line as a qualified variant, beside the two-line spelling
+   accepted; a bare `min` on a `string(N)` field, beside `min = 0` on a
+   ranged integer accepted (§4.2); a reserved word written as a tag; a
+   repeated tag; and a tag repeating a valued key already on the line. **The
+   two variant-list LEXER rules are held here too**: a list whose commas lead
+   their lines parses as one separator per variant rather than two, and a
+   mixed comma-and-newline list parses and re-emits under §7.4's rule 5.
 7. **Golden wire bytes**: per conformance schema, fixed instances with
    checked-in expected wire bytes, every target. This is the one artifact
    that survives a coordinated emitter-plus-oracle change, and a golden-wire
@@ -2227,15 +2292,16 @@ schema file. Rules:
    lines and by comment lines — pad names to align the type column, and pad
    past the longest DEFINITION (the type plus any `= default`) to align the
    `|` qualification column. The same rule aligns `=` in const runs. Single
-   space minimum between columns. **A DOC comment does not break the group**
-   (§4.1): it belongs to the field under it rather than standing between two
+   space minimum between columns. **A `///` DOC comment does not break the
+   group** (§4.1): it belongs to the field under it rather than standing between two
    fields, and a run whose every field is documented would otherwise become a
    run of one-field groups and lose the column the rule exists to produce.
    Any other comment line breaks the group as before.
 3. **Qualifications**: `| min = 0, max = MaxHealth` — a space each side of
    `|`, spaces around `=`, comma-space between entries. Valueless markers
-   first, then valued keys. A trailing `//` comment survives after the
-   section.
+   first, then valued keys — the PARSER accepts any order and this rule is
+   where the one order comes from (§4.2). A trailing `//` comment survives
+   after the section.
 3b. **Migration is a one-shot mode, not the formatter's default**:
    `schema fmt -migrate` additionally accepts the two RETIRED spellings —
    the trailing `[ ... ]` attribute block (with its default after the
@@ -2256,7 +2322,12 @@ schema file. Rules:
    the newline (§4.1), and the `|` column is aligned across the list by rule
    2. That is the one form in which the comma and the pipe would compete for
    the end of a line, and the formatter answers it the same way at every
-   list rather than mixing the two spellings inside one.
+   list rather than mixing the two spellings inside one. **A MIXED list — a
+   comma after one variant and a newline after the next — is accepted by the
+   parser and normalized here**, to this rule when any variant is qualified
+   or documented and to the comma form otherwise. Two separators is what
+   admitting the newline cost, and the formatter is where that cost is paid
+   rather than in a diagnostic.
 6. **switch/case** (reserved for `switch`'s return): `case` at the same
    indent as its `switch`; a single-item case body inline after the label,
    bodies column-aligned across the cases of one switch; multi-item bodies on
@@ -2329,11 +2400,12 @@ Every row to date is settled, deferred with its design banked, or discarded.
    which is replicant's and serialize.pro's.
 4. ~~`schemafmt` timing~~ — settled: built early, as the parser's first
    consumer; rules in §7.4.
-5. ~~Doc comments~~ — settled: §4.1. A `//` block binds to the declaration,
-   field, variant or arm below it, rides the IR verbatim into the `doc`
-   descriptor column (SPEC-TABLES.md §8) and each target's own doc idiom, and
-   moves no id. `| doc = "..."` is refused by name (§4.11) — one text, one
-   spelling.
+5. ~~Doc comments~~ — settled: §4.1, and OPT-IN. A `///` block binds to the
+   declaration, field, variant or arm below it and rides the IR verbatim into
+   the `doc` descriptor column (SPEC-TABLES.md §8) and into line comments in
+   the generated code; a plain `//` block above the same item stays an
+   ordinary comment and reaches nothing. No id moves either way.
+   `| doc = "..."` is refused by name (§4.11) — one text, one spelling.
 6. ~~A root/packet marker~~ — discarded.
 7. ~~Const expressions over enum counts~~ — settled: `E.Max` (§4.2);
    `const NumTeams = Team.Max`. `len(Team)` was declined: it has three

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -164,10 +164,14 @@ order is spelled in names and nothing else. That is the price and it is free:
 both sides of a connection redeploy together, so the rename buys the redeploy
 that was already happening.
 
-**Excluded — each has no effect on the bytes:** comments and whitespace; file
-names, file layout and declaration order; `const`
-declarations (their values are already resolved into the bounds above); type
-tags and native-type attributes.
+**Excluded — each has no effect on the bytes:** comments and whitespace, DOC
+comments among them (§4.1); file names, file layout and declaration order;
+`const` declarations (their values are already resolved into the bounds
+above); TAGS, wherever they are written — on a declaration, a field, a
+variant or an arm (§4.2) — and native-type attributes. The two exclusions
+that carry a promise are the last: a doc comment and a tag are metadata a
+tool reads, never a fact a codec reads, so annotating a shipped schema costs
+no redeploy and is safe to do at any time.
 
 **A union with a `table` arm is excluded WHOLE**, as the table itself is. A
 table has no packet wire, so an arm that names one has no packet encoding to
@@ -243,13 +247,34 @@ from this projection rather than carried in it.
 ### 4.1 Lexical structure
 
 - **Encoding:** UTF-8 source; a UTF-8 BOM is rejected at parse. `//` line
-  comments and `/* */` block comments (non-nesting). Comments are invisible to
-  code generation and preserved by `schemafmt`.
-- **Doc comments are deferred**, with the design pinned for when they land: a
-  `//` comment block whose last line immediately precedes a declaration,
-  field, or enum variant — no blank line between — becomes that item's doc
-  comment, carried through the IR and emitted in each target's own idiom
-  (`///` Rust, `/// <summary>` C#, preceding-line `//` Go, `//` C++).
+  comments and `/* */` block comments (non-nesting). Comments are invisible
+  to code generation and preserved by `schemafmt` — with the one exception
+  below, the DOC comment, which is the only comment the compiler reads.
+- **Doc comments bind upward, to the item below them.** A `//` comment block
+  whose last line immediately precedes a declaration, a field, an enum or
+  flags variant, or a union arm — no blank line between, and nothing but the
+  comment on each of its lines — is that item's DOC COMMENT. A `/* */` block
+  is never one, and neither is a comment that trails an item on the item's
+  own line (`health int16 // hp`), so the comment that terminates a
+  qualification section (§4.2) can never become one either. Above `package`,
+  above a `const( )`, `reserved( )` or `align` item, or above a closing
+  brace, a comment block stays an ordinary comment: those have no descriptor
+  row to carry one (SPEC-TABLES.md §8).
+- **The doc TEXT is the block verbatim, with the marker removed.** Each line
+  contributes what follows its `//`, with at most one leading space dropped
+  and trailing whitespace dropped; the lines join with a single newline and
+  the text ends without one. Nothing else is interpreted — no markup, no
+  keywords, no reflow — so what the author wrote is what a tool prints. The
+  text rides the IR into the `doc` descriptor column (SPEC-TABLES.md §8.1,
+  §8.3) and is emitted in each target's own doc idiom: `//` in C++ and C,
+  `///` in Rust and Dart, `/// <summary>` in C#, a preceding-line `//` in Go,
+  `/** */` in JS and Java, and `@doc` / `@typedoc` in Elixir.
+- **A doc comment moves nothing.** It is excluded from the wire shape
+  projection (§3.1) and from the cook projection (SPEC-TABLES.md §20.2), so
+  it moves neither the protocol id nor the build version; it enters no
+  baseline row (SPEC-TABLES.md §18); and it is not a member of the silent
+  class (SPEC-TABLES.md §4.1), because a comment cannot change what a stored
+  byte means.
 - **Identifiers:** `[A-Za-z_][A-Za-z0-9_]*`. Conventions: type and enum names
   `UpperCamelCase`, enum variants `UpperCamelCase`, fields
   `lower_snake_case`, constants `UpperCamelCase`. The compiler does not
@@ -302,8 +327,12 @@ from this projection rather than carried in it.
   below, a trailing `NL` is satisfied by an actual newline or by the
   immediately following `}` — and **end-of-file synthesizes a terminator**,
   so a file without a trailing newline still parses. Within an enum or flags
-  body, newlines around commas are ordinary whitespace (suppression after
-  `,`) — variants are not items and need no terminator.
+  body a variant is separated from the next by a COMMA or by a NEWLINE, and
+  newlines around commas stay ordinary whitespace (suppression after `,`), so
+  every comma list written to date parses exactly as it did. The newline
+  earns its place at one line kind: a variant carrying a qualification
+  section is terminated by the newline like every other pipe, so it is the
+  last variant on its line and no comma can follow it (§4.2).
 
 ### 4.2 Grammar
 
@@ -319,36 +348,46 @@ Flags       = "flags" ident ( VariantList
             | AttrSection NL VariantList ) NL .                // "flags" contextual, §4.2;
                                                                    // a qualified declaration's
                                                                    // body opens on the NEXT line
-Union       = "union" ident UnionBlock NL .                        // "union" contextual, §4.8
+Union       = "union" ident ( UnionBlock
+            | AttrSection NL UnionBlock ) NL .                     // "union" contextual, §4.8;
+                                                                   // the qualification carries TAGS
+                                                                   // and nothing else (§4.2)
 UnionBlock  = "{" { UnionVariant } "}" .
-UnionVariant = ident [ ArmType [ AttrSection ] ] NL .              // AN ARM IS A FIELD LINE (§4.8):
+UnionVariant = ident [ ArmType ] [ AttrSection ] NL .              // AN ARM IS A FIELD LINE (§4.8):
                                                                    // the arm's name, any field type,
                                                                    // and the value-shaping attributes
                                                                    // that type takes. A BARE NAME is an
-                                                                   // arm with NO PAYLOAD. No "= Default",
-                                                                   // no "?", no was/json: each is
-                                                                   // refused at the arm (§4.8,
-                                                                   // SPEC-TABLES.md §2.6)
+                                                                   // arm with NO PAYLOAD, and it takes a
+                                                                   // qualification of its own — tags
+                                                                   // only, since it shapes no value.
+                                                                   // No "= Default", no "?", no
+                                                                   // was/json: each is refused at the
+                                                                   // arm (§4.8, SPEC-TABLES.md §2.6)
 ArmType     = [ "[" Bound "]" ] Scalar .                           // the field Type without its "?".
                                                                    // An arm that names neither a
                                                                    // declared `type` nor nothing at all
                                                                    // is legal inside a table closure
                                                                    // only (SPEC-TABLES.md §2.6)
 Package     = "package" ident NL .
-Const       = "const" ident [ ConstType ] "=" ConstExpr NL .
+Const       = "const" ident [ ConstType ] "=" ConstExpr [ AttrSection ] NL .
 ConstType   = IntType | "float32" | "float64" .
 ConstExpr   = IntExpr | FloatExpr .
 Enum        = "enum" ident ( VariantList
             | AttrSection NL VariantList ) NL .
-VariantList = "{" [ ident { "," ident } [ "," ] ] "}" .            // commas; trailing comma OK
+VariantList = "{" [ Variant { VariantSep Variant } [ VariantSep ] ] "}" .
+Variant     = ident [ AttrSection ] .                              // the qualification carries TAGS
+                                                                   // and nothing else (§4.2)
+VariantSep  = "," | NL .                                           // a comma, or the newline that
+                                                                   // ends a qualified variant's line;
+                                                                   // a trailing separator is OK
 TypeDecl    = "type" ident ( Block
             | AttrSection NL Block ) NL .               // qualifiers = the type TAG and the
                                                         // cpp_* pair, §4.2
 TableDecl   = "table" ident ( Block
             | AttrSection NL Block ) NL .               // the TABLE wire, SPEC-TABLES.md —
                                                         // a type body, plus pointers and `was`.
-                                                        // A table declaration takes no
-                                                        // qualifier of its own (§4.2)
+                                                        // A table declaration's qualification
+                                                        // carries TAGS and nothing else (§4.2)
 
 Block       = "{" { Item } "}" .
 Item        = Field | ConstField | Reserved | Align | If .
@@ -409,7 +448,9 @@ AttrSection = "|" Attr { "," Attr } .                            // runs to END 
                                                                  // nothing follows a qualification
 Attr        = ident "=" ( ConstExpr | ident | string )           // valued:    min = 0, max = 100,
                                                                  //            cpp_include = "a.h"
-            | ident .                                            // valueless: a type tag (§4.2)
+            | ident .                                            // valueless: a TAG (§4.2) — legal
+                                                                 // in every qualification section,
+                                                                 // in an open namespace
                                                                  // (ident values are keyword-like:
                                                                  // each valued key declares whether
                                                                  // it takes an expression, a word,
@@ -565,19 +606,22 @@ sequence    uint16
   in `foo uint8 // c | min = 0` the `|` is comment text and the field carries
   no qualification.) A `|` with no qualifier before the terminator is a
   parse error ("empty qualification section — write the qualifiers after |
-  or drop it"), and `|` on a line that admits no qualification — a
-  constant or a `union` declaration — is
-  refused with the reason named (`|` is never an operator; the language has
-  no bitwise-or). It cannot wrap: the pipe claims the rest of the line and
-  nothing else can follow it. That **no-exit property is a guarantee**, not
-  an accident — nothing can be appended past the qualifiers, so the
+  or drop it"). **Every declaration line and every declared item admits the
+  section**, because a TAG (below) is legal on all of them: a constant and a
+  `union` declaration take one where they once refused one, and no line kind
+  has to be remembered as the exception. What differs per line is the VALUED
+  vocabulary, which stays closed and per-line exactly as it is. `|` is never
+  an operator; the language has no bitwise-or. It cannot wrap: the pipe
+  claims the rest of the line and nothing else can follow it. That
+  **no-exit property is a guarantee**, not an accident — nothing can be
+  appended past the qualifiers, so the
   definition/qualification partition cannot erode; and the zone right of
   the pipe is deliberately reserved room ("we can get much more creative in
   future after `|` ... if we need to" — the design's stated headroom).
 - **The specified default sits BEFORE the pipe** — `= 1.0` defines what a
   fresh value holds, so it belongs to the definition, not the
   qualification: `w fixed(2, 30) = 1.0 | min = -1, max = 1`.
-- **Declaration lines take the same section**: a type tag or native-type
+- **Declaration lines take the same section**: a tag or a native-type
   binding, an enum's or flags' `max` headroom —
   `type Quat | quat4`, `enum Weapon | max = 15`, `flags Damage | max = 8` —
   and the body brace opens on the next line — with a qualification section
@@ -604,9 +648,12 @@ sequence    uint16
   RETIRED trailing attribute block; the parser refuses it with the `|`
   spelling named. Scalar
   constraints like `min`/`max` apply per element.
-- **Valueless qualifiers** (a type tag, §4.2) and valued keys sit side by
+- **Valueless qualifiers** (a tag, §4.2) and valued keys sit side by
   side in one flat list — `| vec3, cpp_native = VecMath` — valueless
-  markers first, then valued keys; there is no nested argument syntax.
+  markers first, then valued keys; there is no nested argument syntax. The
+  order is one rule at every line kind, so a field reads
+  `health int16 | ui_tuned, min = 0, max = MaxHealth` with the open
+  namespace ahead of the closed one.
 - **The line between positional and attribute:** a *size* that defines the
   type's shape stays positional — `bits(64)`, `string(64)`, `wstring(64)`,
   `bytes(N)`, `fixed(I, F)`, array bounds. A *constraint or refinement* of a
@@ -615,14 +662,23 @@ sequence    uint16
   owns its spelling, and familiarity to other languages' readers is not a
   design constraint where clarity is better served ("let's be bold and do
   our own shit! It's a DSL anyway").
-- **The vocabulary is typed and closed per compiler version — an unknown
-  attribute is a compile error**, never a silently ignored string. The
-  vocabulary: integers take `min`/`max` (both together or neither); `float32`
-  takes `min`/`max`/`resolution` (all three together — §4.3: this IS the
-  compressed float); `fixed`/`ufixed`/`int128` take `min`/`max` (required —
-  §4.3); enum declarations take `max`; type declarations take a tag and the
-  `cpp_native`/`cpp_include` pair (below); a field of a **table** body takes
-  `was` (below); and a **table declaration** takes none.
+- **The VALUED vocabulary is typed and closed per compiler version — an
+  unknown valued key is a compile error**, never a silently ignored string.
+  The vocabulary: integers take `min`/`max` (both together or neither);
+  `float32` takes `min`/`max`/`resolution` (all three together — §4.3: this
+  IS the compressed float); `fixed`/`ufixed`/`int128` take `min`/`max`
+  (required — §4.3); enum and flags declarations take `max`; type
+  declarations take the `cpp_native`/`cpp_include` pair (below); a field of a
+  **table** body takes `was` (below) and `json` (SPEC-TABLES.md §16.4); and a
+  **table** declaration, a **union** declaration, a **constant**, an enum or
+  flags **variant** and a union **arm** take no valued key at all. **The
+  VALUELESS half is open at every one of them** — that is the tag, below.
+- **A bare identifier that spells a known valued key is refused by name**,
+  never taken as a tag: `| min` draws "min takes a value: write min = 0". The
+  open namespace must not be able to swallow a typo in the closed one, and
+  the check is one lookup against the same table the valued vocabulary
+  already is. **A repeated tag on one line is refused by name** too, and so
+  is a tag that repeats a valued key already on the line.
 - **`was = "old_name"` — the rename attribute, table bodies only**
   (SPEC-TABLES.md §5). A table field's wire id is the hash of its name, so a
   bare rename would orphan every byte ever written under the old one; `was`
@@ -633,7 +689,7 @@ sequence    uint16
   edit — field NAMES ride in the projection (§3.1), so renaming a `type`
   field moves the protocol id and both sides redeploy together.
 
-### Type tags — types are the user's; meaning is claimed later
+### Tags — the vocabulary is the user's; meaning is claimed later
 
 **The language pre-defines no composite types** — no built-in vec3, no
 built-in quat, no privileged class list. A user declares a type and may
@@ -659,18 +715,59 @@ type Quat | quat4
 - **The type is entirely the user's** — name, body, component precision. The
   body alone defines storage and wire, like any type; a declared type
   composes anywhere in the unit, order-free.
-- **The tag is one user-chosen identifier, in its own namespace** — any
-  identifier is legal there, unlike field-attribute keys, which stay closed
-  and checked. **In v1 a tag is inert**: parsed, carried through the IR,
-  emitted as an annotation on the generated type, and it changes zero
-  generated code.
+- **A tag is one user-chosen identifier, in its own namespace** — any
+  identifier is legal there, unlike valued attribute keys, which stay closed
+  and checked (a bare identifier spelling one of those keys is refused rather
+  than taken as a tag, above). **A tag is inert**: parsed, carried through
+  the IR, carried into the descriptors (SPEC-TABLES.md §8.1, §8.3), and it
+  changes zero generated wire code.
+- **Every declaration and every declared item may carry tags** — a `type`, a
+  `table`, an `enum`, a `flags`, a `union`, a `const`, a field, an enum or
+  flags variant, and a union arm — because the metadata a game wants to hang
+  on its data is field-level and item-level far more often than it is
+  type-level, and one rule at every line kind is the whole of the mechanism:
+
+  ```
+  const StarterGold = 500 | tuning
+
+  enum Rarity | loot
+  {
+      Common
+      Uncommon
+      Rare      | celebrate
+      Legendary | celebrate
+  }
+
+  table ShipConfig | designer_facing
+  {
+      // The hull's structural health. A hull at zero is destroyed.
+      health   float32 = 100.0 | ui_slider, min = 0.0, max = 1000.0
+      texture  uint64          | asset_ref
+      nickname string(32)      | localized
+  }
+  ```
+
+- **Tags are ID-NEUTRAL and they change no byte.** They are excluded from the
+  wire shape projection (§3.1) and from the cook projection
+  (SPEC-TABLES.md §20.2), so adding, removing or renaming one moves neither
+  the protocol id nor the build version; they enter no baseline row
+  (SPEC-TABLES.md §18); and they are not in the silent class
+  (SPEC-TABLES.md §4.1), because nothing about a stored byte's meaning is in
+  reach of them. Tagging an existing schema is therefore a free edit, and
+  that is what makes the namespace safe to leave open.
 - **Meaning arrives by claiming.** A future pass — the delta pass first —
   claims a tag and assigns its semantics and generated actions
   (interpolation, prediction, normalization, render mapping). Claiming is an
-  ordinary compiler-version event, and the protocol id never moves for it:
-  tags are excluded from the wire shape projection (§3.1). The claiming pass
-  defines its own shape validation for claimed tags (e.g. `| quat4` requiring
-  four float components) and its own policy toward unclaimed strangers.
+  ordinary compiler-version event, and the protocol id never moves for it.
+  The claiming pass defines its own shape validation for claimed tags (e.g.
+  `| quat4` requiring four float components) and its own policy toward
+  unclaimed strangers. Until a pass claims a tag the compiler does not ask
+  what it means, and a tool that reads the tag out of a descriptor is the
+  claiming pass a project writes for itself.
+- **Declared order is kept**, at every line kind: a tool that lists a
+  declaration's tags lists them as they were written, so a listing is a
+  function of the source and the corpus gate (SPEC-TABLES.md §8.7) has one
+  answer to compare against.
 - The architecture: types on one side; a layer that defines the needed
   actions for those types on the other. v1 ships the types; each schema
   declares its own, and each application's actions bind to them by claiming.
@@ -1128,10 +1225,12 @@ union Value
   `UnionVariant` carries neither. A row is a variant name (field-style
   lower_snake, unique within the union), then the arm's type, then the
   value-shaping attributes that type takes: `| min`, `| max`, a compressed
-  float's range and resolution. **A row that is a BARE NAME is an arm with
-  no payload** (below). **What a row may not take is SPEC-TABLES.md §2.6's
-  list**, each refused by name. A union FIELD likewise takes no
-  attributes and no `= default` (it zero-initializes to None, joining
+  float's range and resolution — plus TAGS, which every declared item takes
+  (§4.2), including a bare-name arm, whose qualification section can hold
+  nothing else. **A row that is a BARE NAME is an arm with no payload**
+  (below). **What a row may not take is SPEC-TABLES.md §2.6's list**, each
+  refused by name. A union FIELD likewise takes no valued
+  attribute and no `= default` (it zero-initializes to None, joining
   arrays, strings, wide strings, bytes and composites in §4.2's no-override
   list).
 - **An arm is any field type, or none.** A variant's payload is what a
@@ -1344,6 +1443,9 @@ NAME rather than falling into a generic parse error:
   of the language; every field of a type is identical on every peer.
 - **`round`** (the attribute) — rounding is not an attribute: it is the one
   fixed-point rule, half away from zero, everywhere (§4.3).
+- **`doc`** (the attribute) — documentation is not an attribute: it is the
+  doc comment above the item (§4.1), and one text has one spelling. `| doc =
+  "..."` is refused with the comment form named.
 
 The projection (§3.1) keeps FROZEN tokens — `table=false message=false` on
 every type line, `round=nearest` on every compressed-float field line — so
@@ -2125,7 +2227,11 @@ schema file. Rules:
    lines and by comment lines — pad names to align the type column, and pad
    past the longest DEFINITION (the type plus any `= default`) to align the
    `|` qualification column. The same rule aligns `=` in const runs. Single
-   space minimum between columns.
+   space minimum between columns. **A DOC comment does not break the group**
+   (§4.1): it belongs to the field under it rather than standing between two
+   fields, and a run whose every field is documented would otherwise become a
+   run of one-field groups and lose the column the rule exists to produce.
+   Any other comment line breaks the group as before.
 3. **Qualifications**: `| min = 0, max = MaxHealth` — a space each side of
    `|`, spaces around `=`, comma-space between entries. Valueless markers
    first, then valued keys. A trailing `//` comment survives after the
@@ -2145,7 +2251,12 @@ schema file. Rules:
 5. **Enums**: the variant list is one line while it fits (a qualified enum
    is two lines by grammar — the list is the measured unit); the wrap
    trigger is decided at the first multi-line instance (no line-length
-   limit exists).
+   limit exists). **A list in which any variant carries a qualification or a
+   doc comment is one variant per line with NO commas**, the separator being
+   the newline (§4.1), and the `|` column is aligned across the list by rule
+   2. That is the one form in which the comma and the pipe would compete for
+   the end of a line, and the formatter answers it the same way at every
+   list rather than mixing the two spellings inside one.
 6. **switch/case** (reserved for `switch`'s return): `case` at the same
    indent as its `switch`; a single-item case body inline after the label,
    bodies column-aligned across the cases of one switch; multi-item bodies on
@@ -2218,7 +2329,11 @@ Every row to date is settled, deferred with its design banked, or discarded.
    which is replicant's and serialize.pro's.
 4. ~~`schemafmt` timing~~ — settled: built early, as the parser's first
    consumer; rules in §7.4.
-5. ~~Doc comments~~ — deferred; the design is kept at §4.1.
+5. ~~Doc comments~~ — settled: §4.1. A `//` block binds to the declaration,
+   field, variant or arm below it, rides the IR verbatim into the `doc`
+   descriptor column (SPEC-TABLES.md §8) and each target's own doc idiom, and
+   moves no id. `| doc = "..."` is refused by name (§4.11) — one text, one
+   spelling.
 6. ~~A root/packet marker~~ — discarded.
 7. ~~Const expressions over enum counts~~ — settled: `E.Max` (§4.2);
    `const NumTeams = Team.Max`. `len(Team)` was declined: it has three


### PR DESCRIPTION
Ruling 4 on #523: `doc` and `tags` columns on the descriptors and the view, and
field-level valueless tags in the type-tag grammar. Specification only, no code.

**Second commit: the cold read's named changes, and the owner ruling in it.**
Doc comments are **opt-in**. The marker is `///`; a plain `//` block above a
declaration stays an ordinary comment and reaches no descriptor. The reason is
measured on this repo: 166 comment lines sit directly above a declaration, a
field, a variant or an arm across 40 of its 47 corpus files, working notes to
the last one, and under implicit binding every one would have become a
descriptor string, a comment in nine generated languages, and read-only data in
the binary of every game that links the table headers. Under opt-in the corpus
exhibits the empty spelling everywhere except the one exhibit, and what a build
carries is what an author asked it to carry.

What else landed in that commit:

- **One rule closes every trap**: every `///` line is part of a doc comment or
  is refused by name. A block above `package` or a `const( )` / `reserved( )` /
  `align` item; a block held off its item by a blank line or a `//` line; a
  `///` trailing code on the item's own line. Each is a diagnostic naming `//`,
  because silently dropping an author's opt-in is what opt-in exists to prevent.
- **One escaping rule**, the target's own string-literal escape. Generated code
  takes ordinary LINE comments in every target, never `/** */` and never
  `/// <summary>`, so a `*/` or a `<` in an author's text needs no rule at all.
  Elixir carries the descriptor column alone for a field and a variant.
- **The bare-key lookup is against the union of every valued key on every line
  kind** (`min`, `max`, `resolution`, `was`, `json`, `cpp_native`,
  `cpp_include`) plus the refused-by-name keys (`doc`, `round`), so `| min` on a
  `string(N)` is refused rather than accepted as a tag. Reserved words are
  refused with the word named.
- **Valueless-first ordering is a formatter normalization, not a refusal**, and
  a mixed comma-and-newline variant list is accepted and normalized. Two lexer
  rules are stated (a newline before a comma inside a variant list is
  whitespace) and one refusal added (a `}` on the same line as a qualified
  variant), each with a named negative control in 7.2.
- **8.7's two unreddable cost claims are replaced by observables.** `doc` is
  never NULL is held by a printer that concatenates every row's `doc` with no
  null test, which faults on a NULL. The shared empty string is held by address
  identity in C, C++ and Rust and by one emitted definition against many
  references everywhere else.
- **The exhibit is pinned down.** It annotates EXISTING `tabledemo`
  declarations and adds none, since a new declaration would move that unit's
  build version while the page claims no id moves. `tabledemo` has no recorded
  source golden today (section 15's follow-on), so the commit that adds the
  columns records one. The exhibit's doc text carries the extraction rule's edge
  cases: two leading spaces, an empty marker line, trailing whitespace, a quote,
  a backslash.
- **The independence gate names all three things that move once**: descriptor
  initializers, generated data files gaining doc idioms, formatter output where
  a doc comment no longer breaks an alignment group.
- **Also**: the listing flattens a multi-line doc with `\n` escaped;
  `ViewType.doc` is gated against `type->doc` beside the arm pair; section 8.1
  states which annotations a build can reach without the view file; section
  20.1's "a type tag" row becomes a tag on any line and its comments row names
  the `///` doc comment; section 3.1 says in one sentence why the compiler
  reading a comment is safe under a projection.

Nothing here touches a wire. A doc comment and a tag are excluded from the wire
shape projection and from the cook projection, enter no baseline row, and are
not members of the silent class, so annotating a shipped schema moves no
protocol id, no build version, no wire golden and no stored byte's meaning.
That is the property the open tag namespace rests on, and it is stated in every
place a reader will look for it.

**Draft until #507 merges.** `git merge-tree --write-tree pr507 spec-doc-and-tags`
returns a tree and no conflict, so the two land in either order. This branch
edits SPEC-TABLES.md section 8 only, which #507 does not touch.

## What lands

**SPEC.md**

- **4.1, doc comments.** Opt-in, marker `///` (see above). The text rule is
  exact: each line contributes what follows its `///` with at most one leading
  space dropped, trailing whitespace dropped, lines joined by one newline, no
  trailing newline, nothing interpreted. It rides the IR into the `doc` column
  and into line comments in the generated code.
- **4.2, tags.** A valueless identifier is legal in every qualification
  section: a type, a table, an enum, a flags, a union, a constant, a field, a
  variant, an arm. The valued vocabulary stays exactly as closed and as
  per-line as it was.
- **4.2 grammar.** `Const`, `Union`, `Variant` and a bare-name `UnionVariant`
  gain `AttrSection`. A variant list now separates on a comma **or** a newline.
- **3.1** names doc comments and tags in the excluded list. **4.11** refuses
  `| doc = "..."` with the comment form named. **7.4** gets the two formatter
  consequences. **9 q5** is settled.

**SPEC-TABLES.md section 8**

- **8.1**: `doc`, `num_tags` and `tags` on `TableFieldInfo` and on
  `TableTypeInfo`. Absence is `""` and `0`/NULL. All static, all
  constant-initialized, declared order, zero allocation on a walk. A descriptor
  carries its own annotation and nobody else's. Neither column is in reach of a
  byte, the text form does not read them, the pack tree does not see them.
- **8.3**: the three members on `ViewConstant`, `ViewVariant`,
  `ViewVocabulary` and `ViewType`, plus the rule that the registry listing is
  the whole annotation surface.
- **8.6**: the `| doc` attribute stays refused, the view renders nothing.
- **8.7**: both columns are in the listing gate, one corpus declaration shows
  them filled, the cost claim is held, and the independence gate is restated to
  move once when the columns land.

## Decisions beyond the ruling

Eight, each one a gap the ruling's four records did not reach.

1. **`ViewVocabulary` carries the columns too.** The ruling names
   `TableFieldInfo`, `ViewVariant`, `ViewType` and `ViewConstant`. An enum, a
   flags or a union DECLARATION has a row in none of those, so a doc comment
   above `enum Weapon` would have had nowhere to land. The ruling's own reason
   for adding the columns now is that descriptors are already in nine ports and
   a later column is nine edits, and that reason reaches this record with equal
   force.
2. **`TableTypeInfo` carries them as well as `ViewType`.** A table's descriptor
   lives in the table header, not the view file, so a walker that entered a
   nested table through the `table` column reaches it in a build that compiles
   no view file. `ViewType` keeps its existing `num_tags`/`tags` and gains
   `doc`; the two records carry the same values.
3. **A descriptor carries its own annotation and nobody else's.** A variant's
   doc and tags belong to the enum, flags or union declaration, so they ride
   the registry rows and are one lookup away by `type_name`. No
   `variant_doc( value )` or `variant_tags( value )` function joins the field
   descriptor in nine ports to spell what the registry already spells. The one
   overlap is a general arm, which is a field line and carries a
   `TableFieldInfo`: that descriptor and the arm's `ViewVariant` row carry the
   same two values, and 8.7 checks that they agree.
4. **`TableBlockFieldInfo` carries neither.** It describes where a field sits
   in the block projection; the same field's annotation is one record away.
5. **Absence is `""` and `0`/NULL, not NULL and NULL.** A printer concatenates
   `doc` with no test, and a list has its count checked before it is walked
   whatever it holds. Every absent `doc` is the SAME shared static empty
   string, so a unit that documents nothing pays no string data at all, and
   8.7 holds that.
6. **Tags become legal on every line kind, and the "admits no qualification"
   case disappears.** A constant and a `union` declaration took no pipe at all
   before this. Keeping them as exceptions would have meant remembering two
   line kinds for no gain.
7. **A bare identifier spelling a known valued key is refused by name**
   (`| min` draws "min takes a value: write min = 0"), and so is a repeated
   tag. Without it the open namespace silently swallows typos in the closed
   one, which is the failure mode the closed vocabulary exists to prevent.
8. **A variant list separates on a comma OR a newline.** This is the only real
   grammar problem in the ruling: the pipe claims the rest of the line, and a
   comma-separated variant list wants the comma at the end of that same line.
   The newline as an alternate separator is purely additive (every comma list
   written to date parses unchanged; only previously-illegal programs become
   legal), and one formatter rule keeps the output canonical: a list in which
   any variant carries a qualification or a doc comment is one per line with no
   commas.

Two smaller consequences, both stated on the page: a doc comment does not break
a `schemafmt` alignment group (a documented run would otherwise become a run of
one-field groups), and the columns landing is the one edit that moves the
independence gate's left-hand side, once, because the members sit in the table
headers.

## One removal outside section 8

SPEC-TABLES.md section 15 still listed "DOC STRINGS in the view" as a named
follow-on. It landed here, so the row is scaffolding and is deleted. Section 15
is untouched by #507 and the merge check still returns a tree with no conflict.

## Two corrections made in passing

The 4.2 valued-vocabulary list said "enum declarations take `max`" where `flags`
takes it too, and omitted `json` on a table field. Both are corrected in the
same bullet.

## What this PR does not do

No compiler, no emitter, no corpus file, no golden. The corpus declaration that
exhibits both columns filled is specified in 8.7 and lands with the
implementation.
