### PR TITLE
docs: USAGE's wstring(N) section opens with its present state

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -539,10 +539,13 @@ which is the same wire with no encoding rule (SPEC.md §4.7).
 
 ### wstring(N)
 
-*Specified, not yet emitted. The front end refuses the spelling at parse, no
-backend teaches the type, and the `examples/` declaration and the golden pins
-land with the first implementation (SPEC.md §4.12,
-[#522](https://github.com/mas-bandwidth/schema/issues/522)).*
+*On the packet wire in C++, with the wide corpus under `examples-wide/` as its
+goldens. The other eight targets refuse the spelling by name until their ports
+land ([#590](https://github.com/mas-bandwidth/schema/issues/590)). A table, or
+any type a table reaches, may not carry it yet: the checker refuses it across
+the whole table closure until the table-wire kind lands
+([#522](https://github.com/mas-bandwidth/schema/issues/522)). SPEC.md §4.12 is
+the wire.*
 
 ```
 title wstring(64)


### PR DESCRIPTION
Closes #585. The section said specified and not yet emitted, false since #556. It now says: C++ on the packet wire with the wide corpus as goldens, the eight ports refusing by name until #590, the table closure refused until #522, SPEC.md §4.12 the wire. Found in Stella's inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)