### PR TITLE
certify: the cook-open O(1) gate's band holds an order of magnitude against runner noise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -922,6 +922,31 @@ tables-cook-open-lengths-negative-control: build/cook-open/.stamp
 tables-cook-open-root-negative-control: build/cook-open/.stamp
 	$(call cook_open_sabotage,root,data_length < root_size,if ( root_size == UINT64_MAX ) { return NULL; })
 
+# THE WALK CONTROL, for the OPEN-COST gate (§7.5) rather than the forgery
+# battery. The sabotage (tools/sabotage, cook-open-walk-cpp) leaves every check
+# in place and makes Open sum every word of the region before it returns, which
+# is the one thing the gate exists to refuse; the gate must go RED on its band
+# over the same two fixtures the certification run times. ITERATIONS is low
+# because an Open that walks 100 MB cannot be opened 200000 times in a
+# control's budget, and the gate is a ratio, which the count does not move.
+.PHONY: tables-cook-open-walk-negative-control
+tables-cook-open-walk-negative-control: build/cook-open/.stamp
+	@rm -rf build/cook-open-walk && mkdir -p build/cook-open-walk
+	@go run ./tools/sabotage -name cook-open-walk-cpp -out build/cook-open-walk/cook.gotext internal/codegen/cpptable/cook.go
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/cook.go":"%s/build/cook-open-walk/cook.gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/cook-open-walk/overlay.json
+	@go build -overlay=build/cook-open-walk/overlay.json -o build/cook-open-walk/schema ./cmd/schema
+	./build/cook-open-walk/schema generate --lang cpp --out build/cook-open-walk/gen tables/pointers
+	$(CXX) $(COOK_CXXFLAGS) -Ibuild/cook-open-walk/gen -Itest/tables test/tables/cook_main.cpp -o build/cook-open-walk/test
+	@if ITERATIONS=20 ./build/cook-open-walk/test time Scene build/cook-open/1mb.cook build/cook-open/100mb.cook > build/cook-open-walk/log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: the open-cost gate stayed green with a walk in Open"; cat build/cook-open-walk/log; exit 1; \
+	fi
+	@grep -q "FAILED: open time is not flat" build/cook-open-walk/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on its band"; cat build/cook-open-walk/log; exit 1; }
+	@grep "cook open is O(1)" build/cook-open-walk/log
+	@grep -m1 "FAILED" build/cook-open-walk/log
+	@echo "negative control: a walk in Open turns the open-cost gate RED"
+
 # THE COOK ROUND TRIP THROUGH THE CLI (docs/SPEC-TABLES.md §7.5). The Go tests hold
 # the engine; this holds the three COMMANDS and their flags, over a pinned pack
 # tree, in both byte orders and with the attribution written both ways.
@@ -2439,6 +2464,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) tables-cook-valued
 	$(MAKE) tables-cook-open-lengths-negative-control
 	$(MAKE) tables-cook-open-root-negative-control
+	$(MAKE) tables-cook-open-walk-negative-control
 	$(MAKE) tables-block-zero-cost
 	$(MAKE) tables-block-build-version
 	$(MAKE) tables-block-fill-refuser

