### PR TITLE
tables: the table-closure union tag carries Count, and the reservation reaches it (#601)

### DIFF
--- a/compiler/tagenumsurface_test.go
+++ b/compiler/tagenumsurface_test.go
@@ -124,11 +124,11 @@ func TestUnionTagEnumExportsCountAndItsDebugName(t *testing.T) {
 	}
 }
 
-// COUNT IS RESERVED EXACTLY WHERE THE MEMBER EXISTS. A packet union's tag
-// enum carries Count, so an arm exporting Count would define the member
-// twice, a redefinition in C++ and C#. A TABLE-CLOSURE union's tag shape is
-// emitted beside the tables and carries Max alone, so the name is still free
-// there, and the corpus's own tables/messages/Messages.schema uses it.
+// COUNT IS RESERVED ON EVERY UNION, because every union's tag enum carries
+// the member. A packet union's does and a TABLE-CLOSURE union's does, so an
+// arm exporting Count would define the member twice either way, a
+// redefinition in C++ and C#. The two gates below are one rule read from both
+// sides.
 const countArmPacketUnion = `package tagcount
 
 type A
@@ -183,12 +183,102 @@ func TestAPacketUnionArmNamedCountIsRefusedByName(t *testing.T) {
 	}
 }
 
-// The other side of the same rule: the name stays legal where no Count is
-// emitted. A refusal here would break the corpus, and it would reserve a name
-// against a member that does not exist.
-func TestATableClosureUnionArmNamedCountIsAccepted(t *testing.T) {
-	if errs := checkErrors(t, countArmTableUnion); len(errs) > 0 {
-		t.Errorf("a table-closure union's arm named count was refused, and its tag shape carries no Count: %v", errs[0])
+// The other side of the same rule, and it is the same answer. The
+// table-closure tag shape carries Count too, so the member exists there and
+// an arm exporting it defines it twice. One construct, one reservation.
+func TestATableClosureUnionArmNamedCountIsRefusedByName(t *testing.T) {
+	errs := checkErrors(t, countArmTableUnion)
+	if len(errs) == 0 {
+		t.Fatal("a table-closure union's arm named count passed check, and its tag enum defines Count twice")
+	}
+	var joined []string
+	for _, e := range errs {
+		joined = append(joined, e.Error())
+	}
+	text := strings.Join(joined, "\n")
+	for _, want := range []string{"variant count is a compile error", "the member Count"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("the refusal does not name the rule (%q): %s", want, text)
+		}
+	}
+}
+
+// THE TABLE-CLOSURE TAG SHAPE'S OWN SURFACE GATE.
+//
+// A table-closure union (docs/SPEC-TABLES.md §2.6) has no packet wire, so its
+// tag enum is emitted by a different backend — internal/codegen/cpptable's
+// emitTableUnion, written beside the tables in the Table header rather than
+// among the packet declarations. It is the same construct to a reader, so it
+// presents the same surface: None, the variants, Count, Max and the
+// debug-name function.
+//
+// The table layer is the C++ REFERENCE's (docs/SPEC-TABLES.md §11, §15), and
+// cpptable is the one backend that emits this shape, so this gate is C++'s
+// where the packet gate above is nine-way.
+//
+// The probe unit declares an enum of THREE variants beside a union of two, the
+// trap PR #597 found running the packet control: with both at two, the
+// declared enum's own Count line satisfies a claim meant for the tag enum and
+// the control stays green.
+const tableClosureTagEnumUnit = `package tabletag
+
+enum ShipType { Fighter, Bomber, Scout }
+
+table LaserFire
+{
+    target_id uint16
+}
+
+table MissileFire
+{
+    target_id uint16
+}
+
+union WeaponFire
+{
+    laser   LaserFire
+    missile MissileFire
+}
+
+table FireCommand
+{
+    fire WeaponFire
+}
+`
+
+func TestTableClosureUnionTagEnumExportsCountAndItsDebugName(t *testing.T) {
+	text := generatedText(t, tableClosureTagEnumUnit, "cpp")
+	for _, want := range []string{
+		tagEnumSurface["cpp"].count,
+		tagEnumSurface["cpp"].max,
+		tagEnumSurface["cpp"].nameFunc,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("cpp: the table-closure tag enum's surface is short, %q not emitted", want)
+		}
+	}
+}
+
+// The name function names every value a reader can meet, out-of-set included,
+// and the claim is ANCHORED TO ITS BODY for the reason the packet gate is:
+// None, Laser and Missile all appear elsewhere in the same header — the tag
+// enum's own members, the arm table names, the reflection descriptor's arm
+// name switch — and "???" is that descriptor's own default, so a whole-output
+// claim stays green with the function deleted.
+func TestTableClosureTagEnumDebugNameCoversNoneVariantsAndOutOfSet(t *testing.T) {
+	text := generatedText(t, tableClosureTagEnumUnit, "cpp")
+	open := strings.Index(text, tagEnumSurface["cpp"].nameFunc)
+	if open < 0 {
+		t.Fatalf("cpp: the table-closure tag enum has no name function, %q not emitted", tagEnumSurface["cpp"].nameFunc)
+	}
+	body, _, found := strings.Cut(text[open:], "???")
+	if !found {
+		t.Fatal("cpp: the table-closure tag enum's name function has no out-of-set arm, \"???\" is absent from its body")
+	}
+	for _, want := range []string{"None", "Laser", "Missile"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("cpp: the table-closure tag enum's name function does not name %q in its body:\n%s", want, body)
+		}
 	}
 }
 

--- a/compiler/wasarmmessageid_test.go
+++ b/compiler/wasarmmessageid_test.go
@@ -1,0 +1,62 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// THE REFERENCE'S MESSAGE-FORM DISPATCH READS THE `was` ALIAS, as every other
+// id derivation does (docs/SPEC-TABLES.md §5, §3.3). The announcement's entry
+// for an arm is `ir.TableArmEntry`, which hashes the arm's WIRE name — the old
+// name after a rename — so a `<Table>LoadMessageBody` that switched on the
+// DECLARED name's hash would name nothing its own writer wrote.
+//
+// The gate is the C++ reference's because the table layer is (§11, §15), and
+// it is anchored to the emitted `case` line rather than to the id appearing
+// anywhere in the output: the OLD name's hash is in the header already, in the
+// file form's arm dispatch and in the reflection descriptor, so a
+// whole-output claim stays green with the message form still wrong.
+const wasArmMessageUnit = `package wasarmmsg
+
+table Edit
+{
+    revision uint32
+}
+
+union Body
+{
+    edit  Edit
+    tally int32 | min = 0, max = 100, was = "count"
+}
+
+table Note
+{
+    body Body
+}
+`
+
+func TestTheMessageFormsArmDispatchReadsTheWasAlias(t *testing.T) {
+	text := generatedText(t, wasArmMessageUnit, "cpp")
+	// the DEFINITION, not the forward declaration the header opens with: the
+	// definition is the later of the two, and the body runs to the next
+	// function
+	open := strings.LastIndex(text, "inline bool NoteLoadMessageBody(")
+	if open < 0 {
+		t.Fatal("cpp: the unit emits no NoteLoadMessageBody to dispatch in")
+	}
+	body, _, found := strings.Cut(text[open+len("inline bool NoteLoadMessageBody("):], "\ninline ")
+	if !found {
+		t.Fatal("cpp: NoteLoadMessageBody has no end, and the slice would be the whole header")
+	}
+	want := fmt.Sprintf("case 0x%016xull: // tally", ir.TableWireId("count"))
+	stale := fmt.Sprintf("case 0x%016xull: // tally", ir.TableWireId("tally"))
+	if !strings.Contains(body, want) {
+		t.Errorf("cpp: the message form does not dispatch the renamed arm on its old name's hash, %q absent from NoteLoadMessageBody", want)
+	}
+	if strings.Contains(body, stale) {
+		t.Errorf("cpp: the message form dispatches the renamed arm on its DECLARED name's hash, %q — the announcement writes the alias's", stale)
+	}
+}

--- a/compiler/wasrows_test.go
+++ b/compiler/wasrows_test.go
@@ -34,7 +34,7 @@ union Effect
 {
     shield Ward | was = "ward"
     pong | was = "ping"
-    count int32
+    tally int32
 }
 
 table Cfg

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -1494,8 +1494,8 @@ emitter writes it, so it is worth saying what it writes: `<Union>Type` carries
 declared variant count, `None` excluded) and `Max` (the exported extent), and
 beside the enum the DEBUG-NAME function that takes any value, out-of-set
 included, and returns the variant's spelling or the fixed unknown marker
-(SPEC §4.2, §4.8). It is the same construct to a reader — one logging which
-body arrived writes `EnumName( edit.body.type )` whichever union it holds — so
+(SPEC §4.2, §4.8). It is the same construct to a reader: one logging which
+body arrived writes `EnumName( edit.body.type )` whichever union it holds, so
 it presents the same surface. Nothing on the read or write path calls the
 function and no generated code does. The table layer is the C++ reference's
 (§11, §15), so this shape has ONE emitter where the packet shape has nine.

--- a/docs/SPEC-TABLES.md
+++ b/docs/SPEC-TABLES.md
@@ -1351,7 +1351,7 @@ type a FIELD's is, and an arm may name no type at all:
 ```
 union Value
 {
-    count   int32 | min = 0, max = 100
+    tally   int32 | min = 0, max = 100
     label   string(64)
     blob    bytes(16)
     samples [..8]float32
@@ -1419,7 +1419,7 @@ already spends what it would buy**, and each is refused by name (§11):
 **Selection is presence, so a set arm ALWAYS rides, whatever it holds**
 (§3). A union FIELD holding `None` elides; a union holding a selected arm
 writes the arm id and the arm's payload under its length even when the
-payload is empty or entirely default — a zero `count`, an empty `label`, an
+payload is empty or entirely default — a zero `tally`, an empty `label`, an
 all-default `offset`, a `ping` that has no payload to hold. That is the
 pointer's and the optional's rule
 (§2.3, §3.1) at an arm, and for their reason: otherwise "no arm" and "this
@@ -1440,7 +1440,7 @@ arms, in C++:
 ```
 union
 {
-    int32_t count;
+    int32_t tally;
     struct { char value[65]; int32_t value_length; } label;
     struct { float value[8]; int32_t value_count; } samples;
     Vec3 offset;
@@ -1487,6 +1487,22 @@ reaches (§11). A table holding one has no BLOCK form, by §19's standing rule
 for every union in a block closure. The packet wire's encoding of a general
 arm is stated where the packet union is (SPEC §4.8), and carrying it in the
 nine backends is the named follow-on (§15).
+
+**THE TAG SHAPE IS THE PACKET TAG ENUM'S, MEMBER FOR MEMBER.** A different
+emitter writes it, so it is worth saying what it writes: `<Union>Type` carries
+`None = 0`, then each variant in declared order dense from 1, then `Count` (the
+declared variant count, `None` excluded) and `Max` (the exported extent), and
+beside the enum the DEBUG-NAME function that takes any value, out-of-set
+included, and returns the variant's spelling or the fixed unknown marker
+(SPEC §4.2, §4.8). It is the same construct to a reader — one logging which
+body arrived writes `EnumName( edit.body.type )` whichever union it holds — so
+it presents the same surface. Nothing on the read or write path calls the
+function and no generated code does. The table layer is the C++ reference's
+(§11, §15), so this shape has ONE emitter where the packet shape has nine.
+`Count` is therefore a REFUSED ARM NAME here as it is on a packet union
+(SPEC §4.11): the member exists, so an arm exporting `Count` would define it
+twice, which C++ refuses as a redefinition. The refusal is over the exported
+spelling, so `count` goes with it.
 
 - **A union declared for the TYPE wire keeps refusing table arms.** Types
   are value semantics and their wire is positional; a table arm is a
@@ -9968,6 +9984,12 @@ in build version (§20.5).
   (§2.8) or an UNBOUNDED ARRAY (§2.9)**, whose elements live in the holder's
   NODE EXTENT and would make that extent depend on the union's tag, each
   refusal naming the table wrapper that serves.
+- **An ARM NAMED `Count`** (§2.6), over the EXPORTED spelling, so `count` is
+  refused too. The tag shape a table-closure union gets carries the declared
+  variant count as the member `Count`, exactly as a packet union's tag enum
+  does (SPEC §4.2, §4.8, §4.11), so the arm would define the member twice and
+  C++ refuses that as a redefinition. It is the reservation `None` and `Max`
+  already carry, reaching every union because the member is on every union.
 - **An array of unions** (§2.6): the enum-KEYED spelling `[E]Body`, a named
   follow-on (§15) where the bounded `[..N]Body` and `[N]Body` are not; and
   **an array of unions in a table closure under every backend but C++**,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1157,13 +1157,13 @@ flags declaration's `Count`: `E::Count` (C++), `E.Count` (C#), `ECount`
 Java), `E.count/0` (Elixir). `Count` is a reserved variant name for the same
 reason `Max` is, and it is a claimed name under §4.6 — a declaration whose
 generated symbol would collide with an enum's `Count` is refused, naming the
-enum. A PACKET union's generated `<Union>Type` tag enum carries `Count`
+enum. A union's generated `<Union>Type` tag enum carries `Count`
 beside `Max` too, in the same nine spellings (§4.8), so a tag enum and a
 declared enum present one surface to a reader. A tag set takes no headroom, so
 its `Count` and its `Max` are one number, and the member is there because the
 surface is uniform rather than because the two numbers ever differ. A
-table-closure union's tag shape carries `Max` alone
-([#601](https://github.com/mas-bandwidth/schema/issues/601)).
+TABLE-CLOSURE union's tag shape is a different emitter, written beside the
+tables, and it carries the same members (docs/SPEC-TABLES.md §2.6).
 
 ### 4.3 Field types and their wire encodings
 
@@ -1604,11 +1604,11 @@ union Value
   disagree with the tag. **Reserved variant names are checked over the
   EXPORTED spelling**: any variant whose exported form (the field-name
   mapping) is `None` or `Max` is refused — `none` and `max` included, not
-  just the literal spellings. **`Count` is refused the same way on a PACKET
-  union**, whose tag enum carries the member (below). The reservation is
-  scoped to where the member exists, so the name stays free on a
-  table-closure union, whose tag shape carries `Max` alone
-  ([#601](https://github.com/mas-bandwidth/schema/issues/601)).
+  just the literal spellings. **`Count` is refused the same way**, on every
+  union: each tag enum carries the member (below), the packet shape and the
+  table-closure shape alike, so an arm exporting `Count` defines it twice
+  wherever the union lands. The reservation reaches where the member exists,
+  and the member exists on every union (docs/SPEC-TABLES.md §2.6).
 - **The tag enum is generated, named `<Union>Type`**: `None = 0`, then
   each variant **in declared order**
   (exported spelling per target, the field-name mapping), dense from 1, then
@@ -1649,13 +1649,13 @@ union Value
   | js | `WeaponFireType.Count` | `EnumNameWeaponFireType(value)` |
   | rust | `WeaponFireType::COUNT` | `enum_name_weapon_fire_type` |
 
-- **A TABLE-CLOSURE union's tag shape carries `Max` alone.** It is a
-  different emitter, written beside the tables, and it gets neither `Count`
-  nor the debug-name function. Giving it both, and extending the `Count`
-  reservation to reach it, is a named follow-on
-  ([#601](https://github.com/mas-bandwidth/schema/issues/601)). `Count` is a
-  legal arm name on a table-closure union and a compile error on a packet
-  union. The split is what the checker enforces.
+- **A TABLE-CLOSURE union's tag shape carries the same surface.** It is a
+  different emitter, written beside the tables rather than among the packet
+  declarations (docs/SPEC-TABLES.md §2.6), and it emits `None`, the variants,
+  `Count`, `Max` and the debug-name function, because it is the same construct
+  to a reader. The table layer is the C++ reference's, so the shape has one
+  emitter where the packet shape has nine. `Count` is a compile error as an arm
+  name on every union, for the one reason: the member exists.
 - **The wire.** This bullet is the TYPE wire's, which a union of declared
   `type` arms rides and a table-closure union does not ride at all (above).
   The tag encodes in **minimal bits for `[0, variant
@@ -1844,15 +1844,15 @@ NAME rather than falling into a generic parse error:
 - **`doc`** (the attribute) — documentation is not an attribute: it is the
   `///` doc comment above the item (§4.1), and one text has one spelling.
   `| doc = "..."` is refused with the comment form named.
-- **`Count` as an arm name on a PACKET union.** The generated tag enum
+- **`Count` as an arm name on any union.** The generated tag enum
   carries the declared variant count as the member `Count` (§4.8), so the arm
   would define the member twice, which C++ and C# refuse outright as a
   redefinition. The refusal is over the EXPORTED spelling, so `count` is
   refused too, and the diagnostic names the tag enum that claims the name. It
   is the same reservation `None` and `Max` carry, for the same reason.
-  A table-closure union's tag shape carries no `Count` member, so the
-  name is legal there
-  ([#601](https://github.com/mas-bandwidth/schema/issues/601)).
+  A table-closure union's tag shape carries the member too
+  (docs/SPEC-TABLES.md §2.6), so the reservation reaches it and one rule
+  covers both shapes.
 
 The projection (§3.1) keeps FROZEN tokens — `table=false message=false` on
 every type line, `round=nearest` on every compressed-float field line — so

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1501,7 +1501,7 @@ The tag enum is a full enum. It carries `None`, the variants, `Count` and
 compiles and prints `"Laser"`. It is the same call a declared enum takes, found
 by lookup the same way. Log a tag with it. The switch the program below writes is
 there to reach the payload, which a name cannot do. Because the enum carries
-`Count`, `count` is a refused arm name on a packet union, alongside `none` and
+`Count`, `count` is a refused arm name on every union, alongside `none` and
 `max`.
 
 To select an arm in C++, construct the payload and set its tag:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -154,9 +154,9 @@ excluded — `ShipType::Count` (C++), `ShipType.Count` (C#), `ShipTypeCount`
 `ShipType.count` (Dart and Java), `ShipType.count/0` (Elixir), and
 `E.Count` in schema expressions. Without headroom `Count` and `Max` are the
 same number. Under `| max = 15` they are 3 and 15, and that difference is
-what the two words are for. `Count` is a reserved variant name too, and a
+what the two words are for. `Count` is a reserved variant name too, and every
 union's tag enum carries it beside `Max`, so `Count` is a reserved arm name
-on a packet union for the same reason.
+on every union for the same reason.
 
 A union's tag enum carries the debug-name function too, in the same nine
 spellings the declared enum uses, so logging which arm arrived is the same

--- a/examples-wide/Caption.schema
+++ b/examples-wide/Caption.schema
@@ -36,7 +36,7 @@ union Body
 {
     wide   wstring(4)
     narrow string(4)
-    count  int32
+    tally  int32 | was = "count"
 }
 
 // The root: every site at once, so one instance exercises them all.

--- a/examples-wide/Caption.schema
+++ b/examples-wide/Caption.schema
@@ -36,7 +36,7 @@ union Body
 {
     wide   wstring(4)
     narrow string(4)
-    tally  int32 | was = "count"
+    tally  int32      | was = "count"
 }
 
 // The root: every site at once, so one instance exercises them all.

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -96,7 +96,7 @@ union Effect
 union Shape
 {
     body   Buff
-    count  int32
+    tally  int32
     marks  [..8]float32
     chunk  Chunk
     ack
@@ -354,8 +354,8 @@ func TestRefusals(t *testing.T) {
 		// goes red for one reason, the token beside it.
 		{
 			name:    "a scalar arm's kind widened",
-			edited:  replace(t, "    count  int32\n", "    count  int64\n"),
-			where:   "union Shape.count",
+			edited:  replace(t, "    tally  int32\n", "    tally  int64\n"),
+			where:   "union Shape.tally",
 			what:    "wire kind 4 -> 5",
 			token:   "kind",
 			control: replace(t, "    ack\n", "    ack\n    extra  int32\n"), // an arm ADDED: an id no reader names

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -996,7 +996,7 @@ func (c *checker) resolveBodies() {
 }
 
 // resolveUnion fills a union shell's variants (SPEC §4.8): names checked over
-// the EXPORTED spelling (None/Max reserved post-mapping, uniqueness
+// the EXPORTED spelling (None/Count/Max reserved post-mapping, uniqueness
 // post-mapping — box_a and boxA both export BoxA), payloads restricted to
 // declared types.
 func (c *checker) resolveUnion(d *ast.UnionDecl) {
@@ -1010,6 +1010,12 @@ func (c *checker) resolveUnion(d *ast.UnionDecl) {
 			continue
 		case "Max":
 			c.errf(v.Pos, "variant %s is a compile error — every generated union tag enum carries its extent as the member Max, checked over the exported spelling (SPEC §4.8, §4.2)", v.Name)
+			continue
+		case "Count":
+			// EVERY union's tag enum carries Count, the packet shape and the
+			// table-closure shape alike (docs/SPEC-TABLES.md §2.6), so an arm
+			// exporting it defines the member twice wherever the union lands
+			c.errf(v.Pos, "variant %s is a compile error — a union's generated tag enum carries its declared variant count as the member Count, checked over the exported spelling (SPEC §4.8, §4.2)", v.Name)
 			continue
 		case "Type":
 			c.errf(v.Pos, "variant %s is a compile error — its exported spelling is Type, the tag member's own name in the Go and C# representations; rename at the source (SPEC §4.8)", v.Name)
@@ -1056,20 +1062,6 @@ func (c *checker) resolveUnion(d *ast.UnionDecl) {
 	// dropped variants (duplicates, bad payloads) already errored; Max and
 	// storage stay the DECLARED count so cascade diagnostics do not invent a
 	// second wire shape — the unit is refused either way.
-
-	// Count is reserved exactly where the member exists. A PACKET union's tag
-	// enum carries Count beside Max in all nine targets, so an arm exporting
-	// Count would define the member twice. A TABLE-CLOSURE union's tag shape
-	// is emitted beside the tables and carries Max alone, so the name is free
-	// there. The kind is known only once every arm is resolved, which is why
-	// this sits after the loop rather than beside None, Max and Type.
-	if !un.TableClosureOnly() {
-		for _, v := range d.Variants {
-			if ir.GoExportName(v.Name) == "Count" {
-				c.errf(v.Pos, "variant %s is a compile error — a union's generated tag enum carries its declared variant count as the member Count, checked over the exported spelling (SPEC §4.8, §4.2)", v.Name)
-			}
-		}
-	}
 }
 
 // resolveArm resolves one arm as a FIELD LINE (SPEC §4.8,

--- a/internal/check/diagnostics_test.go
+++ b/internal/check/diagnostics_test.go
@@ -313,6 +313,13 @@ func TestDiagnostics(t *testing.T) {
 			src: "package t\nunion U {\n    u Box\n}\ntype Box { x uint8 }\n"},
 		{name: "union variants colliding after export mapping", want: "both become BoxA",
 			src: "package t\nunion U {\n    box_a Box\n    boxA Box\n}\ntype Box { x uint8 }\n"},
+		// COUNT IS RESERVED ON EVERY UNION, packet and table closure alike:
+		// both tag enums carry the member, so the arm would define it twice
+		// (SPEC §4.8, §4.11, docs/SPEC-TABLES.md §2.6)
+		{name: "union variant named count on a packet union (exported spelling)", want: "carries its declared variant count as the member Count",
+			src: "package t\nunion U {\n    count Box\n}\ntype Box { x uint8 }\ntype T { u U }\n"},
+		{name: "union variant named count on a table-closure union (exported spelling)", want: "carries its declared variant count as the member Count",
+			src: "package t\ntable Box { x uint8 }\nunion U {\n    thing Box\n    count int32 | min = 0, max = 100\n}\ntable Root { u U }\n"},
 		// AN ARM IS A FIELD LINE (docs/SPEC-TABLES.md §2.6): an enum, a
 		// scalar, a string, an array, a pointer and a union are arms, and
 		// what refuses them OUTSIDE a table closure is the closure rule —
@@ -322,18 +329,18 @@ func TestDiagnostics(t *testing.T) {
 		{name: "a union arm outside a table closure", want: "no table reaches U",
 			src: "package t\nunion U {\n    v V\n}\nunion V { }\n"},
 		{name: "a scalar arm outside a table closure", want: "no table reaches U",
-			src: "package t\nunion U {\n    count int32\n}\n"},
+			src: "package t\nunion U {\n    tally int32\n}\n"},
 		{name: "a table-closure union held in a type body", want: "a union in a `type` body takes `type` payloads only",
-			src: "package t\nunion U {\n    count int32\n}\ntype Holder { u U }\ntable Root { h Holder }\n"},
+			src: "package t\nunion U {\n    tally int32\n}\ntype Holder { u U }\ntable Root { h Holder }\n"},
 		// what an ARM may not carry, each refused at the arm (§2.6, §11)
 		{name: "a default on an arm", want: "ZERO-ESTABLISHES at selection",
-			src: "package t\nunion U {\n    count int32 = 3\n}\ntable Root { u U }\n"},
+			src: "package t\nunion U {\n    tally int32 = 3\n}\ntable Root { u U }\n"},
 		{name: "an optional arm", want: "SELECTION IS THE ARM'S PRESENCE",
-			src: "package t\nunion U {\n    count ?int32\n}\ntable Root { u U }\n"},
+			src: "package t\nunion U {\n    tally ?int32\n}\ntable Root { u U }\n"},
 		{name: "was on an arm of a union no table reaches", want: "no table reaches",
 			src: "package t\ntype A { x int32 }\nunion U {\n    a A | was = \"z\"\n}\ntype Root { u U }\n"},
 		{name: "json on an arm", want: "json on an arm is a named follow-on",
-			src: "package t\nunion U {\n    count int32 | json = \"n\"\n}\ntable Root { u U }\n"},
+			src: "package t\nunion U {\n    tally int32 | json = \"n\"\n}\ntable Root { u U }\n"},
 		{name: "an enum-keyed array arm", want: "an enum-keyed array is not an arm",
 			src: "package t\nenum E { A, B }\nunion U {\n    slots [E]int32\n}\ntable Root { u U }\n"},
 
@@ -349,7 +356,7 @@ func TestDiagnostics(t *testing.T) {
 		{name: "[E.Max]T in a table body, of a declared type", want: "spell it [E]Cfg",
 			src: "package t\nenum E { A, B }\ntype Cfg { hp uint16 }\ntable Root { slots [E.Max]Cfg }\n"},
 		{name: "an arm whose range excludes zero", want: "the value it establishes at selection is outside it",
-			src: "package t\nunion U {\n    count int32 | min = 1, max = 10\n}\ntable Root { u U }\n"},
+			src: "package t\nunion U {\n    tally int32 | min = 1, max = 10\n}\ntable Root { u U }\n"},
 		{name: "union payload undefined", want: "undefined type",
 			src: "package t\nunion U {\n    b Box\n}\n"},
 		{name: "union composition cycle", want: "type composition cycle",

--- a/internal/check/projection_test.go
+++ b/internal/check/projection_test.go
@@ -555,7 +555,7 @@ type Ring {
 
 union Shape {
     ring  Ring
-    count int32 | min = 0, max = 100
+    size  int32 | min = 0, max = 100
 }
 
 table Holder {
@@ -568,11 +568,11 @@ table Holder {
 		name   string
 		source string
 	}{
-		{"a scalar arm added", strings.Replace(tableHeld, "    count int32 | min = 0, max = 100\n",
-			"    count int32 | min = 0, max = 100\n    tally int32 | min = 0, max = 100\n", 1)},
+		{"a scalar arm added", strings.Replace(tableHeld, "    size  int32 | min = 0, max = 100\n",
+			"    size  int32 | min = 0, max = 100\n    tally int32 | min = 0, max = 100\n", 1)},
 		{"an arm's declared maximum moved", strings.Replace(tableHeld, "max = 100", "max = 200", 1)},
 		{"an arm's type moved under one width", strings.Replace(tableHeld,
-			"    count int32 | min = 0, max = 100\n", "    count float32\n", 1)},
+			"    size  int32 | min = 0, max = 100\n", "    size  float32\n", 1)},
 		{"a payload-free arm added", strings.Replace(tableHeld, "    ring  Ring\n", "    ring  Ring\n    idle\n", 1)},
 		{"an arm renamed", strings.Replace(tableHeld, "    ring  Ring\n", "    hoop  Ring\n", 1)},
 	}

--- a/internal/codegen/cpptable/messagecodec.go
+++ b/internal/codegen/cpptable/messagecodec.go
@@ -1018,7 +1018,10 @@ func (g *tableGen) emitMessageExtentCases(st *ir.Struct) {
 				if ref == nil || !g.hasExtent(ref) {
 					continue
 				}
-				g.pf("                case 0x%016xull: // %s\n", ir.TableWireId(v.Name), v.Name)
+				// the announcement's own entry, which reads the `was` alias
+				// (docs/SPEC-TABLES.md §5), so the dispatch names what the
+				// writer wrote
+				g.pf("                case 0x%016xull: // %s\n", ir.TableArmEntry(v).Id, v.Name)
 				g.pf("                    if ( arm.kind == %d ) { if ( !%sMessageExtent( r, vocabulary, index_bits, at ) ) { return false; } }\n", tkTable, v.Type)
 				g.pf("                    else if ( !TableMessageSkip( r, vocabulary, index_bits, arm ) ) { return false; } // another kind: a mismatch the load counts\n")
 				g.pf("                    break;\n")

--- a/internal/codegen/cpptable/messageload.go
+++ b/internal/codegen/cpptable/messageload.go
@@ -340,7 +340,10 @@ func (g *tableGen) emitMessageReadUnion(f *ir.Field, dst, ind string) {
 	for _, v := range un.Variants {
 		mine := ir.TableArmEntry(v)
 		g.noteRef(v.Type)
-		g.pf("%s            case 0x%016xull: // %s\n%s            {\n", ind, ir.TableWireId(v.Name), v.Name, ind)
+		// the arm's id is `mine.Id`, the announcement's own entry, which reads
+		// the `was` alias (docs/SPEC-TABLES.md §5): every id derivation does,
+		// so the dispatch names what the writer wrote
+		g.pf("%s            case 0x%016xull: // %s\n%s            {\n", ind, mine.Id, v.Name, ind)
 		g.pf("%s                if ( %s.kind != %d || %s.elem_kind != %d )\n%s                {\n", ind, arm, mine.Kind, arm, mine.Shape.Elem, ind)
 		if !v.Void() && !v.Body() && plainScalar(v.F) {
 			// WIDENED AT AN ARM (§3.3, §4): the arm is SELECTED and its

--- a/internal/codegen/cpptable/unions.go
+++ b/internal/codegen/cpptable/unions.go
@@ -46,8 +46,21 @@ func (g *tableGen) emitTableUnion(un *ir.Union) {
 	for i, v := range un.Variants {
 		g.pf("    %s = %d,\n", ir.GoExportName(v.Name), i+1)
 	}
+	g.pf("    Count = %d, // the declared variant count (SPEC §4.2)\n", len(un.Variants))
 	g.pf("    Max = %d, // the exported extent (SPEC §4.2)\n", len(un.Variants))
 	g.pf("};\n\n")
+	// the tag enum's name surface is a declared enum's, member for member, and
+	// a table arm is no different to a reader: one logging which body arrived
+	// writes EnumName( value ) whichever union it holds. Nothing on the read
+	// or write path calls it.
+	g.pf("// EnumName: debug/log name for any %sType value, out-of-set included\n", un.Name)
+	g.pf("inline const char * EnumName( %sType value )\n{\n", un.Name)
+	g.pf("    switch ( value )\n    {\n")
+	g.pf("        case %sType::None: return \"None\";\n", un.Name)
+	for _, v := range un.Variants {
+		g.pf("        case %sType::%s: return \"%s\";\n", un.Name, ir.GoExportName(v.Name), ir.GoExportName(v.Name))
+	}
+	g.pf("        default: return \"???\";\n    }\n}\n\n")
 
 	arm, typ := "arm", "Arm"
 	if len(un.Variants) > 0 {

--- a/internal/tablewire/messagedecode.go
+++ b/internal/tablewire/messagedecode.go
@@ -857,7 +857,10 @@ func (d *bitDecoder) unionCell(cell *tabletext.Cell, f *ir.Field) bool {
 	}
 	tag := 0
 	for i, v := range un.Variants {
-		if ir.TableWireId(v.Name) == entry.Id {
+		// the announcement's own entry, which reads the `was` alias
+		// (docs/SPEC-TABLES.md §5): every id derivation does, so the
+		// dispatch names what the writer wrote
+		if ir.TableArmEntry(v).Id == entry.Id {
 			tag = i + 1
 			break
 		}

--- a/internal/tablewire/wasarmmessage_test.go
+++ b/internal/tablewire/wasarmmessage_test.go
@@ -1,0 +1,124 @@
+package tablewire_test
+
+import (
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/internal/check"
+	"github.com/mas-bandwidth/schema/v2/internal/parser"
+	"github.com/mas-bandwidth/schema/v2/internal/tabletext"
+	"github.com/mas-bandwidth/schema/v2/internal/tablewire"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// AN ARM RENAMED UNDER `was` RIDES UNDER ITS OLD NAME'S HASH IN EVERY
+// VOCABULARY, the MESSAGE FORM's announcement included (docs/SPEC-TABLES.md
+// §5, §3.3): "every id derivation reads the alias". `ir.TableArmEntry` is that
+// one derivation, and the announcement and the encoder both call it.
+//
+// The message form's arm DISPATCH is the half that has to agree. A reader
+// matching on the DECLARED name's hash names nothing the writer wrote, so the
+// arm is lost at its own build's hands: the value round-trips through the
+// message form as `None` with an `unknown` counted, and a peer holding data
+// written before the rename is refused the very arm the rename was taken to
+// keep.
+const wasArmUnit = `package wasarm
+
+table Edit
+{
+    revision uint32
+}
+
+union Body
+{
+    edit  Edit
+    tally int32 | min = 0, max = 100, was = "count"
+}
+
+table Note
+{
+    body Body
+}
+`
+
+func wasArmModel(t *testing.T) *tabletext.Model {
+	t.Helper()
+	f, perrs := parser.Parse("WasArm.schema", []byte(wasArmUnit))
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs[0])
+	}
+	u, cerrs := check.Unit([]check.SourceFile{{
+		Path: "WasArm.schema", Name: "WasArm.schema", Base: "WasArm", Bytes: []byte(wasArmUnit), AST: f,
+	}})
+	if len(cerrs) > 0 {
+		t.Fatalf("check: %v", cerrs[0])
+	}
+	return tabletext.NewModel(u)
+}
+
+// The announcement's own entry, read straight off the derivation, so the claim
+// below names the id the writer actually spends rather than a hash the test
+// recomputes beside it.
+func TestAWasRenamedArmAnnouncesTheOldNamesHash(t *testing.T) {
+	m := wasArmModel(t)
+	un := m.Unit.TableUnions["Body"]
+	if un == nil {
+		t.Fatal("the unit declares no table-closure union Body")
+	}
+	var arm ir.UnionVariant
+	for _, v := range un.Variants {
+		if v.Name == "tally" {
+			arm = v
+		}
+	}
+	if arm.Name == "" {
+		t.Fatal("union Body declares no arm tally")
+	}
+	if got, want := ir.TableArmEntry(arm).Id, ir.TableWireId("count"); got != want {
+		t.Errorf("the arm's announced id is 0x%016x, not the old name's hash 0x%016x", got, want)
+	}
+}
+
+// AND THE DISPATCH AGREES, which is the claim the round trip holds: the
+// message form writes the value and reads it back into a fresh instance, and
+// the arm must come back SELECTED with its payload. Anchored to the tag and
+// the payload rather than to a byte count, because a lost arm is a silent
+// `None` and a shorter wire, not a decode failure.
+func TestAWasRenamedArmSurvivesTheMessageForm(t *testing.T) {
+	m := wasArmModel(t)
+	inst := place(t, m, "Note", `{"body":{"tally":42}}`)
+	wire, err := tablewire.EncodeMessage(m, inst)
+	if err != nil {
+		t.Fatalf("the message form refused the value: %v", err)
+	}
+	// the unit's OWN announcement, so the two sides are one build and the
+	// claim is not about a version skew
+	var vocabulary tablewire.Vocabulary
+	var announced tabletext.Report
+	if err := vocabulary.AnnounceRead(ir.TableAnnouncement(m.Unit), &announced); err != nil || !vocabulary.Announced() {
+		t.Fatalf("the unit's own announcement was refused: %v %+v", err, announced)
+	}
+	back := m.New(m.Lookup("Note"))
+	var report tabletext.Report
+	ok, err := tablewire.DecodeMessage(m, back, wire, &vocabulary, &report)
+	if err != nil || !ok {
+		t.Fatalf("the message form did not read back: ok=%v err=%v", ok, err)
+	}
+	var body *tabletext.Field
+	for i := range back.Fields {
+		if back.Fields[i].Def.Name == "body" {
+			body = &back.Fields[i]
+		}
+	}
+	if body == nil {
+		t.Fatal("the decoded instance has no field body")
+	}
+	if body.Cell.U == 0 {
+		t.Fatalf("the was-renamed arm was lost: the union reads back None, report %+v", report)
+	}
+	if report.Unknown != 0 {
+		t.Errorf("the was-renamed arm counted unknown %d times, and its own build wrote it", report.Unknown)
+	}
+	if arm := body.Cell.Arm; arm == nil || arm.Cell.I != 42 {
+		t.Errorf("the arm's payload did not survive: %+v", arm)
+	}
+}

--- a/ir/buildversion_test.go
+++ b/ir/buildversion_test.go
@@ -145,7 +145,7 @@ union Effect
 {
     up    Buff
     down  Debuff
-    count int32
+    tally int32
 }
 
 table Row
@@ -199,7 +199,7 @@ table Row
 		// §4.1's FIFTH SILENT MEMBER: an arm retyped under one width moves no
 		// sizeof, no offset and no wire id, and nothing on either wire can see
 		// it — the build version is what does
-		{"an arm retyped under one width", "    count int32", "    count float32"},
+		{"an arm retyped under one width", "    tally int32", "    tally float32"},
 		// A FLAGS FIELD'S REFERENT is a MEANING fact through the block it
 		// reaches (§20.1, §20.2): the field line carries no `flags=` token,
 		// because a slot is a raw u64 copied through — but the declaration it

--- a/tables/messages/Messages.schema
+++ b/tables/messages/Messages.schema
@@ -90,7 +90,7 @@ union EditBody
 {
     insert InsertText
     remove RemoveText
-    count  int32       | min = 0, max = 100
+    tally  int32       | min = 0, max = 100, was = "count"
     marks  [..3]uint16
     blob   bytes(4)
     mode   Mode

--- a/tables/messages/tables.baseline
+++ b/tables/messages/tables.baseline
@@ -67,7 +67,7 @@ flags Capabilities
 union EditBody
     arm insert id=0x7271c68759916228 payload=InsertText
     arm remove id=0xfff83d536a1d457d payload=RemoveText
-    arm count id=0xb1e5e28e4479a274 kind=4 min=0 max=100
+    arm tally id=0xb1e5e28e4479a274 kind=4 min=0 max=100 was=count
     arm marks id=0x9077d4a4e1726e29 kind=14 elem=7 array=bounded bound=3
     arm blob id=0xc573b39bc29148ca kind=14 elem=6 size=4
     arm mode id=0x0d3deba2c41dadb2 kind=7 enum=Mode
@@ -94,3 +94,6 @@ union ToolBody
 
 ### 2026-09-04 — the id-table wire: sixty-four-bit identity, the enum kind, and rendering version 7 (docs/SPEC-TABLES.md §3, §5, §18.1)
 - baseline REGENERATED over an unreadable one (baseline version 6, this compiler writes 7); the projection is this unit as it stands and the history above is preserved, but the previous projection could not be diffed, so no per-edit lines follow
+
+### 2026-09-07 (UTC) — the EditBody arm count is renamed to tally under was: every union's tag enum now carries the member Count, so the name is reserved (#601)
+- no compatibility-affecting edits; the wire absorbs the rest

--- a/test/conformance/harness/messagerules_test.go
+++ b/test/conformance/harness/messagerules_test.go
@@ -588,7 +588,7 @@ type Inner
 union Arm
 {
     ack
-    count int32
+    tally int32
     inner Inner
 }
 

--- a/test/tables/R1.schema
+++ b/test/tables/R1.schema
@@ -30,7 +30,7 @@ union Effect
     boost Boost
     ward  Ward
     ping
-    count int32
+    amount int32
 }
 
 table Cfg

--- a/test/tables/R2.schema
+++ b/test/tables/R2.schema
@@ -32,7 +32,7 @@ union Effect
     boost  Boost
     shield Ward  | was = "ward"
     pong         | was = "ping"
-    count  int32
+    amount int32
 }
 
 table Cfg

--- a/test/tables/RT2.schema
+++ b/test/tables/RT2.schema
@@ -57,7 +57,7 @@ table Bolt
 union Fitting
 {
     bolt  Bolt
-    count int32
+    tally int32
 }
 
 table Parcel

--- a/test/tables/main.cpp
+++ b/test/tables/main.cpp
@@ -5957,8 +5957,8 @@ static void build_message_arm_edits( messagedemo::ToolMessage & m )
     m.body.transact.edits_count = 3;
     messagedemo::Edit & a = m.body.transact.edits[0];
     a.revision = 1;
-    a.body.type = messagedemo::EditBodyType::Count;            // a bounded scalar arm
-    a.body.count = 100;
+    a.body.type = messagedemo::EditBodyType::Tally;            // a bounded scalar arm
+    a.body.tally = 100;
     messagedemo::Edit & b = m.body.transact.edits[1];
     b.revision = 2;
     b.body.type = messagedemo::EditBodyType::Marks;            // a counted-array arm

--- a/testdata/conformance/tables/json-hostile/arm-scalar-null/ToolMessage.json
+++ b/testdata/conformance/tables/json-hostile/arm-scalar-null/ToolMessage.json
@@ -1,1 +1,1 @@
-{ "sequence": 2, "body": { "transact": { "edits": [ { "revision": 1, "body": { "count": null } } ] } } }
+{ "sequence": 2, "body": { "transact": { "edits": [ { "revision": 1, "body": { "tally": null } } ] } } }

--- a/testdata/conformance/tables/json-hostile/arm-scalar-string/ToolMessage.json
+++ b/testdata/conformance/tables/json-hostile/arm-scalar-string/ToolMessage.json
@@ -1,1 +1,1 @@
-{ "sequence": 1, "body": { "transact": { "edits": [ { "revision": 1, "body": { "count": "7" } } ] } } }
+{ "sequence": 1, "body": { "transact": { "edits": [ { "revision": 1, "body": { "tally": "7" } } ] } } }

--- a/testdata/conformance/tables/json/message_arm_edits.json
+++ b/testdata/conformance/tables/json/message_arm_edits.json
@@ -7,7 +7,7 @@
         {
           "revision": 1,
           "body": {
-            "count": 100
+            "tally": 100
           }
         },
         {

--- a/testdata/golden/tables/arms/CarryTable.h
+++ b/testdata/golden/tables/arms/CarryTable.h
@@ -5156,8 +5156,21 @@ enum class CarryType : uint8_t {
     None = 0,
     Leaf = 1,
     Plain = 2,
+    Count = 2, // the declared variant count (SPEC §4.2)
     Max = 2, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any CarryType value, out-of-set included
+inline const char * EnumName( CarryType value )
+{
+    switch ( value )
+    {
+        case CarryType::None: return "None";
+        case CarryType::Leaf: return "Leaf";
+        case CarryType::Plain: return "Plain";
+        default: return "???";
+    }
+}
 
 // union Carry — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage

--- a/testdata/golden/tables/arms/GateTable.h
+++ b/testdata/golden/tables/arms/GateTable.h
@@ -5157,8 +5157,22 @@ enum class ReachType : uint8_t {
     Only = 1,
     Text = 2,
     Plain = 3,
+    Count = 3, // the declared variant count (SPEC §4.2)
     Max = 3, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any ReachType value, out-of-set included
+inline const char * EnumName( ReachType value )
+{
+    switch ( value )
+    {
+        case ReachType::None: return "None";
+        case ReachType::Only: return "Only";
+        case ReachType::Text: return "Text";
+        case ReachType::Plain: return "Plain";
+        default: return "???";
+    }
+}
 
 // union Reach — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage

--- a/testdata/golden/tables/arms/NestTable.h
+++ b/testdata/golden/tables/arms/NestTable.h
@@ -5151,8 +5151,21 @@ enum class InnerType : uint8_t {
     None = 0,
     Leaf = 1,
     Plain = 2,
+    Count = 2, // the declared variant count (SPEC §4.2)
     Max = 2, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any InnerType value, out-of-set included
+inline const char * EnumName( InnerType value )
+{
+    switch ( value )
+    {
+        case InnerType::None: return "None";
+        case InnerType::Leaf: return "Leaf";
+        case InnerType::Plain: return "Plain";
+        default: return "???";
+    }
+}
 
 // union Inner — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage
@@ -5187,8 +5200,21 @@ enum class OuterType : uint8_t {
     None = 0,
     Inner = 1,
     Plain = 2,
+    Count = 2, // the declared variant count (SPEC §4.2)
     Max = 2, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any OuterType value, out-of-set included
+inline const char * EnumName( OuterType value )
+{
+    switch ( value )
+    {
+        case OuterType::None: return "None";
+        case OuterType::Inner: return "Inner";
+        case OuterType::Plain: return "Plain";
+        default: return "???";
+    }
+}
 
 // union Outer — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage

--- a/testdata/golden/tables/arms/RingTable.h
+++ b/testdata/golden/tables/arms/RingTable.h
@@ -5156,8 +5156,21 @@ enum class SlotType : uint8_t {
     None = 0,
     Node = 1,
     Plain = 2,
+    Count = 2, // the declared variant count (SPEC §4.2)
     Max = 2, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any SlotType value, out-of-set included
+inline const char * EnumName( SlotType value )
+{
+    switch ( value )
+    {
+        case SlotType::None: return "None";
+        case SlotType::Node: return "Node";
+        case SlotType::Plain: return "Plain";
+        default: return "???";
+    }
+}
 
 // union Slot — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage
@@ -5193,8 +5206,21 @@ enum class SlotsType : uint8_t {
     None = 0,
     Many = 1,
     Plain = 2,
+    Count = 2, // the declared variant count (SPEC §4.2)
     Max = 2, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any SlotsType value, out-of-set included
+inline const char * EnumName( SlotsType value )
+{
+    switch ( value )
+    {
+        case SlotsType::None: return "None";
+        case SlotsType::Many: return "Many";
+        case SlotsType::Plain: return "Plain";
+        default: return "???";
+    }
+}
 
 // union Slots — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage

--- a/testdata/golden/tables/lists/SaveTable.h
+++ b/testdata/golden/tables/lists/SaveTable.h
@@ -5905,8 +5905,21 @@ enum class HitType : uint8_t {
     None = 0,
     Point = 1,
     Damage = 2,
+    Count = 2, // the declared variant count (SPEC §4.2)
     Max = 2, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any HitType value, out-of-set included
+inline const char * EnumName( HitType value )
+{
+    switch ( value )
+    {
+        case HitType::None: return "None";
+        case HitType::Point: return "Point";
+        case HitType::Damage: return "Damage";
+        default: return "???";
+    }
+}
 
 // union Hit — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage

--- a/testdata/golden/tables/maps/DepthTable.h
+++ b/testdata/golden/tables/maps/DepthTable.h
@@ -5465,8 +5465,21 @@ enum class ForceType : uint8_t {
     None = 0,
     Squad = 1,
     Plain = 2,
+    Count = 2, // the declared variant count (SPEC §4.2)
     Max = 2, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any ForceType value, out-of-set included
+inline const char * EnumName( ForceType value )
+{
+    switch ( value )
+    {
+        case ForceType::None: return "None";
+        case ForceType::Squad: return "Squad";
+        case ForceType::Plain: return "Plain";
+        default: return "???";
+    }
+}
 
 // union Force — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage

--- a/testdata/golden/tables/messages/MessagesTable.h
+++ b/testdata/golden/tables/messages/MessagesTable.h
@@ -2235,8 +2235,23 @@ enum class OriginType : uint8_t {
     Script = 2,
     Pid = 3,
     Note = 4,
+    Count = 4, // the declared variant count (SPEC §4.2)
     Max = 4, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any OriginType value, out-of-set included
+inline const char * EnumName( OriginType value )
+{
+    switch ( value )
+    {
+        case OriginType::None: return "None";
+        case OriginType::User: return "User";
+        case OriginType::Script: return "Script";
+        case OriginType::Pid: return "Pid";
+        case OriginType::Note: return "Note";
+        default: return "???";
+    }
+}
 
 // union Origin — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage
@@ -2287,12 +2302,29 @@ enum class EditBodyType : uint8_t {
     None = 0,
     Insert = 1,
     Remove = 2,
-    Count = 3,
+    Tally = 3,
     Marks = 4,
     Blob = 5,
     Mode = 6,
+    Count = 6, // the declared variant count (SPEC §4.2)
     Max = 6, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any EditBodyType value, out-of-set included
+inline const char * EnumName( EditBodyType value )
+{
+    switch ( value )
+    {
+        case EditBodyType::None: return "None";
+        case EditBodyType::Insert: return "Insert";
+        case EditBodyType::Remove: return "Remove";
+        case EditBodyType::Tally: return "Tally";
+        case EditBodyType::Marks: return "Marks";
+        case EditBodyType::Blob: return "Blob";
+        case EditBodyType::Mode: return "Mode";
+        default: return "???";
+    }
+}
 
 // union EditBody — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage
@@ -2311,7 +2343,7 @@ struct EditBody
     {
         InsertText insert;
         RemoveText remove;
-        int32_t count;
+        int32_t tally;
         struct { uint16_t value[3]; int32_t value_count; } marks; // [..3]uint16
         struct { uint8_t value[4]; int32_t value_length; } blob; // bytes(4)
         Mode mode;
@@ -2369,8 +2401,27 @@ enum class ToolBodyType : uint8_t {
     Spans = 6,
     Origin = 7,
     Ack = 8,
+    Count = 8, // the declared variant count (SPEC §4.2)
     Max = 8, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any ToolBodyType value, out-of-set included
+inline const char * EnumName( ToolBodyType value )
+{
+    switch ( value )
+    {
+        case ToolBodyType::None: return "None";
+        case ToolBodyType::Open: return "Open";
+        case ToolBodyType::Save: return "Save";
+        case ToolBodyType::Transact: return "Transact";
+        case ToolBodyType::Ping: return "Ping";
+        case ToolBodyType::Caps: return "Caps";
+        case ToolBodyType::Spans: return "Spans";
+        case ToolBodyType::Origin: return "Origin";
+        case ToolBodyType::Ack: return "Ack";
+        default: return "???";
+    }
+}
 
 // union ToolBody — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage
@@ -5638,7 +5689,7 @@ inline int64_t EditMeasureBody( TableIds & ids, const Edit & value )
                 bytes += TableLebBytes( arm_ref ) + 1 + TableLebBytes( (uint64_t) ( arm_payload ) ) + ( arm_payload );
                 break;
             }
-            case EditBodyType::Count:
+            case EditBodyType::Tally:
             {
                 int64_t arm_payload = 0;
                 const uint64_t arm_ref = ids.ref( 0xb1e5e28e4479a274ull );
@@ -5729,13 +5780,13 @@ MESSAGEDEMO_TABLE_INLINE bool EditSaveBody( TableWriter & w, TableIds & ids, con
                 if ( !RemoveTextSaveBody( w, ids, value.body.remove ) ) { return false; }
                 break;
             }
-            case EditBodyType::Count:
+            case EditBodyType::Tally:
             {
                 const uint64_t arm_ref = ids.ref( 0xb1e5e28e4479a274ull );
                 int64_t arm_payload = 0;
                 arm_payload += 4; // int32
-                w.putleb( arm_ref ); w.put8( 4 ); w.putleb( (uint64_t) arm_payload ); // count
-                w.put32( uint32_t( value.body.count ) );
+                w.putleb( arm_ref ); w.put8( 4 ); w.putleb( (uint64_t) arm_payload ); // tally
+                w.put32( uint32_t( value.body.tally ) );
                 break;
             }
             case EditBodyType::Marks:
@@ -5905,7 +5956,7 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                             if ( sub.offset != sub.size ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
                             break;
                         }
-                        case 0xb1e5e28e4479a274ull: // count
+                        case 0xb1e5e28e4479a274ull: // tally
                         {
                             if ( arm_kind != 4 )
                             {
@@ -5914,14 +5965,14 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                                     // WIDENED AT AN ARM (§4): the payload decodes at its own width; an L
                                     // that is not that width is the arm's own framing damage (§3)
                                     if ( sub.size != TableKindWidth( arm_kind ) ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
-                                    memset( (void *) &value.body.count, 0, sizeof( value.body.count ) ); // selection establishes the arm (§2.6)
+                                    memset( (void *) &value.body.tally, 0, sizeof( value.body.tally ) ); // selection establishes the arm (§2.6)
                                     int64_t widened_v = 0;
                                     if ( !TableReadSignedAt( sub, arm_kind, widened_v ) ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
                                     int32_t decoded_v = (int32_t) widened_v;
                                     if ( decoded_v < 0 ) { decoded_v = 0; r.report->clamped++; }
                                     else if ( decoded_v > 100 ) { decoded_v = 100; r.report->clamped++; }
-                                    value.body.count = decoded_v;
-                                    value.body.type = EditBodyType::Count;
+                                    value.body.tally = decoded_v;
+                                    value.body.type = EditBodyType::Tally;
                                     r.report->widened++;
                                     break;
                                 }
@@ -5931,13 +5982,13 @@ MESSAGEDEMO_TABLE_INLINE bool EditLoadBody( TableReader & r, Edit & value )
                                 r.report->kind_mismatch++;
                                 break;
                             }
-                            value.body.type = EditBodyType::Count;
+                            value.body.type = EditBodyType::Tally;
                             if ( sub.size != 4 ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; } // an L that is not the kind's width is that arm's own framing damage (§3)
                             if ( !sub.has( 4 ) ) { value.body.type = EditBodyType::None; r.report->malformed = true; break; }
                             int32_t decoded_v = int32_t( sub.get32( ) );
                             if ( decoded_v < 0 ) { decoded_v = 0; r.report->clamped++; }
                             else if ( decoded_v > 100 ) { decoded_v = 100; r.report->clamped++; }
-                            value.body.count = decoded_v;
+                            value.body.tally = decoded_v;
                             break;
                         }
                         case 0x9077d4a4e1726e29ull: // marks
@@ -6155,7 +6206,7 @@ inline int64_t EditMeasureMessageBody( int64_t at, const Edit & value )
                 }
                 break;
             }
-            case EditBodyType::Count:
+            case EditBodyType::Tally:
             {
                 bits += kTableMessageRefBitsHere;
                 bits += 7;
@@ -6220,10 +6271,10 @@ inline bool EditSaveMessageBody( TableBitWriter & w, const Edit & value )
                 if ( !RemoveTextSaveMessageBody( w, value.body.remove ) ) { return false; }
                 break;
             }
-            case EditBodyType::Count:
+            case EditBodyType::Tally:
             {
                 w.put( 32, kTableMessageRefBitsHere );
-                w.put( (uint64_t) ( value.body.count ), 7 );
+                w.put( (uint64_t) ( value.body.tally ), 7 );
                 break;
             }
             case EditBodyType::Marks:
@@ -6368,14 +6419,14 @@ inline bool EditLoadMessageBody( TableBitReader & r, const TableVocabulary & voc
                                 if ( !RemoveTextLoadMessageBody( r, vocabulary, report, index_bits, value.body.remove ) ) { return false; }
                                 break;
                             }
-                            case 0xb1e5e28e4479a274ull: // count
+                            case 0xb1e5e28e4479a274ull: // tally
                             {
                                 if ( arm.kind != 4 || arm.elem_kind != 0 )
                                 {
                                     if ( TableKindWidens( arm.kind, 4 ) )
                                     {
-                                        value.body.type = EditBodyType::Count;
-                                        memset( (void *) &value.body.count, 0, sizeof( value.body.count ) ); // selection establishes the arm (§2.6)
+                                        value.body.type = EditBodyType::Tally;
+                                        memset( (void *) &value.body.tally, 0, sizeof( value.body.tally ) ); // selection establishes the arm (§2.6)
                                         {
                                             const int64_t width_2 = arm.value_bits;
                                             uint64_t raw_2 = 0;
@@ -6390,7 +6441,7 @@ inline bool EditLoadMessageBody( TableBitReader & r, const TableVocabulary & voc
                                             if ( decoded_wide_2 < 0ll ) { decoded_wide_2 = 0ll; report->clamped++; }
                                             if ( decoded_wide_2 > 100ll ) { decoded_wide_2 = 100ll; report->clamped++; }
                                             int32_t decoded_v_2 = (int32_t) decoded_wide_2;
-                                            value.body.count = decoded_v_2;
+                                            value.body.tally = decoded_v_2;
                                         }
                                         report->widened++;
                                         break;
@@ -6399,7 +6450,7 @@ inline bool EditLoadMessageBody( TableBitReader & r, const TableVocabulary & voc
                                     if ( !TableMessageSkip( r, vocabulary, index_bits, arm ) ) { report->malformed = true; return false; }
                                     break;
                                 }
-                                value.body.type = EditBodyType::Count;
+                                value.body.type = EditBodyType::Tally;
                                 {
                                     const int64_t width_2 = arm.value_bits;
                                     uint64_t raw_2 = 0;
@@ -6414,7 +6465,7 @@ inline bool EditLoadMessageBody( TableBitReader & r, const TableVocabulary & voc
                                     if ( decoded_wide_2 < 0ll ) { decoded_wide_2 = 0ll; report->clamped++; }
                                     if ( decoded_wide_2 > 100ll ) { decoded_wide_2 = 100ll; report->clamped++; }
                                     int32_t decoded_v_2 = (int32_t) decoded_wide_2;
-                                    value.body.count = decoded_v_2;
+                                    value.body.tally = decoded_v_2;
                                 }
                                 break;
                             }
@@ -7477,7 +7528,7 @@ inline int64_t TransactionMeasureBody( TableIds & ids, const Transaction & value
                             body_pending += TableLebBytes( arm_refu ) + 1 + TableLebBytes( (uint64_t) ( arm_payloadu ) ) + ( arm_payloadu );
                             break;
                         }
-                        case EditBodyType::Count:
+                        case EditBodyType::Tally:
                         {
                             int64_t arm_payloadu = 0;
                             const uint64_t arm_refu = ids.ref( 0xb1e5e28e4479a274ull );
@@ -7628,7 +7679,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionSaveBody( TableWriter & w, TableIds & i
                             body_pending += TableLebBytes( arm_refu ) + 1 + TableLebBytes( (uint64_t) ( arm_payloadu ) ) + ( arm_payloadu );
                             break;
                         }
-                        case EditBodyType::Count:
+                        case EditBodyType::Tally:
                         {
                             int64_t arm_payloadu = 0;
                             const uint64_t arm_refu = ids.ref( 0xb1e5e28e4479a274ull );
@@ -7706,13 +7757,13 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionSaveBody( TableWriter & w, TableIds & i
                             if ( !RemoveTextSaveBody( w, ids, value.pending[elem_i].remove ) ) { return false; }
                             break;
                         }
-                        case EditBodyType::Count:
+                        case EditBodyType::Tally:
                         {
                             const uint64_t arm_refu = ids.ref( 0xb1e5e28e4479a274ull );
                             int64_t arm_payloadu = 0;
                             arm_payloadu += 4; // int32
-                            w.putleb( arm_refu ); w.put8( 4 ); w.putleb( (uint64_t) arm_payloadu ); // count
-                            w.put32( uint32_t( value.pending[elem_i].count ) );
+                            w.putleb( arm_refu ); w.put8( 4 ); w.putleb( (uint64_t) arm_payloadu ); // tally
+                            w.put32( uint32_t( value.pending[elem_i].tally ) );
                             break;
                         }
                         case EditBodyType::Marks:
@@ -7992,7 +8043,7 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                         if ( elem_arm.offset != elem_arm.size ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
                                         break;
                                     }
-                                    case 0xb1e5e28e4479a274ull: // count
+                                    case 0xb1e5e28e4479a274ull: // tally
                                     {
                                         if ( elem_arm_kind != 4 )
                                         {
@@ -8001,26 +8052,26 @@ MESSAGEDEMO_TABLE_INLINE bool TransactionLoadBody( TableReader & r, Transaction 
                                                 // WIDENED AT AN ARM (§4): the payload decodes at its own width; an L
                                                 // that is not that width is the arm's own framing damage (§3)
                                                 if ( elem_arm.size != TableKindWidth( elem_arm_kind ) ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
-                                                memset( (void *) &value.pending[(int32_t) i].count, 0, sizeof( value.pending[(int32_t) i].count ) ); // selection establishes the arm (§2.6)
+                                                memset( (void *) &value.pending[(int32_t) i].tally, 0, sizeof( value.pending[(int32_t) i].tally ) ); // selection establishes the arm (§2.6)
                                                 int64_t widened_v = 0;
                                                 if ( !TableReadSignedAt( elem_arm, elem_arm_kind, widened_v ) ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
                                                 int32_t decoded_v = (int32_t) widened_v;
                                                 if ( decoded_v < 0 ) { decoded_v = 0; r.report->clamped++; }
                                                 else if ( decoded_v > 100 ) { decoded_v = 100; r.report->clamped++; }
-                                                value.pending[(int32_t) i].count = decoded_v;
-                                                value.pending[(int32_t) i].type = EditBodyType::Count;
+                                                value.pending[(int32_t) i].tally = decoded_v;
+                                                value.pending[(int32_t) i].type = EditBodyType::Tally;
                                                 r.report->widened++;
                                                 break;
                                             }
                                             value.pending[(int32_t) i].type = EditBodyType::None; r.report->kind_mismatch++; break;
                                         }
-                                        value.pending[(int32_t) i].type = EditBodyType::Count;
+                                        value.pending[(int32_t) i].type = EditBodyType::Tally;
                                         if ( elem_arm.size != 4 ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; } // an L that is not the kind's width is that arm's own framing damage (§3)
                                         if ( !elem_arm.has( 4 ) ) { value.pending[(int32_t) i].type = EditBodyType::None; r.report->malformed = true; break; }
                                         int32_t decoded_v = int32_t( elem_arm.get32( ) );
                                         if ( decoded_v < 0 ) { decoded_v = 0; r.report->clamped++; }
                                         else if ( decoded_v > 100 ) { decoded_v = 100; r.report->clamped++; }
-                                        value.pending[(int32_t) i].count = decoded_v;
+                                        value.pending[(int32_t) i].tally = decoded_v;
                                         break;
                                     }
                                     case 0x9077d4a4e1726e29ull: // marks
@@ -8364,7 +8415,7 @@ inline int64_t TransactionMeasureMessageBody( int64_t at, const Transaction & va
                             }
                             break;
                         }
-                        case EditBodyType::Count:
+                        case EditBodyType::Tally:
                         {
                             bits += kTableMessageRefBitsHere;
                             bits += 7;
@@ -8471,10 +8522,10 @@ inline bool TransactionSaveMessageBody( TableBitWriter & w, const Transaction & 
                             if ( !RemoveTextSaveMessageBody( w, value.pending[i].remove ) ) { return false; }
                             break;
                         }
-                        case EditBodyType::Count:
+                        case EditBodyType::Tally:
                         {
                             w.put( 32, kTableMessageRefBitsHere );
-                            w.put( (uint64_t) ( value.pending[i].count ), 7 );
+                            w.put( (uint64_t) ( value.pending[i].tally ), 7 );
                             break;
                         }
                         case EditBodyType::Marks:
@@ -8679,14 +8730,14 @@ inline bool TransactionLoadMessageBody( TableBitReader & r, const TableVocabular
                                         if ( !RemoveTextLoadMessageBody( r, vocabulary, report, index_bits, ( in_bounds ? value.pending[i] : scratch ).remove ) ) { return false; }
                                         break;
                                     }
-                                    case 0xb1e5e28e4479a274ull: // count
+                                    case 0xb1e5e28e4479a274ull: // tally
                                     {
                                         if ( arm_2.kind != 4 || arm_2.elem_kind != 0 )
                                         {
                                             if ( TableKindWidens( arm_2.kind, 4 ) )
                                             {
-                                                ( in_bounds ? value.pending[i] : scratch ).type = EditBodyType::Count;
-                                                memset( (void *) &( in_bounds ? value.pending[i] : scratch ).count, 0, sizeof( ( in_bounds ? value.pending[i] : scratch ).count ) ); // selection establishes the arm (§2.6)
+                                                ( in_bounds ? value.pending[i] : scratch ).type = EditBodyType::Tally;
+                                                memset( (void *) &( in_bounds ? value.pending[i] : scratch ).tally, 0, sizeof( ( in_bounds ? value.pending[i] : scratch ).tally ) ); // selection establishes the arm (§2.6)
                                                 {
                                                     const int64_t width_3 = arm_2.value_bits;
                                                     uint64_t raw_3 = 0;
@@ -8701,7 +8752,7 @@ inline bool TransactionLoadMessageBody( TableBitReader & r, const TableVocabular
                                                     if ( decoded_wide_3 < 0ll ) { decoded_wide_3 = 0ll; report->clamped++; }
                                                     if ( decoded_wide_3 > 100ll ) { decoded_wide_3 = 100ll; report->clamped++; }
                                                     int32_t decoded_v_3 = (int32_t) decoded_wide_3;
-                                                    ( in_bounds ? value.pending[i] : scratch ).count = decoded_v_3;
+                                                    ( in_bounds ? value.pending[i] : scratch ).tally = decoded_v_3;
                                                 }
                                                 report->widened++;
                                                 break;
@@ -8710,7 +8761,7 @@ inline bool TransactionLoadMessageBody( TableBitReader & r, const TableVocabular
                                             if ( !TableMessageSkip( r, vocabulary, index_bits, arm_2 ) ) { report->malformed = true; return false; }
                                             break;
                                         }
-                                        ( in_bounds ? value.pending[i] : scratch ).type = EditBodyType::Count;
+                                        ( in_bounds ? value.pending[i] : scratch ).type = EditBodyType::Tally;
                                         {
                                             const int64_t width_3 = arm_2.value_bits;
                                             uint64_t raw_3 = 0;
@@ -8725,7 +8776,7 @@ inline bool TransactionLoadMessageBody( TableBitReader & r, const TableVocabular
                                             if ( decoded_wide_3 < 0ll ) { decoded_wide_3 = 0ll; report->clamped++; }
                                             if ( decoded_wide_3 > 100ll ) { decoded_wide_3 = 100ll; report->clamped++; }
                                             int32_t decoded_v_3 = (int32_t) decoded_wide_3;
-                                            ( in_bounds ? value.pending[i] : scratch ).count = decoded_v_3;
+                                            ( in_bounds ? value.pending[i] : scratch ).tally = decoded_v_3;
                                         }
                                         break;
                                     }
@@ -13542,9 +13593,9 @@ inline void EditCookBody( uint8_t * at, const Edit & value, TableByteOrder order
         {
             case EditBodyType::Insert: InsertTextCookBody( at + 4 + 4, value.body.insert, order ); break;
             case EditBodyType::Remove: RemoveTextCookBody( at + 4 + 4, value.body.remove, order ); break;
-            case EditBodyType::Count:
+            case EditBodyType::Tally:
             {
-                table_cook_put( at + 4 + 4, (uint64_t) value.body.count, 4, order );
+                table_cook_put( at + 4 + 4, (uint64_t) value.body.tally, 4, order );
                 break;
             }
             case EditBodyType::Marks:
@@ -13606,9 +13657,9 @@ inline void TransactionCookBody( uint8_t * at, const Transaction & value, TableB
             {
                 case EditBodyType::Insert: InsertTextCookBody( at + 964 + i * 308 + 4, value.pending[ i ].insert, order ); break;
                 case EditBodyType::Remove: RemoveTextCookBody( at + 964 + i * 308 + 4, value.pending[ i ].remove, order ); break;
-                case EditBodyType::Count:
+                case EditBodyType::Tally:
                 {
-                    table_cook_put( at + 964 + i * 308 + 4, (uint64_t) value.pending[ i ].count, 4, order );
+                    table_cook_put( at + 964 + i * 308 + 4, (uint64_t) value.pending[ i ].tally, 4, order );
                     break;
                 }
                 case EditBodyType::Marks:
@@ -14465,7 +14516,7 @@ inline const TableTypeInfo * EditTableType()
 {
     static const TableFieldInfo fields[] = {
         { "revision", "revision", "uint32", 0xd6a4dbc46c8e8658ull, 8, false, false, false, 0, (uint32_t) offsetof( Edit, revision ), (uint32_t) sizeof( Edit::revision ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
-        { "body", "body", "EditBody", 0xcd4de79bc6c93295ull, 15, false, false, false, 0, (uint32_t) offsetof( Edit, body ), (uint32_t) sizeof( Edit::body ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 6, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "insert"; case 2: return "remove"; case 3: return "count"; case 4: return "marks"; case 5: return "blob"; case 6: return "mode"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0x7271c68759916228ull; case 2: return 0xfff83d536a1d457dull; case 3: return 0xb1e5e28e4479a274ull; case 4: return 0x9077d4a4e1726e29ull; case 5: return 0xc573b39bc29148caull; case 6: return 0x0d3deba2c41dadb2ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_EditBody[] = { { "count", "count", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( EditBody, count ), (uint32_t) sizeof( EditBody::count ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 100.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "marks", "marks", "uint16", 0x9077d4a4e1726e29ull, 7, true, true, false, 3, (uint32_t) offsetof( EditBody, marks.value ), (uint32_t) sizeof( EditBody::marks.value[0] ), (uint32_t) offsetof( EditBody, marks.value_count ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "blob", "blob", "bytes", 0xc573b39bc29148caull, 6, true, true, false, 4, (uint32_t) offsetof( EditBody, blob.value ), (uint32_t) sizeof( EditBody::blob.value[0] ), (uint32_t) offsetof( EditBody, blob.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "mode", "mode", "Mode", 0x0d3deba2c41dadb2ull, 30, false, false, false, 0, (uint32_t) offsetof( EditBody, mode ), (uint32_t) sizeof( EditBody::mode ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 2, +[]( uint64_t v ) { return EnumName( Mode( v ) ); }, +[]( uint64_t v ) -> uint64_t { uint64_t id = 0; TableEnumId( Mode( v ), id ); return id; }, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( EditBody, insert ), InsertTextTableType(), NULL, 304 }, { (uint32_t) offsetof( EditBody, remove ), RemoveTextTableType(), NULL, 16 }, { (uint32_t) offsetof( EditBody, count ), NULL, &arm_fields_EditBody[0], 4 }, { (uint32_t) offsetof( EditBody, marks ), NULL, &arm_fields_EditBody[1], 12 }, { (uint32_t) offsetof( EditBody, blob ), NULL, &arm_fields_EditBody[2], 8 }, { (uint32_t) offsetof( EditBody, mode ), NULL, &arm_fields_EditBody[3], 1 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( EditBody, type ), (uint32_t) sizeof( EditBody::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
+        { "body", "body", "EditBody", 0xcd4de79bc6c93295ull, 15, false, false, false, 0, (uint32_t) offsetof( Edit, body ), (uint32_t) sizeof( Edit::body ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 6, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "insert"; case 2: return "remove"; case 3: return "tally"; case 4: return "marks"; case 5: return "blob"; case 6: return "mode"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0x7271c68759916228ull; case 2: return 0xfff83d536a1d457dull; case 3: return 0xb1e5e28e4479a274ull; case 4: return 0x9077d4a4e1726e29ull; case 5: return 0xc573b39bc29148caull; case 6: return 0x0d3deba2c41dadb2ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_EditBody[] = { { "tally", "tally", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( EditBody, tally ), (uint32_t) sizeof( EditBody::tally ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 100.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "marks", "marks", "uint16", 0x9077d4a4e1726e29ull, 7, true, true, false, 3, (uint32_t) offsetof( EditBody, marks.value ), (uint32_t) sizeof( EditBody::marks.value[0] ), (uint32_t) offsetof( EditBody, marks.value_count ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "blob", "blob", "bytes", 0xc573b39bc29148caull, 6, true, true, false, 4, (uint32_t) offsetof( EditBody, blob.value ), (uint32_t) sizeof( EditBody::blob.value[0] ), (uint32_t) offsetof( EditBody, blob.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "mode", "mode", "Mode", 0x0d3deba2c41dadb2ull, 30, false, false, false, 0, (uint32_t) offsetof( EditBody, mode ), (uint32_t) sizeof( EditBody::mode ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 2, +[]( uint64_t v ) { return EnumName( Mode( v ) ); }, +[]( uint64_t v ) -> uint64_t { uint64_t id = 0; TableEnumId( Mode( v ), id ); return id; }, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( EditBody, insert ), InsertTextTableType(), NULL, 304 }, { (uint32_t) offsetof( EditBody, remove ), RemoveTextTableType(), NULL, 16 }, { (uint32_t) offsetof( EditBody, tally ), NULL, &arm_fields_EditBody[0], 4 }, { (uint32_t) offsetof( EditBody, marks ), NULL, &arm_fields_EditBody[1], 12 }, { (uint32_t) offsetof( EditBody, blob ), NULL, &arm_fields_EditBody[2], 8 }, { (uint32_t) offsetof( EditBody, mode ), NULL, &arm_fields_EditBody[3], 1 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( EditBody, type ), (uint32_t) sizeof( EditBody::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
     };
     static const TableTypeInfo info = { "Edit", (uint32_t) sizeof( Edit ), 2, fields, +[]( void * p ) { EditReset( *(Edit *) p ); }, TableDocNone, 0, NULL };
     return &info;
@@ -14497,7 +14548,7 @@ inline const TableTypeInfo * TransactionTableType()
     static const TableFieldInfo fields[] = {
         { "reason", "reason", "string", 0x65e8d7f3474f2639ull, 12, false, true, false, 16, (uint32_t) offsetof( Transaction, reason ), (uint32_t) sizeof( Transaction::reason ), (uint32_t) offsetof( Transaction, reason_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
         { "edits", "edits", "Edit", 0x9478d06b697549e6ull, 13, true, true, false, 3, (uint32_t) offsetof( Transaction, edits ), (uint32_t) sizeof( Transaction::edits[0] ), (uint32_t) offsetof( Transaction, edits_count ), 0xffffffffu, EditTableType(), false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
-        { "pending", "pending", "EditBody", 0x52dea0d6eeb5083cull, 15, true, false, false, 2, (uint32_t) offsetof( Transaction, pending ), (uint32_t) sizeof( Transaction::pending[0] ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 6, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "insert"; case 2: return "remove"; case 3: return "count"; case 4: return "marks"; case 5: return "blob"; case 6: return "mode"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0x7271c68759916228ull; case 2: return 0xfff83d536a1d457dull; case 3: return 0xb1e5e28e4479a274ull; case 4: return 0x9077d4a4e1726e29ull; case 5: return 0xc573b39bc29148caull; case 6: return 0x0d3deba2c41dadb2ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_EditBody[] = { { "count", "count", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( EditBody, count ), (uint32_t) sizeof( EditBody::count ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 100.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "marks", "marks", "uint16", 0x9077d4a4e1726e29ull, 7, true, true, false, 3, (uint32_t) offsetof( EditBody, marks.value ), (uint32_t) sizeof( EditBody::marks.value[0] ), (uint32_t) offsetof( EditBody, marks.value_count ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "blob", "blob", "bytes", 0xc573b39bc29148caull, 6, true, true, false, 4, (uint32_t) offsetof( EditBody, blob.value ), (uint32_t) sizeof( EditBody::blob.value[0] ), (uint32_t) offsetof( EditBody, blob.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "mode", "mode", "Mode", 0x0d3deba2c41dadb2ull, 30, false, false, false, 0, (uint32_t) offsetof( EditBody, mode ), (uint32_t) sizeof( EditBody::mode ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 2, +[]( uint64_t v ) { return EnumName( Mode( v ) ); }, +[]( uint64_t v ) -> uint64_t { uint64_t id = 0; TableEnumId( Mode( v ), id ); return id; }, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( EditBody, insert ), InsertTextTableType(), NULL, 304 }, { (uint32_t) offsetof( EditBody, remove ), RemoveTextTableType(), NULL, 16 }, { (uint32_t) offsetof( EditBody, count ), NULL, &arm_fields_EditBody[0], 4 }, { (uint32_t) offsetof( EditBody, marks ), NULL, &arm_fields_EditBody[1], 12 }, { (uint32_t) offsetof( EditBody, blob ), NULL, &arm_fields_EditBody[2], 8 }, { (uint32_t) offsetof( EditBody, mode ), NULL, &arm_fields_EditBody[3], 1 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( EditBody, type ), (uint32_t) sizeof( EditBody::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
+        { "pending", "pending", "EditBody", 0x52dea0d6eeb5083cull, 15, true, false, false, 2, (uint32_t) offsetof( Transaction, pending ), (uint32_t) sizeof( Transaction::pending[0] ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 6, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "insert"; case 2: return "remove"; case 3: return "tally"; case 4: return "marks"; case 5: return "blob"; case 6: return "mode"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0x7271c68759916228ull; case 2: return 0xfff83d536a1d457dull; case 3: return 0xb1e5e28e4479a274ull; case 4: return 0x9077d4a4e1726e29ull; case 5: return 0xc573b39bc29148caull; case 6: return 0x0d3deba2c41dadb2ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_EditBody[] = { { "tally", "tally", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( EditBody, tally ), (uint32_t) sizeof( EditBody::tally ), 0xffffffffu, 0xffffffffu, NULL, true, 0.0, 100.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "marks", "marks", "uint16", 0x9077d4a4e1726e29ull, 7, true, true, false, 3, (uint32_t) offsetof( EditBody, marks.value ), (uint32_t) sizeof( EditBody::marks.value[0] ), (uint32_t) offsetof( EditBody, marks.value_count ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "blob", "blob", "bytes", 0xc573b39bc29148caull, 6, true, true, false, 4, (uint32_t) offsetof( EditBody, blob.value ), (uint32_t) sizeof( EditBody::blob.value[0] ), (uint32_t) offsetof( EditBody, blob.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "mode", "mode", "Mode", 0x0d3deba2c41dadb2ull, 30, false, false, false, 0, (uint32_t) offsetof( EditBody, mode ), (uint32_t) sizeof( EditBody::mode ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 2, +[]( uint64_t v ) { return EnumName( Mode( v ) ); }, +[]( uint64_t v ) -> uint64_t { uint64_t id = 0; TableEnumId( Mode( v ), id ); return id; }, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( EditBody, insert ), InsertTextTableType(), NULL, 304 }, { (uint32_t) offsetof( EditBody, remove ), RemoveTextTableType(), NULL, 16 }, { (uint32_t) offsetof( EditBody, tally ), NULL, &arm_fields_EditBody[0], 4 }, { (uint32_t) offsetof( EditBody, marks ), NULL, &arm_fields_EditBody[1], 12 }, { (uint32_t) offsetof( EditBody, blob ), NULL, &arm_fields_EditBody[2], 8 }, { (uint32_t) offsetof( EditBody, mode ), NULL, &arm_fields_EditBody[3], 1 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( EditBody, type ), (uint32_t) sizeof( EditBody::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
         { "checkpoints", "checkpoints", "uint32", 0x028afa1c4d757704ull, 8, true, false, true, 2, (uint32_t) offsetof( Transaction, checkpoints ), (uint32_t) sizeof( Transaction::checkpoints[0] ), 0xffffffffu, (uint32_t) offsetof( Transaction, checkpoints_present ), NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
         { "snapshots", "snapshots", "Selection", 0x99dc6354a681403aull, 13, true, false, true, 2, (uint32_t) offsetof( Transaction, snapshots ), (uint32_t) sizeof( Transaction::snapshots[0] ), 0xffffffffu, (uint32_t) offsetof( Transaction, snapshots_present ), SelectionTableType(), false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
     };

--- a/testdata/golden/tables/stream/StreamTable.h
+++ b/testdata/golden/tables/stream/StreamTable.h
@@ -4487,8 +4487,23 @@ enum class FrameType : uint8_t {
     Chunk = 2,
     Link = 3,
     Tag = 4,
+    Count = 4, // the declared variant count (SPEC §4.2)
     Max = 4, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any FrameType value, out-of-set included
+inline const char * EnumName( FrameType value )
+{
+    switch ( value )
+    {
+        case FrameType::None: return "None";
+        case FrameType::Header: return "Header";
+        case FrameType::Chunk: return "Chunk";
+        case FrameType::Link: return "Link";
+        case FrameType::Tag: return "Tag";
+        default: return "???";
+    }
+}
 
 // union Frame — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage

--- a/testdata/golden/tables/wide/CaptionTable.h
+++ b/testdata/golden/tables/wide/CaptionTable.h
@@ -2175,9 +2175,23 @@ enum class BodyType : uint8_t {
     None = 0,
     Wide = 1,
     Narrow = 2,
-    Count = 3,
+    Tally = 3,
+    Count = 3, // the declared variant count (SPEC §4.2)
     Max = 3, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any BodyType value, out-of-set included
+inline const char * EnumName( BodyType value )
+{
+    switch ( value )
+    {
+        case BodyType::None: return "None";
+        case BodyType::Wide: return "Wide";
+        case BodyType::Narrow: return "Narrow";
+        case BodyType::Tally: return "Tally";
+        default: return "???";
+    }
+}
 
 // union Body — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage
@@ -2196,7 +2210,7 @@ struct Body
     {
         struct { char16_t value[4 + 1]; int32_t value_length; } wide; // wstring(4), the used length in CODE UNITS
         struct { char value[4 + 1]; int32_t value_length; } narrow; // string(4)
-        int32_t count;
+        int32_t tally;
     };
 
     Body() : type( BodyType::None ) {} // the tag only — arms are established at selection
@@ -2320,7 +2334,7 @@ inline int64_t CaptionMeasureBody( TableIds & ids, const Caption & value )
                 bytes += TableLebBytes( arm_ref ) + 1 + TableLebBytes( (uint64_t) ( arm_payload ) ) + ( arm_payload );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 int64_t arm_payload = 0;
                 const uint64_t arm_ref = ids.ref( 0xb1e5e28e4479a274ull );
@@ -2414,13 +2428,13 @@ WIDE_TABLE_INLINE bool CaptionSaveBody( TableWriter & w, TableIds & ids, const C
                 w.raw( value.body.narrow.value, value.body.narrow.value_length );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 const uint64_t arm_ref = ids.ref( 0xb1e5e28e4479a274ull );
                 int64_t arm_payload = 0;
                 arm_payload += 4; // int32
-                w.putleb( arm_ref ); w.put8( 4 ); w.putleb( (uint64_t) arm_payload ); // count
-                w.put32( uint32_t( value.body.count ) );
+                w.putleb( arm_ref ); w.put8( 4 ); w.putleb( (uint64_t) arm_payload ); // tally
+                w.put32( uint32_t( value.body.tally ) );
                 break;
             }
             default: return false; // write validates the tag before it rides
@@ -2645,7 +2659,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                             }
                             break;
                         }
-                        case 0xb1e5e28e4479a274ull: // count
+                        case 0xb1e5e28e4479a274ull: // tally
                         {
                             if ( arm_kind != 4 )
                             {
@@ -2654,12 +2668,12 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                                     // WIDENED AT AN ARM (§4): the payload decodes at its own width; an L
                                     // that is not that width is the arm's own framing damage (§3)
                                     if ( sub.size != TableKindWidth( arm_kind ) ) { value.body.type = BodyType::None; r.report->malformed = true; break; }
-                                    memset( (void *) &value.body.count, 0, sizeof( value.body.count ) ); // selection establishes the arm (§2.6)
+                                    memset( (void *) &value.body.tally, 0, sizeof( value.body.tally ) ); // selection establishes the arm (§2.6)
                                     int64_t widened_v = 0;
                                     if ( !TableReadSignedAt( sub, arm_kind, widened_v ) ) { value.body.type = BodyType::None; r.report->malformed = true; break; }
                                     int32_t decoded_v = (int32_t) widened_v;
-                                    value.body.count = decoded_v;
-                                    value.body.type = BodyType::Count;
+                                    value.body.tally = decoded_v;
+                                    value.body.type = BodyType::Tally;
                                     r.report->widened++;
                                     break;
                                 }
@@ -2669,11 +2683,11 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                                 r.report->kind_mismatch++;
                                 break;
                             }
-                            value.body.type = BodyType::Count;
+                            value.body.type = BodyType::Tally;
                             if ( sub.size != 4 ) { value.body.type = BodyType::None; r.report->malformed = true; break; } // an L that is not the kind's width is that arm's own framing damage (§3)
                             if ( !sub.has( 4 ) ) { value.body.type = BodyType::None; r.report->malformed = true; break; }
                             int32_t decoded_v = int32_t( sub.get32( ) );
-                            value.body.count = decoded_v;
+                            value.body.tally = decoded_v;
                             break;
                         }
                         default:
@@ -2805,7 +2819,7 @@ inline int64_t CaptionMeasureMessageBody( int64_t at, const Caption & value )
                 bits += (int64_t) value.body.narrow.value_length * 8;
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 bits += kTableMessageRefBitsHere;
                 bits += 32;
@@ -2872,10 +2886,10 @@ inline bool CaptionSaveMessageBody( TableBitWriter & w, const Caption & value )
                 w.putbytes( (const uint8_t *) value.body.narrow.value, value.body.narrow.value_length );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 w.put( 10, kTableMessageRefBitsHere );
-                w.put( (uint64_t) ( value.body.count ), 32 );
+                w.put( (uint64_t) ( value.body.tally ), 32 );
                 break;
             }
             default: return false; // a tag no arm names has no wire identity
@@ -3079,14 +3093,14 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                 }
                                 break;
                             }
-                            case 0xb1e5e28e4479a274ull: // count
+                            case 0xb1e5e28e4479a274ull: // tally
                             {
                                 if ( arm.kind != 4 || arm.elem_kind != 0 )
                                 {
                                     if ( TableKindWidens( arm.kind, 4 ) )
                                     {
-                                        value.body.type = BodyType::Count;
-                                        memset( (void *) &value.body.count, 0, sizeof( value.body.count ) ); // selection establishes the arm (§2.6)
+                                        value.body.type = BodyType::Tally;
+                                        memset( (void *) &value.body.tally, 0, sizeof( value.body.tally ) ); // selection establishes the arm (§2.6)
                                         {
                                             const int64_t width_2 = arm.value_bits;
                                             uint64_t raw_2 = 0;
@@ -3101,7 +3115,7 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                             if ( decoded_wide_2 < -2147483648ll ) { decoded_wide_2 = -2147483648ll; report->clamped++; }
                                             if ( decoded_wide_2 > 2147483647ll ) { decoded_wide_2 = 2147483647ll; report->clamped++; }
                                             int32_t decoded_v_2 = (int32_t) decoded_wide_2;
-                                            value.body.count = decoded_v_2;
+                                            value.body.tally = decoded_v_2;
                                         }
                                         report->widened++;
                                         break;
@@ -3110,7 +3124,7 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                     if ( !TableMessageSkip( r, vocabulary, index_bits, arm ) ) { report->malformed = true; return false; }
                                     break;
                                 }
-                                value.body.type = BodyType::Count;
+                                value.body.type = BodyType::Tally;
                                 {
                                     const int64_t width_2 = arm.value_bits;
                                     uint64_t raw_2 = 0;
@@ -3125,7 +3139,7 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                     if ( decoded_wide_2 < -2147483648ll ) { decoded_wide_2 = -2147483648ll; report->clamped++; }
                                     if ( decoded_wide_2 > 2147483647ll ) { decoded_wide_2 = 2147483647ll; report->clamped++; }
                                     int32_t decoded_v_2 = (int32_t) decoded_wide_2;
-                                    value.body.count = decoded_v_2;
+                                    value.body.tally = decoded_v_2;
                                 }
                                 break;
                             }
@@ -4137,9 +4151,9 @@ inline void CaptionCookBody( uint8_t * at, const Caption & value, TableByteOrder
                 table_cook_put( at + 88 + 12, (uint64_t) (uint32_t) value.body.narrow.value_length, 4, order );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
-                table_cook_put( at + 88 + 4, (uint64_t) value.body.count, 4, order );
+                table_cook_put( at + 88 + 4, (uint64_t) value.body.tally, 4, order );
                 break;
             }
             default: break; // every byte outside the set arm stays zero
@@ -4314,7 +4328,7 @@ inline const TableTypeInfo * CaptionTableType()
         { "title", "title", "wstring", 0xda31296c0c1b6029ull, 33, false, true, false, 7, (uint32_t) offsetof( Caption, title ), (uint32_t) sizeof( Caption::title ), (uint32_t) offsetof( Caption, title_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
         { "line", "line", "Line", 0xbf4ba5ad694f5907ull, 13, false, false, false, 0, (uint32_t) offsetof( Caption, line ), (uint32_t) sizeof( Caption::line ), 0xffffffffu, 0xffffffffu, LineTableType(), false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
         { "lines", "lines", "Line", 0x5ce3f9a9f1d5001cull, 13, true, true, false, 3, (uint32_t) offsetof( Caption, lines ), (uint32_t) sizeof( Caption::lines[0] ), (uint32_t) offsetof( Caption, lines_count ), 0xffffffffu, LineTableType(), false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
-        { "body", "body", "Body", 0xcd4de79bc6c93295ull, 15, false, false, false, 0, (uint32_t) offsetof( Caption, body ), (uint32_t) sizeof( Caption::body ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 3, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "wide"; case 2: return "narrow"; case 3: return "count"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0xa633f1f655715ccaull; case 2: return 0x96569b06f223c29aull; case 3: return 0xb1e5e28e4479a274ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_Body[] = { { "wide", "wide", "wstring", 0xa633f1f655715ccaull, 33, false, true, false, 4, (uint32_t) offsetof( Body, wide.value ), (uint32_t) sizeof( Body::wide.value ), (uint32_t) offsetof( Body, wide.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "narrow", "narrow", "string", 0x96569b06f223c29aull, 12, false, true, false, 4, (uint32_t) offsetof( Body, narrow.value ), (uint32_t) sizeof( Body::narrow.value ), (uint32_t) offsetof( Body, narrow.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "count", "count", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( Body, count ), (uint32_t) sizeof( Body::count ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( Body, wide ), NULL, &arm_fields_Body[0], 16 }, { (uint32_t) offsetof( Body, narrow ), NULL, &arm_fields_Body[1], 12 }, { (uint32_t) offsetof( Body, count ), NULL, &arm_fields_Body[2], 4 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( Body, type ), (uint32_t) sizeof( Body::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
+        { "body", "body", "Body", 0xcd4de79bc6c93295ull, 15, false, false, false, 0, (uint32_t) offsetof( Caption, body ), (uint32_t) sizeof( Caption::body ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 3, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "wide"; case 2: return "narrow"; case 3: return "tally"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0xa633f1f655715ccaull; case 2: return 0x96569b06f223c29aull; case 3: return 0xb1e5e28e4479a274ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_Body[] = { { "wide", "wide", "wstring", 0xa633f1f655715ccaull, 33, false, true, false, 4, (uint32_t) offsetof( Body, wide.value ), (uint32_t) sizeof( Body::wide.value ), (uint32_t) offsetof( Body, wide.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "narrow", "narrow", "string", 0x96569b06f223c29aull, 12, false, true, false, 4, (uint32_t) offsetof( Body, narrow.value ), (uint32_t) sizeof( Body::narrow.value ), (uint32_t) offsetof( Body, narrow.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "tally", "tally", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( Body, tally ), (uint32_t) sizeof( Body::tally ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( Body, wide ), NULL, &arm_fields_Body[0], 16 }, { (uint32_t) offsetof( Body, narrow ), NULL, &arm_fields_Body[1], 12 }, { (uint32_t) offsetof( Body, tally ), NULL, &arm_fields_Body[2], 4 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( Body, type ), (uint32_t) sizeof( Body::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
     };
     static const TableTypeInfo info = { "Caption", (uint32_t) sizeof( Caption ), 4, fields, +[]( void * p ) { CaptionReset( *(Caption *) p ); }, TableDocNone, 0, NULL };
     return &info;

--- a/testdata/golden/wide/cpp/CaptionTable.h
+++ b/testdata/golden/wide/cpp/CaptionTable.h
@@ -2175,9 +2175,23 @@ enum class BodyType : uint8_t {
     None = 0,
     Wide = 1,
     Narrow = 2,
-    Count = 3,
+    Tally = 3,
+    Count = 3, // the declared variant count (SPEC §4.2)
     Max = 3, // the exported extent (SPEC §4.2)
 };
+
+// EnumName: debug/log name for any BodyType value, out-of-set included
+inline const char * EnumName( BodyType value )
+{
+    switch ( value )
+    {
+        case BodyType::None: return "None";
+        case BodyType::Wide: return "Wide";
+        case BodyType::Narrow: return "Narrow";
+        case BodyType::Tally: return "Tally";
+        default: return "???";
+    }
+}
 
 // union Body — at most one of the arms; the tag says which. AN ARM IS A FIELD
 // LINE (docs/SPEC-TABLES.md §2.6), so an arm's storage is the field's storage
@@ -2196,7 +2210,7 @@ struct Body
     {
         struct { char16_t value[4 + 1]; int32_t value_length; } wide; // wstring(4), the used length in CODE UNITS
         struct { char value[4 + 1]; int32_t value_length; } narrow; // string(4)
-        int32_t count;
+        int32_t tally;
     };
 
     Body() : type( BodyType::None ) {} // the tag only — arms are established at selection
@@ -2320,7 +2334,7 @@ inline int64_t CaptionMeasureBody( TableIds & ids, const Caption & value )
                 bytes += TableLebBytes( arm_ref ) + 1 + TableLebBytes( (uint64_t) ( arm_payload ) ) + ( arm_payload );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 int64_t arm_payload = 0;
                 const uint64_t arm_ref = ids.ref( 0xb1e5e28e4479a274ull );
@@ -2414,13 +2428,13 @@ WIDE_TABLE_INLINE bool CaptionSaveBody( TableWriter & w, TableIds & ids, const C
                 w.raw( value.body.narrow.value, value.body.narrow.value_length );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 const uint64_t arm_ref = ids.ref( 0xb1e5e28e4479a274ull );
                 int64_t arm_payload = 0;
                 arm_payload += 4; // int32
-                w.putleb( arm_ref ); w.put8( 4 ); w.putleb( (uint64_t) arm_payload ); // count
-                w.put32( uint32_t( value.body.count ) );
+                w.putleb( arm_ref ); w.put8( 4 ); w.putleb( (uint64_t) arm_payload ); // tally
+                w.put32( uint32_t( value.body.tally ) );
                 break;
             }
             default: return false; // write validates the tag before it rides
@@ -2645,7 +2659,7 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                             }
                             break;
                         }
-                        case 0xb1e5e28e4479a274ull: // count
+                        case 0xb1e5e28e4479a274ull: // tally
                         {
                             if ( arm_kind != 4 )
                             {
@@ -2654,12 +2668,12 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                                     // WIDENED AT AN ARM (§4): the payload decodes at its own width; an L
                                     // that is not that width is the arm's own framing damage (§3)
                                     if ( sub.size != TableKindWidth( arm_kind ) ) { value.body.type = BodyType::None; r.report->malformed = true; break; }
-                                    memset( (void *) &value.body.count, 0, sizeof( value.body.count ) ); // selection establishes the arm (§2.6)
+                                    memset( (void *) &value.body.tally, 0, sizeof( value.body.tally ) ); // selection establishes the arm (§2.6)
                                     int64_t widened_v = 0;
                                     if ( !TableReadSignedAt( sub, arm_kind, widened_v ) ) { value.body.type = BodyType::None; r.report->malformed = true; break; }
                                     int32_t decoded_v = (int32_t) widened_v;
-                                    value.body.count = decoded_v;
-                                    value.body.type = BodyType::Count;
+                                    value.body.tally = decoded_v;
+                                    value.body.type = BodyType::Tally;
                                     r.report->widened++;
                                     break;
                                 }
@@ -2669,11 +2683,11 @@ WIDE_TABLE_INLINE bool CaptionLoadBody( TableReader & r, Caption & value )
                                 r.report->kind_mismatch++;
                                 break;
                             }
-                            value.body.type = BodyType::Count;
+                            value.body.type = BodyType::Tally;
                             if ( sub.size != 4 ) { value.body.type = BodyType::None; r.report->malformed = true; break; } // an L that is not the kind's width is that arm's own framing damage (§3)
                             if ( !sub.has( 4 ) ) { value.body.type = BodyType::None; r.report->malformed = true; break; }
                             int32_t decoded_v = int32_t( sub.get32( ) );
-                            value.body.count = decoded_v;
+                            value.body.tally = decoded_v;
                             break;
                         }
                         default:
@@ -2805,7 +2819,7 @@ inline int64_t CaptionMeasureMessageBody( int64_t at, const Caption & value )
                 bits += (int64_t) value.body.narrow.value_length * 8;
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 bits += kTableMessageRefBitsHere;
                 bits += 32;
@@ -2872,10 +2886,10 @@ inline bool CaptionSaveMessageBody( TableBitWriter & w, const Caption & value )
                 w.putbytes( (const uint8_t *) value.body.narrow.value, value.body.narrow.value_length );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
                 w.put( 10, kTableMessageRefBitsHere );
-                w.put( (uint64_t) ( value.body.count ), 32 );
+                w.put( (uint64_t) ( value.body.tally ), 32 );
                 break;
             }
             default: return false; // a tag no arm names has no wire identity
@@ -3079,14 +3093,14 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                 }
                                 break;
                             }
-                            case 0xb1e5e28e4479a274ull: // count
+                            case 0xb1e5e28e4479a274ull: // tally
                             {
                                 if ( arm.kind != 4 || arm.elem_kind != 0 )
                                 {
                                     if ( TableKindWidens( arm.kind, 4 ) )
                                     {
-                                        value.body.type = BodyType::Count;
-                                        memset( (void *) &value.body.count, 0, sizeof( value.body.count ) ); // selection establishes the arm (§2.6)
+                                        value.body.type = BodyType::Tally;
+                                        memset( (void *) &value.body.tally, 0, sizeof( value.body.tally ) ); // selection establishes the arm (§2.6)
                                         {
                                             const int64_t width_2 = arm.value_bits;
                                             uint64_t raw_2 = 0;
@@ -3101,7 +3115,7 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                             if ( decoded_wide_2 < -2147483648ll ) { decoded_wide_2 = -2147483648ll; report->clamped++; }
                                             if ( decoded_wide_2 > 2147483647ll ) { decoded_wide_2 = 2147483647ll; report->clamped++; }
                                             int32_t decoded_v_2 = (int32_t) decoded_wide_2;
-                                            value.body.count = decoded_v_2;
+                                            value.body.tally = decoded_v_2;
                                         }
                                         report->widened++;
                                         break;
@@ -3110,7 +3124,7 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                     if ( !TableMessageSkip( r, vocabulary, index_bits, arm ) ) { report->malformed = true; return false; }
                                     break;
                                 }
-                                value.body.type = BodyType::Count;
+                                value.body.type = BodyType::Tally;
                                 {
                                     const int64_t width_2 = arm.value_bits;
                                     uint64_t raw_2 = 0;
@@ -3125,7 +3139,7 @@ inline bool CaptionLoadMessageBody( TableBitReader & r, const TableVocabulary & 
                                     if ( decoded_wide_2 < -2147483648ll ) { decoded_wide_2 = -2147483648ll; report->clamped++; }
                                     if ( decoded_wide_2 > 2147483647ll ) { decoded_wide_2 = 2147483647ll; report->clamped++; }
                                     int32_t decoded_v_2 = (int32_t) decoded_wide_2;
-                                    value.body.count = decoded_v_2;
+                                    value.body.tally = decoded_v_2;
                                 }
                                 break;
                             }
@@ -4137,9 +4151,9 @@ inline void CaptionCookBody( uint8_t * at, const Caption & value, TableByteOrder
                 table_cook_put( at + 88 + 12, (uint64_t) (uint32_t) value.body.narrow.value_length, 4, order );
                 break;
             }
-            case BodyType::Count:
+            case BodyType::Tally:
             {
-                table_cook_put( at + 88 + 4, (uint64_t) value.body.count, 4, order );
+                table_cook_put( at + 88 + 4, (uint64_t) value.body.tally, 4, order );
                 break;
             }
             default: break; // every byte outside the set arm stays zero
@@ -4314,7 +4328,7 @@ inline const TableTypeInfo * CaptionTableType()
         { "title", "title", "wstring", 0xda31296c0c1b6029ull, 33, false, true, false, 7, (uint32_t) offsetof( Caption, title ), (uint32_t) sizeof( Caption::title ), (uint32_t) offsetof( Caption, title_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
         { "line", "line", "Line", 0xbf4ba5ad694f5907ull, 13, false, false, false, 0, (uint32_t) offsetof( Caption, line ), (uint32_t) sizeof( Caption::line ), 0xffffffffu, 0xffffffffu, LineTableType(), false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
         { "lines", "lines", "Line", 0x5ce3f9a9f1d5001cull, 13, true, true, false, 3, (uint32_t) offsetof( Caption, lines ), (uint32_t) sizeof( Caption::lines[0] ), (uint32_t) offsetof( Caption, lines_count ), 0xffffffffu, LineTableType(), false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
-        { "body", "body", "Body", 0xcd4de79bc6c93295ull, 15, false, false, false, 0, (uint32_t) offsetof( Caption, body ), (uint32_t) sizeof( Caption::body ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 3, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "wide"; case 2: return "narrow"; case 3: return "count"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0xa633f1f655715ccaull; case 2: return 0x96569b06f223c29aull; case 3: return 0xb1e5e28e4479a274ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_Body[] = { { "wide", "wide", "wstring", 0xa633f1f655715ccaull, 33, false, true, false, 4, (uint32_t) offsetof( Body, wide.value ), (uint32_t) sizeof( Body::wide.value ), (uint32_t) offsetof( Body, wide.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "narrow", "narrow", "string", 0x96569b06f223c29aull, 12, false, true, false, 4, (uint32_t) offsetof( Body, narrow.value ), (uint32_t) sizeof( Body::narrow.value ), (uint32_t) offsetof( Body, narrow.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "count", "count", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( Body, count ), (uint32_t) sizeof( Body::count ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( Body, wide ), NULL, &arm_fields_Body[0], 16 }, { (uint32_t) offsetof( Body, narrow ), NULL, &arm_fields_Body[1], 12 }, { (uint32_t) offsetof( Body, count ), NULL, &arm_fields_Body[2], 4 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( Body, type ), (uint32_t) sizeof( Body::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
+        { "body", "body", "Body", 0xcd4de79bc6c93295ull, 15, false, false, false, 0, (uint32_t) offsetof( Caption, body ), (uint32_t) sizeof( Caption::body ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, 3, +[]( uint64_t v ) -> const char * { switch ( v ) { case 0: return "None"; case 1: return "wide"; case 2: return "narrow"; case 3: return "tally"; default: return "???"; } }, +[]( uint64_t v ) -> uint64_t { switch ( v ) { case 0: return 0; case 1: return 0xa633f1f655715ccaull; case 2: return 0x96569b06f223c29aull; case 3: return 0xb1e5e28e4479a274ull; default: return 0; } }, NULL, NULL, NULL, +[]() -> const TableUnionInfo * { static const TableFieldInfo arm_fields_Body[] = { { "wide", "wide", "wstring", 0xa633f1f655715ccaull, 33, false, true, false, 4, (uint32_t) offsetof( Body, wide.value ), (uint32_t) sizeof( Body::wide.value ), (uint32_t) offsetof( Body, wide.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "narrow", "narrow", "string", 0x96569b06f223c29aull, 12, false, true, false, 4, (uint32_t) offsetof( Body, narrow.value ), (uint32_t) sizeof( Body::narrow.value ), (uint32_t) offsetof( Body, narrow.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, { "tally", "tally", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( Body, tally ), (uint32_t) sizeof( Body::tally ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL }, }; static const TableUnionArmInfo arms[] = { { 0, NULL, NULL, 0 }, { (uint32_t) offsetof( Body, wide ), NULL, &arm_fields_Body[0], 16 }, { (uint32_t) offsetof( Body, narrow ), NULL, &arm_fields_Body[1], 12 }, { (uint32_t) offsetof( Body, tally ), NULL, &arm_fields_Body[2], 4 }, }; static const TableUnionInfo info = { (uint32_t) offsetof( Body, type ), (uint32_t) sizeof( Body::type ), arms }; return &info; }, "", TableDocNone, 0, NULL },
     };
     static const TableTypeInfo info = { "Caption", (uint32_t) sizeof( Caption ), 4, fields, +[]( void * p ) { CaptionReset( *(Caption *) p ); }, TableDocNone, 0, NULL };
     return &info;

--- a/testdata/golden/wide/cpp/WideView.cpp
+++ b/testdata/golden/wide/cpp/WideView.cpp
@@ -61,13 +61,13 @@ const UnitViewInfo * UnitView()
     static const TableFieldInfo Body_view_arm_fields[] = {
     { "wide", "wide", "wstring", 0xa633f1f655715ccaull, 33, false, true, false, 4, (uint32_t) offsetof( Body, wide.value ), (uint32_t) sizeof( Body::wide.value ), (uint32_t) offsetof( Body, wide.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
     { "narrow", "narrow", "string", 0x96569b06f223c29aull, 12, false, true, false, 4, (uint32_t) offsetof( Body, narrow.value ), (uint32_t) sizeof( Body::narrow.value ), (uint32_t) offsetof( Body, narrow.value_length ), 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
-    { "count", "count", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( Body, count ), (uint32_t) sizeof( Body::count ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
+    { "tally", "tally", "int32", 0xb1e5e28e4479a274ull, 4, false, false, false, 0, (uint32_t) offsetof( Body, tally ), (uint32_t) sizeof( Body::tally ), 0xffffffffu, 0xffffffffu, NULL, false, 0.0, 0.0, 0, NULL, -1, NULL, NULL, NULL, NULL, NULL, NULL, "", TableDocNone, 0, NULL },
     };
     static const ViewVariant Body_view_variants[] = {
         { 0, "None", 0, NULL, NULL, NULL, TableDocNone, 0, NULL },
         { 1, "wide", 0xa633f1f655715ccaull, "wstring(4)", NULL, &Body_view_arm_fields[0], TableDocNone, 0, NULL },
         { 2, "narrow", 0x96569b06f223c29aull, "string(4)", NULL, &Body_view_arm_fields[1], TableDocNone, 0, NULL },
-        { 3, "count", 0xb1e5e28e4479a274ull, "int32", NULL, &Body_view_arm_fields[2], TableDocNone, 0, NULL },
+        { 3, "tally", 0xb1e5e28e4479a274ull, "int32", NULL, &Body_view_arm_fields[2], TableDocNone, 0, NULL },
     };
     static const ViewVocabulary unions[] = {
         { "Body", "Caption.schema", 3, 8, 4, Body_view_variants, TableDocNone, 0, NULL },


### PR DESCRIPTION
A PACKET union's tag enum carries `None`, the variants, `Count` and `Max`
plus a debug-name function in all nine targets (#597, F-15). A TABLE-CLOSURE
union's tag shape is a different emitter — `internal/codegen/cpptable`'s
`emitTableUnion`, written beside the tables rather than among the packet
declarations — and it carried `None`, the variants and `Max` alone. One
construct, two surfaces, and `Count` free as an arm name on one side only,
because the member did not exist there to collide with.

This closes that. `Count` and the `EnumName` overload land beside `Max`, and
the reservation moves from "where the member exists" to every union, because
the member is now on every union.

Merge, not rebase: `origin/main` at `bb5f3bd4` fast-forwarded in before the
first commit.

## The measurement, before anything moved

Thirteen tag enums across seven committed C++ table headers carried `Max`
with no `Count` beside it:

| golden | tag enums |
|---|---|
| `tables/arms/{Carry,Gate,Nest,Ring}Table.h` | 6 |
| `tables/messages/MessagesTable.h` | 3 |
| `tables/lists/SaveTable.h`, `tables/maps/DepthTable.h`, `tables/stream/StreamTable.h`, `tables/wide/CaptionTable.h` | 1 each |

Against them, every packet tag enum in `testdata/golden/cpp/` already
carried `Count = N, // the declared variant count (SPEC §4.2)`.

`internal/codegen/cpptable/unions.go:50` is the ONE emitter of that comment
outside the nine packet backends, which is what makes this a one-target
change where F-15 was a nine-target one: the table layer is the C++
reference's (docs/SPEC-TABLES.md §11, §15). **The Go table backend emits no
tag enum at all** — `gotable` references `<Union>TypeNone` from the codecs
but declares nothing — so there is no oracle view of the enum to move.

## Red first

`1211337a` commits the gates alone, so the red is a fact in the history
rather than a claim in a report:

```
--- FAIL: TestATableClosureUnionArmNamedCountIsRefusedByName (0.00s)
    tagenumsurface_test.go:192: a table-closure union's arm named count passed check, and its tag enum defines Count twice
--- FAIL: TestTableClosureUnionTagEnumExportsCountAndItsDebugName (0.00s)
    tagenumsurface_test.go:257: cpp: the table-closure tag enum's surface is short, "    Count = 2, // the declared variant count (SPEC §4.2)" not emitted
    tagenumsurface_test.go:257: cpp: the table-closure tag enum's surface is short, "inline const char * EnumName( WeaponFireType value )" not emitted
--- FAIL: TestTableClosureTagEnumDebugNameCoversNoneVariantsAndOutOfSet (0.00s)
    tagenumsurface_test.go:272: cpp: the table-closure tag enum has no name function, "inline const char * EnumName( WeaponFireType value )" not emitted

--- FAIL: TestDiagnostics/union_variant_named_count_on_a_table-closure_union_(exported_spelling) (0.00s)
    diagnostics_test.go:592: compiled clean — the language broke silently (want "carries its declared variant count as the member Count")
```

The probe unit declares an enum of THREE variants beside a union of two,
the trap #597 found running the packet control: with both at two, the
declared enum's own `Count` line satisfies a claim meant for the tag enum.
The debug-name gate is anchored to the function's BODY, because `None`,
`Laser` and `Missile` all appear elsewhere in the same header.

`TestATableClosureUnionArmNamedCountIsAccepted` is deleted. It pinned the
split as law and the split is gone.

## The change

**The emitter.** `emitTableUnion` writes `Count` beside `Max` and the
`EnumName` overload beneath the enum, to the character the packet emitter
writes them, so a table arm and a type arm read as one family. Nothing on
the read or write path calls the function and no generated code does.

**The reservation.** `Count` moves out of `resolveUnion`'s post-loop block
and into the switch beside `None`, `Max` and `Type`, which is where it
belongs once the kind no longer has to be known: the arm errors and stops
rather than resolving on. `ir.Union.TableClosureOnly` keeps its three other
callers.

## Every id stays put

`Count` is a generated member, not a wire fact:

- `git diff origin/main -- testdata/wire` is **empty**.
- `git diff origin/main -- generated/` is **empty** — the packet corpus
  declares no table-closure union.
- `testdata/golden/id.txt` and `testdata/golden/build-version/` are
  untouched.

The CORPUS MOVE the reservation forces moves no id either, because it is a
`was` rename. `tables/messages`'s `EditBody` arm becomes
`tally int32 | min = 0, max = 100, was = "count"`, and every one of its ids
in `MessagesTable.h` stays `0xb1e5e28e4479a274` — the file form's dispatch,
the message form's, the reflection descriptor and the arms table.
`examples-wide/Caption.schema`'s `Body.count` moves the same way. The
baseline records it and says so:

```
arm tally id=0xb1e5e28e4479a274 kind=4 min=0 max=100 was=count
...
### 2026-09-07 (UTC) — the EditBody arm count is renamed to tally under was: every union's tag enum now carries the member Count, so the name is reserved (#601)
- no compatibility-affecting edits; the wire absorbs the rest
```

Fixtures that carry no stored data move by plain rename with no alias:
`test/tables/R1.schema` and `R2.schema` (to `amount`, since `tally` is
taken there by a keyed array), `test/tables/RT2.schema`,
`ir/buildversion_test.go`, `internal/baseline/baseline_test.go`,
`compiler/wasrows_test.go` and the harness's `rowdemo` unit. No pinned
instance selects any of them.

## The finding this turned up, and why it lands first

`688acf77` is not the pass. It is what the pass depends on.

The `was` rename only keeps the id if **every** id derivation reads the
alias, which docs/SPEC-TABLES.md §5 states outright: *"Every id derivation
reads the alias: the node record, the cooked node directory, the
connection's announced vocabulary (§3.3), the baseline and the build
version."*

Three arm-dispatch sites did not. The announcement's entry is
`ir.TableArmEntry`, whose own comment says it hashes the WIRE name, and the
encoder spends that id. The message form's readers matched on the DECLARED
name's hash instead:

- `internal/codegen/cpptable/messageload.go`, `<Table>LoadMessageBody`
- `internal/codegen/cpptable/messagecodec.go`, the union-arm extent walk
- `internal/tablewire/messagedecode.go`, the Go engine's arm dispatch

So a `was`-renamed arm was written under the old name's hash and read under
the new one: **lost by its own build**, counted `unknown`, in the C++
reference and in the engine alike. The file form was always right —
`decode.go` and every other cpptable site call `WireName()` — and no corpus
carried a message-form `was` arm, so nothing pinned could catch it.

```
--- FAIL: TestAWasRenamedArmSurvivesTheMessageForm (0.00s)
    wasarmmessage_test.go:116: the was-renamed arm was lost: the union reads back None, report {Unknown:1 KindMismatch:0 Widened:0 Clamped:0 Duplicate:0 Malformed:false Refused:false}
```

The C++ gate slices `NoteLoadMessageBody`'s own body rather than the output,
because the old name's hash is already in the header twice over, in the file
form's dispatch and in the reflection descriptor. Its control, the one line
put back:

```
--- FAIL: TestTheMessageFormsArmDispatchReadsTheWasAlias (0.00s)
    wasarmmessageid_test.go:57: cpp: the message form does not dispatch the renamed arm on its old name's hash, "case 0xb1e5e28e4479a274ull: // tally" absent from NoteLoadMessageBody
    wasarmmessageid_test.go:60: cpp: the message form dispatches the renamed arm on its DECLARED name's hash, "case 0xaa3f4d29d02d54ddull: // tally" — the announcement writes the alias's
```

No committed golden moves at that commit: no corpus declared a `was` arm
reaching a message form yet, and `R2.schema`'s two pin no golden.

## The goldens, every moved file and why

| file | why |
|---|---|
| `tables/arms/{Carry,Gate,Nest,Ring}Table.h`, `tables/lists/SaveTable.h`, `tables/maps/DepthTable.h`, `tables/stream/StreamTable.h` | the added `Count` line and the added `EnumName` overload, nothing else |
| `tables/messages/MessagesTable.h` | the same two additions on three tag enums, plus the arm's rename: `Count` -> `Tally` as a tag member, `count` -> `tally` as storage and as the text key, every id unmoved |
| `tables/wide/CaptionTable.h`, `wide/cpp/CaptionTable.h` | the two additions plus the `Body` arm's rename |
| `wide/cpp/WideView.cpp` | the view's arm name and its spelling, twice; the id beside each unchanged |
| `tables/messages/tables.baseline` | the `was` row and a dated history line |
| `testdata/conformance/tables/json/message_arm_edits.json`, the two `json-hostile/arm-scalar-*` texts | an arm's name IS its key in the text form (§16.2), so the key follows the rename; the wire pins those texts encode to are byte-identical |

## The controls, each turning exactly its own claim red

**(1) the `Count` line deleted from `emitTableUnion`.** The coverage gate
beside it stays green, which is right: it gates the name function.

```
--- FAIL: TestTableClosureUnionTagEnumExportsCountAndItsDebugName (0.00s)
    tagenumsurface_test.go:257: cpp: the table-closure tag enum's surface is short, "    Count = 2, // the declared variant count (SPEC §4.2)" not emitted
--- PASS: TestTableClosureTagEnumDebugNameCoversNoneVariantsAndOutOfSet (0.00s)
```

**(2) the name function deleted.** Both claims fire, and the second is the
anchored one:

```
--- FAIL: TestTableClosureUnionTagEnumExportsCountAndItsDebugName (0.00s)
    tagenumsurface_test.go:257: cpp: the table-closure tag enum's surface is short, "inline const char * EnumName( WeaponFireType value )" not emitted
--- FAIL: TestTableClosureTagEnumDebugNameCoversNoneVariantsAndOutOfSet (0.00s)
    tagenumsurface_test.go:272: cpp: the table-closure tag enum has no name function, "inline const char * EnumName( WeaponFireType value )" not emitted
```

**(3) the reservation scoped back off the table-closure shape**, the one
line `if un.TableClosureOnly() { break }` put back in the switch:

```
--- FAIL: TestATableClosureUnionArmNamedCountIsRefusedByName (0.00s)
    tagenumsurface_test.go:192: a table-closure union's arm named count passed check, and its tag enum defines Count twice
--- FAIL: TestDiagnostics/union_variant_named_count_on_a_table-closure_union_(exported_spelling) (0.00s)
    diagnostics_test.go:592: compiled clean — the language broke silently (want "carries its declared variant count as the member Count")
```

**(4) the `was` alias in the message form.** Quoted above.

## The pages, for the cold read

Present tense, no history. Read them on their own with
`git diff bb5f3bd4..HEAD -- docs/`.

- **SPEC §4.2**, the exported-extent paragraph: "A PACKET union's ... A
  table-closure union's tag shape carries `Max` alone (#601)" becomes a
  union's tag enum carrying `Count`, with the table-closure shape named as a
  different emitter carrying the same members.
- **SPEC §4.8**, the reserved-names bullet: `Count` is refused on every
  union, the packet shape and the table-closure shape alike, and the
  scoping sentence is replaced by "the reservation reaches where the member
  exists, and the member exists on every union".
- **SPEC §4.8**, the table-closure bullet: it stated the split and the
  follow-on. It now states the shared surface, names the emitter's location,
  and says the shape has ONE emitter where the packet shape has nine.
- **SPEC §4.11**, the `Count` bullet: "on a PACKET union" becomes "on any
  union", and the legal-there sentence becomes the reservation reaching it.
- **SPEC-TABLES §2.6** gains a paragraph, THE TAG SHAPE IS THE PACKET TAG
  ENUM'S, MEMBER FOR MEMBER, naming every member and the debug-name
  function outright, since a different emitter writes it; and the
  illustrative `union Value`'s `count` arm moves to `tally`, in the schema
  block, the C++ overlay block and the selection paragraph that names it.
- **SPEC-TABLES §11** gains AN ARM NAMED `Count` beside the other arm
  refusals.
- **USAGE** and **TUTORIAL part 5**: "on a packet union" becomes "on every
  union".
- **docs/VERSIONING.md** lists no reserved names, so nothing there moved.

All four `#601` links are gone from SPEC.md.

Closes #601
