### PR TITLE
native: the formatter and analyzer gate, one CI leg per port (#547)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,55 @@
+# The house C and C++ style, and the one the native gate holds the emitted
+# text to (issue #547). clang-format has no canonical style of its own, so the
+# style IS this file, and it is written from the estate's own C and C++: the
+# serialize runtime the generated code sits beside.
+#
+# Every option below states a fact about that code rather than a preference:
+#
+#   IndentWidth 4, UseTab Never   four spaces, no tabs, everywhere.
+#   ColumnLimit 0                 no reflow. The emitted text carries long
+#                                 explanatory trailing comments by design
+#                                 (the documentation doctrine), and a
+#                                 formatter that rewraps them is a formatter
+#                                 fighting the emitter. Line breaks are the
+#                                 emitter's; spacing, bracing and alignment
+#                                 are this file's.
+#   PointerAlignment Middle       `const char * name`.
+#   SpacesInParens Custom, Other  `f( a, b )` and `if ( x )`, the estate
+#                                 spelling; C-style casts stay tight.
+#   AfterNamespace false          `namespace pkg {` on one line, which both
+#                                 C++ emitters already write.
+#   Everything else Allman        classes, structs, unions, enums, functions
+#                                 and control statements open on their own
+#                                 line.
+BasedOnStyle: LLVM
+IndentWidth: 4
+UseTab: Never
+ColumnLimit: 0
+PointerAlignment: Middle
+ReferenceAlignment: Middle
+SpacesInParens: Custom
+SpacesInParensOptions:
+  InConditionalStatements: true
+  InCStyleCasts: false
+  Other: true
+SortIncludes: false
+AlignAfterOpenBracket: DontAlign
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+IndentCaseLabels: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ env:
   SERIALIZE_CS_TAG: v1.9.1
   SERIALIZE_JS_TAG: v1.4.2
 
+  # The C and C++ native legs' clang tooling, by EXACT archive version
+  # (issue #547). ubuntu-24.04 is the archive; the major each leg wants is its
+  # row's, and this is the version that major resolves to there. Bumping it is
+  # a deliberate one-line edit, and the version comes from the policy the
+  # failing install prints.
+  CLANG_APT_PIN: "1:18.1.3-1ubuntu1"
+
 jobs:
   # The compiler's own test suite, and the only job in this file that reads a
   # Go source file. `go test ./...` covers internal/fuzz, whose seeded corpus
@@ -302,6 +309,148 @@ jobs:
 
       - name: the ${{ matrix.lang }} leg over every surface
         run: env ${{ matrix.env }} ./build/conformance-harness run --only ${{ matrix.lang }}
+
+  # THE NATIVE GATE (issue #547), one job per port row of the matrix (#366).
+  #
+  # The law is that what schema emits for a target reads as that language's own
+  # code. Two of its three parts are machine-checkable and this is where they
+  # run: the language's standard FORMATTER in check mode, and its standard
+  # ANALYZER at default strictness, over the GENERATED code of both corpora —
+  # the examples corpus under generated/, the tables corpus under build/ — red
+  # on any finding. The third part, the fluent-reader review, is a person's and
+  # lives on the row's pull request.
+  #
+  # WHAT EACH LEG RUNS is `make native-<lang>`, and that target lives in the
+  # port's own make/<lang>.mk beside its test and conformance legs. So the
+  # instruments a language is held to are a decision made in that language's
+  # file, by whoever knows it, rather than a line in this one.
+  #
+  # THE MATRIX IS DISCOVERED, NOT TYPED, the same way the conformance matrix
+  # above is: `test/native/matrix` reads every test/native/<lang>/ci.json, and
+  # refuses a tree where a port has a conformance driver and no native row. A
+  # row names the make target, the sibling runtime the analyzer needs on disk
+  # to typecheck what the emitter wrote, the toolchain steps to install and
+  # the make overrides that point the leg at them. Registering a port's native
+  # gate is its make target and its ci.json, and no edit here.
+  #
+  # SHARDED PER LEG for the reason the conformance matrix is: a leg's wall is
+  # its own toolchain's, so one job per language keeps the SLOWEST leg inside
+  # the rule rather than the SUM of them, and a leg that stops fitting is named
+  # by the job that missed.
+  native-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+      - id: discover
+        name: the native registry, as a matrix
+        run: |
+          matrix=$(go run ./test/native/matrix)
+          echo "$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  native:
+    name: native (${{ matrix.lang }})
+    needs: native-matrix
+    # NAMED rather than `-latest`, the argument the big-endian and msvc jobs
+    # make: the C and C++ legs install their tooling by exact package version,
+    # and a package version is only meaningful against one archive.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.native-matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # An ANALYZER needs the runtime on disk for the same reason a compiler
+      # does: it typechecks what the emitter wrote, and generated Go, Rust, C#,
+      # C and C++ name a sibling. A leg whose generated code names no runtime
+      # leaves the row's two fields empty and clones nothing.
+      - name: Check out the sibling runtime this leg needs (pinned release)
+        if: matrix.runtime != ''
+        run: |
+          tag=$(printenv "${{ matrix.runtime_tag }}")
+          git clone --quiet --depth 1 --branch "$tag" "https://github.com/mas-bandwidth/${{ matrix.runtime }}.git" "../${{ matrix.runtime }}"
+
+      # bin/schema and the generated trees come out of Go in every leg.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: read the .NET SDK pin
+        if: matrix.dotnet != ''
+        run: echo "DOTNET_SDK_PIN=$(cat .github/dotnet-version)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        if: matrix.dotnet != ''
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_PIN }}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: matrix.node != ''
+        with:
+          node-version: ${{ matrix.node }}
+
+      # rustfmt and clippy are NAMED here: they are the two instruments this
+      # leg is, and a toolchain installed without them fails on a missing
+      # binary rather than on a finding.
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # the stable BRANCH head — the SHA freezes the action, not the compiler: rustup resolves stable at run time
+        if: matrix.rust != ''
+        with:
+          components: rustfmt, clippy
+
+      - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
+        if: matrix.dart != ''
+        with:
+          sdk: ${{ matrix.dart }}
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        if: matrix.java != ''
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        if: matrix.otp != ''
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+
+      # THE C AND C++ TOOLING, by EXACT package version for the reason the
+      # big-endian job installs its cross compiler that way: which diagnostics
+      # clang-tidy has and how clang-format lays a construct out are
+      # toolchain-version facts, so a leg on a floating version would prove a
+      # different thing each month. The row names the major and CLANG_APT_PIN
+      # holds the archive's version; a failing install prints the policy, which
+      # is where the next pin comes from.
+      - name: the pinned clang tooling
+        if: matrix.clang != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            "clang-format-${{ matrix.clang }}=$CLANG_APT_PIN" \
+            "clang-tidy-${{ matrix.clang }}=$CLANG_APT_PIN" || {
+              apt-cache policy "clang-format-${{ matrix.clang }}" "clang-tidy-${{ matrix.clang }}"
+              exit 1
+            }
+          clang-format-${{ matrix.clang }} --version
+          clang-tidy-${{ matrix.clang }} --version
+
+      # NATIVE_JOBS is the fan-out the C and C++ legs use for clang-tidy, which
+      # is one process per translation unit over a couple of hundred of them
+      # and is the only leg here whose wall is not one tool's.
+      - name: the ${{ matrix.lang }} formatter and analyzer over the generated code
+        run: make ${{ matrix.targets }} ${{ matrix.env }} NATIVE_JOBS="$(nproc)"
+
 
   # DOGFOOD BIG-ENDIAN (issue #303). docs/SPEC-TABLES.md §3 says the wire is
   # little-endian and byte-oriented throughout; §7 says a cook is produced in

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,12 @@ erl_crash.dump
 # binary here rather than in build/ — the Makefile always names `-o` and never
 # wants this file. It reached main once already (#345).
 /harness
+
+
+# the Elixir native gate's credo build and its fetched deps
+/test/native/elixir/_build/
+/test/native/elixir/deps/
+
+# a working clone symlinks the pinned toolchains in rather than unpacking a
+# second copy; the ignore above matches the directory, this one the link
+/dist

--- a/Makefile
+++ b/Makefile
@@ -3036,3 +3036,63 @@ registry:
 	@echo "conformance: $(CONFORMANCE_LEGS)"
 	@echo "bench-tables: $(BENCH_TABLES_LEGS)"
 	@echo "goldens: $(GOLDENS_LEGS)"
