### PR TITLE
check: the wstring refusal covers a table's whole closure (#567)

### DIFF
--- a/compiler/widetext_test.go
+++ b/compiler/widetext_test.go
@@ -1,0 +1,51 @@
+// Wide text and the TABLE emitter (docs/SPEC-TABLES.md §11, schema#522): a
+// `wstring(N)` inside a table closure is refused at the front end, so the
+// table emitters never meet the kind they have no arm for.
+package compiler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// wideTextInATableClosure is the smallest unit that reaches the case: the
+// wide text sits in a `type`, and a table holds the type by value.
+const wideTextInATableClosure = `package wide
+
+type Text
+{
+    name wstring(4)
+}
+
+table Root
+{
+    t Text
+}
+`
+
+// TestWideTextInATableClosureNeverReachesTheTableEmitter loads the unit the
+// way the CLI does and asks the C++ target for it: Load refuses the unit by
+// name, and nothing reaches cpptable.Generate. The C++ target is the one
+// packet-wire carrier of wide text, so it is the one target whose table
+// emitter could be handed the kind.
+func TestWideTextInATableClosureNeverReachesTheTableEmitter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Wide.schema")
+	if err := os.WriteFile(path, []byte(wideTextInATableClosure), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := New()
+	u, err := c.Load([]string{path})
+	if err == nil {
+		files, gerr := c.Generate(u, "cpp", Options{})
+		t.Fatalf("Load took a wstring(N) inside a table closure, and the C++ target got it: %d files, err %v", len(files), gerr)
+	}
+	if !strings.Contains(err.Error(), "not carried on the TABLE wire yet") {
+		t.Errorf("the refusal does not name the rule: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Text") || !strings.Contains(err.Error(), "Root") {
+		t.Errorf("the refusal does not name the type and the table that reaches it: %v", err)
+	}
+}

--- a/dist
+++ b/dist
@@ -1,0 +1,1 @@
+/Users/glenn/rowan-working/schema/dist

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -9098,6 +9098,13 @@ in build version (§20.5).
   **`*wstring` is the third spelling and takes every clause above**, its bound
   `*wstring(N)` refused with the other two, because a buffer at its used size
   has no bound to declare whatever units it holds (§2.5).
+- **Wide text in a table closure** (SPEC.md §4.12): a `wstring(N)` field
+  anywhere a table reaches, until the table wire's kind `33` lands
+  (schema#522). A table body's own field and a union arm are refused where
+  they resolve; a field of a `type` is refused once the closure is known,
+  through any nesting of `type`, union, array, bounded array, optional, map
+  value and pointer, naming the field and the edge that put the `type` in the
+  closure. A `type` no table reaches keeps its wide text on the packet wire.
 - **The block form** (§2.7), each refusal naming the table and the field or
   declaration at fault. **Nothing declares the form, so nothing is refused
   FOR it** — a table that cannot have one simply has none (§19) — and there

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2030,6 +2030,9 @@ func walkArms(un *ir.Union, visit func(string), seen map[*ir.Union]bool) {
 
 func (c *checker) checkTables() {
 	closure := map[string]bool{}
+	// the field that pulled each `type` into the closure, so a refusal that
+	// exists BECAUSE of closure membership names the edge that created it
+	reachedBy := map[string]string{}
 	var walk func(name string)
 	walk = func(name string) {
 		if closure[name] {
@@ -2040,15 +2043,28 @@ func (c *checker) checkTables() {
 			return
 		}
 		closure[name] = true
+		what := "type"
+		if st.IsTable {
+			what = "table"
+		}
 		for _, f := range st.Fields {
 			if f.Type.Kind != ir.TNamed {
 				continue
 			}
+			site := fmt.Sprintf("%s %s's field %s", what, name, f.Name)
 			switch ref := f.Type.Ref.(type) {
 			case *ir.Struct:
+				if !closure[ref.Name] {
+					reachedBy[ref.Name] = site
+				}
 				walk(ref.Name)
 			case *ir.Union:
-				walkArms(ref, walk, map[*ir.Union]bool{})
+				walkArms(ref, func(target string) {
+					if !closure[target] {
+						reachedBy[target] = fmt.Sprintf("%s, through an arm of %s,", site, ref.Name)
+					}
+					walk(target)
+				}, map[*ir.Union]bool{})
 			}
 		}
 	}
@@ -2063,6 +2079,7 @@ func (c *checker) checkTables() {
 	}
 	c.tableClosure = closure
 	c.checkTableArmsReached(closure)
+	c.checkWideTextInClosure(closure, reachedBy)
 
 	names := make([]string, 0, len(closure))
 	for name := range closure {
@@ -2169,6 +2186,33 @@ func (c *checker) checkTables() {
 	c.checkTableVariantIdentity(names)
 	c.checkOptionalVariableClosures(names)
 	c.checkJsonKeysInClosure()
+}
+
+// checkWideTextInClosure refuses a `wstring(N)` field of any `type` a table
+// reaches (docs/SPEC-TABLES.md §11, schema#522). Wide text rides the packet
+// wire only today: the table half is kind 33, specified ahead of its
+// implementation, and the table emitters have no arm for the kind. A table
+// body's own wstring field is refused where it resolves; a `type` body
+// resolves as packet wire, so its wide text is refused here, once the closure
+// is known, with the same rule and the edge that put the type in a closure.
+func (c *checker) checkWideTextInClosure(closure map[string]bool, reachedBy map[string]string) {
+	for _, name := range sortedKeys(closure) {
+		st := c.closureMember(name)
+		if st == nil || st.IsTable {
+			continue
+		}
+		pos := ast.Pos{}
+		if d, ok := c.astDecls[name]; ok {
+			pos = d.DeclPos()
+		}
+		for _, f := range st.Fields {
+			if f.Type.Kind != ir.TWString {
+				continue
+			}
+			c.errf(pos, "type %s: field %s: wstring is not carried on the TABLE wire yet — wide text rides the packet wire today (SPEC §4.12), and %s reaches %s, putting it in a table closure; declare the field string(N), or hold %s outside the closure (docs/SPEC-TABLES.md §11, schema#522)",
+				name, f.Name, reachedBy[name], name, name)
+		}
+	}
 }
 
 // checkOptionalVariableClosures refuses an OPTIONAL whose value's closure is

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2028,6 +2028,72 @@ func walkArms(un *ir.Union, visit func(string), seen map[*ir.Union]bool) {
 	}
 }
 
+// closureEdge names the edge a closure member's field makes, as the author
+// wrote it. A generated map entry (docs/SPEC-TABLES.md §2.8) is a closure
+// member the author never spelled, so its value field is named as the map
+// field that generated it, reached through the map's value, climbing a map of
+// maps to the field the author wrote.
+func (c *checker) closureEdge(name string, st *ir.Struct, f *ir.Field) string {
+	if st.MapEntryOf == "" {
+		what := "type"
+		if st.IsTable {
+			what = "table"
+		}
+		return fmt.Sprintf("%s %s's field %s", what, name, f.Name)
+	}
+	owner, field, _ := strings.Cut(st.MapEntryOf, ".")
+	through := "its map value"
+	for entry := c.tables[owner]; entry != nil && entry.MapEntryOf != ""; entry = c.tables[owner] {
+		owner, field, _ = strings.Cut(entry.MapEntryOf, ".")
+		through += "'s map value"
+	}
+	return fmt.Sprintf("table %s's field %s, through %s,", owner, field, through)
+}
+
+// fieldPos is where a declared body spells a field, descending `if` blocks,
+// so a diagnostic about the field lands on its line rather than the
+// declaration's. The declaration's own position stands in when the body does
+// not spell the name.
+func (c *checker) fieldPos(name, field string) ast.Pos {
+	d, ok := c.astDecls[name]
+	if !ok {
+		return ast.Pos{}
+	}
+	var body *ast.Block
+	switch d := d.(type) {
+	case *ast.TypeDecl:
+		body = d.Body
+	case *ast.TableDecl:
+		body = d.Body
+	}
+	if pos, found := blockFieldPos(body, field); found {
+		return pos
+	}
+	return d.DeclPos()
+}
+
+func blockFieldPos(b *ast.Block, field string) (ast.Pos, bool) {
+	if b == nil {
+		return ast.Pos{}, false
+	}
+	for _, item := range b.Items {
+		switch item := item.(type) {
+		case *ast.Field:
+			if item.Name == field {
+				return item.Pos, true
+			}
+		case *ast.IfItem:
+			if pos, found := blockFieldPos(item.Then, field); found {
+				return pos, true
+			}
+			if pos, found := blockFieldPos(item.Else, field); found {
+				return pos, true
+			}
+		}
+	}
+	return ast.Pos{}, false
+}
+
 func (c *checker) checkTables() {
 	closure := map[string]bool{}
 	// the field that pulled each `type` into the closure, so a refusal that
@@ -2043,15 +2109,11 @@ func (c *checker) checkTables() {
 			return
 		}
 		closure[name] = true
-		what := "type"
-		if st.IsTable {
-			what = "table"
-		}
 		for _, f := range st.Fields {
 			if f.Type.Kind != ir.TNamed {
 				continue
 			}
-			site := fmt.Sprintf("%s %s's field %s", what, name, f.Name)
+			site := c.closureEdge(name, st, f)
 			switch ref := f.Type.Ref.(type) {
 			case *ir.Struct:
 				if !closure[ref.Name] {
@@ -2194,22 +2256,19 @@ func (c *checker) checkTables() {
 // implementation, and the table emitters have no arm for the kind. A table
 // body's own wstring field is refused where it resolves; a `type` body
 // resolves as packet wire, so its wide text is refused here, once the closure
-// is known, with the same rule and the edge that put the type in a closure.
+// is known, at the field's own line, with the same rule and the edge that put
+// the type in a closure as the author wrote it.
 func (c *checker) checkWideTextInClosure(closure map[string]bool, reachedBy map[string]string) {
 	for _, name := range sortedKeys(closure) {
 		st := c.closureMember(name)
 		if st == nil || st.IsTable {
 			continue
 		}
-		pos := ast.Pos{}
-		if d, ok := c.astDecls[name]; ok {
-			pos = d.DeclPos()
-		}
 		for _, f := range st.Fields {
 			if f.Type.Kind != ir.TWString {
 				continue
 			}
-			c.errf(pos, "type %s: field %s: wstring is not carried on the TABLE wire yet — wide text rides the packet wire today (SPEC §4.12), and %s reaches %s, putting it in a table closure; declare the field string(N), or hold %s outside the closure (docs/SPEC-TABLES.md §11, schema#522)",
+			c.errf(c.fieldPos(name, f.Name), "type %s: field %s: wstring is not carried on the TABLE wire yet — wide text rides the packet wire today (SPEC §4.12), and %s reaches %s, putting it in a table closure; declare the field string(N), or hold %s outside the closure (docs/SPEC-TABLES.md §11, schema#522)",
 				name, f.Name, reachedBy[name], name, name)
 		}
 	}

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -2042,11 +2042,12 @@ func (c *checker) closureEdge(name string, st *ir.Struct, f *ir.Field) string {
 		return fmt.Sprintf("%s %s's field %s", what, name, f.Name)
 	}
 	owner, field, _ := strings.Cut(st.MapEntryOf, ".")
-	through := "its map value"
+	depth := 0
 	for entry := c.tables[owner]; entry != nil && entry.MapEntryOf != ""; entry = c.tables[owner] {
 		owner, field, _ = strings.Cut(entry.MapEntryOf, ".")
-		through += "'s map value"
+		depth++
 	}
+	through := "its map value" + strings.Repeat("'s map value", depth)
 	return fmt.Sprintf("table %s's field %s, through %s,", owner, field, through)
 }
 

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -1321,3 +1321,65 @@ func TestListQualificationBoundsTheElement(t *testing.T) {
 		t.Fatalf("the qualification did not bound the element: has=%v min=%v max=%v", f.HasIntRange, f.IntMin, f.IntMax)
 	}
 }
+
+// TestWideTextRefusalCoversTheClosure is the wstring refusal over a table's
+// WHOLE closure (docs/SPEC-TABLES.md §11, schema#522): a `type` body a table
+// reaches through any wrapper carries no wstring(N) until the table wire's
+// kind lands, and the refusal names the field and the edge that reached it.
+// Each wrapper is its own case, and the two controls hold the other edge of
+// the rule: a `type` no table reaches keeps its wide text.
+func TestWideTextRefusalCoversTheClosure(t *testing.T) {
+	const text = "type Text { name wstring(4) }\n"
+	const want = "not carried on the TABLE wire yet"
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{name: "a type held by value", src: "package t\n" + text + "table Root { t Text }\n"},
+		{name: "a type held through a nested type", src: "package t\n" + text + "type Outer { t Text }\ntable Root { o Outer }\n"},
+		{name: "a type held through a union arm", src: "package t\n" + text + "union U\n{\n    t Text\n}\ntable Root { u U }\n"},
+		{name: "a type held through a union inside a union", src: "package t\n" + text + "union Inner\n{\n    t Text\n}\nunion Outer\n{\n    i Inner\n}\ntable Root { u Outer }\n"},
+		{name: "a type held as a fixed array's element", src: "package t\n" + text + "table Root { ts [4]Text }\n"},
+		{name: "a type held as a bounded array's element", src: "package t\n" + text + "table Root { ts [..4]Text }\n"},
+		{name: "a type held as an unbounded array's element", src: "package t\n" + text + "table Root { ts []Text }\n"},
+		{name: "a type held as an optional", src: "package t\n" + text + "table Root { t ?Text }\n"},
+		{name: "a type held through a pointer to a table", src: "package t\n" + text + "table Node { t Text }\ntable Root { n *Node }\n"},
+		{name: "a type held through a pointer array", src: "package t\n" + text + "table Node { t Text }\ntable Root { ns [..4]*Node }\n"},
+		{name: "a type held as a map's value", src: "package t\n" + text + "table Root { m map[uint32]Text }\n"},
+		{name: "a type held through an enum-keyed array", src: "package t\nenum E { A, B }\n" + text + "table Root { ts [E]Text }\n"},
+		{name: "a union arm carrying wstring directly", src: "package t\nunion U\n{\n    s wstring(4)\n}\ntable Root { u U }\n"},
+		{name: "a table field carrying wstring directly", src: "package t\ntable Root { s wstring(4) }\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := runUnit(t, map[string]string{"T.schema": tc.src})
+			if len(errs) == 0 {
+				t.Fatalf("compiled clean — a wstring(N) reached a table closure (want %q)", want)
+			}
+			for _, e := range errs {
+				if strings.Contains(e.Error(), want) {
+					return
+				}
+			}
+			t.Fatalf("no diagnostic contains %q; got: %v", want, errs)
+		})
+	}
+	// the CONTROLS: the refusal is the closure's, so a `type` outside one
+	// keeps its wide text, whether or not the unit declares a table
+	controls := []struct {
+		name string
+		src  string
+	}{
+		{name: "a packet-wire unit", src: "package t\n" + text + "type P { t Text }\n"},
+		{name: "a table that does not reach the type", src: "package t\n" + text + "type P { t Text }\ntable Root { x int32 }\n"},
+		{name: "a union no table reaches", src: "package t\n" + text + "union U\n{\n    t Text\n}\ntype P { u U }\ntable Root { x int32 }\n"},
+	}
+	for _, tc := range controls {
+		t.Run("control: "+tc.name, func(t *testing.T) {
+			u := buildUnit(t, tc.src)
+			if u.Structs["Text"].Fields[0].Type.Kind != ir.TWString {
+				t.Fatalf("Text.name is not wstring: %v", u.Structs["Text"].Fields[0].Type.Kind)
+			}
+		})
+	}
+}

--- a/internal/check/tables_test.go
+++ b/internal/check/tables_test.go
@@ -1383,3 +1383,72 @@ func TestWideTextRefusalCoversTheClosure(t *testing.T) {
 		})
 	}
 }
+
+// TestWideTextRefusalLandsOnTheField pins WHERE the closure refusal reports:
+// the wstring field's own line, not the line of the `type` that holds it,
+// including a field an `if` block nests. Two fields of one type each get
+// their own line, so a reader can tell them apart.
+func TestWideTextRefusalLandsOnTheField(t *testing.T) {
+	const src = "package t\n" +
+		"type Text\n" +
+		"{\n" +
+		"    name wstring(4)\n" +
+		"    flag bool\n" +
+		"    title wstring(4)\n" +
+		"    if flag { note wstring(4) }\n" +
+		"}\n" +
+		"table Root { t Text }\n"
+	errs := runUnit(t, map[string]string{"T.schema": src})
+	want := map[string]string{
+		"field name:":  "T.schema:4:",
+		"field title:": "T.schema:6:",
+		"field note:":  "T.schema:7:",
+	}
+	for field, prefix := range want {
+		found := false
+		for _, e := range errs {
+			if !strings.Contains(e.Error(), field) {
+				continue
+			}
+			found = true
+			if !strings.HasPrefix(e.Error(), prefix) {
+				t.Errorf("%s reported at the wrong position, want prefix %q: %v", field, prefix, e)
+			}
+		}
+		if !found {
+			t.Errorf("no diagnostic names %q; got: %v", field, errs)
+		}
+	}
+}
+
+// TestWideTextRefusalNamesTheMapField pins the edge a map makes: the map's
+// value reaches the `type` through a generated entry table the author never
+// wrote, so the refusal names the map field as the author spelled it, and a
+// map of maps climbs to that field.
+func TestWideTextRefusalNamesTheMapField(t *testing.T) {
+	const text = "type Text { name wstring(4) }\n"
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{name: "a map's value", src: "package t\n" + text + "table Root { m map[uint32]Text }\n",
+			want: "table Root's field m, through its map value, reaches Text"},
+		{name: "a map of maps' value", src: "package t\n" + text + "table Root { m map[uint32]map[uint32]Text }\n",
+			want: "table Root's field m, through its map value's map value, reaches Text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := runUnit(t, map[string]string{"T.schema": tc.src})
+			for _, e := range errs {
+				if strings.Contains(e.Error(), tc.want) {
+					if strings.Contains(e.Error(), "Entry") {
+						t.Fatalf("the diagnostic names a generated entry table: %v", e)
+					}
+					return
+				}
+			}
+			t.Fatalf("no diagnostic contains %q; got: %v", tc.want, errs)
+		})
+	}
+}


### PR DESCRIPTION
Closes #567.

A `type` body resolves as packet wire, so `type Text { name wstring(4) }` held by `table Root { t Text }` passed the checker and reached `cpptable.Generate`, which has no arm for the kind: `WideTable.h` spelled `w.put0( uint0_t( value.name ) )`.

**Red first** (commit 2dbca022): twelve wrapper cases in `TestWideTextRefusalCoversTheClosure` compiled clean, and `TestWideTextInATableClosureNeverReachesTheTableEmitter` saw `Load` take the unit and the C++ target emit 6 files.

**The fix** (`internal/check/check.go`): `checkTables` records the edge that pulled each `type` into the closure and `checkWideTextInClosure` refuses every `wstring(N)` field of a closure `type`, with the same rule the direct table field gets and the reaching edge named:

```
type Text: field name: wstring is not carried on the TABLE wire yet — wide text rides the packet wire today (SPEC §4.12), and table Root's field t reaches Text, putting it in a table closure; declare the field string(N), or hold Text outside the closure (docs/SPEC-TABLES.md §11, schema#522)
```

A table body's own field and a union arm keep their refusal where they resolve.

**Tests**: one case per wrapper (by value, nested type, union arm, union in union, `[N]T`, `[..N]T`, `[]T`, `?T`, `*Node`, `[..N]*Node`, map value, enum-keyed array) plus the two direct spellings; three controls hold the other edge (a packet-wire unit, a table that does not reach the type, a union no table reaches keep `Text.name` as `TWString`). The compiler-side test loads the issue's shape the way the CLI does and asserts `Load` refuses it by name, so nothing reaches the table emitter.

**Negative control**: with the `checkWideTextInClosure` call commented out, all twelve wrapper cases go red (`compiled clean — a wstring(N) reached a table closure`) and the compiler test reports `Load took a wstring(N) inside a table closure, and the C++ target got it: 6 files`.

**Docs**: SPEC-TABLES.md §11 gains the "Wide text in a table closure" bullet, present tense.

`go test ./...` green (26 packages), `go vet` clean, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
