### PR TITLE
perf: a diagnostic costs nothing on the read or write path, measured (#546)

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -400,6 +400,61 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.leg == 'go'
         run: make tables-block-gate2-smoke
 
+  # THE PERF GATE (issue #546, bench/PERF-PINS). The owner's law: a diagnostic
+  # surface is admitted at zero MEASURED cost on the read path and the write
+  # path of both wires, or it is declined. A certification leg and not a
+  # pull-request one, for the obvious reason: it compiles two benches and times
+  # them, which is minutes, and a timed measurement wants a quiet box.
+  #
+  # WHAT RUNS HERE, AND WHAT DELIBERATELY DOES NOT. The absolute pins are facts
+  # about ONE machine, and this is a shared runner nobody here owns, so the
+  # gate is NOT asked to compare a rate against them: `check -advisory` proves
+  # the structural half only, that bench/PERF-PINS parses, states its sitting,
+  # and carries a pin for every row the gate guards, and then says out loud
+  # that it is off the pinned box. The enforcing verdict is `make perf-gate` on
+  # the box the pins name.
+  #
+  # WHAT IS PROVEN HERE IS THE INSTRUMENT ITSELF. `make perf-gate-control`
+  # plants one added branch per field on the read path, in a scratch copy of
+  # the generated headers under build/, measures a clean sitting and a planted
+  # sitting back to back, and REQUIRES the gate to go red on round_trip. That
+  # verdict is a ratio inside one sitting, so it holds on this hardware exactly
+  # as it holds on the pinned box. It is also the only thing that answers the
+  # standing question about any noise band, which is whether the band is wide
+  # enough to hide the cost it exists to catch. A gate nobody has watched go
+  # red is a gate nobody has tested, and this is where it gets watched.
+  #
+  # Nothing here touches generated/ or internal/codegen/, so the C/C++ lock
+  # (bench/LOCK) is never approached: the plant lands in build/.
+  perf-gate:
+    name: perf gate (the zero-cost-diagnostic law)
+    runs-on: macos-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Only the classic serialize runtime: the C++ packet leg names it, the
+      # C++ table leg names no runtime at all, and no other leg runs.
+      - name: Check out the serialize runtime (pinned release)
+        run: |
+          cd ..
+          git clone --quiet --depth 1 --branch "$SERIALIZE_TAG" https://github.com/mas-bandwidth/serialize.git serialize
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      # The pin file is the gate's whole authority, so the first thing checked
+      # is the file, not a number: it parses, it states its sitting, and it
+      # pins every row the gate guards.
+      - name: perf gate, the pin file and the off-box refusal
+        run: go run ./bench/tools/perfgate check -advisory
+
+      # The negative control. Red on round_trip is a PASS for this step.
+      - name: perf gate, the planted-cost negative control
+        run: make perf-gate-control
+
   # A new CVE lands with no commit, so govulncheck is the one gate whose
   # verdict changes on its own — the nightly is the trigger that catches it.
   # The same job rides every pull request in ci.yml, deliberately: neither

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,19 +719,26 @@ jobs:
           fi
           echo "no locked paths touched — clean"
 
-  # THE PERF PIN LOCK (issue #546, bench/PERF-PINS), on cpp-lock's model above.
+  # THE PERF PIN LOCK (issue #546, bench/PERF-PINS), on the model bench/LOCK's
+  # standing gate uses since the freeze lifted on 2026-09-05.
   #
   # bench/PERF-PINS holds the numbers `make perf-gate` compares a read and a
-  # write against, so the pins are the gate's whole authority. A pull request
-  # that changes the code AND the pins in one diff can make any regression
-  # green by definition, which is the one way this gate could rot silently.
+  # write against, so the pins are the gate's whole authority, and typing over
+  # them is the one way this gate could rot silently.
   #
-  # So a re-pin is its own act: a pull request whose diff is bench/PERF-PINS
-  # and nothing else, whose file states the sitting the numbers came off (the
-  # box, the date, the commit, the compiler, the load). This job refuses
-  # anything else, and it checks the same two structural things on every pull
-  # request whether or not the pins moved: the file parses, and it carries a
-  # pin for every row the gate guards.
+  # The refusal is NOT "the pins may only move alone". The lifted lock's
+  # replacement rule is that a pull request moving the packet emitters re-pins
+  # the reproduction rows IN THE SAME PR and states the sitting that produced
+  # them, and a rule against a combined diff would forbid that. What is refused
+  # is a re-pin with no sitting behind it: numbers moved while sitting.date,
+  # sitting.uptime and sitting.commit still describe the measurement they
+  # replaced, or a sitting.commit this branch does not contain.
+  #
+  # Two structural things are checked on every pull request whether or not the
+  # pins moved: the file parses and states its sitting, and it carries a pin
+  # for every row the gate guards. When the pins did move, the job also prints
+  # each row's move as a percentage, so the size of a re-pin is visible in the
+  # log rather than buried in two columns of digits.
   #
   # It costs no measurement and needs no quiet box, which is why it belongs on
   # the pull-request gate while the timed half belongs in certify.yml.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,3 +718,33 @@ jobs:
             exit 1
           fi
           echo "no locked paths touched — clean"
+
+  # THE PERF PIN LOCK (issue #546, bench/PERF-PINS), on cpp-lock's model above.
+  #
+  # bench/PERF-PINS holds the numbers `make perf-gate` compares a read and a
+  # write against, so the pins are the gate's whole authority. A pull request
+  # that changes the code AND the pins in one diff can make any regression
+  # green by definition, which is the one way this gate could rot silently.
+  #
+  # So a re-pin is its own act: a pull request whose diff is bench/PERF-PINS
+  # and nothing else, whose file states the sitting the numbers came off (the
+  # box, the date, the commit, the compiler, the load). This job refuses
+  # anything else, and it checks the same two structural things on every pull
+  # request whether or not the pins moved: the file parses, and it carries a
+  # pin for every row the gate guards.
+  #
+  # It costs no measurement and needs no quiet box, which is why it belongs on
+  # the pull-request gate while the timed half belongs in certify.yml.
+  perf-pin-lock:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.26'
+          cache: false
+      - name: refuse an unstated re-pin
+        run: go run ./bench/tools/perfgate pinlock -base "origin/${{ github.base_ref || 'main' }}"

--- a/Makefile
+++ b/Makefile
@@ -2599,6 +2599,46 @@ bench-table-check: build/schema_test_bench_table
 	./build/schema_test_bench_table verify
 
 
+# ---------------------------------------------------------------------------
+# THE PERF GATE (bench/PERF-PINS, bench/tools/perfgate) --------------------
+#
+# The owner's zero-cost-diagnostic law, issue #546: a diagnostic surface is
+# admitted at zero MEASURED cost on the read path and the write path of both
+# wires, or it is declined. The law is on the page (docs/SPEC-TABLES.md §13.2,
+# docs/PERFORMANCE.md). These four targets are the number half of it.
+#
+# `perf-gate` measures the C++ reference over the bench corpus on both wires
+# and compares four rows against bench/PERF-PINS. A CERTIFICATION instrument,
+# never an iteration one: it wants a quiet box, it takes minutes, and off the
+# box the pins name it refuses to render a verdict at all rather than divide
+# one machine's number by another's silicon.
+#
+# `perf-gate-control` is the negative control. It plants one added branch per
+# field on the READ path, in a scratch copy of the generated headers under
+# build/, and REQUIRES the gate to go red on round_trip while write holds. Its
+# verdict is a ratio inside one sitting, so it needs no pins and holds on any
+# box, which is what certification runs.
+#
+# `perf-gate-pin` re-cuts the numbers. Its output is a pull request whose diff
+# is bench/PERF-PINS and nothing else, on bench/LOCK's model.
+#
+# `perf-gate-pinlock` is the cheap half that rides every pull request: the pin
+# file parses and states its sitting, and a diff that moves the pins moves
+# nothing else. No measurement, no quiet box needed.
+.PHONY: perf-gate perf-gate-control perf-gate-pin perf-gate-pinlock
+perf-gate:
+	go run ./bench/tools/perfgate check
+
+perf-gate-control:
+	go run ./bench/tools/perfgate control
+
+perf-gate-pin:
+	go run ./bench/tools/perfgate pin -repeats 7
+
+perf-gate-pinlock:
+	go run ./bench/tools/perfgate pinlock -base origin/main
+
+
 # Prove the COMMITTED generated/ tree matches what the current compiler
 # emits (issue #30). `make test` regenerates every tracked generated file in
 # place, so staleness is precisely a dirty tree afterwards — a tracked file

--- a/Makefile
+++ b/Makefile
@@ -2619,12 +2619,14 @@ bench-table-check: build/schema_test_bench_table
 # verdict is a ratio inside one sitting, so it needs no pins and holds on any
 # box, which is what certification runs.
 #
-# `perf-gate-pin` re-cuts the numbers. Its output is a pull request whose diff
-# is bench/PERF-PINS and nothing else, on bench/LOCK's model.
+# `perf-gate-pin` re-cuts the numbers and fills in the sitting they came off.
 #
-# `perf-gate-pinlock` is the cheap half that rides every pull request: the pin
-# file parses and states its sitting, and a diff that moves the pins moves
-# nothing else. No measurement, no quiet box needed.
+# `perf-gate-pinlock` is the cheap half that rides every pull request, on the
+# model bench/LOCK's standing gate uses since the freeze lifted: a diff may
+# move the pins alongside the change that moved the reference, and must restate
+# the sitting when it does. It refuses pins that moved while the sitting did
+# not, and a sitting.commit the branch does not contain. No measurement, no
+# quiet box needed.
 .PHONY: perf-gate perf-gate-control perf-gate-pin perf-gate-pinlock
 perf-gate:
 	go run ./bench/tools/perfgate check

--- a/bench/PERF-PINS
+++ b/bench/PERF-PINS
@@ -1,0 +1,125 @@
+# The perf gate's pins. The zero-cost-diagnostic law, issue #546.
+#
+# Owner's rule, 2026-09-05:
+#
+#   "i'm all for greater diagnostics, but if it costs speed on read or write,
+#    it's not worth it."
+#
+# and, on widening and the refusal reasons:
+#
+#   "if this costs *any* time, then we should not do this"
+#
+# at runtime, when the packet or the table is being read. The law that follows
+# is stated on the page (docs/SPEC-TABLES.md §13.2, docs/PERFORMANCE.md). This
+# file is the number half of it: every diagnostic surface is admitted at zero
+# MEASURED cost on the read path and the write path of both wires, and these
+# are the measurements it is admitted against.
+#
+#   make perf-gate           measure and compare
+#   make perf-gate-control   plant a read cost, watch the gate go red
+#   make perf-gate-pin       re-measure these numbers (this file, alone, in a PR)
+#
+# ---------------------------------------------------------------------------
+# WHAT IS PINNED, AND WHY THE READ ROW IS CALLED round_trip
+#
+# Four rows, the C++ reference over the bench corpus, both wires:
+#
+#   bench_mixed  write / round_trip    the packet wire  (bench/cpp)
+#   bench_table  write / round_trip    the table wire   (bench/tables/cpp)
+#
+# Neither runner measures a read on its own, deliberately: the decode's output
+# IS the re-encode's input, which is how the read side gets its sink discipline
+# with no per-language fold to audit (BENCH-STANDARD.md §2.7). Both runners do
+# print a read rate, round-trip time minus write time, and both mark it DERIVED
+# and keep it out of the CSV. A gate that pinned that number would be pinning a
+# subtraction of two medians, carrying the noise of both. So the gate pins what
+# was measured, and reads the pair: a cost on the read path raises round_trip
+# and leaves write flat, which is precisely what the negative control shows.
+# A red verdict therefore says WHICH path got slower, not merely that something
+# did.
+#
+# ---------------------------------------------------------------------------
+# THE BAND, AND HOW IT WAS DERIVED
+#
+# "Zero cost" is a claim about the code. A measurement of it lands inside a
+# distribution, so the gate needs a width, and a width chosen by feel is a
+# width that hides whatever it was chosen to hide.
+#
+# band.pct is TWICE THE WORST DEVIATION observed across repeated full sittings
+# on this box while it was quiet, rounded up to a tenth of a percent. The
+# derivation is a command, not a memory:
+#
+#     go run ./bench/tools/perfgate band -repeats 7
+#
+# which runs seven complete sittings, takes the median of each row across them,
+# and reports the largest departure of any single sitting from its row's
+# median. sitting.worst.pct below records what that measurement said on the day
+# these pins were cut, and band.pct is that number doubled. Doubling is the honest
+# margin for a box that was quiet then and may be merely quietish now, and it
+# is stated here rather than folded silently into a rounder-looking figure.
+#
+# WHAT THE BAND COSTS. A regression smaller than band.pct is invisible to this
+# instrument. That is a real limit and this file says so instead of implying
+# otherwise. It is also why the negative control exists: the control plants one
+# added branch per field on the read path, which is the cheapest diagnostic
+# anybody would actually propose, and requires the gate to see it. A band wide
+# enough to hide the control is a band that has stopped guarding anything, and
+# `make perf-gate-control` fails on exactly that.
+#
+# spread.max.pct is a separate refusal and not a band: it is the in-sitting
+# spread each runner already reports across its seven measured runs. A sitting
+# noisier than this cap renders NO verdict, red or green. A quiet box is a
+# precondition of the measurement, and a gate that passes on a noisy box is a
+# gate that passes on noise.
+#
+# ---------------------------------------------------------------------------
+# THE BOX IS PART OF THE PIN
+#
+# A rate in messages per second is a fact about one machine. Off the box named
+# below the gate REFUSES to render a verdict rather than divide one box's
+# number by another's silicon. What still runs anywhere is the negative
+# control, whose verdict is a ratio inside one sitting and needs no pin at all,
+# and that is what certification runs, on hardware nobody here owns.
+#
+# ---------------------------------------------------------------------------
+# MOVING THE PINS, on bench/LOCK's model
+#
+# These numbers are the gate's whole authority, so a diff that changes the code
+# and the pins together can make any regression green by definition. A re-pin
+# is its own pull request whose diff is THIS FILE AND NOTHING ELSE, and whose
+# sitting.* lines state the machine, the date, the commit and the load the
+# numbers came off. `make perf-gate-pinlock` enforces both halves on every pull
+# request and costs no measurement. `perfgate pin` fills the sitting.* lines in
+# and refuses outright while BENCH_CXXFLAGS_PREFIX is set. It deliberately does
+# NOT touch band.pct, because widening a band is a decision and never a side
+# effect of re-measuring.
+#
+# ---------------------------------------------------------------------------
+# The box these pins are facts about:
+
+box.arch            unpinned
+box.cpu             unpinned
+box.os              unpinned
+
+# The gate's two widths, both in percent:
+
+band.pct            0.0
+spread.max.pct      0.0
+
+# The sitting that produced the pins below:
+
+sitting.date        unpinned
+sitting.host        unpinned
+sitting.uptime      unpinned
+sitting.commit      unpinned
+sitting.compiler    unpinned
+sitting.opt         unpinned
+sitting.repeats     0
+sitting.worst.pct   0.00
+
+# pin <bench> <path> <median messages per second> <corpus_id>
+
+pin bench_mixed  write                    0 0000000000000000
+pin bench_mixed  round_trip               0 0000000000000000
+pin bench_table  write                    0 0000000000000000
+pin bench_table  round_trip               0 0000000000000000

--- a/bench/PERF-PINS
+++ b/bench/PERF-PINS
@@ -66,6 +66,14 @@
 # enough to hide the control is a band that has stopped guarding anything, and
 # `make perf-gate-control` fails on exactly that.
 #
+# The control's verdict is the SEPARATION between round_trip and write across
+# its two sittings, not a bare round_trip drop. A bare drop is the obvious test
+# and the fragile one, because a box that ran faster during the planted half
+# can hide a real cost inside its own drift. The difference between the rows
+# cancels whatever the box did to both, and it is the claim the law actually
+# makes: the cost landed on the READ path. Nothing is planted on the write
+# path, so write is the control's own control.
+#
 # spread.max.pct is a separate refusal and not a band: it is the in-sitting
 # spread each runner already reports across its seven measured runs. A sitting
 # noisier than this cap renders NO verdict, red or green. A quiet box is a

--- a/bench/PERF-PINS
+++ b/bench/PERF-PINS
@@ -17,7 +17,7 @@
 #
 #   make perf-gate           measure and compare
 #   make perf-gate-control   plant a read cost, watch the gate go red
-#   make perf-gate-pin       re-measure these numbers (this file, alone, in a PR)
+#   make perf-gate-pin       re-cut these numbers and the sitting they came off
 #
 # ---------------------------------------------------------------------------
 # WHAT IS PINNED, AND WHY THE READ ROW IS CALLED round_trip
@@ -54,9 +54,9 @@
 # which runs seven complete sittings, takes the median of each row across them,
 # and reports the largest departure of any single sitting from its row's
 # median. sitting.worst.pct below records what that measurement said on the day
-# these pins were cut, and band.pct is that number doubled. Doubling is the honest
-# margin for a box that was quiet then and may be merely quietish now, and it
-# is stated here rather than folded silently into a rounder-looking figure.
+# these pins were cut, and band.pct is that number doubled. Doubling is the
+# honest margin for a box that was quiet then and may be merely quietish now,
+# and it is stated here rather than folded silently into a rounder figure.
 #
 # WHAT THE BAND COSTS. A regression smaller than band.pct is invisible to this
 # instrument. That is a real limit and this file says so instead of implying
@@ -85,9 +85,18 @@
 #
 # A rate in messages per second is a fact about one machine. Off the box named
 # below the gate REFUSES to render a verdict rather than divide one box's
-# number by another's silicon. What still runs anywhere is the negative
-# control, whose verdict is a ratio inside one sitting and needs no pin at all,
-# and that is what certification runs, on hardware nobody here owns.
+# number by another's silicon.
+#
+# The identity is the MACHINE and not the machine model, which is why box.host
+# is part of it. Two laptops carrying the same chip differ in thermal headroom,
+# in memory, and in whatever else is running on them, and a shared
+# certification runner can report the same brand string as the box these came
+# off. Naming the host makes an accidental match impossible, which is what
+# keeps certification's advisory path advisory.
+#
+# What still runs anywhere is the negative control, whose verdict is a ratio
+# inside one sitting and needs no pin at all, and that is what certification
+# runs, on hardware nobody here owns.
 #
 # ---------------------------------------------------------------------------
 # RE-PINNING, on the model bench/LOCK's standing gate uses
@@ -107,8 +116,8 @@
 #
 # `make perf-gate-pinlock` runs on every pull request, costs no measurement,
 # and refuses exactly two things: pins that moved while sitting.date,
-# sitting.uptime and sitting.commit did not, and a sitting.commit this branch
-# does not contain. It also prints each pin's move as a percentage, so a
+# sitting.uptime and sitting.commit did not, and a sitting.commit that this
+# branch does not contain. It prints each pin's move as a percentage, so a
 # reviewer sees the size of a re-pin without diffing two columns of digits.
 #
 # `perfgate pin` fills the sitting.* lines in for you, and refuses outright
@@ -122,6 +131,7 @@
 box.arch            unpinned
 box.cpu             unpinned
 box.os              unpinned
+box.host            unpinned
 
 # The gate's two widths, both in percent:
 

--- a/bench/PERF-PINS
+++ b/bench/PERF-PINS
@@ -82,17 +82,31 @@
 # and that is what certification runs, on hardware nobody here owns.
 #
 # ---------------------------------------------------------------------------
-# MOVING THE PINS, on bench/LOCK's model
+# RE-PINNING, on the model bench/LOCK's standing gate uses
 #
-# These numbers are the gate's whole authority, so a diff that changes the code
-# and the pins together can make any regression green by definition. A re-pin
-# is its own pull request whose diff is THIS FILE AND NOTHING ELSE, and whose
-# sitting.* lines state the machine, the date, the commit and the load the
-# numbers came off. `make perf-gate-pinlock` enforces both halves on every pull
-# request and costs no measurement. `perfgate pin` fills the sitting.* lines in
-# and refuses outright while BENCH_CXXFLAGS_PREFIX is set. It deliberately does
-# NOT touch band.pct, because widening a band is a decision and never a side
-# effect of re-measuring.
+# When the C/C++ freeze lifted on 2026-09-05 what replaced it was a standing
+# gate, in the owner's terms: a pull request that moves the packet emitters
+# "re-pins the reproduction rows ... in the same PR and states the sitting that
+# produced them", with a laptop sitting admitted so long as its provenance is
+# stated. These pins take that rule exactly.
+#
+# So a re-pin is NOT required to travel alone. A change that legitimately moves
+# the reference has to move these numbers in the same diff, and a rule against
+# that would forbid the workflow the owner just blessed. What IS refused is a
+# re-pin with no sitting behind it: numbers typed over while the sitting.*
+# header below still describes the measurement they replaced. That is how a
+# regression gets made green by editing the thing that would have caught it.
+#
+# `make perf-gate-pinlock` runs on every pull request, costs no measurement,
+# and refuses exactly two things: pins that moved while sitting.date,
+# sitting.uptime and sitting.commit did not, and a sitting.commit this branch
+# does not contain. It also prints each pin's move as a percentage, so a
+# reviewer sees the size of a re-pin without diffing two columns of digits.
+#
+# `perfgate pin` fills the sitting.* lines in for you, and refuses outright
+# while BENCH_CXXFLAGS_PREFIX is set. It deliberately does NOT touch band.pct,
+# because widening a band is a decision and never a side effect of
+# re-measuring.
 #
 # ---------------------------------------------------------------------------
 # The box these pins are facts about:

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -72,6 +72,10 @@
 #   BENCH_OPT_LEVEL  C/C++ optimization level for the standard leg (default
 #                 O3; §3.3 publishes O2 and O3). Recorded in the flags line
 #                 AND stamped into the runners' opt column via -DBENCH_OPT.
+#   BENCH_CXXFLAGS_PREFIX
+#                 flags prepended to the C++ bench compiles, empty in every
+#                 published pass. One caller: the perf gate's negative control
+#                 (bench/tools/perfgate, issue #546). See the definition below.
 #   BENCH_CPU     core to pin to where taskset exists (default 0)
 #   BENCH_NOISE   noise label recorded in the results preamble, e.g.
 #                 "NOISY: game server owns isolated cores, bench on shared core 0"

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -240,6 +240,17 @@ esac
 RELEASE_FLAGS="-$OPT_LEVEL -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT=\"$OPT_LEVEL\" $COMMON_FLAGS"
 DEBUG_FLAGS="-O0 -g -DSERIALIZE_DEBUG $COMMON_FLAGS"
 
+# BENCH_CXXFLAGS_PREFIX: flags PREPENDED to the C++ bench compiles, and empty in
+# every published pass. One caller exists, the perf gate's negative control
+# (bench/tools/perfgate, issue #546), which points the include path at a
+# scratch copy of the generated headers carrying a planted read cost so the
+# gate can be watched going red. PREPENDED rather than appended because the
+# control's whole job is to win the include search over -Igenerated/bench/cpp.
+# Recorded rather than hidden: `perfgate pin` REFUSES to cut a pin while this
+# is set, since a number measured under flags the shipped build does not carry
+# is a number for a build nobody runs.
+BENCH_CXXFLAGS_PREFIX="${BENCH_CXXFLAGS_PREFIX:-}"
+
 # C: the repo's own C flags (the Makefile's C test leg) at the same Release
 # optimization as the C++ leg. NO -flto, deliberately — every other leg is
 # measured in its language's default release configuration (cargo release is
@@ -392,7 +403,7 @@ if [ -z "$ONLY" ] || [ "$ONLY" = cpp ]; then
         echo "== cpp: reusing build/bench/schema_bench_cpp ==" >&2
     else
         echo "== cpp: build (Release) ==" >&2
-        $CXX_BIN $RELEASE_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp
+        $CXX_BIN $BENCH_CXXFLAGS_PREFIX $RELEASE_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp
     fi
 
     echo "== cpp: run (Release) ==" >&2
@@ -400,7 +411,7 @@ if [ -z "$ONLY" ] || [ "$ONLY" = cpp ]; then
 
     if [ "$DEBUG" = 1 ]; then
         echo "== cpp: build (Debug) ==" >&2
-        $CXX_BIN $DEBUG_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp_debug
+        $CXX_BIN $BENCH_CXXFLAGS_PREFIX $DEBUG_FLAGS bench/cpp/bench_main.cpp -o build/bench/schema_bench_cpp_debug
         echo "" >> "$OUT"
         emit_preamble Debug
         echo "== cpp: run (Debug) ==" >&2

--- a/bench/tables/cpp/leg
+++ b/bench/tables/cpp/leg
@@ -25,9 +25,9 @@ build)
     fi
     mkdir -p build
     # BENCH_CXXFLAGS_PREFIX: prepended, empty in every published pass, one
