### PR TITLE
js: the node pin moves to 26.7.0, and the JavaScript row is measured on it

### DIFF
--- a/.github/workflows/certify.yml
+++ b/.github/workflows/certify.yml
@@ -111,12 +111,14 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_SDK_PIN }}
 
-      # One node version, the runtime's floor (serialize.js engines >= 20):
-      # the runtime's own CI carries the version matrix; this repo proves
-      # wire identity, which does not vary by node version.
+      # One node version, the pin make/js.mk names (the allocation gate holds
+      # its floor on this major and no other): the runtime's own CI carries
+      # the version matrix, and serialize.js's engines floor of >= 20 is
+      # satisfied by it; this repo proves wire identity, which does not vary
+      # by node version.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '26'
 
       # The Dart SDK, pinned to the same version the Makefile documents for
       # the repo-local dist/ (generated Dart is self-contained — the SDK is
@@ -255,7 +257,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '26'
 
       - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:
@@ -355,7 +357,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '26'
 
       - uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1.8.1
         with:

--- a/README.md
+++ b/README.md
@@ -77,16 +77,16 @@ Cost to serialize a representative game packet, relative to generated C++ at
 | C++ | 100% |
 | C | 107% |
 | Java | 169% |
-| Rust | 172% |
-| Go | 230% |
+| Rust | 173% |
+| Go | 231% |
 | C# | 253% |
-| Dart | 256% |
-| JavaScript | 387% |
-| Elixir | 1427% |
+| Dart | 267% |
+| JavaScript | 292% |
+| Elixir | 1451% |
 
-Measured by [the benchmark](bench/) on an Apple M3 Ultra, 2026-09-07;
-[PERFORMANCE.md](docs/PERFORMANCE.md) has the toolchains, the earlier Apple M2 table and what
-moved between them. One 438-byte packet exercising every construct.
+Measured by [the benchmark](bench/) on an Apple M3 Ultra, 2026-09-07, JavaScript on the
+pinned node 26.7.0; [PERFORMANCE.md](docs/PERFORMANCE.md) has every toolchain, the earlier
+Apple M2 table and what moved between them. One 438-byte packet exercising every construct.
 
 ## Install and build
 

--- a/bench/results/2026-09-07-arm64-studio-four-leg-passes.md
+++ b/bench/results/2026-09-07-arm64-studio-four-leg-passes.md
@@ -1,11 +1,11 @@
-# Studio, 2026-09-07: two nine-language sittings, four four-leg driver passes, and what moved since the README's sitting
+# Studio, 2026-09-07: three nine-language sittings, four four-leg driver passes, and the node 20/26 pair
 
 All on the shared Mac Studio (Apple M3 Ultra, 32 cores, 512 GiB, Darwin 25.6.0, Apple clang
 21.0.0 clang-2100.1.1.101, go 1.27.1, cargo 1.98.0), unpinned, a desktop session and a Codex
 session live on the account throughout, the keeper's estate under another user. Loads are in
-each preamble.
+each driver pass's preamble; `bench/run.sh` sittings do not record one.
 
-## The two sittings
+## The two node-20 sittings
 
 `bench/run.sh` sittings, seven measured runs per leg, every leg gated on the wire goldens
 (`corpus_id 6b213fbfa1a03a99`), schema main 3d01b479. The runtimes were at the tags
@@ -25,7 +25,7 @@ README's. Rendered by `bench/render.awk` (round-trip best rate, C++ = 100%), exc
 JavaScript, which render.awk refuses (no C++ row in its file) and is computed here by hand from
 the two files' best rates:
 
-| language | sitting 2 | sitting 1 | Air sitting, 2026-09-01 |
+| language | sitting 2 | sitting 1 | Air (Apple M2) sitting, 2026-09-01 |
 |---|---:|---:|---:|
 | C++ | 100% | 100% | 100% |
 | C | 107% | 109% | 98%, tie |
@@ -51,8 +51,9 @@ Best round-trip rates, messages per second, with the spread of the seven runs:
 | js | 1,199,841 | 1.0% | 1,224,748 | 2.4% | 1,361,635 |
 | elixir | 324,874 | 0.7% | 322,502 | 5.7% | 280,148 |
 
