### PR TITLE
Clarify packet and table wide-text generation coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ define tables_generate
 	$(1) generate --lang cpp --out $(2)/rt3 test/tables/RT3.schema
 	# the WIDE TEXT unit (docs/SPEC-TABLES.md §3, kind 33): its own directory,
 	# because examples/ pins gate 1 for all nine targets and eight of them
-	# refuse wide text on either wire (SPEC.md §4.12)
+	# refuse the table-wide unit; all nine carry its isolated packet file (SPEC.md §4.12)
 	$(1) generate --lang cpp --out $(2)/wide examples-wide
 endef
 


### PR DESCRIPTION
The first nine targets now support packet wide text, so the table-generation comment incorrectly says eight targets refuse it on either wire. Restrict that statement to the table-wide unit and acknowledge the isolated packet file supported by all nine.

This preserves the one remaining comment from #655. Its harness fixes are already present on main through #639 and #647; #655 is closed.

Validation: reviewed the one-line comment diff and ran `git diff --check`. No commands or generated code change, so no additional test run is needed for this correction. The integrated packet certification remains a separate pending receipt.
