### PR TITLE
Refresh six map table header goldens against integrated main

### DIFF
--- a/testdata/golden/tables/maps/CellsTable.h
+++ b/testdata/golden/tables/maps/CellsTable.h
@@ -3752,6 +3752,16 @@ inline int64_t TableRetainInContent( TableRetainIn & s, uint8_t kind, int64_t le
             }
             break;
         }
+        case 15: case 30:
+            // A UNION ARM AND AN ENUM'S VARIANT REFERENCE RESOLVE AS A FRAMED
+            // CONTENT TOO (§6.6): a kind 15 arm whose own payload is a union,
+            // and a kind 16 slot whose element kind is 15 or 30, both arrive
+            // here, and both carry a reference. Copying them as bytes would
+            // re-emit a reference into a permuted trailer, where it names
+            // another id, and would let a kind 17 UNDER A KIND 15 ARM through
+            // a walk whose whole job is to catch it.
+            if ( TableRetainInPayload( s, kind, depth ) < 0 ) { return -1; }
+            break;
         case 17: return -1; // A NODE INDEX ANYWHERE DROPS THE WHOLE RECORD (§6.6)
         default:
             // every other content is bytes: a string, wide text, an escape, a
@@ -4128,6 +4138,11 @@ inline bool TableRetainOutContent( TableRetainOut & s, uint8_t kind, int64_t len
             }
             break;
         }
+        case 15: case 30:
+            // the emit side of the capture's own rule (§6.6): an arm and a
+            // variant reference resolve as a framed content too
+            if ( !TableRetainOutPayload( s, kind, depth ) ) { return false; }
+            break;
         default:
             TableRetainOutRaw( s, s.in + s.at, length );
             s.at += length;
@@ -6480,15 +6495,13 @@ inline bool CellsRowsEntryLoadMessageBody( TableBitReader & r, const TableVocabu
                 {
                     uint64_t n = 0;
                     if ( !r.get( n, TableBitsRequired( 0, entry.max ) ) || !r.align() || !r.has( (int64_t) n * 8 ) ) { report->malformed = true; return false; }
-                    int32_t kept = 0;
-                    if ( n > (uint64_t) 8 ) { kept = 8; report->clamped++; } else { kept = (int32_t) n; }
-                    for ( uint64_t i = 0; i < n; i++ )
-                    {
-                        uint64_t by = 0;
-                        if ( !r.get( by, 8 ) ) { report->malformed = true; return false; }
-                        if ( (int32_t) i < kept ) { value.key[i] = (char) by; }
-                    }
+                    const uint8_t * text = r.buffer + ( r.offset >> 3 );
+                    if ( !TableUtf8Valid( text, n ) ) { report->malformed = true; return false; }
+                    const int32_t kept = (int32_t) TableUtf8Clamp( text, n, 8 );
+                    if ( (uint64_t) kept < n ) { report->clamped++; }
+                    memcpy( value.key, text, (size_t) kept );
                     value.key[kept] = 0;
+                    r.offset += (int64_t) n * 8;
                     value.key_length = kept;
                 }
                 break;

--- a/testdata/golden/tables/maps/ChunksTable.h
+++ b/testdata/golden/tables/maps/ChunksTable.h
@@ -3752,6 +3752,16 @@ inline int64_t TableRetainInContent( TableRetainIn & s, uint8_t kind, int64_t le
             }
             break;
         }
+        case 15: case 30:
+            // A UNION ARM AND AN ENUM'S VARIANT REFERENCE RESOLVE AS A FRAMED
+            // CONTENT TOO (§6.6): a kind 15 arm whose own payload is a union,
+            // and a kind 16 slot whose element kind is 15 or 30, both arrive
+            // here, and both carry a reference. Copying them as bytes would
+            // re-emit a reference into a permuted trailer, where it names
+            // another id, and would let a kind 17 UNDER A KIND 15 ARM through
+            // a walk whose whole job is to catch it.
+            if ( TableRetainInPayload( s, kind, depth ) < 0 ) { return -1; }
+            break;
         case 17: return -1; // A NODE INDEX ANYWHERE DROPS THE WHOLE RECORD (§6.6)
         default:
             // every other content is bytes: a string, wide text, an escape, a
@@ -4128,6 +4138,11 @@ inline bool TableRetainOutContent( TableRetainOut & s, uint8_t kind, int64_t len
             }
             break;
         }
