### PR TITLE
certify: the maps fit control asserts the L refusal by name, and the cap check gets its control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2429,6 +2429,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) tables-zero-cost
 	$(MAKE) tables-zero-cost-negative-control
 	$(MAKE) tables-maps
+	$(MAKE) tables-maps-measure-refusals
 	$(MAKE) tables-json-map-walk
 	$(MAKE) tables-maps-negative-controls
 	$(MAKE) tables-lists
@@ -2538,6 +2539,14 @@ tables-maps: build/schema_test_maps build/schema_test_maps_asan
 	./build/schema_test_maps
 	./build/schema_test_maps_asan
 
+# THE LoadMeasure REFUSALS AT A MAP are a unit test and not a report row
+# (§2.8, §6.5): each wire is built in memory with a SYNTHETIC map count, and
+# the answer and the REASON are asserted by name, with a clean wire beside
+# them that must measure and load.
+.PHONY: tables-maps-measure-refusals
+tables-maps-measure-refusals: build/schema_test_maps
+	./build/schema_test_maps measure-refusals
+
 # THE MAP-WALK GATE (docs/SPEC-TABLES.md §2.8, §16): the map's half of the text
 # form is emitted only in a unit that declares one, and it is ONE half too —
 # the same bytes in every map-bearing .cpp of the corpus, on the walk's own
@@ -2634,12 +2643,22 @@ tables-maps-key-kind-negative-control: bin/schema build/tables-generated/.stamp
 tables-maps-clamp-negative-control: bin/schema build/tables-generated/.stamp
 	$(call map_negative_control,clamp,'s@out.over = key_len > %d;@out.over = ( key_len > %d ) \&\& false;@',internal/codegen/cpptable/maps.go,clamping an over-long key left the map gate GREEN)
 
-# N = 0xFFFFFFFF UNDER A SHORT L. A row of a few dozen bytes asking for
-# gigabytes meets it, and LoadMeasure's answer goes red if the fit check is
-# dropped.
+# N = 100000 UNDER A SHORT L. The measure-refusals row meets it: a Fleet of a
+# few dozen bytes whose map count the body cannot carry answers -1 with the
+# reason count_over_length, and that name goes red if the L check is dropped.
+# The count sits UNDER the int32 cap on purpose, because the cap is tested
+# first and a count past it never reaches the L check.
 .PHONY: tables-maps-fit-negative-control
 tables-maps-fit-negative-control: bin/schema build/tables-generated/.stamp
-	$(call map_negative_control,fit,'s@if ( n > (uint64_t) ( rest / kTableMapEntryFloor ) ) { return false; }@if ( n > (uint64_t) ( rest / kTableMapEntryFloor ) \&\& false ) { return false; }@',internal/codegen/cpptable/maps.go,an N the map L cannot carry left the map gate GREEN)
+	$(call map_negative_control,fit,'s@if ( n > (uint64_t) ( rest / kTableMapEntryFloor ) ) { reason = count_over_length; return false; }@if ( n > (uint64_t) ( rest / kTableMapEntryFloor ) \&\& false ) { reason = count_over_length; return false; }@',internal/codegen/cpptable/maps.go,an N the map L cannot carry left the map gate GREEN)
+
+# N = 0x80000000, PAST THE INT32 CAP. The measure-refusals row meets it: the
+# cap is tested before the L, so the reason is count_over_extent_cap, and a
+# dropped cap check lets the L answer count_over_length instead, which the row
+# asserts by name.
+.PHONY: tables-maps-cap-negative-control
+tables-maps-cap-negative-control: bin/schema build/tables-generated/.stamp
+	$(call map_negative_control,cap,'s@if ( n > (uint64_t) INT32_MAX ) { reason = count_over_extent_cap; return false; }@if ( n > (uint64_t) INT32_MAX \&\& false ) { reason = count_over_extent_cap; return false; }@',internal/codegen/cpptable/maps.go,an N past the int32 cap left the map gate GREEN)
 
 # LOADMEASURE OVER A MAP OF MAPS, summed at ONE DEPTH only. The instance whose
 # value is itself a map meets it, and the measure goes red against the region
