### PR TITLE
certify: make test after the wstring packet wire (#556)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,15 @@ tending/
 
 # CI clones the five serialize runtimes here (see .github/workflows/ci.yml)
 /runtimes/
+
+# a `go build ./bench/tools/...` run from the repository root drops its binary
+# at ./tools, and one reached main once already (#32). The ignore is for THAT
+# FILE. The negation re-includes the DIRECTORY of the same name, which carries
+# tracked tool sources the build runs (tools/sabotage, the wide-text negative
+# controls): a trailing slash matches only a directory, so the stray binary
+# stays ignored and the sources stay committable.
 /tools
+!/tools/
 
 # test-leg build artifact
 /test/go/schematest

--- a/internal/ci/ci_test.go
+++ b/internal/ci/ci_test.go
@@ -326,7 +326,7 @@ func gitLsFiles(t *testing.T, root, dir string) []string {
 		t.Fatalf("git ls-files %s: %v", dir, err)
 	}
 	var paths []string
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		if line != "" {
 			paths = append(paths, line)
 		}

--- a/internal/ci/ci_test.go
+++ b/internal/ci/ci_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -229,4 +230,106 @@ func TestEveryProjectTargetsThePinnedSDK(t *testing.T) {
 			}
 		}
 	}
+}
+
+// makeSources is every file the build itself is written in, relative to the
+// repo root: the root Makefile and the per-language includes it pulls in.
+var makeSources = []string{"Makefile", "make"}
+
+// goPackageArg matches a repo-relative Go package path as it appears on a
+// `go run` / `go build` / `go test` command line: a leading ./ and no wildcard.
+var goPackageArg = regexp.MustCompile(`(?:^|\s)(\./[A-Za-z0-9_./-]+)`)
+
+// goInvocation matches one go subcommand invocation, after line continuations
+// have been joined.
+var goInvocation = regexp.MustCompile(`\bgo\s+(?:run|build|test|vet)\b[^\n]*`)
+
+// TestEveryPackageTheBuildRunsIsCommitted requires every repo-relative Go
+// package the Makefile invokes to be TRACKED BY GIT, not merely present on the
+// author's disk.
+//
+// The class it closes: .gitignore hid a source tree, `git add` skipped it
+// without a word, the author's `make test` stayed green because the file was
+// right there in the working copy, and the first fresh checkout to run the
+// chain was main's own certification. tools/sabotage, which four wide-text
+// negative controls run, landed that way in #556 and reddened every certify
+// leg at `make test`. A working tree cannot see the difference between a file
+// it owns and a file the repository owns. Git can, so the gate asks git.
+func TestEveryPackageTheBuildRunsIsCommitted(t *testing.T) {
+	root := repoRoot(t)
+
+	var text strings.Builder
+	for _, src := range makeSources {
+		path := filepath.Join(root, src)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", src, err)
+		}
+		files := []string{path}
+		if info.IsDir() {
+			files, err = filepath.Glob(filepath.Join(path, "*.mk"))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, file := range files {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("read %s: %v", file, err)
+			}
+			// a recipe wraps across lines with a trailing backslash, and the
+			// package path is often on the wrapped half
+			text.WriteString(strings.ReplaceAll(string(data), "\\\n", " "))
+			text.WriteString("\n")
+		}
+	}
+
+	packages := map[string]bool{}
+	for _, invocation := range goInvocation.FindAllString(text.String(), -1) {
+		for _, match := range goPackageArg.FindAllStringSubmatch(invocation, -1) {
+			pkg := match[1]
+			if strings.Contains(pkg, "...") {
+				continue
+			}
+			packages[strings.TrimSuffix(pkg, "/")] = true
+		}
+	}
+	if len(packages) == 0 {
+		t.Fatal("no repo-relative go packages found in the make sources: this gate is looking at the wrong text")
+	}
+
+	names := make([]string, 0, len(packages))
+	for pkg := range packages {
+		names = append(names, pkg)
+	}
+	sort.Strings(names)
+	t.Logf("packages the make sources run: %s", strings.Join(names, " "))
+
+	for _, pkg := range names {
+		dir := strings.TrimPrefix(pkg, "./")
+		tracked := gitLsFiles(t, root, dir)
+		if len(tracked) == 0 {
+			t.Errorf("the build runs `go ... %s` but git tracks no file under %s/. "+
+				"The package exists on the author's disk and in no checkout. "+
+				"Commit it, and check .gitignore is not swallowing the path.", pkg, dir)
+		}
+	}
+}
+
+// gitLsFiles returns the tracked paths under dir, relative to root.
+func gitLsFiles(t *testing.T, root, dir string) []string {
+	t.Helper()
+	cmd := exec.Command("git", "ls-files", "--", dir)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git ls-files %s: %v", dir, err)
+	}
+	var paths []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
 }

