### PR TITLE
c: the write-side range checks become asserts, as C++'s are

### DIFF
--- a/bench/results/2026-09-07-arm64-studio-c-asserts-twins-pass.csv
+++ b/bench/results/2026-09-07-arm64-studio-c-asserts-twins-pass.csv
@@ -1,0 +1,45 @@
+# schema bench results
+# date: 2026-09-07T16:14:30Z
+# host: studio  arch: arm64  os: Darwin 25.6.0
+# cpu: Apple M3 Ultra
+# build: Release
+# cpp compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# cpp flags: -O3 -DNDEBUG -DSERIALIZE_RELEASE -DBENCH_OPT="O3" -std=c++17 -Wall -Wextra -Werror -ffp-contract=off -fno-rtti -Igenerated/bench/cpp -I../serialize
+# c compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)
+# c flags: -O3 -DNDEBUG -DBENCH_OPT="O3" -std=c99 -Wall -Wextra -Werror -Igenerated/bench/c -I../serialize.c (serialize.c compiled in, no LTO)
+# go: go version go1.27.1 darwin/arm64 (go run, default optimized build)
+# rust: cargo 1.98.0 (797e8a9bc 2026-08-05) (Homebrew); rustc 1.98.0 (88d9e12ae 2026-08-18) (Homebrew) (cargo run --release at opt-level 3, no LTO)
+# dotnet: not present (dotnet run -c Release, workstation GC)
+# node: not present (NODE_ENV=production — serialize.js's caller-trust release mode; the runner records the mode that ran in its checks column)
+# java: not present (generated codecs, zero runtime dependency; default JVM flags, no -ea)
+# dart: not present (generated codecs, zero runtime dependency; AOT executable)
+# elixir: not present (generated codecs, zero runtime dependency; pinned BEAM toolchain)
+# pinning: none
+# noise: unlabelled
+# schema commit: 287dd23b (c-checks-compile-out)
+# serialize commit: 93b8ea2 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize]
+# serialize.c commit: ddea231 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.c]
+# serialize.go commit: 963f6df (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.go]
+# serialize.rs commit: 5e26a78 (HEAD) [build-verified: /private/tmp/claude-501/-Users-glenn-rowan-new/568d2972-6e92-425c-aaef-4d7db11753c2/scratchpad/bench/serialize.rs]
+# serialize.cs commit: 1bf2b19 (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# serialize.js commit: de0591c (HEAD) [UNVERIFIED — leg not run this invocation; path recorded from the environment, not proven against a build]
+# rounds: 7   interleaved: yes
+# langs: cpp c
+# load_start: 8.82 6.83 5.19
+# load_end: 4.46 5.69 4.98
+# load_max: 8.82
+# core_busy_pct: n/a
+# foreign_procs: 6
+# control_start_median: 6679762   control_end_median: 6785250
+# control_delta_pct: 1.6   window: OK
+# twin_gate: OK (§2.6.1 A/A twin legs, alternating positions, same inode)
+# corpus_id: 6b213fbfa1a03a99
+lang,bench,path,iters,bytes_per_op,runs,median_msgs_per_sec,min_msgs_per_sec,max_msgs_per_sec,median_mb_per_sec,spread_pct,corpus_id,family,linkage,checks,opt,inline
+c,bench_mixed,write,4000000,438,14,8775876,8556699,8858514,3665.77,3.44,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bench_mixed,round_trip,4000000,438,14,4368454,4226431,4408928,1824.74,4.18,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+c,bitpacker,write,24576,65518,14,92596,91007,93578,5785.69,2.78,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+c,bitpacker,read,24576,65518,14,77200,75089,77469,4823.64,3.08,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bench_mixed,write,4000000,438,14,8774590,8624430,8863042,3665.23,2.72,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bench_mixed,round_trip,4000000,438,14,4584322,4433868,4636506,1914.91,4.42,6b213fbfa1a03a99,gen,hdr,removed,O3,unknown
+cpp,bitpacker,write,24576,65518,14,92628,90376,93114,5787.66,2.96,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown
+cpp,bitpacker,read,24576,65518,14,124870,121874,125154,7802.23,2.63,6b213fbfa1a03a99,bits,hdr,removed,O3,unknown

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -274,9 +274,10 @@ hand-crafted hostile bytes in the cross-language test corpus.
 No. **The guarantee is on reads** — that is where untrusted input arrives, and
 it holds in all nine languages.
 
-On the write side each language uses its own correctness idiom: C++ has
-`assert`/`NDEBUG`, a check that disappears in release, so that is what it uses;
-Go has no assert idiom, so it returns `ErrValueOutOfRange`, and C, C#, Rust
+On the write side each language uses its own correctness idiom: C++ and C
+have `assert`/`NDEBUG`, a check that disappears in release, so that is what
+they use;
+Go has no assert idiom, so it returns `ErrValueOutOfRange`, and C#, Rust
 and JavaScript likewise return failure rather than invent an assert; Dart
 and Java have `assert`, so like C++ they assert; and the BEAM has no dormant
 assert at all, so Elixir raises `ArgumentError` in every build. A

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -122,12 +122,42 @@ construction. The Rust `-O2` leg is a named harness gap.
 ## Reading the table honestly
 
 **The ratios cross safety contracts, and the harness says so in captions rather than hiding
-it.** C++ compiles its debug asserts and bounds checks out; C validates the wire and API
-contract in every build; Rust, C# and Go carry bounds, range and sticky-error checks in every
-build by contract. A ratio between two of those columns includes the price of a different
-promise. The clearest evidence that the price is real: C and Rust — the two per-field-checked
-writers — land within 5% of each other on every round-trip write row, from wholly independent
-implementations. Two minds arriving at the same cost for the same guarantee.
+it.** C++ compiles its debug asserts and bounds checks out; **so does C, from 2026-09-07** —
+the ruling was "Every language, by design, compiles out asserts/checks in release build. This
+is the whole point!", and the C backend's per-field write-side range and bounds refusals
+became `serialize_assert`s that vanish under `NDEBUG`, the tier C++'s are in (C still asserts
+less than C++ in two places, a flags value wider than its wire width and interior nulls in a
+`string(N)` on write; those are the next change). Two write-side checks stay in every build in
+both, because the spec mandates them in all nine targets: a counted array's count outside
+`[A, B]` (SPEC §4.6) and a union tag outside its variant set (§4.8); every read-side check
+stays in every build everywhere, by the other half of the same ruling. Rust, C# and Go carry bounds,
+range and sticky-error checks in every build by contract. A ratio between two of those columns
+includes the price of a different promise.
+
+**Measured the same day, the C change bought nothing the instrument can see.** A twins pass on
+the C and C++ legs with the asserts in place
+([CSV](../bench/results/2026-09-07-arm64-studio-c-asserts-twins-pass.csv), seven interleaved
+rounds, window OK, control delta 1.6%) renders C at 105.2% of C++, inside the §2.8 tie band
+(the pair's combined round-trip spread, 4.2 + 4.4 = 8.6 points) and so reported as a tie: write 8,858,514 against 8,863,042 messages a second,
+round trip 4,408,928 against 4,636,506. Two passes over identical code earlier the same day
+differed by 0.4%, and a pass with the refusals compiled out by hand moved C by 0.4% and 0.1%
+against them. By row, C is within 3% of C++ on the packet write and faster on the raw
+bit-packer write, and C++ reads raw bits 1.58 times faster; the remaining C-to-C++ distance is
+the C runtime's read path, not the generated code's checks.
+
+**The two dated `<!-- CAPTION -->` lines above this section are the provenance the
+2026-08-15 passes recorded, and they predate both halves of C's move**: the runtime's own
+release checks went in serialize.c ruling #20 on 2026-08-17 (the bench runner has recorded
+`checks=removed` for C since), and the generated code's went today. The sentence those
+captions carry — that C's wire and API contract validation stays in every build — was true of
+the runs they caption and is not true of C now. The C/C++ ratio is no longer a ratio across
+two check models; the pass above is the first rendered without one, and the 2026-08-15 tables
+stand as they were measured.
+
+Rust remains the per-field-checked writer of the set. The older reading of the table — that C
+and Rust, the two then-per-field-checked writers, landing within 5% of each other on every
+round-trip write row was independent confirmation of the cost of that guarantee — describes
+the C that measured, not the C that is here now.
 
 Relative numbers move with compiler and microarchitecture. Treat the table as a dated
 snapshot, not a verdict. Full tables, the pre-campaign baseline of the same day, and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2155,14 +2155,17 @@ readers face untrusted data and keep every mandated check above.
 
 Within that doctrine, misuse surfaces by each target's own convention — a
 language verifies correctness the way that language verifies correctness —
-and the list is exhaustive at all nine. **Three debug-assert**, unchecked in
-release: C++ through `serialize_assert`, Dart and Java through the language's
-own `assert`, live under `--enable-asserts` and `-ea` (Java's contracts ride
-one `check<Name>` predicate call, so a dormant assert costs the JIT one
-inlining slot rather than a body). **One raises in every build**: Elixir's
-`ArgumentError`, the BEAM having no dormant assert to compile out.
-**Five return failure from the write** rather than invent an assert their
-language does not have: C `0`, C# and JavaScript `false`, Go
+and the list is exhaustive at all nine. **Four debug-assert**, unchecked in
+release: C++ and C through `serialize_assert`, Dart and Java through the
+language's own `assert`, live under `--enable-asserts` and `-ea` (Java's
+contracts ride one `check<Name>` predicate call, so a dormant assert costs
+the JIT one inlining slot rather than a body). C's generated writes asserted
+from 2026-09-07, on the ruling "Every language, by design, compiles out
+asserts/checks in release build. This is the whole point!" — C has `assert`
+and `NDEBUG`, so the tier it belongs in is the one C++ is in. **One raises in every
+build**: Elixir's `ArgumentError`, the BEAM having no dormant assert to
+compile out. **Four return failure from the write** rather than invent an
+assert their language does not have: C# and JavaScript `false`, Go
 `serialize.ErrValueOutOfRange`, Rust `Err(serialize::Error::ValueOutOfRange)`
 — and JavaScript's flat tier, which forks checked/production at module load
 (§6.1), refuses with `-1` on the checked side and trusts the caller on the
