### PR TITLE
spec: §8.3 states that UnitView is owed, not emitted (#521 G-11)

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -7774,6 +7774,11 @@ function per unit, name-first in the unit's own namespace beside
 `ProtocolId` (SPEC §6.1), answering with the set of everything the build
 declared:
 
+**BACKEND STATUS: OWED, not emitted.** `UnitView()` is specified ahead of its
+implementation: no backend emits it in any of the nine targets today, and it is
+owed under #523 item 4 with the doc and tag descriptor columns of §8.1. The
+implementation PR that lands it deletes this paragraph.
+
 ```cpp
 struct ViewConstant
 {


### PR DESCRIPTION
The tutorial's second-pass findings (#521, G-11) found `UnitView()` specified in SPEC-TABLES.md §8.3 and emitted by no backend; the section carried no status line and survived #541's sweep. One paragraph in the house form, owed under #523 item 4 with §8.1's descriptor columns. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)