-    # caller only. bench/run.sh carries the same hook and the same comment;
-    # the perf gate's negative control (bench/tools/perfgate, issue #546)
-    # points the include path at a scratch copy of the generated header
+    # caller only, and bench/run.sh carries the same hook and the same
+    # comment. The perf gate's negative control (bench/tools/perfgate, issue
+    # #546) points the include path at a scratch copy of the generated header
     # carrying a planted read cost, so the gate can be watched going red.
     $CXX ${BENCH_CXXFLAGS_PREFIX:-} -std=c++17 -Wall -Wextra -Werror -ffp-contract=off \
         "-$BENCH_OPT_LEVEL" -DNDEBUG -fno-rtti "-DBENCH_OPT=\"$BENCH_OPT_LEVEL\"" \

--- a/bench/tables/cpp/leg
+++ b/bench/tables/cpp/leg
@@ -24,7 +24,12 @@ build)
         exit 2
     fi
     mkdir -p build
-    $CXX -std=c++17 -Wall -Wextra -Werror -ffp-contract=off \
+    # BENCH_CXXFLAGS_PREFIX: prepended, empty in every published pass, one
+    # caller only. bench/run.sh carries the same hook and the same comment;
+    # the perf gate's negative control (bench/tools/perfgate, issue #546)
+    # points the include path at a scratch copy of the generated header
+    # carrying a planted read cost, so the gate can be watched going red.
+    $CXX ${BENCH_CXXFLAGS_PREFIX:-} -std=c++17 -Wall -Wextra -Werror -ffp-contract=off \
         "-$BENCH_OPT_LEVEL" -DNDEBUG -fno-rtti "-DBENCH_OPT=\"$BENCH_OPT_LEVEL\"" \
         -I"$GEN" "$SRC" -o "$BIN"
     ;;

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -849,6 +849,25 @@ func writePlanted(srcDir, dstDir, target string, plant func(string) (string, int
 	return planted, nil
 }
 
+// cmdPlant writes the planted scratch copies and stops, so the transform can
+// be read and compiled without spending a quiet window on a timed run.
+func cmdPlant(args []string) int {
+	parseFlags(args, map[string]*string{}, map[string]*int{})
+	pktN, err := writePlanted("generated/bench/cpp", "build/perfgate/planted/cpp", "BenchWire.h", plantPacket)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate plant:", err)
+		return 1
+	}
+	tblN, err := writePlanted("generated/bench/tables/cpp", "build/perfgate/planted/tables-cpp", "BenchTableTable.h", plantTable)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate plant:", err)
+		return 1
+	}
+	fmt.Printf("build/perfgate/planted/cpp/BenchWire.h            %d read sites planted\n", pktN)
+	fmt.Printf("build/perfgate/planted/tables-cpp/BenchTableTable.h %d read sites planted\n", tblN)
+	return 0
+}
+
 func cmdControl(args []string) int {
 	parseFlags(args, map[string]*string{}, map[string]*int{})
 
@@ -1101,6 +1120,7 @@ func usage() {
 
   perfgate check [-advisory]     measure and compare against bench/PERF-PINS
   perfgate control               plant a read cost and require the gate to go red
+  perfgate plant                 write the planted scratch copies and stop
   perfgate measure [-repeats N]  measure only, print the rows
   perfgate band [-repeats N]     derive the noise band from repeated sittings
   perfgate pin [-repeats N]      rewrite the pins and the sitting they came from
@@ -1116,6 +1136,8 @@ func main() {
 	switch os.Args[1] {
 	case "check":
 		os.Exit(cmdCheck(args))
+	case "plant":
+		os.Exit(cmdPlant(args))
 	case "control":
 		os.Exit(cmdControl(args))
 	case "measure":

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -911,47 +911,57 @@ func cmdControl(args []string) int {
 		return 1
 	}
 
-	// THE CONTROL IS A RATIO INSIDE ONE SITTING, not a comparison against the
-	// pins: the clean half is measured minutes before the planted half on the
-	// same box, so the verdict holds on hardware that has no pins at all.
+	// THE CONTROL COMPARES TWO SITTINGS ON ONE BOX, never the pins: the clean
+	// half is measured minutes before the planted half on the same machine, so
+	// the verdict holds on hardware that has no pins at all.
+	delta := func(s *sitting, k string) float64 { return s.rows[k].rate }
 	fmt.Printf("%-24s %14s %14s %9s  %s\n", "row", "clean M/s", "planted M/s", "delta", "verdict")
-	readRed, writeMoved := false, false
+	pct := map[string]float64{}
 	for _, want := range gateRows {
 		k := want[0] + "/" + want[1]
-		c := clean.rows[k].rate
-		pl := planted.rows[k].rate
-		delta := (pl - c) / c * 100
-		red := delta < -band
+		c, pl := delta(clean, k), delta(planted, k)
+		pct[k] = (pl - c) / c * 100
 		mark := "ok  "
-		if red {
+		if pct[k] < -band {
 			mark = "RED "
 		}
-		fmt.Printf("%-24s %14.3f %14.3f %8.2f%%  %s\n", k, c/1e6, pl/1e6, delta, mark)
-		if want[1] == "round_trip" && red {
-			readRed = true
-		}
-		if want[1] == "write" && red {
-			writeMoved = true
-		}
+		fmt.Printf("%-24s %14.3f %14.3f %8.2f%%  %s\n", k, c/1e6, pl/1e6, pct[k], mark)
 	}
 	fmt.Printf("band: %.2f%%\n\n", band)
 
-	if !readRed {
-		fmt.Printf("CONTROL FAILED. One added branch per field on the read path did not move\n")
-		fmt.Printf("round_trip past the %.2f%% band on both wires. Either the plant did not\n", band)
-		fmt.Printf("reach the compiled code, or the band is wide enough to hide a real cost.\n")
-		fmt.Printf("A gate nobody has seen go red is a gate nobody has tested.\n")
+	// THE VERDICT IS THE SEPARATION, not either row alone, and that is the
+	// deliberate choice here. A raw round_trip drop is the obvious test and it
+	// is the fragile one: if the box happens to run faster during the planted
+	// half, a real cost can hide inside the drift, and this control has to hold
+	// on a shared certification runner nobody here owns. The difference between
+	// the two rows cancels whatever the box did to both, and it is also the
+	// exact claim the law needs: the cost landed on the READ path. Nothing was
+	// planted on the write path, so write is the control's own control.
+	fmt.Printf("%-14s %12s %12s %14s  %s\n", "wire", "write", "round_trip", "separation", "verdict")
+	ok := true
+	for _, b := range []string{"bench_mixed", "bench_table"} {
+		w, rt := pct[b+"/write"], pct[b+"/round_trip"]
+		sep := w - rt
+		mark := "RED  (the plant is visible)"
+		if sep <= band {
+			mark = "GREEN (the plant is invisible)"
+			ok = false
+		}
+		fmt.Printf("%-14s %11.2f%% %11.2f%% %13.2f%%  %s\n", b, w, rt, sep, mark)
+	}
+	fmt.Println()
+
+	if !ok {
+		fmt.Printf("CONTROL FAILED. One added branch per field on the read path did not separate\n")
+		fmt.Printf("round_trip from write by more than the %.2f%% band on both wires. Either the\n", band)
+		fmt.Printf("plant did not reach the compiled code, or the band is wide enough to hide the\n")
+		fmt.Printf("cheapest diagnostic anybody would actually propose, which is the same thing as\n")
+		fmt.Printf("having no gate. A gate nobody has watched go red is a gate nobody has tested.\n")
 		return 1
 	}
-	fmt.Printf("CONTROL PASSED: the planted read cost is RED on round_trip.\n")
-	if writeMoved {
-		fmt.Printf("NOTE: write moved past the band too. Nothing was planted on the write path,\n")
-		fmt.Printf("so this is the box drifting under the two sittings, not the plant. Re-run it\n")
-		fmt.Printf("quiet before reading the read rows as a clean localization.\n")
-	} else {
-		fmt.Printf("write held inside the band on both wires, which is the localization the law\n")
-		fmt.Printf("needs: the gate says WHICH path got slower, not merely that something did.\n")
-	}
+	fmt.Printf("CONTROL PASSED. On both wires the planted read cost separates round_trip from\n")
+	fmt.Printf("write by more than the band, so the gate sees it AND says which path it landed\n")
+	fmt.Printf("on. That separation is what a red perf-gate verdict is reporting.\n")
 	return 0
 }
 

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -358,7 +358,7 @@ func (p *pins) num(key string) (float64, error) {
 // gate's whole authority, so a pin whose sitting is unstated is a number with
 // no provenance, and the gate refuses to read one.
 var requiredDirectives = []string{
-	"box.arch", "box.cpu", "box.os",
+	"box.arch", "box.cpu", "box.os", "box.host",
 	"band.pct", "spread.max.pct",
 	"sitting.date", "sitting.host", "sitting.uptime", "sitting.commit",
 	"sitting.compiler", "sitting.opt", "sitting.repeats", "sitting.worst.pct",
@@ -398,10 +398,17 @@ func (p *pins) validate() error {
 	return nil
 }
 
+// onThisBox: the identity is the MACHINE, not the machine model. Two laptops
+// carrying the same chip differ in thermal headroom, memory and whatever else
+// is running on them, and a shared certification runner can report the same
+// brand string as the box these pins came off. Naming the host as well makes
+// an accidental match impossible, which is what keeps the advisory path
+// advisory.
 func (p *pins) onThisBox() bool {
 	return p.directives["box.arch"] == boxArch() &&
 		p.directives["box.os"] == boxOS() &&
-		p.directives["box.cpu"] == boxCPU()
+		p.directives["box.cpu"] == boxCPU() &&
+		p.directives["box.host"] == boxHost()
 }
 
 // ---------------------------------------------------------------------------
@@ -562,8 +569,8 @@ func cmdCheck(args []string) int {
 
 	if !p.onThisBox() {
 		fmt.Printf("NOT THE PINNED BOX.\n")
-		fmt.Printf("  pinned   %s / %s / %s\n", p.directives["box.arch"], p.directives["box.os"], p.directives["box.cpu"])
-		fmt.Printf("  this box %s / %s / %s\n", boxArch(), boxOS(), boxCPU())
+		fmt.Printf("  pinned   %s / %s / %s / %s\n", p.directives["box.arch"], p.directives["box.os"], p.directives["box.cpu"], p.directives["box.host"])
+		fmt.Printf("  this box %s / %s / %s / %s\n", boxArch(), boxOS(), boxCPU(), boxHost())
 		fmt.Printf("A rate in messages per second is a fact about one machine, and the gate\n")
 		fmt.Printf("will not divide one box's number by another's. Re-pin from this box with a\n")
 		fmt.Printf("pull request that states its sitting, or run the gate where the pins were cut.\n")
@@ -654,6 +661,7 @@ func cmdPin(args []string) int {
 		"box.arch":          last.arch,
 		"box.cpu":           last.cpu,
 		"box.os":            last.os,
+		"box.host":          last.host,
 		"sitting.date":      last.date,
 		"sitting.host":      last.host,
 		"sitting.uptime":    last.uptime,

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -2,7 +2,7 @@
 //
 //	make perf-gate            measure the reference benches and render a verdict
 //	make perf-gate-control    the planted-cost negative control
-//	make perf-gate-pin        re-measure the pins (a PR whose diff is bench/PERF-PINS)
+//	make perf-gate-pin        re-measure the pins and the sitting they came off
 //	make perf-gate-pinlock    the LOCK-model refusal, run on every pull request
 //
 // THE LAW IT ENFORCES. The owner's rule, 2026-09-05, issue #546: "i'm all for
@@ -65,7 +65,7 @@ import (
 
 const pinsPath = "bench/PERF-PINS"
 
-// the four rows the gate pins, in report order
+// gateRows: the four rows the gate pins, in report order.
 var gateRows = [][2]string{
 	{"bench_mixed", "write"},
 	{"bench_mixed", "round_trip"},
@@ -114,10 +114,10 @@ func boxCPU() string {
 		}
 	}
 	if b, err := os.ReadFile("/proc/cpuinfo"); err == nil {
-		for _, line := range strings.Split(string(b), "\n") {
+		for line := range strings.SplitSeq(string(b), "\n") {
 			if strings.HasPrefix(line, "model name") {
-				if i := strings.Index(line, ":"); i >= 0 {
-					return strings.TrimSpace(line[i+1:])
+				if _, after, ok := strings.Cut(line, ":"); ok {
+					return strings.TrimSpace(after)
 				}
 			}
 		}
@@ -708,11 +708,7 @@ func optOf(s *sitting) string {
 }
 
 func pad(key string) int {
-	n := 20 - len(key)
-	if n < 1 {
-		n = 1
-	}
-	return n
+	return max(20-len(key), 1)
 }
 
 // ---------------------------------------------------------------------------
@@ -993,7 +989,7 @@ func cmdPinlock(args []string) int {
 		return 1
 	}
 	touchesPins := false
-	for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+	for f := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
 		if f == pinsPath {
 			touchesPins = true
 		}

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -312,8 +312,14 @@ func loadPins(path string) (*pins, error) {
 		return nil, err
 	}
 	defer f.Close()
+	return parsePins(path, f)
+}
+
+// parsePins reads the file the working tree has, and, for the pin lock, the
+// one the base branch had.
+func parsePins(path string, r io.Reader) (*pins, error) {
 	p := &pins{directives: map[string]string{}, rates: map[string]float64{}, corpus: map[string]string{}}
-	sc := bufio.NewScanner(f)
+	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 1<<20), 1<<20)
 	for sc.Scan() {
 		line := sc.Text()
@@ -935,35 +941,30 @@ func cmdControl(args []string) int {
 }
 
 // ---------------------------------------------------------------------------
-// the pin lock, on bench/LOCK's model
+// the pin lock, on the model bench/LOCK's standing gate uses
 //
-// The pins are the gate's authority, so a re-pin of them is an act with its own
-// pull request and nothing else in the diff, the same shape the C/C++ lock
-// uses for a lift. This runs on every pull request, costs no measurement, and
-// makes an unstated re-pin impossible to merge quietly.
+// When the C/C++ freeze lifted on 2026-09-05 what replaced it was not nothing.
+// It was a standing gate, in the owner's terms: a pull request that moves the
+// packet emitters "re-pins the reproduction rows ... in the same PR and states
+// the sitting that produced them", with a laptop sitting admitted so long as
+// its provenance is stated. This is that rule, applied to these pins.
+//
+// So the refusal here is NOT "the pins may only move alone". A change that
+// legitimately moves the reference has to move the pins in the same diff, and
+// forbidding that would forbid the workflow the owner just blessed. What is
+// refused is a re-pin with no sitting behind it: numbers edited by hand while
+// the sitting.* header still describes the measurement they replaced. A diff
+// that moves the pins restates the sitting, and the commit it names is one
+// this branch actually contains.
+//
+// It runs on every pull request, costs no measurement, and prints the size of
+// each pin's move so a reviewer sees what was re-pinned without diffing two
+// columns of digits.
 
 func cmdPinlock(args []string) int {
 	base := "origin/main"
 	strs := map[string]*string{"base": &base}
 	parseFlags(args, strs, map[string]*int{})
-
-	out, err := exec.Command("git", "diff", "--name-only", base+"...HEAD").Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "perfgate pinlock: cannot diff against %s: %v\n", base, err)
-		return 1
-	}
-	var changed []string
-	for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if f != "" {
-			changed = append(changed, f)
-		}
-	}
-	touchesPins := false
-	for _, f := range changed {
-		if f == pinsPath {
-			touchesPins = true
-		}
-	}
 
 	p, err := loadPins(pinsPath)
 	if err != nil {
@@ -976,27 +977,95 @@ func cmdPinlock(args []string) int {
 	}
 	fmt.Printf("%s parses, states its sitting, and pins every gate row.\n", pinsPath)
 
+	// The sitting names a commit. A sitting cut on a commit this branch does
+	// not contain measured a tree nobody here is proposing to merge.
+	sc := p.directives["sitting.commit"]
+	if err := exec.Command("git", "merge-base", "--is-ancestor", sc, "HEAD").Run(); err != nil {
+		fmt.Printf("\nPERF PIN REFUSAL. sitting.commit is %s, which this branch does not contain.\n", sc)
+		fmt.Printf("A sitting cut on a commit outside this history measured a tree nobody is\n")
+		fmt.Printf("proposing to merge. Re-cut the pins here with `make perf-gate-pin`.\n")
+		return 1
+	}
+
+	out, err := exec.Command("git", "diff", "--name-only", base+"...HEAD").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "perfgate pinlock: cannot diff against %s: %v\n", base, err)
+		return 1
+	}
+	touchesPins := false
+	for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if f == pinsPath {
+			touchesPins = true
+		}
+	}
 	if !touchesPins {
-		fmt.Println("the diff does not move the pins, nothing to refuse")
+		fmt.Printf("sitting.commit %s is in this history, and the diff does not move the pins.\n", sc)
 		return 0
 	}
-	if len(changed) == 1 {
-		fmt.Printf("the diff is %s alone, the re-pin act, allowed\n", pinsPath)
-		fmt.Printf("  sitting %s on %s, %s\n", p.directives["sitting.date"], p.directives["sitting.host"], p.directives["sitting.commit"])
+
+	// The pins moved. Read the base's copy and require the sitting to have
+	// moved with them.
+	old, err := exec.Command("git", "show", base+":"+pinsPath).Output()
+	if err != nil {
+		fmt.Printf("%s is new on this branch, so there is no earlier sitting to restate.\n", pinsPath)
+		fmt.Printf("  sitting %s on %s at %s\n", p.directives["sitting.date"], p.directives["sitting.host"], sc)
 		fmt.Printf("  uptime  %s\n", p.directives["sitting.uptime"])
 		return 0
 	}
-	fmt.Printf("\nPERF PIN REFUSAL. This pull request moves %s and %d other path(s):\n", pinsPath, len(changed)-1)
-	for _, f := range changed {
-		if f != pinsPath {
-			fmt.Println("  " + f)
+	prev, err := parsePins(pinsPath, bytes.NewReader(old))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate pinlock: cannot read the base's pin file:", err)
+		return 1
+	}
+
+	var stale []string
+	for _, k := range []string{"sitting.date", "sitting.uptime", "sitting.commit"} {
+		if prev.directives[k] == p.directives[k] {
+			stale = append(stale, k)
 		}
 	}
-	fmt.Printf("\nThe pins are what the gate compares against, so a diff that changes the code\n")
-	fmt.Printf("and the pins together can make any regression green by definition. Re-pinning\n")
-	fmt.Printf("is its own pull request, whose diff is %s and nothing else, and whose\n", pinsPath)
-	fmt.Printf("file states the sitting that produced the numbers.\n")
-	return 1
+	moved := false
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		if prev.rates[k] != p.rates[k] {
+			moved = true
+		}
+	}
+	if !moved && len(stale) == 3 {
+		fmt.Printf("the diff touches %s but moves no pin and no sitting, so there is nothing\n", pinsPath)
+		fmt.Printf("to state: prose, or a band the author is answering for by hand.\n")
+		return 0
+	}
+
+	fmt.Printf("\nthe pins moved. what changed, row by row:\n")
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		o, n := prev.rates[k], p.rates[k]
+		if o <= 0 {
+			fmt.Printf("  %-24s %14.3f M/s (no earlier pin)\n", k, n/1e6)
+			continue
+		}
+		fmt.Printf("  %-24s %14.3f -> %10.3f M/s  %+6.2f%%\n", k, o/1e6, n/1e6, (n-o)/o*100)
+	}
+
+	if len(stale) > 0 {
+		fmt.Printf("\nPERF PIN REFUSAL. The pins moved and the sitting did not: %s\n", strings.Join(stale, ", "))
+		fmt.Printf("are unchanged from %s.\n\n", base)
+		fmt.Printf("The pins are what the gate compares a read and a write against, so numbers\n")
+		fmt.Printf("edited under a sitting header that describes the measurement they replaced\n")
+		fmt.Printf("are numbers with no provenance, and a regression can be made green by typing\n")
+		fmt.Printf("over the thing that would have caught it. A re-pin restates its sitting: the\n")
+		fmt.Printf("box, the date, the commit, and the load the machine was carrying. Cut it with\n")
+		fmt.Printf("`make perf-gate-pin` on a quiet box, which fills those lines in for you.\n")
+		return 1
+	}
+	fmt.Printf("\nthe sitting is restated, which is what a re-pin owes:\n")
+	fmt.Printf("  %s on %s at %s\n", p.directives["sitting.date"], p.directives["sitting.host"], sc)
+	fmt.Printf("  %s\n", p.directives["sitting.uptime"])
+	fmt.Printf("  %s, %s, %s sittings, worst deviation %s%%\n",
+		p.directives["box.cpu"], p.directives["sitting.compiler"],
+		p.directives["sitting.repeats"], p.directives["sitting.worst.pct"])
+	return 0
 }
 
 // ---------------------------------------------------------------------------

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -311,7 +311,7 @@ func loadPins(path string) (*pins, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return parsePins(path, f)
 }
 
@@ -446,17 +446,17 @@ func compare(s *sitting, p *pins, band, spreadMax float64) ([]verdict, bool) {
 	return out, red
 }
 
-func printVerdicts(w io.Writer, vs []verdict, band float64) {
-	fmt.Fprintf(w, "%-24s %14s %14s %9s %8s  %s\n", "row", "pinned M/s", "measured M/s", "delta", "spread", "verdict")
+func printVerdicts(vs []verdict, band float64) {
+	fmt.Printf("%-24s %14s %14s %9s %8s  %s\n", "row", "pinned M/s", "measured M/s", "delta", "spread", "verdict")
 	for _, v := range vs {
 		mark := "ok  "
 		if v.red {
 			mark = "RED "
 		}
-		fmt.Fprintf(w, "%-24s %14.3f %14.3f %8.2f%% %7.1f%%  %s%s\n",
+		fmt.Printf("%-24s %14.3f %14.3f %8.2f%% %7.1f%%  %s%s\n",
 			v.key, v.pinned/1e6, v.measured/1e6, v.deltaPct, v.spread, mark, v.note)
 	}
-	fmt.Fprintf(w, "band: %.2f%% (bench/PERF-PINS states how it was derived)\n", band)
+	fmt.Printf("band: %.2f%% (bench/PERF-PINS states how it was derived)\n", band)
 }
 
 // ---------------------------------------------------------------------------
@@ -581,7 +581,7 @@ func cmdCheck(args []string) int {
 	}
 	vs, red := compare(s, p, band, spreadMax)
 	fmt.Printf("perf gate: %s, %s\n%s\n\n", s.host, s.date, s.uptime)
-	printVerdicts(os.Stdout, vs, band)
+	printVerdicts(vs, band)
 	if red {
 		fmt.Printf("\nPERF GATE RED. A read or a write on the reference got slower than the pin by\n")
 		fmt.Printf("more than the band. If the change added a diagnostic, the law (issue #546)\n")

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -1,0 +1,1068 @@
+// perfgate: the mechanical half of the zero-cost-diagnostic law (issue #546).
+//
+//	make perf-gate            measure the reference benches and render a verdict
+//	make perf-gate-control    the planted-cost negative control
+//	make perf-gate-pin        re-measure the pins (a PR whose diff is bench/PERF-PINS)
+//	make perf-gate-pinlock    the LOCK-model refusal, run on every pull request
+//
+// THE LAW IT ENFORCES. The owner's rule, 2026-09-05, issue #546: "i'm all for
+// greater diagnostics, but if it costs speed on read or write, it's not worth
+// it." A diagnostic surface is admitted at zero measured cost on the read path
+// and the write path, or it is declined. Prose cannot hold that line, because
+// the cost of a diagnostic is a number and prose has no numbers in it. This
+// does.
+//
+// WHAT IT MEASURES. The C++ reference, over the bench corpus, on both wires:
+//
+//	bench_mixed  write        the packet wire's write path (bench/cpp)
+//	bench_mixed  round_trip   the packet wire's read path, carried
+//	bench_table  write        the table wire's write path (bench/tables/cpp)
+//	bench_table  round_trip   the table wire's read path, carried
+//
+// THE READ ROW IS round_trip, AND THAT IS THE HONEST NAME FOR IT. Neither
+// bench measures a read on its own: the decode's output IS the re-encode's
+// input, which is how the read side gets its sink discipline for free in every
+// language (BENCH-STANDARD.md §2.7), and the read rate both runners print is
+// round-trip time minus write time, marked DERIVED and deliberately kept out
+// of the CSV. A gate that pinned a derived number would be pinning a
+// subtraction of two medians, whose noise is the sum of theirs. So the gate
+// pins what was measured. A cost planted on the read path raises round_trip
+// and leaves write flat, which is exactly what the negative control shows, and
+// a reader of a red verdict can tell a read regression from a write regression
+// by which of the two rows moved.
+//
+// THE BAND, AND WHY IT IS NOT ZERO. "Zero cost" is a claim about the code, and
+// a measurement of it lands inside a distribution. The band is the width of
+// that distribution on a quiet box, derived by repeated sittings and recorded
+// in bench/PERF-PINS beside the numbers it guards. A regression larger than
+// the band is a refusal. A regression smaller than the band is invisible to
+// this instrument, which the pin file states rather than implies.
+//
+// THE BOX IS PART OF THE PIN. A rate in messages per second is a fact about
+// one machine. bench/PERF-PINS names the box that produced it, and off that
+// box the gate REFUSES to render a verdict rather than compare a number to a
+// number from different silicon. What still runs anywhere is the negative
+// control, whose verdict is a ratio inside one sitting: it needs no pin, and
+// it is what certification runs on hardware nobody here owns.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const pinsPath = "bench/PERF-PINS"
+
+// the four rows the gate pins, in report order
+var gateRows = [][2]string{
+	{"bench_mixed", "write"},
+	{"bench_mixed", "round_trip"},
+	{"bench_table", "write"},
+	{"bench_table", "round_trip"},
+}
+
+// ---------------------------------------------------------------------------
+// measured rows
+
+type row struct {
+	bench    string
+	path     string
+	rate     float64 // median_msgs_per_sec
+	spread   float64 // spread_pct, within the sitting
+	corpusID string
+	opt      string
+	iters    int64
+}
+
+func (r row) key() string { return r.bench + "/" + r.path }
+
+type sitting struct {
+	rows        map[string]row
+	arch        string
+	cpu         string
+	os          string
+	host        string
+	uptime      string
+	commit      string
+	compiler    string
+	date        string
+	prefixFlags string
+}
+
+// ---------------------------------------------------------------------------
+// the box
+
+func boxArch() string { return runtime.GOARCH }
+func boxOS() string   { return runtime.GOOS }
+
+func boxCPU() string {
+	if out, err := exec.Command("sysctl", "-n", "machdep.cpu.brand_string").Output(); err == nil {
+		if s := strings.TrimSpace(string(out)); s != "" {
+			return s
+		}
+	}
+	if b, err := os.ReadFile("/proc/cpuinfo"); err == nil {
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.HasPrefix(line, "model name") {
+				if i := strings.Index(line, ":"); i >= 0 {
+					return strings.TrimSpace(line[i+1:])
+				}
+			}
+		}
+	}
+	return "unknown"
+}
+
+func boxHost() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	if i := strings.Index(h, "."); i > 0 {
+		h = h[:i]
+	}
+	return h
+}
+
+func boxUptime() string {
+	out, err := exec.Command("uptime").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func repoCommit() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func compilerVersion() string {
+	cxx := os.Getenv("CXX")
+	if cxx == "" {
+		cxx = "c++"
+	}
+	out, err := exec.Command(cxx, "--version").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+}
+
+// ---------------------------------------------------------------------------
+// running the two reference benches
+//
+// NEITHER LEG'S FLAGS ARE SPELLED HERE, deliberately. The packet leg is
+// bench/run.sh's own cpp leg and the table leg is bench/tables/cpp/leg, so the
+// gate compiles the same translation units, with the same flags, as the
+// published passes do. A gate built with flags of its own would be measuring
+// a build nobody ships.
+
+func run(name string, args []string, prefixFlags string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "BENCH_CXXFLAGS_PREFIX="+prefixFlags)
+	return cmd.Run()
+}
+
+func runCapture(name string, args []string, prefixFlags string) ([]byte, error) {
+	var buf bytes.Buffer
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "BENCH_CXXFLAGS_PREFIX="+prefixFlags)
+	err := cmd.Run()
+	return buf.Bytes(), err
+}
+
+// measure builds and runs both reference benches and returns the sitting.
+// prefixFlags rides into both compiles. The negative control is its only user
+// and `pin` refuses a sitting that carries any.
+func measure(prefixFlags string) (*sitting, error) {
+	s := &sitting{
+		rows:        map[string]row{},
+		arch:        boxArch(),
+		cpu:         boxCPU(),
+		os:          boxOS(),
+		host:        boxHost(),
+		uptime:      boxUptime(),
+		commit:      repoCommit(),
+		compiler:    compilerVersion(),
+		date:        time.Now().Format("2006-01-02"),
+		prefixFlags: prefixFlags,
+	}
+
+	// the packet wire. bench/run.sh refuses to overwrite a results file, which
+	// is a rule about the published ledger under bench/results/ and not about
+	// a scratch file under build/, so the gate removes its own and lets the
+	// refusal stand everywhere else.
+	pkt := "build/perfgate/packet.csv"
+	if err := os.MkdirAll("build/perfgate", 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.Remove(pkt); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if err := run("bench/run.sh", []string{"--only", "cpp", "--bare", "--out", pkt}, prefixFlags); err != nil {
+		return nil, fmt.Errorf("packet leg: %w", err)
+	}
+	pktCSV, err := os.ReadFile(pkt)
+	if err != nil {
+		return nil, err
+	}
+	if err := collect(s, pktCSV); err != nil {
+		return nil, fmt.Errorf("packet leg: %w", err)
+	}
+
+	// the table wire
+	if err := run("bench/tables/cpp/leg", []string{"build"}, prefixFlags); err != nil {
+		return nil, fmt.Errorf("table leg build: %w", err)
+	}
+	tblCSV, err := runCapture("bench/tables/cpp/leg", []string{"run", "--csv"}, prefixFlags)
+	if err != nil {
+		return nil, fmt.Errorf("table leg: %w", err)
+	}
+	if err := collect(s, tblCSV); err != nil {
+		return nil, fmt.Errorf("table leg: %w", err)
+	}
+
+	for _, want := range gateRows {
+		if _, ok := s.rows[want[0]+"/"+want[1]]; !ok {
+			return nil, fmt.Errorf("the sitting is missing the pinned row %s/%s. A gate that cannot see a row cannot guard it", want[0], want[1])
+		}
+	}
+	return s, nil
+}
+
+// collect parses whichever CSV rows a leg emitted and keeps the gate's four.
+// The two runners share one CSV schema (BENCH-STANDARD.md §5), so one parser
+// reads both.
+func collect(s *sitting, data []byte) error {
+	rd := csv.NewReader(bytes.NewReader(data))
+	rd.FieldsPerRecord = -1
+	recs, err := rd.ReadAll()
+	if err != nil {
+		return err
+	}
+	var header []string
+	for _, rec := range recs {
+		if len(rec) == 0 {
+			continue
+		}
+		if rec[0] == "lang" {
+			header = rec
+			continue
+		}
+		if header == nil {
+			continue
+		}
+		if rec[0] != "cpp" {
+			continue
+		}
+		m := map[string]string{}
+		for i, h := range header {
+			if i < len(rec) {
+				m[h] = rec[i]
+			}
+		}
+		r := row{bench: m["bench"], path: m["path"], corpusID: m["corpus_id"], opt: m["opt"]}
+		r.rate, _ = strconv.ParseFloat(m["median_msgs_per_sec"], 64)
+		r.spread, _ = strconv.ParseFloat(m["spread_pct"], 64)
+		r.iters, _ = strconv.ParseInt(m["iters"], 10, 64)
+		for _, want := range gateRows {
+			if want[0] == r.bench && want[1] == r.path {
+				s.rows[r.key()] = r
+			}
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// the pin file
+
+type pins struct {
+	directives map[string]string
+	rates      map[string]float64
+	corpus     map[string]string
+	lines      []string // the file verbatim, for the re-pin rewrite
+}
+
+var pinLine = regexp.MustCompile(`^pin\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*$`)
+
+func loadPins(path string) (*pins, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	p := &pins{directives: map[string]string{}, rates: map[string]float64{}, corpus: map[string]string{}}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		p.lines = append(p.lines, line)
+		t := strings.TrimSpace(line)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		if m := pinLine.FindStringSubmatch(t); m != nil {
+			rate, err := strconv.ParseFloat(m[3], 64)
+			if err != nil {
+				return nil, fmt.Errorf("%s: unreadable rate on %q", path, t)
+			}
+			p.rates[m[1]+"/"+m[2]] = rate
+			p.corpus[m[1]+"/"+m[2]] = m[4]
+			continue
+		}
+		fields := strings.Fields(t)
+		if len(fields) < 2 {
+			return nil, fmt.Errorf("%s: unreadable line %q", path, t)
+		}
+		p.directives[fields[0]] = strings.TrimSpace(strings.TrimPrefix(t, fields[0]))
+	}
+	return p, sc.Err()
+}
+
+func (p *pins) num(key string) (float64, error) {
+	v, ok := p.directives[key]
+	if !ok {
+		return 0, fmt.Errorf("%s: missing directive %s", pinsPath, key)
+	}
+	return strconv.ParseFloat(v, 64)
+}
+
+// requiredDirectives: the sitting a re-pin has to state. The pin file is the
+// gate's whole authority, so a pin whose sitting is unstated is a number with
+// no provenance, and the gate refuses to read one.
+var requiredDirectives = []string{
+	"box.arch", "box.cpu", "box.os",
+	"band.pct", "spread.max.pct",
+	"sitting.date", "sitting.host", "sitting.uptime", "sitting.commit",
+	"sitting.compiler", "sitting.opt", "sitting.repeats", "sitting.worst.pct",
+}
+
+func (p *pins) validate() error {
+	for _, k := range requiredDirectives {
+		if strings.TrimSpace(p.directives[k]) == "" {
+			return fmt.Errorf("%s: the sitting does not state %s", pinsPath, k)
+		}
+	}
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		rate, ok := p.rates[k]
+		if !ok {
+			return fmt.Errorf("%s: no pin for %s", pinsPath, k)
+		}
+		// A zero pin is the skeleton, not a measurement. Every row divides by
+		// its pin, so an unmeasured file has to be a refusal rather than a
+		// division by nothing.
+		if rate <= 0 {
+			return fmt.Errorf("%s: the pin for %s is %g, which is the unmeasured skeleton. Cut the pins with `make perf-gate-pin` on a quiet box", pinsPath, k, rate)
+		}
+	}
+	for _, k := range []string{"band.pct", "spread.max.pct"} {
+		v, err := p.num(k)
+		if err != nil {
+			return err
+		}
+		if v <= 0 {
+			return fmt.Errorf("%s: %s is %g. A width of zero is not a width, and a gate with one refuses everything or nothing", pinsPath, k, v)
+		}
+	}
+	if len(p.rates) != len(gateRows) {
+		return fmt.Errorf("%s: %d pins for %d gate rows. The file and the gate disagree about what is guarded", pinsPath, len(p.rates), len(gateRows))
+	}
+	return nil
+}
+
+func (p *pins) onThisBox() bool {
+	return p.directives["box.arch"] == boxArch() &&
+		p.directives["box.os"] == boxOS() &&
+		p.directives["box.cpu"] == boxCPU()
+}
+
+// ---------------------------------------------------------------------------
+// the verdict
+
+type verdict struct {
+	key      string
+	pinned   float64
+	measured float64
+	deltaPct float64 // negative is slower than the pin
+	spread   float64
+	red      bool
+	note     string
+}
+
+func compare(s *sitting, p *pins, band, spreadMax float64) ([]verdict, bool) {
+	var out []verdict
+	red := false
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		r := s.rows[k]
+		pinned := p.rates[k]
+		v := verdict{key: k, pinned: pinned, measured: r.rate, spread: r.spread}
+		v.deltaPct = (r.rate - pinned) / pinned * 100
+		switch {
+		case p.corpus[k] != "" && r.corpusID != "" && p.corpus[k] != r.corpusID:
+			v.red, v.note = true, "CORPUS MOVED (pinned "+p.corpus[k]+", measured "+r.corpusID+"): different work, no comparison"
+		case r.spread > spreadMax:
+			v.red, v.note = true, fmt.Sprintf("SITTING TOO NOISY (spread %.1f%% over the %.1f%% cap): this box cannot render a verdict now", r.spread, spreadMax)
+		case v.deltaPct < -band:
+			v.red, v.note = true, fmt.Sprintf("SLOWER THAN THE PIN BY %.2f%%, past the %.2f%% band", -v.deltaPct, band)
+		case v.deltaPct > band:
+			v.note = fmt.Sprintf("faster than the pin by %.2f%%: the pin is stale, not the code", v.deltaPct)
+		default:
+			v.note = "within band"
+		}
+		if v.red {
+			red = true
+		}
+		out = append(out, v)
+	}
+	return out, red
+}
+
+func printVerdicts(w io.Writer, vs []verdict, band float64) {
+	fmt.Fprintf(w, "%-24s %14s %14s %9s %8s  %s\n", "row", "pinned M/s", "measured M/s", "delta", "spread", "verdict")
+	for _, v := range vs {
+		mark := "ok  "
+		if v.red {
+			mark = "RED "
+		}
+		fmt.Fprintf(w, "%-24s %14.3f %14.3f %8.2f%% %7.1f%%  %s%s\n",
+			v.key, v.pinned/1e6, v.measured/1e6, v.deltaPct, v.spread, mark, v.note)
+	}
+	fmt.Fprintf(w, "band: %.2f%% (bench/PERF-PINS states how it was derived)\n", band)
+}
+
+// ---------------------------------------------------------------------------
+// commands
+
+func cmdMeasure(args []string) int {
+	repeats := 1
+	parseFlags(args, map[string]*string{}, map[string]*int{"repeats": &repeats})
+	for i := 0; i < repeats; i++ {
+		s, err := measure(os.Getenv("BENCH_CXXFLAGS_PREFIX"))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "perfgate measure:", err)
+			return 1
+		}
+		fmt.Printf("# sitting %d/%d  %s  %s  %s\n", i+1, repeats, s.date, s.host, s.uptime)
+		for _, want := range gateRows {
+			r := s.rows[want[0]+"/"+want[1]]
+			fmt.Printf("sample %-12s %-11s %14.0f %6.1f %s\n", r.bench, r.path, r.rate, r.spread, r.corpusID)
+		}
+	}
+	return 0
+}
+
+// cmdBand is how the band in bench/PERF-PINS was derived, kept as a command so
+// the derivation is repeatable rather than a remembered number: N full
+// sittings, and for each row the worst deviation of any sitting from the
+// median of the sittings.
+func cmdBand(args []string) int {
+	repeats := 7
+	parseFlags(args, map[string]*string{}, map[string]*int{"repeats": &repeats})
+	samples := map[string][]float64{}
+	for i := 0; i < repeats; i++ {
+		s, err := measure("")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "perfgate band:", err)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "== sitting %d/%d: %s\n", i+1, repeats, s.uptime)
+		for _, want := range gateRows {
+			k := want[0] + "/" + want[1]
+			samples[k] = append(samples[k], s.rows[k].rate)
+		}
+	}
+	worst := 0.0
+	fmt.Printf("%-24s %9s %9s %9s %9s\n", "row", "median", "min", "max", "worst dev")
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		v := append([]float64(nil), samples[k]...)
+		sort.Float64s(v)
+		med := v[len(v)/2]
+		if len(v)%2 == 0 {
+			med = (v[len(v)/2-1] + v[len(v)/2]) / 2
+		}
+		dev := 0.0
+		for _, x := range v {
+			d := (x - med) / med * 100
+			if d < 0 {
+				d = -d
+			}
+			if d > dev {
+				dev = d
+			}
+		}
+		if dev > worst {
+			worst = dev
+		}
+		fmt.Printf("%-24s %9.3f %9.3f %9.3f %8.2f%%\n", k, med/1e6, v[0]/1e6, v[len(v)-1]/1e6, dev)
+	}
+	fmt.Printf("\nworst deviation across %d sittings: %.2f%%\n", repeats, worst)
+	fmt.Printf("band to write into %s: %.1f (worst deviation, doubled, rounded up to a tenth)\n", pinsPath, roundBand(worst*2))
+	return 0
+}
+
+func roundBand(x float64) float64 {
+	// up to the next tenth of a percent
+	return float64(int((x+0.0999)*10)) / 10
+}
+
+func cmdCheck(args []string) int {
+	advisory := false
+	flags := map[string]*bool{"advisory": &advisory}
+	parseBoolFlags(args, flags)
+
+	p, err := loadPins(pinsPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate check:", err)
+		return 1
+	}
+	if err := p.validate(); err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate check:", err)
+		return 1
+	}
+	band, err := p.num("band.pct")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate check:", err)
+		return 1
+	}
+	spreadMax, err := p.num("spread.max.pct")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate check:", err)
+		return 1
+	}
+
+	if !p.onThisBox() {
+		fmt.Printf("NOT THE PINNED BOX.\n")
+		fmt.Printf("  pinned   %s / %s / %s\n", p.directives["box.arch"], p.directives["box.os"], p.directives["box.cpu"])
+		fmt.Printf("  this box %s / %s / %s\n", boxArch(), boxOS(), boxCPU())
+		fmt.Printf("A rate in messages per second is a fact about one machine, and the gate\n")
+		fmt.Printf("will not divide one box's number by another's. Re-pin from this box with a\n")
+		fmt.Printf("pull request that states its sitting, or run the gate where the pins were cut.\n")
+		if advisory {
+			fmt.Printf("advisory: the structural half passed. %s parses, and every gate row has a pin.\n", pinsPath)
+			return 0
+		}
+		return 2
+	}
+
+	s, err := measure("")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate check:", err)
+		return 1
+	}
+	vs, red := compare(s, p, band, spreadMax)
+	fmt.Printf("perf gate: %s, %s\n%s\n\n", s.host, s.date, s.uptime)
+	printVerdicts(os.Stdout, vs, band)
+	if red {
+		fmt.Printf("\nPERF GATE RED. A read or a write on the reference got slower than the pin by\n")
+		fmt.Printf("more than the band. If the change added a diagnostic, the law (issue #546)\n")
+		fmt.Printf("declines it: a diagnostic is admitted at zero measured cost on the read and\n")
+		fmt.Printf("write paths, or not at all. If the change is a deliberate cost the owner\n")
+		fmt.Printf("accepted, the pins move in their own pull request, which states its sitting.\n")
+		return 1
+	}
+	fmt.Printf("\nperf gate green.\n")
+	return 0
+}
+
+func cmdPin(args []string) int {
+	repeats := 1
+	parseFlags(args, map[string]*string{}, map[string]*int{"repeats": &repeats})
+
+	if strings.TrimSpace(os.Getenv("BENCH_CXXFLAGS_PREFIX")) != "" {
+		fmt.Fprintf(os.Stderr, "perfgate pin: BENCH_CXXFLAGS_PREFIX is set (%q).\n", os.Getenv("BENCH_CXXFLAGS_PREFIX"))
+		fmt.Fprintf(os.Stderr, "That hook exists for the negative control and for nothing else. A pin cut\n")
+		fmt.Fprintf(os.Stderr, "under flags the shipped build does not carry is a pin for a build nobody runs.\n")
+		return 1
+	}
+
+	// the pins are the median of `repeats` sittings, and the worst deviation
+	// across them is written into the file beside them, so the band's derivation
+	// travels with the numbers rather than living in someone's memory.
+	samples := map[string][]float64{}
+	var last *sitting
+	for i := 0; i < repeats; i++ {
+		s, err := measure("")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "perfgate pin:", err)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "== sitting %d/%d: %s\n", i+1, repeats, s.uptime)
+		for _, want := range gateRows {
+			k := want[0] + "/" + want[1]
+			samples[k] = append(samples[k], s.rows[k].rate)
+		}
+		last = s
+	}
+	worst := 0.0
+	medians := map[string]float64{}
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		v := append([]float64(nil), samples[k]...)
+		sort.Float64s(v)
+		med := v[len(v)/2]
+		if len(v)%2 == 0 {
+			med = (v[len(v)/2-1] + v[len(v)/2]) / 2
+		}
+		medians[k] = med
+		for _, x := range v {
+			d := (x - med) / med * 100
+			if d < 0 {
+				d = -d
+			}
+			if d > worst {
+				worst = d
+			}
+		}
+	}
+
+	p, err := loadPins(pinsPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate pin:", err)
+		return 1
+	}
+	set := map[string]string{
+		"box.arch":          last.arch,
+		"box.cpu":           last.cpu,
+		"box.os":            last.os,
+		"sitting.date":      last.date,
+		"sitting.host":      last.host,
+		"sitting.uptime":    last.uptime,
+		"sitting.commit":    last.commit,
+		"sitting.compiler":  last.compiler,
+		"sitting.opt":       optOf(last),
+		"sitting.repeats":   strconv.Itoa(repeats),
+		"sitting.worst.pct": fmt.Sprintf("%.2f", worst),
+	}
+	var out []string
+	seen := map[string]bool{}
+	wrotePins := false
+	for _, line := range p.lines {
+		t := strings.TrimSpace(line)
+		if fields := strings.Fields(t); len(fields) > 0 && !strings.HasPrefix(t, "#") {
+			if v, ok := set[fields[0]]; ok {
+				out = append(out, fields[0]+strings.Repeat(" ", pad(fields[0]))+v)
+				seen[fields[0]] = true
+				continue
+			}
+			if strings.HasPrefix(t, "pin ") {
+				if !wrotePins {
+					for _, want := range gateRows {
+						k := want[0] + "/" + want[1]
+						out = append(out, fmt.Sprintf("pin %-12s %-11s %14.0f %s", want[0], want[1], medians[k], last.rows[k].corpusID))
+					}
+					wrotePins = true
+				}
+				continue
+			}
+		}
+		out = append(out, line)
+	}
+	if err := os.WriteFile(pinsPath, []byte(strings.Join(out, "\n")+"\n"), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate pin:", err)
+		return 1
+	}
+	fmt.Printf("re-pinned %s from %d sitting(s) on %s (worst deviation %.2f%%)\n", pinsPath, repeats, last.host, worst)
+	fmt.Printf("REVIEW THE band.pct LINE BY HAND: this command records the sitting and the\n")
+	fmt.Printf("numbers, and leaves the band alone. Widening a band is a decision, never a\n")
+	fmt.Printf("side effect of re-measuring.\n")
+	return 0
+}
+
+func optOf(s *sitting) string {
+	for _, r := range s.rows {
+		if r.opt != "" {
+			return r.opt
+		}
+	}
+	return "unknown"
+}
+
+func pad(key string) int {
+	n := 20 - len(key)
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// ---------------------------------------------------------------------------
+// the negative control
+//
+// A gate nobody has seen go red is a gate nobody has tested. This plants the
+// exact shape the law refuses (a counter behind a runtime flag, one added
+// branch per field, on the READ path only) into a scratch copy of the
+// emitter's output, builds the same benches against it, and requires the gate
+// to call it. The plant is OFF at run time: the control measures the price of
+// the branch alone, which is the honest claim the law makes. Nothing under
+// generated/ or internal/codegen/ is touched, so the C/C++ lock (bench/LOCK)
+// is not approached.
+
+const plantBlock = `
+// ---------------------------------------------------------------------------
+// PLANTED BY bench/tools/perfgate: the negative control for issue #546.
+// This file is a scratch copy under build/. The tracked tree has no such code.
+#ifndef SCHEMA_PERFGATE_PLANT_DEFINED
+#define SCHEMA_PERFGATE_PLANT_DEFINED
+#include <stdlib.h>
+#include <stdint.h>
+// The shape of the diagnostic the law refuses: one counter, one runtime flag,
+// one added branch per field read. The flag comes from the environment at
+// static-initialization time, so no compiler can fold the branch away, and the
+// gate never sets it, so what gets measured is the branch and not the counting.
+static bool schema_perfgate_diag_enabled = ( getenv( "SCHEMA_PERFGATE_DIAG" ) != NULL );
+static uint64_t schema_perfgate_diag_count = 0;
+#define SCHEMA_PERFGATE_PLANT() if ( schema_perfgate_diag_enabled ) { schema_perfgate_diag_count++; }
+#endif
+// ---------------------------------------------------------------------------
+`
+
+var (
+	readFnStart  = regexp.MustCompile(`^SCHEMA_READ_INLINE bool Read`)
+	writeFnStart = regexp.MustCompile(`^SCHEMA_WRITE_INLINE bool Write`)
+	readMacro    = regexp.MustCompile(`^read_[a-z0-9_]+\(`)
+	loadFnStart  = regexp.MustCompile(`bool [A-Za-z0-9_]*Load(Body)?\(`)
+	saveFnStart  = regexp.MustCompile(`bool [A-Za-z0-9_]*(Save|Measure)[A-Za-z0-9_]*\(`)
+	caseLine     = regexp.MustCompile(`^case 0x[0-9a-fA-F]+ull:`)
+)
+
+// plantPacket: the packet wire's generated header. read_* is a macro and it
+// appears on the read path and nowhere else, so the site is the call.
+func plantPacket(src string) (string, int) {
+	lines := strings.Split(src, "\n")
+	inRead := false
+	planted := 0
+	var out []string
+	for _, line := range lines {
+		t := strings.TrimSpace(line)
+		switch {
+		case readFnStart.MatchString(line):
+			inRead = true
+		case writeFnStart.MatchString(line):
+			inRead = false
+		}
+		if inRead && readMacro.MatchString(t) {
+			out = append(out, indentOf(line)+"SCHEMA_PERFGATE_PLANT()")
+			planted++
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n"), planted
+}
+
+// plantTable: the table wire's generated header. The read path dispatches on
+// field id, so the site is the case label: one plant per field, once.
+func plantTable(src string) (string, int) {
+	lines := strings.Split(src, "\n")
+	inLoad := false
+	planted := 0
+	var out []string
+	for _, line := range lines {
+		t := strings.TrimSpace(line)
+		switch {
+		case loadFnStart.MatchString(line):
+			inLoad = true
+		case saveFnStart.MatchString(line):
+			inLoad = false
+		}
+		out = append(out, line)
+		if inLoad && caseLine.MatchString(t) {
+			out = append(out, indentOf(line)+"SCHEMA_PERFGATE_PLANT()")
+			planted++
+		}
+	}
+	return strings.Join(out, "\n"), planted
+}
+
+func indentOf(line string) string {
+	return line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+}
+
+func injectBlock(src string) string {
+	i := strings.Index(src, "#pragma once")
+	if i < 0 {
+		return plantBlock + src
+	}
+	j := i + len("#pragma once")
+	return src[:j] + "\n" + plantBlock + src[j:]
+}
+
+// writePlanted copies a generated tree into build/perfgate/planted/<name> and
+// plants the cost in the one header that carries the read path.
+func writePlanted(srcDir, dstDir, target string, plant func(string) (string, int)) (int, error) {
+	if err := os.RemoveAll(dstDir); err != nil {
+		return 0, err
+	}
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return 0, err
+	}
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return 0, err
+	}
+	planted := 0
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(srcDir, e.Name()))
+		if err != nil {
+			return 0, err
+		}
+		text := string(b)
+		if e.Name() == target {
+			text, planted = plant(text)
+			text = injectBlock(text)
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, e.Name()), []byte(text), 0o644); err != nil {
+			return 0, err
+		}
+	}
+	if planted == 0 {
+		return 0, fmt.Errorf("planted nothing in %s. The control would prove the gate green for the wrong reason", target)
+	}
+	return planted, nil
+}
+
+func cmdControl(args []string) int {
+	parseFlags(args, map[string]*string{}, map[string]*int{})
+
+	p, err := loadPins(pinsPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate control:", err)
+		return 1
+	}
+	if err := p.validate(); err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate control:", err)
+		return 1
+	}
+	band, err := p.num("band.pct")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate control:", err)
+		return 1
+	}
+
+	pktN, err := writePlanted("generated/bench/cpp", "build/perfgate/planted/cpp", "BenchWire.h", plantPacket)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate control:", err)
+		return 1
+	}
+	tblN, err := writePlanted("generated/bench/tables/cpp", "build/perfgate/planted/tables-cpp", "BenchTableTable.h", plantTable)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate control:", err)
+		return 1
+	}
+	fmt.Printf("planted %d read sites in BenchWire.h and %d in BenchTableTable.h (scratch copies under build/perfgate/planted)\n\n", pktN, tblN)
+
+	fmt.Fprintln(os.Stderr, "== control: the clean sitting ==")
+	clean, err := measure("")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate control:", err)
+		return 1
+	}
+	fmt.Fprintln(os.Stderr, "== control: the planted sitting ==")
+	planted, err := measure("-Ibuild/perfgate/planted/cpp -Ibuild/perfgate/planted/tables-cpp")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate control:", err)
+		return 1
+	}
+
+	// THE CONTROL IS A RATIO INSIDE ONE SITTING, not a comparison against the
+	// pins: the clean half is measured minutes before the planted half on the
+	// same box, so the verdict holds on hardware that has no pins at all.
+	fmt.Printf("%-24s %14s %14s %9s  %s\n", "row", "clean M/s", "planted M/s", "delta", "verdict")
+	readRed, writeMoved := false, false
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		c := clean.rows[k].rate
+		pl := planted.rows[k].rate
+		delta := (pl - c) / c * 100
+		red := delta < -band
+		mark := "ok  "
+		if red {
+			mark = "RED "
+		}
+		fmt.Printf("%-24s %14.3f %14.3f %8.2f%%  %s\n", k, c/1e6, pl/1e6, delta, mark)
+		if want[1] == "round_trip" && red {
+			readRed = true
+		}
+		if want[1] == "write" && red {
+			writeMoved = true
+		}
+	}
+	fmt.Printf("band: %.2f%%\n\n", band)
+
+	if !readRed {
+		fmt.Printf("CONTROL FAILED. One added branch per field on the read path did not move\n")
+		fmt.Printf("round_trip past the %.2f%% band on both wires. Either the plant did not\n", band)
+		fmt.Printf("reach the compiled code, or the band is wide enough to hide a real cost.\n")
+		fmt.Printf("A gate nobody has seen go red is a gate nobody has tested.\n")
+		return 1
+	}
+	fmt.Printf("CONTROL PASSED: the planted read cost is RED on round_trip.\n")
+	if writeMoved {
+		fmt.Printf("NOTE: write moved past the band too. Nothing was planted on the write path,\n")
+		fmt.Printf("so this is the box drifting under the two sittings, not the plant. Re-run it\n")
+		fmt.Printf("quiet before reading the read rows as a clean localization.\n")
+	} else {
+		fmt.Printf("write held inside the band on both wires, which is the localization the law\n")
+		fmt.Printf("needs: the gate says WHICH path got slower, not merely that something did.\n")
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// the pin lock, on bench/LOCK's model
+//
+// The pins are the gate's authority, so a re-pin of them is an act with its own
+// pull request and nothing else in the diff, the same shape the C/C++ lock
+// uses for a lift. This runs on every pull request, costs no measurement, and
+// makes an unstated re-pin impossible to merge quietly.
+
+func cmdPinlock(args []string) int {
+	base := "origin/main"
+	strs := map[string]*string{"base": &base}
+	parseFlags(args, strs, map[string]*int{})
+
+	out, err := exec.Command("git", "diff", "--name-only", base+"...HEAD").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "perfgate pinlock: cannot diff against %s: %v\n", base, err)
+		return 1
+	}
+	var changed []string
+	for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if f != "" {
+			changed = append(changed, f)
+		}
+	}
+	touchesPins := false
+	for _, f := range changed {
+		if f == pinsPath {
+			touchesPins = true
+		}
+	}
+
+	p, err := loadPins(pinsPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate pinlock:", err)
+		return 1
+	}
+	if err := p.validate(); err != nil {
+		fmt.Fprintln(os.Stderr, "perfgate pinlock:", err)
+		return 1
+	}
+	fmt.Printf("%s parses, states its sitting, and pins every gate row.\n", pinsPath)
+
+	if !touchesPins {
+		fmt.Println("the diff does not move the pins, nothing to refuse")
+		return 0
+	}
+	if len(changed) == 1 {
+		fmt.Printf("the diff is %s alone, the re-pin act, allowed\n", pinsPath)
+		fmt.Printf("  sitting %s on %s, %s\n", p.directives["sitting.date"], p.directives["sitting.host"], p.directives["sitting.commit"])
+		fmt.Printf("  uptime  %s\n", p.directives["sitting.uptime"])
+		return 0
+	}
+	fmt.Printf("\nPERF PIN REFUSAL. This pull request moves %s and %d other path(s):\n", pinsPath, len(changed)-1)
+	for _, f := range changed {
+		if f != pinsPath {
+			fmt.Println("  " + f)
+		}
+	}
+	fmt.Printf("\nThe pins are what the gate compares against, so a diff that changes the code\n")
+	fmt.Printf("and the pins together can make any regression green by definition. Re-pinning\n")
+	fmt.Printf("is its own pull request, whose diff is %s and nothing else, and whose\n", pinsPath)
+	fmt.Printf("file states the sitting that produced the numbers.\n")
+	return 1
+}
+
+// ---------------------------------------------------------------------------
+
+func parseFlags(args []string, strs map[string]*string, ints map[string]*int) []string {
+	var rest []string
+	for i := 0; i < len(args); i++ {
+		a := strings.TrimLeft(args[i], "-")
+		if p, ok := strs[a]; ok && i+1 < len(args) {
+			*p = args[i+1]
+			i++
+			continue
+		}
+		if p, ok := ints[a]; ok && i+1 < len(args) {
+			n, err := strconv.Atoi(args[i+1])
+			if err == nil {
+				*p = n
+			}
+			i++
+			continue
+		}
+		rest = append(rest, args[i])
+	}
+	return rest
+}
+
+func parseBoolFlags(args []string, flags map[string]*bool) {
+	for _, a := range args {
+		if p, ok := flags[strings.TrimLeft(a, "-")]; ok {
+			*p = true
+		}
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, `perfgate: the zero-cost-diagnostic gate (issue #546)
+
+  perfgate check [-advisory]     measure and compare against bench/PERF-PINS
+  perfgate control               plant a read cost and require the gate to go red
+  perfgate measure [-repeats N]  measure only, print the rows
+  perfgate band [-repeats N]     derive the noise band from repeated sittings
+  perfgate pin [-repeats N]      rewrite the pins and the sitting they came from
+  perfgate pinlock [-base REF]   refuse a pull request that moves the pins with code`)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	args := os.Args[2:]
+	switch os.Args[1] {
+	case "check":
+		os.Exit(cmdCheck(args))
+	case "control":
+		os.Exit(cmdControl(args))
+	case "measure":
+		os.Exit(cmdMeasure(args))
+	case "band":
+		os.Exit(cmdBand(args))
+	case "pin":
+		os.Exit(cmdPin(args))
+	case "pinlock":
+		os.Exit(cmdPinlock(args))
+	default:
+		usage()
+		os.Exit(2)
+	}
+}