--- a/tools/sabotage/main.go
+++ b/tools/sabotage/main.go
@@ -1,0 +1,145 @@
+// sabotage writes a deliberately broken COPY of a compiler source file, for
+// the negative controls to build against through a Go overlay.
+//
+// Why a tool rather than the sed the older controls use: these sabotages
+// INSERT emitter lines as well as remove them, and an inserted line carries
+// the two characters `\n` inside a Go string literal, which sed's replacement
+// side spells differently on the BSD and GNU implementations. Exact string
+// replacement in Go spells it once. The exactly-once match is also the
+// control's own guard: an emitter that drifts away from an anchor fails here,
+// loudly, instead of producing an unsabotaged copy that passes and quietly
+// retires the control.
+//
+// The tool NEVER writes the file it reads. Its output is a copy under build/.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// an edit is one exact replacement, which must match exactly once.
+type edit struct{ old, new string }
+
+// sabotages maps a control's name to what it breaks. Each entry names the
+// rule it removes, so a reader of a red control knows what was taken away.
+var sabotages = map[string][]edit{
+	// SPEC §4.12: `wstring(N)` performs NO alignment. serialize.modern's
+	// wstring_ inserts an align between the length and the code units, and
+	// that align is the one thing schema does not do. Put it back on both
+	// paths and every byte after the length field moves.
+	"wstring-align": {{
+		old: `		g.emitWriteRangedFold32(name+"_length", "0", g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)),
+			bitsRequired(big.NewInt(0), big.NewInt(f.Type.Size)), true, ind)
+		g.pf("%sfor ( int32_t i = 0; i < %s_length; i++ )\n%s{\n", ind, name, ind)
+		g.pf("%s    write_bits( stream, uint32_t( %s[i] ), 32 );\n%s}\n", ind, name, ind)`,
+		new: `		g.emitWriteRangedFold32(name+"_length", "0", g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size)),
+			bitsRequired(big.NewInt(0), big.NewInt(f.Type.Size)), true, ind)
+		g.pf("%swrite_align( stream );\n", ind) // SABOTAGED: an align between the length and the code units
+		g.pf("%sfor ( int32_t i = 0; i < %s_length; i++ )\n%s{\n", ind, name, ind)
+		g.pf("%s    write_bits( stream, uint32_t( %s[i] ), 32 );\n%s}\n", ind, name, ind)`,
+	}, {
+		old: `		g.pf("%s{\n%s    bool expect_low_surrogate = false;\n", ind, ind)`,
+		new: `		g.pf("%sread_align( stream );\n", ind) // SABOTAGED: an align between the length and the code units
+		g.pf("%s{\n%s    bool expect_low_surrogate = false;\n", ind, ind)`,
+	}},
+
+	// SPEC §4.12: a high surrogate not immediately followed by a low one
+	// fails, a low not immediately preceded by a high fails, and a high as
+	// the final transmitted group fails. Take the whole pairing rule out.
+	// The group-value and zero-group refusals stay, so what goes red is the
+	// pairing and nothing else.
+	"wstring-accept-unpaired-surrogate": {{
+		old: `		g.pf("%s{\n%s    bool expect_low_surrogate = false;\n", ind, ind)
+		g.pf("%s    for ( int32_t i = 0; i < %s_length; i++ )\n%s    {\n", ind, name, ind)
+		g.pf("%s        uint32_t group = 0;\n", ind)
+		g.pf("%s        read_bits( stream, group, 32 );\n", ind)
+		g.pf("%s        if ( group == 0 || group > 0xFFFF )\n%s        {\n", ind, ind)
+		g.pf("%s            return false; // a zero group and a group above 0xFFFF are content the read refuses (SPEC §4.12)\n%s        }\n", ind, ind)
+		g.pf("%s        const bool high_surrogate = group >= 0xD800 && group <= 0xDBFF;\n", ind)
+		g.pf("%s        const bool low_surrogate = group >= 0xDC00 && group <= 0xDFFF;\n", ind)
+		g.pf("%s        if ( low_surrogate != expect_low_surrogate )\n%s        {\n", ind, ind)
+		g.pf("%s            return false; // an unpaired surrogate is content the read refuses (SPEC §4.12)\n%s        }\n", ind, ind)
+		g.pf("%s        expect_low_surrogate = high_surrogate;\n", ind)
+		g.pf("%s        %s[i] = char16_t( group );\n%s    }\n", ind, name, ind)
+		g.pf("%s    if ( expect_low_surrogate )\n%s    {\n", ind, ind)
+		g.pf("%s        return false; // a high surrogate as the final group is unpaired (SPEC §4.12)\n%s    }\n%s}\n", ind, ind, ind)`,
+		new: `		g.pf("%s{\n", ind) // SABOTAGED: the surrogate pairing rule removed
+		g.pf("%s    for ( int32_t i = 0; i < %s_length; i++ )\n%s    {\n", ind, name, ind)
+		g.pf("%s        uint32_t group = 0;\n", ind)
+		g.pf("%s        read_bits( stream, group, 32 );\n", ind)
+		g.pf("%s        if ( group == 0 || group > 0xFFFF )\n%s        {\n", ind, ind)
+		g.pf("%s            return false; // a zero group and a group above 0xFFFF are content the read refuses (SPEC §4.12)\n%s        }\n", ind, ind)
+		g.pf("%s        %s[i] = char16_t( group );\n%s    }\n%s}\n", ind, name, ind, ind)`,
+	}},
+
+	// SPEC §4.12: in C and C++ a successful read writes the zero unit at
+	// index length, always. Drop the store. The buffer the harness reads
+	// into is poisoned first, so what this reddens is the STORE rather than
+	// the storage's own default initialization.
+	"wstring-drop-terminator": {{
+		old: `		// the terminating zero UNIT, always — §5's one stated tail exception
+		g.pf("%s%s[%s_length] = 0;\n", ind, name, name)`,
+		new: `		// SABOTAGED: the terminating zero unit at index length dropped`,
+	}},
+
+	// SPEC §4.7 as amended (schema#519): the UTF-8 validator runs on the READ
+	// path in every build mode. Put it back where it was, a write-side debug
+	// assert and nothing on read, which is the stance the amendment replaced.
+	"string-write-only-utf8": {{
+		old: `			// a payload that is not well-formed UTF-8 fails the READ, in every
+			// build mode (SPEC §4.7). The refusal is terminal: nothing after it
+			// has a defined position.
+			g.pf("%sif ( !schema_utf8_valid( reinterpret_cast<const uint8_t *>( %s ), %s_length ) )\n%s{\n", ind, name, name, ind)
+			g.pf("%s    return false; // malformed UTF-8 is content the read refuses (SPEC §4.7)\n%s}\n", ind, ind)
+`,
+		new: `			// SABOTAGED: the read-side UTF-8 refusal removed
+`,
+	}, {
+		old: `			g.pf("%sfor ( int32_t i = 0; i < %s_length; i++ )\n%s{\n", ind, name, ind)
+			g.pf("%s    serialize_assert( %s[i] != 0 );\n%s}\n", ind, name, ind)
+		}`,
+		new: `			g.pf("%sfor ( int32_t i = 0; i < %s_length; i++ )\n%s{\n", ind, name, ind)
+			g.pf("%s    serialize_assert( %s[i] != 0 );\n%s}\n", ind, name, ind)
+			g.pf("%sserialize_assert( schema_utf8_valid( reinterpret_cast<const uint8_t *>( %s ), %s_length ) );\n", ind, name, name) // SABOTAGED: the write-only stance restored
+		}`,
+	}},
+}
+
+func main() {
+	name := flag.String("name", "", "the sabotage to apply")
+	out := flag.String("out", "", "where to write the sabotaged copy")
+	flag.Parse()
+	if flag.NArg() != 1 || *name == "" || *out == "" {
+		fmt.Fprintln(os.Stderr, "usage: sabotage -name <name> -out <copy> <source>")
+		os.Exit(2)
+	}
+	edits, ok := sabotages[*name]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "sabotage: no sabotage named %q\n", *name)
+		os.Exit(2)
+	}
+	b, err := os.ReadFile(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "sabotage:", err)
+		os.Exit(1)
+	}
+	s := string(b)
+	for i, e := range edits {
+		if got := strings.Count(s, e.old); got != 1 {
+			fmt.Fprintf(os.Stderr, "sabotage %s: edit %d matched %d times, want exactly 1. The emitter moved away from the anchor, so this negative control no longer breaks what it names. Re-anchor it or retire it.\n", *name, i, got)
+			os.Exit(1)
+		}
+		s = strings.Replace(s, e.old, e.new, 1)
+	}
+	if !strings.Contains(s, "SABOTAGED") {
+		fmt.Fprintf(os.Stderr, "sabotage %s: the copy carries no SABOTAGED marker\n", *name)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(*out, []byte(s), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "sabotage:", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Certification on main at 98a0cd8f (run 33948607072, the first after #556) was red in every `test` and inline-gate leg at the `make test` step, on both ubuntu and macos, while #556's own pull-request CI was 20/20 green and its builder's local `make test` was green on the branch.

## The first real failure

On a fresh checkout of main, in seconds:

```
$ make wide-no-align-negative-control
stat .../schema/tools/sabotage: directory not found
make: *** [wide-no-align-negative-control] Error 1
```

`make test` runs the four wide-text negative controls (`wide-no-align`, `wide-surrogate`, `wide-terminator`, `wide-utf8-read`), and each one is `go run ./tools/sabotage`. That package is in no checkout of this repository. It is not a control behaving differently in CI, not the poisoning harness, not a golden: the tool the controls run was never committed.

## The cause

One line of `.gitignore`, landed a month ago for an unrelated reason.

A 2.67 MB `go build ./bench/tools/...` binary once reached the repository root as the FILE `./tools`. a6424cb8 (#32) deleted it and added `/tools` to `.gitignore` so a sweep could not commit a rebuilt one. That pattern matches a DIRECTORY of the same name just as well.

#556 put the four controls behind a new Go tool at `tools/sabotage`. `git add` skipped the path in silence, `git status` stayed clean, and every run on the branch was green because the file was sitting in the author's working copy. `ci.yml` does not run `make test`, so the first checkout without that file was main's own certification.

The builder's clone still shows the mechanism exactly: `git status --porcelain --ignored` there lists `!! tools/` and nothing else that is source.

## The fix

Both halves.

- `tools/sabotage/main.go` is committed, byte for byte as #556 wrote it.
- The ignore is narrowed to what #32 was actually about. `/tools` still ignores the stray binary and `!/tools/` re-includes the directory, because a trailing slash matches only a directory. Verified both ways in a scratch repository: with the pair in place a FILE named `tools` is still ignored, and a DIRECTORY named `tools` is not.

## The gate

`TestEveryPackageTheBuildRunsIsCommitted`, in `internal/ci` beside the two other repo-level invariants, joins the make sources across line continuations, reads every repo-relative Go package that `go run` / `go build` / `go test` names, and requires git to TRACK a file under each. Ten packages today:

```
./bench/tools/shapegate ./cmd/schema ./compiler ./internal/check ./internal/goldens
./internal/tablecook ./test/conformance/harness ./test/cookgen ./test/vocabgen ./tools/sabotage
```

Its negative control is the defect itself. With `tools/sabotage/main.go` present on disk but not staged, the gate goes red:

```
=== RUN   TestEveryPackageTheBuildRunsIsCommitted
    ci_test.go:311: the build runs `go ... ./tools/sabotage` but git tracks no
    file under tools/sabotage/. The package exists on the author's disk and in
    no checkout. Commit it, and check .gitignore is not swallowing the path.
--- FAIL: TestEveryPackageTheBuildRunsIsCommitted (0.16s)
```

A working tree cannot tell a file it owns from a file the repository owns, which is exactly why the author's `make test` and CI disagreed. Git can, so the gate asks git.

## Verification

- `make wide-no-align-negative-control` now passes and prints its red: `the gate goes red on FAILED: ok == !v.refused on vector wstring-worked-example (test/wide/main.cpp:277)`
- `make test` run whole locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)