+	@echo "native: $(NATIVE_LEGS)"
+
+# ---- THE C AND C++ NATIVE GATE (issue #547) --------------------------------
+#
+# clang-format and clang-tidy are the instruments a C or C++ reader runs, and
+# these two legs hold the emitted text of both corpora to them. The style is
+# the repository's .clang-format, which is written from the estate's own C and
+# C++ and says why each option is what it is; clang-tidy runs its DEFAULT
+# check set, which is the reading the law asks for, with every diagnostic an
+# error.
+#
+# THE VERSION IS NAMED, never `clang-format` bare: which diagnostics exist and
+# how a construct is formatted are exactly toolchain-version facts, so a leg
+# that took whatever a machine had installed would prove a different thing on
+# every machine. CI installs this major at an exact package version; a
+# workstation that has another one overrides these two variables.
+CLANG_MAJOR  ?= 18
+CLANG_FORMAT ?= clang-format-$(CLANG_MAJOR)
+CLANG_TIDY   ?= clang-tidy-$(CLANG_MAJOR)
+
+# clang-tidy is one process per translation unit over ~200 units per leg, and
+# every one of them is independent.
+NATIVE_JOBS ?= 4
+
+# $(1) the language flag clang wants, $(2) the include the runtime lives in,
+# $(3) the directories to walk, $(4) the file extensions in them.
+define native_clang_tidy
+	@set -e; fail=0; \
+	for d in $(3); do \
+		files=$$(ls $$(for e in $(4); do echo $$d/*.$$e; done) 2>/dev/null || true); \
+		[ -n "$$files" ] || continue; \
+		printf '%s\n' $$files | xargs -P $(NATIVE_JOBS) -I{} \
+			$(CLANG_TIDY) --quiet --warnings-as-errors='*' {} -- \
+			$(1) -I$$d -I$(2) || fail=1; \
+	done; \
+	if [ $$fail -ne 0 ]; then exit 1; fi
+endef
+
+NATIVE_CPP_DIRS = generated/cpp generated/cpp/ludicrous $(wildcard build/tables-generated/*/)
+
+.PHONY: native-cpp
+native-cpp: generated/cpp/.stamp generated/cpp/ludicrous/.stamp build/tables-generated/.stamp
+	$(CLANG_FORMAT) --dry-run --Werror \
+		generated/cpp/*.h generated/cpp/ludicrous/*.h \
+		build/tables-generated/*/*.h build/tables-generated/*/*.cpp
+	$(call native_clang_tidy,-xc++ -std=c++17,$(SERIALIZE),$(NATIVE_CPP_DIRS),h cpp)
+	@echo "native C++: clang-format canonical and clang-tidy clean over the examples and tables corpora"
+
+NATIVE_LEGS += native-cpp
+
+# THE NATIVE GATE (issue #547): every registered leg's formatter and analyzer
+# over its own generated code. One target per language, registered by that
+# language's make/<lang>.mk exactly as its test and conformance legs are, so a
+# port lands its native gate by adding the target and nothing else.
+#
+# CI runs the legs SHARDED, one job each, because a leg's wall is its own
+# toolchain's; this target is the whole set, for a workstation with every
+# toolchain installed.
+.PHONY: native
+native: $(NATIVE_LEGS)

--- a/Makefile
+++ b/Makefile
@@ -3056,33 +3056,32 @@ CLANG_MAJOR  ?= 18
 CLANG_FORMAT ?= clang-format-$(CLANG_MAJOR)
 CLANG_TIDY   ?= clang-tidy-$(CLANG_MAJOR)
 
-# clang-tidy is one process per translation unit over ~200 units per leg, and
-# every one of them is independent.
+# clang-tidy is one process per translation unit over a couple of hundred units
+# per leg, and every one of them is independent.
 NATIVE_JOBS ?= 4
 
-# $(1) the language flag clang wants, $(2) the include the runtime lives in,
-# $(3) the directories to walk, $(4) the file extensions in them.
-define native_clang_tidy
-	@set -e; fail=0; \
-	for d in $(3); do \
-		files=$$(ls $$(for e in $(4); do echo $$d/*.$$e; done) 2>/dev/null || true); \
-		[ -n "$$files" ] || continue; \
-		printf '%s\n' $$files | xargs -P $(NATIVE_JOBS) -I{} \
-			$(CLANG_TIDY) --quiet --warnings-as-errors='*' {} -- \
-			$(1) -I$$d -I$(2) || fail=1; \
-	done; \
-	if [ $$fail -ne 0 ]; then exit 1; fi
-endef
-
+# BOTH HALVES RUN, ALWAYS, and the verdict comes at the end. A leg that stopped
+# at its formatter would hide its analyzer's findings behind a whitespace diff,
+# and the whole finding list is what the emitter is owed.
 NATIVE_CPP_DIRS = generated/cpp generated/cpp/ludicrous $(wildcard build/tables-generated/*/)
 
 .PHONY: native-cpp
 native-cpp: generated/cpp/.stamp generated/cpp/ludicrous/.stamp build/tables-generated/.stamp
+	@fail=0; \
+	echo "==== clang-format"; \
 	$(CLANG_FORMAT) --dry-run --Werror \
 		generated/cpp/*.h generated/cpp/ludicrous/*.h \
-		build/tables-generated/*/*.h build/tables-generated/*/*.cpp
-	$(call native_clang_tidy,-xc++ -std=c++17,$(SERIALIZE),$(NATIVE_CPP_DIRS),h cpp)
-	@echo "native C++: clang-format canonical and clang-tidy clean over the examples and tables corpora"
+		build/tables-generated/*/*.h build/tables-generated/*/*.cpp || fail=1; \
+	echo "==== clang-tidy"; \
+	for d in $(NATIVE_CPP_DIRS); do \
+		files=$$(ls $$d/*.h $$d/*.cpp 2>/dev/null); \
+		[ -n "$$files" ] || continue; \
+		printf '%s\n' $$files | xargs -P $(NATIVE_JOBS) -I{} \
+			$(CLANG_TIDY) --quiet --warnings-as-errors='*' {} -- \
+			-xc++ -std=c++17 -I$$d -I$(SERIALIZE) || fail=1; \
+	done; \
+	if [ $$fail -ne 0 ]; then echo "native C++: the findings above are the emitter's"; exit 1; fi; \
+	echo "native C++: clang-format canonical and clang-tidy clean over the examples and tables corpora"
 
 NATIVE_LEGS += native-cpp
 

--- a/internal/codegen/dart/dart.go
+++ b/internal/codegen/dart/dart.go
@@ -347,8 +347,12 @@ func (g *gen) assemble() []byte {
 	}
 	g.emitHelpers(&h)
 	h.WriteString(strings.TrimRight(g.body.String(), "\n"))
-	h.WriteString("\n")
-	return []byte(h.String())
+	// One trailing newline, with no blank line before it. A unit whose Dart
+	// surface is the banner and nothing else (no import, no helper, no
+	// declaration) would otherwise end on the blank line that follows the
+	// banner, and that blank line is the one thing `dart format` rewrites in
+	// this emitter's output.
+	return []byte(strings.TrimRight(h.String(), "\n") + "\n")
 }
 
 // writeImport renders one show-list import, wrapped the way dart format

--- a/make/c.mk
+++ b/make/c.mk
@@ -497,3 +497,18 @@ TEST_LEGS         += test-c
 CONFORMANCE_LEGS  += build/conformance-c
 BENCH_TABLES_LEGS += generated/bench/tables/c/.stamp
 GOLDENS_LEGS      += update-goldens-c
+
+# THE C NATIVE GATE (issue #547), the C++ leg's twin in the Makefile: the same
+# two instruments, the same style file, the same pinned major, over the C
+# emitter's output for both corpora.
+NATIVE_C_DIRS = generated/c generated/c-ludicrous $(wildcard build/tables-generated-c/*/)
+
+.PHONY: native-c
+native-c: generated/c/.stamp generated/c-ludicrous/.stamp build/tables-generated-c/.stamp
+	$(CLANG_FORMAT) --dry-run --Werror \
+		generated/c/*.h generated/c-ludicrous/*.h \
+		build/tables-generated-c/*/*.h build/tables-generated-c/*/*.c
+	$(call native_clang_tidy,-xc -std=c99,$(SERIALIZE_C),$(NATIVE_C_DIRS),h c)
+	@echo "native C: clang-format canonical and clang-tidy clean over the examples and tables corpora"
+
+NATIVE_LEGS       += native-c

--- a/make/c.mk
+++ b/make/c.mk
@@ -500,15 +500,25 @@ GOLDENS_LEGS      += update-goldens-c
 
 # THE C NATIVE GATE (issue #547), the C++ leg's twin in the Makefile: the same
 # two instruments, the same style file, the same pinned major, over the C
-# emitter's output for both corpora.
+# emitter's output for both corpora, both halves always run.
 NATIVE_C_DIRS = generated/c generated/c-ludicrous $(wildcard build/tables-generated-c/*/)
 
 .PHONY: native-c
 native-c: generated/c/.stamp generated/c-ludicrous/.stamp build/tables-generated-c/.stamp
