### PR TITLE
docs: the roadmap's tally follows the wstring cell

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,7 +69,7 @@
 | the unit registry, UnitView | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | widening on read, and the refusal reasons | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
-313 of 1180 cells are done. That is a count of features, not of effort, since the
+314 of 1180 cells are done. That is a count of features, not of effort, since the
 cells are not equal in size. The table will be printed as it stands with every
 release from here.
 
@@ -84,7 +84,7 @@ Each language is in one of three states, applied to each wire on its own.
 
 On the packet wire as released in 2.4.0, C, C++, Rust, C# and Go are
 performant and production ready, and Java, JavaScript, Dart and Elixir are
-done but not yet mature. On the table wire every language is coming, C++ at 29
+done but not yet mature. On the table wire every language is coming, C++ at 30
 of 31 and the rest as the table shows.
 
 ## How the work is done


### PR DESCRIPTION
#617 moved its own cell but not the tally: 314 of 1180, C++ at 30 of 31 on the table wire. Same as the #366 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)