### PR TITLE
bench tools: aggregate walks the column list again, and a test holds it there

### DIFF
--- a/bench/tools/aggregate.go
+++ b/bench/tools/aggregate.go
@@ -52,8 +52,17 @@ func parseRound(meta []string) string {
 	return ""
 }
 
-func aggregateCmd(paths []string) {
-	if len(paths) < 1 {
+// files is the round CSVs; it is deliberately not named `paths`, which is
+// the package-level list of path-column values that the output loop and the
+// straggler refusal below walk. A parameter of that name shadowed the list
+// from the day the list entered (6e1002b7, 2026-08-31, the F4 fix) to
+// 2026-09-07: the output loop walked the input FILE names, printed no row,
+// and the refusal fired on every key of every pass. No command in this
+// package names a parameter or local after a package-level list; the old
+// name still resolves after a rename, so the compiler cannot refuse one
+// left behind, and the tests in aggregate_test.go are what hold it.
+func aggregateCmd(files []string) {
+	if len(files) < 1 {
 		usage()
 	}
 	acc := map[key]*aggRow{}
@@ -62,7 +71,7 @@ func aggregateCmd(paths []string) {
 	seenPath := map[string]string{}
 	var passID identity
 	passIDSet := false
-	for _, p := range paths {
+	for _, p := range files {
 		// the same round file twice yields runs=N+1 spread=0.00 — fake
 		// stability manufactured from one measurement. Refuse by path.
 		clean := filepath.Clean(p)
@@ -176,7 +185,7 @@ func aggregateCmd(paths []string) {
 		}
 	}
 	if printed != len(acc) {
-		fmt.Fprintf(os.Stderr, "aggregate: REFUSING: %d row key(s) accumulated but not printed — the order list does not know every bench the rounds measured:\n", len(acc)-printed)
+		fmt.Fprintf(os.Stderr, "aggregate: REFUSING: %d row key(s) accumulated but not printed — the bench or path lists do not know every row the rounds measured (bench: %s; path: %s):\n", len(acc)-printed, strings.Join(order, ", "), strings.Join(paths, ", "))
 		for _, k := range keys {
 			if !slices.Contains(order, k.bench) || !slices.Contains(paths, k.path) {
 				fmt.Fprintf(os.Stderr, "    %s/%s/%s\n", k.lang, k.bench, k.path)
@@ -186,11 +195,11 @@ func aggregateCmd(paths []string) {
 	}
 }
 
-func controlMedianCmd(paths []string) {
-	if len(paths) != 1 {
+func controlMedianCmd(files []string) {
+	if len(files) != 1 {
 		usage()
 	}
-	rows, _, err := load(paths[0])
+	rows, _, err := load(files[0])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
@@ -205,7 +214,7 @@ func controlMedianCmd(paths []string) {
 		}
 	}
 	if len(rates) == 0 {
-		fmt.Fprintf(os.Stderr, "controlmedian: no cpp family-gen rows in %s\n", paths[0])
+		fmt.Fprintf(os.Stderr, "controlmedian: no cpp family-gen rows in %s\n", files[0])
 		os.Exit(2)
 	}
 	fmt.Printf("%.0f\n", median(rates))

--- a/bench/tools/aggregate_test.go
+++ b/bench/tools/aggregate_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A round file as the pass driver writes one: the runner's CSV with the
+// driver's `# round: K` stamp in the preamble and one measured run per row.
+func writeRound(t *testing.T, dir, name, round string, rows ...string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	body := "# schema bench results\n# round: " + round + "\n" +
+		"lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline\n" +
+		strings.Join(rows, "\n") + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// runTool builds the tool into the test's temp dir, once per call, and runs
+// that binary, so the exit status observed is the tool's own — `go run` would
+// report the tool's exit 2 as its own exit 1.
+func runTool(t *testing.T, args ...string) (string, string, int) {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "bench-tools")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+	cmd := exec.Command(bin, args...)
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	err := cmd.Run()
+	code := 0
+	if exit, ok := errors.AsType[*exec.ExitError](err); ok {
+		code = exit.ExitCode()
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	return out.String(), errb.String(), code
+}
+
+// The output loop of aggregate walks the package-level `paths` list (write,
+// read, round_trip). Until 2026-09-07 the function's own parameter was also
+// named `paths` and shadowed it, so the loop walked the input FILE names,
+// printed no row, and the straggler refusal fired on every key of every
+// pass with the message that the order list did not know the bench. The
+// driver had not run a pass since the loop was written, so nothing noticed.
+// This test is the pass the driver would have run: two rounds, the current
+// corpus's rows, and every row must come out aggregated.
+func TestAggregatePrintsEveryRowOfACurrentCorpusPass(t *testing.T) {
+	dir := t.TempDir()
+	r0 := writeRound(t, dir, "round-0-cpp.csv", "0",
+		"cpp,bench_mixed,write,4000000,100,1,9000000,9000000,9000000,3759.77,0.00,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown",
+		"cpp,bench_mixed,round_trip,4000000,100,1,4500000,4500000,4500000,1879.88,0.00,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown",
+		"cpp,bitpacker,write,24576,65536,1,95000,95000,95000,5937.50,0.00,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown",
+		"cpp,bitpacker,read,24576,65536,1,125000,125000,125000,7812.50,0.00,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown")
+	r1 := writeRound(t, dir, "round-1-cpp.csv", "1",
+		"cpp,bench_mixed,write,4000000,100,1,9200000,9200000,9200000,3843.32,0.00,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown",
+		"cpp,bench_mixed,round_trip,4000000,100,1,4400000,4400000,4400000,1838.11,0.00,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown",
+		"cpp,bitpacker,write,24576,65536,1,97000,97000,97000,6062.50,0.00,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown",
+		"cpp,bitpacker,read,24576,65536,1,123000,123000,123000,7687.50,0.00,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown")
+
+	out, errOut, code := runTool(t, "aggregate", r0, r1)
+	if code != 0 {
+		t.Fatalf("aggregate refused a well-formed two-round pass (exit %d):\n%s", code, errOut)
+	}
+	for _, want := range []string{
+		"cpp,bench_mixed,write,4000000,100,2,9100000,9000000,9200000,",
+		"cpp,bench_mixed,round_trip,4000000,100,2,4450000,4400000,4500000,",
+		"cpp,bitpacker,write,24576,65536,2,96000,95000,97000,",
+		"cpp,bitpacker,read,24576,65536,2,124000,123000,125000,",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("aggregated output lacks the row %q\n--- stdout ---\n%s--- stderr ---\n%s", want, out, errOut)
+		}
+	}
+}
+
+// The negative control: the straggler refusal must still fire on a path the
+// column list does not know, so a runner that grows a new path REFUSES the
+// aggregation rather than losing the row (BENCH-STANDARD §5.1).
+func TestAggregateRefusesAPathTheListDoesNotKnow(t *testing.T) {
+	dir := t.TempDir()
+	r0 := writeRound(t, dir, "round-0-cpp.csv", "0",
+		"cpp,bench_mixed,sideways,4000000,100,1,9000000,9000000,9000000,3759.77,0.00,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown")
+	out, errOut, code := runTool(t, "aggregate", r0)
+	if code != 2 {
+		t.Fatalf("aggregate accepted a row on an unknown path (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+	if !strings.Contains(errOut, "accumulated but not printed") || !strings.Contains(errOut, "cpp/bench_mixed/sideways") {
+		t.Errorf("the straggler refusal did not fire naming the row:\n%s", errOut)
+	}
+}
+
+// bands reads its PRIOR files from its second argument onward. The same
+// shadow class that broke aggregate was recreated here by the first rename
+// (the loop kept reading `paths[1:]`, which had become the column list), so
+// the command opened a file named `read`. Two files, one band, must print
+// band-ok.
+func TestBandsReadsThePriorFilesItIsGiven(t *testing.T) {
+	dir := t.TempDir()
+	cur := writeRound(t, dir, "current.csv", "0",
+		"cpp,bench_mixed,write,4000000,100,7,9000000,8900000,9100000,858.31,2.22,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown")
+	prior := writeRound(t, dir, "prior.csv", "0",
+		"cpp,bench_mixed,write,4000000,100,7,9050000,8950000,9150000,863.08,2.21,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown")
+	out, errOut, code := runTool(t, "bands", cur, prior)
+	if code != 0 || !strings.Contains(out, "band-ok: cpp/bench_mixed/write") {
+		t.Fatalf("bands did not band the current row against its prior (exit %d)\n--- stdout ---\n%s--- stderr ---\n%s", code, out, errOut)
+	}
+}
+
+// controlmedian's refusal names the FILE it found no control rows in; after
+// the first rename it named the first path-column value instead.
+func TestControlMedianRefusalNamesTheFile(t *testing.T) {
+	dir := t.TempDir()
+	bits := writeRound(t, dir, "bits-only.csv", "0",
+		"cpp,bitpacker,write,24576,4096,7,95000,94000,96000,371.09,2.11,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown")
+	_, errOut, code := runTool(t, "controlmedian", bits)
+	if code != 2 || !strings.Contains(errOut, "bits-only.csv") {
+		t.Fatalf("controlmedian did not refuse naming the file (exit %d):\n%s", code, errOut)
+	}
+}

--- a/bench/tools/relative.go
+++ b/bench/tools/relative.go
@@ -494,9 +494,9 @@ func guardRatio(ds *dataset, ka, kb key, a, b row) []string {
 	return d
 }
 
-func merge(paths []string) *dataset {
+func merge(files []string) *dataset {
 	ds := &dataset{rows: map[key]row{}}
-	for _, p := range paths {
+	for _, p := range files {
 		r, meta, err := load(p)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/bench/tools/twinband.go
+++ b/bench/tools/twinband.go
@@ -86,16 +86,16 @@ func keyName(k key) string {
 	return fmt.Sprintf("%s/%s/%s/%s", k.lang, k.bench, k.path, k.codec)
 }
 
-func twingateCmd(paths []string) {
-	if len(paths) != 2 {
+func twingateCmd(files []string) {
+	if len(files) != 2 {
 		usage()
 	}
-	a, _, err := load(paths[0])
+	a, _, err := load(files[0])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
-	b, _, err := load(paths[1])
+	b, _, err := load(files[1])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
@@ -159,11 +159,11 @@ func sameConfig(a, b row) bool {
 		a.linkage == b.linkage && a.checks == b.checks && a.opt == b.opt
 }
 
-func bandsCmd(paths []string) {
-	if len(paths) < 2 {
+func bandsCmd(files []string) {
+	if len(files) < 2 {
 		usage()
 	}
-	cur, _, err := load(paths[0])
+	cur, _, err := load(files[0])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
@@ -173,7 +173,7 @@ func bandsCmd(paths []string) {
 		n      int
 	}
 	bands := map[key]*band{}
-	for _, p := range paths[1:] {
+	for _, p := range files[1:] {
 		rows, meta, err := load(p)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
**What was wrong.** `bench/tools/pass-driver.sh` has refused at its last step, aggregation, on every pass since 6e1002b7 (2026-08-31, the F4 fix) made the package-level `paths` list (`write`, `read`, `round_trip`) the output loop of `aggregate`: `aggregateCmd`'s own parameter, the list of round files, was also named `paths` and shadowed it. The output loop walked the input file names, printed no row, and the straggler refusal fired on every key with a message naming the wrong cause, "the order list does not know every bench the rounds measured". It failed closed, which is the right failure, and no driver pass had run since (every published nine-language sitting was `run.sh`), so nothing noticed until today's Studio pass ran to its end and refused.

**What changes.** The parameter is `files` in every function that took a list of CSVs (`aggregate`, `controlmedian`, `twingate`, `bands`, `merge`); only `aggregate` had the live shadow. A comment at the site says why the name matters and why the compiler cannot hold it: the old name still resolves after a rename. The straggler refusal now names both lists it checked. `bench/tools` gains the package's first test file (the `realpacket-gen` package beside it has its own): two rounds of the current corpus must aggregate to every row with the right runs and rates; a row on a path the list does not know must still trip the straggler refusal and name the row; `bands` must band a current file against a prior; and `controlmedian`'s refusal must name the file. The tests run the built binary, not `go run`, so the exit status they read is the tool's own.

**What the cold read caught, and is fixed here.** The first version of this branch renamed the parameters and left two uses of the old name behind, at `twinband.go:176` and `aggregate.go:213`; after the rename they bound to the package-level list, so `bands` opened a file called `read` and `controlmedian`'s refusal named `write`. The reader also dated the shadow correctly (the list entered on 2026-08-31, not with the driver on 2026-08-14) and found `merge` carrying the same parameter name, benign. All of it is repaired, with the `bands` and `controlmedian` tests as the guard the first version lacked. The shape gate refused the test's first draft for carrying `bench_mixed`'s wire size in synthetic rows, and lint its type assertion on an error; both repaired.

**Receipts.** `go vet ./bench/tools`, `go test ./bench/tools`, `gofmt -l` and `make shape-gate` pass here; the Studio rounds that refused under the shadow aggregate to sixteen rows with the fix. The Studio pass CSVs come in a separate PR once their windows are judged.

A second cold read of the repaired branch returned LAND, reproducing each test's failure on the defective code and its pass at head; its two comment imprecisions are fixed in the last commit.

Opened by Rowan from Glenn's GitHub login, the bench's only one; the commits are authored Rowan and the branch was pushed as rowan-claude.
