### PR TITLE
bench: the pass driver takes the codegen-only legs, and runs all nine by default

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -50,7 +50,11 @@ backends' GENERATED codecs over the same shape under the same contract
 
 **A publishable pass is a driver pass**, not a bare run.sh invocation:
 
-    bench/tools/pass-driver.sh [--rounds 7] [--langs cpp,c,go,rust,cs,js] [--inline]
+    bench/tools/pass-driver.sh [--rounds 7] [--langs cpp,c,go,rust,cs,js,java,dart,elixir] [--inline]
+
+`--langs` defaults to all nine — the languages the published table carries —
+and a leg whose toolchain is absent is skipped and recorded (`# skipped:`)
+rather than failing the pass.
 
 The driver runs the §2 methodology: a C++ control leg, N interleaved rounds
 (every language once per round via `--round K`, so every leg sees the same

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -366,14 +366,14 @@ prov_note() {
         js)   PROV_JS="$resolved" ;;
     esac
 }
-# java/dart/elixir never appear here: their legs build from the repo's own
-# generated sources with no runtime checkout, so there is nothing for the
-# §3.5 guard to verify or misrecord.
+# java/dart/elixir set no PROV_ line here: their legs build from the repo's
+# own generated sources with no runtime checkout, so there is nothing for the
+# §3.5 guard to verify or misrecord. The exemption itself lives in
+# verify_runtime (bench/tools/runtime-paths.sh), which answers "nothing to
+# verify" for them — so this guard and the standalone gate pass-driver.sh
+# runs before its first leg cannot drift apart, and neither repeats the list.
 if [ -n "$ONLY" ]; then
-    case "$ONLY" in
-        java|dart|elixir) ;;
-        *) prov_verify "$ONLY" ;;
-    esac
+    prov_verify "$ONLY"
     for _lang in cpp c go rust cs js; do
         [ "$_lang" != "$ONLY" ] && prov_note "$_lang"
     done

--- a/bench/tools/aggregate_test.go
+++ b/bench/tools/aggregate_test.go
@@ -83,6 +83,47 @@ func TestAggregatePrintsEveryRowOfACurrentCorpusPass(t *testing.T) {
 	}
 }
 
+// The codegen-only legs (java, dart, elixir) run in every pass the driver
+// drives — bench/run.sh has run them since they landed — but they were
+// missing from `langs`, which is aggregate's OUTPUT loop. Their rows would
+// have accumulated and never printed, and the straggler refusal (the #689
+// class) would have taken the whole pass down with them. This test is the
+// pass that carries all three: every row must come out aggregated.
+func TestAggregatePrintsTheCodegenOnlyLegs(t *testing.T) {
+	dir := t.TempDir()
+	r0 := writeRound(t, dir, "round-0-codegen.csv", "0",
+		"java,bench_mixed,write,4000000,100,1,5800000,5800000,5800000,553.13,0.00,6b213fbfa1a03a99,gen,class,contract,default,unknown",
+		"java,bench_mixed,round_trip,4000000,100,1,2200000,2200000,2200000,209.81,0.00,6b213fbfa1a03a99,gen,class,contract,default,unknown",
+		"dart,bench_mixed,write,4000000,100,1,2800000,2800000,2800000,267.03,0.00,6b213fbfa1a03a99,gen,aot,contract,default,unknown",
+		"dart,bench_mixed,round_trip,4000000,100,1,1580000,1580000,1580000,150.68,0.00,6b213fbfa1a03a99,gen,aot,contract,default,unknown",
+		"elixir,bench_mixed,write,4000000,100,1,450000,450000,450000,42.92,0.00,6b213fbfa1a03a99,gen,beam,contract,default,unknown",
+		"elixir,bench_mixed,round_trip,4000000,100,1,280000,280000,280000,26.70,0.00,6b213fbfa1a03a99,gen,beam,contract,default,unknown")
+	r1 := writeRound(t, dir, "round-1-codegen.csv", "1",
+		"java,bench_mixed,write,4000000,100,1,5900000,5900000,5900000,562.67,0.00,6b213fbfa1a03a99,gen,class,contract,default,unknown",
+		"java,bench_mixed,round_trip,4000000,100,1,2300000,2300000,2300000,219.35,0.00,6b213fbfa1a03a99,gen,class,contract,default,unknown",
+		"dart,bench_mixed,write,4000000,100,1,2900000,2900000,2900000,276.57,0.00,6b213fbfa1a03a99,gen,aot,contract,default,unknown",
+		"dart,bench_mixed,round_trip,4000000,100,1,1600000,1600000,1600000,152.59,0.00,6b213fbfa1a03a99,gen,aot,contract,default,unknown",
+		"elixir,bench_mixed,write,4000000,100,1,460000,460000,460000,43.87,0.00,6b213fbfa1a03a99,gen,beam,contract,default,unknown",
+		"elixir,bench_mixed,round_trip,4000000,100,1,300000,300000,300000,28.61,0.00,6b213fbfa1a03a99,gen,beam,contract,default,unknown")
+
+	out, errOut, code := runTool(t, "aggregate", r0, r1)
+	if code != 0 {
+		t.Fatalf("aggregate refused a pass carrying the codegen-only legs (exit %d):\n%s", code, errOut)
+	}
+	for _, want := range []string{
+		"java,bench_mixed,write,4000000,100,2,5850000,5800000,5900000,",
+		"java,bench_mixed,round_trip,4000000,100,2,2250000,2200000,2300000,",
+		"dart,bench_mixed,write,4000000,100,2,2850000,2800000,2900000,",
+		"dart,bench_mixed,round_trip,4000000,100,2,1590000,1580000,1600000,",
+		"elixir,bench_mixed,write,4000000,100,2,455000,450000,460000,",
+		"elixir,bench_mixed,round_trip,4000000,100,2,290000,280000,300000,",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("aggregated output lacks the row %q\n--- stdout ---\n%s--- stderr ---\n%s", want, out, errOut)
+		}
+	}
+}
+
 // The negative control: the straggler refusal must still fire on a path the
 // column list does not know, so a runner that grows a new path REFUSES the
 // aggregation rather than losing the row (BENCH-STANDARD §5.1).

