### PR TITLE
Match the inline certification timeout to full tests

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -304,14 +304,14 @@ jobs:
   # build-time artifact to gate — faking one would be a green light that
   # proves nothing.
   #
-  # THE TIMEOUT COVERS THE `make test` PRECONDITION, not just the legs: that
-  # chain is ~22 minutes on either OS (run 33787248541: 1320 s on ubuntu, and
-  # the macOS test job the same), the selftest and the longest leg add ~5, and
-  # a saturated macOS pool stretches all of it. At 20 minutes four macOS legs
-  # died mid-chain with make still running and read as "cancelled".
+  # The timeout covers the full `make test` precondition, the adversarial
+  # selftest and the inline leg. In run 34080317818, the Ubuntu Go job hit
+  # the 40-minute cap during `make test`, before reaching either inline check.
+  # Match the full test job's 60-minute budget; every precondition and check
+  # remains in place, and the job still has a bounded execution time.
   inline-gate:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The Linux Go inline job in [Certify run 34080317818](https://github.com/mas-bandwidth/schema/actions/runs/34080317818/job/101614236379) exhausted its 40-minute limit during the full `make test` prerequisite. GitHub reports that timeout explicitly; the inline selftest and Go verdict never ran. The other fourteen jobs passed, so the run remains incomplete certification.

Raise the inline job budget to 60 minutes, matching the full-test and release-gate jobs. Every test, negative control, inline check, matrix entry and permission remains unchanged. The comment records the measured reason for the increase.

Validation: `go test ./internal/ci`, YAML syntax parsing with Psych, and `git diff --check` pass. A fresh Certify run on the integrated packet stack is still required. The separate stale TextTable.cpp golden on current main has already been diagnosed and sent to Rowan; this PR changes only the workflow timeout and its comment.