-The sittings, ten minutes apart, differ by 1.1 to 4.2% on every ratio (Elixir's 62 points is
-4.2% of 1489), most of it the C++ denominator; no row in either is past the §2.3 noisy line.
+The sittings, ten minutes apart, differ by 1.1 to 4.2% on every ratio but C++'s, the
+denominator (Elixir's 62 points is 4.2% of 1489), most of it the C++ denominator itself; no
+row in either is past the §2.3 noisy line.
 
 ## The four driver passes: the two-by-two
 
@@ -90,9 +91,10 @@ and 2,040,720 (1.3%), C's between 4,343,435 and 4,454,055 (2.5%); cell D to cell
 7.7% in cell A (4,733,118), 9.3% and 5.5% in the two sittings (4,801,451 and 4,637,510). Both
 changes contribute and the split between them is not resolved: read along one path of the
 two-by-two, the schema commits since 7eba63f add 2.5% (D to C) and serialize.h between
-cebaed2 and v1.16.2 adds 5.1% (C to A); along the other, 4.3% (B to A) and 3.3% (D to B).
-Each step is smaller than the C++ round-trip spread inside the passes it is read from (2.0,
-3.0, 6.8 and 13.4% in D, B, A and C). The schema side changed the C++ emitter,
+cebaed2 and v1.16.2 adds 5.1% (C to A); along the other, 4.3% (B to A) and 3.3% (D to B). The
+four steps are 2.5, 5.1, 4.3 and 3.3%; the C++ round-trip spreads inside the passes they are
+read from are 2.0, 3.0, 6.8 and 13.4% in D, B, A and C. The steps are of the same order as the
+spreads, so the split is not resolved. The schema side changed the C++ emitter,
 `internal/codegen/cpp`, and the generated bench code, `generated/bench/cpp`, not the C++ runner
 in `bench/cpp`; the serialize.h side is 583 lines; which commit is responsible is not
 isolated. C++ is the denominator, so every other language's percentage widened by that much
@@ -106,15 +108,17 @@ check is coarser than the 7.7% move and does not resolve it. Absolute rates do n
 across machines under §2, and the Air-to-Studio rises are reported here for the ledger only:
 cpp 22% (cell D) to 32% (cell A), c 19 to 22%, go 18 to 19%, rust 14 to 17%.
 
-**JavaScript.** The Air's 264% ran node 26.7.0 where the repo pins 20.20.2, which is what ran
-here. The Studio's absolute JavaScript rate, 1.20 to 1.22 million a second, is below the
-Air's 1.36 million while every other leg is 14 to 29% above it. Two terms are open and the
-data does not separate them: the node version, and the Air's own variance on this leg. The
-Air's three sittings of 2026-09-01 rendered JavaScript 461%, 318% and 264% on that one node
-(762,465, 1,124,935 and 1,361,635 a second) and Dart 363, 225, 227; the README's Air number
-was the fast end of that range; the Studio's two sittings agree on JavaScript within 2%. A
-node 26 run on this machine is the measurement that would settle the version term and has
-not been made.
+**JavaScript.** The Air's 264% ran node 26.7.0 where the repo pinned 20.20.2, which is what
+ran in these two sittings and these four passes. The Studio's absolute JavaScript rate on node
+20, 1.20 to 1.22 million a second, is below the Air's 1.36 million while every other leg is 14
+to 29% above it. Two terms were open and this day's data did not separate them: the node
+version, and the Air's own variance on this leg. The Air's three sittings of 2026-09-01
+rendered JavaScript 461%, 318% and 264% on that one node (762,465, 1,124,935 and 1,361,635 a
+second) and Dart 363, 225, 227; the README's Air number was the fast end of that range; the
+Studio's two node-20 sittings agree on JavaScript to 2.1% on absolute rate (1,224,748 in
+sitting 1, 1,199,841 in sitting 2). The node 26 run on this machine that would settle the
+version term has since been made: it is in "The node runs" below, and it is +30.5%. The Air's
+variance on this leg stays true and is now the secondary term.
 
 **What to know before trusting a row.** Pass B's control delta, 4.0%, is inside the 5% window
 and in the standard's warning zone (its control fell from 6,994,002 to 6,717,419 under a