--- a/bench/tools/inline-verdict.sh
+++ b/bench/tools/inline-verdict.sh
@@ -944,6 +944,17 @@ js)
     exit 1
     ;;
 
+java|dart|elixir)
+    # The codegen-only legs. §4.1 states a verdict mechanism for the five AOT
+    # legs (go, clang/gcc, rust, C#) and this tool implements those; none is
+    # written for java, dart or elixir, so their rows stay inline=unknown and
+    # §4.2 refuses their ratios. This arm exists because the driver now runs
+    # these legs by default: "unknown language" would have been a false
+    # reason for a leg the pass measures.
+    echo "inline-verdict: no verdict pass is implemented for $LANG_ARG (a codegen-only leg); $LANG_ARG rows stay inline=unknown" >&2
+    exit 1
+    ;;
+
 *)
     echo "unknown language: $LANG_ARG (c|cpp|go|rust|cs)" >&2
     exit 1

--- a/bench/tools/pass-driver.sh
+++ b/bench/tools/pass-driver.sh
@@ -27,9 +27,10 @@
 #                                   [--compiler CXX] [--inline] [--twins]
 #   --out FILE      final pass CSV (default bench/results/<date>-<arch>-<host>-pass.csv)
 #   --rounds N      measured rounds (default 7, §2.1/§2.4)
-#   --langs a,b,c   subset of cpp,c,go,rust,cs,js (default: all; unavailable
-#                   toolchains are skipped and recorded, a skipped leg is a
-#                   fact not a failure)
+#   --langs a,b,c   subset of cpp,c,go,rust,cs,js,java,dart,elixir (default:
+#                   all nine, the languages the published table carries;
+#                   unavailable toolchains are skipped and recorded, a
+#                   skipped leg is a fact not a failure)
 #   --compiler CXX  C++ compiler for the cpp legs and control legs
 #   --inline        run the §4.1 inline verdict pass per language afterwards
 #                   and backfill the inline column (bench/tools/inline-verdict.sh)
@@ -47,7 +48,9 @@
 #
 # environment: SERIALIZE / SERIALIZE_C / SERIALIZE_GO / SERIALIZE_RS /
 # SERIALIZE_CS / SERIALIZE_JS, BENCH_CPU, BENCH_NOISE, BENCH_OPT_LEVEL — all
-# as bench/run.sh.
+# as bench/run.sh. The codegen-only legs (java, dart, elixir) name no
+# runtime checkout at all; their toolchains are the repo-pinned dist/
+# installs, JAVA/JAVAC/DART/BEAM_PATH overriding, again as bench/run.sh.
 # The SERIALIZE* paths are §3.5-verified against each toolchain's own
 # resolution before the first leg runs, and the pass refuses on mismatch.
 set -u
@@ -56,7 +59,11 @@ cd "$(dirname "$0")/../.."      # repo root
 
 OUT=""
 ROUNDS=7