+	@fail=0; \
+	echo "==== clang-format"; \
 	$(CLANG_FORMAT) --dry-run --Werror \
 		generated/c/*.h generated/c-ludicrous/*.h \
-		build/tables-generated-c/*/*.h build/tables-generated-c/*/*.c
-	$(call native_clang_tidy,-xc -std=c99,$(SERIALIZE_C),$(NATIVE_C_DIRS),h c)
-	@echo "native C: clang-format canonical and clang-tidy clean over the examples and tables corpora"
+		build/tables-generated-c/*/*.h build/tables-generated-c/*/*.c || fail=1; \
+	echo "==== clang-tidy"; \
+	for d in $(NATIVE_C_DIRS); do \
+		files=$$(ls $$d/*.h $$d/*.c 2>/dev/null); \
+		[ -n "$$files" ] || continue; \
+		printf '%s\n' $$files | xargs -P $(NATIVE_JOBS) -I{} \
+			$(CLANG_TIDY) --quiet --warnings-as-errors='*' {} -- \
+			-xc -std=c99 -I$$d -I$(SERIALIZE_C) || fail=1; \
+	done; \
+	if [ $$fail -ne 0 ]; then echo "native C: the findings above are the emitter's"; exit 1; fi; \
+	echo "native C: clang-format canonical and clang-tidy clean over the examples and tables corpora"
 
 NATIVE_LEGS       += native-c

--- a/make/cs.mk
+++ b/make/cs.mk
@@ -315,32 +315,37 @@ BENCH_TABLES_LEGS += generated/bench/tables/cs/.stamp
 GOLDENS_LEGS      += update-goldens-cs
 
 # THE C# NATIVE GATE (issue #547). Two halves, and they cover different sets
-# for a reason that is the emitter's shape rather than a choice here.
+# for a reason that is the emitter's shape rather than a choice here. Both run
+# before the leg reports.
 #
-# THE FORMATTER half is `dotnet format whitespace --folder --verify-no-changes`
-# over the generated trees of both corpora. --folder is what lets the
-# formatter read a DIRECTORY rather than a project, and that is required here:
-# a generated unit's Block and Cook accelerators share one set of blittable
-# records, so no single project compiles a whole unit, let alone the whole
-# corpus (test/conformance/cs/schemaconformance.csproj excludes them by name
-# for exactly this reason). --folder also means whitespace alone; the style
-# and analyzer fixers need a workspace, and what they would see is the second
+# THE FORMATTER half is `dotnet format whitespace --verify-no-changes` over the
+# generated trees of both corpora. --folder is what lets the formatter read a
+# DIRECTORY rather than a project, and that is required here: a generated
+# unit's Block and Cook accelerators share one set of blittable records, so no
+# single project compiles a whole unit, let alone the whole corpus
+# (test/conformance/cs/schemaconformance.csproj excludes them by name for
+# exactly this reason). --folder also means whitespace alone; the style and
+# analyzer fixers need a workspace, and what they would see is the second
 # half's business.
 #
 # THE ANALYZER half is the .NET analyzers at their default mode, warnings as
 # errors, over the two projects that DO compile: the packet corpus through
-# test/cs, and the tables corpus through the conformance project. Analyzers
-# are on by default for this TargetFramework; naming the properties here says
-# what the gate depends on rather than leaving it to an SDK default.
+# test/cs, and the tables corpus through the conformance project. Analyzers are
+# on by default for this TargetFramework; naming the properties here says what
+# the gate depends on rather than leaving it to an SDK default.
 .PHONY: native-cs
 native-cs: generated/cs/.stamp generated/cs-ludicrous/.stamp build/tables-generated-cs/.stamp
-	dotnet format whitespace generated/cs --folder --verify-no-changes
-	dotnet format whitespace generated/cs-ludicrous --folder --verify-no-changes
-	dotnet format whitespace build/tables-generated-cs --folder --verify-no-changes
-	cd test/cs && dotnet build -v q --nologo \
-		-p:EnableNETAnalyzers=true -p:AnalysisMode=Default -p:TreatWarningsAsErrors=true
-	cd test/conformance/cs && dotnet build -v q --nologo \
-		-p:EnableNETAnalyzers=true -p:AnalysisMode=Default -p:TreatWarningsAsErrors=true
-	@echo "native C#: dotnet format canonical and the .NET analyzers clean over the examples and tables corpora"
+	@fail=0; \
+	echo "==== dotnet format"; \
+	dotnet format whitespace generated/cs --folder --verify-no-changes || fail=1; \
+	dotnet format whitespace generated/cs-ludicrous --folder --verify-no-changes || fail=1; \
+	dotnet format whitespace build/tables-generated-cs --folder --verify-no-changes || fail=1; \
+	echo "==== the .NET analyzers"; \
+	( cd test/cs && dotnet build -v q --nologo \
+		-p:EnableNETAnalyzers=true -p:AnalysisMode=Default -p:TreatWarningsAsErrors=true ) || fail=1; \
+	( cd test/conformance/cs && dotnet build -v q --nologo \
+		-p:EnableNETAnalyzers=true -p:AnalysisMode=Default -p:TreatWarningsAsErrors=true ) || fail=1; \
+	if [ $$fail -ne 0 ]; then echo "native C#: the findings above are the emitter's"; exit 1; fi; \
+	echo "native C#: dotnet format canonical and the .NET analyzers clean over the examples and tables corpora"
 
 NATIVE_LEGS       += native-cs

--- a/make/cs.mk
+++ b/make/cs.mk
@@ -313,3 +313,34 @@ TEST_LEGS         += test-cs
 CONFORMANCE_LEGS  += build-conformance-cs build-cs-cook
 BENCH_TABLES_LEGS += generated/bench/tables/cs/.stamp
 GOLDENS_LEGS      += update-goldens-cs
+
+# THE C# NATIVE GATE (issue #547). Two halves, and they cover different sets
+# for a reason that is the emitter's shape rather than a choice here.
+#
+# THE FORMATTER half is `dotnet format whitespace --folder --verify-no-changes`
+# over the generated trees of both corpora. --folder is what lets the
+# formatter read a DIRECTORY rather than a project, and that is required here:
+# a generated unit's Block and Cook accelerators share one set of blittable
+# records, so no single project compiles a whole unit, let alone the whole
+# corpus (test/conformance/cs/schemaconformance.csproj excludes them by name
+# for exactly this reason). --folder also means whitespace alone; the style
+# and analyzer fixers need a workspace, and what they would see is the second
+# half's business.
+#
+# THE ANALYZER half is the .NET analyzers at their default mode, warnings as
+# errors, over the two projects that DO compile: the packet corpus through
+# test/cs, and the tables corpus through the conformance project. Analyzers
+# are on by default for this TargetFramework; naming the properties here says
+# what the gate depends on rather than leaving it to an SDK default.
+.PHONY: native-cs
+native-cs: generated/cs/.stamp generated/cs-ludicrous/.stamp build/tables-generated-cs/.stamp
+	dotnet format whitespace generated/cs --folder --verify-no-changes
+	dotnet format whitespace generated/cs-ludicrous --folder --verify-no-changes
+	dotnet format whitespace build/tables-generated-cs --folder --verify-no-changes
+	cd test/cs && dotnet build -v q --nologo \
+		-p:EnableNETAnalyzers=true -p:AnalysisMode=Default -p:TreatWarningsAsErrors=true
+	cd test/conformance/cs && dotnet build -v q --nologo \
+		-p:EnableNETAnalyzers=true -p:AnalysisMode=Default -p:TreatWarningsAsErrors=true
+	@echo "native C#: dotnet format canonical and the .NET analyzers clean over the examples and tables corpora"
+
+NATIVE_LEGS       += native-cs

--- a/make/dart.mk
+++ b/make/dart.mk
@@ -377,3 +377,18 @@ test-dart: generated/dart/.stamp generated/dart-ludicrous/.stamp generated/bench
 TEST_LEGS         += test-dart
 CONFORMANCE_LEGS  += build/conformance-dart
 BENCH_TABLES_LEGS += generated/bench/tables/dart/.stamp
+
+# THE DART NATIVE GATE (issue #547). `dart analyze` and `dart format` are the
+# language's own two instruments, and this holds BOTH corpora to both of them.
+#
+# It extends tables-dart-clean rather than replacing it: that target holds the
+# tables corpus, and its format half covers the <Base>Table/Block/Cook files
+# alone. This one adds the examples corpus and takes the format check over
+# every generated Dart file of both.
+.PHONY: native-dart
+native-dart: generated/dart/.stamp generated/dart-ludicrous/.stamp build/tables-generated-dart/.stamp
+	$(DART) analyze generated/dart generated/dart-ludicrous build/tables-generated-dart
+	$(DART) format --set-exit-if-changed --output=none generated/dart generated/dart-ludicrous build/tables-generated-dart
+	@echo "native Dart: analyzer clean and format-canonical over the examples and tables corpora"
+
+NATIVE_LEGS       += native-dart

--- a/make/dart.mk
+++ b/make/dart.mk
@@ -379,7 +379,8 @@ CONFORMANCE_LEGS  += build/conformance-dart
 BENCH_TABLES_LEGS += generated/bench/tables/dart/.stamp
 
 # THE DART NATIVE GATE (issue #547). `dart analyze` and `dart format` are the
-# language's own two instruments, and this holds BOTH corpora to both of them.
+# language's own two instruments, and this holds BOTH corpora to both of them,
+# both halves before the verdict.
 #
 # It extends tables-dart-clean rather than replacing it: that target holds the
 # tables corpus, and its format half covers the <Base>Table/Block/Cook files
@@ -387,8 +388,12 @@ BENCH_TABLES_LEGS += generated/bench/tables/dart/.stamp
 # every generated Dart file of both.
 .PHONY: native-dart
 native-dart: generated/dart/.stamp generated/dart-ludicrous/.stamp build/tables-generated-dart/.stamp
-	$(DART) analyze generated/dart generated/dart-ludicrous build/tables-generated-dart
-	$(DART) format --set-exit-if-changed --output=none generated/dart generated/dart-ludicrous build/tables-generated-dart
-	@echo "native Dart: analyzer clean and format-canonical over the examples and tables corpora"
+	@fail=0; \
+	echo "==== dart analyze"; \
+	$(DART) analyze generated/dart generated/dart-ludicrous build/tables-generated-dart || fail=1; \
+	echo "==== dart format"; \
+	$(DART) format --set-exit-if-changed --output=none generated/dart generated/dart-ludicrous build/tables-generated-dart || fail=1; \
+	if [ $$fail -ne 0 ]; then echo "native Dart: the findings above are the emitter's"; exit 1; fi; \
+	echo "native Dart: analyzer clean and format-canonical over the examples and tables corpora"
 
 NATIVE_LEGS       += native-dart

--- a/make/elixir.mk
+++ b/make/elixir.mk
@@ -355,17 +355,22 @@ BENCH_TABLES_LEGS += generated/bench/tables/elixir/.stamp
 
 # THE ELIXIR NATIVE GATE (issue #547). `mix format` is the language's one
 # formatting authority and Credo is the analyzer an Elixir reader runs, and
-# this holds both corpora to both. The format half over the tables corpus is
-# new here: test-elixir above checks the packet emitter's output alone.
+# this holds both corpora to both, both halves before the verdict. The format
+# half over the tables corpus is new here: test-elixir above checks the packet
+# emitter's output alone.
 #
 # CREDO IS PINNED in test/native/elixir/mix.exs, and runs at its DEFAULT
-# strictness — plain `mix credo`, not --strict, which is the reading the law
+# strictness (plain `mix credo`, not --strict), which is the reading the law
 # asks for. Its config there names the two corpora as the files to read; the
 # project holds no source of its own.
 .PHONY: native-elixir
 native-elixir: generated/elixir/.stamp generated/elixir-ludicrous/.stamp build/tables-generated-elixir/.stamp
-	$(MIX) format --check-formatted generated/elixir/*.ex generated/elixir-ludicrous/*.ex build/tables-generated-elixir/*/*.ex
-	cd test/native/elixir && $(MIX) local.hex --force --if-missing && $(MIX) local.rebar --force --if-missing && $(MIX) deps.get && $(MIX) credo
-	@echo "native Elixir: mix format canonical and Credo clean over the examples and tables corpora"
+	@fail=0; \
+	echo "==== mix format"; \
+	$(MIX) format --check-formatted generated/elixir/*.ex generated/elixir-ludicrous/*.ex build/tables-generated-elixir/*/*.ex || fail=1; \
+	echo "==== credo"; \
+	( cd test/native/elixir && $(MIX) local.hex --force --if-missing && $(MIX) local.rebar --force --if-missing && $(MIX) deps.get && $(MIX) credo ) || fail=1; \
+	if [ $$fail -ne 0 ]; then echo "native Elixir: the findings above are the emitter's"; exit 1; fi; \
+	echo "native Elixir: mix format canonical and Credo clean over the examples and tables corpora"
 
 NATIVE_LEGS       += native-elixir