+        case 15: case 30:
+            // the emit side of the capture's own rule (§6.6): an arm and a
+            // variant reference resolve as a framed content too
+            if ( !TableRetainOutPayload( s, kind, depth ) ) { return false; }
+            break;
         default:
             TableRetainOutRaw( s, s.in + s.at, length );
             s.at += length;

--- a/testdata/golden/tables/maps/DocsTable.h
+++ b/testdata/golden/tables/maps/DocsTable.h
@@ -3752,6 +3752,16 @@ inline int64_t TableRetainInContent( TableRetainIn & s, uint8_t kind, int64_t le
             }
             break;
         }
+        case 15: case 30:
+            // A UNION ARM AND AN ENUM'S VARIANT REFERENCE RESOLVE AS A FRAMED
+            // CONTENT TOO (§6.6): a kind 15 arm whose own payload is a union,
+            // and a kind 16 slot whose element kind is 15 or 30, both arrive
+            // here, and both carry a reference. Copying them as bytes would
+            // re-emit a reference into a permuted trailer, where it names
+            // another id, and would let a kind 17 UNDER A KIND 15 ARM through
+            // a walk whose whole job is to catch it.
+            if ( TableRetainInPayload( s, kind, depth ) < 0 ) { return -1; }
+            break;
         case 17: return -1; // A NODE INDEX ANYWHERE DROPS THE WHOLE RECORD (§6.6)
         default:
             // every other content is bytes: a string, wide text, an escape, a
@@ -4128,6 +4138,11 @@ inline bool TableRetainOutContent( TableRetainOut & s, uint8_t kind, int64_t len
             }
             break;
         }
+        case 15: case 30:
+            // the emit side of the capture's own rule (§6.6): an arm and a
+            // variant reference resolve as a framed content too
+            if ( !TableRetainOutPayload( s, kind, depth ) ) { return false; }
+            break;
         default:
             TableRetainOutRaw( s, s.in + s.at, length );
             s.at += length;
@@ -6458,15 +6473,13 @@ inline bool DocsPagesEntryLoadMessageBody( TableBitReader & r, const TableVocabu
                 {
                     uint64_t n = 0;
                     if ( !r.get( n, TableBitsRequired( 0, entry.max ) ) || !r.align() || !r.has( (int64_t) n * 8 ) ) { report->malformed = true; return false; }
-                    int32_t kept = 0;
-                    if ( n > (uint64_t) 8 ) { kept = 8; report->clamped++; } else { kept = (int32_t) n; }
-                    for ( uint64_t i = 0; i < n; i++ )
-                    {
-                        uint64_t by = 0;
-                        if ( !r.get( by, 8 ) ) { report->malformed = true; return false; }
-                        if ( (int32_t) i < kept ) { value.key[i] = (char) by; }
-                    }
+                    const uint8_t * text = r.buffer + ( r.offset >> 3 );
+                    if ( !TableUtf8Valid( text, n ) ) { report->malformed = true; return false; }
+                    const int32_t kept = (int32_t) TableUtf8Clamp( text, n, 8 );
+                    if ( (uint64_t) kept < n ) { report->clamped++; }
+                    memcpy( value.key, text, (size_t) kept );
                     value.key[kept] = 0;
+                    r.offset += (int64_t) n * 8;
                     value.key_length = kept;
                 }
                 break;

--- a/testdata/golden/tables/maps/RunsTable.h
+++ b/testdata/golden/tables/maps/RunsTable.h
@@ -3753,6 +3753,16 @@ inline int64_t TableRetainInContent( TableRetainIn & s, uint8_t kind, int64_t le
             }
             break;
         }
+        case 15: case 30:
+            // A UNION ARM AND AN ENUM'S VARIANT REFERENCE RESOLVE AS A FRAMED
+            // CONTENT TOO (§6.6): a kind 15 arm whose own payload is a union,
+            // and a kind 16 slot whose element kind is 15 or 30, both arrive
+            // here, and both carry a reference. Copying them as bytes would
+            // re-emit a reference into a permuted trailer, where it names
+            // another id, and would let a kind 17 UNDER A KIND 15 ARM through
+            // a walk whose whole job is to catch it.
+            if ( TableRetainInPayload( s, kind, depth ) < 0 ) { return -1; }
+            break;
         case 17: return -1; // A NODE INDEX ANYWHERE DROPS THE WHOLE RECORD (§6.6)
         default:
             // every other content is bytes: a string, wide text, an escape, a
@@ -4129,6 +4139,11 @@ inline bool TableRetainOutContent( TableRetainOut & s, uint8_t kind, int64_t len
             }
             break;
         }