-LANGS="cpp,c,go,rust,cs,js"
+# The default is the nine languages the published table carries: this driver
+# is the certification instrument, and a language it does not run by default
+# is a language no pass certifies. A leg whose toolchain is absent is skipped
+# and recorded (# skipped:), which is a fact, not a failure.
+LANGS="cpp,c,go,rust,cs,js,java,dart,elixir"
 COMPILER="${CXX:-c++}"
 INLINE=0
 TWINS=0
@@ -91,7 +98,10 @@ fi
 # Verify only the languages this pass will RUN (--langs): the gate refusing a
 # pass over a language it was told to skip inverted its own contract — a
 # skipped leg is a fact, not a failure (measured on the EPYC box: go 1.22.2
-# present, serialize.go absent, cpp/c pass refused). ----
+# present, serialize.go absent, cpp/c pass refused). The whole --langs list
+# goes in, java/dart/elixir included: verify_runtime answers "nothing to
+# verify" for the codegen-only legs — the same answer it gives run.sh, which
+# is why the driver does not carry an exemption list of its own. ----
 if ! bench/tools/verify-runtime-paths.sh $(echo "$LANGS" | tr ',' ' ') >&2; then
     echo "REFUSED (§3.5): a leg's build would not use the runtime path the preamble records — no pass, no rows" >&2
     exit 1

--- a/bench/tools/relative.go
+++ b/bench/tools/relative.go
@@ -69,16 +69,27 @@ var order = append(append([]string{}, benchCorpus...), bitpacker)
 // expressed against (Glenn, 2026-08-17: "make C the reference. It is the
 // 100%. C++ is measured against C." — flipped from cpp, which had been the
 // baseline since the table existed).
-// js rides in this list so aggregate PRINTS its rows (the output loop walks
-// langs, and a language missing from it would trip the straggler refusal —
-// exactly the silent-vanish class the refusal exists to catch). It never
-// enters the relative table: js rows carry inline=unknown by design (a JIT
-// has no AOT artifact for the §4.1 verdict), and §5.3 refuses any ratio
-// touching an unknown — relativeTable skips js explicitly rather than
-// letting one un-ratioable-by-construction language refuse the whole table.
+// js and the codegen-only legs (java, dart, elixir) ride in this list so
+// aggregate PRINTS their rows (the output loop walks langs, and a language
+// missing from it would trip the straggler refusal — exactly the
+// silent-vanish class the refusal exists to catch). They never enter the
+// relative table: see unratioable.
 var langs = []struct{ key, name string }{
 	{"c", "C"}, {"cpp", "C++"}, {"rust", "Rust"}, {"cs", "C#"}, {"go", "Go"},
-	{"js", "JavaScript"},
+	{"js", "JavaScript"}, {"java", "Java"}, {"dart", "Dart"}, {"elixir", "Elixir"},
+}
+
+// unratioable: languages whose rows carry inline=unknown by construction, so
+// §5.3 refuses any ratio touching them. js has no AOT artifact for the §4.1
+// verdict (a JIT decides per tier at runtime); §4.1's verdict mechanisms
+// cover the five AOT legs (go, clang/gcc, rust, C#) and bench/tools/
+// inline-verdict.sh implements no pass for java, dart or elixir, so their
+// rows stay inline=unknown exactly as every published pass records them.
+// relativeTable skips them explicitly rather than letting a language that
+// cannot be ratioed by construction refuse the whole table; they publish in
+// the absolute table, which is where the pass reports them.
+var unratioable = map[string]bool{
+	"js": true, "java": true, "dart": true, "elixir": true,
 }
 
 // reference is the table's 100% language.