--- a/make/elixir.mk
+++ b/make/elixir.mk
@@ -352,3 +352,20 @@ test-elixir: generated/bench/tables/elixir/.stamp generated/elixir/.stamp genera
 TEST_LEGS         += test-elixir
 CONFORMANCE_LEGS  += build-conformance-elixir
 BENCH_TABLES_LEGS += generated/bench/tables/elixir/.stamp
+
+# THE ELIXIR NATIVE GATE (issue #547). `mix format` is the language's one
+# formatting authority and Credo is the analyzer an Elixir reader runs, and
+# this holds both corpora to both. The format half over the tables corpus is
+# new here: test-elixir above checks the packet emitter's output alone.
+#
+# CREDO IS PINNED in test/native/elixir/mix.exs, and runs at its DEFAULT
+# strictness — plain `mix credo`, not --strict, which is the reading the law
+# asks for. Its config there names the two corpora as the files to read; the
+# project holds no source of its own.
+.PHONY: native-elixir
+native-elixir: generated/elixir/.stamp generated/elixir-ludicrous/.stamp build/tables-generated-elixir/.stamp
+	$(MIX) format --check-formatted generated/elixir/*.ex generated/elixir-ludicrous/*.ex build/tables-generated-elixir/*/*.ex
+	cd test/native/elixir && $(MIX) local.hex --force --if-missing && $(MIX) local.rebar --force --if-missing && $(MIX) deps.get && $(MIX) credo
+	@echo "native Elixir: mix format canonical and Credo clean over the examples and tables corpora"
+
+NATIVE_LEGS       += native-elixir

--- a/make/go.mk
+++ b/make/go.mk
@@ -228,25 +228,27 @@ BENCH_TABLES_LEGS += generated/bench/tables/go/.stamp
 
 # THE GO NATIVE GATE (issue #547). Generated Go is held to the two instruments
 # a Go reader already runs over their own tree: gofmt, which is the language's
-# one formatting authority, and go vet at its default set. Both corpora ride —
-# the examples corpus under generated/, the tables corpus under build/ — so an
-# emitter that drifts in the surface the packet backend writes is not covered
-# by the table backend's cleanliness, or the other way round.
+# one formatting authority, and go vet at its default set. Both corpora ride,
+# the examples corpus under generated/ and the tables corpus under build/, so
+# an emitter that drifts in the surface the packet backend writes is not
+# covered by the table backend's cleanliness, or the other way round. Both
+# halves run before the leg reports.
 #
 # vet runs PER MODULE because every generated unit is its own module with its
 # own replace of the serialize.go sibling; a walk from the repo root would not
 # see them at all.
 .PHONY: native-go
 native-go: generated/go/.stamp generated/go-ludicrous/.stamp build/tables-generated-go/.stamp
-	@out=$$(gofmt -l generated/go generated/go-ludicrous build/tables-generated-go); \
-	if [ -n "$$out" ]; then \
-		echo "$$out"; \
-		echo "native-go: gofmt would rewrite the generated files above"; exit 1; \
-	fi
-	@for m in generated/go generated/go-ludicrous build/tables-generated-go/*/; do \
+	@fail=0; \
+	echo "==== gofmt"; \
+	out=$$(gofmt -l generated/go generated/go-ludicrous build/tables-generated-go); \
+	if [ -n "$$out" ]; then echo "$$out"; echo "gofmt would rewrite the generated files above"; fail=1; fi; \
+	echo "==== go vet"; \
+	for m in generated/go generated/go-ludicrous build/tables-generated-go/*/; do \
 		test -f $$m/go.mod || continue; \
