### PR TITLE
build: dist never enters the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ tending/
 /test/go/schematest
 
 # pinned toolchains unpacked locally (Dart SDK, JDK — see the Makefile DART and JAVA variables)
-/dist/
+/dist
 
 # a crashed BEAM run drops its dump wherever it ran
 erl_crash.dump

--- a/dist
+++ b/dist
@@ -1,1 +1,0 @@
-/Users/glenn/rowan-working/schema/dist


### PR DESCRIPTION
A symlink named `dist` reached main in #572. The ignore rule `/dist/` matches a directory and not a symlink, and every schema clone on a shared bench links `dist` to one toolchain tree, so the link was committed under an unrelated message. A `git pull` in the clone that tree lives in then checked the tracked symlink out over the ignored toolchain directory, since git treats ignored files as expendable, and every clone on the bench lost its pinned SDKs until they were restored from copies (2026-09-05, 16:53 PDT).

This PR removes the tracked symlink and changes the rule to `/dist`, which ignores a directory and a symlink alike. No generated code or page moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)