### PR TITLE
bench: the README's table moves to the Studio; two sittings and the two-by-two say what moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,19 @@ Cost to serialize a representative game packet, relative to generated C++ at
 
 | Language | % |
 |---|---:|
-| C | 100% |
 | C++ | 100% |
-| Rust | 154% |
-| Java | 162% |
-| Go | 210% |
-| C# | 225% |
-| Dart | 227% |
-| JavaScript | 264% |
-| Elixir | 1283% |
+| C | 107% |
+| Java | 169% |
+| Rust | 172% |
+| Go | 230% |
+| C# | 253% |
+| Dart | 256% |
+| JavaScript | 387% |
+| Elixir | 1427% |
 
-Measured by [the benchmark](bench/). One 438-byte packet exercising every construct. 
+Measured by [the benchmark](bench/) on an Apple M3 Ultra, 2026-09-07;
+[PERFORMANCE.md](docs/PERFORMANCE.md) has the toolchains, the earlier Apple M2 table and what
+moved between them. One 438-byte packet exercising every construct.
 
 ## Install and build
 

--- a/bench/results/2026-09-07-arm64-studio-four-leg-passes.md
+++ b/bench/results/2026-09-07-arm64-studio-four-leg-passes.md
@@ -1,0 +1,152 @@
+# Studio, 2026-09-07: two nine-language sittings, four four-leg driver passes, and what moved since the README's sitting
+
+All on the shared Mac Studio (Apple M3 Ultra, 32 cores, 512 GiB, Darwin 25.6.0, Apple clang
+21.0.0 clang-2100.1.1.101, go 1.27.1, cargo 1.98.0), unpinned, a desktop session and a Codex
+session live on the account throughout, the keeper's estate under another user. Loads are in
+each preamble.
+
+## The two sittings
+
+`bench/run.sh` sittings, seven measured runs per leg, every leg gated on the wire goldens
+(`corpus_id 6b213fbfa1a03a99`), schema main 3d01b479. The runtimes were at the tags
+`.github/workflows/ci.yml` checks out (serialize v1.16.2, serialize.c v1.9.2, serialize.go
+v1.15.1, serialize.rs v2.4.0, serialize.cs v1.9.1, serialize.js v1.4.2; each preamble records
+the commit its tag resolved to). Five legs ran on the toolchains the repository pins: the
+codegen-only legs on `make/*.mk`'s (OpenJDK 21.0.12.1, the Temurin build; Dart 3.13.2;
+Erlang/OTP 29.0.5 with Elixir 1.20.4), C# on .NET SDK 10.0.400 for the `10.0` in
+`.github/dotnet-version`, JavaScript on node 20.20.2. The other four ran on the machine's
+compilers, which the repository does not pin: Apple clang 21.0.0, go 1.27.1 (CI runs 1.26),
+cargo 1.98.0 (CI resolves Rust's stable at run time).
+Sitting 1 (`2026-09-07-arm64-studio-ninelang-sitting.csv`, 14:22:47Z) skipped JavaScript because
+the runner finds node on the PATH and the pinned node was not on it; that leg ran alone into
+`2026-09-07-arm64-studio-ninelang-sitting-js.csv` afterwards (14:29:25Z). Sitting 2
+(`2026-09-07-arm64-studio-ninelang-sitting-2.csv`, 14:32:38Z) ran all nine in one file and is the
+README's. Rendered by `bench/render.awk` (round-trip best rate, C++ = 100%), except sitting 1's
+JavaScript, which render.awk refuses (no C++ row in its file) and is computed here by hand from
+the two files' best rates:
+
+| language | sitting 2 | sitting 1 | Air sitting, 2026-09-01 |
+|---|---:|---:|---:|
+| C++ | 100% | 100% | 100% |
+| C | 107% | 109% | 98%, tie |
+| Java | 169% | 175% | 162% |
+| Rust | 172% | 174% | 154% |
+| Go | 230% | 238% | 210% |
+| C# | 253% | 260% | 225% |
+| Dart | 256% | 264% | 227% |
+| JavaScript | 387% | 392% (by hand, two files) | 264% (node 26.7.0) |
+| Elixir | 1427% | 1489% | 1283% |
+
+Best round-trip rates, messages per second, with the spread of the seven runs:
+
+| leg | sitting 2 | spread | sitting 1 | spread | Air |
+|---|---:|---:|---:|---:|---:|
+| cpp | 4,637,510 | 1.7% | 4,801,451 | 2.5% | 3,594,435 |
+| c | 4,343,435 | 2.0% | 4,398,224 | 2.6% | 3,662,957 |
+| java | 2,739,857 | 3.3% | 2,747,725 | 1.2% | 2,216,563 |
+| rust | 2,692,124 | 1.9% | 2,757,736 | 1.5% | 2,336,475 |
+| go | 2,013,759 | 1.3% | 2,018,407 | 0.6% | 1,715,160 |
+| cs | 1,836,489 | 0.7% | 1,846,057 | 0.9% | 1,599,897 |
+| dart | 1,812,096 | 2.4% | 1,820,703 | 2.1% | 1,586,561 |
+| js | 1,199,841 | 1.0% | 1,224,748 | 2.4% | 1,361,635 |
+| elixir | 324,874 | 0.7% | 322,502 | 5.7% | 280,148 |
+
+The sittings, ten minutes apart, differ by 1.1 to 4.2% on every ratio (Elixir's 62 points is
+4.2% of 1489), most of it the C++ denominator; no row in either is past the §2.3 noisy line.
+
+## The four driver passes: the two-by-two
+
+`bench/tools/pass-driver.sh`, four legs (cpp, c, go, rust), seven interleaved rounds, every leg
+twice per round as §2.6.1 A/A twins, a C++ control leg before and after, the two changes since
+the README sitting (schema 7eba63f to today's main; the runtimes at their 2026-08-25 to 09-01
+commits, cebaed2, 37db942, 287e2fe, 6b52aa6, to CI's tags) crossed:
+
+| pass | schema (preamble) | runtimes | control delta | twins | load peak | CSV |
+|---|---|---|---:|---|---:|---|
+| A | `b414f078-dirty` | the tags | 0.7% | OK | 10.5 | `2026-09-07-arm64-studio-four-legs-twins-pass.csv` |
+| B | `7eba63fe` | the tags | 4.0% | OK | 20.5 | `2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-pass.csv` |
+| C | `a7b80a42` | the sitting's | 0.7% | OK | 6.0 | `2026-09-07-arm64-studio-four-legs-twins-oldruntimes-pass.csv` |
+| D | `7eba63fe` | the sitting's | 1.2% | OK | 7.7 | `2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-oldruntimes-pass.csv` |
+
+Four separate passes, at 13:38, 13:45, 13:53 and 14:40Z: the control legs and the twins
+certify each pass within itself, not one pass against another. Cell D ran last, after the two
+sittings, with node and dotnet on the PATH (its preamble records them where A, B and C record
+`not present`; none of the four runners uses either).
+
+Rendered, with the best round-trip rates:
+
+| cell | C measured | Rust | Go | cpp | c | rust | go |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| D: the sitting's schema, the sitting's runtimes | 99.1%, tie | 163% | 216% | 4,394,048 | 4,431,927 | 2,693,626 | 2,035,252 |
+| B: the sitting's schema, today's runtimes | 101.9%, tie | 167% | 222% | 4,538,961 | 4,454,055 | 2,714,060 | 2,040,720 |
+| C: today's schema, the sitting's runtimes | 103.3%, tie | 169% | 223% | 4,504,872 | 4,359,488 | 2,671,639 | 2,017,175 |
+| A: today's schema, today's runtimes | 106.7%, tie | 174% | 233% | 4,733,118 | 4,434,673 | 2,727,040 | 2,033,271 |
+| the Air sitting | 98.1%, tie | 154% | 210% | 3,594,435 | 3,662,957 | 2,336,475 | 1,715,160 |
+
+**What moved.** Rust's best round-trip rate stays between 2,671,639 and 2,757,736 a second
+across the four cells and both sittings (3.2% from lowest to highest), Go's between 2,013,759
+and 2,040,720 (1.3%), C's between 4,343,435 and 4,454,055 (2.5%); cell D to cell A, Go is
+-0.1% and C +0.1%. C++'s best rate on today's code is 5.5 to 9.3% above cell D's 4,394,048:
+7.7% in cell A (4,733,118), 9.3% and 5.5% in the two sittings (4,801,451 and 4,637,510). Both
+changes contribute and the split between them is not resolved: read along one path of the
+two-by-two, the schema commits since 7eba63f add 2.5% (D to C) and serialize.h between
+cebaed2 and v1.16.2 adds 5.1% (C to A); along the other, 4.3% (B to A) and 3.3% (D to B).
+Each step is smaller than the C++ round-trip spread inside the passes it is read from (2.0,
+3.0, 6.8 and 13.4% in D, B, A and C). The schema side changed the C++ emitter,
+`internal/codegen/cpp`, and the generated bench code, `generated/bench/cpp`, not the C++ runner
+in `bench/cpp`; the serialize.h side is 583 lines; which commit is responsible is not
+isolated. C++ is the denominator, so every other language's percentage widened by that much
+while the other three legs stayed inside their own spreads. Ratios move with
+microarchitecture, and cell D, the Air's code on the Air's runtimes, measures that move: Rust
+163% and Go 216% on this machine against 154% and 210% on the Air. The Air's own three
+sittings of 2026-09-01 render Rust 153, 153, 154 and Go 208, 209, 210, so its noise on these
+two ratios is about a point; on its JavaScript and Dart rows it is not (below). `bands A B C`,
+the standard's ±15% cross-pass check, reports every row of A inside the band of B and C; the
+check is coarser than the 7.7% move and does not resolve it. Absolute rates do not compare
+across machines under §2, and the Air-to-Studio rises are reported here for the ledger only:
+cpp 22% (cell D) to 32% (cell A), c 19 to 22%, go 18 to 19%, rust 14 to 17%.
+
+**JavaScript.** The Air's 264% ran node 26.7.0 where the repo pins 20.20.2, which is what ran
+here. The Studio's absolute JavaScript rate, 1.20 to 1.22 million a second, is below the
+Air's 1.36 million while every other leg is 14 to 29% above it. Two terms are open and the
+data does not separate them: the node version, and the Air's own variance on this leg. The
+Air's three sittings of 2026-09-01 rendered JavaScript 461%, 318% and 264% on that one node
+(762,465, 1,124,935 and 1,361,635 a second) and Dart 363, 225, 227; the README's Air number
+was the fast end of that range; the Studio's two sittings agree on JavaScript within 2%. A
+node 26 run on this machine is the measurement that would settle the version term and has
+not been made.
+
+**What to know before trusting a row.** Pass B's control delta, 4.0%, is inside the 5% window
+and in the standard's warning zone (its control fell from 6,994,002 to 6,717,419 under a
+one-minute load that peaked at 20.5). Pass C's `rust/bitpacker/write` row carries a 16.12%
+spread, past the §2.3 noisy line, and its C and C++ round-trip spreads of 13.8% and 13.4% are
+why its tie band is 27 points wide. The twin CSVs the gate compared are not committed; the
+`# twin_gate: OK` line in each preamble is the record. One toolchain difference against the Air
+sitting is not excluded: it ran go 1.27.0, these go 1.27.1, and CI runs 1.26; clang and rustc
+are identical strings.
+
+**Provenance.** Pass A's preamble reads `b414f078-dirty`: it started 29 seconds before the
+bench tools fix (#689) was first committed in the same worktree, and that fix sat uncommitted
+when the preamble was stamped. Pass C started on `a7b80a42`, the fix branch, whose whole diff
+from b414f078 is the four files of `bench/tools`. The runners are built from
+`generated/bench/<lang>` and `bench/<lang>`, which the fix does not touch, so A and C measure
+b414f078's generated code. Passes B and D ran the 7eba63f tree's own driver, byte-identical to
+today's, with `BENCH_TOOLS` pointed at a build of the fixed tools. Every runtime path was
+§3.5-verified against its toolchain's resolution before the first leg. These are the first
+passes the driver has aggregated since 2026-08-31: `aggregate` had refused every pass since
+then, failing closed, because its parameter shadowed the path-column list; today's first pass
+ran to the end and refused, which is how the shadow was found and fixed. That first pass, the
+same configuration as A earlier the same day, rendered Rust 172% and Go 234%, and is not published:
+it was aggregated by hand after the fix rather than by the driver. When these passes ran, the
+driver refused the three codegen-only legs at its §3.5 pre-flight (no case for java, dart and
+elixir; `bench/run.sh` exempted them by name; #692 gives the pre-flight the case); that is why
+the nine-language numbers are sittings and the two-by-two is four legs.
+
+```sh
+bench/run.sh --out bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv     # node, dotnet on PATH
+bench/tools/pass-driver.sh --rounds 7 --langs cpp,c,go,rust --twins --out bench/results/2026-09-07-arm64-studio-four-legs-twins-pass.csv
+# in a worktree at 7eba63f, beside the same runtime checkouts:
+BENCH_TOOLS=<fixed bench/tools binary> bench/tools/pass-driver.sh --rounds 7 --langs cpp,c,go,rust --twins --out bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-pass.csv
+SERIALIZE=<cebaed2> SERIALIZE_C=<37db942> SERIALIZE_GO=<287e2fe> SERIALIZE_RS=<6b52aa6> bench/tools/pass-driver.sh --rounds 7 --langs cpp,c,go,rust --twins --out <pass C or D>
+awk -F, -v skips="" -f bench/render.awk <csv>
+```

--- a/bench/results/2026-09-07-arm64-studio-four-legs-twins-oldruntimes-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-four-legs-twins-oldruntimes-pass.csv
@@ -1,0 +1,53 @@
+# schema bench results
+# date: 2026-09-07T13:53:09Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I/private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I/private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: not present (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: NOISY: desktop session with agents running; a Codex session live on this account; the keeper's estate under user rowan; A/B leg: schema at today's main, runtimes at the README sitting's commits (cebaed2, 37db942, 287e2fe, 6b52aa6)
+# schema commit: a7b80a42 (bench-tools-aggregate-walks-the-column-list)
+# serialize commit: cebaed2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize]
+# serialize.c commit: 37db942 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.c]
+# serialize.go commit: 287e2fe (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.go]
+# serialize.rs commit: 6b52aa6 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c go rust
+# load_start: 4.53 7.70 6.99
+# load_end: 5.52 5.83 6.24
+# load_max: 5.98
+# core_busy_pct: n/a
+# foreign_procs: 13
+# control_start_median: 6675256   control_end_median: 6631368
+# control_delta_pct: 0.7   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8696428,7834212,8810903,3632.58,11.23,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4244224,3774721,4359488,1772.85,13.78,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,91742,88605,93601,5732.33,5.45,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,75818,71506,77793,4737.35,8.29,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8772360,7955560,8937536,3664.30,11.19,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4418354,3911269,4504872,1845.59,13.43,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,92038,87948,93305,5750.83,5.82,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,123218,120870,124981,7698.98,3.34,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+rust,bench_mixed,write,4000000,438,14,7462460,7330681,7523765,3117.14,2.59,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,14,2638709,2603708,2671639,1102.21,2.57,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,14,36427,31550,37421,2276.06,16.12,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,14,44744,43784,45233,2795.73,3.24,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+go,bench_mixed,write,4000000,438,14,3984716,3821090,4065040,1664.45,6.12,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,14,1999790,1823882,2017175,835.33,9.67,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,14,12160,11877,12356,759.79,3.94,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,14,13908,13064,14165,869.04,7.92,6b213fbfa1a03a99,bits,pkg,always,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-four-legs-twins-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-four-legs-twins-pass.csv
@@ -1,0 +1,53 @@
+# schema bench results
+# date: 2026-09-07T13:38:14Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: not present (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: NOISY: desktop session with agents running; a Codex session live on this account; the keeper's estate under user rowan
+# schema commit: b414f078-dirty (bench-tools-aggregate-walks-the-column-list)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c go rust
+# load_start: 3.45 4.06 5.00
+# load_end: 7.07 6.18 5.59
+# load_max: 10.51
+# core_busy_pct: n/a
+# foreign_procs: 18
+# control_start_median: 6886362   control_end_median: 6935947
+# control_delta_pct: 0.7   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8911126,8381685,9019084,3722.26,7.15,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4343136,4258042,4434673,1814.17,4.07,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,93193,90124,97211,5822.96,7.60,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,77058,75443,80053,4814.77,5.98,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,9029799,8701782,9184407,3771.83,5.34,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4611742,4420236,4733118,1926.37,6.78,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,93956,91386,97261,5870.67,6.25,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,124153,122634,127681,7757.43,4.07,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+rust,bench_mixed,write,4000000,438,14,7490488,7407478,7602581,3128.85,2.60,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,14,2686471,2628755,2727040,1122.16,3.66,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,14,35702,33836,36949,2230.79,8.72,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,14,44992,43554,46248,2811.23,5.99,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+go,bench_mixed,write,4000000,438,14,4065728,3993981,4120119,1698.29,3.10,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,14,2000956,1967944,2033271,835.82,3.26,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,14,12301,12134,12606,768.60,3.84,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,14,14095,13484,14221,880.70,5.23,6b213fbfa1a03a99,bits,pkg,always,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-oldruntimes-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-oldruntimes-pass.csv
@@ -1,0 +1,53 @@
+# schema bench results
+# date: 2026-09-07T14:40:29Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I/private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I/private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v20.20.2 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: NOISY: shared Mac Studio; A/B fourth cell: schema at 7eba63f with the README sitting's runtime commits
+# schema commit: 7eba63fe (HEAD)
+# serialize commit: cebaed2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize]
+# serialize.c commit: 37db942 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.c]
+# serialize.go commit: 287e2fe (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.go]
+# serialize.rs commit: 6b52aa6 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/old/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.js]
+# rounds: 7   interleaved: yes
+# langs: cpp c go rust
+# load_start: 4.06 4.40 4.26
+# load_end: 2.79 4.25 4.39
+# load_max: 7.68
+# core_busy_pct: n/a
+# foreign_procs: 10
+# control_start_median: 6703686   control_end_median: 6783094
+# control_delta_pct: 1.2   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8751427,8358863,8906821,3655.55,6.26,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4392462,4343525,4431927,1834.77,2.01,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,92356,91533,93165,5770.66,1.77,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,76738,75174,77757,4794.81,3.37,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8884333,8716525,9172412,3711.07,5.13,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4369874,4307796,4394048,1825.34,1.97,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,92463,91669,93259,5777.35,1.72,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,124285,121901,124801,7765.68,2.33,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+rust,bench_mixed,write,4000000,438,14,7414134,7169487,7516849,3096.95,4.69,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,14,2667900,2662677,2693626,1114.41,1.16,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,14,36428,34328,37522,2276.12,8.77,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,14,44906,44487,45072,2805.89,1.30,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+go,bench_mixed,write,4000000,438,14,4047605,4009920,4064546,1690.72,1.35,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,14,2026478,2016934,2035252,846.48,0.90,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,14,12254,12205,12309,765.66,0.85,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,14,14106,14020,14183,881.38,1.16,6b213fbfa1a03a99,bits,pkg,always,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-pass.csv
@@ -1,0 +1,53 @@
+# schema bench results
+# date: 2026-09-07T13:45:29Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: not present (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: NOISY: desktop session with agents running; a Codex session live on this account; the keeper's estate under user rowan; A/B leg: schema at 7eba63f (the README sitting's commit), runtimes at today's CI tags
+# schema commit: 7eba63fe (HEAD)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c go rust
+# load_start: 6.74 6.13 5.58
+# load_end: 4.53 7.70 6.99
+# load_max: 20.48
+# core_busy_pct: n/a
+# foreign_procs: 15
+# control_start_median: 6994002   control_end_median: 6717419
+# control_delta_pct: 4.0   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8666778,8402426,8951490,3620.19,6.34,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4350430,4279645,4454055,1817.22,4.01,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,92900,90244,94240,5804.62,4.30,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,76603,75219,78174,4786.37,3.86,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8826262,8392794,9293341,3686.81,10.20,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4446318,4405345,4538961,1857.27,3.01,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,92086,85683,94578,5753.79,9.66,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,123668,121152,126141,7727.13,4.03,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+rust,bench_mixed,write,4000000,438,14,7339759,6502403,7518050,3065.89,13.84,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,14,2657060,2540033,2714060,1109.88,6.55,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,14,35276,33288,37396,2204.18,11.65,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,14,44464,43822,45434,2778.24,3.63,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+go,bench_mixed,write,4000000,438,14,4015024,3839308,4086064,1677.11,6.15,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,14,2008673,1963164,2040720,839.04,3.86,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,14,12125,11902,12361,757.60,3.79,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,14,14022,13635,14163,876.10,3.77,6b213fbfa1a03a99,bits,pkg,always,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv
+++ b/bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv
@@ -1,0 +1,61 @@
+# schema bench results
+# date: 2026-09-07T14:32:38Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v20.20.2 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: NOISY: shared Mac Studio, desktop session with agents running, a Codex session live on this account, the keeper's estate under another user; unpinned; second sitting of the day, node on PATH
+# schema commit: 3d01b479 (HEAD)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,7,9308675,9169202,9399230,3888.32,2.47,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,7,4607033,4560366,4637510,1924.40,1.67,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,7,92499,91846,93462,5779.62,1.75,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,7,122762,120472,123990,7670.49,2.87,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,7,8798634,8543011,8902539,3675.27,4.09,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,7,4303338,4257634,4343435,1797.54,1.99,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,7,92751,92012,96868,5795.36,5.24,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,7,77379,75777,78378,4834.84,3.36,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,7,4033611,3994620,4081829,1684.88,2.16,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,7,2002721,1988422,2013759,836.56,1.27,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,7,12199,12125,12303,762.20,1.46,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,7,14037,13871,14161,877.09,2.07,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,7,7430719,7375043,7493742,3103.88,1.60,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,7,2652629,2641128,2692124,1108.03,1.92,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,7,36516,35250,37167,2281.61,5.25,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,7,44956,44582,45092,2809.00,1.13,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+cs,bench_mixed,write,4000000,438,7,3732155,3696647,3752890,1558.96,1.51,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,1827726,1823796,1836489,763.46,0.69,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,21807,21649,22190,1362.57,2.48,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,23005,22825,23103,1437.44,1.21,6b213fbfa1a03a99,bits,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,7,2200766,2108566,2250677,919.28,6.46,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,7,1194105,1188453,1199841,498.79,0.95,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bitpacker,write,24576,65518,7,7315,6355,7393,457.04,14.19,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,6390,5586,6412,399.27,12.94,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,7,6720262,6654655,6778885,2807.12,1.85,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,7,2725980,2649158,2739857,1138.67,3.33,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,7,3038542,2973102,3063069,1269.23,2.96,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,7,1784126,1768994,1812096,745.25,2.42,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,4000000,438,7,495539,474041,499570,206.99,5.15,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,4000000,438,7,323541,322496,324874,135.15,0.74,6b213fbfa1a03a99,gen,beam,contract,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-ninelang-sitting-js.csv
+++ b/bench/results/2026-09-07-arm64-studio-ninelang-sitting-js.csv
@@ -1,0 +1,30 @@
+# schema bench results
+# date: 2026-09-07T14:29:25Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v20.20.2 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: NOISY: shared Mac Studio, desktop session with agents running, a Codex session live on this account, the keeper's estate under another user; unpinned
+# schema commit: 3d01b479 (HEAD)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,7,2250402,2219515,2309408,940.01,3.99,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,7,1200692,1196168,1224748,501.54,2.38,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bitpacker,write,24576,65518,7,7304,6479,7382,456.39,12.36,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,6358,5605,6410,397.28,12.66,6b213fbfa1a03a99,bits,esm,contract,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-ninelang-sitting.csv
+++ b/bench/results/2026-09-07-arm64-studio-ninelang-sitting.csv
@@ -1,0 +1,56 @@
+# schema bench results
+# date: 2026-09-07T14:22:47Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: NOISY: shared Mac Studio, desktop session with agents running, a Codex session live on this account, the keeper's estate under another user; unpinned
+# schema commit: 3d01b479 (HEAD)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg cannot run this invocation; path recorded from the environment, not proven against a build]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,7,9179764,8833591,9293981,3834.47,5.02,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,7,4786317,4680609,4801451,1999.29,2.52,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,7,94532,91245,96167,5906.63,5.21,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,7,124022,123768,127593,7749.25,3.08,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,7,9254675,9206471,9276008,3865.76,0.75,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,7,4358766,4285275,4398224,1820.70,2.59,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,7,94996,94341,96221,5935.63,1.98,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,7,78279,77125,79420,4891.09,2.93,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,7,4063096,4031999,4072541,1697.19,1.00,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,7,2010403,2006942,2018407,839.76,0.57,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,7,12397,12167,12419,774.60,2.03,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,7,14092,14008,14195,880.51,1.33,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,7,7402789,7299970,7513516,3092.21,2.88,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,7,2740775,2717190,2757736,1144.85,1.48,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,7,36309,35368,36923,2268.71,4.28,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,7,44672,44204,45047,2791.22,1.89,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+cs,bench_mixed,write,4000000,438,7,3740825,3694115,3767821,1562.58,1.97,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,1835735,1830488,1846057,766.80,0.85,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,22092,21709,22149,1380.40,1.99,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,22977,22795,23017,1435.66,0.96,6b213fbfa1a03a99,bits,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,7,6699173,6680897,6776945,2798.31,1.43,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,7,2736343,2715616,2747725,1143.00,1.17,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,7,3021075,2924590,3050020,1261.93,4.15,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,7,1800299,1783160,1820703,752.00,2.09,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,4000000,438,7,501333,470265,507693,209.41,7.47,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,4000000,438,7,317413,304376,322502,132.59,5.71,6b213fbfa1a03a99,gen,beam,contract,default,unknown

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -5,6 +5,71 @@
 > ([BENCH-STANDARD §5](../bench/BENCH-STANDARD.md#5-reporting-format)). The tables below
 > are kept exactly as published, in their recorded convention (C++ = 100%).
 
+## 2026-09-07: the Studio's nine-language table, and what moved since the Air's
+
+The README's table is now a sitting on the Apple M3 Ultra Studio, schema main at 3d01b479,
+every leg gated on the wire goldens, seven measured runs per leg, rendered by the README's
+own instrument (`bench/render.awk`: round-trip best rate, C++ = 100%). Five legs ran on the
+toolchains the repository pins: node 20.20.2, OpenJDK 21.0.12.1 (the Temurin build
+`make/java.mk` names), Dart 3.13.2, Erlang/OTP 29.0.5 with Elixir 1.20.4, and .NET SDK
+10.0.400 for the `10.0` in `.github/dotnet-version`. The other four ran on the machine's
+compilers, which the repository does not pin: Apple clang 21.0.0, go 1.27.1 (CI runs 1.26)
+and cargo 1.98.0 (CI resolves stable at run time); the runtimes were at the tags CI checks
+out. It is C++ = 100% like the tables below it because the C = 100% form the standard prefers
+is not producible for these rows: the `rel` tool refuses rows without an inline verdict, and
+none of these carry one. The Air's table it replaces, and a second Studio sitting ten minutes
+earlier, stand beside it:
+
+| language | [Studio, sitting 2](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv) (the README's) | [Studio, sitting 1](../bench/results/2026-09-07-arm64-studio-ninelang-sitting.csv) | [Air, 2026-09-01](../bench/results/2026-09-02-sitting4-arm64-macbook.csv) |
+|---|---:|---:|---:|
+| C++ | 100% | 100% | 100% |
+| C | 107% | 109% | 100%, a §2.8 tie (measured 98%) |
+| Java | 169% | 175% | 162% |
+| Rust | 172% | 174% | 154% |
+| Go | 230% | 238% | 210% |
+| C# | 253% | 260% | 225% |
+| Dart | 256% | 264% | 227% |
+| JavaScript | 387% | 392% ([its own file](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-js.csv), computed by hand across the two files) | 264%, on node 26.7.0 |
+| Elixir | 1427% | 1489% | 1283% |
+
+The two Studio sittings differ by 1.1 to 4.2% on every row, most of it the C++ denominator
+(4,801,451 then 4,637,510 messages a second); sitting 1's JavaScript leg ran in its own file
+because the runner finds node on the PATH and the pinned node was not on it.
+
+**What moved, measured on one machine.** Four four-leg driver passes (C++, C, Go, Rust; seven
+interleaved rounds, twins, control legs inside the 5% window every time; each pass controlled
+within itself, none against another; a fifth, the day's first, is not published) fill the
+two-by-two of the Air sitting's schema commit and runtime commits against today's:
+
+| schema | runtimes | C++ round-trip, best | Rust | Go | CSV |
+|---|---|---:|---:|---:|---|
+| 7eba63f | the sitting's | 4,394,048 | 163% | 216% | [pass D](../bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-oldruntimes-pass.csv) |
+| 7eba63f | today's tags | 4,538,961 | 167% | 222% | [pass B](../bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-pass.csv) |
+| a7b80a42 (today's) | the sitting's | 4,504,872 | 169% | 223% | [pass C](../bench/results/2026-09-07-arm64-studio-four-legs-twins-oldruntimes-pass.csv) |
+| b414f078, dirty (today's; the note says how) | today's tags | 4,733,118 | 174% | 233% | [pass A](../bench/results/2026-09-07-arm64-studio-four-legs-twins-pass.csv) |
+
+Rust's best round-trip rate stays between 2.67 and 2.76 million messages a second across every
+cell and both sittings (3.2% from lowest to highest), Go's between 2.01 and 2.04 million
+(1.3%), C's within 2.5%. C++'s best rate on today's code is 5.5 to 9.3% above the first row's
+(7.7% in the last row, 9.3% and 5.5% in the two sittings). Both changes contribute and the
+split between them is not resolved: read one way through the table, the schema commits since
+7eba63f add 2.5% and serialize.h between cebaed2 and v1.16.2 adds 5.1%; read the other way,
+4.3% and 3.3%; each step is smaller than the C++ spread inside the passes it is read from, and
+which commit is not isolated. C++ is the denominator, so every other language's percentage
+widened by that much while the other three legs stayed inside their own spreads. Ratios move
+with microarchitecture, as this page says below, and the first row measures that move: the
+Air's code on the Air's runtimes renders Rust 163% and Go 216% on this machine against 154%
+and 210% on the Air. JavaScript is the one row with a further term: the Air's 264% ran node
+26.7.0 where the pin is 20.20.2, the Studio's absolute JavaScript rate is below the Air's
+while every other leg is 14 to 29% above it, and the Air's own three sittings of 2026-09-01
+rendered JavaScript 461%, 318% and 264% on that one node; whether the version or the Air's
+variance on this leg is the term is not measured on one machine.
+
+These are the first passes the driver has aggregated since 2026-08-31: its `aggregate` had
+refused every pass since then, failing closed, because a parameter shadowed the path-column
+list (#689), and these passes were the ones that found it. The passes' own caveats and the
+rates are in [the note beside the CSVs](../bench/results/2026-09-07-arm64-studio-four-leg-passes.md).
+
 Generated-code performance as time relative to C++ (100%; higher is slower), medians across
 the corpus on an **Apple M3 Ultra**, the 2026-08-15 five-language pass **at `-O3`**
 ([raw CSV](../bench/results/2026-08-15-arm64-studio-postlane-O3-pass.csv),


### PR DESCRIPTION
The README's performance table moves to the Studio, with the measurements that say what changed since the Air's, all of it in one change: two nine-language sittings, four four-leg driver passes, a results note, the README table and caption, and a dated section on the performance page.

**What was asked.** A profile of the packet wire across the nine supported languages, posted, and the README's table updated if the numbers had not shifted, or the shift worked out if they had.

**The table.** A `bench/run.sh` sitting on the Apple M3 Ultra, schema main 3d01b479, five legs on the toolchains the repo pins and four on the machine's compilers (go 1.27.1 where CI runs 1.26; the note and PERFORMANCE.md list every version), every leg gated on the wire goldens, rendered by the README's own instrument: C++ 100, C 107, Java 169, Rust 172, Go 230, C# 253, Dart 256, JavaScript 387, Elixir 1427. A second sitting ten minutes earlier agrees within 1.1 to 4.2% on every row. The Air's table it replaces read 100, 100, 162, 154, 210, 225, 227, 264, 1283.

**What shifted, and why, measured on one machine.** Four published driver passes (four legs, twins, seven interleaved rounds, every window OK; each pass controlled within itself, none against another) fill the two-by-two of the Air sitting's schema commit and runtime commits against today's. Rust's and Go's absolute round-trip rates stay within 3.2% and 1.3% of themselves, lowest to highest, across every cell and both sittings; C++'s on today's code is 5.5 to 9.3% above the Air-code cell's; both changes contribute and the split between them is not resolved (the two paths through the table give the schema commits 2.5% or 4.3% and serialize.h 5.1% or 3.3%); C++ is the denominator, so every other percentage widened by that much while the other three legs stayed inside their own spreads. JavaScript has two open terms the data does not separate: the Air's number ran node 26.7.0 where the pin is 20.20.2, and the Air's own three sittings rendered that leg 461, 318 and 264% on that one node, where the Studio's two sittings agree within 2%; not measured on one machine.

**What changes here.** Seven CSVs (two sittings, the separate JavaScript leg of the first, four passes; every driver window OK, every twin gate OK, loads recorded), the note beside them with the rendered tables, the rates, the caveats (one pass's 4.0% control delta in the standard's warning zone, one noisy row, the twin CSVs not committed, go 1.27.0 on the Air against 1.27.1 here and 1.26 in CI, the four cells being separate passes) and the provenance; the README's table and its caption naming the machine and the date; PERFORMANCE.md's dated section with the Studio table beside the Air's, the toolchains, the two-by-two, and why the table is C++ = 100%.

**Provenance worth knowing.** These are the first passes the driver has aggregated since 2026-08-31; its `aggregate` had refused every pass since then, failing closed, because a parameter shadowed the path-column list, which today's first pass found and #689 fixed; that first pass is the fifth, not published. Two preambles read `b414f078-dirty` and `a7b80a42` for the reasons the note gives; the runners are built from files that fix does not touch. The driver refused the codegen-only legs (java, dart, elixir) when these ran, which is why the nine-language numbers are sittings; #692 fixes that. Three cold reads: the first reproduced every number of the first version from the CSVs and found five prose faults; the second reproduced every number of the second version (every ratio cell, rate, spread, control delta, gate line and load) and found the prose over-claiming in nine places (the caption's "CI pins", the JavaScript mechanism, a decomposition stated as "about half", counts and timings), all repaired here; the third checks the repairs before the merge.

Opened by Rowan from Glenn's GitHub login, the bench's only one; the commit is authored Rowan and the branch was pushed as rowan-claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