-		( cd $$m && go vet ./... ) || exit 1; \
-	done
-	@echo "native Go: gofmt-canonical and go vet clean over the examples and tables corpora"
+		( cd $$m && go vet ./... ) || fail=1; \
+	done; \
+	if [ $$fail -ne 0 ]; then echo "native Go: the findings above are the emitter's"; exit 1; fi; \
+	echo "native Go: gofmt-canonical and go vet clean over the examples and tables corpora"
 
 NATIVE_LEGS       += native-go

--- a/make/go.mk
+++ b/make/go.mk
@@ -225,3 +225,28 @@ test-go: generated/bench/tables/go/.stamp generated/go/.stamp generated/go-ludic
 TEST_LEGS         += test-go
 CONFORMANCE_LEGS  += build/conformance-go
 BENCH_TABLES_LEGS += generated/bench/tables/go/.stamp
+
+# THE GO NATIVE GATE (issue #547). Generated Go is held to the two instruments
+# a Go reader already runs over their own tree: gofmt, which is the language's
+# one formatting authority, and go vet at its default set. Both corpora ride —
+# the examples corpus under generated/, the tables corpus under build/ — so an
+# emitter that drifts in the surface the packet backend writes is not covered
+# by the table backend's cleanliness, or the other way round.
+#
+# vet runs PER MODULE because every generated unit is its own module with its
+# own replace of the serialize.go sibling; a walk from the repo root would not
+# see them at all.
+.PHONY: native-go
+native-go: generated/go/.stamp generated/go-ludicrous/.stamp build/tables-generated-go/.stamp
+	@out=$$(gofmt -l generated/go generated/go-ludicrous build/tables-generated-go); \
+	if [ -n "$$out" ]; then \
+		echo "$$out"; \
+		echo "native-go: gofmt would rewrite the generated files above"; exit 1; \
+	fi
+	@for m in generated/go generated/go-ludicrous build/tables-generated-go/*/; do \
+		test -f $$m/go.mod || continue; \
+		( cd $$m && go vet ./... ) || exit 1; \
+	done
+	@echo "native Go: gofmt-canonical and go vet clean over the examples and tables corpora"
+
+NATIVE_LEGS       += native-go

--- a/make/java.mk
+++ b/make/java.mk
@@ -524,13 +524,13 @@ CONFORMANCE_LEGS  += build-conformance-java
 CONFORMANCE_ENV   += JAVA=$(JAVA)
 BENCH_TABLES_LEGS += generated/bench/tables/java/.stamp
 
-# THE JAVA NATIVE GATE (issue #547). Java's analyzer is the JDK's own lint —
+# THE JAVA NATIVE GATE (issue #547). Java's analyzer is the JDK's own lint,
 # `javac -Xlint:all -Werror`, which the compile gates above already hold both
-# corpora to — and its formatter is google-java-format, in the AOSP profile:
-# four-space indent, which is what this emitter writes and what the rest of
-# the estate's Java uses. The Google profile's two spaces is the only thing
-# that separates them, and choosing between the two profiles is choosing an
-# indent, not a standard.
+# corpora to, and its formatter is google-java-format in the AOSP profile:
+# four-space indent, which is what this emitter writes and what the rest of the
+# estate's Java uses. The Google profile's two spaces is the only thing that
+# separates the two profiles, so choosing between them is choosing an indent,
+# not a standard. Both halves run before the leg reports.
 #
 # THE FORMATTER IS PINNED AND CACHED under dist/ keyed by its version, like
 # every other toolchain in this tree: the jar is fetched once, checked against
@@ -538,8 +538,8 @@ BENCH_TABLES_LEGS += generated/bench/tables/java/.stamp
 # nothing runs a floating version.
 #
 # The --add-exports run is the invocation google-java-format documents for
-# JDK 16 and later: it reads the compiler's own parser, which the module
-# system closes by default.
+# JDK 16 and later: it reads the compiler's own parser, which the module system
+# closes by default.
 GOOGLE_JAVA_FORMAT_VERSION ?= 1.36.1
 GOOGLE_JAVA_FORMAT_SHA256  ?= 25b400f003089d23cc5320cdaf1a16cabee19b8aa3434d0ff021b3d9f42154b4
 GOOGLE_JAVA_FORMAT_JAR     := dist/google-java-format-$(GOOGLE_JAVA_FORMAT_VERSION)-all-deps.jar
@@ -562,13 +562,17 @@ GOOGLE_JAVA_FORMAT = $(JAVA) \
 
 .PHONY: native-java
 native-java: generated/java/.stamp generated/java-ludicrous/.stamp build/tables-generated-java/.stamp $(GOOGLE_JAVA_FORMAT_JAR)
-	$(MAKE) tables-java-compile-all
-	@rm -rf build/java-native-classes && mkdir -p build/java-native-classes
-	$(JAVAC) --release 17 -Xlint:all -Werror -d build/java-native-classes generated/java/*.java
-	@rm -rf build/java-native-classes-ludicrous && mkdir -p build/java-native-classes-ludicrous
-	$(JAVAC) --release 17 -Xlint:all -Werror -d build/java-native-classes-ludicrous generated/java-ludicrous/*.java
+	@fail=0; \
+	echo "==== javac -Xlint:all -Werror"; \
+	$(MAKE) --no-print-directory tables-java-compile-all || fail=1; \
+	rm -rf build/java-native-classes && mkdir -p build/java-native-classes; \
+	$(JAVAC) --release 17 -Xlint:all -Werror -d build/java-native-classes generated/java/*.java || fail=1; \
+	rm -rf build/java-native-classes-ludicrous && mkdir -p build/java-native-classes-ludicrous; \
+	$(JAVAC) --release 17 -Xlint:all -Werror -d build/java-native-classes-ludicrous generated/java-ludicrous/*.java || fail=1; \
+	echo "==== google-java-format --aosp"; \
 	$(GOOGLE_JAVA_FORMAT) --dry-run --set-exit-if-changed \
-		generated/java/*.java generated/java-ludicrous/*.java build/tables-generated-java/*/*.java
-	@echo "native Java: -Xlint:all -Werror clean and google-java-format canonical over the examples and tables corpora"
+		generated/java/*.java generated/java-ludicrous/*.java build/tables-generated-java/*/*.java || fail=1; \
+	if [ $$fail -ne 0 ]; then echo "native Java: the findings above are the emitter's"; exit 1; fi; \
+	echo "native Java: -Xlint:all -Werror clean and google-java-format canonical over the examples and tables corpora"
 
 NATIVE_LEGS       += native-java

--- a/make/java.mk
+++ b/make/java.mk
@@ -523,3 +523,52 @@ TEST_LEGS         += test-java
 CONFORMANCE_LEGS  += build-conformance-java
 CONFORMANCE_ENV   += JAVA=$(JAVA)
 BENCH_TABLES_LEGS += generated/bench/tables/java/.stamp