--- a/make/cs.mk
+++ b/make/cs.mk
@@ -226,6 +226,40 @@ tables-cook-open-cs-lengths-negative-control: build/cook-open/.stamp
 tables-cook-open-cs-root-negative-control: build/cook-open/.stamp
 	$(call cook_open_cs_sabotage,root,if (dataLength < %d) { return false; },if (dataLength == ulong.MaxValue) { return false; } // NEGATIVE CONTROL)
 
+# THE WALK CONTROL, the C# half of the Makefile's tables-cook-open-walk-negative-control:
+# the sabotage (tools/sabotage, cook-open-walk-cs) leaves every check in place
+# and makes Open sum every word of the region before it returns, and the
+# open-cost gate must go RED on its band over the two fixtures the certification
+# run times. ITERATIONS is low for the reason given there.
+.PHONY: tables-cook-open-cs-walk-negative-control
+tables-cook-open-cs-walk-negative-control: build/cook-open/.stamp
+	@rm -rf build/cook-open-cs-walk && mkdir -p build/cook-open-cs-walk
+	@go run ./tools/sabotage -name cook-open-walk-cs -out build/cook-open-cs-walk/cook.gotext internal/codegen/cstable/cook.go
+	@printf '{"Replace":{"%s/internal/codegen/cstable/cook.go":"%s/build/cook-open-cs-walk/cook.gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/cook-open-cs-walk/overlay.json
+	@go build -overlay=build/cook-open-cs-walk/overlay.json -o build/cook-open-cs-walk/schema ./cmd/schema
+	./build/cook-open-cs-walk/schema generate --lang cs --out build/cook-open-cs-walk/gen tables/pointers
+	@if ( cd test/cs-cook && dotnet build -v q --nologo \
+			-p:CookGeneratedDir=../../build/cook-open-cs-walk/gen \
+			-p:BaseOutputPath=../../build/cook-open-cs-walk/bin/ \
+			-p:BaseIntermediateOutputPath=../../build/cook-open-cs-walk/obj/ \
+			> ../../build/cook-open-cs-walk/build.log 2>&1 ); then :; else \
+		echo "NEGATIVE CONTROL FAILED: the sabotaged emitter's output does not compile"; \
+		cat build/cook-open-cs-walk/build.log; exit 1; \
+	fi
+	@if ( cd test/cs-cook && ITERATIONS=10 dotnet run --no-build \
+			-p:CookGeneratedDir=../../build/cook-open-cs-walk/gen \
+			-p:BaseOutputPath=../../build/cook-open-cs-walk/bin/ \
+			-p:BaseIntermediateOutputPath=../../build/cook-open-cs-walk/obj/ \
+			-- time Scene ../../build/cook-open/1mb.cook ../../build/cook-open/100mb.cook > ../../build/cook-open-cs-walk/log 2>&1 ); then \
+		echo "NEGATIVE CONTROL FAILED: the open-cost gate stayed green with a walk in Open"; cat build/cook-open-cs-walk/log; exit 1; \
+	fi
+	@grep -q "FAILED: open time is not flat" build/cook-open-cs-walk/log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on its band"; cat build/cook-open-cs-walk/log; exit 1; }
+	@grep "cook open is O(1)" build/cook-open-cs-walk/log
+	@grep -m1 "FAILED" build/cook-open-cs-walk/log
+	@echo "negative control: a walk in Open turns the C# open-cost gate RED"
+
 generated/bench/tables/cs/.stamp: bin/schema bench/corpus/BenchTable.schema
 	@mkdir -p generated/bench/tables/cs
 	./bin/schema generate --lang cs --out generated/bench/tables/cs bench/corpus/BenchTable.schema
@@ -304,6 +338,7 @@ test-cs: build/tables-generated-cs/.stamp generated/bench/tables/cs/.stamp gener
 	$(MAKE) tables-cook-open-cs
 	$(MAKE) tables-cook-open-cs-lengths-negative-control
 	$(MAKE) tables-cook-open-cs-root-negative-control
+	$(MAKE) tables-cook-open-cs-walk-negative-control
 	dotnet build bench/tables/cs -c Release --nologo -v quiet
 	cd bench/cs && dotnet build -c Release --nologo -v quiet
 	cd test/cs && dotnet run

--- a/test/cs-cook/src/Program.cs
+++ b/test/cs-cook/src/Program.cs
@@ -850,7 +850,7 @@ static unsafe class Program
         return samples[runs / 2];
     }
 
-    static void ModeTime(Root root, string smallPath, string largePath)
+    static void ModeTime(Root root, string smallPath, string largePath, long iterations)
     {
         byte[] smallSource = WholeFile(smallPath);
         byte[] largeSource = WholeFile(largePath);
@@ -864,7 +864,6 @@ static unsafe class Program
             Fail.Now("one of the two fixtures did not open");
         }
 
-        const long iterations = 200000;
         // warm both — a tiered runtime measured before it settles measures
         // tier-up and not codegen — then interleave, so a machine that drifts
         // drifts under both arms
@@ -880,11 +879,13 @@ static unsafe class Program
                           ", paired, one sitting) — ratio " + ratio.ToString("F3"));
 
         // The bar is FLAT, and flat is stated as a band rather than as
-        // equality: a header match is tens of nanoseconds, where the scheduler
-        // and the cache are the whole variance. A walk of any shape over a
-        // hundred-megabyte region would be five orders of magnitude out, so
-        // this band cannot pass one by accident.
-        if (ratio > 2.0 || ratio < 0.5)
+        // equality: a header match is tens of nanoseconds, where one cache
+        // miss or one scheduler tick on a shared runner is a 2x by itself. The
+        // walk this gate refuses is at least 100x, by the two fixtures' size
+        // spread, so a band of 10 holds an order of magnitude of headroom on
+        // both sides: above what a certification runner's noise reaches, below
+        // the cheapest walk there is.
+        if (ratio > 10.0 || ratio < 0.1)
         {
             Fail.Now("open time is not flat across the two sizes: ratio " + ratio.ToString("F3"));
         }