+        case 15: case 30:
+            // the emit side of the capture's own rule (§6.6): an arm and a
+            // variant reference resolve as a framed content too
+            if ( !TableRetainOutPayload( s, kind, depth ) ) { return false; }
+            break;
         default:
             TableRetainOutRaw( s, s.in + s.at, length );
             s.at += length;

--- a/testdata/golden/tables/maps/SlotsTable.h
+++ b/testdata/golden/tables/maps/SlotsTable.h
@@ -3753,6 +3753,16 @@ inline int64_t TableRetainInContent( TableRetainIn & s, uint8_t kind, int64_t le
             }
             break;
         }
+        case 15: case 30:
+            // A UNION ARM AND AN ENUM'S VARIANT REFERENCE RESOLVE AS A FRAMED
+            // CONTENT TOO (§6.6): a kind 15 arm whose own payload is a union,
+            // and a kind 16 slot whose element kind is 15 or 30, both arrive
+            // here, and both carry a reference. Copying them as bytes would
+            // re-emit a reference into a permuted trailer, where it names
+            // another id, and would let a kind 17 UNDER A KIND 15 ARM through
+            // a walk whose whole job is to catch it.
+            if ( TableRetainInPayload( s, kind, depth ) < 0 ) { return -1; }
+            break;
         case 17: return -1; // A NODE INDEX ANYWHERE DROPS THE WHOLE RECORD (§6.6)
         default:
             // every other content is bytes: a string, wide text, an escape, a
@@ -4129,6 +4139,11 @@ inline bool TableRetainOutContent( TableRetainOut & s, uint8_t kind, int64_t len
             }
             break;
         }
+        case 15: case 30:
+            // the emit side of the capture's own rule (§6.6): an arm and a
+            // variant reference resolve as a framed content too
+            if ( !TableRetainOutPayload( s, kind, depth ) ) { return false; }
+            break;
         default:
             TableRetainOutRaw( s, s.in + s.at, length );
             s.at += length;

--- a/testdata/golden/tables/maps/SpansTable.h
+++ b/testdata/golden/tables/maps/SpansTable.h
@@ -3753,6 +3753,16 @@ inline int64_t TableRetainInContent( TableRetainIn & s, uint8_t kind, int64_t le
             }
             break;
         }
+        case 15: case 30:
+            // A UNION ARM AND AN ENUM'S VARIANT REFERENCE RESOLVE AS A FRAMED
+            // CONTENT TOO (§6.6): a kind 15 arm whose own payload is a union,
+            // and a kind 16 slot whose element kind is 15 or 30, both arrive
+            // here, and both carry a reference. Copying them as bytes would
+            // re-emit a reference into a permuted trailer, where it names
+            // another id, and would let a kind 17 UNDER A KIND 15 ARM through
+            // a walk whose whole job is to catch it.
+            if ( TableRetainInPayload( s, kind, depth ) < 0 ) { return -1; }
+            break;
         case 17: return -1; // A NODE INDEX ANYWHERE DROPS THE WHOLE RECORD (§6.6)
         default:
             // every other content is bytes: a string, wide text, an escape, a
@@ -4129,6 +4139,11 @@ inline bool TableRetainOutContent( TableRetainOut & s, uint8_t kind, int64_t len
             }
             break;
         }
+        case 15: case 30:
+            // the emit side of the capture's own rule (§6.6): an arm and a
+            // variant reference resolve as a framed content too
+            if ( !TableRetainOutPayload( s, kind, depth ) ) { return false; }
+            break;
         default:
             TableRetainOutRaw( s, s.in + s.at, length );
             s.at += length;


### PR DESCRIPTION
The generated-code check on current main fails for six map table headers added with the expanded map-value corpus. This also blocks unrelated PRs, including #669: CI run 34109282889 reports CellsTable.h, ChunksTable.h, DocsTable.h, RunsTable.h, SlotsTable.h and SpansTable.h as moved.

Refresh only those six snapshots with the compiler from main dcdd5cdd. The generated differences carry the existing retained-payload handling for union/enum references, plus the existing message-form UTF-8 validation and code-point clamp for string keys in Cells and Docs. No emitter, schema, workflow or runtime code changes.

Validation: reproduced `make tables-block-zero-cost` failing on exactly these six files before the refresh; after it, the gate passes and reports all 117 table sources byte-identical to their pins. Reviewed the generated diff and passed `git diff --check`.

This is separate from #669's certification queue policy. Land this correction and carry current main into that PR before expecting its generated check to pass.
