### PR TITLE
baseline: a replacement union's arms compare as fields (#568)

### DIFF
--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -11983,8 +11983,15 @@ and each vocabulary's standard is its own (§3):
   meaning of every stored body, and that is the flagship class this file
   exists to refuse. The facts are judged by the same rules a field's own
   facts are, so the two paths cannot disagree.
-- An **enum** value is its variant NAME hash and a **union** body opens
-  with its arm NAME hash, so those stand in when the names survive.
+- An **enum** value is its variant NAME hash, so it stands in when every
+  variant name survives.
+- A **union** body opens with its arm NAME hash, and each arm is a field
+  line (§2.6), so it stands in when every arm name survives AND THE FACTS
+  UNDER THOSE ARMS ARE UNCHANGED. The facts are judged by the same rules a
+  field's own facts are, the arm's payload included, which is the table
+  rule above applied one level in: a union whose arm names all survive
+  under a twin payload rewrites the meaning of every stored body that
+  selects the arm, and is refused naming the arm and the fact that moved.
 - A **flags** mask carries no names at all, so it stands in only when the
   old variants sit at the same bits.
 
@@ -11998,8 +12005,9 @@ still an edit a save game may not survive.
 **AN ARM'S REFERENT IS JUDGED BY THE SAME THREE STANDARDS**, selected by the
 same token, because an arm's line is a field's line (§18.1, §2.6): an arm
 naming a table or a `type` stands in when the ids and the facts under them
-survive, an arm naming an enum or a union when the names do, an arm naming
-a `flags` when the bits do. An arm that names NO declaration — a scalar, a
+survive, an arm naming an enum when the names do, an arm naming a union
+when the arm names and the facts under them do, an arm naming a `flags`
+when the bits do. An arm that names NO declaration — a scalar, a
 string, an array of scalars — has its kind and its shape tokens instead.
 Those admit no substitute at all, so any change to one refuses: there is
 nothing to stand in for, and the change is the silent edit itself.
@@ -12051,6 +12059,10 @@ arm against an `int64` arm, on `kind=`; a `[..8]float32` arm against a
 arm, on `payload=`; a `Chunk` arm against a `*Chunk` arm, on the token SET,
 which moves from `payload=` to the field tokens; and a payload-free arm
 against the same arm given an `int32`, on `kind=none` against `kind=4`.
+A field REPOINTED at another union carries a pair too (§18.3): a
+replacement whose shared arm holds a twin payload refuses on `default=`, one
+whose shared arm holds a scalar refuses on `payload=`, and a union carrying
+every arm of the old one under the same facts stands in.
 The projection over the corpus regenerates byte-identical. The warn class
 warns and does not refuse. A tightened range
 warns from either end and a loosened one is silent, over a ranged integer, a

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -1635,3 +1635,104 @@ func TestBaselineHistoryStampsUTCAndLabelsIt(t *testing.T) {
 		t.Errorf("the history entry is not a labelled UTC stamp:\n%s", data)
 	}
 }
