### PR TITLE
tables: the list-walk gate derives the list-free set from the schemas (red on main since #662)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1859,7 +1859,7 @@ tables-shared-node-negative-control: bin/schema
 	fi
 	@grep -q "^FAIL test/tables/main.cpp" build/tables-no-identity.log || \
 		{ echo "NEGATIVE CONTROL FAILED: the suite went red, but not on a CHECK"; cat build/tables-no-identity.log; exit 1; }
-	@echo "negative control: a pack with no identity map turns the TABLES SUITE red — $$(grep -c '^FAIL' build/tables-no-identity.log) failures"
+	@echo "negative control: a pack with no identity map turns the TABLES SUITE red on $$(grep -c '^FAIL' build/tables-no-identity.log) failures"
 
 # The NEGATIVE CONTROL for a keyed array's ITERATION RANGE (docs/SPEC-TABLES.md
 # §2.4). The iteration's whole promise is that it walks EVERY stored slot and
@@ -1894,7 +1894,7 @@ tables-keyed-iteration-negative-control: bin/schema
 	fi
 	@grep -q "^FAIL test/tables/main.cpp" build/tables-first-slot.log || \
 		{ echo "NEGATIVE CONTROL FAILED: the suite went red, but not on a CHECK"; cat build/tables-first-slot.log; exit 1; }
-	@echo "negative control: begin() past the first stored slot turns the TABLES SUITE red — $$(grep -c '^FAIL' build/tables-first-slot.log) failures"
+	@echo "negative control: begin() past the first stored slot turns the TABLES SUITE red on $$(grep -c '^FAIL' build/tables-first-slot.log) failures"
 
 # THE None REFUSAL, HELD UNDER -DNDEBUG (docs/SPEC-TABLES.md §2.4). The refusal is
 # unconditional by ruling: indexing a keyed array by None is a program error in
@@ -2095,7 +2095,7 @@ tables-clamp-limits-negative-control: bin/schema
 	@grep -q "always false" build/clamp-limits-negative.log || \
 		{ echo "NEGATIVE CONTROL FAILED: the build went red, but not on a comparison that cannot fire"; \
 		  cat build/clamp-limits-negative.log; exit 1; }
-	@echo "negative control: the storage-limit clamps back turn the build red — $$(grep -c 'always false' build/clamp-limits-negative.log) comparisons that cannot fire"
+	@echo "negative control: the storage-limit clamps back turn the build red on $$(grep -c 'always false' build/clamp-limits-negative.log) comparisons that cannot fire"
 
 # THE ZERO-RANGE GATE and its NEGATIVE CONTROL (SPEC §4.6). A field whose
 # declared range excludes zero and declares no default is born outside its own
@@ -2928,6 +2928,7 @@ test: build/schema_test build/schema_test_guard build/schema_test_tables build/s
 	$(MAKE) tables-lists
 	$(MAKE) tables-list-measure-refusals
 	$(MAKE) tables-json-list-walk
+	$(MAKE) tables-json-list-walk-negative-controls
 	$(MAKE) tables-lists-negative-controls
 	$(MAKE) tables-arms
 	$(MAKE) tables-arms-negative-controls
@@ -3108,7 +3109,7 @@ define map_negative_control
 	fi
 	@grep -q "^FAIL test/tables/maps_main.cpp" build/map-$(1).log || \
 		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on a CHECK"; cat build/map-$(1).log; exit 1; }
-	@echo "negative control: $(1) turns the MAP GATE red — $$(grep -c '^FAIL' build/map-$(1).log) failures"
+	@echo "negative control: $(1) turns the MAP GATE red on $$(grep -c '^FAIL' build/map-$(1).log) failures"
 endef
 
 # THE WRITER EMITS INSERTION ORDER instead of sorted. The instance built OUT OF
@@ -3229,7 +3230,7 @@ tables-maps-entry-node-negative-control: bin/schema build/tables-generated/.stam
 	fi
 	@grep -q "^FAIL test/tables/maps_main.cpp" build/map-entrynode.log || \
 		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on a CHECK"; cat build/map-entrynode.log; exit 1; }
-	@echo "negative control: entrynode turns the MAP GATE red — $$(grep -c '^FAIL' build/map-entrynode.log) failures"
+	@echo "negative control: entrynode turns the MAP GATE red on $$(grep -c '^FAIL' build/map-entrynode.log) failures"
 
 # AN UNREACHED NON-EMPTY MAP SLOT IS REFUSED by Cook and by Lock, the same
 # refusal §7.6 gives a pointer in that position. The `Depth` instance whose
@@ -3412,29 +3413,86 @@ tables-lists: build/schema_test_lists build/schema_test_lists_asan
 tables-list-measure-refusals: build/schema_test_lists
 	./build/schema_test_lists measure-refusals
 
-# THE LIST-WALK GATE (docs/SPEC-TABLES.md §2.9, §16): the list's half of the
-# text form is emitted only in a unit that declares one, it is ONE half, the
-# same bytes in every list-bearing .cpp, and none of it reaches a list-free
+# THE LIST-WALK GATE (docs/SPEC-TABLES.md §2.9, §13.5, §16): the list's half of
+# the text form is emitted only in a unit that declares one, it is ONE half,
+# the same bytes in every list-bearing .cpp, and none of it reaches a list-free
 # unit, which is the zero-cost property (§2.2) holding for the text form.
+#
+# THE LIST-FREE SET IS DERIVED, NOT NAMED. It was three directory names in this
+# recipe until #662 gave `tables/maps` a `map[uint8][]Item`: the unit became
+# list-bearing, the emitter emitted the half correctly, and the copy of the
+# fact standing here reported that as a leak. The premise was right and the
+# instrument was wrong. `internal/listwalk` asks the COMPILER'S OWN IR instead.
+# A unit is list-free when no table in its closure carries an unbounded array,
+# and a map's generated entry is a table of that closure (§2.8), so `map[K][]T`
+# reaches the answer with no clause of its own. The corpus is the units
+# `tables_generate` emits, read from that define, so the scan is every
+# generated .cpp of the tree rather than one directory's five.
 .PHONY: tables-json-list-walk
 tables-json-list-walk: build/tables-generated/.stamp
-	@rm -rf build/json-list-walk && mkdir -p build/json-list-walk
-	@for f in build/tables-generated/lists/*Table.cpp; do \
-		out=build/json-list-walk/$$(echo $$f | tr / _); \
-		awk '/---- json list walk: begin ----/,/---- json list walk: end ----/' $$f > $$out; \
-		if [ ! -s $$out ]; then echo "LIST-WALK GATE FAILED: no list half in $$f"; exit 1; fi; \
-	done
-	@first=""; for f in build/json-list-walk/*; do \
-		if [ -z "$$first" ]; then first=$$f; else \
-			cmp -s $$first $$f || { echo "LIST-WALK GATE FAILED: the list half in $$f is not the list half in $$first"; exit 1; }; \
-		fi; \
-	done
-	@for f in build/tables-generated/examples/*Table.cpp build/tables-generated/pointers/*Table.cpp build/tables-generated/maps/*Table.cpp; do \
-		if grep -q "json list walk: begin" $$f; then \
-			echo "LIST-WALK GATE FAILED: the list half reached the list-free unit $$f"; exit 1; \
-		fi; \
-	done
-	@echo "tables list-walk gate: one list half, byte-identical in $$(ls build/json-list-walk | wc -l | tr -d ' ') list-bearing .cpp files, and none in a list-free one"
+	@mkdir -p build
+	SCHEMA_LIST_WALK_DIR=$$PWD/build/tables-generated \
+		SCHEMA_LIST_WALK_SUMMARY=$$PWD/build/list-walk.summary \
+		go test -count=1 ./internal/listwalk -run TestListWalkHalfRidesTheListBearingUnits
+	@cat build/list-walk.summary
+
+# THE NEGATIVE CONTROLS for the list-walk gate (docs/SPEC-TABLES.md §2.9,
+# §16). A gate that cannot go red proves nothing, and the three ways this one
+# can fail to hold are the three ways the half can land wrong:
+#
+#   1. PLANTED. The half is put into a list-free unit's emitted .cpp in a
+#      throwaway copy. Nothing generates it and no emitter is patched, so
+#      this control holds the SCAN alone: it must name the file.
+#   2. UNGATED. The emitter's own `if anyList` is removed, so every unit's
+#      .cpp carries the real half. This is the control the gate exists for,
+#      because it is what §13.5's ruling costs a list-free consumer the day
+#      the gating goes, and the derived set has to say which units are free.
+#   3. DROPPED. The other half of the same switch: the list half is never
+#      emitted, so a list-bearing unit's .cpp carries the stub. A gate that
+#      only refused leaks would stay green here.
+#
+# Each control narrows the run with SCHEMA_LIST_WALK_UNITS, so its red is its
+# own and not thirty-five absent trees.
+#
+# The two gating controls share a recipe. $(1) the control's short name, $(2)
+# the sed script over the JSON emitter, $(3) the corpus directory the control
+# regenerates and scans, $(4) the sentence a reader gets when the gate stayed
+# green, $(5) the clause the red has to be on.
+define list_walk_gating_control
+	@sed -e $(2) internal/codegen/cpptable/json.go > build/list-walk-$(1).gotext
+	@cmp -s build/list-walk-$(1).gotext internal/codegen/cpptable/json.go && \
+		{ echo "NEGATIVE CONTROL FAILED: the $(1) sabotage patched nothing"; exit 1; } || true
+	@printf '{"Replace":{"%s/internal/codegen/cpptable/json.go":"%s/build/list-walk-$(1).gotext"}}\n' \
+		"$(CURDIR)" "$(CURDIR)" > build/list-walk-$(1)-overlay.json
+	@go build -overlay=build/list-walk-$(1)-overlay.json -o build/schema-list-walk-$(1) ./cmd/schema
+	@rm -rf build/list-walk-$(1)-tree && mkdir -p build/list-walk-$(1)-tree
+	@./build/schema-list-walk-$(1) generate --lang cpp --out build/list-walk-$(1)-tree/$(3) tables/$(3)
+	@if SCHEMA_LIST_WALK_DIR=$$PWD/build/list-walk-$(1)-tree SCHEMA_LIST_WALK_UNITS=$(3) \
+			go test -count=1 ./internal/listwalk -run TestListWalkHalfRidesTheListBearingUnits \
+			> build/list-walk-$(1).log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: $(4)"; exit 1; \
+	fi
+	@grep -q "$(5)" build/list-walk-$(1).log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not on the $(1) clause"; cat build/list-walk-$(1).log; exit 1; }
+	@echo "negative control: $(1) turns the LIST-WALK GATE red on $$(grep -c 'LIST-WALK GATE FAILED' build/list-walk-$(1).log) named file(s)"
+endef
+
+.PHONY: tables-json-list-walk-negative-controls
+tables-json-list-walk-negative-controls: bin/schema build/tables-generated/.stamp
+	@rm -rf build/list-walk-planted && mkdir -p build/list-walk-planted/examples
+	@cp build/tables-generated/examples/TablesTable.cpp build/list-walk-planted/examples/TablesTable.cpp
+	@printf '// ---- json list walk: begin ----\n// PLANTED\n// ---- json list walk: end ----\n' \
+		>> build/list-walk-planted/examples/TablesTable.cpp
+	@if SCHEMA_LIST_WALK_DIR=$$PWD/build/list-walk-planted SCHEMA_LIST_WALK_UNITS=examples \
+			go test -count=1 ./internal/listwalk -run TestListWalkHalfRidesTheListBearingUnits \
+			> build/list-walk-planted.log 2>&1; then \
+		echo "NEGATIVE CONTROL FAILED: the list half planted in a list-free unit left the gate GREEN"; exit 1; \
+	fi
+	@grep -q "the list half reached the list-free unit.*examples/TablesTable.cpp" build/list-walk-planted.log || \
+		{ echo "NEGATIVE CONTROL FAILED: the gate went red, but not by naming the planted file"; cat build/list-walk-planted.log; exit 1; }
+	@echo "negative control: a planted list half turns the LIST-WALK GATE red on $$(grep -c 'LIST-WALK GATE FAILED' build/list-walk-planted.log) named file(s)"
+	$(call list_walk_gating_control,ungated,'s@listAdapters := tableJsonNoListAdapters@listAdapters := tableJsonListAdapters // SABOTAGED@',examples,the list half emitted into every unit left the gate GREEN,the list half reached the list-free unit)
+	$(call list_walk_gating_control,dropped,'s@listAdapters = tableJsonListAdapters@listAdapters = tableJsonNoListAdapters // SABOTAGED@',lists,the list half emitted into no unit at all left the gate GREEN,no list half in)
 
 # ---- the NEGATIVE CONTROLS §2.9 names ------------------------------------
 #

--- a/internal/listwalk/listwalk.go
+++ b/internal/listwalk/listwalk.go
@@ -1,0 +1,102 @@
+// Package listwalk is the LIST-WALK GATE's instrument (docs/SPEC-TABLES.md
+// §2.9, §13.5, §16): it answers, per generated translation unit, whether the
+// JSON walker's LIST half belongs in it, and it answers from the SCHEMAS
+// rather than from a list of directory names kept beside them.
+//
+// WHY THE FACT IS DERIVED. The gate's premise is §13.5's: the list half is a
+// body of non-template code that every consumer of a header would otherwise
+// re-parse, so it rides only where a list rides, and a list-free unit pays
+// nothing for the text form's list surface. The premise did not move. What
+// moved was the corpus: the gate named `tables/maps` list-free by directory,
+// #662 gave `Spans` a `map[uint8][]Item`, the unit became list-bearing, the
+// copy of the fact did not, and the gate reported correct emission as a leak.
+// A copied fact rots on the day the thing it copies changes; a derived one
+// cannot.
+//
+// WHAT DERIVES IT. `ir.ListFields` walks the unit's TABLE CLOSURE and names
+// every `[]T` an author wrote, including a list-typed MAP VALUE, because a
+// map's generated entry is a real table of that closure (§2.8), which is what
+// makes `map[K][]T` reach this answer with no clause of its own.
+//
+// AND WHAT DOES NOT. The answer here is never asked of the C++ emitter. The
+// emitter has its own `unitHasList`, and a gate that shared it would move with
+// every sabotage of it and stay green: the negative controls patch the
+// emitter's gating and this package must still say what the schemas say.
+package listwalk
+
+import (
+	"strings"
+
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// Bearing names the unbounded arrays in a unit's table closure, as
+// `Table.field`, sorted. A unit is LIST-BEARING when it names one and
+// LIST-FREE when it names none.
+func Bearing(u *ir.Unit) []string { return ir.ListFields(u) }
+
+// The MARKERS the emitter writes around the list half
+// (internal/codegen/cpptable/json.go). The gate reads the emitted text for
+// them rather than for a function name, so the region compared is exactly the
+// region the emitter claims is one half.
+const (
+	Begin = "// ---- json list walk: begin ----"
+	End   = "// ---- json list walk: end ----"
+)
+
+// Half returns the list half of one generated .cpp, marker lines included, and
+// reports whether the file carries one at all. A file whose begin marker has
+// no end marker carries no half and says so, so a truncated region is a red
+// rather than a silent pass.
+func Half(source string) (string, bool) {
+	begin := strings.Index(source, Begin)
+	if begin < 0 {
+		return "", false
+	}
+	end := strings.Index(source[begin:], End)
+	if end < 0 {
+		return "", false
+	}
+	return source[begin : begin+end+len(End)], true
+}
+
+// GeneratedUnit is one unit of the C++ table corpus: the directory
+// `tables_generate` emits it into, and the schema path it is generated from.
+type GeneratedUnit struct {
+	Dir    string
+	Source string
+}
+
+// Corpus reads the units out of the Makefile's `tables_generate` define, which
+// is the list that GENERATES the tree the gate scans.
+//
+// IT IS THE GENERATOR'S OWN LIST, not a second one beside it. A gate whose
+// corpus is hand-kept holds the units someone remembered to add; this one
+// holds every unit the build emits, so a unit added to `tables_generate` is
+// under the gate the same day, list-bearing or list-free.
+func Corpus(makefile string) []GeneratedUnit {
+	var out []GeneratedUnit
+	inside := false
+	for line := range strings.SplitSeq(makefile, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !inside {
+			inside = trimmed == "define tables_generate"
+			continue
+		}
+		if trimmed == "endef" {
+			break
+		}
+		fields := strings.Fields(trimmed)
+		// `$(1) generate --lang cpp --out $(2)/<dir> <source>` and nothing
+		// else; a comment line or a recipe of another shape is not a unit.
+		if len(fields) != 7 || fields[1] != "generate" || fields[4] != "--out" {
+			continue
+		}
+		dir, ok := strings.CutPrefix(fields[5], "$(2)/")
+		if !ok {
+			continue
+		}
+		out = append(out, GeneratedUnit{Dir: dir, Source: fields[6]})
+	}
+	return out
+}

--- a/internal/listwalk/listwalk_test.go
+++ b/internal/listwalk/listwalk_test.go
@@ -1,0 +1,172 @@
+package listwalk_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/mas-bandwidth/schema/v2/compiler"
+	"github.com/mas-bandwidth/schema/v2/internal/listwalk"
+	"github.com/mas-bandwidth/schema/v2/ir"
+)
+
+// TestListWalkHalfRidesTheListBearingUnits is the LIST-WALK GATE
+// (docs/SPEC-TABLES.md §2.9, §13.5, §16). Three claims, one per unit of the
+// C++ table corpus, and the LIST-FREE SET IS DERIVED FROM THE SCHEMAS:
+//
+//  1. a LIST-BEARING unit's every generated .cpp carries the list half;
+//  2. a LIST-FREE unit's carries none of it, which is §2.2's zero-cost
+//     property holding for the text form;
+//  3. the half is ONE half, the same bytes wherever it rides.
+//
+// `make tables-json-list-walk` points SCHEMA_LIST_WALK_DIR at the generated
+// tree. Without it this test still derives the answer for every unit of the
+// corpus and holds the derivation itself honest, which is what keeps
+// `go test ./...` saying something about the fact the gate is built on.
+func TestListWalkHalfRidesTheListBearingUnits(t *testing.T) {
+	dir := os.Getenv("SCHEMA_LIST_WALK_DIR")
+	// SCHEMA_LIST_WALK_UNITS narrows the scan to named generated directories,
+	// which is what a NEGATIVE CONTROL needs: a control regenerates one or two
+	// units, and a run that also went red over thirty-five missing trees would
+	// be red for the wrong reason.
+	only := map[string]bool{}
+	for name := range strings.SplitSeq(os.Getenv("SCHEMA_LIST_WALK_UNITS"), ",") {
+		if name != "" {
+			only[name] = true
+		}
+	}
+
+	units := corpus(t)
+	var bearingUnits, freeUnits, bearingFiles, freeFiles int
+	firstName, firstHalf := "", ""
+
+	for _, unit := range units {
+		if len(only) > 0 && !only[unit.Dir] {
+			continue
+		}
+		lists := listwalk.Bearing(load(t, unit.Source))
+		if len(lists) > 0 {
+			bearingUnits++
+		} else {
+			freeUnits++
+		}
+		if dir == "" {
+			continue
+		}
+		sources, err := filepath.Glob(filepath.Join(dir, unit.Dir, "*Table.cpp"))
+		if err != nil {
+			t.Fatalf("%s: %v", unit.Dir, err)
+		}
+		sort.Strings(sources)
+		for _, source := range sources {
+			text, err := os.ReadFile(source)
+			if err != nil {
+				t.Fatalf("%s: %v", source, err)
+			}
+			half, carried := listwalk.Half(string(text))
+			switch {
+			case len(lists) == 0 && carried:
+				freeFiles++
+				t.Errorf("LIST-WALK GATE FAILED: the list half reached the list-free unit %s.\n"+
+					"No table in %s's closure carries an unbounded array", source, unit.Source)
+			case len(lists) > 0 && !carried:
+				bearingFiles++
+				t.Errorf("LIST-WALK GATE FAILED: no list half in %s.\n"+
+					"%s declares %s", source, unit.Source, strings.Join(lists, ", "))
+			case carried:
+				bearingFiles++
+				if firstHalf == "" {
+					firstName, firstHalf = source, half
+				} else if half != firstHalf {
+					t.Errorf("LIST-WALK GATE FAILED: the list half in %s is not the list half in %s.\n%s",
+						source, firstName, firstDifference(firstHalf, half))
+				}
+			default:
+				freeFiles++
+			}
+		}
+	}
+
+	// The two claims below are about the WHOLE corpus, so a narrowed run,
+	// which is a negative control's, is not asked for them.
+	if len(only) == 0 {
+		if bearingUnits == 0 || freeUnits == 0 {
+			// A derivation that answers the same for every unit holds nothing:
+			// it would report green over a corpus of one kind. The corpus
+			// carries both, so the instrument owes both answers.
+			t.Fatalf("the derived list-free set is %d list-bearing and %d list-free units. "+
+				"The corpus carries both kinds, and an instrument that reports one is not deriving anything",
+				bearingUnits, freeUnits)
+		}
+		if dir != "" && firstHalf == "" {
+			t.Fatal("LIST-WALK GATE FAILED: not one generated .cpp of the corpus carries a list half")
+		}
+	}
+	// The counts below are what the gate COUNTED, so they are reported only
+	// when it held: a red run's numbers describe the failure, not the corpus.
+	if dir == "" || t.Failed() {
+		return
+	}
+	summary := "tables list-walk gate: one list half, byte-identical in " + strconv.Itoa(bearingFiles) +
+		" .cpp files across " + strconv.Itoa(bearingUnits) + " list-bearing units, and in none of the " +
+		strconv.Itoa(freeFiles) + " .cpp files of the " + strconv.Itoa(freeUnits) +
+		" list-free ones, the set derived from the schemas\n"
+	if path := os.Getenv("SCHEMA_LIST_WALK_SUMMARY"); path != "" {
+		if err := os.WriteFile(path, []byte(summary), 0o644); err != nil {
+			t.Fatalf("the gate's summary cannot be written: %v", err)
+		}
+	}
+	t.Log(summary)
+}
+
+// corpus is every unit `tables_generate` emits, read out of the Makefile
+// rather than restated here, so the tree the gate scans and the units it
+// derives an answer for are ONE list. A unit added to the build is under the
+// gate with no edit to this file.
+func corpus(t *testing.T) []listwalk.GeneratedUnit {
+	t.Helper()
+	text, err := os.ReadFile("../../Makefile")
+	if err != nil {
+		t.Fatalf("the Makefile carries tables_generate and cannot be read: %v", err)
+	}
+	units := listwalk.Corpus(string(text))
+	if len(units) == 0 {
+		t.Fatal("the Makefile's tables_generate names no unit. That define IS the gate's corpus")
+	}
+	return units
+}
+
+// firstDifference names the first line two halves disagree about, which is
+// what a reader needs rather than two whole walkers.
+func firstDifference(want, got string) string {
+	a, b := strings.Split(want, "\n"), strings.Split(got, "\n")
+	for i := 0; i < len(a) || i < len(b); i++ {
+		x, y := "", ""
+		if i < len(a) {
+			x = a[i]
+		}
+		if i < len(b) {
+			y = b[i]
+		}
+		if x != y {
+			return "line " + strconv.Itoa(i+1) + " of the half:\n  first: " + x + "\n  this:  " + y
+		}
+	}
+	return "the halves differ in trailing bytes alone"
+}
+
+func load(t *testing.T, source string) *ir.Unit {
+	t.Helper()
+	paths, err := compiler.GatherPaths([]string{"../../" + source})
+	if err != nil {
+		t.Fatalf("%s: %v", source, err)
+	}
+	unit, err := compiler.New().Load(paths)
+	if err != nil {
+		t.Fatalf("%s: %v", source, err)
+	}
+	return unit
+}


### PR DESCRIPTION
`make test` has been red at `tables-json-list-walk` on main since #662 merged
(e123f1b2). This is the instrument, not the emitter.

## Red first, on main's tree

Clean clone of `origin/main` (dcdd5cdd), `make bin/schema`,
`make build/tables-generated/.stamp`, then:

```
$ make tables-json-list-walk
LIST-WALK GATE FAILED: the list half reached the list-free unit build/tables-generated/maps/CellsTable.cpp
make: *** [tables-json-list-walk] Error 1
```

## The judgment

**The gate's PREMISE is right.** §13.5 put the JSON walk in `<Base>Table.cpp`
because it is non-template, non-constant code every consumer would otherwise
re-parse, and the list half of it rides only where a list rides. A list-free
unit pays nothing for the text form's list surface. That is §2.2's zero-cost
property holding for the text form, and it did not move.

**The gate's INSTRUMENT was wrong.** It named the list-free set by directory:

```make
for f in build/tables-generated/examples/*Table.cpp \
         build/tables-generated/pointers/*Table.cpp \
         build/tables-generated/maps/*Table.cpp; do ...
```

That is a COPY of a fact the schemas own. #662 added
`Spans { tracks map[uint8][]Item }` to `tables/maps`, which makes the whole
unit list-bearing; the emitter emitted the half into all ten of its `.cpp`
files, correctly, and the copy standing in the recipe reported correct emission
as a leak. #662's own body records the movement ("the four `<Base>Table.cpp`
files gained the JSON LIST WALK") and did not carry it into the recipe. A
copied fact rots on the day the thing it copies changes.

## The instrument's new shape

`internal/listwalk` asks the compiler's own IR.

- **The fact.** A unit is LIST-FREE when no table in its closure carries an
  unbounded array. `ir.ListFields` walks `ir.TableClosure` and names every
  `[]T`, and a map's generated entry is a real table of that closure (§2.8),
  so `map[K][]T` reaches the answer with no clause of its own. No directory
  name appears anywhere in the gate.
- **The corpus.** Read out of the Makefile's `tables_generate` define, which
  is the list that GENERATES the tree the gate scans. One list, read by both
  halves, on `internal/viewlisting`'s rule: a unit added to the build is under
  the gate the same day, list-bearing or list-free.
- **The assertion, per unit.** A list-bearing unit's every generated `.cpp`
  carries the half; a list-free unit's carries none of it; the half is ONE
  half, the same bytes wherever it rides.
- **What it does NOT ask.** The C++ emitter. `internal/codegen/cpptable` has
  its own `unitHasList`, and a gate that shared it would move with every
  sabotage of it and stay green. Two of the three controls below patch exactly
  that gating.

Driven from the Makefile the way `tables-view` drives `internal/viewlisting`:
`SCHEMA_LIST_WALK_DIR` points at the generated tree, `SCHEMA_LIST_WALK_UNITS`
narrows a control's run, and without either the test still derives the answer
for every unit of the corpus, so `go test ./...` keeps saying something about
the fact the gate is built on.

## Green, and wider

```
$ make tables-json-list-walk
tables list-walk gate: one list half, byte-identical in 21 .cpp files across 5
list-bearing units, and in none of the 42 .cpp files of the 32 list-free ones,
the set derived from the schemas
```

The scan widened. It held five `.cpp` files in one directory and scanned three
directories for the absence; it now holds all 63 generated `.cpp` files of the
corpus. `arms`, `rt1` and `rt2` carry the list half and were held by neither
clause.

## The controls

`make tables-json-list-walk-negative-controls`, new, and in `make test` beside
the gate.

**PLANTED** puts the half into a list-free unit's emitted `.cpp` in a throwaway
copy. Nothing is generated and no emitter is patched, so it holds the SCAN
alone:

```
LIST-WALK GATE FAILED: the list half reached the list-free unit
  build/list-walk-planted/examples/TablesTable.cpp.
  No table in tables/examples's closure carries an unbounded array
```

**UNGATED** removes the emitter's own gating through a Go overlay
(`listAdapters := tableJsonNoListAdapters` becomes the real half), so every
unit's `.cpp` carries it. This is the control the gate exists for: it is what
§13.5's ruling costs a list-free consumer the day the gating goes.

```
LIST-WALK GATE FAILED: the list half reached the list-free unit
  build/list-walk-ungated-tree/examples/GuardedTable.cpp.
  No table in tables/examples's closure carries an unbounded array
  ... 7 named files
```

**DROPPED** is the other half of that switch: the list half is never emitted,
so a list-bearing unit is left with the stub. A gate that only refused leaks
would stay green here.

```
LIST-WALK GATE FAILED: no list half in
  build/list-walk-dropped-tree/lists/HoldersTable.cpp.
  tables/lists declares Album.photos, Army.squads, Bytes.data, Floats.values,
  Ints.values, Mixed.bounds, Mixed.grades, Mixed.hits, Mixed.perms, Row.items,
  Save.log, Save.placements, Save.scores, Sheet.rows, Unbounded.items
  ... 5 named files
```

Each control narrows with `SCHEMA_LIST_WALK_UNITS`, so its red is its own and
not thirty-five absent trees. A sabotage that patches nothing is itself a
failure, and a red that is not on the named clause is a failure too.

## Named follow-on, not folded in

**The map-walk gate keeps the same hand-kept shape.** It is narrow rather than
red: its byte compare covers the ten `.cpp` files of `maps/` while seventeen
carry a map half (`lists/`'s five, `rt1`, `rt2`), and its absence scan names
`examples/` and `pointers/` only. Nothing is wrong with what it asserts today;
it is one corpus change away from the failure this PR repairs, and
`internal/listwalk` generalizes to it in a predicate. Left for its own issue
rather than widened into a red-fixing PR.

## Test

`make tables-json-list-walk` and `make tables-json-map-walk` green.
`make tables-json-list-walk-negative-controls` red on all three controls, by
name. `go test ./...` green across 31 packages, including
`internal/ci`'s `TestEveryPackageTheBuildRunsIsCommitted`, which is what makes
the new package's tracking a gate rather than a habit. `make test` whole to the
absent-toolchain stop: it reaches `build-conformance-cs` and stops on
`dotnet: command not found` (Error 127), with the list-walk gate and its three
controls green above it and no other failure in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