@@ -2654,16 +2673,17 @@ tables-maps-depth-negative-control: bin/schema build/tables-generated/.stamp
 # goes red if the writer walks the entries any other way.
 .PHONY: tables-maps-text-order-negative-control
 tables-maps-text-order-negative-control: bin/schema build/tables-generated/.stamp
-	$(call map_negative_control,textorder,'s@const void \* entry = f->map_at( slot, i );@const void * entry = f->map_at( slot, count - 1 - i );@',internal/codegen/cpptable/json.go,writing a map text out of key order left the map gate GREEN)
+	$(call map_negative_control,textorder,'s@const void \* entry = (const void \*) ( entries + (int64_t) i \* f->elem_size );@const void * entry = (const void *) ( entries + (int64_t) ( count - 1 - i ) * f->elem_size ); // SABOTAGED@',internal/codegen/cpptable/json.go,writing a map text out of key order left the map gate GREEN)
 
 # AN UNREACHED NON-EMPTY MAP SLOT IS REFUSED by Cook and by Lock, the same
 # refusal §7.6 gives a pointer in that position. The `Depth` instance whose
 # counted array holds a map PAST ITS LIVE COUNT meets it, and dropping the
 # refusal lets Lock write that map's entries into an extent nothing reserved
-# for them.
+# for them. The predicate is the one a list slot answers by (§2.9), so the
+# sabotage patches extent.go and each gate names its own red.
 .PHONY: tables-maps-unreached-negative-control
 tables-maps-unreached-negative-control: bin/schema build/tables-generated/.stamp
-	$(call map_negative_control,unreached,'s@inline bool TableMapUnreachedEmpty( int64_t extent ) { return extent == 0; }@inline bool TableMapUnreachedEmpty( int64_t ) { return true; }@',internal/codegen/cpptable/maps.go,writing an unreached non-empty map left the map gate GREEN)
+	$(call map_negative_control,unreached,'s@inline bool TableExtentUnreachedEmpty( int64_t extent ) { return extent == 0; }@inline bool TableExtentUnreachedEmpty( int64_t ) { return true; }@',internal/codegen/cpptable/extent.go,writing an unreached non-empty map left the map gate GREEN)
 
 .PHONY: tables-maps-negative-controls
 tables-maps-negative-controls: tables-maps-sort-negative-control \
@@ -2673,6 +2693,7 @@ tables-maps-negative-controls: tables-maps-sort-negative-control \
 	tables-maps-key-kind-negative-control \
 	tables-maps-clamp-negative-control \
 	tables-maps-fit-negative-control \
+	tables-maps-cap-negative-control \
 	tables-maps-depth-negative-control \
 	tables-maps-text-order-negative-control \
 	tables-maps-unreached-negative-control