+
+// swapSrc is the fixture for a field REPOINTED at another union
+// (docs/SPEC-TABLES.md §18.3). Both unions stay in the closure through their
+// own fields, so nothing vanishes and no rename pairing fires; both carry an
+// arm named item; and the payloads behind that arm are twins carrying one
+// field id under different specified defaults.
+const swapSrc = `package swap
+
+type OldPayload
+{
+    value int32 = 1
+}
+
+type NewPayload
+{
+    value int32 = 2
+}
+
+union U1
+{
+    item OldPayload
+}
+
+// U1's arm under a twin payload: every arm name survives, and a stored body
+// whose elided value meant 1 now means 2
+union U2
+{
+    item NewPayload
+}
+
+// U1's arm under U1's payload, plus one: a union that really can stand in
+union U1Plus
+{
+    item  OldPayload
+    extra NewPayload
+}
+
+// U1's arm under a scalar: the arm's own facts moved, with no payload to judge
+union U3
+{
+    item int32
+}
+
+table Root
+{
+    selected U1
+    one      U1
+    two      U2
+    plus     U1Plus
+    three    U3
+}
+`
+
+// TestReplacementUnionArmsCompareAsFields is the referent rule for a UNION
+// (docs/SPEC-TABLES.md §18.3): the arms a replacement shares with the union
+// it replaces are field lines, judged by the one policy an in-place edit is
+// judged by, so a union whose arm names all survive still cannot stand in
+// when a fact under a shared arm moved.
+func TestReplacementUnionArmsCompareAsFields(t *testing.T) {
+	base := committed(t, swapSrc)
+	judge := func(edited string, policy map[string]baseline.TokenRule) []baseline.Finding {
+		return baseline.Diff(base, baseline.Render(unit(t, edited)), policy)
+	}
+	cases := []struct {
+		name   string
+		edited string
+		what   string
+		token  string
+	}{
+		{
+			name:   "a twin payload under a shared arm",
+			edited: editOf(t, swapSrc, "    selected U1\n", "    selected U2\n"),
+			what:   "union U1 -> U2, and item's arm payload OldPayload -> NewPayload, and value's specified default 1 -> 2",
+			token:  "default",
+		},
+		{
+			name:   "a scalar under a shared arm",
+			edited: editOf(t, swapSrc, "    selected U1\n", "    selected U3\n"),
+			what:   "union U1 -> U3, and item's arm payload OldPayload removed",
+			token:  "payload",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := judge(tc.edited, baseline.DefaultTokenPolicy)
+			if !find(got, baseline.Refuse, "Root.selected", tc.what) {
+				t.Fatalf("the edit was not refused; wanted Root.selected: %s, got:%s", tc.what, summary(got))
+			}
+			// the ATTRIBUTION control: the arm's fact is judged by that
+			// policy row and no other
+			if got := judge(tc.edited, without(tc.token)); find(got, baseline.Refuse, "Root.selected", tc.what) {
+				t.Errorf("with the %q rule removed the refusal should be gone, got:%s", tc.token, summary(got))
+			}
+		})
+	}
+	// the DISCRIMINATION control: a union carrying every arm of the old one
+	// under the same facts stands in
+	if got := judge(editOf(t, swapSrc, "    selected U1\n", "    selected U1Plus\n"), baseline.DefaultTokenPolicy); len(got) != 0 {
+		t.Errorf("a union that carries every arm under the same facts should stand in, got:%s", summary(got))
+	}
+}