@@ -624,11 +635,11 @@ func relativeTable(ds *dataset) string {
 		if l.key == reference {
 			continue
 		}
-		if l.key == "js" {
-			// DELIBERATE: js rows are inline=unknown by construction (no
-			// AOT artifact to verdict, §4.1) and §5.3 refuses ratios on
-			// unknown — attempting the ratio would refuse the whole table.
-			// js publishes in the absolute table only.
+		if unratioable[l.key] {
+			// DELIBERATE: these rows are inline=unknown by construction
+			// (§4.1 has no verdict pass for them) and §5.3 refuses ratios
+			// on unknown — attempting the ratio would refuse the whole
+			// table. They publish in the absolute table only.
 			continue
 		}
 		// write and round_trip are the gen family's two MEASURED paths

--- a/bench/tools/runtime-paths.sh
+++ b/bench/tools/runtime-paths.sh
@@ -190,9 +190,11 @@ EOF
     fi
 }
 
-# verify_runtime <cpp|c|go|rust|cs|js> — the §3.5 fail-closed check.
+# verify_runtime <cpp|c|go|rust|cs|js|java|dart|elixir> — the §3.5
+# fail-closed check.
 #   stdout: the toolchain-resolved absolute runtime path (verified)
-#   return: 0 verified; 2 leg cannot run this invocation (reason on stderr);
+#   return: 0 verified; 2 nothing to verify in this invocation — the leg
+#             cannot run, or it has no runtime checkout (reason on stderr);
 #           1 MISMATCH or unprovable — the caller must refuse to emit rows.
 verify_runtime() {
     local want got id items
@@ -322,6 +324,19 @@ EOF
             return 1
         fi
         echo "$got"
+        ;;
+
+    java|dart|elixir)
+        # The codegen-only legs. schema's backends for these languages emit
+        # self-contained code with no runtime library, so the legs build from
+        # the repo's own generated sources with no runtime checkout — there
+        # is nothing for the §3.5 guard to verify or misrecord, and no
+        # SERIALIZE* variable names them. This arm is the ONE place that
+        # exemption lives: run.sh's own preamble guard and the standalone
+        # gate (which pass-driver.sh calls before its first leg) both reach
+        # it through here, so the two callers cannot drift apart.
+        echo "$1: generated codecs, no runtime checkout — nothing for the §3.5 guard to verify" >&2
+        return 2
         ;;
 
     *)

--- a/bench/tools/verify-runtime-paths.sh
+++ b/bench/tools/verify-runtime-paths.sh
@@ -3,6 +3,11 @@
 #
 #   bench/tools/verify-runtime-paths.sh [lang ...]     (default: all six)
 #
+# The six defaulted are the languages that HAVE a runtime checkout. The
+# codegen-only legs (java, dart, elixir) may be named too — verify_runtime
+# answers "nothing to verify" for them rather than refusing, which is what
+# lets pass-driver.sh hand this gate its whole --langs list.
+#
 # For each language, asks the toolchain what runtime path its build will
 # actually resolve (bench/tools/runtime-paths.sh: cargo pkgid, go list -m,
 # msbuild -getItem:Compile; cpp/c share one variable between -I and the
@@ -24,7 +29,7 @@ for lang in $LANGS; do
     resolved="$(verify_runtime "$lang")" || rc=$?
     case $rc in
         0) echo "$lang: VERIFIED $resolved" ;;
-        2) echo "$lang: leg cannot run this invocation (see above) — nothing to verify" ;;
+        2) echo "$lang: nothing to verify (reason above)" ;;
         *) echo "$lang: MISMATCH — the build would not use the recorded runtime path (§3.5)"; FAIL=1 ;;
     esac
 done


### PR DESCRIPTION
**What was wrong.** `bench/tools/pass-driver.sh --langs ...,java,dart,elixir` refused before its first leg: its §3.5 pre-flight calls `verify_runtime`, whose case knew only the six legs with a serialize runtime checkout, and its catch-all returned 1, which the gate reads as MISMATCH. `bench/run.sh` already exempted the three codegen-only legs by name (generated codecs, no runtime checkout, nothing to verify), so the runner could measure a leg the certification instrument refused; that is why today's nine-language numbers are sittings and the driver passes are four legs.

**What changes.** `verify_runtime` gains the java, dart and elixir arm returning the benign code with the runner's own reason, and the runner's duplicate arm goes, so the exemption exists once. `verify-runtime-paths.sh`'s wording no longer says a codegen-only leg cannot run. The driver's usage lists all nine and its default `--langs` becomes nine: the driver is the certification instrument and the README's table is nine languages; a language the driver does not run by default is a language no pass certifies, and an absent toolchain still lands in `# skipped:`. `relative.go`'s `langs` list gains the three (it lacked them, so the aggregator's straggler refusal would have fired on their rows, the class #689 fixed this morning) and the relative table's unratioable set names all four inline-less legs. `inline-verdict.sh` refuses the three by name, as it does js. `bench/README.md`'s driver usage line follows. A test holds the `langs` fix: rounds carrying java, dart and elixir rows must aggregate to every row.

**Receipts.** `gofmt -l`, `go vet`, `go test ./bench/tools`, `make shape-gate` clean; the test fails with `langs` reverted to six. A one-round probe on `cpp,java,dart,elixir` with the pinned toolchains ran all four legs, aggregated every row, and stamped `window: OK` (control delta 3.8% under ambient desktop load; a probe, not a publishable pass; its CSV was not kept). One thing left alone and named: the driver's quiet-window process matchers know the Dart AOT binary but not a JVM or the BEAM; judged theoretical and a stall risk to widen, so flagged rather than changed.

Written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's GitHub login, the bench's only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