@@ -2171,7 +2174,7 @@ only unwinding path in the nine, and it is the BEAM's own.
 
 **The tier split has exactly one stated exception, and it is a counted
 array's COUNT.** A count outside its declared `[A, B]` is refused by the
-write IN EVERY BUILD in all nine targets, so C++, Dart and Java refuse it
+write IN EVERY BUILD in all nine targets, so C++, C, Dart and Java refuse it
 from the write rather than through the assert their other contracts ride,
 and JavaScript's flat production tier refuses it rather than trusting the
 caller. The count is not a diagnostic: it guards the element loop and the

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -540,8 +540,10 @@ char name[MaxName + 1] = {};
 int32_t name_length = 0;
 ```
 
-The write refuses embedded NULs and any length past the maximum, and the
-read validates both. In C and C++ a successful read also writes the zero
+The write holds embedded NULs and any length past the maximum in its
+target's own §5 idiom (C++ asserts both, dormant under `NDEBUG`; C's
+runtime asserts the length and C does not yet scan for the NUL), and the
+read validates both in every build. In C and C++ a successful read also writes the zero
 byte at `name[name_length]`, so `name` is a valid C string every time the
 read succeeds, which is what the `+ 1` in the array is for. The other seven
 targets carry the buffer and the used length with nothing written past it.
@@ -805,8 +807,11 @@ and it holds in every language.
 
 **Each language uses its own correctness idiom on the write side.** C++ has
 `assert`/`NDEBUG`, a check that disappears in a release build, so the C++
-backend uses `serialize_assert`. Go has no assert idiom, so it returns
-`ErrValueOutOfRange`; C, C#, Rust and JavaScript likewise return failure
+backend uses `serialize_assert` — and so does the C backend, which has the
+same `assert` and the same `NDEBUG` (2026-09-07: "Every language, by design,
+compiles out asserts/checks in release build. This is the whole point!").
+Go has no assert idiom, so it returns
+`ErrValueOutOfRange`; C#, Rust and JavaScript likewise return failure
 rather than invent an assert. Dart has `assert` — active under
 `--enable-asserts`, compiled out of release and AOT builds — so the Dart
 writer asserts, exactly like C++; Java's `assert` is active under `-ea` and
@@ -818,9 +823,9 @@ correctness the way that language verifies correctness — not that every
 target behaves identically here.
 
 So writing `health = 2000` into a field declared `| min = 0, max = 1000`
-asserts in a C++, checked-Dart or `-ea` Java build, raises in Elixir, silently
-writes the truncated low bits in a C++ release, Dart AOT or default-JVM build,
-and returns failure in the others.
+asserts in a C++, C, checked-Dart or `-ea` Java build, raises in Elixir,
+silently writes the truncated low bits in a C++ or C release (`NDEBUG`), Dart
+AOT or default-JVM build, and returns failure in the others.
 
 Do not build on any of it. **Keep your values inside their declared bounds on
 the write side** — your simulation already knows they are, and that is the only

--- a/generated/bench/c/BenchWire.h
+++ b/generated/bench/c/BenchWire.h
@@ -165,26 +165,17 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 /* Writes BenchPacket. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_packet( serialize_write_stream_t * stream, const BenchPacket * value )
 {
-    if ( (serialize_int64_t) value->a < -100 || (serialize_int64_t) value->a > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->a >= -100 && (serialize_int64_t) value->a <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->a) - (-100) ), 8 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->b < 0 || (serialize_int64_t) value->b > 65535 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->b >= 0 && (serialize_int64_t) value->b <= 65535 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->b ), 16 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->c < -1000000 || (serialize_int64_t) value->c > 1000000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->c >= -1000000 && (serialize_int64_t) value->c <= 1000000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->c) - (-1000000) ), 21 ) )
     {
         return 0;
@@ -339,82 +330,52 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_bench_packet( serialize_read_
 /* Writes BenchInts. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_ints( serialize_write_stream_t * stream, const BenchInts * value )
 {
-    if ( (serialize_int64_t) value->f0 < -100 || (serialize_int64_t) value->f0 > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f0 >= -100 && (serialize_int64_t) value->f0 <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f0) - (-100) ), 8 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f1 < 0 || (serialize_int64_t) value->f1 > 65535 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f1 >= 0 && (serialize_int64_t) value->f1 <= 65535 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f1 ), 16 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f2 < -1000000 || (serialize_int64_t) value->f2 > 1000000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f2 >= -1000000 && (serialize_int64_t) value->f2 <= 1000000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f2) - (-1000000) ), 21 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f3 < 0 || (serialize_int64_t) value->f3 > 3 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f3 >= 0 && (serialize_int64_t) value->f3 <= 3 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f3 ), 2 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f4 < -15 || (serialize_int64_t) value->f4 > 15 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f4 >= -15 && (serialize_int64_t) value->f4 <= 15 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f4) - (-15) ), 5 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f5 < 0 || (serialize_int64_t) value->f5 > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f5 >= 0 && (serialize_int64_t) value->f5 <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f5 ), 10 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f6 < -2048 || (serialize_int64_t) value->f6 > 2047 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f6 >= -2048 && (serialize_int64_t) value->f6 <= 2047 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f6) - (-2048) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f7 < 0 || (serialize_int64_t) value->f7 > 255 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f7 >= 0 && (serialize_int64_t) value->f7 <= 255 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f7 ), 8 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f8 < -600000 || (serialize_int64_t) value->f8 > 600000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f8 >= -600000 && (serialize_int64_t) value->f8 <= 600000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f8) - (-600000) ), 21 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f9 < 0 || (serialize_int64_t) value->f9 > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f9 >= 0 && (serialize_int64_t) value->f9 <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f9 ), 7 ) )
     {
         return 0;
@@ -695,26 +656,17 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_entity( serialize_wri
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->pos_x < -16383 || (serialize_int64_t) value->pos_x > 16383 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->pos_x >= -16383 && (serialize_int64_t) value->pos_x <= 16383 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->pos_x) - (-16383) ), 15 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->pos_y < -16383 || (serialize_int64_t) value->pos_y > 16383 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->pos_y >= -16383 && (serialize_int64_t) value->pos_y <= 16383 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->pos_y) - (-16383) ), 15 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->pos_z < -16383 || (serialize_int64_t) value->pos_z > 16383 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->pos_z >= -16383 && (serialize_int64_t) value->pos_z <= 16383 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->pos_z) - (-16383) ), 15 ) )
     {
         return 0;
@@ -727,42 +679,27 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_entity( serialize_wri
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->vel_x < -2048 || (serialize_int64_t) value->vel_x > 2047 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->vel_x >= -2048 && (serialize_int64_t) value->vel_x <= 2047 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->vel_x) - (-2048) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->vel_y < -2048 || (serialize_int64_t) value->vel_y > 2047 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->vel_y >= -2048 && (serialize_int64_t) value->vel_y <= 2047 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->vel_y) - (-2048) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->vel_z < -2048 || (serialize_int64_t) value->vel_z > 2047 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->vel_z >= -2048 && (serialize_int64_t) value->vel_z <= 2047 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->vel_z) - (-2048) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->health < 0 || (serialize_int64_t) value->health > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->health >= 0 && (serialize_int64_t) value->health <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->health ), 10 ) )
     {
         return 0;
     }
-    if ( value->weapon > 15 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->weapon <= 15 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->weapon, 4 ) )
     {
         return 0;
@@ -945,10 +882,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_stat( serialize_write
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->delta < -512 || (serialize_int64_t) value->delta > 511 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->delta >= -512 && (serialize_int64_t) value->delta <= 511 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->delta) - (-512) ), 10 ) )
     {
         return 0;
@@ -991,18 +925,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_hit_event( serialize_
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->damage < 0 || (serialize_int64_t) value->damage > 4095 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->damage >= 0 && (serialize_int64_t) value->damage <= 4095 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->damage ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->hit_kind < 0 || (serialize_int64_t) value->hit_kind > 7 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->hit_kind >= 0 && (serialize_int64_t) value->hit_kind <= 7 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->hit_kind ), 3 ) )
     {
         return 0;
@@ -1063,10 +991,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_mixed_hit_event( serialize_re
 /* Writes MixedChatEvent. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_chat_event( serialize_write_stream_t * stream, const MixedChatEvent * value )
 {
-    if ( (serialize_int64_t) value->channel < 0 || (serialize_int64_t) value->channel > 3 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->channel >= 0 && (serialize_int64_t) value->channel <= 3 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->channel ), 2 ) )
     {
         return 0;
@@ -1113,10 +1038,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_mixed_pickup_event( seriali
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->amount < 0 || (serialize_int64_t) value->amount > 255 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->amount >= 0 && (serialize_int64_t) value->amount <= 255 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->amount ), 8 ) )
     {
         return 0;
@@ -1218,10 +1140,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->ack_sequence < 0 || (serialize_int64_t) value->ack_sequence > 65535 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->ack_sequence >= 0 && (serialize_int64_t) value->ack_sequence <= 65535 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->ack_sequence ), 16 ) )
     {
         return 0;
@@ -1249,10 +1168,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
             return 0;
         }
     }
-    if ( (serialize_int64_t) value->world_time < -1000000000000 || (serialize_int64_t) value->world_time > 1000000000000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->world_time >= -1000000000000 && (serialize_int64_t) value->world_time <= 1000000000000 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->world_time) - (-1000000000000) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -1401,10 +1317,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
     }
     if ( value->has_extra )
     {
-        if ( (serialize_int64_t) value->extra < 0 || (serialize_int64_t) value->extra > 255 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->extra >= 0 && (serialize_int64_t) value->extra <= 255 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->extra ), 8 ) )
         {
             return 0;
@@ -1412,10 +1325,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_bench_mixed( serialize_writ
     }
     else
     {
-        if ( (serialize_int64_t) value->idle_ticks < 0 || (serialize_int64_t) value->idle_ticks > 15 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->idle_ticks >= 0 && (serialize_int64_t) value->idle_ticks <= 15 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->idle_ticks ), 4 ) )
         {
             return 0;

--- a/generated/bench/c/RealWorldWire.h
+++ b/generated/bench/c/RealWorldWire.h
@@ -53,10 +53,7 @@ extern "C" {
 /* Writes RealPacket. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_write_stream_t * stream, const RealPacket * value )
 {
-    if ( (serialize_int64_t) value->f001_int < -805495 || (serialize_int64_t) value->f001_int > 805495 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f001_int >= -805495 && (serialize_int64_t) value->f001_int <= 805495 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f001_int) - (-805495) ), 21 ) )
     {
         return 0;
@@ -65,10 +62,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f003_int < -835897 || (serialize_int64_t) value->f003_int > 835897 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f003_int >= -835897 && (serialize_int64_t) value->f003_int <= 835897 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f003_int) - (-835897) ), 21 ) )
     {
         return 0;
@@ -77,18 +71,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f005_uint > 7316 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f005_uint <= 7316 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f005_uint ), 13 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f006_int < -1513 || (serialize_int64_t) value->f006_int > 1513 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f006_int >= -1513 && (serialize_int64_t) value->f006_int <= 1513 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f006_int) - (-1513) ), 12 ) )
     {
         return 0;
@@ -101,10 +89,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f009_int < -22 || (serialize_int64_t) value->f009_int > 22 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f009_int >= -22 && (serialize_int64_t) value->f009_int <= 22 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f009_int) - (-22) ), 6 ) )
     {
         return 0;
@@ -127,18 +112,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f014_uint > 775 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f014_uint <= 775 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f014_uint ), 10 ) )
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f015_int < -21 || (serialize_int64_t) value->f015_int > 21 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f015_int >= -21 && (serialize_int64_t) value->f015_int <= 21 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f015_int) - (-21) ), 6 ) )
         {
             return 0;
@@ -150,19 +129,13 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
                 return 0;
             }
         }
-        if ( (serialize_int64_t) value->f017_uint > 4606 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f017_uint <= 4606 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f017_uint ), 13 ) )
         {
             return 0;
         }
     }
-    if ( (serialize_int64_t) value->f018_int < -834 || (serialize_int64_t) value->f018_int > 834 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f018_int >= -834 && (serialize_int64_t) value->f018_int <= 834 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f018_int) - (-834) ), 11 ) )
     {
         return 0;
@@ -225,26 +198,17 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f032_int < -3 || (serialize_int64_t) value->f032_int > 3 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f032_int >= -3 && (serialize_int64_t) value->f032_int <= 3 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f032_int) - (-3) ), 3 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f033_uint > 142780 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f033_uint <= 142780 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f033_uint ), 18 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f034_uint > 14149 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f034_uint <= 14149 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f034_uint ), 14 ) )
     {
         return 0;
@@ -253,10 +217,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( value->f036_enum > 5 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->f036_enum <= 5 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->f036_enum, 3 ) )
     {
         return 0;
@@ -280,10 +241,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
             return 0;
         }
     }
-    if ( (serialize_int64_t) value->f041_int < -55 || (serialize_int64_t) value->f041_int > 55 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f041_int >= -55 && (serialize_int64_t) value->f041_int <= 55 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f041_int) - (-55) ), 7 ) )
     {
         return 0;
@@ -306,18 +264,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f046_uint > 76063 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f046_uint <= 76063 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f046_uint ), 17 ) )
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f047_int < -430976 || (serialize_int64_t) value->f047_int > 430976 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f047_int >= -430976 && (serialize_int64_t) value->f047_int <= 430976 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f047_int) - (-430976) ), 20 ) )
         {
             return 0;
@@ -344,10 +296,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f052_int < -57 || (serialize_int64_t) value->f052_int > 57 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f052_int >= -57 && (serialize_int64_t) value->f052_int <= 57 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f052_int) - (-57) ), 7 ) )
         {
             return 0;
@@ -356,10 +305,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f054_int < -35 || (serialize_int64_t) value->f054_int > 35 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f054_int >= -35 && (serialize_int64_t) value->f054_int <= 35 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f054_int) - (-35) ), 7 ) )
         {
             return 0;
@@ -369,18 +315,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f056_int < -13 || (serialize_int64_t) value->f056_int > 13 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f056_int >= -13 && (serialize_int64_t) value->f056_int <= 13 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f056_int) - (-13) ), 5 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f057_int < -15 || (serialize_int64_t) value->f057_int > 15 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f057_int >= -15 && (serialize_int64_t) value->f057_int <= 15 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f057_int) - (-15) ), 5 ) )
     {
         return 0;
@@ -401,10 +341,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f062_uint > 503 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f062_uint <= 503 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f062_uint ), 9 ) )
     {
         return 0;
@@ -413,10 +350,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f064_uint > 299 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f064_uint <= 299 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f064_uint ), 9 ) )
     {
         return 0;
@@ -444,10 +378,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f070_uint > 2 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f070_uint <= 2 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f070_uint ), 2 ) )
     {
         return 0;
@@ -460,10 +391,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f073_int < -4 || (serialize_int64_t) value->f073_int > 4 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f073_int >= -4 && (serialize_int64_t) value->f073_int <= 4 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f073_int) - (-4) ), 4 ) )
     {
         return 0;
@@ -478,18 +406,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f076_int < -26218 || (serialize_int64_t) value->f076_int > 26218 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f076_int >= -26218 && (serialize_int64_t) value->f076_int <= 26218 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f076_int) - (-26218) ), 16 ) )
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f077_int < -17 || (serialize_int64_t) value->f077_int > 17 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f077_int >= -17 && (serialize_int64_t) value->f077_int <= 17 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f077_int) - (-17) ), 6 ) )
         {
             return 0;
@@ -498,10 +420,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
         {
             return 0;
         }
-        if ( (serialize_int64_t) value->f079_uint > 17 )
-        {
-            return 0;
-        }
+        serialize_assert( (serialize_int64_t) value->f079_uint <= 17 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f079_uint ), 5 ) )
         {
             return 0;
@@ -519,10 +438,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( value->f083_enum > 5 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->f083_enum <= 5 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->f083_enum, 3 ) )
     {
         return 0;
@@ -538,10 +454,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f086_uint > 399 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f086_uint <= 399 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f086_uint ), 9 ) )
     {
         return 0;
@@ -550,10 +463,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->f088_int < -694 || (serialize_int64_t) value->f088_int > 694 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f088_int >= -694 && (serialize_int64_t) value->f088_int <= 694 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->f088_int) - (-694) ), 11 ) )
     {
         return 0;
@@ -569,10 +479,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_real_packet( serialize_writ
             return 0;
         }
     }
-    if ( (serialize_int64_t) value->f090_uint > 214 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->f090_uint <= 214 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->f090_uint ), 8 ) )
     {
         return 0;

--- a/generated/bench/tables/c/BenchTableWire.h
+++ b/generated/bench/tables/c/BenchTableWire.h
@@ -58,18 +58,12 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_table_hit_event( serialize_
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->damage < 0 || (serialize_int64_t) value->damage > 4095 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->damage >= 0 && (serialize_int64_t) value->damage <= 4095 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->damage ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->hit_kind < 0 || (serialize_int64_t) value->hit_kind > 7 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->hit_kind >= 0 && (serialize_int64_t) value->hit_kind <= 7 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->hit_kind ), 3 ) )
     {
         return 0;
@@ -130,10 +124,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_table_hit_event( serialize_re
 /* Writes TableChatEvent. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_table_chat_event( serialize_write_stream_t * stream, const TableChatEvent * value )
 {
-    if ( (serialize_int64_t) value->channel < 0 || (serialize_int64_t) value->channel > 3 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->channel >= 0 && (serialize_int64_t) value->channel <= 3 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->channel ), 2 ) )
     {
         return 0;
@@ -180,10 +171,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_table_pickup_event( seriali
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->amount < 0 || (serialize_int64_t) value->amount > 255 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->amount >= 0 && (serialize_int64_t) value->amount <= 255 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->amount ), 8 ) )
     {
         return 0;

--- a/generated/c-ludicrous/LudicrousWire.h
+++ b/generated/c-ludicrous/LudicrousWire.h
@@ -199,10 +199,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_w
             }
         }
     }
-    if ( (serialize_uint64_t) value->locked != 196608ULL )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_uint64_t) value->locked == 196608ULL );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->tail, 8 ) )
     {
         return 0;
@@ -326,10 +323,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_st
 /* Writes LudicrousState. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
 {
-    if ( value->mode > 3 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->mode <= 3 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->mode, 2 ) )
     {
         return 0;
@@ -432,18 +426,9 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_re
 /* Writes DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
 {
-    if ( (serialize_int64_t) value->locked_fixed != -196608LL )
-    {
-        return 0;
-    }
-    if ( (serialize_int64_t) value->locked_int < 7 || (serialize_int64_t) value->locked_int > 7 )
-    {
-        return 0;
-    }
-    if ( !serialize_int128_equal( value->locked_wide, serialize_int128_from_int64( -12345678901234 ) ) )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->locked_fixed == -196608LL );
+    serialize_assert( (serialize_int64_t) value->locked_int >= 7 && (serialize_int64_t) value->locked_int <= 7 );
+    serialize_assert( serialize_int128_equal( value->locked_wide, serialize_int128_from_int64( -12345678901234 ) ) );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->tail, 8 ) )
     {
         return 0;

--- a/generated/c/ArmDefaultsWire.h
+++ b/generated/c/ArmDefaultsWire.h
@@ -72,10 +72,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_arm( serialize_writ
             }
         }
     }
-    if ( (serialize_int64_t) value->marker > 7 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->marker <= 7 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->marker ), 3 ) )
     {
         return 0;

--- a/generated/c/ClausesWire.h
+++ b/generated/c/ClausesWire.h
@@ -177,10 +177,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w13( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 8191 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
             {
                 return 0;
@@ -235,10 +232,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w17( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 131071 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 131071 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 17 ) )
             {
                 return 0;
@@ -293,10 +287,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w26( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 67108863 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 67108863 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 26 ) )
             {
                 return 0;
@@ -351,10 +342,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w1( serialize_write_stream_
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 1 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 1 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 1 ) )
             {
                 return 0;
@@ -409,10 +397,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w52( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_uint64_t) value->items[i] > 4503599627370495 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_uint64_t) value->items[i] <= 4503599627370495 );
             {
                 serialize_uint64_t offset_value = (serialize_uint64_t) ( value->items[i] );
                 if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -479,10 +464,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w50( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_uint64_t) value->items[i] > 1125899906842623 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_uint64_t) value->items[i] <= 1125899906842623 );
             {
                 serialize_uint64_t offset_value = (serialize_uint64_t) ( value->items[i] );
                 if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -541,10 +523,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_f13( serialize_write_stream
         int32_t i;
         for ( i = 0; i < 7; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 8191 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
             {
                 return 0;

--- a/generated/c/JoinsWire.h
+++ b/generated/c/JoinsWire.h
@@ -631,10 +631,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arm_array( serialize_write_
             int32_t i;
             for ( i = 0; i < value->items_count; i++ )
             {
-                if ( (serialize_int64_t) value->items[i] > 8191 )
-                {
-                    return 0;
-                }
+                serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
                 if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
                 {
                     return 0;
@@ -964,10 +961,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_regain_after_align( seriali
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 8191 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
             {
                 return 0;

--- a/generated/c/RenderWire.h
+++ b/generated/c/RenderWire.h
@@ -70,10 +70,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_wr
     {
         return 0;
     }
-    if ( value->team > 2 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->team <= 2 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->team, 2 ) )
     {
         return 0;

--- a/generated/c/TypesWire.h
+++ b/generated/c/TypesWire.h
@@ -136,10 +136,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t
 /* Writes Handle. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_stream_t * stream, const Handle * value )
 {
-    if ( (serialize_int64_t) value->object_id < 0 || (serialize_int64_t) value->object_id > MAX_OBJECTS - 1 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->object_id >= 0 && (serialize_int64_t) value->object_id <= MAX_OBJECTS - 1 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->object_id ), 14 ) )
     {
         return 0;
@@ -182,26 +179,17 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream
 /* Writes QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
 {
-    if ( (serialize_int64_t) value->x < -MAX_POSITION_UNITS || (serialize_int64_t) value->x > MAX_POSITION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->x >= -MAX_POSITION_UNITS && (serialize_int64_t) value->x <= MAX_POSITION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->x) - (-MAX_POSITION_UNITS) ), 25 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->y < -MAX_POSITION_UNITS || (serialize_int64_t) value->y > MAX_POSITION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->y >= -MAX_POSITION_UNITS && (serialize_int64_t) value->y <= MAX_POSITION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->y) - (-MAX_POSITION_UNITS) ), 25 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->z < -MAX_POSITION_UNITS || (serialize_int64_t) value->z > MAX_POSITION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->z >= -MAX_POSITION_UNITS && (serialize_int64_t) value->z <= MAX_POSITION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->z) - (-MAX_POSITION_UNITS) ), 25 ) )
     {
         return 0;
@@ -260,26 +248,17 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize
 /* Writes QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
 {
-    if ( (serialize_int64_t) value->x < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->x > MAX_VELOCITY_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->x >= -MAX_VELOCITY_UNITS && (serialize_int64_t) value->x <= MAX_VELOCITY_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->x) - (-MAX_VELOCITY_UNITS) ), 23 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->y < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->y > MAX_VELOCITY_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->y >= -MAX_VELOCITY_UNITS && (serialize_int64_t) value->y <= MAX_VELOCITY_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->y) - (-MAX_VELOCITY_UNITS) ), 23 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->z < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->z > MAX_VELOCITY_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->z >= -MAX_VELOCITY_UNITS && (serialize_int64_t) value->z <= MAX_VELOCITY_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->z) - (-MAX_VELOCITY_UNITS) ), 23 ) )
     {
         return 0;
@@ -338,34 +317,22 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize
 /* Writes QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
 {
-    if ( (serialize_int64_t) value->x < -ROTATION_UNITS || (serialize_int64_t) value->x > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->x >= -ROTATION_UNITS && (serialize_int64_t) value->x <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->x) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->y < -ROTATION_UNITS || (serialize_int64_t) value->y > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->y >= -ROTATION_UNITS && (serialize_int64_t) value->y <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->y) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->z < -ROTATION_UNITS || (serialize_int64_t) value->z > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->z >= -ROTATION_UNITS && (serialize_int64_t) value->z <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->z) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->w < -ROTATION_UNITS || (serialize_int64_t) value->w > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->w >= -ROTATION_UNITS && (serialize_int64_t) value->w <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->w) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
@@ -697,10 +664,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_
 /* Writes ShipCreate. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
 {
-    if ( value->ship_type > 5 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->ship_type <= 5 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->ship_type, 3 ) )
     {
         return 0;
@@ -728,34 +692,22 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_writ
             return 0;
         }
     }
-    if ( value->team > 2 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->team <= 2 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->team, 2 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->health < 0 || (serialize_int64_t) value->health > MAX_HEALTH )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->health >= 0 && (serialize_int64_t) value->health <= MAX_HEALTH );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->health ), 10 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->thrust < 0 || (serialize_int64_t) value->thrust > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->thrust >= 0 && (serialize_int64_t) value->thrust <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->thrust ), 7 ) )
     {
         return 0;
     }
-    if ( value->pending > 0 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->pending <= 0 );
     return 1;
 }
 
@@ -852,18 +804,12 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_s
 /* Writes ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize_write_stream_t * stream, const ExpressionProbe * value )
 {
-    if ( (serialize_int64_t) value->hardpoint_index < 0 || (serialize_int64_t) value->hardpoint_index > (SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->hardpoint_index >= 0 && (serialize_int64_t) value->hardpoint_index <= (SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->hardpoint_index ), 5 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->spin_rate < -(-ROTATION_UNITS) || (serialize_int64_t) value->spin_rate > ROTATION_UNITS * 2 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->spin_rate >= -(-ROTATION_UNITS) && (serialize_int64_t) value->spin_rate <= ROTATION_UNITS * 2 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->spin_rate) - (-(-ROTATION_UNITS)) ), 11 ) )
     {
         return 0;
@@ -908,10 +854,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_r
 /* Writes ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_write_stream_t * stream, const ExtremeProbe * value )
 {
-    if ( (serialize_int64_t) value->floor_bound > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->floor_bound <= 100 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->floor_bound) - (( -9223372036854775807LL - 1 )) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -923,10 +866,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
             return 0;
         }
     }
-    if ( (serialize_int64_t) value->doubled_floor > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->doubled_floor <= 100 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->doubled_floor) - (( -9223372036854775807LL - 1 )) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -938,10 +878,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
             return 0;
         }
     }
-    if ( (serialize_uint64_t) value->ceiling_range < 1 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_uint64_t) value->ceiling_range >= 1 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->ceiling_range) - (1) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -1046,10 +983,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read
 /* Writes ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_write_stream_t * stream, const ExtremeRow * value )
 {
-    if ( (serialize_int64_t) value->clamped_floor > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->clamped_floor <= 100 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->clamped_floor) - (( -9223372036854775807LL - 1 )) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -1061,10 +995,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_writ
             return 0;
         }
     }
-    if ( (serialize_uint64_t) value->clamped_ceiling < 1 || (serialize_uint64_t) value->clamped_ceiling > 18446744073709551614ULL )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_uint64_t) value->clamped_ceiling >= 1 && (serialize_uint64_t) value->clamped_ceiling <= 18446744073709551614ULL );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->clamped_ceiling) - (1) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )

--- a/generated/c/WireWire.h
+++ b/generated/c/WireWire.h
@@ -374,10 +374,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_wri
     }
     if ( value->active )
     {
-        if ( value->weapon > 15 )
-        {
-            return 0; /* headroom above the wire range cannot ride */
-        }
+        serialize_assert( value->weapon <= 15 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) value->weapon, 4 ) )
         {
             return 0;
@@ -546,10 +543,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_st
 /* Writes ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write_stream_t * stream, const ProbeSlab * value )
 {
-    if ( (serialize_int64_t) value->width > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->width <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->width ), 7 ) )
     {
         return 0;
@@ -718,10 +712,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_wri
     {
         return 0;
     }
-    if ( value->preferred > 15 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->preferred <= 15 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->preferred, 4 ) )
     {
         return 0;
@@ -818,26 +809,17 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_strea
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->test_b < 0 || (serialize_int64_t) value->test_b > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->test_b >= 0 && (serialize_int64_t) value->test_b <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->test_b ), 10 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->test_c < 0 || (serialize_int64_t) value->test_c > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->test_c >= 0 && (serialize_int64_t) value->test_c <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->test_c ), 10 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->test_d < 0 || (serialize_int64_t) value->test_d > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->test_d >= 0 && (serialize_int64_t) value->test_d <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->test_d ), 10 ) )
     {
         return 0;
@@ -1009,26 +991,17 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_
 /* Writes TestData. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_stream_t * stream, const TestData * value )
 {
-    if ( (serialize_int64_t) value->a < -100 || (serialize_int64_t) value->a > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->a >= -100 && (serialize_int64_t) value->a <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->a) - (-100) ), 8 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->b < -100 || (serialize_int64_t) value->b > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->b >= -100 && (serialize_int64_t) value->b <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->b) - (-100) ), 8 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->c < -100 || (serialize_int64_t) value->c > 150 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->c >= -100 && (serialize_int64_t) value->c <= 150 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->c) - (-100) ), 8 ) )
     {
         return 0;
@@ -1061,10 +1034,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] < 0 || (serialize_int64_t) value->items[i] > 255 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] >= 0 && (serialize_int64_t) value->items[i] <= 255 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 8 ) )
             {
                 return 0;
@@ -1111,10 +1081,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->int64_range < -1000000000000 || (serialize_int64_t) value->int64_range > 1000000000000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->int64_range >= -1000000000000 && (serialize_int64_t) value->int64_range <= 1000000000000 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->int64_range) - (-1000000000000) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )

--- a/internal/codegen/c/c.go
+++ b/internal/codegen/c/c.go
@@ -702,14 +702,16 @@ func (g *gen) emitWriteFunc(st *ir.Struct) {
 		g.pf("    (void) stream;\n    (void) value;\n    return 1; /* no fields: no wire bits */\n}\n\n")
 		return
 	}
-	if len(st.Fields) == 0 {
-		g.pf("    (void) value; /* items only — reserved/const/align carry no storage */\n")
-	}
 	if ir.MaxBitsStruct(st) == 0 {
-		// every range degenerate: the body refuses out-of-contract values but
-		// never touches the stream (zero wire bits — found by
-		// FuzzGeneratedCompiles)
-		g.pf("    (void) stream; /* zero wire bits */\n")
+		// every range degenerate: the body's only value uses are
+		// serialize_asserts that compile away under NDEBUG, and it never
+		// touches the stream (zero wire bits — found by
+		// FuzzGeneratedCompiles). Both casts keep -Wall -Wextra -Werror
+		// consumers building in every configuration, the way the C++ backend
+		// does it.
+		g.pf("    (void) stream;\n    (void) value; /* zero wire bits — asserts compile away under NDEBUG */\n")
+	} else if len(st.Fields) == 0 {
+		g.pf("    (void) value; /* items only — reserved/const/align carry no storage */\n")
 	}
 	g.emitWriteItems(st.Items, "    ")
 	g.pf("    return 1;\n}\n\n")

--- a/internal/codegen/c/expr_test.go
+++ b/internal/codegen/c/expr_test.go
@@ -79,18 +79,19 @@ func TestExprBounds(t *testing.T) {
 	data, wire := generateExprCorpus(t)
 	for _, want := range []string{
 		// the issue's own example: a declared bound as the author's expression
-		"(serialize_int64_t) value->object_id > MAX_OBJECTS - 1",
+		// (the write-side bound is a serialize_assert — see emitRangeAssertWrite)
+		"(serialize_int64_t) value->object_id <= MAX_OBJECTS - 1",
 		// doubled minus parenthesizes — "--MAX_UNITS" would be a decrement
-		"(serialize_int64_t) value->doubled < -(-MAX_UNITS)",
-		"(serialize_int64_t) value->doubled > MAX_UNITS * 2",
+		"(serialize_int64_t) value->doubled >= -(-MAX_UNITS)",
+		"(serialize_int64_t) value->doubled <= MAX_UNITS * 2",
 		// hex bound keeps its source spelling
-		"(serialize_int64_t) value->hexed > 0x10",
+		"(serialize_int64_t) value->hexed <= 0x10",
 		// int-carrier overflow folds to the literal, suffixed as always
-		"(serialize_int64_t) value->overflow > 6000000000LL",
+		"(serialize_int64_t) value->overflow <= 6000000000LL",
 		// a wide leaf rides symbolically, no suffix needed
-		"(serialize_int64_t) value->wide_ok < -WIDE",
+		"(serialize_int64_t) value->wide_ok >= -WIDE",
 		// an enum-max bound folds
-		"(serialize_int64_t) value->team_size > 2LL",
+		"(serialize_int64_t) value->team_size <= 2LL",
 		// counted array bound and string size
 		"serialize_read_int( stream, &value->counted_count, 0, MAX_OBJECTS )",
 		"serialize_read_int( stream, &value->name_length, 0, MAX_UNITS )",

--- a/internal/codegen/c/fields.go
+++ b/internal/codegen/c/fields.go
@@ -94,7 +94,12 @@ func (g *gen) emitWriteScalar(f *ir.Field, expr, ind string) {
 		switch ref := f.Type.Ref.(type) {
 		case *ir.Enum:
 			bits := ir.BitsRequired(big.NewInt(0), big.NewInt(ref.Max))
-			g.pf("%sif ( %s > %d )\n%s{\n%s    return 0; /* headroom above the wire range cannot ride */\n%s}\n", ind, expr, ref.Max, ind, ind, ind)
+			// storage headroom above the wire range is writer misuse, not
+			// content: a debug assert that compiles out under NDEBUG, the
+			// same guard the C++ backend folds in (SPEC §5). The low half is
+			// vacuous where the enum's underlying type is unsigned, which is
+			// what the emitted storage asks for.
+			g.pf("%sserialize_assert( %s <= %d );\n", ind, expr, ref.Max)
 			if bits > 0 {
 				g.call(ind, fmt.Sprintf("serialize_write_bits( stream, (serialize_uint32_t) %s, %d )", expr, bits))
 			}
@@ -165,8 +170,12 @@ func (g *gen) emitWriteRangedInt(f *ir.Field, expr, ind string) {
 	g.pf("%s}\n", ind)
 }
 
-// emitRangeAssertWrite refuses an out-of-contract write rather than wrapping
-// it -- the same guard the other backends fold in.
+// emitRangeAssertWrite asserts the field's declared range on write. A value
+// outside it is WRITER MISUSE, not content: the guard is a serialize_assert
+// that fires in a debug build and compiles out under NDEBUG, exactly as the
+// C++ backend's emitWriteRangedFold32/64 fold it in (SPEC §5). "Every
+// language, by design, compiles out asserts/checks in release build. This is
+// the whole point!"
 //
 // Each half is emitted only when it CAN be false for the storage type. GCC's
 // -Wtype-limits rejects a vacuous comparison (an unsigned value < 0, or a
@@ -199,14 +208,13 @@ func (g *gen) emitRangeAssertWrite(f *ir.Field, expr, ind string) {
 	var cond string
 	switch {
 	case loNeeded && hiNeeded:
-		cond = fmt.Sprintf("(%s) %s < %s || (%s) %s > %s", cast, expr, lo, cast, expr, hi)
+		cond = fmt.Sprintf("(%s) %s >= %s && (%s) %s <= %s", cast, expr, lo, cast, expr, hi)
 	case loNeeded:
-		cond = fmt.Sprintf("(%s) %s < %s", cast, expr, lo)
+		cond = fmt.Sprintf("(%s) %s >= %s", cast, expr, lo)
 	default:
-		cond = fmt.Sprintf("(%s) %s > %s", cast, expr, hi)
+		cond = fmt.Sprintf("(%s) %s <= %s", cast, expr, hi)
 	}
-	g.pf("%sif ( %s )\n%s{\n%s    return 0;\n%s}\n",
-		ind, cond, ind, ind, ind)
+	g.pf("%sserialize_assert( %s );\n", ind, cond)
 }
 
 // storageRange is the inclusive range the field's STORAGE type can hold. A
@@ -427,25 +435,25 @@ func (g *gen) emitWriteFixed(f *ir.Field, expr, ind string) {
 		return
 	}
 	if lo.Cmp(hi) == 0 {
-		// degenerate range: ZERO bits — the range refusal and no wire call
+		// degenerate range: ZERO bits — the §5 misuse assert and no wire call
 		// at all, so no runtime degenerate support is needed (SPEC §4.6,
 		// decided deliberately). The one legal raw is min << F, compared in
 		// the storage's own signedness (a wide ufixed raw can live above
-		// INT64_MAX).
+		// INT64_MAX). The C++ backend asserts the same equality.
 		rawMin := new(big.Int).Lsh(lo, uint(f.Type.FracBits))
 		switch {
 		case f.Type.Width == 128 && f.Type.Signed:
-			g.pf("%sif ( !serialize_int128_equal( %s, %s ) )\n%s{\n%s    return 0;\n%s}\n",
-				ind, expr, g.int128Literal(nil, rawMin), ind, ind, ind)
+			g.pf("%sserialize_assert( serialize_int128_equal( %s, %s ) );\n",
+				ind, expr, g.int128Literal(nil, rawMin))
 		case f.Type.Width == 128:
-			g.pf("%sif ( !serialize_uint128_equal( %s, %s ) )\n%s{\n%s    return 0;\n%s}\n",
-				ind, expr, uint128Literal(rawMin), ind, ind, ind)
+			g.pf("%sserialize_assert( serialize_uint128_equal( %s, %s ) );\n",
+				ind, expr, uint128Literal(rawMin))
 		case f.Type.Signed:
-			g.pf("%sif ( (serialize_int64_t) %s != %s )\n%s{\n%s    return 0;\n%s}\n",
-				ind, expr, intLit(rawMin, "LL"), ind, ind, ind)
+			g.pf("%sserialize_assert( (serialize_int64_t) %s == %s );\n",
+				ind, expr, intLit(rawMin, "LL"))
 		default:
-			g.pf("%sif ( (serialize_uint64_t) %s != %s )\n%s{\n%s    return 0;\n%s}\n",
-				ind, expr, intLit(rawMin, "ULL"), ind, ind, ind)
+			g.pf("%sserialize_assert( (serialize_uint64_t) %s == %s );\n",
+				ind, expr, intLit(rawMin, "ULL"))
 		}
 		return
 	}
@@ -575,9 +583,10 @@ func (g *gen) emitWrite128(f *ir.Field, expr, ind string) {
 		return
 	}
 	if f.IntMin.Cmp(f.IntMax) == 0 {
-		// degenerate range: ZERO bits — refusal only (SPEC §4.6)
-		g.pf("%sif ( !serialize_int128_equal( %s, %s ) )\n%s{\n%s    return 0;\n%s}\n",
-			ind, expr, g.int128Literal(f.IntMinExpr, f.IntMin), ind, ind, ind)
+		// degenerate range: ZERO bits — the §5 misuse assert only, the same
+		// guard the C++ backend folds in (SPEC §4.6)
+		g.pf("%sserialize_assert( serialize_int128_equal( %s, %s ) );\n",
+			ind, expr, g.int128Literal(f.IntMinExpr, f.IntMin))
 		return
 	}
 	g.call(ind, fmt.Sprintf("serialize_write_int128( stream, %s, %s, %s )",

--- a/internal/codegen/c/wstring.go
+++ b/internal/codegen/c/wstring.go
@@ -10,10 +10,14 @@ import (
 func (g *gen) emitWriteWString(f *ir.Field, ind string) {
 	name := "value->" + f.Name
 	bound := g.renderInt(f.Type.SizeExpr, big.NewInt(f.Type.Size))
-	g.pf("%sif ( %s_length < 0 || %s_length > %s )\n%s{\n%s    return 0;\n%s}\n", ind, name, name, bound, ind, ind, ind)
+	// the used length and an interior null are writer misuse, not content:
+	// debug asserts that compile out under NDEBUG, the same two guards the
+	// C++ backend folds in (SPEC §4.12, §5). Surrogate pairing is the
+	// READER's refusal, below.
+	g.pf("%sserialize_assert( %s_length >= 0 && %s_length <= %s );\n", ind, name, name, bound)
 	g.call(ind, fmt.Sprintf("serialize_write_int( stream, %s_length, 0, %s )", name, bound))
 	g.pf("%s{\n%s    int32_t i;\n%s    for ( i = 0; i < %s_length; i++ )\n%s    {\n", ind, ind, ind, name, ind)
-	g.pf("%s        if ( %s[i] == 0 ) { return 0; } /* interior null on write (SPEC §4.12) */\n", ind, name)
+	g.pf("%s        serialize_assert( %s[i] != 0 ); /* interior null on write (SPEC §4.12) */\n", ind, name)
 	g.call(ind+"        ", fmt.Sprintf("serialize_write_bits( stream, (serialize_uint32_t) %s[i], 32 )", name))
 	g.pf("%s    }\n%s}\n", ind, ind)
 }

--- a/test/c-ludicrous/main.c
+++ b/test/c-ludicrous/main.c
@@ -177,7 +177,7 @@ int main( void )
        fixed128 entry's low lane — and this byte-compare against the
        C++-pinned golden is the gate. Values mirror test/ludicrous_main.cpp. */
     {
-        UnsignedProbe in, out, bad;
+        UnsignedProbe in, out;
         int i;
         memset( &in, 0, sizeof( in ) );
         in.angle = 2981888;                                          /* +45.5 * 2^16 */
@@ -208,12 +208,12 @@ int main( void )
         check( out.locked == 196608, "the degenerate ufixed materializes from the range alone" );
         check( out.tail == 0xA5, "the tail rides after zero degenerate bits" );
 
-        /* the write-side degenerate refusal: any raw but 3 * 2^16 is
-           refused before a single bit is written */
-        bad = in;
-        bad.locked = 196609;
-        serialize_write_stream_init( &w, buffer, sizeof( buffer ) );
-        check( !write_unsigned_probe( &w, &bad ), "a wrong degenerate ufixed raw is REFUSED on write" );
+        /* NO write-side degenerate refusal is tested here. A raw other than
+           3 * 2^16 is WRITER MISUSE, held by a serialize_assert that fires in
+           a debug build and compiles out under NDEBUG — the same contract the
+           C++ leg holds (test/ludicrous_main.cpp tests no such refusal
+           either). "Every language, by design, compiles out asserts/checks in
+           release build. This is the whole point!" */
 
         /* hostile: span's 64 offset bits (bits 25..88) all-ones = 2^64 - 1,
            above the raw range 0xFFFFFFFFFFFF0000 — the headroom is exactly

--- a/test/packet-wide/c_contract.c
+++ b/test/packet-wide/c_contract.c
@@ -12,15 +12,16 @@ int main(void)
     serialize_write_stream_t w;
     serialize_read_stream_t r;
     memset(&value, 0, sizeof(value));
-    value.text_length = 8;
-    serialize_write_stream_init(&w, (unsigned char *)buffer, sizeof(buffer));
-    check(!write_wide_seven(&w, &value));
-    value.text_length = -1;
-    serialize_write_stream_init(&w, (unsigned char *)buffer, sizeof(buffer));
-    check(!write_wide_seven(&w, &value));
+    /* The two WRITE-side rules of SPEC §4.12 — the used length within [0, N]
+       and no zero code unit among the used units — are WRITER MISUSE held in
+       this target's own §5 idiom: serialize_asserts that fire in a debug
+       build and compile out under NDEBUG, exactly as the C++ backend holds
+       them. ("Every language, by design, compiles out asserts/checks in
+       release build. This is the whole point!") They are not exercised here:
+       this file is built and run in BOTH modes, and an assert is not a value
+       a passing run can observe in either. What follows is the READ side,
+       which refuses in every build. */
     value.text_length = 1;
-    serialize_write_stream_init(&w, (unsigned char *)buffer, sizeof(buffer));
-    check(!write_wide_seven(&w, &value)); /* zero code unit, in every mode */
     value.text[0] = 0xd800;
     serialize_write_stream_init(&w, (unsigned char *)buffer, sizeof(buffer));
     check(write_wide_seven(&w, &value)); /* pairing is read-side */

--- a/testdata/golden/c/ArmDefaultsWire.h
+++ b/testdata/golden/c/ArmDefaultsWire.h
@@ -72,10 +72,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_default_arm( serialize_writ
             }
         }
     }
-    if ( (serialize_int64_t) value->marker > 7 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->marker <= 7 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->marker ), 3 ) )
     {
         return 0;

--- a/testdata/golden/c/ClausesWire.h
+++ b/testdata/golden/c/ClausesWire.h
@@ -177,10 +177,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w13( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 8191 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
             {
                 return 0;
@@ -235,10 +232,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w17( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 131071 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 131071 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 17 ) )
             {
                 return 0;
@@ -293,10 +287,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w26( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 67108863 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 67108863 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 26 ) )
             {
                 return 0;
@@ -351,10 +342,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w1( serialize_write_stream_
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 1 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 1 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 1 ) )
             {
                 return 0;
@@ -409,10 +397,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w52( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_uint64_t) value->items[i] > 4503599627370495 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_uint64_t) value->items[i] <= 4503599627370495 );
             {
                 serialize_uint64_t offset_value = (serialize_uint64_t) ( value->items[i] );
                 if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -479,10 +464,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_w50( serialize_write_stream
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_uint64_t) value->items[i] > 1125899906842623 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_uint64_t) value->items[i] <= 1125899906842623 );
             {
                 serialize_uint64_t offset_value = (serialize_uint64_t) ( value->items[i] );
                 if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -541,10 +523,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_f13( serialize_write_stream
         int32_t i;
         for ( i = 0; i < 7; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 8191 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
             {
                 return 0;

--- a/testdata/golden/c/JoinsWire.h
+++ b/testdata/golden/c/JoinsWire.h
@@ -631,10 +631,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_arm_array( serialize_write_
             int32_t i;
             for ( i = 0; i < value->items_count; i++ )
             {
-                if ( (serialize_int64_t) value->items[i] > 8191 )
-                {
-                    return 0;
-                }
+                serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
                 if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
                 {
                     return 0;
@@ -964,10 +961,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_regain_after_align( seriali
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] > 8191 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] <= 8191 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 13 ) )
             {
                 return 0;

--- a/testdata/golden/c/RenderWire.h
+++ b/testdata/golden/c/RenderWire.h
@@ -70,10 +70,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_render_sprite( serialize_wr
     {
         return 0;
     }
-    if ( value->team > 2 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->team <= 2 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->team, 2 ) )
     {
         return 0;

--- a/testdata/golden/c/TypesWire.h
+++ b/testdata/golden/c/TypesWire.h
@@ -136,10 +136,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quat( serialize_read_stream_t
 /* Writes Handle. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_handle( serialize_write_stream_t * stream, const Handle * value )
 {
-    if ( (serialize_int64_t) value->object_id < 0 || (serialize_int64_t) value->object_id > MAX_OBJECTS - 1 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->object_id >= 0 && (serialize_int64_t) value->object_id <= MAX_OBJECTS - 1 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->object_id ), 14 ) )
     {
         return 0;
@@ -182,26 +179,17 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_handle( serialize_read_stream
 /* Writes QuantizedPosition. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_position( serialize_write_stream_t * stream, const QuantizedPosition * value )
 {
-    if ( (serialize_int64_t) value->x < -MAX_POSITION_UNITS || (serialize_int64_t) value->x > MAX_POSITION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->x >= -MAX_POSITION_UNITS && (serialize_int64_t) value->x <= MAX_POSITION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->x) - (-MAX_POSITION_UNITS) ), 25 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->y < -MAX_POSITION_UNITS || (serialize_int64_t) value->y > MAX_POSITION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->y >= -MAX_POSITION_UNITS && (serialize_int64_t) value->y <= MAX_POSITION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->y) - (-MAX_POSITION_UNITS) ), 25 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->z < -MAX_POSITION_UNITS || (serialize_int64_t) value->z > MAX_POSITION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->z >= -MAX_POSITION_UNITS && (serialize_int64_t) value->z <= MAX_POSITION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->z) - (-MAX_POSITION_UNITS) ), 25 ) )
     {
         return 0;
@@ -260,26 +248,17 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_position( serialize
 /* Writes QuantizedVelocity. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_velocity( serialize_write_stream_t * stream, const QuantizedVelocity * value )
 {
-    if ( (serialize_int64_t) value->x < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->x > MAX_VELOCITY_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->x >= -MAX_VELOCITY_UNITS && (serialize_int64_t) value->x <= MAX_VELOCITY_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->x) - (-MAX_VELOCITY_UNITS) ), 23 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->y < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->y > MAX_VELOCITY_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->y >= -MAX_VELOCITY_UNITS && (serialize_int64_t) value->y <= MAX_VELOCITY_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->y) - (-MAX_VELOCITY_UNITS) ), 23 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->z < -MAX_VELOCITY_UNITS || (serialize_int64_t) value->z > MAX_VELOCITY_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->z >= -MAX_VELOCITY_UNITS && (serialize_int64_t) value->z <= MAX_VELOCITY_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->z) - (-MAX_VELOCITY_UNITS) ), 23 ) )
     {
         return 0;
@@ -338,34 +317,22 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_quantized_velocity( serialize
 /* Writes QuantizedRotation. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_quantized_rotation( serialize_write_stream_t * stream, const QuantizedRotation * value )
 {
-    if ( (serialize_int64_t) value->x < -ROTATION_UNITS || (serialize_int64_t) value->x > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->x >= -ROTATION_UNITS && (serialize_int64_t) value->x <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->x) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->y < -ROTATION_UNITS || (serialize_int64_t) value->y > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->y >= -ROTATION_UNITS && (serialize_int64_t) value->y <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->y) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->z < -ROTATION_UNITS || (serialize_int64_t) value->z > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->z >= -ROTATION_UNITS && (serialize_int64_t) value->z <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->z) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->w < -ROTATION_UNITS || (serialize_int64_t) value->w > ROTATION_UNITS )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->w >= -ROTATION_UNITS && (serialize_int64_t) value->w <= ROTATION_UNITS );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->w) - (-ROTATION_UNITS) ), 12 ) )
     {
         return 0;
@@ -697,10 +664,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_input_packet( serialize_read_
 /* Writes ShipCreate. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_write_stream_t * stream, const ShipCreate * value )
 {
-    if ( value->ship_type > 5 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->ship_type <= 5 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->ship_type, 3 ) )
     {
         return 0;
@@ -728,34 +692,22 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ship_create( serialize_writ
             return 0;
         }
     }
-    if ( value->team > 2 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->team <= 2 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->team, 2 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->health < 0 || (serialize_int64_t) value->health > MAX_HEALTH )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->health >= 0 && (serialize_int64_t) value->health <= MAX_HEALTH );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->health ), 10 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->thrust < 0 || (serialize_int64_t) value->thrust > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->thrust >= 0 && (serialize_int64_t) value->thrust <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->thrust ), 7 ) )
     {
         return 0;
     }
-    if ( value->pending > 0 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->pending <= 0 );
     return 1;
 }
 
@@ -852,18 +804,12 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ship_create( serialize_read_s
 /* Writes ExpressionProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_expression_probe( serialize_write_stream_t * stream, const ExpressionProbe * value )
 {
-    if ( (serialize_int64_t) value->hardpoint_index < 0 || (serialize_int64_t) value->hardpoint_index > (SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->hardpoint_index >= 0 && (serialize_int64_t) value->hardpoint_index <= (SHIP_MAX_LASERS + SHIP_MAX_MISSILES) - 1 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->hardpoint_index ), 5 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->spin_rate < -(-ROTATION_UNITS) || (serialize_int64_t) value->spin_rate > ROTATION_UNITS * 2 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->spin_rate >= -(-ROTATION_UNITS) && (serialize_int64_t) value->spin_rate <= ROTATION_UNITS * 2 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->spin_rate) - (-(-ROTATION_UNITS)) ), 11 ) )
     {
         return 0;
@@ -908,10 +854,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_expression_probe( serialize_r
 /* Writes ExtremeProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_write_stream_t * stream, const ExtremeProbe * value )
 {
-    if ( (serialize_int64_t) value->floor_bound > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->floor_bound <= 100 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->floor_bound) - (( -9223372036854775807LL - 1 )) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -923,10 +866,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
             return 0;
         }
     }
-    if ( (serialize_int64_t) value->doubled_floor > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->doubled_floor <= 100 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->doubled_floor) - (( -9223372036854775807LL - 1 )) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -938,10 +878,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_probe( serialize_wr
             return 0;
         }
     }
-    if ( (serialize_uint64_t) value->ceiling_range < 1 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_uint64_t) value->ceiling_range >= 1 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->ceiling_range) - (1) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -1046,10 +983,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_extreme_probe( serialize_read
 /* Writes ExtremeRow. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_write_stream_t * stream, const ExtremeRow * value )
 {
-    if ( (serialize_int64_t) value->clamped_floor > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->clamped_floor <= 100 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->clamped_floor) - (( -9223372036854775807LL - 1 )) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )
@@ -1061,10 +995,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_extreme_row( serialize_writ
             return 0;
         }
     }
-    if ( (serialize_uint64_t) value->clamped_ceiling < 1 || (serialize_uint64_t) value->clamped_ceiling > 18446744073709551614ULL )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_uint64_t) value->clamped_ceiling >= 1 && (serialize_uint64_t) value->clamped_ceiling <= 18446744073709551614ULL );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->clamped_ceiling) - (1) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )

--- a/testdata/golden/c/WireWire.h
+++ b/testdata/golden/c/WireWire.h
@@ -374,10 +374,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_sample( serialize_wri
     }
     if ( value->active )
     {
-        if ( value->weapon > 15 )
-        {
-            return 0; /* headroom above the wire range cannot ride */
-        }
+        serialize_assert( value->weapon <= 15 );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) value->weapon, 4 ) )
         {
             return 0;
@@ -546,10 +543,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_ring( serialize_read_st
 /* Writes ProbeSlab. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_slab( serialize_write_stream_t * stream, const ProbeSlab * value )
 {
-    if ( (serialize_int64_t) value->width > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->width <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->width ), 7 ) )
     {
         return 0;
@@ -718,10 +712,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_probe_config( serialize_wri
     {
         return 0;
     }
-    if ( value->preferred > 15 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->preferred <= 15 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->preferred, 4 ) )
     {
         return 0;
@@ -818,26 +809,17 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test( serialize_write_strea
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->test_b < 0 || (serialize_int64_t) value->test_b > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->test_b >= 0 && (serialize_int64_t) value->test_b <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->test_b ), 10 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->test_c < 0 || (serialize_int64_t) value->test_c > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->test_c >= 0 && (serialize_int64_t) value->test_c <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->test_c ), 10 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->test_d < 0 || (serialize_int64_t) value->test_d > 1000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->test_d >= 0 && (serialize_int64_t) value->test_d <= 1000 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->test_d ), 10 ) )
     {
         return 0;
@@ -1009,26 +991,17 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_probe_report( serialize_read_
 /* Writes TestData. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_stream_t * stream, const TestData * value )
 {
-    if ( (serialize_int64_t) value->a < -100 || (serialize_int64_t) value->a > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->a >= -100 && (serialize_int64_t) value->a <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->a) - (-100) ), 8 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->b < -100 || (serialize_int64_t) value->b > 100 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->b >= -100 && (serialize_int64_t) value->b <= 100 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->b) - (-100) ), 8 ) )
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->c < -100 || (serialize_int64_t) value->c > 150 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->c >= -100 && (serialize_int64_t) value->c <= 150 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) ( (value->c) - (-100) ), 8 ) )
     {
         return 0;
@@ -1061,10 +1034,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
         int32_t i;
         for ( i = 0; i < value->items_count; i++ )
         {
-            if ( (serialize_int64_t) value->items[i] < 0 || (serialize_int64_t) value->items[i] > 255 )
-            {
-                return 0;
-            }
+            serialize_assert( (serialize_int64_t) value->items[i] >= 0 && (serialize_int64_t) value->items[i] <= 255 );
             if ( !serialize_write_bits( stream, (serialize_uint32_t) ( value->items[i] ), 8 ) )
             {
                 return 0;
@@ -1111,10 +1081,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_test_data( serialize_write_
     {
         return 0;
     }
-    if ( (serialize_int64_t) value->int64_range < -1000000000000 || (serialize_int64_t) value->int64_range > 1000000000000 )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->int64_range >= -1000000000000 && (serialize_int64_t) value->int64_range <= 1000000000000 );
     {
         serialize_uint64_t offset_value = (serialize_uint64_t) ( (value->int64_range) - (-1000000000000) );
         if ( !serialize_write_bits( stream, (serialize_uint32_t) ( offset_value & 0xFFFFFFFFu ), 32 ) )

--- a/testdata/golden/ludicrous/c/LudicrousWire.h
+++ b/testdata/golden/ludicrous/c/LudicrousWire.h
@@ -199,10 +199,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_unsigned_probe( serialize_w
             }
         }
     }
-    if ( (serialize_uint64_t) value->locked != 196608ULL )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_uint64_t) value->locked == 196608ULL );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->tail, 8 ) )
     {
         return 0;
@@ -326,10 +323,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_probe( serialize_read_st
 /* Writes LudicrousState. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_ludicrous_state( serialize_write_stream_t * stream, const LudicrousState * value )
 {
-    if ( value->mode > 3 )
-    {
-        return 0; /* headroom above the wire range cannot ride */
-    }
+    serialize_assert( value->mode <= 3 );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->mode, 2 ) )
     {
         return 0;
@@ -432,18 +426,9 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_ludicrous_state( serialize_re
 /* Writes DegenerateProbe. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_degenerate_probe( serialize_write_stream_t * stream, const DegenerateProbe * value )
 {
-    if ( (serialize_int64_t) value->locked_fixed != -196608LL )
-    {
-        return 0;
-    }
-    if ( (serialize_int64_t) value->locked_int < 7 || (serialize_int64_t) value->locked_int > 7 )
-    {
-        return 0;
-    }
-    if ( !serialize_int128_equal( value->locked_wide, serialize_int128_from_int64( -12345678901234 ) ) )
-    {
-        return 0;
-    }
+    serialize_assert( (serialize_int64_t) value->locked_fixed == -196608LL );
+    serialize_assert( (serialize_int64_t) value->locked_int >= 7 && (serialize_int64_t) value->locked_int <= 7 );
+    serialize_assert( serialize_int128_equal( value->locked_wide, serialize_int128_from_int64( -12345678901234 ) ) );
     if ( !serialize_write_bits( stream, (serialize_uint32_t) value->tail, 8 ) )
     {
         return 0;

--- a/testdata/golden/packet-wide/c/WideTextWire.h
+++ b/testdata/golden/packet-wide/c/WideTextWire.h
@@ -164,10 +164,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int schema_interior_null_( const seria
 /* Writes WideSeven. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_seven( serialize_write_stream_t * stream, const WideSeven * value )
 {
-    if ( value->text_length < 0 || value->text_length > 7 )
-    {
-        return 0;
-    }
+    serialize_assert( value->text_length >= 0 && value->text_length <= 7 );
     if ( !serialize_write_int( stream, value->text_length, 0, 7 ) )
     {
         return 0;
@@ -176,7 +173,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_seven( serialize_write
         int32_t i;
         for ( i = 0; i < value->text_length; i++ )
         {
-            if ( value->text[i] == 0 ) { return 0; } /* interior null on write (SPEC §4.12) */
+            serialize_assert( value->text[i] != 0 ); /* interior null on write (SPEC §4.12) */
             if ( !serialize_write_bits( stream, (serialize_uint32_t) value->text[i], 32 ) )
             {
                 return 0;
@@ -220,10 +217,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_wide_seven( serialize_read_st
 /* Writes WideFour. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_four( serialize_write_stream_t * stream, const WideFour * value )
 {
-    if ( value->text_length < 0 || value->text_length > 4 )
-    {
-        return 0;
-    }
+    serialize_assert( value->text_length >= 0 && value->text_length <= 4 );
     if ( !serialize_write_int( stream, value->text_length, 0, 4 ) )
     {
         return 0;
@@ -232,7 +226,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_four( serialize_write_
         int32_t i;
         for ( i = 0; i < value->text_length; i++ )
         {
-            if ( value->text[i] == 0 ) { return 0; } /* interior null on write (SPEC §4.12) */
+            serialize_assert( value->text[i] != 0 ); /* interior null on write (SPEC §4.12) */
             if ( !serialize_write_bits( stream, (serialize_uint32_t) value->text[i], 32 ) )
             {
                 return 0;
@@ -313,10 +307,7 @@ static SCHEMA_UNUSED SCHEMA_C_READ_INLINE int read_narrow_fifteen( serialize_rea
 /* Writes WideInterop. */
 static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_interop( serialize_write_stream_t * stream, const WideInterop * value )
 {
-    if ( value->caption_length < 0 || value->caption_length > 7 )
-    {
-        return 0;
-    }
+    serialize_assert( value->caption_length >= 0 && value->caption_length <= 7 );
     if ( !serialize_write_int( stream, value->caption_length, 0, 7 ) )
     {
         return 0;
@@ -325,7 +316,7 @@ static SCHEMA_UNUSED SCHEMA_C_WRITE_INLINE int write_wide_interop( serialize_wri
         int32_t i;
         for ( i = 0; i < value->caption_length; i++ )
         {
-            if ( value->caption[i] == 0 ) { return 0; } /* interior null on write (SPEC §4.12) */
+            serialize_assert( value->caption[i] != 0 ); /* interior null on write (SPEC §4.12) */
             if ( !serialize_write_bits( stream, (serialize_uint32_t) value->caption[i], 32 ) )
             {
                 return 0;


### PR DESCRIPTION
Glenn's ruling, verbatim, today: "No runtime should ever promise to keep checks in writing packets (asserts) in release build. Removing them is the whole point. The documented posture of the serialize and schema libraries is that it is *your responsibility* in shipping release builds on the write side to be correct. checks are *DEBUG ONLY*" and "Of course, on read side we MUST always do the checks!"

**What was wrong.** The C backend emitted `if ( out of range ) return 0;` per ranged field on write, in every build, where the C++ backend emits `serialize_assert`, which compiles out under NDEBUG. Both runtimes define their assert as plain `assert`. On the packet-wire bench that is about 144 compare-and-branch pairs per message that C ran and C++ did not, and it is the countable part of why the C leg measured 107% of C++ this morning where it was a tie two weeks ago (C's absolute rate never moved; C++'s rose with an unrelated read-path change and a compilation effect).

**What changes.** internal/codegen/c: ranged ints, enum headroom, degenerate fixed and int128, wstring used-length and interior null on write become `serialize_assert`, the same guards C++ folds in; a zero-wire-bit struct's write body casts `value` to void so `-Werror` holds under NDEBUG, as C++ already does. Unchanged, both backends: the §4.6 count refusal and the §4.8 union-tag refusal on write (every build, all nine targets today; a ruling on those is asked separately), and every read-side check. The wire and the protocol id do not move. Nine generated C headers and eight goldens regenerate. SPEC §5's tier list moves C from "returns failure from the write" to the assert tier and adds C to the §4.6 list; USAGE, FAQ and PERFORMANCE follow, PERFORMANCE's "Reading the table honestly" rewritten and dated, its two 2026-08-15 caption comments left as the record they are. Three tests change: expr_test's seven pinned bound spellings invert into the assert; c-ludicrous drops one every-build refusal check its C++ twin never had; packet-wide's c_contract drops three write-refusal checks (the read half stays; the pairing negative control still bites the read path).

**Receipts.** make test-c green in debug and under -DNDEBUG with ASan/UBSan (schema_test_c, c-ludicrous, bench_c, conformance-c, packet-wide-c, both negative controls); go test ./... clean; make shape-gate clean; gofmt, go vet clean. The bench's C provenance already read `checks=removed` (bench/c since 2026-08-17); the generated code has now caught up with that word. Two pre-existing gaps in the other direction are named and left alone: C emits no assert for a flags storage wider than the wire, and none for string(N) interior nulls on write, where C++ asserts both.

**Measured.** A twins pass on this branch (seven interleaved rounds, window OK, control delta 1.6%; CSV in bench/results) renders C at 105.2% of C++, a §2.8 tie inside an 8.6-point band: write 8,858,514 against 8,863,042, round trip 4,408,928 against 4,636,506. The change buys nothing the instrument resolves (two identical-code passes differ by 0.4%; a hand-built pass with the refusals compiled out moved 0.4% and 0.1%); the remaining distance is the C runtime's bit reader (C++ reads raw bits 1.58x faster), being worked separately. PERFORMANCE.md says so, dated.

Written by an Opus worker under Rowan's brief; commit authored Rowan, branch pushed as rowan-claude, PR opened from Glenn's login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)