--- a/bench/tools/perfgate/main.go
+++ b/bench/tools/perfgate/main.go
@@ -751,62 +751,61 @@ static uint64_t schema_perfgate_diag_count = 0;
 `
 
 var (
-	readFnStart  = regexp.MustCompile(`^SCHEMA_READ_INLINE bool Read`)
-	writeFnStart = regexp.MustCompile(`^SCHEMA_WRITE_INLINE bool Write`)
-	readMacro    = regexp.MustCompile(`^read_[a-z0-9_]+\(`)
-	loadFnStart  = regexp.MustCompile(`bool [A-Za-z0-9_]*Load(Body)?\(`)
-	saveFnStart  = regexp.MustCompile(`bool [A-Za-z0-9_]*(Save|Measure)[A-Za-z0-9_]*\(`)
-	caseLine     = regexp.MustCompile(`^case 0x[0-9a-fA-F]+ull:`)
+	// A top-level function definition in either generated header: a line that
+	// starts at column zero and opens a parameter list. Tracking THE CURRENT
+	// FUNCTION, rather than toggling a flag on the two kinds of function the
+	// plant cares about, is what makes the filter robust: a helper that is
+	// neither a read nor a write ends the read function it follows, instead of
+	// inheriting whatever the previous toggle left behind.
+	topLevelFn = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_ &*:<>]*\(`)
+
+	readFn    = regexp.MustCompile(`^SCHEMA_READ_INLINE bool Read`)
+	readMacro = regexp.MustCompile(`^read_[a-z0-9_]+\(`)
+
+	loadFn   = regexp.MustCompile(`bool [A-Za-z0-9_]*LoadBody\(`)
+	caseLine = regexp.MustCompile(`^case 0x[0-9a-fA-F]+ull:`)
 )
 
-// plantPacket: the packet wire's generated header. read_* is a macro and it
-// appears on the read path and nowhere else, so the site is the call.
-func plantPacket(src string) (string, int) {
-	lines := strings.Split(src, "\n")
-	inRead := false
+// plantAt walks a generated header, tracks which top-level function each line
+// belongs to, and inserts the plant at every site inside a function the filter
+// accepts. `before` puts the plant ahead of the site line rather than after it.
+func plantAt(src string, inFunction, isSite *regexp.Regexp, before bool) (string, int) {
 	planted := 0
 	var out []string
-	for _, line := range lines {
-		t := strings.TrimSpace(line)
-		switch {
-		case readFnStart.MatchString(line):
-			inRead = true
-		case writeFnStart.MatchString(line):
-			inRead = false
+	accepting := false
+	for line := range strings.SplitSeq(src, "\n") {
+		if topLevelFn.MatchString(line) {
+			accepting = inFunction.MatchString(line)
 		}
-		if inRead && readMacro.MatchString(t) {
+		site := accepting && isSite.MatchString(strings.TrimSpace(line))
+		if site && before {
 			out = append(out, indentOf(line)+"SCHEMA_PERFGATE_PLANT()")
 			planted++
 		}
 		out = append(out, line)
+		if site && !before {
+			out = append(out, indentOf(line)+"SCHEMA_PERFGATE_PLANT()")
+			planted++
+		}
 	}
 	return strings.Join(out, "\n"), planted
+}
+
+// plantPacket: the packet wire's generated header. Every field read is a
+// read_* macro call on a line of its own, so the site is the call and the
+// plant goes ahead of it.
+func plantPacket(src string) (string, int) {
+	return plantAt(src, readFn, readMacro, true)
 }
 
 // plantTable: the table wire's generated header. The read path dispatches on
-// field id, so the site is the case label: one plant per field, once.
+// field id, so the site is the case label inside a LoadBody: one plant per
+// field, once, placed where the field's own decode begins. The enum-id lookup
+// helper carries case labels too and is deliberately not a site, because a
+// plant there would price enum values rather than fields.
 func plantTable(src string) (string, int) {
-	lines := strings.Split(src, "\n")
-	inLoad := false
-	planted := 0
-	var out []string
-	for _, line := range lines {
-		t := strings.TrimSpace(line)
-		switch {
-		case loadFnStart.MatchString(line):
-			inLoad = true
-		case saveFnStart.MatchString(line):
-			inLoad = false
-		}
-		out = append(out, line)
-		if inLoad && caseLine.MatchString(t) {
-			out = append(out, indentOf(line)+"SCHEMA_PERFGATE_PLANT()")
-			planted++
-		}
-	}
-	return strings.Join(out, "\n"), planted
+	return plantAt(src, loadFn, caseLine, false)
 }
-
 func indentOf(line string) string {
 	return line[:len(line)-len(strings.TrimLeft(line, " \t"))]
 }

--- a/bench/tools/perfgate/main_test.go
+++ b/bench/tools/perfgate/main_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The planter is the negative control's whole mechanism, and a planter that
+// silently stops matching would leave the control passing for the wrong
+// reason. These run against the REAL generated trees, so a change in what the
+// emitters produce is caught here rather than in a timed sitting.
+
+func TestPlantReachesTheReadPathAndOnlyTheReadPath(t *testing.T) {
+	b, err := os.ReadFile("../../../generated/bench/cpp/BenchWire.h")
+	if err != nil {
+		t.Skip("no generated packet unit in this tree")
+	}
+	out, n := plantPacket(string(b))
+
+	// THE ORACLE IS AN INDEPENDENT COUNT, not a second copy of the planter's
+	// own state machine. Every field read on this wire is a read_* macro call on
+	// a line of its own, and those calls appear on the read path and nowhere
+	// else, so a plain scan of the untransformed file says how many sites there
+	// are. A planter that started matching write_ too, or stopped matching a
+	// macro the emitter renamed, disagrees with this number.
+	sites := 0
+	for line := range strings.SplitSeq(string(b), "\n") {
+		if readMacro.MatchString(strings.TrimSpace(line)) {
+			sites++
+		}
+	}
+	if sites < 20 {
+		t.Fatalf("the packet unit has %d read sites, too few for this test to mean anything", sites)
+	}
+	if n != sites {
+		t.Fatalf("planted %d sites, an independent scan finds %d", n, sites)
+	}
+	if got := strings.Count(out, "SCHEMA_PERFGATE_PLANT()"); got != sites {
+		t.Fatalf("the planted text carries %d plants for %d sites", got, sites)
+	}
+}
+
+func TestTablePlanterReachesTheLoadPathAndOnlyTheLoadPath(t *testing.T) {
+	b, err := os.ReadFile("../../../generated/bench/tables/cpp/BenchTableTable.h")
+	if err != nil {
+		t.Skip("no generated table unit in this tree")
+	}
+	out, n := plantTable(string(b))
+	if n < 20 {
+		t.Fatalf("planted %d sites, which is too few to be the read path", n)
+	}
+
+	// Here the filter is doing real work and the test has to prove it. Case
+	// labels appear in the enum-id lookup helper as well as in the decode
+	// bodies, and a plant in the helper would price enum values rather than
+	// fields. So the planted count must be strictly under the file's total,
+	// and every plant must sit immediately after a case label rather than
+	// wherever the walk happened to leave it.
+	total := 0
+	for line := range strings.SplitSeq(string(b), "\n") {
+		if caseLine.MatchString(strings.TrimSpace(line)) {
+			total++
+		}
+	}
+	if n >= total {
+		t.Fatalf("planted %d of %d case labels, so the load-path filter filtered nothing", n, total)
+	}
+	lines := strings.Split(out, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "SCHEMA_PERFGATE_PLANT()") || i == 0 {
+			continue
+		}
+		if !caseLine.MatchString(strings.TrimSpace(lines[i-1])) {
+			t.Fatalf("line %d planted a cost that does not follow a case label: %q", i+1, lines[i-1])
+		}
+	}
+}
+
+func TestPlantBlockLandsAfterPragmaOnce(t *testing.T) {
+	got := injectBlock("// header\n#pragma once\n\n#include <x>\n")
+	pragma := strings.Index(got, "#pragma once")
+	block := strings.Index(got, "SCHEMA_PERFGATE_PLANT_DEFINED")
+	inc := strings.Index(got, "#include <x>")
+	if pragma < 0 || block < pragma || inc < block {
+		t.Fatalf("the block must sit between the pragma and the first include, got:\n%s", got)
+	}
+}
+
+// The pin file is the gate's authority, so the refusals that keep an
+// unmeasured or malformed one out are worth their own control.
+
+func TestValidateRefusesTheUnmeasuredSkeleton(t *testing.T) {
+	p := skeletonPins()
+	if err := p.validate(); err == nil {
+		t.Fatal("a pin file full of zeros validated, so an unmeasured gate would run")
+	}
+}
+
+func TestValidateRefusesAWidthOfZero(t *testing.T) {
+	p := skeletonPins()
+	for _, want := range gateRows {
+		p.rates[want[0]+"/"+want[1]] = 1e6
+	}
+	p.directives["spread.max.pct"] = "4.0"
+	if err := p.validate(); err == nil {
+		t.Fatal("band.pct of zero validated, and a gate with no width refuses everything or nothing")
+	}
+	p.directives["band.pct"] = "3.0"
+	if err := p.validate(); err != nil {
+		t.Fatalf("a fully stated pin file was refused: %v", err)
+	}
+}
+
+func TestValidateRefusesAnUnstatedSitting(t *testing.T) {
+	p := statedPins()
+	delete(p.directives, "sitting.uptime")
+	if err := p.validate(); err == nil {
+		t.Fatal("a pin file with no sitting.uptime validated, so a pin could carry no provenance")
+	}
+}
+
+// The verdict itself: slower past the band is red, faster is not, and a noisy
+// sitting renders no green verdict at all.
+
+func TestCompareIsRedPastTheBandAndOnlyPastIt(t *testing.T) {
+	p := statedPins()
+	for _, want := range gateRows {
+		p.rates[want[0]+"/"+want[1]] = 1e6
+	}
+
+	within := sittingAt(map[string]float64{"": 0.98e6}) // 2% slower, inside a 3% band
+	if _, red := compare(within, p, 3.0, 5.0); red {
+		t.Fatal("2% slower went red inside a 3% band")
+	}
+	past := sittingAt(map[string]float64{"": 0.95e6}) // 5% slower
+	if _, red := compare(past, p, 3.0, 5.0); !red {
+		t.Fatal("5% slower stayed green inside a 3% band, so a real regression would merge")
+	}
+	faster := sittingAt(map[string]float64{"": 1.20e6})
+	if _, red := compare(faster, p, 3.0, 5.0); red {
+		t.Fatal("faster than the pin went red")
+	}
+}
+
+func TestANoisySittingRendersNoVerdict(t *testing.T) {
+	p := statedPins()
+	for _, want := range gateRows {
+		p.rates[want[0]+"/"+want[1]] = 1e6
+	}
+	s := sittingAt(map[string]float64{"": 1e6})
+	for k, r := range s.rows {
+		r.spread = 9.0
+		s.rows[k] = r
+	}
+	vs, red := compare(s, p, 3.0, 5.0)
+	if !red {
+		t.Fatal("a sitting over the spread cap passed, and a gate that passes on noise passes on anything")
+	}
+	if !strings.Contains(vs[0].note, "NOISY") {
+		t.Fatalf("the refusal did not name the noise: %q", vs[0].note)
+	}
+}
+
+func TestADriftedCorpusIsNotAComparison(t *testing.T) {
+	p := statedPins()
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		p.rates[k] = 1e6
+		p.corpus[k] = "aaaaaaaaaaaaaaaa"
+	}
+	s := sittingAt(map[string]float64{"": 1e6})
+	vs, red := compare(s, p, 3.0, 5.0)
+	if !red {
+		t.Fatal("a run against a different corpus was compared to the pins as if it were the same work")
+	}
+	if !strings.Contains(vs[0].note, "CORPUS MOVED") {
+		t.Fatalf("the refusal did not name the corpus: %q", vs[0].note)
+	}
+}
+
+// helpers
+
+func skeletonPins() *pins {
+	p := &pins{directives: map[string]string{}, rates: map[string]float64{}, corpus: map[string]string{}}
+	for _, k := range requiredDirectives {
+		p.directives[k] = "stated"
+	}
+	p.directives["band.pct"] = "0.0"
+	p.directives["spread.max.pct"] = "0.0"
+	for _, want := range gateRows {
+		p.rates[want[0]+"/"+want[1]] = 0
+	}
+	return p
+}
+
+func statedPins() *pins {
+	p := skeletonPins()
+	p.directives["band.pct"] = "3.0"
+	p.directives["spread.max.pct"] = "5.0"
+	for _, want := range gateRows {
+		p.rates[want[0]+"/"+want[1]] = 1e6
+	}
+	return p
+}
+
+// sittingAt builds a sitting whose every gate row carries rates[""].
+func sittingAt(rates map[string]float64) *sitting {
+	s := &sitting{rows: map[string]row{}}
+	for _, want := range gateRows {
+		k := want[0] + "/" + want[1]
+		s.rows[k] = row{bench: want[0], path: want[1], rate: rates[""], spread: 1.0, corpusID: "bbbbbbbbbbbbbbbb"}
+	}
+	return s
+}

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -68,6 +68,38 @@ Relative numbers move with compiler and microarchitecture. Treat the table as a 
 snapshot, not a verdict. Full tables, the pre-campaign baseline of the same day, and
 per-gap analysis: [bench/results/](../bench/results/).
 
+## A diagnostic costs nothing on the read or write path
+
+The owner's rule, 2026-09-05 (issue #546): **"i'm all for greater diagnostics, but if
+it costs speed on read or write, it's not worth it"**, and, on widening and the refusal
+reasons, **"if this costs *any* time, then we should not do this"** at runtime, when the
+packet or the table is being read. Every reporting surface in this project, the read
+report and its counters, the refusal reasons, retain-unknown's counters, the descriptor
+columns, and anything added later that reports, is admitted at zero MEASURED cost on the
+read path and the write path of both wires, or it is declined and its page says so.
+
+The word doing the work is MEASURED, so the law ships as an instrument rather than an
+intention. `make perf-gate` runs the C++ reference over the bench corpus on both wires,
+the packet wire's `bench_mixed` and the table wire's `bench_table`, and compares four
+rows against [bench/PERF-PINS](../bench/PERF-PINS), which records the sitting that cut
+them: the box, the date, the commit, the compiler and the load the machine was carrying.
+A row slower than its pin by more than the stated band is a refusal. Neither runner times
+a read on its own, deliberately, because the decode's output is the re-encode's input and
+that is what gives the read side its sink discipline in every language
+([BENCH-STANDARD §2.7](../bench/BENCH-STANDARD.md)), so the read row is `round_trip` and
+the pair is read together: a cost on the read path raises `round_trip` and leaves `write`
+flat. A red verdict says which path got slower, not merely that something did.
+
+Two refusals keep the gate from going quietly green. Off the box the pins name it renders
+no verdict at all, because a rate in messages per second is a fact about one machine. And
+a sitting whose in-run spread is over the cap renders no verdict either, since a gate that
+passes on a noisy box is a gate that passes on noise. What runs anywhere, including on
+certification hardware nobody here owns, is `make perf-gate-control`: it plants one added
+branch per field on the read path in a scratch copy of the generated headers and requires
+the gate to go red on `round_trip` while `write` holds. That control is the answer to the
+obvious question about any band, which is whether it is wide enough to hide the very thing
+it guards against. A gate nobody has watched go red is a gate nobody has tested.
+
 ---
 
 Measurement code and the full tables live in [bench/](../bench/).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -95,10 +95,16 @@ no verdict at all, because a rate in messages per second is a fact about one mac
 a sitting whose in-run spread is over the cap renders no verdict either, since a gate that
 passes on a noisy box is a gate that passes on noise. What runs anywhere, including on
 certification hardware nobody here owns, is `make perf-gate-control`: it plants one added
-branch per field on the read path in a scratch copy of the generated headers and requires
-the gate to go red on `round_trip` while `write` holds. That control is the answer to the
-obvious question about any band, which is whether it is wide enough to hide the very thing
-it guards against. A gate nobody has watched go red is a gate nobody has tested.
+branch per field on the read path in a scratch copy of the generated headers, measures a
+clean sitting and a planted one back to back, and requires the plant to separate
+`round_trip` from `write` by more than the band on both wires. The separation, rather than
+a bare `round_trip` drop, is the verdict on purpose. It cancels whatever the box did to
+both rows between the two sittings, which is what lets the control run on a shared runner,
+and it is the exact claim the law makes: the cost landed on the read path, and nothing was
+planted on the write path, so `write` is the control's own control. That control is also
+the answer to the obvious question about any band, which is whether it is wide enough to
+hide the very thing it guards against. A gate nobody has watched go red is a gate nobody
+has tested.
 
 ---
 

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -9031,6 +9031,28 @@ are these rulings, in the owner's words:
   that case want to blow out memory with extra union tables you don't need
   and so on" — and the primitive itself, "yes, I like byte buffer as
   primitive", so that "we can include say, images or assets inside them."
+- **What a diagnostic may cost, which is nothing**: "i'm all for greater
+  diagnostics, but if it costs speed on read or write, it's not worth it",
+  and, on widening and the refusal reasons, "if this costs *any* time, then
+  we should not do this" at runtime, when the packet or the table is being
+  read.
+
+**THE ZERO-COST-DIAGNOSTIC LAW** (issue #546) is that last ruling made
+binding over every reporting surface this document defines: the read report
+and its counters, the refusal reasons, retain-unknown's counters (§6.6), the
+descriptor columns (§8.1), and anything added later that reports. Each is
+admitted at zero MEASURED cost on the read path and the write path of both
+wires, or it is declined and this page says so. Measured is the operative
+word, so the law arrives with an instrument rather than an intention:
+`make perf-gate` runs the C++ reference over the bench corpus on both wires
+and refuses a pull request whose read or write fell behind
+[bench/PERF-PINS](../bench/PERF-PINS) by more than a stated band, and
+`make perf-gate-control` plants one added branch per field on the read path
+and requires the gate to see it. Cost is admitted where the ladder above
+already admits it, on the authoring side and at build time, and the gate
+measures only the two paths the ruling names. A surface that wants a
+diagnostic and cannot pay for it out of the write side gets it behind a
+build-time switch or does not get it.
 
 ### 13.3 The fixed-class constructs, ruled
 


### PR DESCRIPTION
Closes #546.

The owner's rule, 2026-09-05:

> "i'm all for greater diagnostics, but if it costs speed on read or write, it's not worth it."

and, on widening and the refusal reasons:

> "if this costs *any* time, then we should not do this"

at runtime, when the packet or the table is being read.

## 1. The law, on the page

`docs/SPEC-TABLES.md` §13.2 (Cost and allocation, ruled) gains the quotation as a bullet beside the ladder's other rulings, and a paragraph naming what it binds: the read report and its counters, the refusal reasons, retain-unknown's counters (§6.6), the descriptor columns (§8.1), and anything added later that reports. `docs/PERFORMANCE.md` gains a section of its own, because that is the page a reader goes to with a question about speed.

Both say the same thing and neither says it alone: **measured** is the operative word, so the law arrives with an instrument.

## 2. The gate

`make perf-gate` runs the C++ reference over the bench corpus on both wires and compares four rows against `bench/PERF-PINS`:

| row | what it guards |
|---|---|
| `bench_mixed` write | the packet wire's write path |
| `bench_mixed` round_trip | the packet wire's read path, carried |
| `bench_table` write | the table wire's write path |
| `bench_table` round_trip | the table wire's read path, carried |

**The read row is `round_trip`, and that is a decision the page had to make.** Neither runner times a read on its own, deliberately: the decode's output IS the re-encode's input, which is how the read side gets its sink discipline with no per-language fold to audit (BENCH-STANDARD §2.7). Both runners do print a read rate, round-trip minus write, and both mark it DERIVED and keep it out of the CSV. A gate pinning that number would be pinning a subtraction of two medians, carrying the noise of both. So the gate pins what was measured and reads the pair: a cost on the read path raises `round_trip` and leaves `write` flat. A red verdict says WHICH path got slower, not merely that something did.

Neither leg's flags are spelled in the gate. It drives `bench/run.sh`'s own cpp leg and `bench/tables/cpp/leg`, so it compiles the same translation units, with the same flags, as the published passes do.

Two refusals keep it from going quietly green:

- **Off the pinned box it renders no verdict at all.** A rate in messages per second is a fact about one machine.
- **A sitting noisier than `spread.max.pct` renders no verdict either.** A gate that passes on a noisy box is a gate that passes on noise.

## 3. The negative control

`make perf-gate-control` plants the exact shape the law refuses, a counter behind a runtime flag with one added branch per field, on the READ path only, into a scratch copy of the emitter's output under `build/`. It measures a clean sitting and a planted one back to back and requires the plant to **separate `round_trip` from `write` by more than the band on both wires.**

The separation, rather than a bare `round_trip` drop, is the verdict on purpose: a box that ran faster during the planted half can hide a real cost inside its own drift, and the difference between the rows cancels whatever the box did to both. It is also the claim the law makes. Nothing is planted on the write path, so `write` is the control's own control.

Nothing under `generated/` or `internal/codegen/` is touched. The plant lands in `build/`.

## 4. Wired into certification

`certify.yml` gains a `perf-gate` leg. It runs `check -advisory` (the pin file parses, states its sitting, pins every guarded row, and the job says out loud that it is off the pinned box) and then the negative control, whose verdict is a ratio inside one sitting and therefore holds on hardware nobody here owns. The enforcing comparison stays on the box the pins name.

`ci.yml` gains `perf-pin-lock`, which costs no measurement. It takes the model `bench/LOCK`'s standing gate uses since the freeze lifted in #545: a pull request moving the packet emitters re-pins the reproduction rows in the same PR and states the sitting. So a combined diff is **allowed**. What is refused is a re-pin with no sitting behind it (pins moved while `sitting.date`, `sitting.uptime` and `sitting.commit` did not), and a `sitting.commit` the branch does not contain. When the pins move it prints each row's move as a percentage, so the size of a re-pin is visible in the log.

## 5. The pins

Cut on this machine at a stated quiet moment. `bench/PERF-PINS` records the box, the date, the commit, the compiler and the `uptime` line the machine was carrying, and the band's derivation travels with the numbers.

<!-- NUMBERS -->

## One shared hook

`bench/run.sh` and `bench/tables/cpp/leg` gain `BENCH_CXXFLAGS_PREFIX`, prepended to the C++ bench compiles and empty in every published pass. One caller exists: the negative control, which needs to win the include search over `-Igenerated/bench/cpp`. `perfgate pin` refuses to cut a pin while it is set, because a number measured under flags the shipped build does not carry is a number for a build nobody runs.