--- a/test/tables/maps_main.cpp
+++ b/test/tables/maps_main.cpp
@@ -643,9 +643,11 @@ static void test_reader()
         CHECK_EQ( v.after, 777 );
     }
     {
-        // CONTROL: an `N` past what the map's `L` can carry. A row of a few
-        // dozen bytes asking for gigabytes — LoadMeasure's answer goes red if
-        // the fit check is dropped (§4.2).
+        // An `N` past the int32 cap, in a row of a few dozen bytes: LoadMeasure
+        // refuses from the framing alone and read_row never reaches Load
+        // (§6.5). The cap is tested before the map's `L`, so this row cannot
+        // see the `L` check, and test_measure_refusals asserts both refusals
+        // by their reason.
         RowSpec spec = ascending_spec();
         spec.declared_n = 0xFFFFFFFFll;
         RowWire w = build_row( spec );
@@ -777,6 +779,105 @@ static void test_load_measure_depth()
     TableReport short_report;
     CHECK( FleetLoad( region, need - 1, wire, n, &short_report ) == NULL );
     free( region );
+}
+
+// ---- the LoadMeasure REFUSALS at a map (docs/SPEC-TABLES.md §2.8, §6.5) ----
+//
+// A unit test and not a `report` row, because a refusal produces no counters.
+// Each wire is built in memory with a SYNTHETIC map count rather than a
+// golden: a count above the int32 cap, which no golden could carry because
+// the file would be two gigabytes, a count whose entries cannot fit the map's
+// own L, and a clean wire beside them, which must measure and load. The
+// REASON is asserted by name, because the cap is tested before the L: a count
+// past both answers count_over_extent_cap, and only a count under the cap
+// reaches the L check, so a dropped L check goes red on the 100000 row and
+// nowhere a count past the cap is used.
+
+struct Wire
+{
+    uint8_t bytes[4096];
+    int64_t size;
+};
+
+// a `Fleet` body written FROM THE GRAMMAR: its `ships` map as a kind 14 array
+// of kind 13 `{ key, value }` entries (§2.8), with the declared count a knob
+// of its own and the entries actually written a second one
+static Wire build_fleet_wire( uint64_t ships, int32_t real_ships )
+{
+    WireBuilder b;
+    b.field( "ships", 14 );
+    const int64_t body = b.open_len();
+    b.u8( 13 );
+    b.leb( ships );
+    for ( int32_t i = 0; i < real_ships; i++ )
+    {
+        const int64_t entry = b.open_len();
+        b.field( "key", 12 );
+        b.leb( 1 );
+        b.u8( (uint8_t) ( 'a' + i ) );
+        b.field( "value", 13 );
+        const int64_t ship = b.open_len();
+        b.field( "health", 4 );
+        b.u32( (uint32_t) ( 100 + i ) );
+        b.end();
+        b.close_len( ship );
+        b.end();
+        b.close_len( entry );
+    }
+    b.close_len( body );
+    b.end();
+    Wire w;
+    w.size = b.finish( w.bytes );
+    return w;
+}
+
+static void report_silent( const TableReport & r, const char * where )
+{
+    if ( r.unknown != 0 || r.kind_mismatch != 0 || r.clamped != 0 || r.duplicate != 0 || r.malformed )
+    {
+        printf( "FAIL %s: the report is not silent (unknown %d, kind_mismatch %d, clamped %d, duplicate %d, malformed %d)\n",
+                where, r.unknown, r.kind_mismatch, r.clamped, r.duplicate, (int) r.malformed );
+        failures++;
+    }
+}
+
+static void test_measure_refusals()
+{
+    // a count above the int32 cap: the cap answers first
+    {
+        Wire w = build_fleet_wire( 0x80000000ull, 1 );
+        TableRefuseReason reason = count_over_length;
+        CHECK_EQ( FleetLoadMeasure( w.bytes, w.size, NULL, &reason ), -1 );
+        CHECK( reason == count_over_extent_cap );
+    }
+    // a count under the cap that the map's L cannot carry: the L answers
+    {
+        Wire w = build_fleet_wire( 100000, 1 );
+        TableRefuseReason reason = count_over_extent_cap;
+        CHECK_EQ( FleetLoadMeasure( w.bytes, w.size, NULL, &reason ), -1 );
+        CHECK( reason == count_over_length );
+    }
+    // and a clean wire beside them, which must measure and load silently
+    {
+        Wire w = build_fleet_wire( 2, 2 );
+        TableRefuseReason reason = count_over_length;
+        const int64_t need = FleetLoadMeasure( w.bytes, w.size, NULL, &reason );
+        CHECK( need > 0 );
+        uint8_t * region = (uint8_t *) MEASURED_CALLOC( need, 0 );
+        if ( region == NULL ) { return; }
+        TableReport r;
+        const Fleet * fleet = FleetLoad( region, need, w.bytes, w.size, &r );
+        CHECK( fleet != NULL );
+        report_silent( r, "the clean wire beside the refusals" );
+        if ( fleet != NULL )
+        {
+            CHECK_EQ( fleet->ships.size(), 2 );
+            const ShipConfig * ship = fleet->ships.Find( "b" );
+            CHECK( ship != NULL );
+            if ( ship != NULL ) { CHECK_EQ( ship->health, 101 ); }
+        }
+        free( region );
+    }
 }
 
 // ---- the TEXT form (docs/SPEC-TABLES.md §2.8, §16) ----
@@ -992,14 +1093,26 @@ static void test_depth()
     CHECK( memcmp( relocked, wire, (size_t) n ) == 0 );
 }
 