--- a/internal/baseline/diff.go
+++ b/internal/baseline/diff.go
@@ -786,7 +786,9 @@ func (d *differ) pairedRename(key, was string) string {
 //     class this whole file exists to refuse.
 //   - an ENUM value is its variant NAME hash, so it stands in when every
 //     variant name survives;
-//   - a UNION body opens with its arm NAME hash, same rule;
+//   - a UNION body opens with its arm NAME hash, and an arm is a field line,
+//     so it stands in when every arm name survives AND THE FACTS UNDER THOSE
+//     ARMS ARE UNCHANGED, the payload's own ids and facts included;
 //   - a FLAGS mask is POSITIONAL and carries no names at all, so it stands in
 //     only when the old declaration's variants sit at the same bits.
 //   - an ENUM-KEYED array's KEY enum is judged as an enum: its slots ride
@@ -799,8 +801,7 @@ func (d *differ) substitutable(key, was, now string) []Finding {
 		return namesRide(enumNames(d.base, was), enumNames(d.live, now), now,
 			"variant name", "stored values naming them read as None")
 	case "union":
-		return namesRide(armNames(d.base, was), armNames(d.live, now), now,
-			"arm name", "stored bodies naming them are skipped")
+		return d.armsRide(was, now)
 	default: // "type", "payload" — a table body, read by field id
 		return d.bodyRides(was, now)
 	}
@@ -837,6 +838,43 @@ func (d *differ) bodyRides(was, now string) []Finding {
 	if missing > 0 {
 		out = append(out, Finding{Refuse, "", fmt.Sprintf(
 			"%d of %d field ids do not ride — that much of every stored body reads back as declared defaults", missing, len(before.Fields))})
+	}
+	return out
+}
+
+// armsRide compares two union declarations as a reader would meet them: the
+// arm names that stop riding, then EVERY FACT the policy judges on the arms
+// that do. An arm is a field line (docs/SPEC-TABLES.md §2.6, §18.1), so it
+// reuses diffTokens exactly as bodyRides does, and a replacement union is
+// judged by the one path an in-place edit is: a shared arm's payload is a
+// referent, walked by field id through the same recursion guard.
+func (d *differ) armsRide(was, now string) []Finding {
+	before, after := findUnion(d.base, was), findUnion(d.live, now)
+	if after == nil {
+		return []Finding{{Refuse, "", now + " is not described by this baseline"}}
+	}
+	if before == nil {
+		return nil
+	}
+	liveArms := map[string]Field{}
+	for _, a := range after.Arms {
+		liveArms[a.Name] = a
+	}
+	var out []Finding
+	missing := 0
+	for _, ba := range before.Arms {
+		la, ok := liveArms[ba.Name]
+		if !ok {
+			missing++
+			continue
+		}
+		for _, f := range d.diffTokens("", ba, la) {
+			out = append(out, Finding{f.Verdict, "", fmt.Sprintf("%s's %s", ba.Name, f.What)})
+		}
+	}
+	if missing > 0 {
+		out = append(out, Finding{Refuse, "", fmt.Sprintf(
+			"%d of %d arm names do not ride — stored bodies naming them are skipped", missing, len(before.Arms))})
 	}
 	return out
 }
@@ -897,16 +935,11 @@ func enumNames(u *Unit, name string) map[string]bool {
 	return nil
 }
 
-func armNames(u *Unit, name string) map[string]bool {
-	for _, un := range u.Unions {
-		if un.Name != name {
-			continue
+func findUnion(u *Unit, name string) *Union {
+	for i := range u.Unions {
+		if u.Unions[i].Name == name {
+			return &u.Unions[i]
 		}
-		set := map[string]bool{}
-		for _, a := range un.Arms {
-			set[a.Name] = true
-		}
-		return set
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #568.

`substitutable` judged a replacement union on arm names alone, so a field repointed from `U1` to `U2`, both in the closure and both carrying an arm named `item`, passed while the payloads behind the arm were twins under different specified defaults. A stored body whose elided `value` meant 1 now meant 2, and the independent declaration walks caught nothing because no declaration changed.

**Red first** (commit 58687e9f): `TestReplacementUnionArmsCompareAsFields` on the issue's exact shape (`OldPayload.value = 1`, `NewPayload.value = 2`, only `Root.selected` moving from `U1` to `U2`) reported `(no findings)`.

**The fix** (`internal/baseline/diff.go`): the union case of `substitutable` goes through `armsRide`, which walks the shared arms through `diffTokens`, the one path in-place union edits and table replacement (`bodyRides`) already take, under the existing `visiting` recursion guard, and refuses the arm names that stop riding as before. `armNames` is gone, `findUnion` mirrors `findTable`. The finding reads:

```
Root.selected: union U1 -> U2, and item's arm payload OldPayload -> NewPayload, and value's specified default 1 -> 2
```

**Tests**: two refusals (a twin payload under a shared arm, on `default=`, and a scalar under a shared arm, on `payload=`), each with the attribution control (that policy row removed, the finding is gone), and the discrimination control (a union carrying every arm of the old one under the same facts stands in with no findings).

**Negative control**: with the `diffTokens` walk over shared arms dropped from `armsRide`, both cases go red with `the edit was not refused ... got:(no findings)`.

**Docs** (`docs/SPEC-TABLES.md`): §18.3's referent list states the union rule as the facts-under-ids rule applied to arms as fields, present tense, in place of the names-only sentence; the arm's-referent paragraph below it no longer says a union stands in on names alone; §18.6 names the pair.

`go test ./...` green (26 packages), `go vet` clean, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