@@ -142,11 +146,81 @@ driver refused the three codegen-only legs at its §3.5 pre-flight (no case for 
 elixir; `bench/run.sh` exempted them by name; #692 gives the pre-flight the case); that is why
 the nine-language numbers are sittings and the two-by-two is four legs.
 
+## The node runs
+
+Three files taken after the four passes, when the node pin moved from 20.20.2 to 26.7.0. All
+three are `bench/run.sh` sittings on the same Studio, seven measured runs per leg, every leg
+gated on the same wire goldens (`corpus_id 6b213fbfa1a03a99`), and every preamble records
+schema commit `3d01b479` — the tree the two sittings above ran. Main's `7622f23b` after that
+commit changed only `bench/tools`, `bench/run.sh`, docs and results, so the generated code and
+the runtime checkouts under these three are identical to the two sittings' and to today's
+main. `run.sh` sittings carry no `load_*` preamble line — automatic load capture is a
+pass-driver feature — so the load under them is unrecorded; the desktop and Codex sessions
+named at the top of this note were live throughout.
+
+| file | date | node | legs |
+|---|---|---|---|
+| `2026-09-07-arm64-studio-js-node20.csv` | 15:42:19Z | v20.20.2 | js |
+| `2026-09-07-arm64-studio-js-node26.csv` | 15:44:00Z | v26.7.0 | js |
+| `2026-09-07-arm64-studio-ninelang-sitting-node26.csv` | 15:45:27Z | v26.7.0 | all nine |
+
+**The back-to-back pair.** The JavaScript leg alone, run twice on one machine 101 seconds
+apart, the node version the only thing changed between them:
+
+| node | best round-trip | median | spread |
+|---|---:|---:|---:|
+| 20.20.2 | 1,222,630 | 1,207,413 | 2.08% |
+| 26.7.0 | 1,595,367 | 1,580,122 | 1.46% |
+
++30.5% on best rate, +30.9% on median. Both spreads are well under the step. This is the
+measurement the JavaScript paragraph above wanted and did not have: the version term, on one
+machine, with nothing else moving. It does not measure the Air's variance on this leg, which
+is a separate term and stays open. In the `bits` family the two files are less comparable: the
+node-20 file's `js/bitpacker` write and read rows carry 14.19% and 14.26% spreads against the
+node-26 file's 1.51% and 2.18% — under §2.3's 15% noisy threshold, but the pair's claim is the
+`gen` round-trip row above, not those.
+
+**The nine-language sitting on node 26.7.0.** Rendered by `bench/render.awk` (round-trip best
+rate, C++ = 100%), with sitting 2's node-20 ratios beside it:
+
+| language | node 26 | sitting 2 (node 20) | best round-trip, node 26 | spread |
+|---|---:|---:|---:|---:|
+| C++ | 100% | 100% | 4,665,785 | 3.16% |
+| C | 107% | 107% | 4,378,533 | 1.40% |
+| Java | 169% | 169% | 2,754,761 | 2.08% |
+| Rust | 173% | 172% | 2,701,657 | 2.69% |
+| Go | 231% | 230% | 2,020,216 | 0.65% |
+| C# | 253% | 253% | 1,843,454 | 1.03% |
+| Dart | 267% | 256% | 1,746,369 | 2.81% |
+| JavaScript | 292% | 387% | 1,598,165 | 0.80% |
+| Elixir | 1451% | 1427% | 321,467 | 4.13% |
+
+JavaScript, 387% to 292%, is the row that moved with the runtime, and the pair above is what
+moved it. Every other ratio is within a point of sitting 2's except Dart, 256% to 267%, and
+Elixir, 1427% to 1451%; on absolute rate Dart is -3.6% and Elixir -1.0% against sitting 2
+while the C++ denominator is +0.6%. Those two are sitting-to-sitting variance, the same kind
+the two node-20 sittings show, and nothing here measures a cause for them. No row in the file
+is past §2.3's noisy threshold (the highest is `elixir/bench_mixed/write` at 8.47%).
+
+The sitting's JavaScript best, 1,598,165, is 0.2% above the pair's node-26 run — two
+independent node-26 measurements of the same leg inside one three-minute window. Against the
+Air, the Studio's JavaScript leg on node 26 is 17.4% above (1,598,165 against 1,361,635),
+inside the 10.1 to 29.8% the other eight legs run above the Air in this same sitting; on node
+20 it was 11.9% *below*. The row no longer stands apart from the rest of the table.
+
+The invocations below are reconstructed from the preambles, not copied from a shell history;
+the node runs selected the runtime by putting its bin directory first on the PATH, which the
+lines do not show.
+
 ```sh
 bench/run.sh --out bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv     # node, dotnet on PATH
 bench/tools/pass-driver.sh --rounds 7 --langs cpp,c,go,rust --twins --out bench/results/2026-09-07-arm64-studio-four-legs-twins-pass.csv
 # in a worktree at 7eba63f, beside the same runtime checkouts:
 BENCH_TOOLS=<fixed bench/tools binary> bench/tools/pass-driver.sh --rounds 7 --langs cpp,c,go,rust --twins --out bench/results/2026-09-07-arm64-studio-four-legs-twins-schema7eba63f-pass.csv
 SERIALIZE=<cebaed2> SERIALIZE_C=<37db942> SERIALIZE_GO=<287e2fe> SERIALIZE_RS=<6b52aa6> bench/tools/pass-driver.sh --rounds 7 --langs cpp,c,go,rust --twins --out <pass C or D>
+# the node runs, with the named node first on the PATH:
+bench/run.sh --only js --out bench/results/2026-09-07-arm64-studio-js-node20.csv   # node v20.20.2
+bench/run.sh --only js --out bench/results/2026-09-07-arm64-studio-js-node26.csv   # node v26.7.0
+bench/run.sh          --out bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv   # node v26.7.0, dotnet on PATH
 awk -F, -v skips="" -f bench/render.awk <csv>
 ```

--- a/bench/results/2026-09-07-arm64-studio-js-node20.csv
+++ b/bench/results/2026-09-07-arm64-studio-js-node20.csv
@@ -1,0 +1,30 @@
+# schema bench results
+# date: 2026-09-07T15:42:19Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v20.20.2 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 3d01b479 (HEAD)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,7,2291396,2236355,2327963,957.14,4.00,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,7,1207413,1197547,1222630,504.35,2.08,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bitpacker,write,24576,65518,7,7371,6407,7453,460.58,14.19,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,6378,5565,6474,398.49,14.26,6b213fbfa1a03a99,bits,esm,contract,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-js-node26.csv
+++ b/bench/results/2026-09-07-arm64-studio-js-node26.csv
@@ -1,0 +1,30 @@
+# schema bench results
+# date: 2026-09-07T15:44:00Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 3d01b479 (HEAD)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,7,2942087,2922334,2965948,1228.94,1.48,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,7,1580122,1572270,1595367,660.03,1.46,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bitpacker,write,24576,65518,7,8227,8183,8307,514.02,1.51,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,6264,6226,6363,391.38,2.18,6b213fbfa1a03a99,bits,esm,contract,default,unknown

--- a/bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv
+++ b/bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv
@@ -1,0 +1,61 @@
+# schema bench results
+# date: 2026-09-07T15:45:27Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: 10.0.400 (dotnet run -c Release, workstation GC)
+# node: v26.7.0 (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: openjdk 21.0.12.1 2026-08-18 LTS (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: Dart SDK version: 3.13.2 (stable) (Tue Aug 25 01:01:12 2026 -0700) on "macos_arm64" (generated codecs, zero runtime dependency; AOT executable)
+# elixir: 1.20.4 (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 3d01b479 (HEAD)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.cs]
+# serialize.js commit: de0591c (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.js]
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+cpp,bench_mixed,write,4000000,438,7,8865269,8622642,9185220,3703.11,6.35,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,7,4592365,4520680,4665785,1918.27,3.16,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,7,92578,90612,93240,5784.51,2.84,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,7,124551,124235,124881,7782.32,0.52,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,7,8776607,8678371,8910035,3666.07,2.64,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,7,4349140,4317547,4378533,1816.68,1.40,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,7,93012,91649,96686,5811.63,5.42,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,7,77731,76745,78969,4856.84,2.86,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+go,bench_mixed,write,4000000,438,7,4049584,3996390,4061070,1691.55,1.60,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bench_mixed,round_trip,4000000,438,7,2015239,2007175,2020216,841.78,0.65,6b213fbfa1a03a99,gen,pkg,always,default,unknown
+go,bitpacker,write,24576,65518,7,12339,12291,12368,770.96,0.62,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+go,bitpacker,read,24576,65518,7,14198,14096,14230,887.11,0.94,6b213fbfa1a03a99,bits,pkg,always,default,unknown
+rust,bench_mixed,write,4000000,438,7,7520388,7433013,7554548,3141.34,1.62,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bench_mixed,round_trip,4000000,438,7,2648281,2630540,2701657,1106.21,2.69,6b213fbfa1a03a99,gen,crate,always,O3,unknown
+rust,bitpacker,write,24576,65518,7,36585,35477,37403,2285.93,5.27,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+rust,bitpacker,read,24576,65518,7,45168,44412,45379,2822.24,2.14,6b213fbfa1a03a99,bits,crate,always,O3,unknown
+cs,bench_mixed,write,4000000,438,7,3740902,3696281,3768372,1562.61,1.93,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bench_mixed,round_trip,4000000,438,7,1830261,1824517,1843454,764.52,1.03,6b213fbfa1a03a99,gen,asm,always,default,unknown
+cs,bitpacker,write,24576,65518,7,21787,21688,21919,1361.32,1.06,6b213fbfa1a03a99,bits,asm,always,default,unknown
+cs,bitpacker,read,24576,65518,7,23023,22873,23222,1438.55,1.52,6b213fbfa1a03a99,bits,asm,always,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+js,bench_mixed,write,4000000,438,7,2948508,2919805,2962202,1231.62,1.44,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bench_mixed,round_trip,4000000,438,7,1587829,1585475,1598165,663.25,0.80,6b213fbfa1a03a99,gen,esm,contract,default,unknown,flat
+js,bitpacker,write,24576,65518,7,8277,8228,8316,517.15,1.07,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+js,bitpacker,read,24576,65518,7,6291,6195,6365,393.09,2.70,6b213fbfa1a03a99,bits,esm,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+java,bench_mixed,write,4000000,438,7,6709098,6634836,6761018,2802.45,1.88,6b213fbfa1a03a99,gen,class,contract,default,unknown
+java,bench_mixed,round_trip,4000000,438,7,2710948,2698376,2754761,1132.39,2.08,6b213fbfa1a03a99,gen,class,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+dart,bench_mixed,write,4000000,438,7,3051460,2960110,3090123,1274.62,4.26,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+dart,bench_mixed,round_trip,4000000,438,7,1742881,1697460,1746369,728.02,2.81,6b213fbfa1a03a99,gen,aot,contract,default,unknown
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+elixir,bench_mixed,write,4000000,438,7,468068,441234,480868,195.52,8.47,6b213fbfa1a03a99,gen,beam,contract,default,unknown
+elixir,bench_mixed,round_trip,4000000,438,7,315892,308424,321467,131.95,4.13,6b213fbfa1a03a99,gen,beam,contract,default,unknown

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -7,34 +7,43 @@
 
 ## 2026-09-07: the Studio's nine-language table, and what moved since the Air's
 
-The README's table is now a sitting on the Apple M3 Ultra Studio, schema main at 3d01b479,
-every leg gated on the wire goldens, seven measured runs per leg, rendered by the README's
-own instrument (`bench/render.awk`: round-trip best rate, C++ = 100%). Five legs ran on the
-toolchains the repository pins: node 20.20.2, OpenJDK 21.0.12.1 (the Temurin build
-`make/java.mk` names), Dart 3.13.2, Erlang/OTP 29.0.5 with Elixir 1.20.4, and .NET SDK
-10.0.400 for the `10.0` in `.github/dotnet-version`. The other four ran on the machine's
-compilers, which the repository does not pin: Apple clang 21.0.0, go 1.27.1 (CI runs 1.26)
-and cargo 1.98.0 (CI resolves stable at run time); the runtimes were at the tags CI checks
-out. It is C++ = 100% like the tables below it because the C = 100% form the standard prefers
-is not producible for these rows: the `rel` tool refuses rows without an inline verdict, and
-none of these carry one. The Air's table it replaces, and a second Studio sitting ten minutes
-earlier, stand beside it:
+The README's table is now a sitting on the Apple M3 Ultra Studio taken on the pinned node
+26.7.0 ([CSV](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv),
+15:45:27Z), every leg gated on the wire goldens, seven measured runs per leg, rendered by the
+README's own instrument (`bench/render.awk`: round-trip best rate, C++ = 100%). Its preamble
+records schema commit 3d01b479; main's 7622f23b after it changed only `bench/tools`,
+`bench/run.sh`, docs and results, so the generated code and the runtime checkouts this sitting
+measured are the ones on today's main. Five legs ran on the toolchains the repository pins:
+node 26.7.0 (the pin was 20.20.2 until 2026-09-07; the two older Studio sittings below ran on
+it, the Air's already on 26.7.0), OpenJDK 21.0.12.1 (the Temurin build `make/java.mk` names),
+Dart 3.13.2, Erlang/OTP 29.0.5 with Elixir 1.20.4, and .NET SDK 10.0.400 for the `10.0` in
+`.github/dotnet-version`. The other four ran on the machine's compilers, which the repository
+does not pin: Apple clang 21.0.0, go 1.27.1 (CI runs 1.26) and cargo 1.98.0 (CI resolves stable
+at run time); the runtimes were at the tags CI checks out. It is C++ = 100% like the tables
+below it because the C = 100% form the standard prefers is not producible for these rows: the
+`rel` tool refuses rows without an inline verdict, and none of these carry one. The two node-20
+Studio sittings it replaces, and the Air's table before them, stand beside it:
 
-| language | [Studio, sitting 2](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv) (the README's) | [Studio, sitting 1](../bench/results/2026-09-07-arm64-studio-ninelang-sitting.csv) | [Air, 2026-09-01](../bench/results/2026-09-02-sitting4-arm64-macbook.csv) |
-|---|---:|---:|---:|
-| C++ | 100% | 100% | 100% |
-| C | 107% | 109% | 100%, a §2.8 tie (measured 98%) |
-| Java | 169% | 175% | 162% |
-| Rust | 172% | 174% | 154% |
-| Go | 230% | 238% | 210% |
-| C# | 253% | 260% | 225% |
-| Dart | 256% | 264% | 227% |
-| JavaScript | 387% | 392% ([its own file](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-js.csv), computed by hand across the two files) | 264%, on node 26.7.0 |
-| Elixir | 1427% | 1489% | 1283% |
+| language | [Studio, node 26.7.0](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-node26.csv) (the README's) | [Studio, sitting 2](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-2.csv), node 20.20.2 | [Studio, sitting 1](../bench/results/2026-09-07-arm64-studio-ninelang-sitting.csv), node 20.20.2 | [Air (Apple M2), 2026-09-01](../bench/results/2026-09-02-sitting4-arm64-macbook.csv), node 26.7.0 |
+|---|---:|---:|---:|---:|
+| C++ | 100% | 100% | 100% | 100% |
+| C | 107% | 107% | 109% | 100%, a §2.8 tie (measured 98%) |
+| Java | 169% | 169% | 175% | 162% |
+| Rust | 173% | 172% | 174% | 154% |
+| Go | 231% | 230% | 238% | 210% |
+| C# | 253% | 253% | 260% | 225% |
+| Dart | 267% | 256% | 264% | 227% |
+| JavaScript | 292% | 387% | 392% ([its own file](../bench/results/2026-09-07-arm64-studio-ninelang-sitting-js.csv), computed by hand across the two files) | 264% |
+| Elixir | 1451% | 1427% | 1489% | 1283% |
 
-The two Studio sittings differ by 1.1 to 4.2% on every row, most of it the C++ denominator
-(4,801,451 then 4,637,510 messages a second); sitting 1's JavaScript leg ran in its own file
-because the runner finds node on the PATH and the pinned node was not on it.
+Against sitting 2, one leg moved with the runtime: JavaScript, 387% to 292%. Of the rest,
+Dart's 256% to 267% is the largest move in proportion (its absolute rate fell 3.6% against a
+denominator up 0.6%) and Elixir's 1427% to 1451% the next (down 1.0%); both are
+sitting-to-sitting variance, not measured to anything. The two node-20 Studio sittings differ
+by 1.1 to 4.2% on every row but C++'s, the denominator, and most of that spread is the
+denominator itself (4,801,451 then 4,637,510 messages a second); sitting 1's JavaScript leg
+ran in its own file because the runner finds node on the PATH and the pinned node was not on
+it.
 
 **What moved, measured on one machine.** Four four-leg driver passes (C++, C, Go, Rust; seven
 interleaved rounds, twins, control legs inside the 5% window every time; each pass controlled
@@ -49,21 +58,36 @@ two-by-two of the Air sitting's schema commit and runtime commits against today'
 | b414f078, dirty (today's; the note says how) | today's tags | 4,733,118 | 174% | 233% | [pass A](../bench/results/2026-09-07-arm64-studio-four-legs-twins-pass.csv) |
 
 Rust's best round-trip rate stays between 2.67 and 2.76 million messages a second across every
-cell and both sittings (3.2% from lowest to highest), Go's between 2.01 and 2.04 million
+cell and all three sittings (3.2% from lowest to highest), Go's between 2.01 and 2.04 million
 (1.3%), C's within 2.5%. C++'s best rate on today's code is 5.5 to 9.3% above the first row's
-(7.7% in the last row, 9.3% and 5.5% in the two sittings). Both changes contribute and the
-split between them is not resolved: read one way through the table, the schema commits since
-7eba63f add 2.5% and serialize.h between cebaed2 and v1.16.2 adds 5.1%; read the other way,
-4.3% and 3.3%; each step is smaller than the C++ spread inside the passes it is read from, and
-which commit is not isolated. C++ is the denominator, so every other language's percentage
-widened by that much while the other three legs stayed inside their own spreads. Ratios move
-with microarchitecture, as this page says below, and the first row measures that move: the
-Air's code on the Air's runtimes renders Rust 163% and Go 216% on this machine against 154%
-and 210% on the Air. JavaScript is the one row with a further term: the Air's 264% ran node
-26.7.0 where the pin is 20.20.2, the Studio's absolute JavaScript rate is below the Air's
-while every other leg is 14 to 29% above it, and the Air's own three sittings of 2026-09-01
-rendered JavaScript 461%, 318% and 264% on that one node; whether the version or the Air's
-variance on this leg is the term is not measured on one machine.
+(7.7% in the last row; 9.3%, 6.2% and 5.5% in the three sittings). Both changes contribute and
+the split between them is not resolved: read one way through the table, the schema commits
+since 7eba63f add 2.5% (D to C) and serialize.h between cebaed2 and v1.16.2 adds 5.1% (C to A);
+read the other way, 4.3% (B to A) and 3.3% (D to B). The C++ round-trip spreads inside the four
+passes those steps are read from are 2.0, 3.0, 6.8 and 13.4% in D, B, A and C: the steps are of
+the same order as the spreads, so the split is not resolved and which commit is responsible is
+not isolated. C++ is the denominator, so every other language's percentage widened by that much
+while the other three legs stayed inside their own spreads. Ratios move with microarchitecture,
+as this page says below, and the first row measures that move: the Air's code on the Air's
+runtimes renders Rust 163% and Go 216% on this machine against 154% and 210% on the Air.
+
+**JavaScript, and the node version.** JavaScript was the one row these passes left with an
+unmeasured term: the Air's 264% ran node 26.7.0 where the pin was then 20.20.2, and the
+Studio's absolute JavaScript rate was *below* the Air's while every other leg was 14 to 29%
+above it. Two runs of the JavaScript leg alone, on this one machine 101 seconds apart, settle
+the version term. Seven measured runs each, best round-trip rate:
+
+| node | best round-trip, msgs/sec | spread | CSV |
+|---|---:|---:|---|
+| 20.20.2, 15:42:19Z | 1,222,630 | 2.08% | [js node 20](../bench/results/2026-09-07-arm64-studio-js-node20.csv) |
+| 26.7.0, 15:44:00Z | 1,595,367 | 1.46% | [js node 26](../bench/results/2026-09-07-arm64-studio-js-node26.csv) |
+
+That is +30.5%, one machine, back to back, each spread an order below the step. On node 26 the
+Studio's JavaScript leg runs 17.4% above the Air's, inside the 10.1 to 29.8% range the other
+eight legs occupy in the same sitting — the row no longer stands apart. The Air's own variance
+on this leg remains true and is now a secondary term: its three sittings of 2026-09-01
+rendered JavaScript 461%, 318% and 264% on that one node, and the README's Air number was the
+fast end of that range, so Air-to-Studio comparisons of this row still carry it.
 
 These are the first passes the driver has aggregated since 2026-08-31: its `aggregate` had
 refused every pass since then, failing closed, because a parameter shadowed the path-column

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -168,9 +168,9 @@ to a cross-port rule at docs/SPEC-TABLES.md's JavaScript allocation paragraph.
 
 **Proven in.** C++; measured in JavaScript.
 
-**Measured effect.** On the pinned node major a float crossing a helper was
-steady at sixteen bytes a call, and invisible on a newer V8 — which is why the
-gate is pinned (I14).
+**Measured effect.** On one node major a float crossing a helper was steady at
+sixteen bytes a call, and invisible on another — which is why the gate is
+pinned to one (I14).
 
 **Negative control.** The allocation gate's wire rows: a helper put back
 reads as bytes per iteration on the pinned runtime.
@@ -1255,8 +1255,8 @@ the magnitude tie-break and requires red (19 of 60 on the pinned seed).
 
 **Method.** The gate reads the runtime's version and, on any other than the
 pinned one, sets failed and returns without measuring; an escape hatch reports
-and does not certify. A newer JIT optimizes generated bodies an older one
-leaves on its threshold, where a double store boxes, so a floor measured on
+and does not certify. One major's JIT inlines a generated body another leaves
+over its threshold, where a double store boxes, so a floor measured on
 whatever binary a PATH lookup found says nothing about the runtime the claim
 is for. A native codec's allocations are in its source and a compiler adds
 none, so the native legs state that reason here rather than a pin.
@@ -1267,7 +1267,7 @@ refusal, `SCHEMA_JS_ALLOC_ANY_NODE`).
 **Proven in.** JavaScript.
 
 **Measured effect.** The allocation the gate exists to catch is invisible on
-a newer V8 and steady at sixteen bytes a call on the pinned one.
+one V8 major and steady at sixteen bytes a call on another.
 
 **Negative control.** Running the gate on another major must refuse.
 

--- a/make/js.mk
+++ b/make/js.mk
@@ -17,11 +17,11 @@
 # (test/js-tables/main.mjs, PinnedNodeMajor). The default points at the repo-local unpacked runtime; CI
 # installs the same major and overrides with NODE=node. To populate dist/
 # (gitignored):
-#   Node.js 20.20.2 (LTS, darwin-arm64)
-#   url:    https://nodejs.org/dist/v20.20.2/node-v20.20.2-darwin-arm64.tar.gz
-#   sha256: 466e05f3477c20dfb723054dfebffe55bc74660ee77f612166fca121dacb65b6
-#   untar into dist/ (the tarball already unpacks to node-v20.20.2-darwin-arm64)
-NODE ?= $(CURDIR)/dist/node-v20.20.2-darwin-arm64/bin/node
+#   Node.js 26.7.0 (darwin-arm64)
+#   url:    https://nodejs.org/dist/v26.7.0/node-v26.7.0-darwin-arm64.tar.gz
+#   sha256: 7ee659a7768e641bbfd5360940660b8e8fd0052f77488f365562bac522fc15d4
+#   untar into dist/ (the tarball already unpacks to node-v26.7.0-darwin-arm64)
+NODE ?= $(CURDIR)/dist/node-v26.7.0-darwin-arm64/bin/node
 # the conformance driver is a shell script the harness spawns, so it reads the
 # pin from the environment and falls back to PATH
 export NODE
@@ -480,8 +480,8 @@ test-js: toolchain-js generated/js/.stamp generated/js-ludicrous/.stamp generate
 	$(MAKE) conformance-negative-control-js
 	$(MAKE) tables-js-runtime-home
 	$(MAKE) tables-js-runtime-home-negative-control
-	cd test/js && node main.mjs && NODE_ENV=production node main.mjs
-	cd test/js-ludicrous && node main.mjs && NODE_ENV=production node main.mjs
+	cd test/js && $(NODE) main.mjs && NODE_ENV=production $(NODE) main.mjs
+	cd test/js-ludicrous && $(NODE) main.mjs && NODE_ENV=production $(NODE) main.mjs
 
 TEST_LEGS         += test-js
 TOOLCHAIN_LEGS    += js

--- a/make/negative-controls.json
+++ b/make/negative-controls.json
@@ -436,7 +436,7 @@
         "tables-js-runtime-home-negative-control",
         "tables-js-slot-negative-control"
       ],
-      "node": "20"
+      "node": "26"
     },
     {
       "name": "dart",

--- a/test/conformance/js/ci.json
+++ b/test/conformance/js/ci.json
@@ -1,2 +1,2 @@
 {"targets": "build/conformance-harness build/tables-generated-js/.stamp",
- "node": "20"}
+ "node": "26"}

--- a/test/js-tables/main.mjs
+++ b/test/js-tables/main.mjs
@@ -1201,8 +1201,8 @@ function alloc(iterations, body, baseline, budgetMs) {
 // same number four times, which is what ONE SMALL ALLOCATION looks like.
 //
 // Eight bytes is the residual of the instrument itself after the empty body is
-// subtracted: on the pinned node it reads 0.00 exactly, and on the newer one it
-// reads under 1.5. Anything a port could plausibly allocate — a boxed double is
+// subtracted: on one V8 major it reads 0.00 exactly and on another under 1.5
+// (0.0 to 0.4 on the pinned 26.7.0, measured 2026-09-07). Anything a port could plausibly allocate — a boxed double is
 // sixteen bytes, the smallest object literal thirty-four, a BigInt more — sits
 // clear of it, and the negative control puts eight objects in.
 const ZeroFloor = 8;
@@ -1403,13 +1403,13 @@ function gateAllocation(measured, where) {
 }
 
 // THE RUNTIME THIS PROPERTY IS CLAIMED FOR, and the gate refuses to certify on
-// another. That is not fussiness: an allocation a newer V8 optimizes away can
-// be steady at sixteen bytes a call on the pinned one — a generated body
-// sitting over the older engine's optimization threshold — and a number read
-// on whatever `node` a PATH lookup found says nothing about the runtime the
-// claim is for. Pass SCHEMA_JS_ALLOC_ANY_NODE=1 to read the numbers on
-// another runtime; the gate then reports and does not certify.
-const PinnedNodeMajor = "20";
+// another. That is not fussiness: an allocation one major optimizes away can be
+// steady at sixteen bytes a call on another — a generated body sitting over
+// that engine's inlining threshold — and a number read on whatever `node` a
+// PATH lookup found says nothing about the runtime the claim is for. Pass
+// SCHEMA_JS_ALLOC_ANY_NODE=1 to read the numbers on another runtime; the gate
+// then reports and does not certify.
+const PinnedNodeMajor = "26";
 
 function checkAllocation(iterations) {
   let bad = false;
@@ -1418,10 +1418,10 @@ function checkAllocation(iterations) {
   if (major !== PinnedNodeMajor && !anyNode) {
     console.log("FAILED: this gate holds an allocation floor for node " + PinnedNodeMajor +
       ", which is the version CI pins, and it is running on node " + process.versions.node +
-      ". A newer V8 optimizes generated bodies an older one leaves on its threshold, where a " +
-      "double store boxes — so a floor measured here says nothing about the runtime the claim is " +
-      "for. Run `make dist-node` and re-run, or set SCHEMA_JS_ALLOC_ANY_NODE=1 to read the numbers " +
-      "without certifying them.");
+      ". V8 inlines generated bodies differently between majors, and a body left over the " +
+      "inlining threshold boxes its double store — so a floor measured here says nothing about " +
+      "the runtime the claim is for. Unpack the pinned runtime into dist/ (make/js.mk says how) and re-run, or set " +
+      "SCHEMA_JS_ALLOC_ANY_NODE=1 to read the numbers without certifying them.");
     failed = true;
     return;
   }

--- a/test/packet-defaults/README.md
+++ b/test/packet-defaults/README.md
@@ -73,7 +73,7 @@ constructor-byte control builds before failing its marker, and both checks
 ride `test-java`. Table-closure defaults stay refused.
 
 `make packet-defaults-js` checks both runtime and flat codecs in development
-and production on pinned Node 20.20.2. Runtime reads check the consumed bits;
+and production on pinned Node 26.7.0. Runtime reads check the consumed bits;
 flat reads must accept the exact bit bound and refuse one bit less. A
 `ChoiceEnvelope` type places its union at bit zero so the flat API, which
 exposes type codecs, consumes the same standalone union pin. Existing eight


### PR DESCRIPTION
**Asked.** "Please do the node run." and "And update the pin for node."

**The pin.** make/js.mk (path, url, sha256 from nodejs.org's SHASUMS256.txt; "LTS" dropped because 26.7.0's `process.release` carries no `lts` field), `PinnedNodeMajor` in test/js-tables/main.mjs, certify.yml's three `node-version` lines, and the two generated matrix sites that feed `matrix.node` in ci.yml and certify.yml (test/conformance/js/ci.json and make/negative-controls.json, cross-checked by tools/negativecontrols). PORTING.md's wording and the packet-defaults README follow. One pre-existing fix: test-js's last two legs ran on whatever `node` the PATH had, not `$(NODE)`; now the pin, which is what the file's own comment says the pin is for.

**The gates on 26.7.0.** toolchain-js, tables-js-alloc, packet-defaults-js, the conformance harness for js and make test-js all pass. The allocation gate certifies with more headroom than on 20: every zero-floor path reads under 0.5 bytes per iteration against its ceiling of 8, and the one licensed allocation (RenderFrame ships flags) reads about 121 bytes (120.2 to 121.2 across runs) against 224.5 on node 20, ceiling 320. On node 20 the gate now refuses by design, as it did on 26 before.

**The measurement.** Back to back on the Studio, two minutes apart, schema 3d01b479 (main's generated code; main since then changed only bench tools, docs and results): the JavaScript leg's best round-trip rate is 1,222,630 messages a second on node 20.20.2 and 1,595,367 on 26.7.0, +30.5% (median +30.9%). That settles the open term in the previous section: the README's 387% on node 20 against the Air's 264% on node 26 was the runtime. A nine-language sitting on node 26 (15:45Z) is the README's table now: C++ 100, C 107, Java 169, Rust 173, Go 231, C# 253, Dart 267, JavaScript 292, Elixir 1451; the largest sitting-to-sitting move against the node-20 sitting is Dart, 256 to 267, reported as variance with no cause measured. PERFORMANCE.md's dated section carries the node-26 sitting beside the two node-20 sittings and the Air's, the results note carries the three CSVs' essentials, and four sentences a cold read faulted in the previous section are corrected (the step-versus-spread claim, "on every row" including the denominator, "within 2%" made 2.1%, the Air labelled Apple M2).

**Receipts.** make shape-gate clean; `ledger --check` ingests the three CSVs; every markdown table uniform; every relative link resolves. Sittings record no load line (that is a pass-driver feature); the note says so, and it says its command block is reconstructed. A cold read reproduced every number and faulted six sentences (two stale major-specific comments, a reconstructed command block not marked as such, "largest move" without the proportion, "two minutes" for 101 seconds, and this body's allocation figures stated finer than the instrument); all repaired.

Pin change by an Opus worker under Rowan's brief; results by a second; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login, the bench's only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