-int main()
+int main( int argc, char ** argv )
 {
+    if ( argc > 1 && strcmp( argv[1], "measure-refusals" ) == 0 )
+    {
+        test_measure_refusals();
+        if ( failures != 0 )
+        {
+            printf( "\n%d measure refusal check(s) failed\n", failures );
+            return 1;
+        }
+        printf( "map measure refusals: two -1s with their reasons, one clean measure, no counter moved (docs/SPEC-TABLES.md §2.8, §6.5)\n" );
+        return 0;
+    }
     test_writer();
     test_builder();
     test_const_forms();
     test_reader();
     test_key_kind();
     test_load_measure_depth();
+    test_measure_refusals();
     test_text();
     test_depth();
 


### PR DESCRIPTION
## The event

Main at dc6ce205 is red on certification: every `make test` leg fails at `tables-maps-fit-negative-control` with `NEGATIVE CONTROL FAILED: the fit sabotage patched nothing`.

## The cause

PR #562 rewrote `TableMapWireExtent` in `internal/codegen/cpptable/maps.go`. The L bound line now assigns its reason (`{ reason = count_over_length; return false; }`), and an int32 cap test (`if ( n > (uint64_t) INT32_MAX ) { reason = count_over_extent_cap; return false; }`) sits before it. The fit control's sed pattern still named the old line, so the sabotage patched nothing and the macro's own guard fired.

Repointing the pattern was not enough. The map gate had no row asserting `count_over_length` by name. The control had relied on a side effect: the reader row's hostile count of 0xFFFFFFFF, with the L check disabled, produced a measure of about 86 GB that tripped `measured_calloc`'s 256 MiB ceiling. That count sits past INT32_MAX, so the new cap test refuses it before the L check is reached, and the gate stayed green under the sabotage.

The same certification found two more map controls whose patterns #562 moved out from under them: `textorder` named an `f->map_at( slot, i )` call the JSON walk no longer makes (it indexes the entry array in place now), and `unreached` named `TableMapUnreachedEmpty`, which `extent.go`'s `TableExtentUnreachedEmpty` replaced for a map and a list alike.

## The fix

- `test/tables/maps_main.cpp` gains `test_measure_refusals` in the list gate's shape: a synthetic `Fleet` wire whose `ships` map count is 100000 against a short body answers `LoadMeasure == -1` with `count_over_length`, a count of 0x80000000 answers `count_over_extent_cap`, and a clean wire measures and loads. `schema_test_maps measure-refusals` prints one summary line, wired into `make test` as `tables-maps-measure-refusals` beside the list one.
- `tables-maps-fit-negative-control` targets the new L line, keeping its shape and its failure message.
- `tables-maps-cap-negative-control` is new beside it: the INT32_MAX line sabotaged the same way, red when the 0x80000000 row answers `count_over_length` instead of `count_over_extent_cap`.
- `tables-maps-text-order-negative-control` and `tables-maps-unreached-negative-control` point at the emitted lines as they stand (the unreached one patches `extent.go`).
- The reader row's comment says what that row now tests (the cap, from the framing alone).

Every other map and list control pattern was checked against its source file (`maps.go`, `lists.go`, `extent.go`, `pointers.go`, `json.go`) and matches.

## The output

```
maps: all checks passed (docs/SPEC-TABLES.md §2.8)
map measure refusals: two -1s with their reasons, one clean measure, no counter moved (docs/SPEC-TABLES.md §2.8, §6.5)
negative control: sort turns the MAP GATE red — 24 failures
negative control: dead turns the MAP GATE red — 6 failures
negative control: ascending turns the MAP GATE red — 4 failures
negative control: duplicate turns the MAP GATE red — 2 failures
negative control: keykind turns the MAP GATE red — 3 failures
negative control: clamp turns the MAP GATE red — 2 failures
negative control: fit turns the MAP GATE red — 2 failures
negative control: cap turns the MAP GATE red — 1 failures
negative control: depth turns the MAP GATE red — 33 failures
negative control: textorder turns the MAP GATE red — 1 failures
negative control: unreached turns the MAP GATE red — 2 failures
```

The fit control's red, from `build/map-fit.log`:

```
FAIL test/tables/maps_main.cpp:857: FleetLoadMeasure( w.bytes, w.size, NULL, &reason ) = 11600088, want -1
FAIL test/tables/maps_main.cpp:858: reason == count_over_length
```

The cap control's red, from `build/map-cap.log`:

```
FAIL test/tables/maps_main.cpp:851: reason == count_over_extent_cap
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
