### PR TITLE
spec: status lines for every section that landed ahead of its implementation (#539)

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -1133,6 +1133,16 @@ its bytes are the packet wire's, and every fact of it projects (SPEC.md
 §3.1). The refusal is the TABLE body's alone, and it is what §2.2's mode
 derivation already made a per-body question.
 
+**CHECKER STATUS: NOT REFUSED YET.** The refusal is specified ahead of its
+implementation, on the terms §3.3 and §6.6 take. `schema check` accepts
+`[E.Max]T` in a table body today, with no diagnostic and exit 0, so a unit
+that spells the array positionally compiles and carries the positional class
+this rule exists to close. Two sections rest on the refusal being made,
+§4.1's count of the silent class and SPEC.md §3.1's one exception to
+reachability, and each is written from this rule rather than from the tree.
+Owed as schema#540, and this line is deleted by the implementation PR that
+lands the behavior.
+
 **A KEY ENUM IS IN THE TABLE CLOSURE'S VOCABULARY**, and the closure's
 rules reach it through the keying field. An enum that a table closure
 reaches ONLY as an array key — never as a field type — still rides by
@@ -4627,6 +4637,16 @@ games decide their own policy over it. Nothing crashes on data from a
 different schema version, in either direction, and that property is held by
 a both-directions evolution test in the corpus.
 
+**BACKEND STATUS for `widened`: OWED, not counted.** The counter and the two
+ladders above are specified ahead of their implementation, on the terms §3.3
+and §6.6 take. No report struct carries a `widened` member in any target or
+in the tool, and every pair the ladders accept is a `kind_mismatch` today,
+the payload skipped by its framing and the field left at its declared
+default. What a caller sees is the five that remain, `unknown`,
+`kind_mismatch`, `clamped`, `duplicate` and the `malformed` flag. Owed as
+schema#523, and this line is deleted by the implementation PR that lands the
+behavior.
+
 **TWO MORE COUNTERS RIDE ON THE SAME STRUCT AND STAY ZERO UNTIL A CALLER ASKS
 FOR THEM**: `retained` and `retain_lost`, the retain-unknown pair (§6.6). They
 report on RETENTION rather than on the read, and they change no counter above.
@@ -5567,6 +5587,14 @@ The builder is designed to go wide, lock-free by ownership:
   to report, and the reason is where the answer lives. **This shares a surface
   with the accelerators' refusal and lands with it**, so a build that has one
   has the other.
+
+  **BACKEND STATUS: OWED, not emitted.** The enum is specified ahead of its
+  implementation, on the terms §3.3 and §6.6 take. `TableRefuseReason` is
+  spelled in no target, in no runtime and in no tool, a bare `-1` is the whole
+  of a measure's answer today, and the name is not claimed either, so a unit
+  declaring a table or a type called `TableRefuseReason` compiles.
+  Owed as schema#523, with §7's check order and §19.2's block clauses, and
+  this line is deleted by the implementation PR that lands the behavior.
 - **Into a builder** — the tool's path. The same tolerant decode into a
   fresh builder, so loaded data can be edited and locked again. **Its own
   refusal is a NULL** rather than a `-1`, and the report it leaves behind is
@@ -6253,6 +6281,15 @@ the wire, and keeps the flexibility that comes with it.
   word, its base being 64-byte aligned by construction, so `bad_alignment` has
   nothing to validate. One order, one enum, and the two accelerators differ
   only in which clauses they have.
+
+  **BACKEND STATUS: OWED, not emitted.** The out-parameter and its enum are
+  specified ahead of their implementation, on the terms §3.3 and §6.6 take.
+  The C++ reference emits `const Scene * SceneOpen( const void * bytes,
+  uint64_t length )` and nothing more, every other backend's `Open` is that
+  same shape in its own spelling, and the null alone is the whole of a
+  refusal's answer. Owed as schema#523, with §6.5's measure values and
+  §19.2's block clauses, and this line is deleted by the implementation PR
+  that lands the behavior.
 
 - **`Open` is the RUNTIME's only entry point.** There is no second one: a
   build either wrote a file or it did not, and the build version is what says
@@ -7424,6 +7461,16 @@ doc comment is not a value. **The pack tree does not see them either**
 tree is ever spelled by a doc or a tag. Documenting and tagging a shipped
 schema is a free edit, and that is the property the open namespace rests on.
 
+**BACKEND STATUS: OWED, not emitted.** The `doc`, `num_tags` and `tags`
+columns are specified ahead of their implementation, on the terms §3.3 and
+§6.6 take. No target emits any of the three on `TableFieldInfo` or on
+`TableTypeInfo` today, no registry row (§8.3) carries them, and nothing
+upstream of the columns exists to fill one: the compiler reads no `///`
+block (SPEC.md §4.1) and carries a tag on a `type` declaration alone
+(SPEC.md §4.2). Owed as schema#523 ruling 4, which lands the front end and
+the columns together, and this line is deleted by the implementation PR that
+lands the behavior.
+
 **A field carries WHERE IT LIVES, and the spelling is the language's.** C++
 carries an offset and a width, because its storage is one flat struct; a
 language whose fields have no address carries the pair that reads and writes
@@ -8308,6 +8355,9 @@ in build version (§20.5).
   table closure, `| max = K` headroom and variant id collisions, each
   diagnostic naming the keying field that pulled the enum in. A slot value no variant names is a SAVE failure, not a silent `None`
   (§3.2).