+
+# THE JAVA NATIVE GATE (issue #547). Java's analyzer is the JDK's own lint —
+# `javac -Xlint:all -Werror`, which the compile gates above already hold both
+# corpora to — and its formatter is google-java-format, in the AOSP profile:
+# four-space indent, which is what this emitter writes and what the rest of
+# the estate's Java uses. The Google profile's two spaces is the only thing
+# that separates them, and choosing between the two profiles is choosing an
+# indent, not a standard.
+#
+# THE FORMATTER IS PINNED AND CACHED under dist/ keyed by its version, like
+# every other toolchain in this tree: the jar is fetched once, checked against
+# its sha256, and never fetched again. Nothing reaches for a system binary and
+# nothing runs a floating version.
+#
+# The --add-exports run is the invocation google-java-format documents for
+# JDK 16 and later: it reads the compiler's own parser, which the module
+# system closes by default.
+GOOGLE_JAVA_FORMAT_VERSION ?= 1.36.1
+GOOGLE_JAVA_FORMAT_SHA256  ?= 25b400f003089d23cc5320cdaf1a16cabee19b8aa3434d0ff021b3d9f42154b4
+GOOGLE_JAVA_FORMAT_JAR     := dist/google-java-format-$(GOOGLE_JAVA_FORMAT_VERSION)-all-deps.jar
+GOOGLE_JAVA_FORMAT_URL     := https://github.com/google/google-java-format/releases/download/v$(GOOGLE_JAVA_FORMAT_VERSION)/google-java-format-$(GOOGLE_JAVA_FORMAT_VERSION)-all-deps.jar
+
+$(GOOGLE_JAVA_FORMAT_JAR):
+	@mkdir -p dist
+	curl -fsSL -o $@.tmp $(GOOGLE_JAVA_FORMAT_URL)
+	@printf '%s  %s\n' "$(GOOGLE_JAVA_FORMAT_SHA256)" "$@.tmp" > $@.sha256
+	@if command -v sha256sum > /dev/null 2>&1; then sha256sum -c $@.sha256; else shasum -a 256 -c $@.sha256; fi
+	@mv $@.tmp $@
+
+GOOGLE_JAVA_FORMAT = $(JAVA) \
+	--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+	--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+	--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+	--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+	--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+	-jar $(GOOGLE_JAVA_FORMAT_JAR) --aosp
+
+.PHONY: native-java
+native-java: generated/java/.stamp generated/java-ludicrous/.stamp build/tables-generated-java/.stamp $(GOOGLE_JAVA_FORMAT_JAR)
+	$(MAKE) tables-java-compile-all
+	@rm -rf build/java-native-classes && mkdir -p build/java-native-classes
+	$(JAVAC) --release 17 -Xlint:all -Werror -d build/java-native-classes generated/java/*.java
+	@rm -rf build/java-native-classes-ludicrous && mkdir -p build/java-native-classes-ludicrous
+	$(JAVAC) --release 17 -Xlint:all -Werror -d build/java-native-classes-ludicrous generated/java-ludicrous/*.java
+	$(GOOGLE_JAVA_FORMAT) --dry-run --set-exit-if-changed \
+		generated/java/*.java generated/java-ludicrous/*.java build/tables-generated-java/*/*.java
+	@echo "native Java: -Xlint:all -Werror clean and google-java-format canonical over the examples and tables corpora"
+
+NATIVE_LEGS       += native-java

--- a/make/js.mk
+++ b/make/js.mk
@@ -451,3 +451,39 @@ test-js: generated/js/.stamp generated/js-ludicrous/.stamp generated/bench/js/.s
 TEST_LEGS         += test-js
 CONFORMANCE_LEGS  += build/tables-generated-js/.stamp
 BENCH_TABLES_LEGS += generated/bench/tables/js/.stamp
+
+# npm, from the same pinned Node the leg above documents; CI installs the same
+# major and overrides with NPM=npm.
+NPM ?= $(CURDIR)/dist/node-v20.20.2-darwin-arm64/bin/npm
+
+# THE JAVASCRIPT NATIVE GATE (issue #547). ESLint is the language's standard
+# analyzer, and JavaScript has no standard formatter to pair with it — so this
+# leg is the analyzer alone, at its own recommended severities, over the
+# generated ES modules of both corpora.
+#
+# THE ANALYZER IS PINNED like every other dependency in this tree: the version
+# lives in test/native/js/package.json and the whole closure in the lockfile
+# beside it, and `npm ci` installs exactly that. Nothing here runs @latest and
+# nothing reaches for a system eslint.
+#
+# IT INSTALLS UNDER build/_native-js, and the leading underscore is the whole
+# reason: `go build ./...` and `go test ./...` walk build/, npm packages ship
+# Go files, and the Go tool skips a directory whose name starts with an
+# underscore. The config is copied in beside the tree so that its own
+# `import "@eslint/js"` resolves where the packages are.
+NATIVE_JS_DIR := build/_native-js
+
+$(NATIVE_JS_DIR)/.stamp: test/native/js/package.json test/native/js/package-lock.json test/native/js/eslint.config.mjs
+	@mkdir -p $(NATIVE_JS_DIR)
+	cp test/native/js/package.json test/native/js/package-lock.json test/native/js/eslint.config.mjs $(NATIVE_JS_DIR)/
+	cd $(NATIVE_JS_DIR) && $(NPM) ci
+	@touch $@
+
+.PHONY: native-js
+native-js: generated/js/.stamp generated/js-ludicrous/.stamp build/tables-generated-js/.stamp $(NATIVE_JS_DIR)/.stamp
+	$(NODE) $(NATIVE_JS_DIR)/node_modules/eslint/bin/eslint.js \
+		--no-config-lookup --config $(NATIVE_JS_DIR)/eslint.config.mjs \
+		generated/js generated/js-ludicrous build/tables-generated-js
+	@echo "native JavaScript: ESLint clean over the examples and tables corpora"
+
+NATIVE_LEGS       += native-js

--- a/make/rust.mk
+++ b/make/rust.mk
@@ -331,3 +331,30 @@ test-rust: generated/rust/.stamp generated/rust-ludicrous/.stamp generated/bench
 TEST_LEGS         += test-rust
 CONFORMANCE_LEGS  += build/conformance-rust
 BENCH_TABLES_LEGS += generated/bench/tables/rust/.stamp