@@ -1105,7 +1106,13 @@ static unsafe class Program
                     Console.WriteLine("FAILED: time wants two cooks");
                     return 1;
                 }
-                ModeTime(root, args[2], args[3]);
+                // ITERATIONS is the walk control's knob: an Open sabotaged to
+                // walk 100 MB cannot be opened 200000 times in a control's
+                // budget, and the gate is a ratio, which the count does not move
+                long iterations = 200000;
+                string it = Environment.GetEnvironmentVariable("ITERATIONS");
+                if (!string.IsNullOrEmpty(it)) { iterations = (long)ParseNumber(it); }
+                ModeTime(root, args[2], args[3], iterations);
                 break;
             case "accept": ModeOrder(root, args[2], true); break;
             case "refuse": ModeOrder(root, args[2], false); break;

--- a/test/tables/cook_main.cpp
+++ b/test/tables/cook_main.cpp
@@ -2129,7 +2129,7 @@ static double median_open_ns( const Root * root, const File & file, int64_t iter
     return samples[runs / 2];
 }
 
-static void mode_time( const Root * root, const char * small_path, const char * large_path )
+static void mode_time( const Root * root, const char * small_path, const char * large_path, int64_t iterations )
 {
     uint64_t small_length = 0, large_length = 0;
     uint8_t * small_source = whole_file( small_path, &small_length );
@@ -2142,7 +2142,6 @@ static void mode_time( const Root * root, const char * small_path, const char * 
          root->open( large_file.base, large_file.length ) == NULL )
         fail( "one of the two fixtures did not open" );
 
-    const int64_t iterations = 200000;
     // warm both, then interleave: two arms measured in one sitting, alternating,
     // so a machine that drifts drifts under both
     median_open_ns( root, small_file, iterations / 10 );
@@ -2157,11 +2156,12 @@ static void mode_time( const Root * root, const char * small_path, const char * 
             (unsigned long long) large_length, large_ns, (long long) iterations, ratio );
 
     // The bar is FLAT, and flat is stated as a band rather than as equality: a
-    // header match is tens of nanoseconds, where the scheduler and the cache
-    // are the whole variance. A walk of any shape over a hundred-megabyte
-    // region would be five orders of magnitude out, so this band cannot pass
-    // one by accident.
-    if ( ratio > 2.0 || ratio < 0.5 )
+    // header match is tens of nanoseconds, where one cache miss or one
+    // scheduler tick on a shared runner is a 2x by itself. The walk this gate
+    // refuses is at least 100x, by the two fixtures' size spread, so a band of
+    // 10 holds an order of magnitude of headroom on both sides: above what a
+    // certification runner's noise reaches, below the cheapest walk there is.
+    if ( ratio > 10.0 || ratio < 0.1 )
         fail( "open time is not flat across the two sizes: ratio %.3f", ratio );
 
     small_file.destroy();
@@ -2280,7 +2280,13 @@ int main( int argc, char ** argv )
     else if ( strcmp( mode, "time" ) == 0 )
     {
         if ( argc < 5 ) { printf( "FAILED: time wants two cooks\n" ); return 1; }
-        mode_time( root, argv[3], argv[4] );
+        // ITERATIONS is the walk control's knob: an Open sabotaged to walk
+        // 100 MB cannot be opened 200000 times in a control's budget, and the
+        // gate is a ratio, which the count does not move
+        int64_t iterations = 200000;
+        if ( const char * e = getenv( "ITERATIONS" ) )
+            if ( *e != 0 ) iterations = strtoll( e, NULL, 0 );
+        mode_time( root, argv[3], argv[4], iterations );
     }
     else if ( strcmp( mode, "accept" ) == 0 )
     {

--- a/tools/sabotage/main.go
+++ b/tools/sabotage/main.go
@@ -106,6 +106,32 @@ var sabotages = map[string][]edit{
 			g.pf("%sserialize_assert( schema_utf8_valid( reinterpret_cast<const uint8_t *>( %s ), %s_length ) );\n", ind, name, name) // SABOTAGED: the write-only stance restored
 		}`,
 	}},
+
+	// SPEC-TABLES §7.5: Open is O(1) in the file's size, a header match and
+	// nothing per node. Put a walk in: every word of the region is summed
+	// before the base is returned, and the sum is kept live by a compare
+	// no file can satisfy. Every check stays, so the forgery battery keeps
+	// its answers and what goes red is the open-cost gate alone.
+	"cook-open-walk-cpp": {{
+		old: `    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    return base;
+`,
+		new: `    if ( ( (uintptr_t) base % (uintptr_t) alignment ) != 0 ) { return NULL; }
+    uint64_t walk = 0; // SABOTAGED: Open walks every word of the region
+    for ( uint64_t i = 0; i < length / 8; i++ ) { walk += ( (const uint64_t *) raw )[i]; }
+    if ( walk == UINT64_MAX ) { return NULL; }
+    return base;
+`,
+	}},
+
+	// the same walk on the C# leg's Open
+	"cook-open-walk-cs": {{
+		old: `	g.hf("        cook = new %sCook(at + dataOffset, (long) dataLength);\n", name)`,
+		new: `	g.hf("        ulong walk = 0; // SABOTAGED: Open walks every word of the region\n")
+	g.hf("        for (ulong i = 0; i < bytes / 8; i++) { walk += ((ulong*) at)[i]; }\n")
+	g.hf("        if (walk == ulong.MaxValue) { return false; }\n")
+	g.hf("        cook = new %sCook(at + dataOffset, (long) dataLength);\n", name)`,
+	}},
 }
 
 func main() {


### PR DESCRIPTION
## The event

Main's push certification (run 33953041737, commit 6a0848c2) went red on exactly one leg, inline-gate (macos-latest, c), at `make test` → `test-cs` → `tables-cook-open-cs`:

```
cook open is O(1) in the file's size: Scene at 1572832 bytes opens in 38.0 ns, at 157286368 bytes in 85.9 ns (medians of 9 x 200000, paired, one sitting) — ratio 2.257
FAILED: open time is not flat across the two sizes: ratio 2.257
```

The scheduled certification (run 33957965367) on the same commit, two hours later, was green.

## The cause

The gate's band was `ratio > 2.0 || ratio < 0.5` on a measurement of tens of nanoseconds taken on a shared CI runner, where a single cache miss or a scheduler tick is a 2× by itself. A certification gate must not be able to go red on runner noise; this one could.

## The fix

Both twins — `test/tables/cook_main.cpp` `mode_time()` and `test/cs-cook/src/Program.cs` `ModeTime()` — now refuse outside `[0.1, 10]`, with the comment rewritten to state the present reasoning: the fixtures differ 100× in size, so any O(n) open puts the ratio at 100 or far above; 10 holds an order of magnitude of headroom on both sides. The two remain word-for-word parallel in structure.

`docs/SPEC-TABLES.md` §7.5, the Makefile's scale-fixture comment, and `bench/SHAPE-GATE.allow` only say "flat"; none states the band numerically, so they are unchanged.

## The negative control

No control existed for the open-cost gate (the two `cook_open_sabotage` controls run the forgery battery). This adds one in the #556 pattern, in both languages since the C# side already carries cook-open controls:

- `tools/sabotage/main.go`: `cook-open-walk-cpp` and `cook-open-walk-cs`, which leave every check in place and make the emitted `Open` sum every word of the region before returning.
- `Makefile`: `tables-cook-open-walk-negative-control`, wired into `make test` beside the lengths/root controls.
- `make/cs.mk`: `tables-cook-open-cs-walk-negative-control`, wired into `test-cs` beside its lengths/root controls.
- The `time` mode of both twins reads `ITERATIONS` from the environment (default 200000): a 100 MB walk cannot be opened 200000 times in a control's budget, and the gate is a ratio, which the count does not move.

Local results (MacBook Air, Apple Silicon):

```
# real gate, C++
cook open is O(1) in the file's size: Scene at 1572832 bytes opens in 17.2 ns, at 157286368 bytes in 15.6 ns (medians of 9 x 200000, paired, one sitting) — ratio 0.907
# real gate, C#
cook open is O(1) in the file's size: Scene at 1572832 bytes opens in 43.9 ns, at 157286368 bytes in 41.2 ns (medians of 9 x 200000, paired, one sitting) — ratio 0.939
# control, C++ (5.5 s)
cook open is O(1) in the file's size: Scene at 1572832 bytes opens in 173450.0 ns, at 157286368 bytes in 17865750.0 ns (medians of 9 x 20, paired, one sitting) — ratio 103.002
FAILED: open time is not flat across the two sizes: ratio 103.002
negative control: a walk in Open turns the open-cost gate RED
# control, C# (6.6 s)
cook open is O(1) in the file's size: Scene at 1572832 bytes opens in 198545.8 ns, at 157286368 bytes in 19954041.7 ns (medians of 9 x 10, paired, one sitting) — ratio 100.501
FAILED: open time is not flat across the two sizes: ratio 100.501
negative control: a walk in Open turns the C# open-cost gate RED
```

`make shape-gate` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