+  **CHECKER STATUS: the positional spelling is NOT REFUSED YET**, accepted in
+  a table body today with no diagnostic, owed as schema#540 (§2.4), and this
+  sentence is deleted by the implementation PR that lands it.
 - **Maps** (§2.8): a map in a `type` body; a key that is an enum (the
   diagnostic names `[E]T`), a `bool`, a float, a `flags`, a `bits(N)`, a
   `bytes(N)`, a `wstring(N)` (the diagnostic names `string(N)`, because
@@ -11776,6 +11826,11 @@ schema name, as everywhere else in that backend.
   for the reason above. One enum serves both
   accelerators because a consumer that falls back from either falls back the
   same way, and two vocabularies would have said the same things twice.
+
+  **BACKEND STATUS: OWED, not emitted**, on the terms §3.3 and §6.6 take.
+  `<Name>BlockOpen` returns a bare `bool` today and names no reason, exactly
+  as a cook's `Open` returns a bare null (§7). Owed as schema#523, and this
+  line is deleted by the implementation PR that lands the behavior.
 - **An array is ITERATED, not indexed by hand.** The accessor yields a
   reference to each row where it lies, at the pitch the instance gives, for
   `count` rows — a range-for in C++, an enumerator in C#, the equivalent per

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -139,6 +139,17 @@ turned every edit to an author's prose into a coordinated redeploy, while a
 projection carries the facts the bytes depend on and a doc comment is not
 one of them (Excluded, below).
 
+**Compiler status for that sentence: NO COMMENT KIND IS READ YET.** The
+`///` block is specified ahead of its implementation, on the terms
+SPEC-TABLES.md §3.3 and §6.6 take. The scanner lexes a `///` line as the
+ordinary `//` line comment it is and discards it, no doc text reaches the IR
+or a descriptor column (SPEC-TABLES.md §8.1), and none of §4.1's
+misplacement refusals fires, so a `///` block above `package` and a `///`
+trailing a field both compile today. What this paragraph says about the
+PROJECTION holds either way, because a comment is excluded from it whether or
+not the compiler reads one. Owed as schema#523 ruling 4, and this line is
+deleted by the implementation PR that lands the behavior.
+
 **Included — each fact moves the wire, for every declaration the closure
 below carries:** the package; every type's field order; field NAMES; type
 kind, width and signedness; declared bounds; array kind and bounds;
@@ -978,6 +989,20 @@ type Quat | quat4
 - The architecture: types on one side; a layer that defines the needed
   actions for those types on the other. v1 ships the types; each schema
   declares its own, and each application's actions bind to them by claiming.
+
+**Front-end status: ONE LINE KIND CARRIES A TAG TODAY.** The rule at every
+line kind is specified ahead of its implementation, on the terms
+SPEC-TABLES.md §3.3 and §6.6 take. What the tree carries is a tag on a
+`type` DECLARATION alone, gathered into `ir.Struct.Tags` and emitted as the
+inert comment above. Every other line kind refuses one, each under a
+diagnostic written for a different rule: a field's pipe draws "unknown
+attribute ... the vocabulary is typed and closed per compiler version", a
+`table` and a `union` declaration draw "takes no qualification", a `const`
+draws "a constant takes no qualification, and | is never an operator", a
+union arm's pipe draws "expected a field type", and an enum or flags variant
+carrying one does not parse at all. Owed as schema#523 ruling 4, together
+with the descriptor columns it feeds (SPEC-TABLES.md §8.1), and this line is
+deleted by the implementation PR that lands the behavior.
 
 ### Native type mapping — `cpp_native` / `cpp_include`
 


### PR DESCRIPTION
Closes #539. Docs only: `docs/SPEC.md` and `docs/SPEC-TABLES.md`. No rule
changes and no code.

Several specification sections state present-tense behavior the tree does not
carry. Each now says so in the house form §3.3, §6.6 and §2.9 already use: the
behavior is specified ahead of its implementation, what the tree does today,
and the issue that owes it. Every line is deleted by the implementation PR
that lands the behavior.

Each present-state sentence below was confirmed against the tree, with a probe
unit through `schema check` where the claim is a refusal.

| site | what the tree does today | owed |
|---|---|---|
| SPEC.md §3.1 | the scanner lexes `///` as an ordinary `//` line comment and discards it, no `Doc` field exists in `internal/ast` or `ir`, and none of §4.1's misplacement refusals fires: a `///` above `package` and a `///` trailing a field both compile | #523 ruling 4 |
| SPEC.md §4.2 | `internal/check` gathers tags on `*ast.TypeDecl` alone. A field's pipe draws "unknown attribute", a `table` and a `union` declaration draw "takes no qualification", a `const` draws its own, a union arm's pipe draws "expected a field type", and a qualified enum or flags variant does not parse | #523 ruling 4 |
| SPEC-TABLES.md §8.1 | no target emits `doc`, `num_tags` or `tags` on `TableFieldInfo` or `TableTypeInfo`, and nothing upstream exists to fill one | #523 ruling 4 |
| §6.5, §7, §19.2 | `TableRefuseReason` is spelled in no target, no runtime and no tool. `Open` is `const Scene * SceneOpen( const void * bytes, uint64_t length )`, `BlockOpen` returns a bare `bool`, a measure answers a bare `-1`, and the name is not claimed, so a unit may declare it | #523 |
| §4 | no report struct carries a `widened` member. Any kind difference is one `kind_mismatch` and the payload is skipped, so the counters a caller sees are `unknown`, `kind_mismatch`, `clamped`, `duplicate` and `malformed` | #523 |
| §2.4, §11 | `schema check` accepts `[E.Max]T` in a table body with no diagnostic and exit 0 | #540 |

`docs/VERSIONING.md` needs nothing from this branch: #536 landed the
`[E.Max]T` entry in its "Owed before 3.0.0" list, keyed to #540, and the
`///`-and-tags entry beside it. Rebased onto that, so the one owed entry per
site is main's.

`go test ./compiler/ -run Doc` passes, which is the gate that parses the
pages' own schema blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)