### PR TITLE
Packet wire: clear final harness lint gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ define tables_generate
 	$(1) generate --lang cpp --out $(2)/rt3 test/tables/RT3.schema
 	# the WIDE TEXT unit (docs/SPEC-TABLES.md §3, kind 33): its own directory,
 	# because examples/ pins gate 1 for all nine targets and eight of them
-	# refuse wide text on either wire (SPEC.md §4.12)
+	# refuse the table-wide unit; all nine carry its isolated packet file (SPEC.md §4.12)
 	$(1) generate --lang cpp --out $(2)/wide examples-wide
 endef
 

--- a/test/packet-text/harness/main.go
+++ b/test/packet-text/harness/main.go
@@ -37,7 +37,7 @@ func packed(s string) string {
 func corpus(path string, wide bool) []vector {
 	f, err := os.Open(path)
 	must(err)
-	defer f.Close()
+	defer func() { must(f.Close()) }()
 	var all []vector
 	v := vector{}
 	flush := func() {
@@ -176,7 +176,7 @@ func main() {
 			}
 		}
 		if want[i] != expected {
-			must(fmt.Errorf("C++ disagrees with pinned corpus on %s: got %q, want %q", v.name, want[i], expected))
+			must(fmt.Errorf("oracle C++ disagrees with pinned corpus on %s: got %q, want %q", v.name, want[i], expected))
 		}
 	}
 	if refusals == 0 {

--- a/test/packet-text/harness/main.go
+++ b/test/packet-text/harness/main.go
@@ -129,7 +129,7 @@ func main() {
 			var payload strings.Builder
 			for j, unit := range units {
 				fmt.Fprintf(&payload, "%04x", unit)
-				for k := 0; k < 16; k++ {
+				for k := range 16 {
 					if unit&(1<<k) != 0 {
 						offset := 3 + 32*j + k
 						wire[offset/8] |= 1 << (offset % 8)


### PR DESCRIPTION
The final packet stack's CI found two lint issues in the shared corpus harness: an unchecked read-file close and a capitalized diagnostic. The harness now checks close errors, uses an oracle-prefixed diagnostic and follows the pinned modernize tool’s integer-range loop rule. A stale Makefile comment now distinguishes the unsupported table unit from the supported packet unit.

Validation: `packet-wire-nine` passes again, including defaults, UTF-8 and wide-string checks across the first nine languages and all 24 port controls. Focused Go tests, source goldens, vet and pinned modernize pass. The wide row and its eight controls also passed after the integer-range change. Generated codecs, protocol identities and wire pins are unchanged. The fresh full `make test` passed at implementation head 0af60e8d with a clean checkout afterward. The follow-up only changes the harness and a comment; generated codecs, source pins and wire pins are identical between the tested implementation and this head.

Stacked on Elixir wide PR654. The earlier CI run 34080316452 finished with lint as its only failed job; exact-head [CI run 34080885695](https://github.com/mas-bandwidth/schema/actions/runs/34080885695) passes at final head 06d11889.