+
+# THE RUST NATIVE GATE (issue #547). rustfmt and clippy are the two
+# instruments a Rust reader runs, and this holds the generated crates of both
+# corpora to them: `cargo fmt --check`, which has no options to argue about,
+# and `cargo clippy` with `-D warnings`, which is what "red on any finding"
+# means here.
+#
+# IT IS NOT tables-rust-clippy, and neither replaces the other. That target
+# asks whether a CONSUMER's build survives the generated code, so it runs
+# clippy's default exit status and stays green on a lint; this one asks
+# whether the emitted text is what a Rust author would have written, so a lint
+# is the finding. The cost of the difference is named: clippy's lint set moves
+# with the stable toolchain, so this leg can go red on a rustup release with
+# no commit here, exactly as govulncheck can. That is the gate the law asks
+# for, and the pin question belongs to the workflow that installs the
+# toolchain.
+.PHONY: native-rust
+native-rust: generated/rust/.stamp generated/rust-ludicrous/.stamp build/tables-generated-rust/.stamp
+	@for c in generated/rust generated/rust-ludicrous build/tables-generated-rust/*/; do \
+		test -f $$c/Cargo.toml || continue; \
+		echo "native-rust: $$c"; \
+		( cd $$c && PATH="$(RUSTUP_BIN):$$PATH" cargo fmt --check ) || exit 1; \
+		( cd $$c && PATH="$(RUSTUP_BIN):$$PATH" cargo clippy --quiet --all-targets -- -D warnings ) || exit 1; \
+	done
+	@echo "native Rust: rustfmt-canonical and clippy clean over the examples and tables corpora"
+
+NATIVE_LEGS       += native-rust

--- a/make/rust.mk
+++ b/make/rust.mk
@@ -332,29 +332,31 @@ TEST_LEGS         += test-rust
 CONFORMANCE_LEGS  += build/conformance-rust
 BENCH_TABLES_LEGS += generated/bench/tables/rust/.stamp
 
-# THE RUST NATIVE GATE (issue #547). rustfmt and clippy are the two
-# instruments a Rust reader runs, and this holds the generated crates of both
-# corpora to them: `cargo fmt --check`, which has no options to argue about,
-# and `cargo clippy` with `-D warnings`, which is what "red on any finding"
-# means here.
+# THE RUST NATIVE GATE (issue #547). rustfmt and clippy are the two instruments
+# a Rust reader runs, and this holds the generated crates of both corpora to
+# them: `cargo fmt --check`, which has no options to argue about, and
+# `cargo clippy` with `-D warnings`, which is what "red on any finding" means
+# here. Both run over every crate before the leg reports, so one run names the
+# whole list.
 #
 # IT IS NOT tables-rust-clippy, and neither replaces the other. That target
 # asks whether a CONSUMER's build survives the generated code, so it runs
-# clippy's default exit status and stays green on a lint; this one asks
-# whether the emitted text is what a Rust author would have written, so a lint
-# is the finding. The cost of the difference is named: clippy's lint set moves
-# with the stable toolchain, so this leg can go red on a rustup release with
-# no commit here, exactly as govulncheck can. That is the gate the law asks
-# for, and the pin question belongs to the workflow that installs the
-# toolchain.
+# clippy's default exit status and stays green on a lint; this one asks whether
+# the emitted text is what a Rust author would have written, so a lint is the
+# finding. The cost of the difference is named: clippy's lint set moves with
+# the stable toolchain, so this leg can go red on a rustup release with no
+# commit here, exactly as govulncheck can. That is the gate the law asks for,
+# and the pin question belongs to the workflow that installs the toolchain.
 .PHONY: native-rust
 native-rust: generated/rust/.stamp generated/rust-ludicrous/.stamp build/tables-generated-rust/.stamp
-	@for c in generated/rust generated/rust-ludicrous build/tables-generated-rust/*/; do \
+	@fail=0; \
+	for c in generated/rust generated/rust-ludicrous build/tables-generated-rust/*/; do \
 		test -f $$c/Cargo.toml || continue; \
-		echo "native-rust: $$c"; \
-		( cd $$c && PATH="$(RUSTUP_BIN):$$PATH" cargo fmt --check ) || exit 1; \
-		( cd $$c && PATH="$(RUSTUP_BIN):$$PATH" cargo clippy --quiet --all-targets -- -D warnings ) || exit 1; \
-	done
-	@echo "native Rust: rustfmt-canonical and clippy clean over the examples and tables corpora"
+		echo "==== $$c"; \
+		( cd $$c && PATH="$(RUSTUP_BIN):$$PATH" cargo fmt --check ) || fail=1; \
+		( cd $$c && PATH="$(RUSTUP_BIN):$$PATH" cargo clippy --quiet --all-targets -- -D warnings ) || fail=1; \
+	done; \
+	if [ $$fail -ne 0 ]; then echo "native Rust: the findings above are the emitter's"; exit 1; fi; \
+	echo "native Rust: rustfmt-canonical and clippy clean over the examples and tables corpora"
 
 NATIVE_LEGS       += native-rust

--- a/test/native/README.md
+++ b/test/native/README.md
@@ -1,0 +1,65 @@
+# The native gate
+
+Generated code has to read as the target language's own. That is the law in
+issue #547, and this directory is the half of it a machine can check: for every
+port, the language's standard formatter in check mode and its standard analyzer
+at default strictness, run over the generated code of both corpora, red on any
+finding.
+
+Two corpora, always both. `generated/<lang>` is what the packet backend emits
+from `examples/`; `build/tables-generated-<lang>` is what the table backend
+emits from `tables/`. They are different emitters, and one being clean says
+nothing about the other.
+
+## Where a leg lives
+
+The check itself is `make native-<lang>`, and it lives in that port's
+`make/<lang>.mk`, beside its test and conformance legs. The language's own file
+is where the decision about which instruments a language is held to belongs.
+
+This directory holds only what CI needs to run it:
+
+    test/native/<lang>/ci.json    the port's CI row
+    test/native/matrix            the command that prints the matrix from them
+
+`ci.json` names the make target, the sibling runtime the analyzer needs on disk
+to typecheck what the emitter wrote, the toolchain steps CI installs, and the
+make overrides that point the leg at them. Every key is optional except
+`targets`; a leg that needs no runtime leaves `runtime` out and CI clones
+nothing.
+
+Some legs also carry their instrument's own configuration here — the ESLint
+config and its lockfile under `js/`, the Credo project under `elixir/`. A leg
+whose analyzer needs no project of its own carries nothing but its row.
+
+## Registering a port
+
+Add `native-<lang>` to `make/<lang>.mk`, register it with
+`NATIVE_LEGS += native-<lang>`, and add `test/native/<lang>/ci.json`. Nothing
+else is edited: `.github/workflows/ci.yml` fans out over whatever the registry
+prints.
+
+A port with a conformance driver and no native row is a build failure, in
+`test/native/matrix` and in `go test ./...`. That is deliberate. A port that
+lands without its native gate is exactly the gap this registry exists to close.
+
+## What is pinned
+
+Every instrument, and none of them from the machine's PATH by accident:
+
+| leg | formatter | analyzer |
+|---|---|---|
+| c | clang-format 18, `.clang-format` at the repository root | clang-tidy 18, default checks |
+| cpp | clang-format 18, the same style file | clang-tidy 18, default checks |
+| cs | `dotnet format whitespace --verify-no-changes` | the .NET analyzers, default mode, warnings as errors |
+| dart | `dart format --set-exit-if-changed` | `dart analyze` |
+| elixir | `mix format --check-formatted` | Credo, pinned in `elixir/mix.exs`, default strictness |
+| go | `gofmt -l` | `go vet` |
+| java | google-java-format, AOSP profile, pinned by version and sha256 | `javac -Xlint:all -Werror` |
+| js | none — JavaScript has no standard formatter | ESLint, pinned by lockfile, its own recommended set |
+| rust | `cargo fmt --check` | `cargo clippy -D warnings` |
+
+The C and C++ style file is the one thing on that list a tool does not supply:
+clang-format has no canonical style, so `.clang-format` at the repository root
+is the style, written from the estate's own C and C++ and stating why each
+option is what it is.

--- a/test/native/c/ci.json
+++ b/test/native/c/ci.json
@@ -1,0 +1,3 @@
+{"targets": "native-c",
+ "runtime": "serialize.c", "runtime_tag": "SERIALIZE_C_TAG",
+ "clang": "18"}

--- a/test/native/cpp/ci.json
+++ b/test/native/cpp/ci.json
@@ -1,0 +1,3 @@
+{"targets": "native-cpp",
+ "runtime": "serialize", "runtime_tag": "SERIALIZE_TAG",
+ "clang": "18"}

--- a/test/native/cs/ci.json
+++ b/test/native/cs/ci.json
@@ -1,0 +1,3 @@
+{"targets": "native-cs",
+ "runtime": "serialize.cs", "runtime_tag": "SERIALIZE_CS_TAG",
+ "dotnet": ".github/dotnet-version"}

--- a/test/native/dart/ci.json
+++ b/test/native/dart/ci.json
@@ -1,0 +1,1 @@
+{"targets": "native-dart", "dart": "3.13.2", "env": "DART=dart"}

--- a/test/native/elixir/.credo.exs
+++ b/test/native/elixir/.credo.exs
@@ -1,0 +1,21 @@
+# Credo's config for the native gate (issue #547). One check set, the default
+# one Credo ships, over the generated Elixir of both corpora and nothing else.
+# `mix credo` runs it at DEFAULT strictness; --strict is a different question
+# and not the one the law asks.
+%{
+  configs: [
+    %{
+      name: "default",
+      files: %{
+        included: [
+          "../../../generated/elixir/",
+          "../../../generated/elixir-ludicrous/",
+          "../../../build/tables-generated-elixir/"
+        ],
+        excluded: []
+      },
+      strict: false,
+      checks: %{}
+    }
+  ]
+}

--- a/test/native/elixir/ci.json
+++ b/test/native/elixir/ci.json
@@ -1,0 +1,1 @@
+{"targets": "native-elixir", "otp": "29.0.5", "elixir": "1.20.4"}

--- a/test/native/elixir/mix.exs
+++ b/test/native/elixir/mix.exs
@@ -1,0 +1,23 @@
+# The Elixir native gate's Credo project (issue #547). It carries no source of
+# its own: it exists so that `mix credo` has a project to run in, and so the
+# analyzer's version is pinned here rather than taken from whatever a machine
+# happens to have installed.
+defmodule SchemaNative.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :schema_native,
+      version: "0.0.0",
+      elixir: "~> 1.17",
+      elixirc_paths: [],
+      deps: deps()
+    ]
+  end
+
+  # Credo, at an exact version: a release that adds a check has to be a
+  # deliberate bump here, not a Tuesday.
+  defp deps do
+    [{:credo, "1.7.19", only: [:dev, :test], runtime: false}]
+  end
+end

--- a/test/native/go/ci.json
+++ b/test/native/go/ci.json
@@ -1,0 +1,2 @@
+{"targets": "native-go",
+ "runtime": "serialize.go", "runtime_tag": "SERIALIZE_GO_TAG"}

--- a/test/native/java/ci.json
+++ b/test/native/java/ci.json
@@ -1,0 +1,1 @@
+{"targets": "native-java", "java": "21", "env": "JAVA=java JAVAC=javac"}

--- a/test/native/js/ci.json
+++ b/test/native/js/ci.json
@@ -1,0 +1,1 @@
+{"targets": "native-js", "node": "20", "env": "NODE=node NPM=npm"}

--- a/test/native/js/eslint.config.mjs
+++ b/test/native/js/eslint.config.mjs
@@ -1,0 +1,27 @@
+// The JavaScript native gate's config (issue #547). ESLint is the language's
+// standard analyzer and ships no config of its own, so "default strictness"
+// here is its own recommended set and nothing added: js.configs.recommended,
+// over the generated ES modules of both corpora, every rule at the severity
+// ESLint ships it at.
+//
+// Beyond that this file states only what the emitted files ARE. They are ES
+// modules at the current language level. They name no browser and no Node
+// global except TextEncoder and TextDecoder, which are WHATWG globals every
+// JavaScript host the generated code targets provides — declaring them is
+// telling ESLint what the environment is, not excusing a finding.
+import js from "@eslint/js";
+
+export default [
+    js.configs.recommended,
+    {
+        files: ["**/*.js", "**/*.mjs"],
+        languageOptions: {
+            ecmaVersion: "latest",
+            sourceType: "module",
+            globals: {
+                TextDecoder: "readonly",
+                TextEncoder: "readonly",
+            },
+        },
+    },
+];

--- a/test/native/js/package-lock.json
+++ b/test/native/js/package-lock.json
@@ -1,0 +1,991 @@
+{
+  "name": "schema-native-js",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "schema-native-js",
+      "devDependencies": {
+        "@eslint/js": "10.0.1",
+        "eslint": "10.10.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+      "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+      "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.3",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "11.1.5 || >11.1.6 <12",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.23"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/test/native/js/package.json
+++ b/test/native/js/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "schema-native-js",
+  "private": true,
+  "description": "ESLint, pinned, for the JavaScript native gate (issue #547). Nothing imports this package: `npm ci` here installs the analyzer the make target runs.",
+  "type": "module",
+  "devDependencies": {
+    "@eslint/js": "10.0.1",
+    "eslint": "10.10.0"
+  }
+}

--- a/test/native/matrix/main.go
+++ b/test/native/matrix/main.go
@@ -1,0 +1,135 @@
+// The native gate's CI registry (issue #547): DISCOVERED, not listed.
+//
+// A port's native row is test/native/<lang>/ci.json, and this command prints
+// the matrix .github/workflows/ci.yml fans out over — one job per port,
+// running that port's `make native-<lang>`. A row names the make targets, the
+// sibling runtime the leg's analyzer needs on disk to typecheck what the
+// emitter wrote, the toolchain steps CI installs, and the make overrides that
+// point the leg at them.
+//
+// THE REGISTRY IS TIED TO THE PORT SET. The nine rows the law owes are the
+// nine ports, so this command reads the conformance registry — the one file
+// set that already says which languages exist — and refuses a tree where a
+// port has no native row, or a native row names no port. A port that lands
+// without its native gate is the gap this file exists to close.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// portsDir is the committed port registry: one directory per language, each
+// holding a conformance `driver`. The native gate owes one row per port.
+const portsDir = "test/conformance"
+
+// nativeDir holds the native rows, one directory per language.
+const nativeDir = "test/native"
+
+func main() {
+	out, err := matrix(nativeDir, portsDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "native matrix:", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
+}
+
+// ports lists every language with a conformance driver, in name order.
+func ports(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(dir, e.Name(), "driver"))
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+// rows lists every language with a native row, in name order.
+func rows(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, e.Name(), "ci.json")); err != nil {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+// matrix prints `{"include": [...]}`, one row per port, from every
+// test/native/<lang>/ci.json. A row is that file's keys plus "lang", and every
+// row carries every key any row set, empty where it did not — so a workflow
+// step comparing matrix.<key> with the empty string reads the same for every
+// leg, which is what lets one job serve nine toolchains.
+func matrix(dir, portRegistry string) ([]byte, error) {
+	langs, err := ports(portRegistry)
+	if err != nil {
+		return nil, err
+	}
+	if len(langs) == 0 {
+		return nil, fmt.Errorf("%s: no port has a driver — this matrix would fan out over nothing", portRegistry)
+	}
+	registered, err := rows(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, lang := range registered {
+		if !slices.Contains(langs, lang) {
+			return nil, fmt.Errorf("%s/%s/ci.json: a native row for %q, which is not a port in %s", dir, lang, lang, portRegistry)
+		}
+	}
+
+	keys := map[string]bool{"lang": true, "targets": true}
+	rows := make([]map[string]string, 0, len(langs))
+	for _, lang := range langs {
+		path := filepath.Join(dir, lang, "ci.json")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: the %s port has no native row: %w", path, lang, err)
+		}
+		row := map[string]string{}
+		if err := json.Unmarshal(data, &row); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		if strings.TrimSpace(row["targets"]) == "" {
+			return nil, fmt.Errorf("%s: \"targets\" names no make target", path)
+		}
+		row["lang"] = lang
+		for k := range row {
+			keys[k] = true
+		}
+		rows = append(rows, row)
+	}
+	for _, row := range rows {
+		for k := range keys {
+			if _, ok := row[k]; !ok {
+				row[k] = ""
+			}
+		}
+	}
+	return json.Marshal(map[string]any{"include": rows})
+}

--- a/test/native/matrix/matrix_test.go
+++ b/test/native/matrix/matrix_test.go
@@ -1,0 +1,85 @@
+// The registry's own gate. `go test ./...` carries it, so a port that lands a
+// conformance driver without a native row goes red on the diff that lands it
+// rather than on whoever reads the matrix next.
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// repoRoot is two directories up from this package.
+const repoRoot = "../../.."
+
+func TestEveryPortHasANativeRow(t *testing.T) {
+	t.Chdir(repoRoot)
+	langs, err := ports(portsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(langs) < 9 {
+		t.Fatalf("%s: %d ports discovered, and the law owes a native row for nine", portsDir, len(langs))
+	}
+	for _, lang := range langs {
+		if _, err := os.Stat(filepath.Join(nativeDir, lang, "ci.json")); err != nil {
+			t.Errorf("%s has a conformance driver and no native row at %s/%s/ci.json (issue #547)", lang, nativeDir, lang)
+		}
+	}
+}
+
+func TestMatrixCarriesEveryPortAndNamesItsTarget(t *testing.T) {
+	t.Chdir(repoRoot)
+	out, err := matrix(nativeDir, portsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Include []map[string]string `json:"include"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	langs, err := ports(portsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Include) != len(langs) {
+		t.Fatalf("matrix has %d rows for %d ports", len(got.Include), len(langs))
+	}
+	for _, row := range got.Include {
+		if want := "native-" + row["lang"]; row["targets"] != want {
+			t.Errorf("%s: targets is %q, and the leg CI runs is %q", row["lang"], row["targets"], want)
+		}
+	}
+}
+
+// Every row carries every key, so a workflow step conditioned on one reads the
+// same for a leg that set it and a leg that did not.
+func TestEveryRowCarriesEveryKey(t *testing.T) {
+	t.Chdir(repoRoot)
+	out, err := matrix(nativeDir, portsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Include []map[string]string `json:"include"`
+	}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	keys := map[string]bool{}
+	for _, row := range got.Include {
+		for k := range row {
+			keys[k] = true
+		}
+	}
+	for _, row := range got.Include {
+		for k := range keys {
+			if _, ok := row[k]; !ok {
+				t.Errorf("%s: no %q key", row["lang"], k)
+			}
+		}
+	}
+}

--- a/test/native/rust/ci.json
+++ b/test/native/rust/ci.json
@@ -1,0 +1,3 @@
+{"targets": "native-rust",
+ "runtime": "serialize.rs", "runtime_tag": "SERIALIZE_RS_TAG",
+ "rust": "stable", "env": "RUSTUP_BIN=/usr/bin"}


### PR DESCRIPTION
The gate half of #547.

The law is that what schema emits for a target reads as that language's own code. Two of its three parts are machine-checkable, and this lands them: the language's standard formatter in check mode and its standard analyzer at default strictness, over the generated code of **both** corpora — the examples corpus under `generated/`, the tables corpus under `build/` — red on any finding. The third part, the fluent-reader review, is a person's and belongs on each row's own pull request.

**Most of these legs are red today, deliberately.** They are not skipped and no finding is silenced. Each red leg's findings are enumerated below and filed as one issue per target, as work owed by the emitter.

## Shape

One `make native-<lang>` per port, in that port's own `make/<lang>.mk` beside its test and conformance legs, registered with `NATIVE_LEGS`. One CI job per port, fanned out over a registry the workflow discovers rather than a list it carries: `test/native/<lang>/ci.json` names the make target, the sibling runtime the analyzer needs on disk to typecheck what the emitter wrote, the toolchains to install, and the make overrides. A port with a conformance driver and no native row fails `go test ./...`.

Every instrument is pinned and none comes from a machine's PATH by accident.

## Status per target

Filled in once CI has run.